### PR TITLE
refactor(cli): extract services/polling.py from 4 spinner copies

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
@@ -1,0 +1,9459 @@
+{
+  "aliases": {
+    "download cinematic-video": {
+      "canonical": "download video",
+      "same_callback": true,
+      "same_params": true
+    },
+    "generate cinematic-video": {
+      "canonical": "generate video --format cinematic",
+      "same_callback": true,
+      "same_params": true
+    }
+  },
+  "click_groups": {
+    "agent": [
+      "show"
+    ],
+    "artifact": [
+      "delete",
+      "export",
+      "get",
+      "list",
+      "poll",
+      "rename",
+      "suggestions",
+      "wait"
+    ],
+    "download": [
+      "audio",
+      "cinematic-video",
+      "data-table",
+      "flashcards",
+      "infographic",
+      "mind-map",
+      "quiz",
+      "report",
+      "slide-deck",
+      "video"
+    ],
+    "generate": [
+      "audio",
+      "cinematic-video",
+      "data-table",
+      "flashcards",
+      "infographic",
+      "mind-map",
+      "quiz",
+      "report",
+      "revise-slide",
+      "slide-deck",
+      "video"
+    ],
+    "language": [
+      "get",
+      "list",
+      "set"
+    ],
+    "note": [
+      "create",
+      "delete",
+      "get",
+      "list",
+      "rename",
+      "save"
+    ],
+    "profile": [
+      "create",
+      "delete",
+      "list",
+      "rename",
+      "switch"
+    ],
+    "research": [
+      "status",
+      "wait"
+    ],
+    "share": [
+      "add",
+      "public",
+      "remove",
+      "status",
+      "update",
+      "view-level"
+    ],
+    "skill": [
+      "install",
+      "show",
+      "status",
+      "uninstall"
+    ],
+    "source": [
+      "add",
+      "add-drive",
+      "add-research",
+      "clean",
+      "delete",
+      "delete-by-title",
+      "fulltext",
+      "get",
+      "guide",
+      "list",
+      "refresh",
+      "rename",
+      "stale",
+      "wait"
+    ]
+  },
+  "commands": {
+    "agent": {
+      "class": "Group",
+      "commands": [
+        "show"
+      ],
+      "params": [],
+      "short_help": "Show bundled instructions for supported..."
+    },
+    "agent show": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "target",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "codex",
+              "claude"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Display instructions for Codex or Claude..."
+    },
+    "artifact": {
+      "class": "Group",
+      "commands": [
+        "delete",
+        "export",
+        "get",
+        "list",
+        "poll",
+        "rename",
+        "suggestions",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Artifact management commands."
+    },
+    "artifact delete": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete an artifact."
+    },
+    "artifact export": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Title for exported document",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "docs",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "export_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "docs",
+              "sheets"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Export artifact to Google Docs/Sheets."
+    },
+    "artifact get": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get artifact details."
+    },
+    "artifact list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by type",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "audio",
+              "video",
+              "slide-deck",
+              "quiz",
+              "flashcard",
+              "infographic",
+              "data-table",
+              "mind-map",
+              "report"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show at most N rows. 0 = show no rows. Omit for unlimited. Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List artifacts in a notebook."
+    },
+    "artifact poll": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "task_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Single non-blocking generation status check."
+    },
+    "artifact rename": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename an artifact."
+    },
+    "artifact suggestions": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON format",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get AI-suggested report topics based on..."
+    },
+    "artifact wait": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Block until artifact generation finishes..."
+    },
+    "ask": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "question",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Continue a specific conversation",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "conversation_id",
+          "opts": [
+            "--conversation-id",
+            "-c"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Start a fresh conversation. DESTRUCTIVE: this deletes the notebook's current server-side conversation (turns are not recoverable) before asking. Prompts for confirmation unless ``--yes`` is passed.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "new_conversation",
+          "opts": [
+            "--new"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip the ``--new`` destructive-delete confirmation prompt. ``--json`` implies ``--yes`` so scripted callers never hang.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "assume_yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs (can be repeated)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON (includes references)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Save response as a note. When the answer has citations, the saved note preserves interactive [N] hover-anchor links (matching the NotebookLM web UI's 'Save to note' behavior); otherwise falls back to a plain-text note.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "save_as_note",
+          "opts": [
+            "--save-as-note"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Note title (use with --save-as-note)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "note_title",
+          "opts": [
+            "--note-title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "HTTP request timeout in seconds (default: 30, from the library). Increase for long or complex prompts.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        }
+      ],
+      "short_help": "Ask a notebook a question."
+    },
+    "auth": {
+      "class": "Group",
+      "commands": [
+        "check",
+        "inspect",
+        "logout",
+        "refresh"
+      ],
+      "params": [],
+      "short_help": "Authentication management commands."
+    },
+    "auth check": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Test token fetch (makes network request)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "test_fetch",
+          "opts": [
+            "--test"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check authentication status and diagnose..."
+    },
+    "auth inspect": {
+      "class": "Command",
+      "params": [
+        {
+          "default": "auto",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Browser to read cookies from (chrome, firefox, brave, edge, safari, arc, ...). 'auto' picks the first one rookiepy can read. Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container. Requires: pip install 'notebooklm-py[cookies]'",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_name",
+          "opts": [
+            "--browser"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Opt in to enumerating accounts via sibling-product cookies. Same syntax as 'notebooklm login --include-domains'. By default this command only consults required Google auth cookies, which is sufficient for account discovery on every tested path.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Also show which browser user-profile each account's cookies came from. Useful for Chromium-family browsers with multiple user-profiles.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "verbose",
+          "opts": [
+            "-v",
+            "--verbose"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List Google accounts visible to a..."
+    },
+    "auth logout": {
+      "class": "Command",
+      "params": [],
+      "short_help": "Log out by clearing saved authentication."
+    },
+    "auth refresh": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Re-extract cookies from an installed browser and match the profile account from context.json. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_cookies",
+          "opts": [
+            "--browser-cookies",
+            "--browser-cookie"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Forward to the browser-cookie reader (only meaningful with --browser-cookies). Same syntax as 'notebooklm login --include-domains'.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Suppress success output (only print on error)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "quiet",
+          "opts": [
+            "--quiet",
+            "-q"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Refresh stored cookies by exercising the..."
+    },
+    "clear": {
+      "class": "Command",
+      "params": [],
+      "short_help": "Clear current notebook context."
+    },
+    "completion": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "shell",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "bash",
+              "zsh",
+              "fish"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Print the shell completion script for SHELL."
+    },
+    "configure": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Predefined chat mode",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "chat_mode",
+          "opts": [
+            "--mode"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "learning-guide",
+              "concise",
+              "detailed"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom persona prompt (up to 10,000 chars)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "persona",
+          "opts": [
+            "--persona"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Response verbosity",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "response_length",
+          "opts": [
+            "--response-length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "longer",
+              "shorter"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Configure chat persona and response settings."
+    },
+    "create": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Set the new notebook as the current context (like 'notebooklm use <id>').",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "switch_context",
+          "opts": [
+            "--use",
+            "-u"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Create a new notebook."
+    },
+    "delete": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a notebook."
+    },
+    "doctor": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Attempt to fix detected issues",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "fix_issues",
+          "opts": [
+            "--fix"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check profile setup, auth status, and..."
+    },
+    "download": {
+      "class": "Group",
+      "commands": [
+        "audio",
+        "cinematic-video",
+        "data-table",
+        "flashcards",
+        "infographic",
+        "mind-map",
+        "quiz",
+        "report",
+        "slide-deck",
+        "video"
+      ],
+      "params": [],
+      "short_help": "Download generated content."
+    },
+    "download audio": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download audio overview(s) to file."
+    },
+    "download cinematic-video": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download cinematic video overview(s) to file."
+    },
+    "download data-table": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download data table(s) as CSV files."
+    },
+    "download flashcards": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "json",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output format: json (default), markdown, or html",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "json",
+              "markdown",
+              "html"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download flashcard deck."
+    },
+    "download infographic": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download infographic(s) to file."
+    },
+    "download mind-map": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download mind map(s) as JSON files."
+    },
+    "download quiz": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "json",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output format: json (default), markdown, or html",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "json",
+              "markdown",
+              "html"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download quiz questions."
+    },
+    "download report": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download report(s) as markdown files."
+    },
+    "download slide-deck": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "pdf",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download format: pdf (default) or pptx",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "slide_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "pdf",
+              "pptx"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download slide deck(s) as PDF or PPTX."
+    },
+    "download video": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download video overview(s) to file."
+    },
+    "generate": {
+      "class": "Group",
+      "commands": [
+        "audio",
+        "cinematic-video",
+        "data-table",
+        "flashcards",
+        "infographic",
+        "mind-map",
+        "quiz",
+        "report",
+        "revise-slide",
+        "slide-deck",
+        "video"
+      ],
+      "params": [],
+      "short_help": "Generate content from notebook."
+    },
+    "generate audio": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "deep-dive",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "audio_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "deep-dive",
+              "brief",
+              "critique",
+              "debate"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "default",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "audio_length",
+          "opts": [
+            "--length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "short",
+              "default",
+              "long"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate audio overview (podcast)."
+    },
+    "generate cinematic-video": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "explainer",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "video_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "explainer",
+              "brief",
+              "cinematic"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "custom",
+              "classic",
+              "whiteboard",
+              "kawaii",
+              "anime",
+              "watercolor",
+              "retro-print",
+              "heritage",
+              "paper-craft"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom visual style prompt",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style_prompt",
+          "opts": [
+            "--style-prompt"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 600,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 600)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate cinematic video overview..."
+    },
+    "generate data-table": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate data table."
+    },
+    "generate flashcards": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "quantity",
+          "opts": [
+            "--quantity"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fewer",
+              "standard",
+              "more"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "medium",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "difficulty",
+          "opts": [
+            "--difficulty"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate flashcards."
+    },
+    "generate infographic": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "landscape",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "orientation",
+          "opts": [
+            "--orientation"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "landscape",
+              "portrait",
+              "square"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "detail",
+          "opts": [
+            "--detail"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "concise",
+              "standard",
+              "detailed"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "sketch-note",
+              "professional",
+              "bento-grid",
+              "editorial",
+              "instructional",
+              "bricks",
+              "clay",
+              "anime",
+              "kawaii",
+              "scientific"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate infographic."
+    },
+    "generate mind-map": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom instructions for the mind map",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "instructions",
+          "opts": [
+            "--instructions"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate mind map."
+    },
+    "generate quiz": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "quantity",
+          "opts": [
+            "--quantity"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fewer",
+              "standard",
+              "more"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "medium",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "difficulty",
+          "opts": [
+            "--difficulty"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate quiz."
+    },
+    "generate report": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": "briefing-doc",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Report format (default: briefing-doc)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "report_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "briefing-doc",
+              "study-guide",
+              "blog-post",
+              "custom"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Append extra instructions to the built-in prompt for non-custom formats. Has no effect with --format custom.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "append_instructions",
+          "opts": [
+            "--append"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate a report (briefing doc, study..."
+    },
+    "generate revise-slide": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Slide deck artifact ID to revise",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Zero-based index of the slide to revise (0 = first slide)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "slide_index",
+          "opts": [
+            "--slide"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Revise an individual slide in an existing..."
+    },
+    "generate slide-deck": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "detailed",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "deck_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "detailed",
+              "presenter"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "default",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "deck_length",
+          "opts": [
+            "--length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "short"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate slide deck."
+    },
+    "generate video": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "explainer",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "video_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "explainer",
+              "brief",
+              "cinematic"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "custom",
+              "classic",
+              "whiteboard",
+              "kawaii",
+              "anime",
+              "watercolor",
+              "retro-print",
+              "heritage",
+              "paper-craft"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom visual style prompt",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style_prompt",
+          "opts": [
+            "--style-prompt"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 600,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 600)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate video overview."
+    },
+    "history": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 100,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum number of Q&A turns to show",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit",
+            "-l"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Clear local conversation cache",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "clear_cache",
+          "opts": [
+            "--clear"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Save history as a note",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "save_as_note",
+          "opts": [
+            "--save"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Note title (with --save)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "note_title",
+          "opts": [
+            "-t",
+            "--note-title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show full Q&A content instead of preview",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "show_all",
+          "opts": [
+            "--show-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Disable the 50-char preview cap on Question/Answer columns in the table view.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get conversation history or save it as a..."
+    },
+    "language": {
+      "class": "Group",
+      "commands": [
+        "get",
+        "list",
+        "set"
+      ],
+      "params": [],
+      "short_help": "Manage output language for artifact..."
+    },
+    "language get": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show local config only (skip server sync)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "local",
+          "opts": [
+            "--local"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get current language setting."
+    },
+    "language list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all supported language codes."
+    },
+    "language set": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "code",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Set local config only (skip server sync)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "local",
+          "opts": [
+            "--local"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set default language for artifact generation."
+    },
+    "list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show at most N rows. 0 = show no rows. Omit for unlimited. Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all notebooks."
+    },
+    "login": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Where to save storage_state.json (default: profile-specific location)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "storage",
+          "opts": [
+            "--storage"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": "chromium",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Browser to use for login (default: chromium). Use 'chrome' for system Google Chrome (workaround when bundled Chromium crashes, e.g. macOS 15+), 'msedge' for Microsoft Edge.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser",
+          "opts": [
+            "--browser"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "chromium",
+              "msedge",
+              "chrome"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read cookies from an installed browser instead of launching Playwright. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... For Chromium-family profiles, target one with 'chrome::<profile>' (e.g. 'chrome::Profile 1' or 'brave::Work'). For Firefox Multi-Account Containers, target a specific container with 'firefox::<container-name>' (or 'firefox::none' for the default). Requires: pip install 'notebooklm-py[cookies]'",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_cookies",
+          "opts": [
+            "--browser-cookies"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Pick a signed-in Google account by email when several are present in the browser. Only valid with --browser-cookies.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "account_email",
+          "opts": [
+            "--account"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Extract every Google account signed in to the browser into its own profile (auto-named from each account's email). Only valid with --browser-cookies.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "all_accounts",
+          "opts": [
+            "--all-accounts"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "With --all-accounts: when an account's natural profile name (e.g. 'alice' for alice@gmail.com) already exists but has no account metadata, update that profile in place instead of creating a suffixed 'alice-2'. Profiles that already bind a different email are still given a suffix to avoid clobbering. Only valid with --all-accounts.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "update",
+          "opts": [
+            "--update"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Name to give the new profile when extracting a non-default account. Defaults to the account email's local-part. Only valid with --browser-cookies.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "profile_name",
+          "opts": [
+            "--profile-name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Start with a clean browser session (deletes cached browser profile). Use to switch Google accounts.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "fresh",
+          "opts": [
+            "--fresh"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Opt in to extracting sibling-product cookies (default: required Google auth/Drive cookies only). Pass labels comma-separated or repeat the flag: --include-domains=youtube,docs OR --include-domains=youtube --include-domains=docs. Supported labels: youtube, docs, myaccount, mail, all.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Log in to NotebookLM via browser."
+    },
+    "metadata": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON (default: human-readable)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Export notebook metadata with sources list."
+    },
+    "note": {
+      "class": "Group",
+      "commands": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "rename",
+        "save"
+      ],
+      "params": [],
+      "short_help": "Note management commands."
+    },
+    "note create": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "content",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Note content (or '-' to read from stdin). Mutually exclusive with the positional CONTENT argument.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "content_flag",
+          "opts": [
+            "--content"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "New Note",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Note title",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "-t",
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Create a new note."
+    },
+    "note delete": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a note."
+    },
+    "note get": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get note content."
+    },
+    "note list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all notes in a notebook."
+    },
+    "note rename": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename a note."
+    },
+    "note save": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "New title",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "New content",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "content",
+          "opts": [
+            "--content"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Update note content."
+    },
+    "notebooklm": {
+      "class": "SectionedGroup",
+      "commands": [
+        "agent",
+        "artifact",
+        "ask",
+        "auth",
+        "clear",
+        "completion",
+        "configure",
+        "create",
+        "delete",
+        "doctor",
+        "download",
+        "generate",
+        "history",
+        "language",
+        "list",
+        "login",
+        "metadata",
+        "note",
+        "profile",
+        "rename",
+        "research",
+        "share",
+        "skill",
+        "source",
+        "status",
+        "summary",
+        "use"
+      ],
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show the version and exit.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "version",
+          "opts": [
+            "--version"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Path to storage_state.json (default: ~/.notebooklm/profiles/<profile>/storage_state.json)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "storage",
+          "opts": [
+            "--storage"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Profile name (default: from config or 'default'). Use 'notebooklm profile list' to see profiles.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "profile",
+          "opts": [
+            "-p",
+            "--profile"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Increase verbosity (-v for INFO, -vv for DEBUG)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "verbose",
+          "opts": [
+            "-v",
+            "--verbose"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Suppress status output and INFO/WARN log records (only errors survive). Mutually exclusive with -v/-vv.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "quiet",
+          "opts": [
+            "--quiet"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "NotebookLM CLI."
+    },
+    "profile": {
+      "class": "Group",
+      "commands": [
+        "create",
+        "delete",
+        "list",
+        "rename",
+        "switch"
+      ],
+      "params": [],
+      "short_help": "Manage authentication profiles for..."
+    },
+    "profile create": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Create a new profile."
+    },
+    "profile delete": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation prompt",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "confirm",
+          "opts": [
+            "--confirm"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a profile and its data."
+    },
+    "profile list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all profiles and their status."
+    },
+    "profile rename": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "old_name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Rename a profile."
+    },
+    "profile switch": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Set the default profile."
+    },
+    "rename": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Rename a notebook."
+    },
+    "research": {
+      "class": "Group",
+      "commands": [
+        "status",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Research management commands."
+    },
+    "research status": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check research status for the current..."
+    },
+    "research wait": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 5,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 5)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Import all found sources when done",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "import_all",
+          "opts": [
+            "--import-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "With --import-all, import only cited sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "cited_only",
+          "opts": [
+            "--cited-only"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Wait for research to complete."
+    },
+    "share": {
+      "class": "Group",
+      "commands": [
+        "add",
+        "public",
+        "remove",
+        "status",
+        "update",
+        "view-level"
+      ],
+      "params": [],
+      "short_help": "Notebook sharing commands."
+    },
+    "share add": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "viewer",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Permission level (default: viewer)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "permission",
+          "opts": [
+            "--permission",
+            "-p"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "editor",
+              "viewer"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Don't send email notification",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_notify",
+          "opts": [
+            "--no-notify"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Welcome message for the user",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "message",
+          "opts": [
+            "--message",
+            "-m"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Share notebook with a user."
+    },
+    "share public": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": true,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Enable or disable public sharing",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "enable",
+          "opts": [
+            "--enable"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--disable"
+          ],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Enable or disable public link sharing."
+    },
+    "share remove": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Remove a user's access to the notebook."
+    },
+    "share status": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Show sharing status and shared users."
+    },
+    "share update": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "New permission level",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "permission",
+          "opts": [
+            "--permission",
+            "-p"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "editor",
+              "viewer"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Update a user's permission level."
+    },
+    "share view-level": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "level",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "full",
+              "chat"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set what viewers can access."
+    },
+    "skill": {
+      "class": "Group",
+      "commands": [
+        "install",
+        "show",
+        "status",
+        "uninstall"
+      ],
+      "params": [],
+      "short_help": "Manage NotebookLM agent skill integration."
+    },
+    "skill install": {
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Install for the current user or into the current project.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Install for Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Install or update the NotebookLM skill for..."
+    },
+    "skill show": {
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read an installed skill from user or project scope.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "source",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show the packaged skill source or an installed target.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "source",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Display the packaged skill content or an..."
+    },
+    "skill status": {
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Inspect user-level or project-level skill installs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Inspect Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Check installed skill targets and version..."
+    },
+    "skill uninstall": {
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Remove user-level or project-level skill installs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Remove Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Remove the NotebookLM skill from supported..."
+    },
+    "source": {
+      "class": "Group",
+      "commands": [
+        "add",
+        "add-drive",
+        "add-research",
+        "clean",
+        "delete",
+        "delete-by-title",
+        "fulltext",
+        "get",
+        "guide",
+        "list",
+        "refresh",
+        "rename",
+        "stale",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Source management commands."
+    },
+    "source add": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "content",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Source type (auto-detected if not specified)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "source_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "url",
+              "text",
+              "file",
+              "youtube"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom title for text and uploaded-file sources",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "[Deprecated] MIME type for file sources \u2014 unused; the server derives MIME from the filename extension. Drive sources retain this option (see ``source add-drive``).",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mime_type",
+          "opts": [
+            "--mime-type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "HTTP request timeout in seconds (default: 30, from the library). Increase when adding slow URLs or large files that exceed the default.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "float"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Follow symbolic links when uploading a file. By default, symlinks are rejected so a workspace symlink cannot silently exfiltrate the file it points at (e.g. ~/Downloads/foo.pdf -> /etc/passwd).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "follow_symlinks",
+          "opts": [
+            "--follow-symlinks"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Add a source to a notebook."
+    },
+    "source add-drive": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "file_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "google-doc",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Document type (default: google-doc)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mime_type",
+          "opts": [
+            "--mime-type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "google-doc",
+              "google-slides",
+              "google-sheets",
+              "pdf"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Add a Google Drive document as a source."
+    },
+    "source add-research": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "query",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "web",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Search source (default: web)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "search_source",
+          "opts": [
+            "--from"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "web",
+              "drive"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "fast",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Search mode (default: fast)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mode",
+          "opts": [
+            "--mode"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fast",
+              "deep"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Import all found sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "import_all",
+          "opts": [
+            "--import-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "With --import-all, import only cited sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "cited_only",
+          "opts": [
+            "--cited-only"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Start research and return immediately (use 'research status/wait' to monitor)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_wait",
+          "opts": [
+            "--no-wait"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 1800,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Per-phase seconds budget for (a) the research-completion poll loop and (b) the --import-all retry loop (default: 1800). Each phase gets the full budget independently, so worst-case total wall time is up to 2\u00d7 this value. Matches 'research wait --timeout' semantics. Bumping this is required for deep research that runs longer than the legacy 5-minute cap \u2014 otherwise the CLI gives up before IMPORT_RESEARCH fires and the NotebookLM web UI is left showing an 'Add sources?' modal.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        }
+      ],
+      "short_help": "Search web or drive and add sources from..."
+    },
+    "source clean": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show what would be deleted without actually deleting",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Automatically remove duplicate, error, and..."
+    },
+    "source delete": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a source."
+    },
+    "source delete-by-title": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a source by exact title."
+    },
+    "source fulltext": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Write content to file",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output",
+          "opts": [
+            "--output",
+            "-o"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": "text",
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Content format: text (default) or markdown",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format",
+            "-f"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "text",
+              "markdown"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Get full content of a source."
+    },
+    "source get": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get source details."
+    },
+    "source guide": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get AI-generated source summary and keywords."
+    },
+    "source list": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show at most N rows. 0 = show no rows. Omit for unlimited. Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all sources in a notebook."
+    },
+    "source refresh": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Refresh a URL/Drive source."
+    },
+    "source rename": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename a source."
+    },
+    "source stale": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check if a URL/Drive source needs refresh."
+    },
+    "source wait": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 120,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum seconds to wait (default: 120)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 1,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Seconds between status checks (default: 1)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Wait for a source to finish processing."
+    },
+    "status": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Show resolved file paths",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "show_paths",
+          "opts": [
+            "--paths"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Show current context (active notebook and..."
+    },
+    "summary": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Include suggested topics",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "topics",
+          "opts": [
+            "--topics"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get notebook summary with AI-generated..."
+    },
+    "use": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "notebook_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Skip the existence check and persist the notebook ID even if verification fails. Use for offline work or debugging.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set the current notebook context."
+    }
+  },
+  "completion_callbacks": {
+    "download_artifact": true,
+    "notebook": true
+  },
+  "root_commands": [
+    "agent",
+    "artifact",
+    "ask",
+    "auth",
+    "clear",
+    "completion",
+    "configure",
+    "create",
+    "delete",
+    "doctor",
+    "download",
+    "generate",
+    "history",
+    "language",
+    "list",
+    "login",
+    "metadata",
+    "note",
+    "profile",
+    "rename",
+    "research",
+    "share",
+    "skill",
+    "source",
+    "status",
+    "summary",
+    "use"
+  ],
+  "schema_version": 1,
+  "top_level_surfaces": {
+    "chat": [
+      "ask",
+      "configure",
+      "history"
+    ],
+    "notebook": [
+      "list",
+      "create",
+      "delete",
+      "rename",
+      "metadata",
+      "summary"
+    ],
+    "session": [
+      "login",
+      "auth",
+      "use",
+      "status",
+      "clear"
+    ]
+  },
+  "tracked_surfaces": [
+    "download",
+    "source",
+    "generate",
+    "artifact",
+    "session",
+    "profile",
+    "notebook",
+    "chat",
+    "note",
+    "share",
+    "research"
+  ]
+}

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -11,10 +11,6 @@ Commands:
     suggestions Get AI-suggested report topics
 """
 
-import asyncio
-import contextlib
-import time
-from collections.abc import AsyncIterator
 from typing import Literal
 
 import click
@@ -23,7 +19,7 @@ from rich.table import Table
 from ..client import NotebookLMClient
 from ..types import ExportType
 from .auth_runtime import with_client
-from .error_handler import _output_error, emit_cancelled_and_exit
+from .error_handler import _output_error
 from .options import json_option, list_options, notebook_option, wait_polling_options
 from .rendering import (
     cli_name_to_artifact_type,
@@ -37,66 +33,7 @@ from .resolve import (
     resolve_artifact_id,
     resolve_notebook_id,
 )
-
-
-@contextlib.asynccontextmanager
-async def _status_with_elapsed(
-    message: str,
-    *,
-    json_output: bool = False,
-    resume_hint: str | None = None,
-) -> AsyncIterator[None]:
-    """Show a Rich spinner with a periodically updated elapsed timer.
-
-    Used by ``artifact wait`` so interactive callers see live feedback during
-    the blocking poll. No-op (for the spinner) when
-    ``json_output`` is True so stdout stays pure JSON for automation. The
-    spinner is transient — it disappears on exit, leaving only the final
-    completion / failure line.
-
-    The ticker task updates the status text once per second while the wrapped
-    coroutine awaits the long-running call. Cancellation is best-effort: if
-    the wrapped block raises, the ticker is cancelled in ``finally`` and the
-    exception propagates unchanged.
-
-    SIGINT handling: when ``resume_hint`` is provided, a
-    ``KeyboardInterrupt`` raised inside the wrapped block is caught and
-    converted into a friendly cancellation message via
-    :func:`emit_cancelled_and_exit`, which prints
-    ``Cancelled. Resume with: <resume_hint>`` to stderr (or a structured
-    ``CANCELLED`` envelope under ``--json``) and exits 130.
-    """
-
-    @contextlib.contextmanager
-    def _sigint_guard():
-        try:
-            yield
-        except KeyboardInterrupt:
-            if resume_hint is None:
-                raise
-            emit_cancelled_and_exit(resume_hint, json_output=json_output)
-
-    if json_output:
-        with _sigint_guard():
-            yield
-        return
-    start = time.monotonic()
-    with console.status(message) as status:
-
-        async def _ticker() -> None:
-            while True:
-                await asyncio.sleep(1.0)
-                elapsed = int(time.monotonic() - start)
-                status.update(f"{message} [{elapsed}s elapsed]")
-
-        ticker_task = asyncio.create_task(_ticker())
-        try:
-            with _sigint_guard():
-                yield
-        finally:
-            ticker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await ticker_task
+from .services.polling import status_with_elapsed
 
 
 @click.group()
@@ -535,7 +472,7 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                 # of a Python KeyboardInterrupt traceback. Same hint shape as
                 # ``generate <kind> --wait`` because both polling loops resume
                 # via ``artifact poll``.
-                async with _status_with_elapsed(
+                async with status_with_elapsed(
                     f"Waiting for artifact {resolved_id} to complete...",
                     json_output=json_output,
                     resume_hint=f"notebooklm artifact poll {resolved_id}",

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -5,7 +5,7 @@ Commands:
     wait        Wait for research to complete (blocking)
 """
 
-import asyncio
+from typing import Any
 
 import click
 
@@ -23,6 +23,7 @@ from .resolve import (
     require_notebook,
     resolve_notebook_id,
 )
+from .services.polling import poll_until, status_with_elapsed
 
 # UI-only cap for the research summary preview shown in `research status` /
 # `research wait`. Unlike RPC error previews (see
@@ -151,12 +152,10 @@ def research_wait(
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            max_iterations = max(1, timeout // interval)
-            status = None
-            task_id = None
+            task_id: str | None = None
 
-            async def _poll_loop() -> bool:
-                """Poll until completion or terminal state; returns True on success.
+            async def _fetch_status() -> dict[str, Any]:
+                """Fetch the next research status and pin a discovered task id.
 
                 Once the first poll identifies a task_id, subsequent polls pin
                 to that specific task via the ``task_id`` discriminator. This
@@ -165,32 +164,39 @@ def research_wait(
                 or a retry) could substitute its results into ``status`` /
                 ``sources`` and mis-attribute provenance on import.
                 """
-                nonlocal status, task_id
-                for _ in range(max_iterations):
-                    status = await client.research.poll(nb_id_resolved, task_id=task_id)
-                    status_val = status.get("status", "unknown")
+                nonlocal task_id
+                current_status = await client.research.poll(nb_id_resolved, task_id=task_id)
+                status_val = current_status.get("status", "unknown")
 
-                    if status_val == "completed":
-                        task_id = status.get("task_id")
-                        return True
-                    elif status_val == "no_research":
-                        if json_output:
-                            json_output_response(
-                                {"status": "no_research", "error": "No research running"}
-                            )
-                        else:
-                            console.print("[red]No research running[/red]")
-                        raise SystemExit(1)
+                if status_val == "no_research":
+                    if json_output:
+                        json_output_response(
+                            {"status": "no_research", "error": "No research running"}
+                        )
+                    else:
+                        console.print("[red]No research running[/red]")
+                    raise SystemExit(1)
 
-                    # Pin to the discovered task_id on subsequent iterations.
-                    # The first in-progress poll is unambiguous if only one
-                    # task is in flight; on the next iteration we have a
-                    # concrete discriminator from the wire.
-                    if task_id is None:
-                        task_id = status.get("task_id")
+                if task_id is None:
+                    task_id = current_status.get("task_id")
 
-                    await asyncio.sleep(interval)
+                return current_status
 
+            def _is_complete(current_status: dict[str, Any]) -> bool:
+                return current_status.get("status", "unknown") == "completed"
+
+            async with status_with_elapsed(
+                "Waiting for research to complete...",
+                json_output=json_output,
+            ):
+                poll_result = await poll_until(
+                    _fetch_status,
+                    _is_complete,
+                    timeout=float(timeout),
+                    interval=float(interval),
+                )
+
+            if poll_result.timed_out:
                 if json_output:
                     json_output_response(
                         {"status": "timeout", "error": f"Timed out after {timeout}s"}
@@ -199,15 +205,9 @@ def research_wait(
                     console.print(f"[yellow]Timed out after {timeout} seconds[/yellow]")
                 raise SystemExit(1)
 
-            if json_output:
-                await _poll_loop()
-            else:
-                with console.status("Waiting for research to complete..."):
-                    await _poll_loop()
-
-            # Research completed — _poll_loop either populated `status` or
-            # raised SystemExit, so a non-None status is guaranteed here.
-            assert status is not None
+            # Research completed — poll_until returned the terminal status,
+            # or raised SystemExit above for no-research / timeout cases.
+            status = poll_result.value
             sources = status.get("sources", [])
             query = status.get("query", "")
 

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -1,15 +1,14 @@
 """CLI-internal services for artifact generation commands."""
 
 import asyncio
-import contextlib
-import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from ...client import NotebookLMClient
 from ...types import GenerationStatus
-from ..error_handler import emit_cancelled_and_exit, output_error
+from ..error_handler import output_error
 from ..rendering import console, json_output_response
+from .polling import status_with_elapsed
 
 # Retry constants
 RETRY_INITIAL_DELAY = 60.0  # seconds
@@ -50,64 +49,7 @@ def _format_status_message(artifact_type: str, elapsed: float | None = None) -> 
     return f"{base} [{int(elapsed)}s elapsed]"
 
 
-@contextlib.asynccontextmanager
-async def _status_with_elapsed(
-    artifact_type: str,
-    *,
-    json_output: bool = False,
-    resume_hint: str | None = None,
-) -> AsyncIterator[None]:
-    """Show a Rich spinner with a periodically updated elapsed timer.
-
-    No-op (for the spinner) when ``json_output`` is True so stdout stays pure
-    JSON for automation. The spinner is transient — it disappears on exit, so
-    the final ``[green]... ready[/green]`` line is the only persistent output.
-
-    The ticker task updates the status text once per second while the wrapped
-    coroutine awaits the long-running call. Cancellation is best-effort: if
-    the wrapped block raises, the ticker is cancelled in ``finally`` and the
-    exception propagates unchanged.
-
-    SIGINT handling: when ``resume_hint`` is provided, a
-    ``KeyboardInterrupt`` raised inside the wrapped block is caught and
-    converted into a friendly cancellation message via
-    :func:`emit_cancelled_and_exit`, which prints
-    ``Cancelled. Resume with: <resume_hint>`` to stderr (or a structured
-    ``CANCELLED`` envelope under ``--json``) and exits 130. When
-    ``resume_hint`` is ``None`` the interrupt propagates so the generic
-    handler in ``error_handler.handle_errors`` keeps owning non-wait paths.
-    """
-
-    @contextlib.contextmanager
-    def _sigint_guard() -> Any:
-        try:
-            yield
-        except KeyboardInterrupt:
-            if resume_hint is None:
-                raise
-            emit_cancelled_and_exit(resume_hint, json_output=json_output)
-
-    if json_output:
-        with _sigint_guard():
-            yield
-        return
-    start = time.monotonic()
-    initial = _format_status_message(artifact_type)
-    with console.status(initial) as status:
-
-        async def _ticker() -> None:
-            while True:
-                await asyncio.sleep(1.0)
-                status.update(_format_status_message(artifact_type, time.monotonic() - start))
-
-        ticker_task = asyncio.create_task(_ticker())
-        try:
-            with _sigint_guard():
-                yield
-        finally:
-            ticker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await ticker_task
+_status_with_elapsed = status_with_elapsed
 
 
 def calculate_backoff_delay(
@@ -255,8 +197,8 @@ async def handle_generation_result(
         # so Ctrl-C during the wait surfaces the resume command instead of
         # a Python KeyboardInterrupt traceback. See ``cli/error_handler.py``
         # ``emit_cancelled_and_exit``.
-        async with _status_with_elapsed(
-            artifact_type,
+        async with status_with_elapsed(
+            _format_status_message(artifact_type),
             json_output=json_output,
             resume_hint=f"notebooklm artifact poll {task_id}",
         ):

--- a/src/notebooklm/cli/services/polling.py
+++ b/src/notebooklm/cli/services/polling.py
@@ -1,0 +1,122 @@
+"""Shared polling helpers for CLI wait commands."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from ..error_handler import emit_cancelled_and_exit
+from ..rendering import console
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class PollResult(Generic[T]):
+    """Result returned by :func:`poll_until`.
+
+    Attributes:
+        value: Last fetched value. This is the completed value on success and
+            the most recent non-terminal value on timeout.
+        attempts: Number of times ``fetch`` was awaited.
+        elapsed: Seconds elapsed according to ``time.monotonic``.
+        timed_out: Whether the timeout was reached before ``is_done`` returned
+            true.
+    """
+
+    value: T
+    attempts: int
+    elapsed: float
+    timed_out: bool
+
+
+@contextlib.asynccontextmanager
+async def status_with_elapsed(
+    message: str,
+    *,
+    json_output: bool = False,
+    resume_hint: str | None = None,
+) -> AsyncIterator[None]:
+    """Show a transient Rich status spinner with an elapsed-seconds counter.
+
+    The context manager is a no-op in JSON mode so stdout remains parseable.
+    In text mode it updates the spinner once per second and cancels that
+    ticker when the wrapped block exits. If ``resume_hint`` is provided,
+    ``KeyboardInterrupt`` is converted to the CLI's structured/friendly
+    cancellation response; otherwise the interrupt propagates unchanged.
+    """
+
+    @contextlib.contextmanager
+    def _sigint_guard() -> Iterator[None]:
+        try:
+            yield
+        except KeyboardInterrupt:
+            if resume_hint is None:
+                raise
+            emit_cancelled_and_exit(resume_hint, json_output=json_output)
+
+    if json_output:
+        with _sigint_guard():
+            yield
+        return
+
+    start = time.monotonic()
+    with console.status(message) as status:
+
+        async def _ticker() -> None:
+            while True:
+                await asyncio.sleep(1.0)
+                elapsed = int(time.monotonic() - start)
+                status.update(f"{message} [{elapsed}s elapsed]")
+
+        ticker_task = asyncio.create_task(_ticker())
+        try:
+            with _sigint_guard():
+                yield
+        finally:
+            ticker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker_task
+
+
+async def poll_until(
+    fetch: Callable[[], Awaitable[T]],
+    is_done: Callable[[T], bool],
+    *,
+    timeout: float,
+    interval: float,
+) -> PollResult[T]:
+    """Poll ``fetch`` until ``is_done`` returns true or ``timeout`` elapses.
+
+    ``fetch`` is called immediately, then after each ``interval`` while the
+    value remains non-terminal. Timeout is reported as a ``PollResult`` with
+    ``timed_out=True`` and the last fetched value. ``asyncio.CancelledError``
+    and other exceptions from ``fetch`` or ``is_done`` are not swallowed, so
+    caller-level cancellation and domain errors keep their normal semantics.
+    """
+    if timeout < 0:
+        raise ValueError("timeout must be non-negative")
+    if interval <= 0:
+        raise ValueError("interval must be positive")
+
+    start = time.monotonic()
+    attempts = 0
+
+    while True:
+        value = await fetch()
+        attempts += 1
+        elapsed = time.monotonic() - start
+
+        if is_done(value):
+            return PollResult(value=value, attempts=attempts, elapsed=elapsed, timed_out=False)
+        if elapsed >= timeout:
+            return PollResult(value=value, attempts=attempts, elapsed=elapsed, timed_out=True)
+
+        await asyncio.sleep(min(interval, timeout - elapsed))
+
+
+__all__ = ["PollResult", "poll_until", "status_with_elapsed"]

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -21,8 +21,6 @@ import asyncio
 import contextlib
 import os
 import re
-import time
-from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Literal
 
@@ -32,7 +30,7 @@ from rich.table import Table
 from ..client import NotebookLMClient
 from ..types import Source, source_status_to_str
 from .auth_runtime import with_client
-from .error_handler import _output_error, emit_cancelled_and_exit
+from .error_handler import _output_error
 from .input import read_stdin_text, resolve_prompt
 from .options import (
     json_option,
@@ -56,66 +54,7 @@ from .resolve import require_notebook, resolve_notebook_id, resolve_source_id, v
 from .runtime import is_quiet
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
-
-
-@contextlib.asynccontextmanager
-async def _status_with_elapsed(
-    message: str,
-    *,
-    json_output: bool = False,
-    resume_hint: str | None = None,
-) -> AsyncIterator[None]:
-    """Show a Rich spinner with a periodically updated elapsed timer.
-
-    Used by ``source wait`` so interactive callers see live feedback during
-    the blocking poll. No-op (for the spinner) when
-    ``json_output`` is True so stdout stays pure JSON for automation. The
-    spinner is transient — it disappears on exit, leaving only the final
-    ready / failure / timeout line.
-
-    The ticker task updates the status text once per second while the wrapped
-    coroutine awaits the long-running call. Cancellation is best-effort: if
-    the wrapped block raises, the ticker is cancelled in ``finally`` and the
-    exception propagates unchanged.
-
-    SIGINT handling: when ``resume_hint`` is provided, a
-    ``KeyboardInterrupt`` raised inside the wrapped block is caught and
-    converted into a friendly cancellation message via
-    :func:`emit_cancelled_and_exit`. ``source wait`` uses the parallel
-    ``notebooklm source wait <source_id>`` hint (no separate ``poll`` command
-    exists for sources — re-running the same wait IS the resume).
-    """
-
-    @contextlib.contextmanager
-    def _sigint_guard():
-        try:
-            yield
-        except KeyboardInterrupt:
-            if resume_hint is None:
-                raise
-            emit_cancelled_and_exit(resume_hint, json_output=json_output)
-
-    if json_output:
-        with _sigint_guard():
-            yield
-        return
-    start = time.monotonic()
-    with console.status(message) as status:
-
-        async def _ticker() -> None:
-            while True:
-                await asyncio.sleep(1.0)
-                elapsed = int(time.monotonic() - start)
-                status.update(f"{message} [{elapsed}s elapsed]")
-
-        ticker_task = asyncio.create_task(_ticker())
-        try:
-            with _sigint_guard():
-                yield
-        finally:
-            ticker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await ticker_task
+from .services.polling import status_with_elapsed
 
 
 def _looks_like_path(content: str) -> bool:
@@ -1305,7 +1244,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                 # elapsed-seconds counter, then disappears so the final
                 # ready / failure / timeout line stands alone. No-op under
                 # --json so stdout stays pure JSON.
-                async with _status_with_elapsed(
+                async with status_with_elapsed(
                     f"Waiting for source {resolved_id} to finish processing...",
                     json_output=json_output,
                     # Parallel hint for ``source wait``: there is

--- a/tests/unit/test_polling_service.py
+++ b/tests/unit/test_polling_service.py
@@ -1,0 +1,79 @@
+"""Unit tests for shared CLI polling helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm.cli.services import polling
+from notebooklm.cli.services.polling import poll_until, status_with_elapsed
+
+
+@pytest.mark.asyncio
+async def test_poll_until_returns_timeout_result_with_last_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeouts return the last fetched value without hiding the timeout state."""
+    clock = 0.0
+    calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        nonlocal clock
+        clock += delay
+
+    async def fetch() -> dict[str, int | str]:
+        calls.append(clock)
+        return {"status": "pending", "attempt": len(calls)}
+
+    monkeypatch.setattr(polling.time, "monotonic", lambda: clock)
+    monkeypatch.setattr(polling.asyncio, "sleep", fake_sleep)
+
+    result = await poll_until(
+        fetch,
+        lambda value: value["status"] == "completed",
+        timeout=0.5,
+        interval=0.25,
+    )
+
+    assert result.timed_out is True
+    assert result.value == {"status": "pending", "attempt": 3}
+    assert result.attempts == 3
+    assert result.elapsed == 0.5
+    assert calls == [0.0, 0.25, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_poll_until_propagates_cancellation() -> None:
+    """Cancellation is not converted into a timeout result."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fetch() -> str:
+        started.set()
+        await release.wait()
+        return "pending"
+
+    task = asyncio.create_task(
+        poll_until(fetch, lambda value: value == "completed", timeout=60.0, interval=1.0)
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_status_with_elapsed_json_output_is_no_op() -> None:
+    """JSON mode must not start a Rich spinner that could pollute stdout."""
+    entered = False
+
+    with patch.object(polling.console, "status") as status:
+        async with status_with_elapsed("Waiting for work...", json_output=True):
+            entered = True
+
+    assert entered is True
+    status.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `cli/services/polling.py` with `status_with_elapsed`, `poll_until`, and typed `PollResult`.
- Replace duplicated wait spinners in source, artifact, artifact generation, and research wait.
- Move the research wait loop onto `poll_until` while preserving task-id pinning and existing output/exit behavior.
- Add unit coverage for timeout, cancellation propagation, and JSON-mode spinner no-op.
- Restore the exact Phase 10 CLI contract baseline JSON after `e1450c9 chore: untrack sisyphus artifacts` removed it while `tests/unit/cli/test_phase10_cli_contract.py` still reads that fixture.

## Verification
- `uv run pytest tests/unit/cli/test_phase10_cli_contract.py -q` (14 passed)
- `uv run pytest tests/unit/test_polling_service.py tests/unit/cli/test_artifact.py tests/unit/cli/test_source.py tests/unit/cli/test_research.py tests/unit/cli/test_generate.py -q` (348 passed)
- `uv run ruff check src/notebooklm/cli tests/unit/test_polling_service.py`
- `uv run mypy src/notebooklm/cli --ignore-missing-imports`
- Pre-rebase: `uv run pytest tests/unit tests/integration -q` (5684 passed, 49 skipped)
- Pre-fix post-rebase failure was the missing Phase 10 baseline fixture from upstream Sisyphus artifact untracking; fixed by restoring the exact tracked baseline file from `e1450c9^`.