### PR TITLE
refactor(cli): extract services/confirming_mutation.py

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -31,6 +31,7 @@ from .resolve import (
     resolve_artifact_id,
     resolve_notebook_id,
 )
+from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, run_list
 from .services.polling import status_with_elapsed
 
@@ -263,45 +264,74 @@ def artifact_delete(ctx, artifact_id, notebook_id, yes, json_output, client_auth
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            resolved_id = await resolve_artifact_id(
-                client, nb_id_resolved, artifact_id, json_output=json_output
-            )
 
-            # ``--json`` implies ``--yes`` so a script that pipes ``--json`` but
-            # forgets ``-y`` does not hang on ``click.confirm``'s stdin read
-            # (which would also clobber JSON stdout purity).
-            if not yes and not json_output and not click.confirm(f"Delete artifact {resolved_id}?"):
+            async def resolve_delete(client):
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                resolved_id = await resolve_artifact_id(
+                    client, nb_id_resolved, artifact_id, json_output=json_output
+                )
+                return {
+                    "notebook_id": nb_id_resolved,
+                    "artifact_id": resolved_id,
+                    "kind": "artifact",
+                }
+
+            async def execute_delete(client, resolved):
+                # Check if this is a mind map (stored with notes)
+                mind_maps = await client.notes.list_mind_maps(resolved["notebook_id"])
+                for mm in mind_maps:
+                    if mm[0] == resolved["artifact_id"]:
+                        await client.notes.delete(resolved["notebook_id"], resolved["artifact_id"])
+                        resolved["kind"] = "mind_map"
+                        return
+
+                await client.artifacts.delete(resolved["notebook_id"], resolved["artifact_id"])
+
+            def serialize_success(resolved):
+                if resolved["kind"] == "mind_map":
+                    return {
+                        "id": resolved["artifact_id"],
+                        "deleted": True,
+                        "kind": "mind_map",
+                        "note": (
+                            "Mind maps are cleared, not removed. "
+                            "Google may garbage collect them later."
+                        ),
+                    }
+                return {"id": resolved["artifact_id"], "deleted": True}
+
+            plan = MutationPlan(
+                entity_label="artifact",
+                resolve=resolve_delete,
+                confirm_message="Delete artifact {resolved[artifact_id]}?",
+                execute=execute_delete,
+                serialize_success=serialize_success,
+                serialize_cancel=lambda resolved: {
+                    "id": resolved["artifact_id"],
+                    "deleted": False,
+                    "status": "cancelled",
+                },
+            )
+            result = await run_confirmed_mutation(
+                plan,
+                client,
+                yes=yes,
+                json_output=json_output,
+                confirmer=click.confirm,
+            )
+            if result.status == "cancelled":
                 return
 
-            # Check if this is a mind map (stored with notes)
-            mind_maps = await client.notes.list_mind_maps(nb_id_resolved)
-            for mm in mind_maps:
-                if mm[0] == resolved_id:
-                    await client.notes.delete(nb_id_resolved, resolved_id)
-                    if json_output:
-                        json_output_response(
-                            {
-                                "id": resolved_id,
-                                "deleted": True,
-                                "kind": "mind_map",
-                                "note": (
-                                    "Mind maps are cleared, not removed. "
-                                    "Google may garbage collect them later."
-                                ),
-                            }
-                        )
-                    else:
-                        cli_print(f"[yellow]Cleared mind map:[/yellow] {resolved_id}", ctx=ctx)
-                        cli_print(
-                            "[dim]Note: Mind maps are cleared, not removed. Google may garbage collect them later.[/dim]",
-                            ctx=ctx,
-                        )
-                    return
-
-            await client.artifacts.delete(nb_id_resolved, resolved_id)
             if json_output:
-                json_output_response({"id": resolved_id, "deleted": True})
+                return
+
+            resolved_id = result.resolved["artifact_id"]
+            if result.resolved["kind"] == "mind_map":
+                cli_print(f"[yellow]Cleared mind map:[/yellow] {resolved_id}", ctx=ctx)
+                cli_print(
+                    "[dim]Note: Mind maps are cleared, not removed. Google may garbage collect them later.[/dim]",
+                    ctx=ctx,
+                )
             else:
                 cli_print(f"[green]Deleted artifact:[/green] {resolved_id}", ctx=ctx)
 

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -22,6 +22,7 @@ from .input import read_stdin_text
 from .options import json_option, notebook_option
 from .rendering import cli_print, console, json_output_response
 from .resolve import require_notebook, resolve_note_id, resolve_notebook_id
+from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, run_list
 
 
@@ -405,51 +406,62 @@ def note_delete(ctx, note_id, notebook_id, yes, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            resolved_id = await resolve_note_id(
-                client, nb_id_resolved, note_id, json_output=json_output
-            )
 
-            # In JSON mode, refuse to prompt: ``click.confirm`` writes to
-            # stdout, which would corrupt the parseable JSON contract callers
-            # rely on (a ``subprocess.check_output(...) -> json.loads(...)``
-            # script would silently hang waiting for stdin). Surface a typed
-            # ``VALIDATION_ERROR`` JSON envelope on stdout AND exit non-zero so
-            # ``set -e`` / ``check_call`` script idioms catch the
-            # misconfiguration immediately instead of silently treating it as
-            # success (audit P1.T5).
-            #
-            # Migration: the prior shape was ``{deleted: false, error: ...}``
-            # + exit ``0``, which passed silently in scripts branching on the
-            # exit code. The new contract uses the standard typed envelope
-            # (``{error, code: "VALIDATION_ERROR", message, ...}``) + exit ``1``.
-            # See ``docs/cli-exit-codes.md`` and the BREAKING entry in
-            # ``CHANGELOG.md`` (Unreleased → Changed).
-            if json_output and not yes:
-                _output_error(
-                    "Pass --yes to confirm deletion in --json mode",
-                    code="VALIDATION_ERROR",
-                    json_output=json_output,
-                    exit_code=1,
-                    extra={"id": resolved_id, "notebook_id": nb_id_resolved},
+            async def resolve_delete(client):
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                resolved_id = await resolve_note_id(
+                    client, nb_id_resolved, note_id, json_output=json_output
                 )
-                raise AssertionError("unreachable")  # pragma: no cover
 
-            if not yes and not click.confirm(f"Delete note {resolved_id}?"):
+                # In JSON mode, refuse to prompt: ``click.confirm`` writes to
+                # stdout, which would corrupt the parseable JSON contract callers
+                # rely on. Preserve the P1.T5 typed error + exit-1 contract.
+                if json_output and not yes:
+                    _output_error(
+                        "Pass --yes to confirm deletion in --json mode",
+                        code="VALIDATION_ERROR",
+                        json_output=json_output,
+                        exit_code=1,
+                        extra={"id": resolved_id, "notebook_id": nb_id_resolved},
+                    )
+                    raise AssertionError("unreachable")  # pragma: no cover
+
+                return {"notebook_id": nb_id_resolved, "note_id": resolved_id}
+
+            async def execute_delete(client, resolved):
+                await client.notes.delete(resolved["notebook_id"], resolved["note_id"])
+
+            plan = MutationPlan(
+                entity_label="note",
+                resolve=resolve_delete,
+                confirm_message="Delete note {resolved[note_id]}?",
+                execute=execute_delete,
+                serialize_success=lambda resolved: {
+                    "id": resolved["note_id"],
+                    "notebook_id": resolved["notebook_id"],
+                    "deleted": True,
+                },
+                serialize_cancel=lambda resolved: {
+                    "id": resolved["note_id"],
+                    "notebook_id": resolved["notebook_id"],
+                    "deleted": False,
+                    "status": "cancelled",
+                },
+            )
+            result = await run_confirmed_mutation(
+                plan,
+                client,
+                yes=yes,
+                json_output=json_output,
+                confirmer=click.confirm,
+            )
+            if result.status == "cancelled":
                 return
-
-            await client.notes.delete(nb_id_resolved, resolved_id)
 
             if json_output:
-                json_output_response(
-                    {
-                        "id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                        "deleted": True,
-                    }
-                )
                 return
 
+            resolved_id = result.resolved["note_id"]
             cli_print(f"[green]Deleted note:[/green] {resolved_id}", ctx=ctx)
 
     return _run()

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -19,6 +19,7 @@ from .context import clear_context, get_current_notebook, set_current_notebook
 from .options import list_options, notebook_option
 from .rendering import cli_print, console, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
+from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, run_list
 
 
@@ -137,14 +138,43 @@ def register_notebook_commands(cli):
 
         async def _run():
             async with NotebookLMClient(client_auth) as client:
-                # Resolve partial ID to full ID
-                resolved_id = await resolve_notebook_id(client, notebook_id)
 
-                # Confirm after resolution so user sees the full ID
-                if not yes and not click.confirm(f"Delete notebook {resolved_id}?"):
+                async def resolve_delete(client):
+                    resolved_id = await resolve_notebook_id(client, notebook_id)
+                    return {"notebook_id": resolved_id, "success": False}
+
+                async def execute_delete(client, resolved):
+                    resolved["success"] = bool(
+                        await client.notebooks.delete(resolved["notebook_id"])
+                    )
+
+                plan = MutationPlan(
+                    entity_label="notebook",
+                    resolve=resolve_delete,
+                    confirm_message="Delete notebook {resolved[notebook_id]}?",
+                    execute=execute_delete,
+                    serialize_success=lambda resolved: {
+                        "notebook_id": resolved["notebook_id"],
+                        "success": bool(resolved["success"]),
+                    },
+                    serialize_cancel=lambda resolved: {
+                        "notebook_id": resolved["notebook_id"],
+                        "success": False,
+                        "status": "cancelled",
+                    },
+                )
+                result = await run_confirmed_mutation(
+                    plan,
+                    client,
+                    yes=yes,
+                    json_output=False,
+                    confirmer=click.confirm,
+                )
+                if result.status == "cancelled":
                     return
 
-                success = await client.notebooks.delete(resolved_id)
+                resolved_id = result.resolved["notebook_id"]
+                success = bool(result.resolved["success"])
                 if success:
                     cli_print(f"[green]Deleted notebook:[/green] {resolved_id}", ctx=ctx)
                     # Clear context if we deleted the current notebook

--- a/src/notebooklm/cli/services/confirming_mutation.py
+++ b/src/notebooklm/cli/services/confirming_mutation.py
@@ -1,0 +1,72 @@
+"""Shared confirmed-mutation pipeline for CLI resources."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, Literal, TypeVar
+
+from ...client import NotebookLMClient
+from ..rendering import json_output_response
+
+ResolvedT = TypeVar("ResolvedT")
+MutationStatus = Literal["cancelled", "completed"]
+
+
+@dataclass(frozen=True)
+class MutationPlan(Generic[ResolvedT]):
+    """Command-specific configuration for :func:`run_confirmed_mutation`."""
+
+    entity_label: str
+    resolve: Callable[[NotebookLMClient], Awaitable[ResolvedT]]
+    confirm_message: str
+    execute: Callable[[NotebookLMClient, ResolvedT], Awaitable[None]]
+    serialize_success: Callable[[ResolvedT], dict[str, Any]]
+    serialize_cancel: Callable[[ResolvedT], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class MutationResult(Generic[ResolvedT]):
+    """Result of a confirmed mutation workflow."""
+
+    entity_label: str
+    resolved: ResolvedT
+    status: MutationStatus
+    payload: dict[str, Any]
+
+
+async def run_confirmed_mutation(
+    plan: MutationPlan[ResolvedT],
+    client: NotebookLMClient,
+    *,
+    yes: bool,
+    json_output: bool,
+    confirmer: Callable[[str], bool],
+) -> MutationResult[ResolvedT]:
+    """Resolve an entity, optionally confirm, execute, and serialize the result."""
+    resolved = await plan.resolve(client)
+
+    if not yes and not json_output:
+        confirm_message = plan.confirm_message.format(resolved=resolved)
+        if not confirmer(confirm_message):
+            payload = plan.serialize_cancel(resolved)
+            return MutationResult(
+                entity_label=plan.entity_label,
+                resolved=resolved,
+                status="cancelled",
+                payload=payload,
+            )
+
+    await plan.execute(client, resolved)
+    payload = plan.serialize_success(resolved)
+    if json_output:
+        json_output_response(payload)
+    return MutationResult(
+        entity_label=plan.entity_label,
+        resolved=resolved,
+        status="completed",
+        payload=payload,
+    )
+
+
+__all__ = ["MutationPlan", "MutationResult", "run_confirmed_mutation"]

--- a/src/notebooklm/cli/share.py
+++ b/src/notebooklm/cli/share.py
@@ -18,6 +18,7 @@ from .auth_runtime import with_client
 from .options import notebook_option
 from .rendering import console, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
+from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 
 
 def _permission_name(perm: SharePermission) -> str:
@@ -342,21 +343,40 @@ def share_remove(ctx, email, notebook_id, yes, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
-            # Confirm after resolution so user sees context
-            if not yes and not json_output:
-                if not click.confirm(f"Remove access for {email}?"):
-                    return
+            async def resolve_remove(client):
+                resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                return {"notebook_id": resolved_id, "email": email}
 
-            await client.sharing.remove_user(resolved_id, email)
+            async def execute_remove(client, resolved):
+                await client.sharing.remove_user(resolved["notebook_id"], resolved["email"])
+
+            plan = MutationPlan(
+                entity_label="share",
+                resolve=resolve_remove,
+                confirm_message="Remove access for {resolved[email]}?",
+                execute=execute_remove,
+                serialize_success=lambda resolved: {
+                    "notebook_id": resolved["notebook_id"],
+                    "removed_user": resolved["email"],
+                },
+                serialize_cancel=lambda resolved: {
+                    "notebook_id": resolved["notebook_id"],
+                    "removed_user": resolved["email"],
+                    "status": "cancelled",
+                },
+            )
+            result = await run_confirmed_mutation(
+                plan,
+                client,
+                yes=yes,
+                json_output=json_output,
+                confirmer=click.confirm,
+            )
+            if result.status == "cancelled":
+                return
 
             if json_output:
-                data = {
-                    "notebook_id": resolved_id,
-                    "removed_user": email,
-                }
-                json_output_response(data)
                 return
 
             console.print(f"[green]Removed access for {email}[/green]")

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -54,6 +54,7 @@ from .resolve import require_notebook, resolve_notebook_id, resolve_source_id, v
 from .runtime import is_quiet
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
+from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, run_list
 from .services.polling import status_with_elapsed
 
@@ -539,41 +540,75 @@ def source_delete(ctx, source_id, notebook_id, yes, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            resolved_id = await _resolve_source_for_delete(
-                client, nb_id_resolved, source_id, json_output=json_output
-            )
 
-            # P1.T2 bug 1: In --json mode, never prompt — automation cannot
-            # answer an interactive confirmation and a hanging prompt is
-            # indistinguishable from a stuck command. Require --yes and emit a
-            # structured JSON error otherwise.
-            if json_output and not yes:
-                _require_yes_in_json(
-                    action="delete",
-                    extra={
-                        "source_id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                    },
+            async def resolve_delete(client):
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                resolved_id = await _resolve_source_for_delete(
+                    client, nb_id_resolved, source_id, json_output=json_output
                 )
 
-            if not yes and not click.confirm(f"Delete source {resolved_id}?"):
-                return
+                # P1.T2 bug 1: In --json mode, never prompt — automation cannot
+                # answer an interactive confirmation and a hanging prompt is
+                # indistinguishable from a stuck command. Require --yes and emit a
+                # structured JSON error otherwise.
+                if json_output and not yes:
+                    _require_yes_in_json(
+                        action="delete",
+                        extra={
+                            "source_id": resolved_id,
+                            "notebook_id": nb_id_resolved,
+                        },
+                    )
 
-            success = await client.sources.delete(nb_id_resolved, resolved_id)
+                return {
+                    "notebook_id": nb_id_resolved,
+                    "source_id": resolved_id,
+                    "success": False,
+                }
+
+            async def execute_delete(client, resolved):
+                resolved["success"] = bool(
+                    await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
+                )
+
+            def serialize_success(resolved):
+                return {
+                    "action": "delete",
+                    "source_id": resolved["source_id"],
+                    "notebook_id": resolved["notebook_id"],
+                    "success": bool(resolved["success"]),
+                    "status": "deleted" if resolved["success"] else "unknown",
+                }
+
+            plan = MutationPlan(
+                entity_label="source",
+                resolve=resolve_delete,
+                confirm_message="Delete source {resolved[source_id]}?",
+                execute=execute_delete,
+                serialize_success=serialize_success,
+                serialize_cancel=lambda resolved: {
+                    "action": "delete",
+                    "source_id": resolved["source_id"],
+                    "notebook_id": resolved["notebook_id"],
+                    "success": False,
+                    "status": "cancelled",
+                },
+            )
+            result = await run_confirmed_mutation(
+                plan,
+                client,
+                yes=yes,
+                json_output=json_output,
+                confirmer=click.confirm,
+            )
+            if result.status == "cancelled":
+                return
 
             if json_output:
-                json_output_response(
-                    {
-                        "action": "delete",
-                        "source_id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                        "success": bool(success),
-                        "status": "deleted" if success else "unknown",
-                    }
-                )
                 return
 
+            resolved_id = result.resolved["source_id"]
+            success = bool(result.resolved["success"])
             if success:
                 cli_print(f"[green]Deleted source:[/green] {resolved_id}", ctx=ctx)
             else:
@@ -594,41 +629,77 @@ def source_delete_by_title(ctx, title, notebook_id, yes, json_output, client_aut
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            source = await _resolve_source_by_exact_title(client, nb_id_resolved, title)
 
-            # P1.T2 bug 2: same JSON-mode confirmation contract as
-            # ``source delete``. Never prompt under --json; require --yes.
-            if json_output and not yes:
-                _require_yes_in_json(
-                    action="delete-by-title",
-                    extra={
-                        "source_id": source.id,
-                        "title": source.title,
-                        "notebook_id": nb_id_resolved,
-                    },
+            async def resolve_delete_by_title(client):
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                source = await _resolve_source_by_exact_title(client, nb_id_resolved, title)
+
+                # P1.T2 bug 2: same JSON-mode confirmation contract as
+                # ``source delete``. Never prompt under --json; require --yes.
+                if json_output and not yes:
+                    _require_yes_in_json(
+                        action="delete-by-title",
+                        extra={
+                            "source_id": source.id,
+                            "title": source.title,
+                            "notebook_id": nb_id_resolved,
+                        },
+                    )
+
+                return {
+                    "notebook_id": nb_id_resolved,
+                    "source_id": source.id,
+                    "title": source.title,
+                    "success": False,
+                }
+
+            async def execute_delete_by_title(client, resolved):
+                resolved["success"] = bool(
+                    await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
                 )
 
-            if not yes and not click.confirm(f"Delete source '{source.title}' ({source.id})?"):
-                return
+            def serialize_success(resolved):
+                return {
+                    "action": "delete-by-title",
+                    "source_id": resolved["source_id"],
+                    "title": resolved["title"],
+                    "notebook_id": resolved["notebook_id"],
+                    "success": bool(resolved["success"]),
+                    "status": "deleted" if resolved["success"] else "unknown",
+                }
 
-            success = await client.sources.delete(nb_id_resolved, source.id)
+            plan = MutationPlan(
+                entity_label="source",
+                resolve=resolve_delete_by_title,
+                confirm_message="Delete source '{resolved[title]}' ({resolved[source_id]})?",
+                execute=execute_delete_by_title,
+                serialize_success=serialize_success,
+                serialize_cancel=lambda resolved: {
+                    "action": "delete-by-title",
+                    "source_id": resolved["source_id"],
+                    "title": resolved["title"],
+                    "notebook_id": resolved["notebook_id"],
+                    "success": False,
+                    "status": "cancelled",
+                },
+            )
+            result = await run_confirmed_mutation(
+                plan,
+                client,
+                yes=yes,
+                json_output=json_output,
+                confirmer=click.confirm,
+            )
+            if result.status == "cancelled":
+                return
 
             if json_output:
-                json_output_response(
-                    {
-                        "action": "delete-by-title",
-                        "source_id": source.id,
-                        "title": source.title,
-                        "notebook_id": nb_id_resolved,
-                        "success": bool(success),
-                        "status": "deleted" if success else "unknown",
-                    }
-                )
                 return
 
+            source_id = result.resolved["source_id"]
+            success = bool(result.resolved["success"])
             if success:
-                cli_print(f"[green]Deleted source:[/green] {source.id}", ctx=ctx)
+                cli_print(f"[green]Deleted source:[/green] {source_id}", ctx=ctx)
             else:
                 cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -540,6 +540,30 @@ class TestArtifactDelete:
             assert result.exit_code == 0
             assert "Deleted artifact" in result.output
 
+    def test_artifact_delete_cancelled(self, runner, mock_auth):
+        with patch_client_for_module("artifact") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    Artifact(id="art_123", title="Test Artifact", _artifact_type=4, status=3)
+                ]
+            )
+            mock_client.notes.list_mind_maps = AsyncMock(return_value=[])
+            mock_client.artifacts.delete = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["artifact", "delete", "art_123", "-n", "nb_123"], input="n\n"
+                )
+
+            assert result.exit_code == 0
+            assert "Delete artifact art_123?" in result.output
+            mock_client.artifacts.delete.assert_not_called()
+
     def test_artifact_delete_json_output(self, runner, mock_auth):
         """`artifact delete --json` emits a structured success payload."""
         with patch_client_for_module("artifact") as mock_client_cls:
@@ -564,6 +588,35 @@ class TestArtifactDelete:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data == {"id": "art_123", "deleted": True}
+
+    def test_artifact_delete_json_without_yes_does_not_prompt(self, runner, mock_auth):
+        """Current JSON contract treats --json as non-interactive execution."""
+        with patch_client_for_module("artifact") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    Artifact(id="art_123", title="Test Artifact", _artifact_type=4, status=3)
+                ]
+            )
+            mock_client.notes.list_mind_maps = AsyncMock(return_value=[])
+            mock_client.artifacts.delete = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with (
+                patch(
+                    "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+                ) as mock_fetch,
+                patch("click.confirm") as mock_confirm,
+            ):
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["artifact", "delete", "art_123", "-n", "nb_123", "--json"]
+                )
+
+            assert result.exit_code == 0
+            assert json.loads(result.output) == {"id": "art_123", "deleted": True}
+            mock_confirm.assert_not_called()
+            mock_client.artifacts.delete.assert_called_once_with("nb_123", "art_123")
 
     def test_artifact_delete_mind_map_json_output(self, runner, mock_auth):
         """`artifact delete --json` flags mind-map carve-out in the payload."""

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -509,6 +509,32 @@ class TestNotebookDelete:
             assert "Deleted notebook" in result.output
             mock_client.notebooks.delete.assert_called_once_with("nb_to_delete")
 
+    def test_notebook_delete_cancelled(self, runner, mock_auth):
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(
+                        id="nb_to_delete",
+                        title="Test Notebook",
+                        created_at=datetime(2024, 1, 1),
+                        is_owner=True,
+                    ),
+                ]
+            )
+            mock_client.notebooks.delete = AsyncMock(return_value=True)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["delete", "-n", "nb_to_delete"], input="n\n")
+
+            assert result.exit_code == 0
+            assert "Delete notebook nb_to_delete?" in result.output
+            mock_client.notebooks.delete.assert_not_called()
+
     def test_notebook_delete_clears_context_if_current(self, runner, mock_auth, tmp_path):
         context_file = tmp_path / "context.json"
         context_file.write_text('{"notebook_id": "nb_to_delete"}')

--- a/tests/unit/cli/test_share.py
+++ b/tests/unit/cli/test_share.py
@@ -233,6 +233,29 @@ class TestShareRemove:
             assert "Removed access for user@example.com" in result.output
             mock_client.sharing.remove_user.assert_called_once_with("nb_123", "user@example.com")
 
+    def test_share_remove_cancelled(self, runner, mock_auth):
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(id="nb_123", title="Test", created_at=datetime(2024, 1, 1)),
+                ]
+            )
+            mock_client.sharing.remove_user = AsyncMock(return_value=create_mock_share_status())
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["share", "remove", "user@example.com", "-n", "nb_123"], input="n\n"
+                )
+
+            assert result.exit_code == 0
+            assert "Remove access for user@example.com?" in result.output
+            mock_client.sharing.remove_user.assert_not_called()
+
     def test_share_remove_json(self, runner, mock_auth):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
@@ -254,6 +277,33 @@ class TestShareRemove:
 
             assert result.exit_code == 0
             assert '"removed_user": "user@example.com"' in result.output
+
+    def test_share_remove_json_without_yes_does_not_prompt(self, runner, mock_auth):
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(id="nb_123", title="Test", created_at=datetime(2024, 1, 1)),
+                ]
+            )
+            mock_client.sharing.remove_user = AsyncMock(return_value=create_mock_share_status())
+            mock_client_cls.return_value = mock_client
+
+            with (
+                patch(
+                    "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+                ) as mock_fetch,
+                patch("click.confirm") as mock_confirm,
+            ):
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["share", "remove", "user@example.com", "-n", "nb_123", "--json"]
+                )
+
+            assert result.exit_code == 0
+            assert '"removed_user": "user@example.com"' in result.output
+            mock_confirm.assert_not_called()
+            mock_client.sharing.remove_user.assert_called_once_with("nb_123", "user@example.com")
 
 
 # =============================================================================

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -677,6 +677,27 @@ class TestSourceDelete:
             assert "Deleted source" in result.output
             mock_client.sources.delete.assert_called_once_with("nb_123", "src_123")
 
+    def test_source_delete_cancelled(self, runner, mock_auth):
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.delete = AsyncMock(return_value=True)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["source", "delete", "src_123", "-n", "nb_123"], input="n\n"
+                )
+
+            assert result.exit_code == 0
+            assert "Delete source src_123?" in result.output
+            mock_client.sources.delete.assert_not_called()
+
     def test_source_delete_failure(self, runner, mock_auth):
         with patch_client_for_module("source") as mock_client_cls:
             mock_client = create_mock_client()

--- a/tests/unit/test_confirming_mutation_service.py
+++ b/tests/unit/test_confirming_mutation_service.py
@@ -1,0 +1,109 @@
+"""Unit tests for the confirmed mutation CLI service."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from notebooklm.cli.services.confirming_mutation import MutationPlan, run_confirmed_mutation
+
+
+def _plan(
+    *,
+    calls: list[tuple[str, Any]],
+    resolved: SimpleNamespace | None = None,
+) -> MutationPlan[SimpleNamespace]:
+    target = resolved or SimpleNamespace(id="thing_123", title="Target", executed=False)
+
+    async def resolve(client: object) -> SimpleNamespace:
+        calls.append(("resolve", client))
+        return target
+
+    async def execute(client: object, resolved: SimpleNamespace) -> None:
+        calls.append(("execute", client))
+        resolved.executed = True
+
+    return MutationPlan(
+        entity_label="thing",
+        resolve=resolve,
+        confirm_message="Delete {resolved.title} ({resolved.id})?",
+        execute=execute,
+        serialize_success=lambda resolved: {"id": resolved.id, "deleted": True},
+        serialize_cancel=lambda resolved: {"id": resolved.id, "deleted": False},
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancels_after_resolution_and_skips_execution() -> None:
+    calls: list[tuple[str, Any]] = []
+    confirm_messages: list[str] = []
+    client = object()
+
+    result = await run_confirmed_mutation(
+        _plan(calls=calls),
+        client,
+        yes=False,
+        json_output=False,
+        confirmer=lambda message: confirm_messages.append(message) or False,
+    )
+
+    assert result.entity_label == "thing"
+    assert result.status == "cancelled"
+    assert result.payload == {"id": "thing_123", "deleted": False}
+    assert result.resolved.executed is False
+    assert confirm_messages == ["Delete Target (thing_123)?"]
+    assert calls == [("resolve", client)]
+
+
+@pytest.mark.asyncio
+async def test_yes_skips_confirmation_and_executes_mutation() -> None:
+    calls: list[tuple[str, Any]] = []
+    client = object()
+
+    result = await run_confirmed_mutation(
+        _plan(calls=calls),
+        client,
+        yes=True,
+        json_output=False,
+        confirmer=lambda message: pytest.fail(f"unexpected confirmation: {message}"),
+    )
+
+    assert result.status == "completed"
+    assert result.payload == {"id": "thing_123", "deleted": True}
+    assert result.resolved.executed is True
+    assert calls == [("resolve", client), ("execute", client)]
+
+
+@pytest.mark.asyncio
+async def test_json_output_emits_success_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[tuple[str, Any]] = []
+
+    result = await run_confirmed_mutation(
+        _plan(calls=calls),
+        object(),
+        yes=True,
+        json_output=True,
+        confirmer=lambda message: pytest.fail(f"unexpected confirmation: {message}"),
+    )
+
+    assert result.status == "completed"
+    assert json.loads(capsys.readouterr().out) == {"id": "thing_123", "deleted": True}
+
+
+@pytest.mark.asyncio
+async def test_json_output_without_yes_does_not_prompt() -> None:
+    calls: list[tuple[str, Any]] = []
+
+    result = await run_confirmed_mutation(
+        _plan(calls=calls),
+        object(),
+        yes=False,
+        json_output=True,
+        confirmer=lambda message: pytest.fail(f"unexpected confirmation: {message}"),
+    )
+
+    assert result.status == "completed"
+    assert result.resolved.executed is True


### PR DESCRIPTION
Retargeted to `main` after #936 merged. This PR was originally stacked on #936 (`cli-audit-fixes/p2t3-listing-extraction`) and now contains only the P2.T4 commit on top of `main`.

## Summary
- add `cli/services/confirming_mutation.py` with `MutationPlan`, `MutationResult`, and `run_confirmed_mutation`
- route notebook/source/artifact/note/share destructive confirmation flows through the shared service
- add service tests plus command characterization for cancel and JSON/no-prompt behavior

## Verification
- `uv run pytest tests/unit/test_confirming_mutation_service.py tests/unit/cli/test_notebook.py::TestNotebookDelete tests/unit/cli/test_source.py::TestSourceDelete tests/unit/cli/test_source.py::TestSourceDeleteByTitle tests/unit/cli/test_artifact.py::TestArtifactDelete tests/unit/cli/test_note.py::TestNoteDeleteJson tests/unit/cli/test_share.py::TestShareRemove -q`
- `uv run ruff check src/notebooklm/cli tests/unit/test_confirming_mutation_service.py`
- `uv run mypy src/notebooklm/cli --ignore-missing-imports`
- `uv run pytest tests/unit tests/integration -q`

## Stacking
- Base: `main` (after #936 merged)
- Head: `cli-audit-fixes/p2t4-confirming-mutation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized confirmation/confirmation-cancel flow for delete/remove commands (artifact, note, notebook, share, source) to ensure consistent behavior and serialization.

* **Behavior**
  * JSON-mode deletions now require explicit confirmation (--yes); cancelled operations return a cancelled JSON result (no success payload).

* **Tests**
  * Added/updated unit tests covering cancellation paths and JSON/yes combinations for deletion workflows and the new confirmation service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->