### PR TITLE
refactor(notes): delete NotesAPI._core dead slot

### DIFF
--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -22,7 +22,6 @@ from typing import Any, Protocol
 
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteRowKind, NoteService
-from ._session_contracts import RpcCaller
 from .types import AskResult, Note
 
 logger = logging.getLogger(__name__)
@@ -67,7 +66,6 @@ class NotesAPI:
 
     def __init__(
         self,
-        rpc: RpcCaller,
         *,
         notes: NoteService,
         mind_maps: NoteBackedMindMapService,
@@ -76,14 +74,6 @@ class NotesAPI:
         """Initialize the notes API.
 
         Args:
-            rpc: RPC dispatch surface (the narrow ``RpcCaller``
-                capability). Kept on ``NotesAPI`` so the legacy
-                ``self._core`` attribute (still expected by tests and
-                the ``_core`` shim) continues to point at a live
-                capability. The ``_core`` alias is preserved for
-                back-compat (refactor.md Non-Goals); a future arc may
-                rename the internal slot but it is not in scope for
-                Phase 7.
             notes: Backend note-row primitives. Owns
                 ``fetch_note_rows`` / ``classify_row`` / ``create_note``
                 / ``update_note`` / ``delete_note``.
@@ -96,12 +86,6 @@ class NotesAPI:
                 root. No default — without it, ``create_from_chat``
                 cannot delegate.
         """
-        # Preserve the legacy ``self._core`` attribute name so the
-        # ``_core`` compatibility shim and tests that inspect
-        # ``client.notes._core`` keep working. The alias is preserved
-        # indefinitely per refactor.md Non-Goals (ADR-013); renaming the
-        # internal slot is a future-arc task.
-        self._core = rpc
         self._notes = notes
         self._mind_maps = mind_maps
         self._save_chat_answer = save_chat_answer

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -332,7 +332,6 @@ class NotebookLMClient:
         # has NotesAPI delegate via constructor injection.
         self.chat = ChatAPI(self._session, notebooks=self.notebooks)
         self.notes = NotesAPI(
-            self._session,
             notes=note_service,
             mind_maps=mind_maps,
             save_chat_answer=self.chat.save_answer_as_note,

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -1027,7 +1027,6 @@ def test_artifacts_rejects_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None
 
     core = MagicMock()
     notes = NotesAPI(
-        core,
         notes=MagicMock(spec=NoteService),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         save_chat_answer=AsyncMock(),
@@ -1067,7 +1066,6 @@ def test_artifacts_before_notes_construction_order(mock_auth: AuthTokens) -> Non
 
     def _make_notes() -> NotesAPI:
         return NotesAPI(
-            core,
             notes=MagicMock(spec=NoteService),
             mind_maps=MagicMock(spec=NoteBackedMindMapService),
             save_chat_answer=AsyncMock(),

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -48,7 +48,6 @@ def notes_api(mock_core, save_chat_answer):
     note_service = NoteService(mock_core)
     mind_maps = NoteBackedMindMapService(note_service)
     return NotesAPI(
-        mock_core,
         notes=note_service,
         mind_maps=mind_maps,
         save_chat_answer=save_chat_answer,


### PR DESCRIPTION
## Summary
- remove the unused `rpc` constructor parameter from `NotesAPI`
- delete the stale `self._core` alias and preservation comments
- update the four positional construction sites

## Verification
- `git grep -nE '_core\b' src/notebooklm/_notes.py` -> no hits
- `git grep -nE 'notes\._core|notes_api\._core' src/ tests/` -> no hits
- `uv run python -c "from notebooklm._notes import NotesAPI; import inspect; assert 'rpc' not in inspect.signature(NotesAPI.__init__).parameters; print('OK: rpc parameter removed')"`
- `uv run pytest tests/unit/test_notes_unit.py tests/unit/test_init_order.py -v`
- `uv run ruff check src/notebooklm`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest` (5743 passed, 12 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified `NotesAPI` constructor by removing the `rpc` parameter dependency and eliminating the legacy `self._core` attribute assignment. The API now accepts only `notes`, `mind_maps`, and `save_chat_answer` as parameters. This represents a breaking change for any code directly instantiating `NotesAPI`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->