### PR TITLE
refactor(transport): drop underscores from shared authed transport symbols

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -107,7 +107,7 @@ a Protocol-shim host interface so it can be unit-tested against a stub
 | `_client_metrics.py` | `ClientMetrics` | `ClientMetricsSnapshot` counters, queue-wait recorders, `on_rpc_event` async callback. |
 | `_transport_drain.py` | `TransportDrainTracker` | In-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. |
 | `_reqid_counter.py` | `ReqidCounter` | Monotonic `_reqid` counter for chat backend (baseline 100000, step 100000). |
-| `_session_auth.py` | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. |
+| `_session_auth.py` | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `AuthSnapshot` rotation. |
 | `_session_lifecycle.py` | `ClientLifecycle` | Loop-affinity guard, `aclose` plumbing, keepalive task wiring. |
 | `_rpc_executor.py` | `RpcExecutor` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols. |
 | `_authed_transport.py` | `AuthedTransport` | Authed HTTP POST path, retry loops (429 + 5xx). |

--- a/docs/migration-tier-12-to-13.md
+++ b/docs/migration-tier-12-to-13.md
@@ -106,7 +106,7 @@ import from.
 | `notebooklm._middleware_auth_refresh` | Tier 12 PR 12.8 — auth-refresh-on-401 middleware. |
 | `notebooklm._middleware_semaphore` | Tier 12 PR 12.9 — global RPC concurrency cap. |
 | `notebooklm._chat_transport` | Chat-domain consumer-side error mapping over `AuthedTransport`. Replaces the chat-side wrapper that previously lived on `_core.rpc_call`. |
-| `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `_AuthSnapshot` and `_BuildRequest` from `_authed_transport` under the public-without-underscore names `AuthSnapshot` / `BuildRequest`, plus a new `BuildRequestResult` dataclass. |
+| `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `AuthSnapshot` and `BuildRequest` from `_authed_transport`, plus the `BuildRequestResult` dataclass. |
 
 ## Deleted symbols and changed defaults
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -295,7 +295,7 @@ sequence across concurrent coroutines on the same client. Guarded by
 `_reqid_lock`.
 
 **Per-attempt and across-attempt auth snapshot atomicity**.
-`_auth_snapshot_lock` serializes `_AuthSnapshot` reads against the
+`_auth_snapshot_lock` serializes `AuthSnapshot` reads against the
 refresh-side mutation block — without this, a token refresh that
 completed between the URL-build step and the POST step could produce a
 URL stitched together from a mix of pre- and post-refresh credentials
@@ -569,7 +569,7 @@ historical `notebooklm._core` compatibility shim was removed in v0.5.0.
 | `_session_config` | Module-level constants: `DEFAULT_TIMEOUT`, `DEFAULT_KEEPALIVE_MIN_INTERVAL`, `DEFAULT_MAX_CONCURRENT_RPCS`, `DEFAULT_MAX_CONCURRENT_UPLOADS`, `CORE_LOGGER_NAME`, `normalize_max_concurrent_uploads`. | Pure constants; importable without side effects. |
 | `_session_helpers` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval`. | Cross-seam pure helpers; behaviour-bearing (and therefore unit-tested). |
 | `_error_injection` | `ERROR_INJECT_ENV_VAR`, `_get_error_injection_mode`, `_refuse_synthetic_error_outside_test_context`. | Env-var resolver + startup guard for the synthetic-error harness. |
-| `_session_auth` | `AuthRefreshCoordinator`: refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. | Lazy `asyncio.Lock` construction; never instantiated outside a running loop. |
+| `_session_auth` | `AuthRefreshCoordinator`: refresh-task lifecycle, refresh lock, `AuthSnapshot` rotation. | Lazy `asyncio.Lock` construction; never instantiated outside a running loop. |
 | `_conversation_cache` | Per-instance LRU `_conversation_cache` for `ChatAPI` continuity. | Pure in-process state; not shared across `Session` instances. |
 | `_cookie_persistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. | Exposes a `SaveCookiesToStorage` Protocol host. |
 | `_transport_drain` | `TransportDrainTracker`: in-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. | Construction is event-loop-agnostic; the `Condition` is allocated on first use. |
@@ -578,7 +578,7 @@ historical `notebooklm._core` compatibility shim was removed in v0.5.0.
 | `_polling_registry` | Pending-poll registry shared by long-running artifact generations. | Used by artifacts and the legacy `Session._pending_polls` compatibility bridge. |
 | `_reqid_counter` | `ReqidCounter`: monotonic `_reqid` for the chat backend, lazy `asyncio.Lock` for concurrent `ChatAPI.ask` callers. | Baseline `_value=100000`, default `step=100000` — both are chat-API contract values; do not change. |
 | `_rpc_executor` | RPC dispatch executor; exposes `DecodeResponse` and `RpcOwner` Protocols so callers can be unit-tested against a stub. | `Session.rpc_call` delegates here. |
-| `_authed_transport` | Authed HTTP POST path, retry loops (429 + 5xx), `_AuthedTransportHost` Protocol. | Owns `_TransportAuthExpired` / `_TransportRateLimited` / `_TransportServerError` transport-level exceptions. |
+| `_authed_transport` | Authed HTTP POST path, retry loops (429 + 5xx), `_AuthedTransportHost` Protocol. | Owns `TransportAuthExpired` / `TransportRateLimited` / `TransportServerError` transport-level exceptions. |
 
 Feature APIs depend on narrow per-capability Protocols defined in
 `notebooklm._session_contracts` (and feature-local runtime Protocols

--- a/src/notebooklm/_authed_transport.py
+++ b/src/notebooklm/_authed_transport.py
@@ -7,14 +7,14 @@ __all__ = [
     "MAX_RPC_RESPONSE_BYTES",
     "AuthedTransport",
     "_AuthedTransportHost",
-    "_AuthSnapshot",
-    "_BuildRequest",
-    "_PostBody",
-    "_TransportAuthExpired",
-    "_TransportRateLimited",
-    "_TransportServerError",
-    "_parse_retry_after",
-    "_stream_post_with_size_cap",
+    "AuthSnapshot",
+    "BuildRequest",
+    "PostBody",
+    "TransportAuthExpired",
+    "TransportRateLimited",
+    "TransportServerError",
+    "parse_retry_after",
+    "stream_post_with_size_cap",
 ]
 
 import logging
@@ -54,7 +54,7 @@ MAX_RPC_RESPONSE_BYTES = 50 * 1024 * 1024
 _STRIP_HEADERS_ON_REBUFFER = frozenset({"content-encoding", "content-length"})
 
 
-def _parse_retry_after(value: str | None) -> int | None:
+def parse_retry_after(value: str | None) -> int | None:
     """Parse RFC 7231 Retry-After: integer-seconds OR HTTP-date.
 
     Returns seconds-until-retry as a non-negative int, clamped to
@@ -82,7 +82,7 @@ def _parse_retry_after(value: str | None) -> int | None:
 
 
 @dataclass(frozen=True)
-class _AuthSnapshot:
+class AuthSnapshot:
     """Point-in-time view of auth headers used to build a single request.
 
     Captured once per HTTP attempt by ``_perform_authed_post`` and passed
@@ -97,7 +97,7 @@ class _AuthSnapshot:
     account_email: str | None
 
 
-class _TransportAuthExpired(Exception):
+class TransportAuthExpired(Exception):
     """Raised by ``AuthRefreshMiddleware`` when the refresh callback itself
     failed during an auth recovery attempt.
 
@@ -105,7 +105,7 @@ class _TransportAuthExpired(Exception):
     PR 12.8 lifted that branch into
     :class:`notebooklm._middleware_auth_refresh.AuthRefreshMiddleware`;
     the class definition stays here so the existing import path
-    (``from notebooklm._authed_transport import _TransportAuthExpired``)
+    (``from notebooklm._authed_transport import TransportAuthExpired``)
     keeps working for ``_chat_transport.chat_aware_authed_post`` and its
     tests.
 
@@ -119,7 +119,7 @@ class _TransportAuthExpired(Exception):
         self.original = original
 
 
-class _TransportRateLimited(Exception):
+class TransportRateLimited(Exception):
     """Raised by ``_perform_authed_post`` when the 429 retry budget is
     exhausted (or no retries are configured).
     """
@@ -138,7 +138,7 @@ class _TransportRateLimited(Exception):
         self.original = original
 
 
-class _TransportServerError(Exception):
+class TransportServerError(Exception):
     """Raised by ``_perform_authed_post`` when the server-error retry budget
     is exhausted.
     """
@@ -157,18 +157,18 @@ class _TransportServerError(Exception):
         self.status_code = status_code
 
 
-# Build-request factory: receives a fresh ``_AuthSnapshot`` and returns the
+# Build-request factory: receives a fresh ``AuthSnapshot`` and returns the
 # triple (url, body, extra_headers) for one HTTP attempt. The transport invokes
 # this once per attempt so refreshed snapshots are picked up on retry.
-_PostBody = str | bytes
-_BuildRequest = Callable[[_AuthSnapshot], tuple[str, _PostBody, dict[str, str] | None]]
+PostBody = str | bytes
+BuildRequest = Callable[[AuthSnapshot], tuple[str, PostBody, dict[str, str] | None]]
 
 
-async def _stream_post_with_size_cap(
+async def stream_post_with_size_cap(
     client: httpx.AsyncClient,
     url: str,
     *,
-    body: _PostBody,
+    body: PostBody,
     headers: dict[str, str] | None,
     max_bytes: int = MAX_RPC_RESPONSE_BYTES,
 ) -> httpx.Response:
@@ -249,12 +249,12 @@ class _AuthedTransportHost(Protocol):
 
     - ``_kernel`` (concrete-class reference; streaming-POST transport
       + pre-open guard via ``get_http_client()``)
-    - ``_snapshot`` (fresh ``_AuthSnapshot`` per attempt)
+    - ``_snapshot`` (fresh ``AuthSnapshot`` per attempt)
     """
 
     _kernel: Kernel
 
-    async def _snapshot(self) -> _AuthSnapshot: ...
+    async def _snapshot(self) -> AuthSnapshot: ...
 
 
 class AuthedTransport:
@@ -279,7 +279,7 @@ class AuthedTransport:
     async def perform_authed_post(
         self,
         *,
-        build_request: _BuildRequest,
+        build_request: BuildRequest,
         log_label: str,
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
@@ -319,7 +319,7 @@ class AuthedTransport:
         start = time.perf_counter()
 
         # The leaf is a pure POST: 429 and 5xx/network failures raise
-        # ``_TransportRateLimited`` / ``_TransportServerError`` so
+        # ``TransportRateLimited`` / ``TransportServerError`` so
         # :class:`RetryMiddleware` (outside this leaf) decides whether to
         # retry; raw ``httpx.HTTPStatusError`` (e.g. 400 / 401 / 403)
         # propagates so :class:`AuthRefreshMiddleware` (also outside this
@@ -344,8 +344,8 @@ class AuthedTransport:
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
             # --- 429: raise for ``RetryMiddleware`` to catch ----------
             if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
-                retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
-                raise _TransportRateLimited(
+                retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
+                raise TransportRateLimited(
                     f"{log_label} rate-limited (HTTP 429)",
                     retry_after=retry_after,
                     response=exc.response,
@@ -354,14 +354,14 @@ class AuthedTransport:
 
             # --- 5xx / network: raise for ``RetryMiddleware`` ---------
             if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
-                raise _TransportServerError(
+                raise TransportServerError(
                     f"{log_label} server error (HTTP {exc.response.status_code})",
                     original=exc,
                     response=exc.response,
                     status_code=exc.response.status_code,
                 ) from exc
             if isinstance(exc, httpx.RequestError):
-                raise _TransportServerError(
+                raise TransportServerError(
                     f"{log_label} network error: {exc}",
                     original=exc,
                 ) from exc

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -12,7 +12,7 @@ from typing import Any, Protocol
 
 import httpx
 
-from ._authed_transport import _AuthSnapshot
+from ._authed_transport import AuthSnapshot
 from ._chat_notes import save_chat_answer_as_note
 from ._chat_protocol import (
     build_streaming_chat_request,
@@ -302,7 +302,7 @@ class ChatAPI:
             # duplicate ``_reqid`` URL params.
             reqid = await self._runtime.next_reqid()
 
-            def build_request(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            def build_request(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
                 return self._build_chat_request(
                     snapshot=snapshot,
                     notebook_id=notebook_id,
@@ -781,7 +781,7 @@ class ChatAPI:
     def _build_chat_request(
         self,
         *,
-        snapshot: _AuthSnapshot,
+        snapshot: AuthSnapshot,
         notebook_id: str,
         question: str,
         source_ids: list[str],

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -3,8 +3,8 @@
 This module owns the chat-flavored exception mapping that wraps a
 single authed POST attempt against the NotebookLM batchexecute
 endpoint. It is the chat-domain consumer-side seam: transport-layer
-exceptions (``_TransportAuthExpired``, ``_TransportRateLimited``,
-``_TransportServerError``, raw ``httpx.HTTPStatusError``) raised by
+exceptions (``TransportAuthExpired``, ``TransportRateLimited``,
+``TransportServerError``, raw ``httpx.HTTPStatusError``) raised by
 ``Session._perform_authed_post`` are translated into ``ChatError``
 or ``NetworkError`` so callers (currently only :class:`ChatAPI.ask`)
 stay free of HTTP-status branching.
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING
 import httpx
 
 from ._authed_transport import (
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
+    TransportAuthExpired,
+    TransportRateLimited,
+    TransportServerError,
 )
 from .exceptions import ChatError, NetworkError
 
@@ -68,16 +68,16 @@ async def chat_aware_authed_post(
             build_request=build_request,
             parse_label=parse_label,
         )
-    except _TransportAuthExpired as exc:
+    except TransportAuthExpired as exc:
         raise ChatError(
             f"{parse_label} failed: authentication expired and refresh did not recover"
         ) from exc
-    except _TransportRateLimited as exc:
+    except TransportRateLimited as exc:
         raise ChatError(
             f"{parse_label} rate-limited (HTTP 429)."
             + (f" Retry after {exc.retry_after} seconds." if exc.retry_after is not None else "")
         ) from exc
-    except _TransportServerError as exc:
+    except TransportServerError as exc:
         if isinstance(exc.original, httpx.HTTPStatusError):
             raise ChatError(
                 f"{parse_label} failed with HTTP {exc.original.response.status_code} "
@@ -85,13 +85,13 @@ async def chat_aware_authed_post(
             ) from exc
         # Network-layer failure (RequestError / Timeout).
         # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
-        # ``_TransportServerError`` on the network path; this guard keeps
+        # ``TransportServerError`` on the network path; this guard keeps
         # the contract enforced under ``python -O`` (where ``assert``
         # would be stripped) and gives a clear diagnostic if the
         # invariant ever drifts.
         if not isinstance(exc.original, httpx.RequestError):
             raise TypeError(
-                f"Unexpected _TransportServerError.original type: {type(exc.original)}. "
+                f"Unexpected TransportServerError.original type: {type(exc.original)}. "
                 "Expected httpx.HTTPStatusError or httpx.RequestError."
             ) from exc
         # Preserve the timeout-specific message: TimeoutException is a
@@ -117,5 +117,5 @@ async def chat_aware_authed_post(
     # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
     # handlers were removed here because ``_perform_authed_post`` always
     # either retries those errors or wraps them in
-    # ``_TransportServerError`` (handled above), so they cannot reach
+    # ``TransportServerError`` (handled above), so they cannot reach
     # this scope.

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -62,7 +62,7 @@ T = TypeVar("T")
 # request fails in a way that *might* have committed the write on the
 # server. With ``disable_internal_retries=True``, ``_perform_authed_post``
 # does not retry these on its own; instead it lets ``rpc_call`` translate
-# the underlying ``_TransportServerError``/network failure into
+# the underlying ``TransportServerError``/network failure into
 # ``ServerError`` / ``NetworkError`` / ``RateLimitError`` and surface it
 # here. ``idempotent_create`` catches exactly these; anything else (auth,
 # validation, decoding) propagates unchanged because it indicates the

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 
 import httpx
 
-from ._authed_transport import _PostBody, _stream_post_with_size_cap
+from ._authed_transport import PostBody, stream_post_with_size_cap
 from .auth import AuthTokens, build_cookie_jar
 from .types import ConnectionLimits
 
@@ -96,10 +96,10 @@ class Kernel:
         self,
         url: str,
         headers: Mapping[str, str] | None,
-        body: _PostBody,
+        body: PostBody,
     ) -> httpx.Response:
         """Issue a raw buffered POST through the live HTTP client."""
-        return await _stream_post_with_size_cap(
+        return await stream_post_with_size_cap(
             self.get_http_client(),
             url,
             body=body,

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -108,7 +108,7 @@ class RpcResponse:
     """The buffered :class:`httpx.Response` from the transport leaf.
 
     Identical in shape to what ``AuthedTransport.perform_authed_post``
-    returns today (see ``_authed_transport._stream_post_with_size_cap``):
+    returns today (see ``_authed_transport.stream_post_with_size_cap``):
     fully-buffered body, headers stripped of ``content-encoding`` /
     ``content-length`` so ``.text`` / ``.content`` work synchronously.
     """

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -21,16 +21,16 @@ Why "exactly once": ADR-009 §"Retry semantics" pins
 "**exactly one** retry per ``next_call`` invocation. If the retry also
 raises 401, the exception propagates — no second retry, no recursion."
 ``RetryMiddleware`` outside this middleware does NOT retry on auth
-errors (it catches only ``_TransportRateLimited`` /
-``_TransportServerError``), so a persistent 401 surfaces cleanly to the
+errors (it catches only ``TransportRateLimited`` /
+``TransportServerError``), so a persistent 401 surfaces cleanly to the
 caller without burning the rate-limit / server-error budget on auth
 loops.
 
 Refresh-failure path: if the refresh callback itself raises (network
 flake, login expired, etc.), the middleware wraps the original
-``httpx.HTTPStatusError`` in :class:`_TransportAuthExpired` so callers
+``httpx.HTTPStatusError`` in :class:`TransportAuthExpired` so callers
 that key on the transport exception type still see a coherent shape.
-Matches the pre-PR-12.8 leaf-side ``_TransportAuthExpired`` raise.
+Matches the pre-PR-12.8 leaf-side ``TransportAuthExpired`` raise.
 
 Pre-refresh sleep: when ``refresh_retry_delay > 0`` the middleware sleeps
 that duration AFTER the successful refresh and BEFORE the retry. Matches
@@ -76,7 +76,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
-from ._authed_transport import _TransportAuthExpired
+from ._authed_transport import TransportAuthExpired
 from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._session_config import CORE_LOGGER_NAME
 
@@ -185,7 +185,7 @@ class AuthRefreshMiddleware:
            :class:`AuthRefreshCoordinator`).
         3. Mark ``context["auth_refreshed"] = True`` on success.
         4. If the refresh callable itself raises, wrap in
-           ``_TransportAuthExpired(original=exc)`` and propagate.
+           ``TransportAuthExpired(original=exc)`` and propagate.
         5. Optional post-refresh sleep (``refresh_retry_delay``).
         6. Increment ``rpc_auth_retries`` metric.
         7. Re-invoke ``next_call(request)`` — exactly once. If the retry
@@ -211,7 +211,7 @@ class AuthRefreshMiddleware:
                 await self._refresh_callable()
             except Exception as refresh_error:
                 self._logger.warning("Token refresh failed: %s", refresh_error)
-                raise _TransportAuthExpired(
+                raise TransportAuthExpired(
                     f"auth refresh failed for {log_label}",
                     original=exc,
                 ) from refresh_error

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -22,8 +22,8 @@ the innermost wrapper.
 PR 12.7 lifted the 429 / 5xx retry loops out of the leaf into
 ``RetryMiddleware``; PR 12.8 lifts the auth-refresh-once retry too.
 After PR 12.8 the leaf is a *pure* POST — every retry decision happens
-in the chain. The leaf still raises ``_TransportRateLimited`` /
-``_TransportServerError`` for 429 / 5xx so ``RetryMiddleware`` can
+in the chain. The leaf still raises ``TransportRateLimited`` /
+``TransportServerError`` for 429 / 5xx so ``RetryMiddleware`` can
 catch; raw ``httpx.HTTPStatusError`` (400/401/403) propagates so
 ``AuthRefreshMiddleware`` can catch via ``is_auth_error`` and drive
 refresh-then-retry.

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -29,12 +29,12 @@ middleware is now the only production substitution surface.
 Behavior contract:
 
 - Env var unset → ``await next_call(request)`` unchanged (pass-through).
-- Env var set, mode ``"429"`` → raise :class:`_TransportRateLimited` so the
+- Env var set, mode ``"429"`` → raise :class:`TransportRateLimited` so the
   OUTER ``RetryMiddleware`` retries (restoring ADR-009 §"ErrorInjection
   inside Retry — synthetic transient failures trigger retry"; codex iter-1
   catch on PR 12.7). The raised exception carries the synthetic
   ``Retry-After`` header so the retry honors the rate-limit timing.
-- Env var set, mode ``"5xx"`` → raise :class:`_TransportServerError` so
+- Env var set, mode ``"5xx"`` → raise :class:`TransportServerError` so
   ``RetryMiddleware`` retries with exponential backoff.
 - Env var set, mode ``"expired_csrf"`` (HTTP 400) → raise the raw
   :class:`httpx.HTTPStatusError` so ``AuthRefreshMiddleware`` (outside
@@ -78,9 +78,9 @@ import httpx
 
 from . import _error_injection
 from ._authed_transport import (
-    _parse_retry_after,
-    _TransportRateLimited,
-    _TransportServerError,
+    TransportRateLimited,
+    TransportServerError,
+    parse_retry_after,
 )
 from ._error_injection import ERROR_INJECT_ENV_VAR
 from ._middleware import NextCall, RpcRequest, RpcResponse
@@ -164,9 +164,9 @@ class ErrorInjectionMiddleware:
         # Raise the proper exception for each mode so the OUTER chain
         # middlewares actually fire — restoring ADR-009 §"Chain ordering
         # rationale" end-to-end:
-        # - 429 → ``_TransportRateLimited`` → ``RetryMiddleware`` retries
+        # - 429 → ``TransportRateLimited`` → ``RetryMiddleware`` retries
         #   with Retry-After or exponential backoff
-        # - 5xx → ``_TransportServerError`` → ``RetryMiddleware`` retries
+        # - 5xx → ``TransportServerError`` → ``RetryMiddleware`` retries
         #   with exponential backoff
         # - 400 / expired_csrf → raw ``httpx.HTTPStatusError`` →
         #   ``AuthRefreshMiddleware`` catches via ``is_auth_error``,
@@ -185,15 +185,15 @@ class ErrorInjectionMiddleware:
             response=response,
         )
         if status_code == 429:
-            retry_after = _parse_retry_after(response.headers.get("retry-after"))
-            raise _TransportRateLimited(
+            retry_after = parse_retry_after(response.headers.get("retry-after"))
+            raise TransportRateLimited(
                 f"{log_label} rate-limited (HTTP 429)",
                 retry_after=retry_after,
                 response=response,
                 original=original,
             ) from original
         if 500 <= status_code < 600:
-            raise _TransportServerError(
+            raise TransportServerError(
                 f"{log_label} server error (HTTP {status_code})",
                 original=original,
                 response=response,

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -11,8 +11,8 @@ ships the interim 5-middleware chain
 This PR lifts the **retry-on-429** and **retry-on-5xx/network** loops out
 of ``AuthedTransport.perform_authed_post`` (the chain leaf). After PR
 12.7 the leaf is a single POST attempt that raises
-:class:`_TransportRateLimited` on HTTP 429 or
-:class:`_TransportServerError` on HTTP 5xx / network failures —
+:class:`TransportRateLimited` on HTTP 429 or
+:class:`TransportServerError` on HTTP 5xx / network failures —
 **immediately**, without internal retry. The middleware catches those
 exceptions and decides whether to retry by re-invoking the chain.
 Auth-refresh-and-retry stays in the leaf as a localized loop until PR
@@ -38,8 +38,8 @@ Behavior preservation (vs. pre-PR-12.7):
   produced by ``_idempotency.resolve_effective_disable_internal_retries``
   before chain entry; see ADR-009 §"Per-request behavior").
 - **Same exception types on exhaustion** —
-  :class:`_TransportRateLimited` /
-  :class:`_TransportServerError` re-raised verbatim so
+  :class:`TransportRateLimited` /
+  :class:`TransportServerError` re-raised verbatim so
   ``_chat_transport.chat_aware_authed_post`` (which catches both) sees
   the same shape it always did.
 
@@ -69,7 +69,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from ._authed_transport import _parse_retry_after, _TransportRateLimited, _TransportServerError
+from ._authed_transport import TransportRateLimited, TransportServerError, parse_retry_after
 from ._backoff import compute_backoff_delay
 from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._session_config import CORE_LOGGER_NAME
@@ -182,7 +182,7 @@ class RetryMiddleware:
         while True:
             try:
                 return await next_call(request)
-            except _TransportRateLimited as exc:
+            except TransportRateLimited as exc:
                 rate_limit_max = self._resolve_rate_limit_max()
                 if disable_internal_retries or rate_limit_retries >= rate_limit_max:
                     raise
@@ -196,7 +196,7 @@ class RetryMiddleware:
                 if self._metrics is not None:
                     self._metrics.increment(rpc_rate_limit_retries=1)
                 continue
-            except _TransportServerError as exc:
+            except TransportServerError as exc:
                 server_error_max = self._resolve_server_error_max()
                 if disable_internal_retries or server_error_retries >= server_error_max:
                     raise
@@ -214,7 +214,7 @@ class RetryMiddleware:
     async def _wait_for_rate_limit(
         self,
         *,
-        exc: _TransportRateLimited,
+        exc: TransportRateLimited,
         attempt: int,
         log_label: str,
         rate_limit_max: int,
@@ -222,14 +222,14 @@ class RetryMiddleware:
         """Honor ``Retry-After`` if present; otherwise exponential backoff.
 
         ``Retry-After`` is read from ``exc.retry_after`` — the leaf already
-        parsed it via :func:`_parse_retry_after` when it raised. We accept
+        parsed it via :func:`parse_retry_after` when it raised. We accept
         either the parsed integer (preferred) or fall back to re-parsing
         the header off ``exc.response`` if the parsed value is missing
         (defensive — production always populates ``retry_after``).
         """
         retry_after = exc.retry_after
         if retry_after is None and exc.response is not None:
-            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+            retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
 
         if retry_after is not None:
             sleep_seconds: float = float(retry_after)
@@ -256,7 +256,7 @@ class RetryMiddleware:
     async def _wait_for_server_error(
         self,
         *,
-        exc: _TransportServerError,
+        exc: TransportServerError,
         attempt: int,
         log_label: str,
         server_error_max: int,

--- a/src/notebooklm/_request_types.py
+++ b/src/notebooklm/_request_types.py
@@ -1,23 +1,18 @@
-"""Public-ish request-shape aliases for the Tier-12 middleware chain.
+"""Request-shape exports for the Tier-12 middleware chain.
 
-This module promotes a small set of types that were previously private to
-``_authed_transport.py`` so the Tier-12 middleware chain (introduced in PRs
-12.1–12.9) can refer to them without reaching across underscore-prefixed
-seams. The originals (``_AuthSnapshot`` and ``_BuildRequest`` in
-``_authed_transport.py``) remain in place; this module simply exposes them
-under names without a leading underscore. PR 12.9 collapses the aliases by
-relocating the definitions into this module and deleting the underscore
-originals.
+This module gathers the shared request-construction types used by the
+middleware chain. ``AuthSnapshot`` and ``BuildRequest`` are defined in
+``_authed_transport.py`` and re-exported here for call sites that prefer the
+request-types namespace; ``BuildRequestResult`` is owned here because it is the
+named dataclass shape used by auth-refresh request rebuilding.
 
 Three names live here:
 
 - :data:`AuthSnapshot` — point-in-time view of auth headers used to build
-  one HTTP attempt; alias for :class:`notebooklm._authed_transport._AuthSnapshot`.
-  ADR-009 pins this as the public input type of the
+  one HTTP attempt. ADR-009 pins this as the public input type of the
   ``AuthRefreshMiddleware`` callbacks.
 - :data:`BuildRequest` — sync callable that maps an ``AuthSnapshot`` to a
-  ``(url, body, headers)`` tuple ready for the transport. Alias for the
-  existing ``_BuildRequest`` callable type. The chain leaf in PR 12.2 reads
+  ``(url, body, headers)`` tuple ready for the transport. The chain leaf reads
   the callable from ``RpcRequest.context["build_request"]`` and invokes it
   inside ``AuthedTransport.perform_authed_post``.
 - :class:`BuildRequestResult` — the *named* dataclass form of the same
@@ -26,12 +21,6 @@ Three names live here:
   shape is preferred for new code (named fields, immutable, type-checked
   at construction) over the legacy tuple return. Existing callers continue
   to use the tuple shape until they migrate.
-
-The underscore-prefixed originals (``_AuthSnapshot``, ``_BuildRequest``)
-are imported here too so callers that want the private name during the
-one-cycle transition can write ``from notebooklm._request_types import
-_AuthSnapshot``. They are deliberately excluded from ``__all__`` so
-star-imports do not propagate the private names.
 
 See ``docs/adr/0009-middleware-chain.md`` for the full chain contract and
 ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
@@ -43,25 +32,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-# Re-exported under public names below. The underscore originals are also
-# kept importable from this module (see ``__all__`` note above).
-from ._authed_transport import _AuthSnapshot, _BuildRequest
-
-#: Point-in-time view of auth headers used to build one HTTP attempt.
-#:
-#: Alias for :class:`notebooklm._authed_transport._AuthSnapshot`. The underscore
-#: original remains the canonical definition site for one cycle; PR 12.9
-#: collapses the alias by relocating the dataclass definition here.
-AuthSnapshot = _AuthSnapshot
-
-#: Build-request factory callable type used by the transport and chain leaf.
-#:
-#: Receives a fresh ``AuthSnapshot`` and returns a ``(url, body, headers)``
-#: tuple for one HTTP attempt. Alias for the existing
-#: :data:`notebooklm._authed_transport._BuildRequest` type. Carried in
-#: :attr:`notebooklm._middleware.RpcRequest.context` under the
-#: ``"build_request"`` key (PR 12.2 wires the chain leaf).
-BuildRequest = _BuildRequest
+from ._authed_transport import AuthSnapshot, BuildRequest
 
 
 @dataclass(frozen=True)
@@ -78,7 +49,7 @@ class BuildRequestResult:
     - ``url`` — fully-built ``batchexecute`` URL (including ``authuser`` and
       ``_reqid`` query params).
     - ``body`` — encoded ``batchexecute`` body. Pinned to :class:`bytes` in
-      ADR-009; the legacy ``_BuildRequest`` tuple accepts ``str | bytes`` for
+      ADR-009; the legacy ``BuildRequest`` tuple accepts ``str | bytes`` for
       backward compatibility with existing call sites that build the body as
       a UTF-8 string.
     - ``headers`` — extra headers to merge for this request, or ``None`` when
@@ -94,11 +65,6 @@ class BuildRequestResult:
     headers: Mapping[str, str] | None
 
 
-# Only the public-named symbols are part of the module's documented API.
-# ``_AuthSnapshot`` and ``_BuildRequest`` remain importable from this module
-# (because they are bound at module scope by the ``from ._authed_transport ...``
-# line above) but are excluded from ``__all__`` so ``from notebooklm._request_types
-# import *`` does not propagate the private names.
 __all__ = [
     "AuthSnapshot",
     "BuildRequest",

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
     from ._kernel import Kernel
 
 from ._authed_transport import (
-    _AuthSnapshot,
-    _BuildRequest,
-    _parse_retry_after,
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
+    AuthSnapshot,
+    BuildRequest,
+    TransportAuthExpired,
+    TransportRateLimited,
+    TransportServerError,
+    parse_retry_after,
 )
 from ._env import get_default_language
 from ._idempotency import (
@@ -65,7 +65,7 @@ class RpcOwner(Protocol):
     async def _perform_authed_post(
         self,
         *,
-        build_request: _BuildRequest,
+        build_request: BuildRequest,
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
@@ -252,7 +252,7 @@ class RpcExecutor:
         resolved_id = resolve_rpc_id(method.name, method.value)
         rpc_request = encode_rpc_request(method, params, rpc_id_override=resolved_id)
 
-        def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def _build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             url = self.build_url(method, snapshot, source_path, rpc_id_override=resolved_id)
             body = build_request_body(rpc_request, snapshot.csrf_token)
             return url, body, {}
@@ -264,10 +264,10 @@ class RpcExecutor:
                 disable_internal_retries=effective_disable_internal_retries,
                 rpc_method=method.name,
             )
-        except _TransportAuthExpired as exc:
+        except TransportAuthExpired as exc:
             # Preserve the historical raw transport exception on refresh failure.
             raise exc.original from exc.__cause__
-        except _TransportRateLimited as exc:
+        except TransportRateLimited as exc:
             elapsed = time.perf_counter() - start
             logger.error("RPC %s failed after %.3fs: HTTP 429", method.name, elapsed)
             msg = f"API rate limit exceeded calling {method.name}"
@@ -278,7 +278,7 @@ class RpcExecutor:
                 method_id=method.value,
                 retry_after=exc.retry_after,
             ) from exc.original
-        except _TransportServerError as exc:
+        except TransportServerError as exc:
             elapsed = time.perf_counter() - start
             if isinstance(exc.original, httpx.HTTPStatusError):
                 logger.error(
@@ -299,7 +299,7 @@ class RpcExecutor:
                 self.raise_rpc_error_from_request_error(exc.original, method)
 
             raise TypeError(
-                f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                f"Unexpected TransportServerError.original type: {type(exc.original)}"
             ) from exc
         except httpx.HTTPStatusError as exc:
             elapsed = time.perf_counter() - start
@@ -355,7 +355,7 @@ class RpcExecutor:
     def build_url(
         self,
         rpc_method: RPCMethod,
-        snapshot: _AuthSnapshot,
+        snapshot: AuthSnapshot,
         source_path: str = "/",
         rpc_id_override: str | None = None,
     ) -> str:
@@ -384,7 +384,7 @@ class RpcExecutor:
         status = exc.response.status_code
 
         if status == 429:
-            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+            retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
             msg = f"API rate limit exceeded calling {method.name}"
             if retry_after:
                 msg += f". Retry after {retry_after} seconds"

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -12,8 +12,8 @@ import httpx
 
 from ._authed_transport import (
     AuthedTransport,
-    _AuthSnapshot,
-    _BuildRequest,
+    AuthSnapshot,
+    BuildRequest,
 )
 from ._client_metrics import ClientMetrics
 from ._cookie_persistence import CookiePersistence
@@ -734,7 +734,7 @@ class Session:
         """
         return self._auth_coord.get_refresh_lock()
 
-    async def _snapshot(self) -> _AuthSnapshot:
+    async def _snapshot(self) -> AuthSnapshot:
         """Delegate to :meth:`AuthRefreshCoordinator.snapshot`.
 
         Body lived here pre-PR-8 so the AST guard at
@@ -777,7 +777,7 @@ class Session:
     def _build_url(
         self,
         rpc_method: RPCMethod,
-        snapshot: _AuthSnapshot,
+        snapshot: AuthSnapshot,
         source_path: str = "/",
         rpc_id_override: str | None = None,
     ) -> str:
@@ -828,7 +828,7 @@ class Session:
     async def _perform_authed_post(
         self,
         *,
-        build_request: _BuildRequest,
+        build_request: BuildRequest,
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
@@ -906,7 +906,7 @@ class Session:
 
     async def transport_post(
         self,
-        build_request: _BuildRequest,
+        build_request: BuildRequest,
         parse_label: str,
         *,
         disable_internal_retries: bool = False,

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -50,7 +50,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import httpx
 
-from ._authed_transport import _AuthSnapshot
+from ._authed_transport import AuthSnapshot
 from ._loop_affinity import assert_bound_loop
 from ._session_config import CORE_LOGGER_NAME
 from .auth import AuthTokens
@@ -179,7 +179,7 @@ class AuthRefreshCoordinator:
     # longer a "second body" to keep in sync.
     # ------------------------------------------------------------------
 
-    async def snapshot(self, host: _AuthRefreshHost) -> _AuthSnapshot:
+    async def snapshot(self, host: _AuthRefreshHost) -> AuthSnapshot:
         """Capture the current auth scalars as a frozen snapshot.
 
         Acquires :attr:`_auth_snapshot_lock` for the four scalar reads so a
@@ -199,7 +199,7 @@ class AuthRefreshCoordinator:
         wait_start = time.perf_counter()
         async with self.get_auth_snapshot_lock():
             host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
-            return _AuthSnapshot(
+            return AuthSnapshot(
                 csrf_token=host.auth.csrf_token,
                 session_id=host.auth.session_id,
                 authuser=host.auth.authuser,

--- a/tests/_fixtures/chain.py
+++ b/tests/_fixtures/chain.py
@@ -57,7 +57,7 @@ class FakeAuthedPost:
     arguments arrived. The default return is a minimal
     :class:`httpx.Response` with status 200 and an empty body (no attached
     ``.request``, unlike the production buffered response from
-    ``_stream_post_with_size_cap``) — enough for middlewares that just
+    ``stream_post_with_size_cap``) — enough for middlewares that just
     observe and pass through.
 
     Override the return value by setting :attr:`response` (single fixed

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -827,8 +827,8 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
 # :mod:`notebooklm._session_helpers` for ``is_auth_error`` and the retry
 # middleware for 429/5xx) keys on:
 #
-#   - HTTP 429  -> ``_TransportRateLimited`` -> ``RateLimitError``
-#   - HTTP 5xx  -> ``_TransportServerError`` -> ``ServerError``
+#   - HTTP 429  -> ``TransportRateLimited`` -> ``RateLimitError``
+#   - HTTP 5xx  -> ``TransportServerError`` -> ``ServerError``
 #   - HTTP 400  -> ``is_auth_error()``       -> refresh path + ``AuthError`` on
 #                                               second failure
 #

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -17,7 +17,7 @@ generation. The fix introduces a dedicated ``_auth_snapshot_lock`` that:
 2. The refresh-side mutation block in ``client.refresh_auth`` writes
    ``csrf_token`` + ``session_id`` under the same lock — tiny critical
    section, no awaits inside.
-3. ``_build_url()`` consumes the resulting ``_AuthSnapshot`` rather than
+3. ``_build_url()`` consumes the resulting ``AuthSnapshot`` rather than
    re-reading ``self.auth`` live, so the URL is built from the same
    generation the body was.
 
@@ -278,7 +278,7 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
         f"{len(torn)}/{len(captured)} requests carried mixed-generation auth state. "
         f"Sample: {torn[:5]}. This indicates the (csrf, sid, cookies) triple is no "
         f"longer atomic under refresh — check _snapshot() lock acquisition and that "
-        f"_build_url() consumes _AuthSnapshot rather than reading self.auth live."
+        f"_build_url() consumes AuthSnapshot rather than reading self.auth live."
     )
 
     # The refresh task MUST have completed (otherwise the concurrency

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -197,10 +197,10 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
 
     This test exercises ``_perform_authed_post`` directly with
     ``disable_internal_retries=True`` and verifies the very first 429
-    raises ``_TransportRateLimited`` (which the API layer translates
+    raises ``TransportRateLimited`` (which the API layer translates
     into ``RateLimitError``) without sleeping.
     """
-    from notebooklm._authed_transport import _TransportRateLimited
+    from notebooklm._authed_transport import TransportRateLimited
 
     mock_post = AsyncMock(return_value=_build_429("1"))
 
@@ -215,7 +215,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     def _build_request(_snap):
         return ("https://example.invalid/x", b"body", None)
 
-    with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(_TransportRateLimited):
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(TransportRateLimited):
         await client._session._perform_authed_post(
             build_request=_build_request,
             log_label="test",

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -115,7 +115,7 @@ class TestErrorPaths:
         ``{"error": {"code": 429, ...}}`` body. With the rate-limit retry
         budget set to 0 on the client core, the first 429 surfaces directly
         as :class:`RateLimitError` (the documented mapping in
-        ``_core.py::_TransportRateLimited`` → ``rpc_call`` exception handler).
+        ``_core.py::TransportRateLimited`` → ``rpc_call`` exception handler).
         """
         client = NotebookLMClient(_synthetic_auth())
         # Disable rate-limit retries so the single synthetic 429 in the
@@ -154,7 +154,7 @@ class TestErrorPaths:
         returns HTTP 500 with a minimal ``{"error": {"code": 500, ...}}`` body.
         With the server-error retry budget set to 0 on the client core, the
         first 500 surfaces as :class:`ServerError` via the
-        ``_TransportServerError`` → ``_raise_rpc_error_from_http_status`` chain
+        ``TransportServerError`` → ``_raise_rpc_error_from_http_status`` chain
         in ``_core.py``.
         """
         client = NotebookLMClient(_synthetic_auth())

--- a/tests/integration/test_gzip_cassette_replay.py
+++ b/tests/integration/test_gzip_cassette_replay.py
@@ -1,4 +1,4 @@
-"""Replay a gzipped cassette through ``_stream_post_with_size_cap``.
+"""Replay a gzipped cassette through ``stream_post_with_size_cap``.
 
 #769 was a real production bug — every RPC failed with ``Error -3 while
 decompressing data: incorrect header check`` — that slipped through the
@@ -29,7 +29,7 @@ import httpx
 import pytest
 import vcr
 
-from notebooklm._authed_transport import _stream_post_with_size_cap
+from notebooklm._authed_transport import stream_post_with_size_cap
 
 # Required by the tier-enforcement rule in :mod:`tests.integration.conftest`
 # — every integration test must carry ``@pytest.mark.vcr``, be decorated
@@ -95,7 +95,7 @@ async def test_gzipped_cassette_replays_without_double_decode() -> None:
     """
     with _gzip_replay_vcr.use_cassette("artifacts_revise_slide_gzipped.yaml"):
         async with httpx.AsyncClient() as client:
-            response = await _stream_post_with_size_cap(
+            response = await stream_post_with_size_cap(
                 client,
                 _REVISE_SLIDE_URL,
                 body=_REVISE_SLIDE_BODY,

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -510,7 +510,7 @@ class TestBuildUrlHL:
     This is the load-bearing site for setting the interface language on
     every RPC call.
 
-    ``_build_url`` now requires an ``_AuthSnapshot`` (consumes
+    ``_build_url`` now requires an ``AuthSnapshot`` (consumes
     ``session_id`` / ``authuser`` / ``account_email`` from it rather
     than reading ``self.auth`` live). Tests construct a snapshot inline
     from the fixture's ``AuthTokens`` so the URL-construction logic is
@@ -519,9 +519,9 @@ class TestBuildUrlHL:
 
     @staticmethod
     def _snapshot_for(core):
-        from notebooklm._authed_transport import _AuthSnapshot
+        from notebooklm._authed_transport import AuthSnapshot
 
-        return _AuthSnapshot(
+        return AuthSnapshot(
             csrf_token=core.auth.csrf_token,
             session_id=core.auth.session_id,
             authuser=core.auth.authuser,

--- a/tests/scripts/inject_gzip_into_cassette.py
+++ b/tests/scripts/inject_gzip_into_cassette.py
@@ -9,7 +9,7 @@ Why this exists
 gunzips the body), so 89/89 cassettes in ``tests/cassettes/`` carry NO
 encoding header and a plaintext body. That hid issue #769 — every RPC
 failed in production with ``Error -3 while decompressing data: incorrect
-header check`` because :func:`notebooklm._authed_transport._stream_post_with_size_cap`
+header check`` because :func:`notebooklm._authed_transport.stream_post_with_size_cap`
 rebuilt the response with the upstream ``Content-Encoding: gzip`` header
 attached to *already-decoded* body bytes, triggering a second gzip-decode
 inside :class:`httpx.Response.__init__`. Cassettes that don't carry the
@@ -160,7 +160,7 @@ def inject_gzip_into_cassette(cassette: dict[str, Any]) -> int:
 
     Only responses whose request is a POST to a path containing
     ``batchexecute`` are touched — those are the ones that flow through
-    :func:`notebooklm._authed_transport._stream_post_with_size_cap` and
+    :func:`notebooklm._authed_transport.stream_post_with_size_cap` and
     exercise the rebuild step that bit #769. SPA-shell GET responses are
     left alone so the cassette diff stays focused.
 

--- a/tests/unit/test_auth_refresh_middleware.py
+++ b/tests/unit/test_auth_refresh_middleware.py
@@ -4,8 +4,8 @@ Pins the contract documented in ``src/notebooklm/_middleware_auth_refresh.py``
 and ADR-009 §"Chain ordering":
 
 - **Pass-through on success.** Single ``next_call``; result returned.
-- **Pass-through on non-auth exception.** ``_TransportRateLimited`` /
-  ``_TransportServerError`` propagate to ``RetryMiddleware`` outside.
+- **Pass-through on non-auth exception.** ``TransportRateLimited`` /
+  ``TransportServerError`` propagate to ``RetryMiddleware`` outside.
 - **Pass-through when no refresh callback configured.** The
   ``refresh_callback_enabled`` gate matches the legacy
   ``host._refresh_callback is not None`` check.
@@ -14,7 +14,7 @@ and ADR-009 §"Chain ordering":
   callable runs (coalesced single-flight) → optional post-refresh sleep
   → metric increment → exactly one retry via ``next_call(request)``.
 - **Refresh failure** → wrap original ``HTTPStatusError`` in
-  ``_TransportAuthExpired`` and propagate.
+  ``TransportAuthExpired`` and propagate.
 - **Exactly one retry.** Per ADR-009 §"Retry semantics", a second auth
   error on the retry leg propagates — no second refresh, no recursion.
 - **Post-refresh sleep honored** when ``refresh_retry_delay > 0``.
@@ -43,9 +43,9 @@ import pytest
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
 from notebooklm._authed_transport import (
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
+    TransportAuthExpired,
+    TransportRateLimited,
+    TransportServerError,
 )
 from notebooklm._client_metrics import ClientMetrics
 from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
@@ -128,9 +128,9 @@ async def test_passes_through_on_success() -> None:
 
 @pytest.mark.asyncio
 async def test_passes_through_on_rate_limited() -> None:
-    """``_TransportRateLimited`` propagates to ``RetryMiddleware`` outside."""
+    """``TransportRateLimited`` propagates to ``RetryMiddleware`` outside."""
     request = httpx.Request("POST", "https://example.test/x")
-    boom = _TransportRateLimited(
+    boom = TransportRateLimited(
         "rate limited",
         retry_after=1,
         response=httpx.Response(429, request=request),
@@ -140,7 +140,7 @@ async def test_passes_through_on_rate_limited() -> None:
     middleware = _make_middleware()
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportRateLimited) as excinfo:
+    with pytest.raises(TransportRateLimited) as excinfo:
         await chain(make_request())
 
     assert excinfo.value is boom
@@ -149,9 +149,9 @@ async def test_passes_through_on_rate_limited() -> None:
 
 @pytest.mark.asyncio
 async def test_passes_through_on_server_error() -> None:
-    """``_TransportServerError`` propagates."""
+    """``TransportServerError`` propagates."""
     request = httpx.Request("POST", "https://example.test/x")
-    boom = _TransportServerError(
+    boom = TransportServerError(
         "server error",
         original=httpx.HTTPStatusError("HTTP 503", request=request, response=httpx.Response(503)),
     )
@@ -159,7 +159,7 @@ async def test_passes_through_on_server_error() -> None:
     middleware = _make_middleware()
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportServerError) as excinfo:
+    with pytest.raises(TransportServerError) as excinfo:
         await chain(make_request())
 
     assert excinfo.value is boom
@@ -290,13 +290,13 @@ async def test_refresh_retry_delay_zero_skips_sleep() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Refresh failure → _TransportAuthExpired
+# Refresh failure → TransportAuthExpired
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_refresh_failure_raises_transport_auth_expired() -> None:
-    """Refresh callable raises → wrap in ``_TransportAuthExpired``."""
+    """Refresh callable raises → wrap in ``TransportAuthExpired``."""
     boom = _auth_error(status=401)
     terminal, calls = _scripted_terminal([boom])  # only one attempt — refresh fails before retry
     refresh_error = RuntimeError("refresh blew up")
@@ -307,7 +307,7 @@ async def test_refresh_failure_raises_transport_auth_expired() -> None:
     middleware = _make_middleware(refresh_callable=refresh)
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportAuthExpired) as excinfo:
+    with pytest.raises(TransportAuthExpired) as excinfo:
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     assert excinfo.value.original is boom
@@ -441,7 +441,7 @@ async def test_metrics_not_incremented_on_refresh_failure() -> None:
     middleware = _make_middleware(refresh_callable=refresh, metrics=metrics)
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportAuthExpired):
+    with pytest.raises(TransportAuthExpired):
         await chain(make_request())
 
     assert metrics.snapshot().rpc_auth_retries == 0
@@ -488,7 +488,7 @@ async def test_log_shape_on_refresh_failure(caplog: pytest.LogCaptureFixture) ->
 
     with (
         caplog.at_level("WARNING", logger="notebooklm._core"),
-        pytest.raises(_TransportAuthExpired),
+        pytest.raises(TransportAuthExpired),
     ):
         await chain(make_request())
 

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -5,12 +5,12 @@ extracted from ``_rpc_call_impl``:
 
 - ``build_request`` factory is called once per HTTP attempt.
 - On a single auth-error retry, the factory is called TWICE, and the second
-  invocation observes a fresh ``_AuthSnapshot`` capturing whatever the
+  invocation observes a fresh ``AuthSnapshot`` capturing whatever the
   refresh callback mutated.
 - The request-id correlation tag (``[req=<id>]``) is stable across the retry
   chain.
 - ``rate_limit_max_retries`` bounds 429 retries; exhausting the budget
-  raises ``_TransportRateLimited``.
+  raises ``TransportRateLimited``.
 - The historical ``rpc_call`` happy path is unchanged byte-for-byte
   (URL + body identical to pre-extraction).
 
@@ -33,10 +33,10 @@ import pytest
 from conftest import install_post_as_stream
 from notebooklm._authed_transport import (
     AuthedTransport,
-    _AuthSnapshot,
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
+    AuthSnapshot,
+    TransportAuthExpired,
+    TransportRateLimited,
+    TransportServerError,
 )
 from notebooklm._logging import get_request_id
 from notebooklm._middleware import RpcRequest, RpcResponse
@@ -131,7 +131,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
         # through Python's module identity.
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -158,7 +158,7 @@ async def test_authed_transport_requires_open_client():
     core = _make_core()
     transport = core._get_authed_transport()
 
-    def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+    def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
         return "https://example.test/x", "payload", {}
 
     with pytest.raises(RuntimeError, match="Client not initialized"):
@@ -261,7 +261,7 @@ async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
     await core.open()
     try:
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -310,7 +310,7 @@ async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
         monkeypatch.setattr("notebooklm._session.random.uniform", lambda a, b: 0.2)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -345,7 +345,7 @@ async def test_authed_transport_disable_internal_retries_short_circuits(monkeypa
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -356,7 +356,7 @@ async def test_authed_transport_disable_internal_retries_short_circuits(monkeypa
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await transport.perform_authed_post(
                 build_request=build,
                 log_label="test",
@@ -374,9 +374,9 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
     core = _make_core()
     await core.open()
     try:
-        calls: list[_AuthSnapshot] = []
+        calls: list[AuthSnapshot] = []
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             calls.append(snapshot)
             return "https://example.test/x", "payload", {}
 
@@ -412,9 +412,9 @@ async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch
     core = _make_core(refresh_callback=refresh)
     await core.open()
     try:
-        snapshots: list[_AuthSnapshot] = []
+        snapshots: list[AuthSnapshot] = []
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             snapshots.append(snapshot)
             return "https://example.test/x", f"body-{snapshot.csrf_token}", {}
 
@@ -456,7 +456,7 @@ async def test_transport_auth_expired_when_refresh_fails(monkeypatch):
     await core.open()
     try:
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         original = _status_error(401)
@@ -466,7 +466,7 @@ async def test_transport_auth_expired_when_refresh_fails(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportAuthExpired) as exc_info:
+        with pytest.raises(TransportAuthExpired) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         assert exc_info.value.original is original
@@ -488,7 +488,7 @@ async def test_429_retries_exhaust_to_transport_rate_limited(monkeypatch):
 
         monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -499,7 +499,7 @@ async def test_429_retries_exhaust_to_transport_rate_limited(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportRateLimited) as exc_info:
+        with pytest.raises(TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # Initial attempt + 2 retries = 3 total POSTs.
@@ -516,7 +516,7 @@ async def test_429_without_retry_budget_raises_immediately(monkeypatch):
     await core.open()
     try:
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         async def fake_post(*args, **kwargs):
@@ -524,7 +524,7 @@ async def test_429_without_retry_budget_raises_immediately(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportRateLimited) as exc_info:
+        with pytest.raises(TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         assert exc_info.value.retry_after == 60
@@ -547,7 +547,7 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
     try:
         observed_request_ids: list[str | None] = []
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             observed_request_ids.append(get_request_id())
             return "https://example.test/x", "payload", {}
 
@@ -646,7 +646,7 @@ async def test_5xx_retries_then_succeeds(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -671,7 +671,7 @@ async def test_5xx_retries_then_succeeds(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
-    """Persistent 502 with budget=3 → 4 total attempts, then _TransportServerError."""
+    """Persistent 502 with budget=3 → 4 total attempts, then TransportServerError."""
     core = _make_core(server_error_max_retries=3)
     await core.open()
     try:
@@ -682,7 +682,7 @@ async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -693,7 +693,7 @@ async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError) as exc_info:
+        with pytest.raises(TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # Initial + 3 retries = 4 total attempts.
@@ -719,7 +719,7 @@ async def test_network_error_retries_then_succeeds(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -743,7 +743,7 @@ async def test_network_error_retries_then_succeeds(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_network_error_exhausts_budget_raises_transport_server_error(monkeypatch):
-    """Repeated httpx.ConnectError → exhausts budget → _TransportServerError
+    """Repeated httpx.ConnectError → exhausts budget → TransportServerError
     wrapping the underlying RequestError (status_code/response are None)."""
     core = _make_core(server_error_max_retries=2)
     await core.open()
@@ -755,7 +755,7 @@ async def test_network_error_exhausts_budget_raises_transport_server_error(monke
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         async def fake_post(*args, **kwargs):
@@ -763,7 +763,7 @@ async def test_network_error_exhausts_budget_raises_transport_server_error(monke
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError) as exc_info:
+        with pytest.raises(TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # Initial + 2 retries = 3 attempts; 2 sleeps (1, 2).
@@ -788,7 +788,7 @@ async def test_server_error_budget_zero_raises_immediately(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         call_count = {"n": 0}
@@ -799,7 +799,7 @@ async def test_server_error_budget_zero_raises_immediately(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError) as exc_info:
+        with pytest.raises(TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # Exactly one attempt, no sleep.
@@ -823,7 +823,7 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         async def fake_post(*args, **kwargs):
@@ -831,7 +831,7 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # min(2 ** attempt, 30) for attempt in 0..7 → 1, 2, 4, 8, 16, 30, 30, 30.
@@ -854,7 +854,7 @@ async def test_5xx_path_does_not_touch_429_path(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         async def fake_post(*args, **kwargs):
@@ -862,7 +862,7 @@ async def test_5xx_path_does_not_touch_429_path(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportRateLimited) as exc_info:
+        with pytest.raises(TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
 
         # 429-path sleep uses Retry-After (5), NOT exponential backoff.
@@ -894,7 +894,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
 
         monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
 
         async def fake_post(*args, **kwargs):
@@ -902,7 +902,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await core._perform_authed_post(build_request=build, log_label="test")
 
         assert refresh_calls == []
@@ -911,7 +911,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# rpc_call wrapper for _TransportServerError
+# rpc_call wrapper for TransportServerError
 # ---------------------------------------------------------------------------
 
 
@@ -998,7 +998,7 @@ async def test_streamed_response_size_cap(monkeypatch):
     """
     from contextlib import asynccontextmanager
 
-    from notebooklm._authed_transport import _stream_post_with_size_cap
+    from notebooklm._authed_transport import stream_post_with_size_cap
     from notebooklm.exceptions import RPCResponseTooLargeError
 
     cap = 1024  # 1 KiB cap so the test stays fast and small.
@@ -1031,7 +1031,7 @@ async def test_streamed_response_size_cap(monkeypatch):
         monkeypatch.setattr(client, "stream", fake_stream)
 
         with pytest.raises(RPCResponseTooLargeError) as exc_info:
-            await _stream_post_with_size_cap(
+            await stream_post_with_size_cap(
                 client,
                 "https://example.test/x",
                 body=b"",
@@ -1054,7 +1054,7 @@ async def test_normal_response_below_cap_works(monkeypatch):
     """A normal-sized response decodes through the streaming wrapper unchanged."""
     from contextlib import asynccontextmanager
 
-    from notebooklm._authed_transport import _stream_post_with_size_cap
+    from notebooklm._authed_transport import stream_post_with_size_cap
 
     payload = b"hello world" * 1000  # ~11 KB, well under the 50 MiB default
 
@@ -1079,7 +1079,7 @@ async def test_normal_response_below_cap_works(monkeypatch):
     try:
         monkeypatch.setattr(client, "stream", fake_stream)
 
-        response = await _stream_post_with_size_cap(
+        response = await stream_post_with_size_cap(
             client,
             "https://example.test/x",
             body=b"",
@@ -1101,7 +1101,7 @@ async def test_streaming_raise_for_status_propagates_before_size_check(monkeypat
     auth-refresh / 429 / 5xx branches see the same error they always did."""
     from contextlib import asynccontextmanager
 
-    from notebooklm._authed_transport import _stream_post_with_size_cap
+    from notebooklm._authed_transport import stream_post_with_size_cap
 
     chunk_reads = 0
 
@@ -1135,7 +1135,7 @@ async def test_streaming_raise_for_status_propagates_before_size_check(monkeypat
         monkeypatch.setattr(client, "stream", fake_stream)
 
         with pytest.raises(httpx.HTTPStatusError):
-            await _stream_post_with_size_cap(
+            await stream_post_with_size_cap(
                 client,
                 "https://example.test/x",
                 body=b"",
@@ -1184,7 +1184,7 @@ async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkey
         pytest.importorskip("zstandard")
     from contextlib import asynccontextmanager
 
-    from notebooklm._authed_transport import _stream_post_with_size_cap
+    from notebooklm._authed_transport import stream_post_with_size_cap
 
     # Realistic batchexecute prefix; only the bytes matter, not the framing.
     decoded_payload = b')]}\'\n\n[["wrb.fr",null,"[1]",null,null,null,"generic"]]'
@@ -1217,7 +1217,7 @@ async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkey
         monkeypatch.setattr(client, "stream", fake_stream)
 
         # Pre-fix this call raised httpx.DecodingError during Response.__init__.
-        response = await _stream_post_with_size_cap(
+        response = await stream_post_with_size_cap(
             client,
             "https://example.test/x",
             body=b"",

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -555,7 +555,7 @@ def test_audit_repair_list_entries_exist() -> None:
 # ``Content-Encoding`` from every recorded response. Pre-#751 that was fine
 # because the response went through ``client.post`` once and decoded
 # exactly once; #751 introduced the streaming rebuild path in
-# :func:`notebooklm._authed_transport._stream_post_with_size_cap`, and the
+# :func:`notebooklm._authed_transport.stream_post_with_size_cap`, and the
 # combination of an upstream gzip header re-applied to already-decoded
 # bytes is what bit #769 in production. The existing cassette suite
 # couldn't surface that regression because no cassette carried the
@@ -613,7 +613,7 @@ def test_at_least_one_cassette_advertises_content_encoding_gzip() -> None:
     assert matches, (
         "No cassette under tests/cassettes/ advertises Content-Encoding: gzip "
         "on any response. The streaming rebuild path in "
-        "notebooklm._authed_transport._stream_post_with_size_cap is invisible to "
+        "notebooklm._authed_transport.stream_post_with_size_cap is invisible to "
         "VCR replay without it (see #769/#771). Regenerate the gzip-coverage "
         "cassette(s) via:\n"
         "    uv run python tests/scripts/inject_gzip_into_cassette.py "

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -30,7 +30,7 @@ import pytest
 
 from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
-from notebooklm._authed_transport import _AuthSnapshot
+from notebooklm._authed_transport import AuthSnapshot
 from notebooklm._chat import ChatAPI
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
@@ -254,7 +254,7 @@ class TestChatReqid:
 
 class TestChatRefreshRetry:
     """Snapshot-per-attempt invariant: ``build_request`` is invoked once
-    per attempt with a *fresh* ``_AuthSnapshot``, so the retry body carries
+    per attempt with a *fresh* ``AuthSnapshot``, so the retry body carries
     the post-refresh CSRF token rather than replaying the stale pre-refresh
     body."""
 
@@ -428,7 +428,7 @@ class TestBuildChatRequestFactory:
 
     def test_build_request_omits_authuser_for_default_profile(self):
         chat = self._factory()
-        snapshot = _AuthSnapshot(
+        snapshot = AuthSnapshot(
             csrf_token="csrf",
             session_id="sid",
             authuser=0,
@@ -450,7 +450,7 @@ class TestBuildChatRequestFactory:
 
     def test_build_request_authuser_email_wins_over_index(self):
         chat = self._factory()
-        snapshot = _AuthSnapshot(
+        snapshot = AuthSnapshot(
             csrf_token="csrf",
             session_id="sid",
             authuser=5,
@@ -470,7 +470,7 @@ class TestBuildChatRequestFactory:
 
     def test_build_request_omits_at_when_csrf_blank(self):
         chat = self._factory()
-        snapshot = _AuthSnapshot(
+        snapshot = AuthSnapshot(
             csrf_token="",
             session_id="sid",
             authuser=0,
@@ -489,7 +489,7 @@ class TestBuildChatRequestFactory:
 
     def test_build_request_source_encoding_is_triple_nested(self):
         chat = self._factory()
-        snapshot = _AuthSnapshot(
+        snapshot = AuthSnapshot(
             csrf_token="csrf",
             session_id="sid",
             authuser=0,

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -32,9 +32,9 @@ import httpx
 import pytest
 
 from notebooklm._authed_transport import (
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
+    TransportAuthExpired,
+    TransportRateLimited,
+    TransportServerError,
 )
 from notebooklm._chat_transport import chat_aware_authed_post
 from notebooklm.exceptions import ChatError, NetworkError
@@ -109,14 +109,14 @@ async def test_chat_aware_authed_post_returns_response_and_balances_bookkeeping(
 
 
 # ---------------------------------------------------------------------------
-# _TransportAuthExpired → ChatError
+# TransportAuthExpired → ChatError
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_transport_auth_expired_maps_to_chat_error():
     original = _make_status_error(401)
-    transport_exc = _TransportAuthExpired("auth refresh failed", original=original)
+    transport_exc = TransportAuthExpired("auth refresh failed", original=original)
     session = _make_stub_session(transport_side_effect=transport_exc)
 
     with pytest.raises(ChatError) as excinfo:
@@ -132,7 +132,7 @@ async def test_transport_auth_expired_maps_to_chat_error():
 
 
 # ---------------------------------------------------------------------------
-# _TransportRateLimited → ChatError
+# TransportRateLimited → ChatError
 # ---------------------------------------------------------------------------
 
 
@@ -140,7 +140,7 @@ async def test_transport_auth_expired_maps_to_chat_error():
 async def test_transport_rate_limited_with_retry_after_includes_retry_seconds():
     original = _make_status_error(429, retry_after="42")
     response = original.response
-    transport_exc = _TransportRateLimited(
+    transport_exc = TransportRateLimited(
         "rate-limited",
         retry_after=42,
         response=response,
@@ -166,7 +166,7 @@ async def test_transport_rate_limited_with_retry_after_includes_retry_seconds():
 async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
     original = _make_status_error(429)
     response = original.response
-    transport_exc = _TransportRateLimited(
+    transport_exc = TransportRateLimited(
         "rate-limited",
         retry_after=None,
         response=response,
@@ -189,14 +189,14 @@ async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
 
 
 # ---------------------------------------------------------------------------
-# _TransportServerError variants
+# TransportServerError variants
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_transport_server_error_with_http_status_error_maps_to_chat_error():
     original = _make_status_error(503)
-    transport_exc = _TransportServerError(
+    transport_exc = TransportServerError(
         "5xx after retries",
         original=original,
         response=original.response,
@@ -220,7 +220,7 @@ async def test_transport_server_error_with_http_status_error_maps_to_chat_error(
 @pytest.mark.asyncio
 async def test_transport_server_error_with_request_error_maps_to_network_error():
     original = httpx.RequestError("connect failed", request=_make_request())
-    transport_exc = _TransportServerError("network failure", original=original)
+    transport_exc = TransportServerError("network failure", original=original)
     session = _make_stub_session(transport_side_effect=transport_exc)
 
     with pytest.raises(NetworkError) as excinfo:
@@ -243,7 +243,7 @@ async def test_transport_server_error_with_timeout_exception_keeps_timeout_messa
     ``httpx.RequestError``; without the explicit timeout branch the message
     would collapse to the generic "network error after retries" line."""
     original = httpx.ReadTimeout("read timed out", request=_make_request())
-    transport_exc = _TransportServerError("timeout", original=original)
+    transport_exc = TransportServerError("timeout", original=original)
     session = _make_stub_session(transport_side_effect=transport_exc)
 
     with pytest.raises(NetworkError) as excinfo:
@@ -263,7 +263,7 @@ async def test_transport_server_error_with_timeout_exception_keeps_timeout_messa
 @pytest.mark.asyncio
 async def test_transport_server_error_with_unexpected_original_type_raises_type_error():
     """Defensive: the transport layer should only wrap
-    ``HTTPStatusError`` / ``RequestError`` into ``_TransportServerError``.
+    ``HTTPStatusError`` / ``RequestError`` into ``TransportServerError``.
     Anything else surfaces as ``TypeError`` so an invariant drift is loud
     rather than silently mis-mapped."""
 
@@ -271,7 +271,7 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
         pass
 
     original = _UnexpectedException("not http, not request")
-    transport_exc = _TransportServerError("bogus original", original=original)
+    transport_exc = TransportServerError("bogus original", original=original)
     session = _make_stub_session(transport_side_effect=transport_exc)
 
     with pytest.raises(TypeError) as excinfo:
@@ -282,7 +282,7 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
         )
 
     message = str(excinfo.value)
-    assert "_TransportServerError.original" in message
+    assert "TransportServerError.original" in message
     # The diagnostic must include both the actual type and the expected
     # types so a future invariant drift produces an actionable error
     # (per gemini-code-assist review on PR #832).

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -929,16 +929,16 @@ class TestRpcCallAutoRetry:
 class TestBuildUrlAuthuser:
     """Regression for #359: batchexecute URL routes non-default profiles.
 
-    ``_build_url`` consumes an ``_AuthSnapshot`` rather than reading
+    ``_build_url`` consumes an ``AuthSnapshot`` rather than reading
     ``self.auth`` live, so each test constructs the snapshot
     inline from its ``AuthTokens`` fixture.
     """
 
     @staticmethod
     def _snapshot_for(core):
-        from notebooklm._authed_transport import _AuthSnapshot
+        from notebooklm._authed_transport import AuthSnapshot
 
-        return _AuthSnapshot(
+        return AuthSnapshot(
             csrf_token=core.auth.csrf_token,
             session_id=core.auth.session_id,
             authuser=core.auth.authuser,

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -22,7 +22,7 @@ The auth-snapshot lock hardened the invariant by:
   observed atomically with respect to ``refresh_auth``'s
   write-block; and
 - refactoring ``_build_url()`` to consume the resulting
-  ``_AuthSnapshot`` rather than reading ``self.auth`` LIVE — that
+  ``AuthSnapshot`` rather than reading ``self.auth`` LIVE — that
   prior live-read was the actual torn-read hazard, since it let a
   refresh's write to ``self.auth.session_id`` slip into the URL between
   snapshot capture and request build.
@@ -39,7 +39,7 @@ This file *locks* the invariant in three ways:
 2. ``test_build_url_does_not_read_self_auth`` — static AST guard
    against any ``self.auth.<field>`` attribute access in
    ``RpcExecutor.build_url``. The method MUST consume only its
-   ``snapshot: _AuthSnapshot`` parameter; reverting to ``self.auth``
+   ``snapshot: AuthSnapshot`` parameter; reverting to ``self.auth``
    would silently un-do the atomicity fix.
 
 3. ``test_concurrent_refresh_does_not_corrupt_inflight_rpc_request`` —
@@ -143,7 +143,7 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
 
         Accepts either historical shape:
         - ``await client.post(...)`` (pre-streaming),
-        - ``await _stream_post_with_size_cap(...)`` (the helper performs the
+        - ``await stream_post_with_size_cap(...)`` (the helper performs the
           streaming POST internally, so it's the same conceptual POST site for
           the purposes of this concurrency invariant).
         """
@@ -155,7 +155,7 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
         func = call.func
         if isinstance(func, ast.Attribute) and func.attr == "post":
             return True
-        return isinstance(func, ast.Name) and func.id == "_stream_post_with_size_cap"
+        return isinstance(func, ast.Name) and func.id == "stream_post_with_size_cap"
 
     def _walk_outer(parent):
         """Yield nodes lexically inside ``parent`` itself (skip nested defs).
@@ -222,7 +222,7 @@ def test_build_url_does_not_read_self_auth():
     — producing a request whose URL was stamped with the *new*
     generation while the body still carried the *old* CSRF.
 
-    The fix made ``_build_url`` accept ``snapshot: _AuthSnapshot`` and
+    The fix made ``_build_url`` accept ``snapshot: AuthSnapshot`` and
     read every auth scalar off the snapshot. This guard asserts that
     contract statically so a future "convenience" refactor (e.g.
     "let's just read ``self.auth`` again, it's right there") can't

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -72,11 +72,11 @@ def test_core_build_url_uses_enterprise_base_url(monkeypatch):
     monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
     core = Session(AuthTokens(cookies={}, csrf_token="csrf", session_id="sid"))
 
-    # ``_build_url`` consumes an ``_AuthSnapshot`` so callers
+    # ``_build_url`` consumes an ``AuthSnapshot`` so callers
     # outside ``_perform_authed_post`` must build one inline.
-    from notebooklm._authed_transport import _AuthSnapshot
+    from notebooklm._authed_transport import AuthSnapshot
 
-    snapshot = _AuthSnapshot(
+    snapshot = AuthSnapshot(
         csrf_token=core.auth.csrf_token,
         session_id=core.auth.session_id,
         authuser=core.auth.authuser,

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -7,8 +7,8 @@ and ADR-009 §"Chain ordering":
   to ``next_call``; production behavior is byte-for-byte unchanged.
 - **Raise transport exceptions for 429 / 5xx (PR 12.7).** When the env var
   resolves to ``"429"`` the middleware raises
-  :class:`_TransportRateLimited` (carrying the synthetic ``Retry-After``);
-  ``"5xx"`` raises :class:`_TransportServerError`. This is the contract
+  :class:`TransportRateLimited` (carrying the synthetic ``Retry-After``);
+  ``"5xx"`` raises :class:`TransportServerError`. This is the contract
   that lets the OUTER ``RetryMiddleware`` retry, restoring ADR-009
   §"ErrorInjection inside Retry — synthetic transient failures trigger
   retry" (codex iter-1 catch on PR 12.7).
@@ -40,7 +40,7 @@ import pytest
 # pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
-from notebooklm._authed_transport import _TransportRateLimited, _TransportServerError
+from notebooklm._authed_transport import TransportRateLimited, TransportServerError
 from notebooklm._error_injection import ERROR_INJECT_ENV_VAR
 from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
 from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
@@ -122,7 +122,7 @@ async def test_passes_through_when_env_var_unknown_mode(
 
 
 # ---------------------------------------------------------------------------
-# 429 → raise _TransportRateLimited
+# 429 → raise TransportRateLimited
 # ---------------------------------------------------------------------------
 
 
@@ -130,7 +130,7 @@ async def test_passes_through_when_env_var_unknown_mode(
 async def test_429_mode_raises_transport_rate_limited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``429`` mode raises :class:`_TransportRateLimited` for ``RetryMiddleware``.
+    """``429`` mode raises :class:`TransportRateLimited` for ``RetryMiddleware``.
 
     Restores ADR-009 §"ErrorInjection inside Retry — synthetic transient
     failures trigger retry" (codex iter-1 catch on PR 12.7). The raised
@@ -142,7 +142,7 @@ async def test_429_mode_raises_transport_rate_limited(
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportRateLimited) as excinfo:
+    with pytest.raises(TransportRateLimited) as excinfo:
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     assert calls == []
@@ -163,7 +163,7 @@ async def test_429_response_carries_synthetic_request_url_and_body(
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
-    with pytest.raises(_TransportRateLimited) as excinfo:
+    with pytest.raises(TransportRateLimited) as excinfo:
         await chain(make_request(url=custom_url, body=b"chain-body"))
 
     response = excinfo.value.response
@@ -175,7 +175,7 @@ async def test_429_response_carries_synthetic_request_url_and_body(
 
 
 # ---------------------------------------------------------------------------
-# 5xx → raise _TransportServerError
+# 5xx → raise TransportServerError
 # ---------------------------------------------------------------------------
 
 
@@ -183,13 +183,13 @@ async def test_429_response_carries_synthetic_request_url_and_body(
 async def test_5xx_mode_raises_transport_server_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``5xx`` mode raises :class:`_TransportServerError` for ``RetryMiddleware``."""
+    """``5xx`` mode raises :class:`TransportServerError` for ``RetryMiddleware``."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportServerError) as excinfo:
+    with pytest.raises(TransportServerError) as excinfo:
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     assert calls == []
@@ -264,7 +264,7 @@ async def test_retry_outside_error_injection_retries_synthetic_429(
     """End-to-end: chain ``[Retry, ErrorInjection]`` retries synthetic 429s.
 
     This is the codex iter-1 catch: without ErrorInjection raising
-    :class:`_TransportRateLimited`, the synthetic 429 flowed back as a
+    :class:`TransportRateLimited`, the synthetic 429 flowed back as a
     returned response and Retry never saw it. With the exception-raising
     fix, Retry catches and retries N times before re-raising.
     """
@@ -286,7 +286,7 @@ async def test_retry_outside_error_injection_retries_synthetic_429(
         [retry, error_injection], _static_terminal(httpx.Response(200, content=b"x"))
     )
 
-    with pytest.raises(_TransportRateLimited):
+    with pytest.raises(TransportRateLimited):
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     # 1 initial + 2 retries → 2 sleeps observed.
@@ -318,7 +318,7 @@ async def test_retry_outside_error_injection_retries_synthetic_5xx(
         [retry, error_injection], _static_terminal(httpx.Response(200, content=b"x"))
     )
 
-    with pytest.raises(_TransportServerError):
+    with pytest.raises(TransportServerError):
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     # 1 initial + 1 retry → 1 sleep observed.
@@ -444,12 +444,12 @@ async def test_builder_loaded_once_across_calls(
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     assert middleware._builder is None
-    with pytest.raises(_TransportRateLimited):
+    with pytest.raises(TransportRateLimited):
         await chain(make_request())
     first = middleware._builder
     assert first is not None
 
-    with pytest.raises(_TransportRateLimited):
+    with pytest.raises(TransportRateLimited):
         await chain(make_request())
     assert middleware._builder is first  # same object — no re-load
 
@@ -477,7 +477,7 @@ async def test_activation_flip_between_calls_is_observed(
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
 
     # Call 2: short-circuit (now raises), leaf NOT reached again.
-    with pytest.raises(_TransportServerError):
+    with pytest.raises(TransportServerError):
         await chain(make_request())
     assert len(calls) == 1  # still 1 — leaf was bypassed on second call
 
@@ -517,7 +517,7 @@ async def test_monkeypatch_setattr_on_get_error_injection_mode_is_live(
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportServerError):
+    with pytest.raises(TransportServerError):
         await chain(make_request())
 
     assert calls == []
@@ -536,11 +536,11 @@ async def test_activation_log_fires_once_per_instance(
     with caplog.at_level("INFO", logger="notebooklm._core"):
         # Each call raises; this verifies the log is emitted on the FIRST
         # call's path and suppressed on subsequent calls.
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await chain(make_request())
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await chain(make_request())
-        with pytest.raises(_TransportServerError):
+        with pytest.raises(TransportServerError):
             await chain(make_request())
 
     activations = [r for r in caplog.records if "synthetic-error injection enabled" in r.message]

--- a/tests/unit/test_middleware_types.py
+++ b/tests/unit/test_middleware_types.py
@@ -292,8 +292,8 @@ def test_build_chain_each_call_gets_independent_closures() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_auth_snapshot_alias_round_trip() -> None:
-    """``AuthSnapshot`` is a value-equivalent alias for ``_AuthSnapshot``."""
+def test_auth_snapshot_round_trip() -> None:
+    """``AuthSnapshot`` keeps value semantics through the request-types export."""
     snap = AuthSnapshot(
         csrf_token="csrf-1",
         session_id="sid-1",
@@ -313,15 +313,11 @@ def test_auth_snapshot_alias_round_trip() -> None:
     )
 
 
-def test_auth_snapshot_alias_is_same_object_as_underscore_original() -> None:
-    """The public alias and the private original refer to the same class.
+def test_auth_snapshot_export_is_same_object_as_transport_export() -> None:
+    """``AuthSnapshot`` re-exports the transport snapshot dataclass."""
+    from notebooklm._authed_transport import AuthSnapshot as TransportAuthSnapshot
 
-    PR 12.9 will collapse the alias by relocating the definition into
-    ``_request_types.py``; until then, the two names point at the same class.
-    """
-    from notebooklm._authed_transport import _AuthSnapshot
-
-    assert AuthSnapshot is _AuthSnapshot
+    assert AuthSnapshot is TransportAuthSnapshot
 
 
 def test_build_request_alias_is_callable_type() -> None:
@@ -343,11 +339,11 @@ def test_build_request_alias_is_callable_type() -> None:
     assert headers == {"X-Goog-AuthUser": "0"}
 
 
-def test_build_request_alias_is_same_object_as_underscore_original() -> None:
-    """``BuildRequest`` is the same type alias as ``_BuildRequest``."""
-    from notebooklm._authed_transport import _BuildRequest
+def test_build_request_export_is_same_object_as_transport_export() -> None:
+    """``BuildRequest`` re-exports the transport callable type."""
+    from notebooklm._authed_transport import BuildRequest as TransportBuildRequest
 
-    assert BuildRequest is _BuildRequest
+    assert BuildRequest is TransportBuildRequest
 
 
 def test_build_request_result_value_semantics() -> None:
@@ -364,29 +360,11 @@ def test_build_request_result_accepts_none_headers() -> None:
     assert r.headers is None
 
 
-# ---------------------------------------------------------------------------
-# _request_types underscore re-exports are still importable
-# ---------------------------------------------------------------------------
-
-
-def test_underscore_originals_remain_importable_from_request_types() -> None:
-    """The underscore-prefixed originals are importable from ``_request_types``.
-
-    They're excluded from ``__all__`` so star-imports don't propagate them,
-    but explicit import works for one cycle. PR 12.9 collapses the shim.
-    """
-    from notebooklm._request_types import _AuthSnapshot, _BuildRequest
-
-    assert _AuthSnapshot is AuthSnapshot
-    assert _BuildRequest is BuildRequest
-
-
-def test_request_types_all_excludes_underscore_names() -> None:
-    """``__all__`` is the canonical export list and excludes underscore names."""
+def test_request_types_all_contains_only_public_names() -> None:
+    """``__all__`` is the canonical public-within-package export list."""
     from notebooklm import _request_types
 
     assert "AuthSnapshot" in _request_types.__all__
     assert "BuildRequest" in _request_types.__all__
     assert "BuildRequestResult" in _request_types.__all__
-    assert "_AuthSnapshot" not in _request_types.__all__
-    assert "_BuildRequest" not in _request_types.__all__
+    assert all(not name.startswith("_") for name in _request_types.__all__)

--- a/tests/unit/test_retry_after.py
+++ b/tests/unit/test_retry_after.py
@@ -1,14 +1,14 @@
 from datetime import datetime, timedelta, timezone
 
-from notebooklm._authed_transport import MAX_RETRY_AFTER_SECONDS, _parse_retry_after
+from notebooklm._authed_transport import MAX_RETRY_AFTER_SECONDS, parse_retry_after
 
 
 def test_parse_retry_after_integer():
-    assert _parse_retry_after("30") == 30
-    assert _parse_retry_after(" 120 ") == 120
-    assert _parse_retry_after("0") == 0
-    assert _parse_retry_after("-5") == 0
-    assert _parse_retry_after(str(MAX_RETRY_AFTER_SECONDS + 1)) == MAX_RETRY_AFTER_SECONDS
+    assert parse_retry_after("30") == 30
+    assert parse_retry_after(" 120 ") == 120
+    assert parse_retry_after("0") == 0
+    assert parse_retry_after("-5") == 0
+    assert parse_retry_after(str(MAX_RETRY_AFTER_SECONDS + 1)) == MAX_RETRY_AFTER_SECONDS
 
 
 def test_parse_retry_after_http_date():
@@ -18,7 +18,7 @@ def test_parse_retry_after_http_date():
     date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
     # Allow some slack (1-2 seconds) for test execution time
-    result = _parse_retry_after(date_str)
+    result = parse_retry_after(date_str)
     assert result is not None
     assert 58 <= result <= 60
 
@@ -26,12 +26,12 @@ def test_parse_retry_after_http_date():
 def test_parse_retry_after_past_date():
     past = datetime.now(timezone.utc) - timedelta(seconds=60)
     date_str = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
-    assert _parse_retry_after(date_str) == 0
+    assert parse_retry_after(date_str) == 0
 
 
 def test_parse_retry_after_invalid():
-    assert _parse_retry_after("not a date") is None
-    assert _parse_retry_after("") is None
-    assert _parse_retry_after("   ") is None
+    assert parse_retry_after("not a date") is None
+    assert parse_retry_after("") is None
+    assert parse_retry_after("   ") is None
     # Partially valid but not what we want
-    assert _parse_retry_after("2026-05-13") is None
+    assert parse_retry_after("2026-05-13") is None

--- a/tests/unit/test_retry_middleware.py
+++ b/tests/unit/test_retry_middleware.py
@@ -5,9 +5,9 @@ ADR-009 §"Chain ordering":
 
 - **Pass-through on success.** Single ``next_call`` invocation; result
   returned unchanged.
-- **Retry on ``_TransportRateLimited``** up to ``rate_limit_max_retries``;
+- **Retry on ``TransportRateLimited``** up to ``rate_limit_max_retries``;
   honor ``Retry-After`` when present, otherwise exponential backoff.
-- **Retry on ``_TransportServerError``** up to ``server_error_max_retries``;
+- **Retry on ``TransportServerError``** up to ``server_error_max_retries``;
   exponential backoff.
 - **Disable gate**: when ``context["disable_internal_retries"]`` is truthy,
   the first failure propagates without retry.
@@ -39,7 +39,7 @@ import pytest
 # pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
-from notebooklm._authed_transport import _TransportRateLimited, _TransportServerError
+from notebooklm._authed_transport import TransportRateLimited, TransportServerError
 from notebooklm._client_metrics import ClientMetrics
 from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
 from notebooklm._middleware_retry import RetryMiddleware
@@ -65,13 +65,13 @@ def _rate_limited(
     log_label: str = "RPC LIST_NOTEBOOKS",
     retry_after: int | None = None,
     status: int = 429,
-) -> _TransportRateLimited:
-    """Build a ``_TransportRateLimited`` instance shaped like the leaf would raise."""
+) -> TransportRateLimited:
+    """Build a ``TransportRateLimited`` instance shaped like the leaf would raise."""
     request = httpx.Request("POST", "https://example.test/x")
     headers = {"retry-after": str(retry_after)} if retry_after is not None else {}
     response = httpx.Response(status, request=request, headers=headers)
     original = httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
-    return _TransportRateLimited(
+    return TransportRateLimited(
         f"{log_label} rate-limited (HTTP {status})",
         retry_after=retry_after,
         response=response,
@@ -83,12 +83,12 @@ def _server_error(
     *,
     log_label: str = "RPC LIST_NOTEBOOKS",
     status: int = 503,
-) -> _TransportServerError:
-    """Build a ``_TransportServerError`` instance shaped like the leaf would raise."""
+) -> TransportServerError:
+    """Build a ``TransportServerError`` instance shaped like the leaf would raise."""
     request = httpx.Request("POST", "https://example.test/x")
     response = httpx.Response(status, request=request)
     original = httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
-    return _TransportServerError(
+    return TransportServerError(
         f"{log_label} server error (HTTP {status})",
         original=original,
         response=response,
@@ -96,11 +96,11 @@ def _server_error(
     )
 
 
-def _network_error(*, log_label: str = "RPC LIST_NOTEBOOKS") -> _TransportServerError:
-    """Build a ``_TransportServerError`` wrapping an ``httpx.RequestError``."""
+def _network_error(*, log_label: str = "RPC LIST_NOTEBOOKS") -> TransportServerError:
+    """Build a ``TransportServerError`` wrapping an ``httpx.RequestError``."""
     request = httpx.Request("POST", "https://example.test/x")
     original = httpx.RequestError("connect failed", request=request)
-    return _TransportServerError(
+    return TransportServerError(
         f"{log_label} network error: {original}",
         original=original,
     )
@@ -207,7 +207,7 @@ async def test_429_without_retry_after_uses_exponential_backoff() -> None:
 
 @pytest.mark.asyncio
 async def test_429_budget_exhausted_reraises_last_exception() -> None:
-    """After ``rate_limit_max_retries`` exhausted, the last ``_TransportRateLimited`` propagates."""
+    """After ``rate_limit_max_retries`` exhausted, the last ``TransportRateLimited`` propagates."""
     sleep, slept = _recording_sleep()
     last = _rate_limited(retry_after=1)
     terminal, calls = _scripted_terminal(
@@ -224,7 +224,7 @@ async def test_429_budget_exhausted_reraises_last_exception() -> None:
     )
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportRateLimited) as excinfo:
+    with pytest.raises(TransportRateLimited) as excinfo:
         await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
     assert excinfo.value is last
@@ -264,7 +264,7 @@ async def test_retries_on_503_until_success() -> None:
 
 @pytest.mark.asyncio
 async def test_retries_on_network_error_until_success() -> None:
-    """``httpx.RequestError`` wrapped as ``_TransportServerError`` → retried."""
+    """``httpx.RequestError`` wrapped as ``TransportServerError`` → retried."""
     sleep, _slept = _recording_sleep()
     terminal, calls = _scripted_terminal(
         [
@@ -287,7 +287,7 @@ async def test_retries_on_network_error_until_success() -> None:
 
 @pytest.mark.asyncio
 async def test_5xx_budget_exhausted_reraises_last_exception() -> None:
-    """After ``server_error_max_retries`` exhausted, last ``_TransportServerError`` propagates."""
+    """After ``server_error_max_retries`` exhausted, last ``TransportServerError`` propagates."""
     sleep, _slept = _recording_sleep()
     last = _server_error(status=502)
     terminal, calls = _scripted_terminal(
@@ -303,7 +303,7 @@ async def test_5xx_budget_exhausted_reraises_last_exception() -> None:
     )
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportServerError) as excinfo:
+    with pytest.raises(TransportServerError) as excinfo:
         await chain(make_request())
 
     assert excinfo.value is last
@@ -328,7 +328,7 @@ async def test_disable_internal_retries_skips_429_retry() -> None:
     )
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportRateLimited) as excinfo:
+    with pytest.raises(TransportRateLimited) as excinfo:
         await chain(make_request(context={"disable_internal_retries": True}))
 
     assert excinfo.value is boom
@@ -349,7 +349,7 @@ async def test_disable_internal_retries_skips_5xx_retry() -> None:
     )
     chain = build_chain([middleware], terminal)
 
-    with pytest.raises(_TransportServerError) as excinfo:
+    with pytest.raises(TransportServerError) as excinfo:
         await chain(make_request(context={"disable_internal_retries": True}))
 
     assert excinfo.value is boom

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from notebooklm._authed_transport import _AuthSnapshot
+from notebooklm._authed_transport import AuthSnapshot
 from notebooklm._rpc_executor import RpcExecutor
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
@@ -60,7 +60,7 @@ class _Owner:
         self.rpc_retry_calls: list[dict[str, Any]] = []
         self.rpc_retry_result: Any = {"retried": True}
         self.response = _ok_response()
-        self.snapshot = _AuthSnapshot(
+        self.snapshot = AuthSnapshot(
             csrf_token="CSRF_SNAPSHOT",
             session_id="SID_SNAPSHOT",
             authuser=1,
@@ -147,7 +147,7 @@ def _executor(
 @pytest.mark.asyncio
 async def test_client_rpc_executor_wrappers_delegate_to_rpc_executor(monkeypatch) -> None:
     core = Session(_auth_tokens())
-    snapshot = _AuthSnapshot(
+    snapshot = AuthSnapshot(
         csrf_token="csrf",
         session_id="session",
         authuser=0,

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -29,7 +29,7 @@ def mock_core():
     invokes the caller-supplied ``build_request`` factory so URL/body
     assertions still exercise the production request builder.
     """
-    from notebooklm._authed_transport import _AuthSnapshot
+    from notebooklm._authed_transport import AuthSnapshot
 
     core = MagicMock()
 
@@ -68,7 +68,7 @@ def mock_core():
     # answer response. Individual tests that need to inspect the URL/body can
     # read ``core._last_chat_request`` after calling ``ChatAPI.ask``.
     async def _transport_post_default(*, build_request, parse_label):
-        snapshot = _AuthSnapshot(
+        snapshot = AuthSnapshot(
             csrf_token=core.auth.csrf_token,
             session_id=core.auth.session_id,
             authuser=core.auth.authuser,

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -156,7 +156,7 @@ async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
 # Removed: ``test_retry_after_non_integer_logs_debug`` was self-fulfilling — it
 # called ``core_mod.logger.debug(...)`` inline rather than exercising production
 # code. A later refactor replaced the original "Retry-After header not an integer" log
-# site with the ``_parse_retry_after`` helper, which returns ``None`` silently
+# site with the ``parse_retry_after`` helper, which returns ``None`` silently
 # for unparseable input. Parse semantics are covered by
 # ``tests/unit/test_retry_after.py``.
 

--- a/tests/unit/test_tier_13_all_exports.py
+++ b/tests/unit/test_tier_13_all_exports.py
@@ -24,14 +24,14 @@ EXPECTED_AUTHED_TRANSPORT_ALL: list[str] = [
     "MAX_RPC_RESPONSE_BYTES",
     "AuthedTransport",
     "_AuthedTransportHost",
-    "_AuthSnapshot",
-    "_BuildRequest",
-    "_PostBody",
-    "_TransportAuthExpired",
-    "_TransportRateLimited",
-    "_TransportServerError",
-    "_parse_retry_after",
-    "_stream_post_with_size_cap",
+    "AuthSnapshot",
+    "BuildRequest",
+    "PostBody",
+    "TransportAuthExpired",
+    "TransportRateLimited",
+    "TransportServerError",
+    "parse_retry_after",
+    "stream_post_with_size_cap",
 ]
 
 EXPECTED_RPC_EXECUTOR_ALL: list[str] = ["DecodeResponse", "RpcExecutor", "RpcOwner"]

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -415,10 +415,10 @@ def test_build_synthetic_error_response_status_codes(mode, expected_status):
 
 def test_build_synthetic_error_response_429_has_retry_after():
     """The 429 shape carries a Retry-After header so the client's parser sees
-    a numeric hint to consume (parsed via ``_parse_retry_after``)."""
+    a numeric hint to consume (parsed via ``parse_retry_after``)."""
     _, _, headers = build_synthetic_error_response("429")
     assert "Retry-After" in headers
-    # Integer-seconds form so it round-trips through _parse_retry_after.
+    # Integer-seconds form so it round-trips through parse_retry_after.
     assert headers["Retry-After"].isdigit()
 
 


### PR DESCRIPTION
## Summary
- rename the 8 documented shared `_authed_transport` symbols to unprefixed public-within-package names
- update first-party source consumers, tests, scripts, and living docs
- rewrite `_request_types.py` to re-export `AuthSnapshot` / `BuildRequest` directly and remove the old transition contract
- keep `_AuthedTransportHost` underscored as the host Protocol contract

## Verification
- `git grep -nE '\b_(AuthSnapshot|BuildRequest|PostBody|stream_post_with_size_cap|parse_retry_after|TransportRateLimited|TransportServerError|TransportAuthExpired)\b' -- src/notebooklm tests docs/development.md docs/python-api.md docs/migration-tier-12-to-13.md tests/scripts` -> no hits
- `git grep -nE 'from \._authed_transport import _(AuthSnapshot|BuildRequest|PostBody|stream_post_with_size_cap|parse_retry_after|TransportRateLimited|TransportServerError|TransportAuthExpired)' src/notebooklm/` -> no hits
- `uv run ruff check .`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest tests/unit/test_middleware_types.py tests/unit/test_tier_13_all_exports.py tests/unit/test_authed_transport.py tests/unit/test_retry_after.py tests/unit/test_retry_middleware.py tests/unit/test_auth_refresh_middleware.py tests/unit/test_chat_transport.py tests/unit/test_rpc_executor.py -q`
- `uv run pytest` (5743 passed, 12 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Promoted previously internal authentication, request-building, and transport error handling APIs to public API status, providing stable support for advanced authentication and transport customization use cases.

* **Documentation**
  * Updated API documentation and guides to reflect newly public APIs and their usage patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->