### PR TITLE
refactor(cli): extract services/listing.py for shared list pipeline

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -11,8 +11,6 @@ Commands:
     suggestions Get AI-suggested report topics
 """
 
-from typing import Literal
-
 import click
 from rich.table import Table
 
@@ -33,6 +31,7 @@ from .resolve import (
     resolve_artifact_id,
     resolve_notebook_id,
 )
+from .services.listing import ListSpec, run_list
 from .services.polling import status_with_elapsed
 
 
@@ -98,53 +97,49 @@ def artifact_list(ctx, notebook_id, artifact_type, json_output, limit, no_trunca
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            # artifacts.list() already includes mind maps from notes system
-            artifacts = await client.artifacts.list(nb_id_resolved, artifact_type=type_filter)
-            # Client-side offset slicing.
-            if limit is not None and limit >= 0:
-                artifacts = artifacts[:limit]
 
-            if json_output:
-                nb = await client.notebooks.get(nb_id_resolved)
-                data = {
-                    "notebook_id": nb_id_resolved,
-                    "notebook_title": nb.title if nb else None,
-                    "artifacts": [
-                        {
-                            "index": i,
-                            "id": art.id,
-                            "title": art.title,
-                            "type": get_artifact_type_display(art).split(" ", 1)[-1],
-                            "type_id": art.kind.value,
-                            "status": art.status_str,
-                            "status_id": art.status,
-                            "created_at": art.created_at.isoformat() if art.created_at else None,
-                        }
-                        for i, art in enumerate(artifacts, 1)
-                    ],
-                    "count": len(artifacts),
-                }
-                json_output_response(data)
-                return
+            async def envelope_extras(
+                client: NotebookLMClient, notebook_id: str
+            ) -> dict[str, str | None]:
+                nb = await client.notebooks.get(notebook_id)
+                return {"notebook_id": notebook_id, "notebook_title": nb.title if nb else None}
 
-            if not artifacts:
-                console.print(f"[yellow]No {artifact_type} artifacts found[/yellow]")
-                return
-
-            table = Table(title=f"Artifacts in {nb_id_resolved}")
-            table.add_column("ID", style="cyan")
-            title_overflow: Literal["fold", "ellipsis"] = "fold" if no_truncate else "ellipsis"
-            table.add_column("Title", style="green", overflow=title_overflow)
-            table.add_column("Type")
-            table.add_column("Created", style="dim")
-            table.add_column("Status", style="yellow")
-
-            for art in artifacts:
-                type_display = get_artifact_type_display(art)
-                created = art.created_at.strftime("%Y-%m-%d %H:%M") if art.created_at else "-"
-                table.add_row(art.id, art.title, type_display, created, art.status_str)
-
-            console.print(table)
+            spec = ListSpec(
+                title="Artifacts in {notebook_id}",
+                items_key="artifacts",
+                # artifacts.list() already includes mind maps from notes system
+                fetch=lambda client, notebook_id: client.artifacts.list(
+                    notebook_id,
+                    artifact_type=type_filter,
+                ),
+                serialize=lambda art: {
+                    "id": art.id,
+                    "title": art.title,
+                    "type": get_artifact_type_display(art).split(" ", 1)[-1],
+                    "type_id": art.kind.value,
+                    "status": art.status_str,
+                    "status_id": art.status,
+                    "created_at": art.created_at.isoformat() if art.created_at else None,
+                },
+                columns=["ID", "Title", "Type", "Created", "Status"],
+                row=lambda art: [
+                    art.id,
+                    art.title,
+                    get_artifact_type_display(art),
+                    art.created_at.strftime("%Y-%m-%d %H:%M") if art.created_at else "-",
+                    art.status_str,
+                ],
+                envelope_extras=envelope_extras,
+                empty_message=f"[yellow]No {artifact_type} artifacts found[/yellow]",
+            )
+            await run_list(
+                spec,
+                client,
+                notebook_id=nb_id_resolved,
+                limit=limit,
+                json_output=json_output,
+                no_truncate=no_truncate,
+            )
 
     return _run()
 

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -13,7 +13,6 @@ from dataclasses import asdict
 from typing import Any
 
 import click
-from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import Note
@@ -23,6 +22,7 @@ from .input import read_stdin_text
 from .options import json_option, notebook_option
 from .rendering import cli_print, console, json_output_response
 from .resolve import require_notebook, resolve_note_id, resolve_notebook_id
+from .services.listing import ListSpec, run_list
 
 
 @click.group()
@@ -57,46 +57,51 @@ def note_list(ctx, notebook_id, json_output, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            notes = await client.notes.list(nb_id_resolved)
 
-            if json_output:
-                serialized = [
-                    {
-                        "id": n.id,
-                        "title": n.title or "Untitled",
-                        "preview": (n.content or "")[:100],
-                    }
-                    for n in notes
-                    if isinstance(n, Note)
-                ]
-                json_output_response(
-                    {
-                        "notebook_id": nb_id_resolved,
-                        "notes": serialized,
-                        "count": len(serialized),
-                    }
-                )
-                return
+            async def fetch_notes(client: NotebookLMClient, notebook_id: str) -> list[Note]:
+                notes = await client.notes.list(notebook_id)
+                return [note for note in notes if isinstance(note, Note)]
 
-            if not notes:
-                console.print("[yellow]No notes found[/yellow]")
-                return
+            async def envelope_extras(
+                _client: NotebookLMClient, notebook_id: str
+            ) -> dict[str, str]:
+                return {"notebook_id": notebook_id}
 
-            table = Table(title=f"Notes in {nb_id_resolved}")
-            table.add_column("ID", style="cyan", no_wrap=True)
-            table.add_column("Title", style="green")
-            table.add_column("Preview", style="dim", max_width=50)
-
-            for n in notes:
-                if isinstance(n, Note):
-                    preview = n.content[:50] if n.content else ""
-                    table.add_row(
-                        n.id,
-                        n.title or "Untitled",
-                        preview + "..." if len(n.content or "") > 50 else preview,
-                    )
-
-            console.print(table)
+            spec = ListSpec(
+                title="Notes in {notebook_id}",
+                items_key="notes",
+                fetch=fetch_notes,
+                serialize=lambda n: {
+                    "id": n.id,
+                    "title": n.title or "Untitled",
+                    "preview": (n.content or "")[:100],
+                },
+                columns=["ID", "Title", "Preview"],
+                column_options={
+                    "ID": {"style": "cyan", "no_wrap": True},
+                    "Title": {"style": "green"},
+                    "Preview": {"style": "dim", "max_width": 50},
+                },
+                row=lambda n: [
+                    n.id,
+                    n.title or "Untitled",
+                    (
+                        f"{n.content[:50]}..."
+                        if len(n.content or "") > 50
+                        else (n.content[:50] if n.content else "")
+                    ),
+                ],
+                envelope_extras=envelope_extras,
+                include_index=False,
+                empty_message="[yellow]No notes found[/yellow]",
+            )
+            await run_list(
+                spec,
+                client,
+                notebook_id=nb_id_resolved,
+                limit=None,
+                json_output=json_output,
+            )
 
     return _run()
 

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -11,10 +11,7 @@ Commands:
 Note: Sharing commands moved to 'share' command group.
 """
 
-from typing import Literal
-
 import click
-from rich.table import Table
 
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
@@ -22,6 +19,7 @@ from .context import clear_context, get_current_notebook, set_current_notebook
 from .options import list_options, notebook_option
 from .rendering import cli_print, console, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
+from .services.listing import ListSpec, run_list
 
 
 def register_notebook_commands(cli):
@@ -42,49 +40,32 @@ def register_notebook_commands(cli):
 
         async def _run():
             async with NotebookLMClient(client_auth) as client:
-                notebooks = await client.notebooks.list()
-
-                # Client-side offset slicing. No server-side
-                # cursors in scope for this phase — `client.notebooks.list()`
-                # always returns the full result set, we just trim before
-                # rendering / counting.
-                if limit is not None and limit >= 0:
-                    notebooks = notebooks[:limit]
-
-                if json_output:
-                    data = {
-                        "notebooks": [
-                            {
-                                "index": i,
-                                "id": nb.id,
-                                "title": nb.title,
-                                "is_owner": nb.is_owner,
-                                "created_at": nb.created_at.isoformat() if nb.created_at else None,
-                            }
-                            for i, nb in enumerate(notebooks, 1)
-                        ],
-                        "count": len(notebooks),
-                    }
-                    json_output_response(data)
-                    return
-
-                table = Table(title="Notebooks")
-                table.add_column("ID", style="cyan")
-                # Keep the legacy unconstrained Title rendering
-                # by default and rely on the explicit --no-truncate to also
-                # disable Rich's auto-ellipsis at narrow terminals via
-                # overflow="fold".
-                title_overflow: Literal["fold", "ellipsis"] = "fold" if no_truncate else "ellipsis"
-                table.add_column("Title", style="green", overflow=title_overflow)
-                table.add_column("Owner")
-                table.add_column("Created", style="dim")
-
-                for nb in notebooks:
-                    created = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else "-"
-                    owner_status = "Owner" if nb.is_owner else "Shared"
-                    table.add_row(nb.id, nb.title, owner_status, created)
-
-                console.print(table)
+                spec = ListSpec(
+                    title="Notebooks",
+                    items_key="notebooks",
+                    fetch=lambda client, _: client.notebooks.list(),
+                    serialize=lambda nb: {
+                        "id": nb.id,
+                        "title": nb.title,
+                        "is_owner": nb.is_owner,
+                        "created_at": nb.created_at.isoformat() if nb.created_at else None,
+                    },
+                    columns=["ID", "Title", "Owner", "Created"],
+                    row=lambda nb: [
+                        nb.id,
+                        nb.title,
+                        "Owner" if nb.is_owner else "Shared",
+                        nb.created_at.strftime("%Y-%m-%d") if nb.created_at else "-",
+                    ],
+                )
+                await run_list(
+                    spec,
+                    client,
+                    notebook_id="",
+                    limit=limit,
+                    json_output=json_output,
+                    no_truncate=no_truncate,
+                )
 
         return _run()
 

--- a/src/notebooklm/cli/services/listing.py
+++ b/src/notebooklm/cli/services/listing.py
@@ -1,0 +1,123 @@
+"""Shared list-command pipeline for CLI resources.
+
+``ListSpec.envelope_extras`` is the per-command hook for JSON envelope fields
+that do not belong to the entity array itself. For example, source and artifact
+lists return extras like ``{"notebook_id": "...", "notebook_title": "..."}``.
+``run_list`` merges the returned dict at the top level WITHOUT validation,
+before adding the entity list and ``count`` keys. Future list commands should
+treat this docstring as the canonical contract for command-specific envelope
+fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, Literal, TypeVar
+
+from rich.table import Table
+
+from ...client import NotebookLMClient
+from ..rendering import console, json_output_response
+
+T = TypeVar("T")
+
+EnvelopeExtras = Callable[[NotebookLMClient, str], Awaitable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class ListSpec(Generic[T]):
+    """Command-specific configuration for :func:`run_list`."""
+
+    title: str
+    items_key: str
+    fetch: Callable[[NotebookLMClient, str], Awaitable[list[T]]]
+    serialize: Callable[[T], dict[str, Any]]
+    columns: list[str]
+    row: Callable[[T], list[str]]
+    envelope_extras: EnvelopeExtras | None = None
+    column_options: dict[str, dict[str, Any]] | None = None
+    include_index: bool = True
+    empty_message: str | None = None
+
+
+@dataclass(frozen=True)
+class ListResult(Generic[T]):
+    """Rendered list result returned for focused tests and future composition."""
+
+    items: list[T]
+    envelope: dict[str, Any] | None = None
+
+
+def _table_title(title: str, notebook_id: str) -> str:
+    """Format a table title with the resolved notebook id."""
+    return title.format(notebook_id=notebook_id)
+
+
+def _column_options(header: str, *, no_truncate: bool) -> dict[str, Any]:
+    """Return the default Rich column options for common list-table headers."""
+    title_overflow: Literal["fold", "ellipsis"] = "fold" if no_truncate else "ellipsis"
+    if header == "ID":
+        return {"style": "cyan"}
+    if header == "Title":
+        return {"style": "green", "overflow": title_overflow}
+    if header == "Created":
+        return {"style": "dim"}
+    if header == "Status":
+        return {"style": "yellow"}
+    if header == "Preview":
+        return {"style": "dim", "max_width": 50}
+    return {}
+
+
+def _serialize_items(spec: ListSpec[T], items: list[T]) -> list[dict[str, Any]]:
+    """Serialize fetched items and inject 1-based indexes when configured."""
+    serialized: list[dict[str, Any]] = []
+    for index, item in enumerate(items, 1):
+        payload = spec.serialize(item)
+        if spec.include_index:
+            payload = {"index": index, **payload}
+        serialized.append(payload)
+    return serialized
+
+
+async def run_list(
+    spec: ListSpec[T],
+    client: NotebookLMClient,
+    *,
+    notebook_id: str,
+    limit: int | None,
+    json_output: bool,
+    no_truncate: bool = False,
+) -> ListResult[T]:
+    """Fetch and render a list command in text or JSON mode."""
+    items = await spec.fetch(client, notebook_id)
+    if limit is not None and limit >= 0:
+        items = items[:limit]
+
+    if json_output:
+        extras: dict[str, Any] = {}
+        if spec.envelope_extras is not None:
+            extras = await spec.envelope_extras(client, notebook_id)
+        serialized = _serialize_items(spec, items)
+        envelope = {**extras, spec.items_key: serialized, "count": len(serialized)}
+        json_output_response(envelope)
+        return ListResult(items=items, envelope=envelope)
+
+    if not items and spec.empty_message is not None:
+        console.print(spec.empty_message)
+        return ListResult(items=items)
+
+    table = Table(title=_table_title(spec.title, notebook_id))
+    for header in spec.columns:
+        options = _column_options(header, no_truncate=no_truncate)
+        if spec.column_options and header in spec.column_options:
+            options.update(spec.column_options[header])
+        table.add_column(header, **options)
+    for item in items:
+        table.add_row(*spec.row(item))
+    console.print(table)
+    return ListResult(items=items)
+
+
+__all__ = ["ListResult", "ListSpec", "run_list"]

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -22,7 +22,7 @@ import contextlib
 import os
 import re
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import click
 from rich.table import Table
@@ -54,6 +54,7 @@ from .resolve import require_notebook, resolve_notebook_id, resolve_source_id, v
 from .runtime import is_quiet
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
+from .services.listing import ListSpec, run_list
 from .services.polling import status_with_elapsed
 
 
@@ -257,51 +258,44 @@ def source_list(ctx, notebook_id, json_output, limit, no_truncate, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await client.sources.list(nb_id_resolved)
-            # Client-side offset slicing.
-            if limit is not None and limit >= 0:
-                sources = sources[:limit]
-            nb = None
-            if json_output:
-                nb = await client.notebooks.get(nb_id_resolved)
 
-            if json_output:
-                data = {
-                    "notebook_id": nb_id_resolved,
-                    "notebook_title": nb.title if nb else None,
-                    "sources": [
-                        {
-                            "index": i,
-                            "id": src.id,
-                            "title": src.title,
-                            "type": str(src.kind),
-                            "url": src.url,
-                            "status": source_status_to_str(src.status),
-                            "status_id": src.status,
-                            "created_at": src.created_at.isoformat() if src.created_at else None,
-                        }
-                        for i, src in enumerate(sources, 1)
-                    ],
-                    "count": len(sources),
-                }
-                json_output_response(data)
-                return
+            async def envelope_extras(
+                client: NotebookLMClient, notebook_id: str
+            ) -> dict[str, str | None]:
+                nb = await client.notebooks.get(notebook_id)
+                return {"notebook_id": notebook_id, "notebook_title": nb.title if nb else None}
 
-            table = Table(title=f"Sources in {nb_id_resolved}")
-            table.add_column("ID", style="cyan")
-            title_overflow: Literal["fold", "ellipsis"] = "fold" if no_truncate else "ellipsis"
-            table.add_column("Title", style="green", overflow=title_overflow)
-            table.add_column("Type")
-            table.add_column("Created", style="dim")
-            table.add_column("Status", style="yellow")
-
-            for src in sources:
-                type_display = get_source_type_display(src.kind)
-                created = src.created_at.strftime("%Y-%m-%d %H:%M") if src.created_at else "-"
-                status = source_status_to_str(src.status)
-                table.add_row(src.id, src.title or "-", type_display, created, status)
-
-            console.print(table)
+            spec = ListSpec(
+                title="Sources in {notebook_id}",
+                items_key="sources",
+                fetch=lambda client, notebook_id: client.sources.list(notebook_id),
+                serialize=lambda src: {
+                    "id": src.id,
+                    "title": src.title,
+                    "type": str(src.kind),
+                    "url": src.url,
+                    "status": source_status_to_str(src.status),
+                    "status_id": src.status,
+                    "created_at": src.created_at.isoformat() if src.created_at else None,
+                },
+                columns=["ID", "Title", "Type", "Created", "Status"],
+                row=lambda src: [
+                    src.id,
+                    src.title or "-",
+                    get_source_type_display(src.kind),
+                    src.created_at.strftime("%Y-%m-%d %H:%M") if src.created_at else "-",
+                    source_status_to_str(src.status),
+                ],
+                envelope_extras=envelope_extras,
+            )
+            await run_list(
+                spec,
+                client,
+                notebook_id=nb_id_resolved,
+                limit=limit,
+                json_output=json_output,
+                no_truncate=no_truncate,
+            )
 
     return _run()
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -64,7 +64,9 @@ class TestArtifactList:
                 result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
-            assert "Quiz One" in result.output or "art_1" in result.output
+            assert "Artifacts in nb_123" in result.output
+            assert "art_1" in result.output
+            assert "Quiz One" in result.output
 
     def test_artifact_list_includes_mind_maps(self, runner, mock_auth):
         """Test that artifacts.list() includes mind maps (they come from the API now)."""
@@ -107,8 +109,21 @@ class TestArtifactList:
 
             assert result.exit_code == 0
             data = json.loads(result.output)
+            assert list(data) == ["notebook_id", "notebook_title", "artifacts", "count"]
+            assert data["notebook_id"] == "nb_123"
+            assert data["notebook_title"] == "Test Notebook"
             assert "artifacts" in data
             assert data["count"] == 1
+            assert list(data["artifacts"][0]) == [
+                "index",
+                "id",
+                "title",
+                "type",
+                "type_id",
+                "status",
+                "status_id",
+                "created_at",
+            ]
 
     @pytest.mark.filterwarnings("ignore::notebooklm.types.UnknownTypeWarning")
     def test_artifact_list_limit_caps_rows(self, runner, mock_auth):

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -69,6 +69,10 @@ class TestNoteList:
                 result = runner.invoke(cli, ["note", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
+            assert "Notes in nb_123" in result.output
+            assert "note_1" in result.output
+            assert "Note Title" in result.output
+            assert "Content 1" in result.output
 
     def test_note_list_empty(self, runner, mock_auth):
         """Shows 'No notes found' when the notebook has no notes."""
@@ -106,9 +110,11 @@ class TestNoteList:
 
             assert result.exit_code == 0
             data = json.loads(result.output)
+            assert list(data) == ["notebook_id", "notes", "count"]
             assert data["notebook_id"] == "nb_123"
             assert len(data["notes"]) == 2
             assert data["count"] == 2
+            assert list(data["notes"][0]) == ["id", "title", "preview"]
             assert data["notes"][0]["id"] == "note_1"
 
     def test_note_list_json_empty(self, runner, mock_auth):

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -83,6 +83,8 @@ class TestNotebookList:
                 result = runner.invoke(cli, ["list"])
 
             assert result.exit_code == 0
+            assert "Notebooks" in result.output
+            assert "nb_1" in result.output
             assert "First Notebook" in result.output
             assert "Second Notebook" in result.output
 
@@ -109,8 +111,16 @@ class TestNotebookList:
 
             assert result.exit_code == 0
             data = json.loads(result.output)
+            assert list(data) == ["notebooks", "count"]
             assert "notebooks" in data
             assert data["count"] == 1
+            assert list(data["notebooks"][0]) == [
+                "index",
+                "id",
+                "title",
+                "is_owner",
+                "created_at",
+            ]
             assert data["notebooks"][0]["id"] == "nb_1"
 
     def test_notebook_list_limit_caps_rows(self, runner, mock_auth):

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -66,7 +66,9 @@ class TestSourceList:
                 result = runner.invoke(cli, ["source", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
-            assert "Source One" in result.output or "src_1" in result.output
+            assert "Sources in nb_123" in result.output
+            assert "src_1" in result.output
+            assert "Source One" in result.output
 
     def test_source_list_json_output(self, runner, mock_auth):
         with patch_client_for_module("source") as mock_client_cls:
@@ -91,8 +93,21 @@ class TestSourceList:
 
             assert result.exit_code == 0
             data = json.loads(result.output)
+            assert list(data) == ["notebook_id", "notebook_title", "sources", "count"]
+            assert data["notebook_id"] == "nb_123"
+            assert data["notebook_title"] == "Test Notebook"
             assert "sources" in data
             assert data["count"] == 1
+            assert list(data["sources"][0]) == [
+                "index",
+                "id",
+                "title",
+                "type",
+                "url",
+                "status",
+                "status_id",
+                "created_at",
+            ]
             assert data["sources"][0]["id"] == "src_1"
 
     def test_source_list_limit_caps_rows(self, runner, mock_auth):

--- a/tests/unit/test_listing_service.py
+++ b/tests/unit/test_listing_service.py
@@ -1,0 +1,139 @@
+"""Unit tests for the shared CLI list-command service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from notebooklm.cli.services import listing
+
+
+@dataclass
+class Thing:
+    id: str
+    title: str
+
+
+class RecordingConsole:
+    def __init__(self) -> None:
+        self.printed: list[Any] = []
+
+    def print(self, value: Any) -> None:
+        self.printed.append(value)
+
+
+@pytest.mark.asyncio
+async def test_run_list_json_merges_envelope_extras_before_items_and_count(capsys):
+    async def fetch(client: object, notebook_id: str) -> list[Thing]:
+        assert client is fake_client
+        assert notebook_id == "nb_123"
+        return [Thing("thing_1", "Thing One"), Thing("thing_2", "Thing Two")]
+
+    async def envelope_extras(client: object, notebook_id: str) -> dict[str, str]:
+        assert client is fake_client
+        assert notebook_id == "nb_123"
+        return {"notebook_id": notebook_id, "notebook_title": "Notebook"}
+
+    fake_client = object()
+    spec = listing.ListSpec[Thing](
+        title="Things in {notebook_id}",
+        items_key="things",
+        fetch=fetch,
+        serialize=lambda thing: {"id": thing.id, "title": thing.title},
+        columns=["ID", "Title"],
+        row=lambda thing: [thing.id, thing.title],
+        envelope_extras=envelope_extras,
+    )
+
+    result = await listing.run_list(
+        spec,
+        fake_client,
+        notebook_id="nb_123",
+        limit=1,
+        json_output=True,
+    )
+
+    data = json.loads(capsys.readouterr().out)
+    assert list(data) == ["notebook_id", "notebook_title", "things", "count"]
+    assert data == {
+        "notebook_id": "nb_123",
+        "notebook_title": "Notebook",
+        "things": [{"index": 1, "id": "thing_1", "title": "Thing One"}],
+        "count": 1,
+    }
+    assert result.items == [Thing("thing_1", "Thing One")]
+    assert result.envelope == data
+
+
+@pytest.mark.asyncio
+async def test_run_list_text_renders_table_without_envelope_extras(monkeypatch):
+    extras_called = False
+
+    async def fetch(client: object, notebook_id: str) -> list[Thing]:
+        return [Thing("thing_1", f"Thing in {notebook_id}")]
+
+    async def envelope_extras(client: object, notebook_id: str) -> dict[str, str]:
+        nonlocal extras_called
+        extras_called = True
+        return {"notebook_id": notebook_id}
+
+    console = RecordingConsole()
+    monkeypatch.setattr(listing, "console", console)
+    spec = listing.ListSpec[Thing](
+        title="Things in {notebook_id}",
+        items_key="things",
+        fetch=fetch,
+        serialize=lambda thing: {"id": thing.id, "title": thing.title},
+        columns=["ID", "Title"],
+        row=lambda thing: [thing.id, thing.title],
+        envelope_extras=envelope_extras,
+    )
+
+    result = await listing.run_list(
+        spec,
+        object(),
+        notebook_id="nb_123",
+        limit=None,
+        json_output=False,
+        no_truncate=True,
+    )
+
+    assert not extras_called
+    assert result.envelope is None
+    assert result.items == [Thing("thing_1", "Thing in nb_123")]
+    assert len(console.printed) == 1
+    table = console.printed[0]
+    assert table.title == "Things in nb_123"
+    assert [column.header for column in table.columns] == ["ID", "Title"]
+
+
+@pytest.mark.asyncio
+async def test_run_list_text_uses_empty_message_instead_of_empty_table(monkeypatch):
+    async def fetch(client: object, notebook_id: str) -> list[Thing]:
+        return []
+
+    console = RecordingConsole()
+    monkeypatch.setattr(listing, "console", console)
+    spec = listing.ListSpec[Thing](
+        title="Things in {notebook_id}",
+        items_key="things",
+        fetch=fetch,
+        serialize=lambda thing: {"id": thing.id, "title": thing.title},
+        columns=["ID", "Title"],
+        row=lambda thing: [thing.id, thing.title],
+        empty_message="[yellow]No things found[/yellow]",
+    )
+
+    result = await listing.run_list(
+        spec,
+        object(),
+        notebook_id="nb_123",
+        limit=None,
+        json_output=False,
+    )
+
+    assert result.items == []
+    assert console.printed == ["[yellow]No things found[/yellow]"]


### PR DESCRIPTION
## Summary
- Stacked on `cli-audit-fixes/p2t2-polling-extraction` for P2.T3.
- Add `src/notebooklm/cli/services/listing.py` with `ListSpec`, `ListResult`, and `run_list` for shared list fetch/render/JSON envelope handling.
- Move notebook/source/artifact/note list commands onto the shared pipeline while preserving JSON envelope key order and text output characterization.

## Stacked PR
Base branch: `cli-audit-fixes/p2t2-polling-extraction`

Do not merge until the P2.T2 base is merged or this PR is cleanly retargeted.

## Verification
- `uv run pytest tests/unit/test_listing_service.py tests/unit/cli/test_notebook.py::TestNotebookList tests/unit/cli/test_source.py::TestSourceList tests/unit/cli/test_artifact.py::TestArtifactList tests/unit/cli/test_note.py::TestNoteList -q`
- `uv run pytest tests/unit tests/integration -q`
- `uv run ruff check src/notebooklm/cli tests/unit/test_listing_service.py`
- `uv run mypy src/notebooklm/cli --ignore-missing-imports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced multiple ad hoc "list" implementations with a shared listing pipeline for artifact, note, notebook, and source commands—unifying pagination, JSON envelope, and table rendering.

* **Tests**
  * Tightened assertions across list command tests and added unit tests for the new listing pipeline to validate JSON envelopes, table output, limits, and empty-state behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->