### PR TITLE
refactor(cli): unify exit paths through error_handler

### DIFF
--- a/src/notebooklm/cli/agent.py
+++ b/src/notebooklm/cli/agent.py
@@ -3,6 +3,7 @@
 import click
 
 from .agent_templates import get_agent_source_content
+from .error_handler import exit_with_code
 from .rendering import console
 
 
@@ -19,6 +20,6 @@ def show_agent(target: str):
     content = get_agent_source_content(target)
     if content is None:
         console.print(f"[red]Error:[/red] {target} instructions not found in package data.")
-        raise SystemExit(1)
+        exit_with_code(1)
 
     console.print(content)

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -17,7 +17,7 @@ from rich.table import Table
 from ..client import NotebookLMClient
 from ..types import ExportType
 from .auth_runtime import with_client
-from .error_handler import _output_error
+from .error_handler import _output_error, exit_with_code
 from .options import json_option, list_options, notebook_option, wait_polling_options
 from .rendering import (
     cli_name_to_artifact_type,
@@ -235,7 +235,12 @@ def artifact_rename(ctx, artifact_id, new_title, notebook_id, json_output, clien
             mind_maps = await client.notes.list_mind_maps(nb_id_resolved)
             for mm in mind_maps:
                 if mm[0] == resolved_id:
-                    raise click.ClickException("Mind maps cannot be renamed")
+                    _output_error(
+                        "Error: Mind maps cannot be renamed",
+                        "VALIDATION_ERROR",
+                        json_output,
+                        1,
+                    )
 
             await client.artifacts.rename(nb_id_resolved, resolved_id, new_title)
             # The rename API returns None; if no exception was raised, the operation succeeded.
@@ -523,7 +528,7 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                     # automation sees a JSON payload with an "error" message
                     # but the command still exits 0.
                     if status.status != "completed":
-                        raise SystemExit(1)
+                        exit_with_code(1)
                 else:
                     if status.status == "completed":
                         console.print(f"[green]✓ Artifact completed:[/green] {resolved_id}")
@@ -531,7 +536,7 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                             console.print(f"[dim]URL:[/dim] {status.url}")
                     elif status.error:
                         console.print(f"[red]✗ Generation failed:[/red] {status.error}")
-                        raise SystemExit(1)
+                        exit_with_code(1)
                     else:
                         console.print(f"[yellow]Status:[/yellow] {status.status}")
 
@@ -546,7 +551,7 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                     )
                 else:
                     console.print(f"[red]✗ Timeout after {timeout}s[/red]")
-                raise SystemExit(1) from None
+                exit_with_code(1)
 
     return _run()
 

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -130,6 +130,7 @@ def get_auth_tokens(ctx) -> AuthTokens:
 def handle_auth_error(json_output: bool = False) -> NoReturn:
     """Handle authentication errors with helpful context."""
     from ..paths import get_path_info, get_storage_path
+    from .error_handler import exit_with_code
 
     helpers = _helpers_facade()
     ctx = click.get_current_context(silent=True)
@@ -157,7 +158,7 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     else:
         helpers.console.print("[red]Not logged in.[/red]\n")
         helpers.console.print("[dim]Checked locations:[/dim]")
@@ -170,7 +171,7 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
         helpers.console.print("  1. Run: [green]notebooklm login[/green]")
         helpers.console.print("  2. Set [cyan]NOTEBOOKLM_AUTH_JSON[/cyan] env var (for CI/CD)")
         helpers.console.print("  3. Use [cyan]--storage /path/to/file.json[/cyan] flag")
-        raise SystemExit(1)
+        exit_with_code(1)
 
 
 def with_auth_and_errors(

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -16,6 +16,7 @@ from ..client import NotebookLMClient
 from ..types import ChatMode
 from .auth_runtime import with_client
 from .context import get_current_conversation, get_current_notebook, set_current_conversation
+from .error_handler import _output_error, exit_with_code
 from .input import resolve_prompt
 from .options import _complete_sources, json_option, notebook_option, prompt_file_option
 from .rendering import (
@@ -232,7 +233,7 @@ def register_chat_commands(cli):
                             # ``handle_errors`` catch-all (error_handler.py)
                             # would remap to exit 2.
                             console.print("[yellow]Aborted — no conversation deleted.[/yellow]")
-                            raise SystemExit(1)
+                            exit_with_code(1)
                         await client.chat.delete_conversation(nb_id_resolved, last_conv_id)
                     effective_conv_id: str | None = None
                 else:
@@ -538,8 +539,11 @@ def register_chat_commands(cli):
 
                 if save_as_note:
                     if not qa_pairs:
-                        raise click.ClickException(
-                            "No conversation history found for this notebook."
+                        _output_error(
+                            "Error: No conversation history found for this notebook.",
+                            "NOT_FOUND",
+                            json_output,
+                            1,
                         )
                     content = _format_history(qa_pairs)
                     title = note_title or "Chat History"

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -30,6 +30,7 @@ from .download_helpers import (
     resolve_partial_artifact_id,
     select_artifact,
 )
+from .error_handler import exit_with_code
 from .options import _complete_artifacts, notebook_option
 from .rendering import console, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
@@ -803,7 +804,7 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     # the operation failed even though JSON mode returned a parseable legacy
     # error document (free-form ``error`` string, no typed ``code``).
     if "error" in result:
-        raise SystemExit(1)
+        exit_with_code(1)
 
 
 @download.command("report")

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -26,6 +26,61 @@ from ._encoding import safe_echo
 
 logger = logging.getLogger(__name__)
 
+# Sites where direct Click exceptions remain appropriate because they are
+# input-validation boundaries before command output is committed. The lint in
+# ``tests/_lint/test_error_handler_allowlist.py`` keeps this list exact.
+ALLOWED_CLICK_EXCEPTION_SITES: list[tuple[str, int, str]] = [
+    ("src/notebooklm/cli/input.py", 31, "stdin must decode as UTF-8 before command body runs"),
+    ("src/notebooklm/cli/input.py", 80, "prompt-file path validation"),
+    ("src/notebooklm/cli/input.py", 84, "prompt-file read validation"),
+    ("src/notebooklm/cli/input.py", 86, "prompt-file UTF-8 validation"),
+    ("src/notebooklm/cli/profile.py", 149, "profile path/name validation"),
+    ("src/notebooklm/cli/profile.py", 151, "profile create duplicate validation"),
+    ("src/notebooklm/cli/profile.py", 171, "profile path/name validation"),
+    ("src/notebooklm/cli/profile.py", 175, "profile switch target validation"),
+    ("src/notebooklm/cli/profile.py", 189, "profile config write validation"),
+    ("src/notebooklm/cli/profile.py", 210, "profile path/name validation"),
+    ("src/notebooklm/cli/profile.py", 216, "profile delete active/default validation"),
+    ("src/notebooklm/cli/profile.py", 222, "profile delete target validation"),
+    ("src/notebooklm/cli/profile.py", 249, "profile path/name validation"),
+    ("src/notebooklm/cli/profile.py", 252, "profile rename source validation"),
+    ("src/notebooklm/cli/profile.py", 254, "profile rename destination validation"),
+    ("src/notebooklm/cli/resolve.py", 58, "entity ID argument validation"),
+    (
+        "src/notebooklm/cli/services/login.py",
+        54,
+        "shared profile-name argument validation",
+    ),
+]
+
+# Raw ``raise SystemExit`` should live in this module. If a future path truly
+# cannot route through ``exit_with_code``/``_output_error``, it must be listed
+# here with a reason.
+ALLOWED_RAW_SYSEXIT_SITES: list[tuple[str, int, str]] = []
+
+
+def current_json_output(default: bool = False) -> bool:
+    """Infer the active Click command's JSON-output flag, if any."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return default
+    try:
+        current: click.Context | None = ctx
+        while current is not None:
+            for key in ("json_output", "json"):
+                value = current.params.get(key)
+                if isinstance(value, bool):
+                    return value
+            current = current.parent
+    except (AttributeError, RuntimeError):
+        return default
+    return default
+
+
+def exit_with_code(exit_code: int = 1) -> NoReturn:
+    """Canonical raw exit path for callers that already emitted their payload."""
+    raise SystemExit(exit_code)
+
 
 def _output_error(
     message: str,

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -29,6 +29,7 @@ from . import rendering as rendering_helpers
 from . import research_import as research_import_helpers
 from . import runtime as runtime_helpers
 from ._encoding import safe_echo
+from .error_handler import exit_with_code
 from .resolve import (
     _resolve_partial_id as _resolve_partial_id,
 )
@@ -291,7 +292,7 @@ def handle_error(e: Exception):
         console.print(f"[red]{message}[/red]")
     except UnicodeEncodeError:
         safe_echo(message, err=True)
-    raise SystemExit(1)
+    exit_with_code(1)
 
 
 def handle_auth_error(json_output: bool = False) -> NoReturn:

--- a/src/notebooklm/cli/language.py
+++ b/src/notebooklm/cli/language.py
@@ -16,6 +16,7 @@ from ..client import NotebookLMClient
 from ..io import atomic_update_json
 from ..paths import get_config_path, get_home_dir
 from .auth_runtime import get_auth_tokens
+from .error_handler import exit_with_code
 from .options import json_option
 from .rendering import console, json_error_response, json_output_response
 from .runtime import run_async
@@ -340,7 +341,7 @@ def language_set(ctx, code, local, json_output):
             )
         console.print(f"[red]Unknown language code: {code}[/red]")
         console.print("\nRun [cyan]notebooklm language list[/cyan] to see supported codes.")
-        raise SystemExit(1)
+        exit_with_code(1)
 
     # Save locally first
     set_language(code)

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -355,7 +355,7 @@ def note_rename(ctx, note_id, new_title, notebook_id, json_output, client_auth):
             # ``CHANGELOG.md`` (Unreleased → Changed).
             #
             # The trailing ``raise AssertionError`` is unreachable at runtime
-            # (``_output_error`` always ``raise SystemExit``s) — it exists
+            # (``_output_error`` always exits) — it exists
             # solely to narrow ``n`` from ``Note | None`` to ``Note`` for
             # mypy without forcing a ``NoReturn`` annotation onto
             # ``error_handler._output_error`` (which would change the shared

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -179,11 +179,10 @@ def json_output_response(data: dict | list) -> None:
 
 def json_error_response(code: str, message: str, extra: dict | None = None) -> NoReturn:
     """Print JSON error and exit (no colors for machine parsing)."""
-    response: dict[str, Any] = {"error": True, "code": code, "message": message}
-    if extra:
-        response.update(extra)
-    click.echo(json.dumps(response, indent=2, default=str, ensure_ascii=False))
-    raise SystemExit(1)
+    from .error_handler import output_error
+
+    output_error(message, code, json_output=True, exit_code=1, extra=extra)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 _RESULT_TYPE_LABELS = {

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -11,6 +11,7 @@ import click
 
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
+from .error_handler import exit_with_code
 from .options import notebook_option
 from .rendering import (
     console,
@@ -175,7 +176,7 @@ def research_wait(
                         )
                     else:
                         console.print("[red]No research running[/red]")
-                    raise SystemExit(1)
+                    exit_with_code(1)
 
                 if task_id is None:
                     task_id = current_status.get("task_id")
@@ -203,7 +204,7 @@ def research_wait(
                     )
                 else:
                     console.print(f"[yellow]Timed out after {timeout} seconds[/yellow]")
-                raise SystemExit(1)
+                exit_with_code(1)
 
             # Research completed — poll_until returned the terminal status,
             # or raised SystemExit above for no-research / timeout cases.

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -17,6 +17,7 @@ from .. import paths as paths_module
 from ..paths import get_context_path
 from . import context as context_helpers
 from . import rendering as rendering_helpers
+from .error_handler import exit_with_code
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
@@ -164,7 +165,7 @@ def require_notebook(
         "[red]No notebook specified. Use 'notebooklm use <id>' to set context, "
         "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK.[/red]"
     )
-    raise SystemExit(1)
+    exit_with_code(1)
 
 
 # Accessor types for the sync resolver core. The default ``_attr_id`` /

--- a/src/notebooklm/cli/services/login.py
+++ b/src/notebooklm/cli/services/login.py
@@ -28,6 +28,7 @@ from ...auth import (
 from ...client import NotebookLMClient
 from ...io import atomic_write_json
 from ...paths import get_storage_path
+from ..error_handler import exit_with_code
 from ..language import set_language
 from ..rendering import console
 from ..runtime import run_async
@@ -186,7 +187,7 @@ def _enumerate_one_jar(
                 f"{e}\n\n"
                 "Make sure you are logged into Google in your browser."
             )
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     cookie_map = extract_cookies_with_domains(storage_state)
     jar = build_cookie_jar(cookies=cookie_map)
@@ -205,7 +206,7 @@ def _enumerate_one_jar(
                 "If you'd rather skip the browser entirely, use "
                 "[cyan]notebooklm login[/cyan] (Playwright flow)."
             )
-        raise SystemExit(1) from None
+        exit_with_code(1)
     except httpx.RequestError as e:
         # Distinct from "signed out / stale" SystemExit branches above:
         # a network failure means EVERY profile probe will fail the same
@@ -216,7 +217,7 @@ def _enumerate_one_jar(
                 f"[red]Account discovery failed (network error):[/red] {e}\n"
                 "Check your internet connection and try again."
             )
-            raise SystemExit(1) from None
+            exit_with_code(1)
         raise
 
     if browser_profile is None:
@@ -358,7 +359,7 @@ def _enumerate_chromium_profiles_fanout(
                 "or directly:\n"
                 "  pip install rookiepy"
             )
-            raise SystemExit(1) from None
+            exit_with_code(1)
         except (OSError, RuntimeError) as e:
             # One profile failing (e.g. a locked DB) shouldn't kill discovery
             # of the others. Surface a per-profile note and continue.
@@ -393,7 +394,7 @@ def _enumerate_chromium_profiles_fanout(
                 f"[red]Account discovery failed (network error):[/red] {e}\n"
                 "Check your internet connection and try again."
             )
-            raise SystemExit(1) from None
+            exit_with_code(1)
 
         per_profile_cookies[profile.directory_name] = raw
         for account in accounts:
@@ -430,7 +431,7 @@ def _enumerate_chromium_profiles_fanout(
             f"{browser_name} user-profiles.[/red]\n"
             "Sign in to a Google account in your browser and try again."
         )
-        raise SystemExit(1)
+        exit_with_code(1)
 
     return per_profile_cookies, aggregated
 
@@ -652,7 +653,7 @@ def _select_account(
             f"[red]Account {account_email} not found among signed-in accounts.[/red]\n"
             f"Available accounts: {available}"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     default_account = next((a for a in accounts if a.is_default), None)
     if default_account is not None:
         return default_account
@@ -687,7 +688,7 @@ def _write_extracted_cookies(
             f"{e}\n\n"
             "Make sure you are logged into Google in your browser."
         )
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     try:
         storage_path.parent.mkdir(parents=True, exist_ok=True)
@@ -699,7 +700,7 @@ def _write_extracted_cookies(
     except OSError as e:
         logger.error("Failed to save authentication to %s: %s", storage_path, e)
         console.print(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     from ...auth import write_account_metadata
 
@@ -750,7 +751,7 @@ def _select_refresh_account(
             f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan] "
             "or sign that account back into the browser."
         )
-        raise SystemExit(1)
+        exit_with_code(1)
 
     raw_authuser = metadata.get("authuser")
     if isinstance(raw_authuser, int) and raw_authuser >= 0:
@@ -763,7 +764,7 @@ def _select_refresh_account(
             f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan], then "
             f"[cyan]notebooklm login --browser-cookies {browser_name} --account EMAIL[/cyan]."
         )
-        raise SystemExit(1)
+        exit_with_code(1)
 
     return next((account for account in accounts if account.is_default), accounts[0])
 
@@ -782,7 +783,7 @@ def _refresh_from_browser_cookies(
     )
     if not accounts:
         console.print(f"[red]No signed-in Google accounts found in {browser_name}.[/red]")
-        raise SystemExit(1)
+        exit_with_code(1)
 
     metadata = read_account_metadata(storage_path)
     selected = _select_refresh_account(accounts, metadata, browser_name)
@@ -955,7 +956,7 @@ def _read_chromium_profile_cookies_from_selector(
         profile = chromium_profiles.resolve_chromium_profile(browser_name, profile_selector)
     except ValueError as e:
         console.print(f"[red]{e}[/red]")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     domains = _build_google_cookie_domains(include_domains=include_domains)
     if verbose:
@@ -974,10 +975,10 @@ def _read_chromium_profile_cookies_from_selector(
             "or directly:\n"
             "  pip install rookiepy"
         )
-        raise SystemExit(1) from None
+        exit_with_code(1)
     except (OSError, RuntimeError) as e:
         _handle_rookiepy_error(e, f"{profile.browser} profile '{profile.human_name}'")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     return profile, cookies
 
@@ -1020,13 +1021,13 @@ def _read_firefox_container_cookies(
             "container-aware extractor cannot find it. Drop the '::<container>' "
             "suffix to fall back to rookiepy's autodetection."
         )
-        raise SystemExit(1)
+        exit_with_code(1)
 
     try:
         container_id = firefox_containers.resolve_container_id(profile_path, container_spec)
     except ValueError as e:
         console.print(f"[red]{e}[/red]")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     if verbose:
         if container_id == "none":
@@ -1044,13 +1045,13 @@ def _read_firefox_container_cookies(
         )
     except FileNotFoundError as e:
         console.print(f"[red]{e}[/red]")
-        raise SystemExit(1) from None
+        exit_with_code(1)
     except (OSError, RuntimeError) as e:
         _handle_rookiepy_error(e, "firefox")
-        raise SystemExit(1) from None
+        exit_with_code(1)
     except sqlite3.DatabaseError as e:
         console.print(f"[red]Failed to read Firefox cookies database:[/red] {e}")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
 
 def _maybe_warn_firefox_containers_in_use() -> None:
@@ -1130,7 +1131,7 @@ def _read_browser_cookies(
                 "Use [cyan]firefox::<container-name>[/cyan] (e.g. 'firefox::Work') or "
                 "[cyan]firefox::none[/cyan] for the no-container default."
             )
-            raise SystemExit(1)
+            exit_with_code(1)
         return _read_firefox_container_cookies(
             container_spec, verbose=verbose, include_domains=include_domains
         )
@@ -1156,7 +1157,7 @@ def _read_browser_cookies(
             "or directly:\n"
             "  pip install rookiepy"
         )
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     domains = _build_google_cookie_domains(include_domains=include_domains)
 
@@ -1169,7 +1170,7 @@ def _read_browser_cookies(
             return rookiepy.load(domains=domains)
         except (OSError, RuntimeError) as e:
             _handle_rookiepy_error(e, "auto-detect")
-            raise SystemExit(1) from None
+            exit_with_code(1)
 
     canonical = _ROOKIEPY_BROWSER_ALIASES.get(browser_name.lower())
     if canonical is None:
@@ -1177,7 +1178,7 @@ def _read_browser_cookies(
             f"[red]Unknown browser: '{browser_name}'[/red]\n"
             f"Supported: {', '.join(sorted(_ROOKIEPY_BROWSER_ALIASES))}"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     if verbose:
         console.print(f"[yellow]Reading cookies from {browser_name}...[/yellow]")
     browser_fn = getattr(rookiepy, canonical, None)
@@ -1186,12 +1187,12 @@ def _read_browser_cookies(
             f"[red]rookiepy does not support '{canonical}' on this platform.[/red]\n"
             "Check that rookiepy is properly installed: pip install rookiepy"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     try:
         cookies = browser_fn(domains=domains)
     except (OSError, RuntimeError) as e:
         _handle_rookiepy_error(e, browser_name)
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     # Back-compat warning: unscoped 'firefox' silently merges cookies from
     # every Multi-Account Container. Skip when ``verbose=False`` so callers
@@ -1233,7 +1234,7 @@ def _login_with_browser_cookies(
             f"{e}\n\n"
             "Make sure you are logged into Google in your browser."
         )
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     # Create parent directory (avoid mode= on Windows to prevent ACL issues)
     try:
@@ -1248,7 +1249,7 @@ def _login_with_browser_cookies(
     except OSError as e:
         logger.error("Failed to save authentication to %s: %s", storage_path, e)
         console.print(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     # Record account metadata so future calls target the same Google account.
     # Even on a default-account login (authuser=0, no email), remove stale

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -47,7 +47,7 @@ from .context import (
     get_current_notebook,
     set_current_notebook,
 )
-from .error_handler import handle_errors
+from .error_handler import _output_error, exit_with_code, handle_errors
 from .rendering import console, json_output_response
 from .resolve import resolve_notebook_id
 from .runtime import run_async
@@ -293,7 +293,7 @@ def _ensure_chromium_installed() -> None:
                 "[red]Failed to install Chromium browser.[/red]\n"
                 f'Run manually: "{sys.executable}" -m playwright install chromium'
             )
-            raise SystemExit(1)
+            exit_with_code(1)
         console.print("[green]Chromium installed successfully.[/green]\n")
     except SystemExit:
         raise
@@ -323,7 +323,7 @@ def _recover_page(context: BrowserContext, console: Console) -> Page:
         if TARGET_CLOSED_ERROR in error_str:
             logger.error("Browser context is dead, cannot recover page: %s", error_str)
             console.print(BROWSER_CLOSED_HELP)
-            raise SystemExit(1) from exc
+            exit_with_code(1)
         # Not a TargetClosedError — don't mask the real problem
         logger.error("Failed to create new page for recovery: %s", error_str)
         raise
@@ -340,7 +340,7 @@ def _validate_login_flag_conflicts(
 ) -> None:
     """Enforce ``login`` flag mutual-exclusion rules.
 
-    Emits a styled error and ``raise SystemExit(1)`` on the first conflict.
+    Emits a styled error and ``exit_with_code(1)`` on the first conflict.
     The ``NOTEBOOKLM_AUTH_JSON`` env-var check is intentionally not handled
     here: it is an environment vs file-auth conflict, distinct from flag
     mutual-exclusion, and stays in the ``login`` orchestrator.
@@ -352,21 +352,21 @@ def _validate_login_flag_conflicts(
             "[red]Error: --account, --all-accounts, and --profile-name "
             "require --browser-cookies.[/red]"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     if all_accounts and (account_email is not None or profile_name is not None):
         console.print(
             "[red]Error: --all-accounts cannot be combined with --account or --profile-name.[/red]"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     if all_accounts and storage:
         console.print(
             "[red]Error: --all-accounts writes one profile per account "
             "and cannot be combined with --storage.[/red]"
         )
-        raise SystemExit(1)
+        exit_with_code(1)
     if update and not all_accounts:
         console.print("[red]Error: --update only applies to --all-accounts.[/red]")
-        raise SystemExit(1)
+        exit_with_code(1)
 
 
 def _prepare_login_paths(
@@ -397,7 +397,7 @@ def _prepare_login_paths(
                 "Close any open browser windows and try again.\n"
                 f"If the problem persists, manually delete: {browser_profile}"
             )
-            raise SystemExit(1) from exc
+            exit_with_code(1)
 
     if sys.platform == "win32":
         # On Windows < Python 3.13, mode= is ignored by mkdir(). On
@@ -450,7 +450,7 @@ def _run_playwright_login(
             install_hint = '  pip install "notebooklm-py[browser]"\n  playwright install chromium'
         console.print("[red]Playwright not installed. Run:[/red]")
         console.print(install_hint, markup=False)
-        raise SystemExit(1) from None
+        exit_with_code(1)
 
     # Pre-flight check: verify Chromium browser is installed (system Chrome
     # and Edge are checked at launch time by Playwright's channel routing).
@@ -531,7 +531,7 @@ def _run_playwright_login(
                             error_str,
                         )
                         console.print(BROWSER_CLOSED_HELP)
-                        raise SystemExit(1) from exc
+                        exit_with_code(1)
                     elif is_retryable:
                         # Exhausted retries on network errors
                         logger.error(
@@ -539,7 +539,7 @@ def _run_playwright_login(
                             f"Last error: {error_str}"
                         )
                         console.print(_connection_error_help())
-                        raise SystemExit(1) from exc
+                        exit_with_code(1)
                     else:
                         # Non-retryable error - re-raise immediately
                         logger.debug("Non-retryable error: %s", error_str)
@@ -562,14 +562,14 @@ def _run_playwright_login(
                         "[red]Login not detected within 5 minutes.[/red]\n"
                         "Try again with: notebooklm login"
                     )
-                    raise SystemExit(1) from None
+                    exit_with_code(1)
                 except PlaywrightError as exc:
                     # Browser/tab closed during the wait. Cannot resume a
                     # partially completed SSO form, so surface the same
                     # help text other browser-closed paths use.
                     if TARGET_CLOSED_ERROR in str(exc):
                         console.print(BROWSER_CLOSED_HELP)
-                        raise SystemExit(1) from exc
+                        exit_with_code(1)
                     raise
                 console.print("[green]Login detected.[/green]")
 
@@ -591,7 +591,7 @@ def _run_playwright_login(
                             if TARGET_CLOSED_ERROR in str(inner_exc):
                                 # Recovered page also dead -- context/browser is gone
                                 console.print(BROWSER_CLOSED_HELP)
-                                raise SystemExit(1) from inner_exc
+                                exit_with_code(1)
                             elif not _is_navigation_interrupted_error(inner_exc):
                                 raise
                     elif not _is_navigation_interrupted_error(error_str):
@@ -609,7 +609,7 @@ def _run_playwright_login(
                     "Authentication may be incomplete. "
                     "Try: notebooklm login --fresh"
                 )
-                raise SystemExit(1)
+                exit_with_code(1)
 
             # Atomic write with chmod 0o600 — Playwright's path= argument
             # writes directly (non-atomic + world-readable window).
@@ -660,7 +660,7 @@ def _run_playwright_login(
                         f"Install from: {install_url}\n"
                         "Or use the default Chromium browser: notebooklm login"
                     )
-                    raise SystemExit(1) from e
+                    exit_with_code(1)
             # Downgraded from ``logger.error(..., exc_info=True)``:
             # the previous traceback dump duplicated whatever ``handle_errors``
             # already shows the user. Keep the diagnostic available at
@@ -802,7 +802,7 @@ def register_session_commands(cli):
         # Playwright internal crashes that bubble out of the catch-all
         # except-block in _run_playwright_login) emit a friendly
         # 'Unexpected error: <msg>' line + exit 2 instead of a Python
-        # traceback. Existing ``raise SystemExit(N)`` calls inside the
+        # traceback. Existing ``exit_with_code(N)`` calls inside the
         # body propagate unchanged — handle_errors does not intercept
         # SystemExit.
         with handle_errors():
@@ -815,7 +815,7 @@ def register_session_commands(cli):
                     "  1. Unset NOTEBOOKLM_AUTH_JSON and run 'login' again\n"
                     "  2. Continue using NOTEBOOKLM_AUTH_JSON for authentication"
                 )
-                raise SystemExit(1)
+                exit_with_code(1)
 
             _validate_login_flag_conflicts(
                 browser_cookies=browser_cookies,
@@ -963,15 +963,18 @@ def register_session_commands(cli):
             # ambiguity or "no match"). These already exit non-zero with a
             # clear message and never reach the persistence branch.
             raise
-        except NotebookNotFoundError as exc:
+        except NotebookNotFoundError:
             # Server confirmed the notebook does not exist. Fail closed: do
             # not persist anything to context.json, and exit 1 with a clear
             # error.
-            raise click.ClickException(
-                f"Notebook {notebook_id!r} not found. "
+            _output_error(
+                f"Error: Notebook {notebook_id!r} not found. "
                 "Run 'notebooklm list' to see available notebooks, "
-                "or pass --force to bypass verification."
-            ) from exc
+                "or pass --force to bypass verification.",
+                "NOT_FOUND",
+                json_output,
+                1,
+            )
         except AuthError:
             # Auth expired (e.g. SID/SSID cookies stale). Route through the
             # typed UX so the user sees "Run notebooklm login" instead of
@@ -984,10 +987,13 @@ def register_session_commands(cli):
             # All other failures (network errors, RPC errors, etc.) also
             # fail closed — we cannot confirm the notebook exists, so refuse
             # to persist. --force is the documented escape hatch.
-            raise click.ClickException(
-                f"Could not verify notebook {notebook_id!r}: {exc}. "
-                "Pass --force to persist without verification."
-            ) from exc
+            _output_error(
+                f"Error: Could not verify notebook {notebook_id!r}: {exc}. "
+                "Pass --force to persist without verification.",
+                "VERIFICATION_FAILED",
+                json_output,
+                1,
+            )
 
         created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
         set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
@@ -1194,7 +1200,7 @@ def register_session_commands(cli):
                     "Close any running notebooklm commands and try again.\n"
                     f"If the problem persists, manually delete: {storage_path}"
                 )
-                raise SystemExit(1) from exc
+                exit_with_code(1)
 
         # Remove browser profile directory
         if browser_profile.exists():
@@ -1215,7 +1221,7 @@ def register_session_commands(cli):
                     "Close any open browser windows and try again.\n"
                     f"If the problem persists, manually delete: {browser_profile}"
                 )
-                raise SystemExit(1) from exc
+                exit_with_code(1)
 
         # Clear cached notebook / conversation context so post-logout commands
         # don't silently reuse IDs from the previous account. When logout is
@@ -1237,7 +1243,7 @@ def register_session_commands(cli):
                 "Close any running notebooklm commands and try again.\n"
                 f"If the problem persists, manually delete: {context_file}"
             )
-            raise SystemExit(1) from exc
+            exit_with_code(1)
 
         if removed_any:
             console.print("[green]Logged out.[/green] Run 'notebooklm login' to sign in again.")
@@ -1493,7 +1499,7 @@ def register_session_commands(cli):
             # process exit code must agree so callers can fail-fast on
             # `notebooklm auth check --json`.
             if not all_passed:
-                raise SystemExit(1)
+                exit_with_code(1)
             return
 
         # Rich output
@@ -1636,7 +1642,7 @@ def register_session_commands(cli):
         # (AuthError, NetworkError, ValidationError, ...) get user-friendly
         # one-liners + hints; unexpected exceptions become 'Unexpected error:
         # <msg>' (exit 2) instead of leaking ``type(exc).__name__`` into the
-        # user message. Existing ``raise SystemExit(N)`` calls inside the body
+        # user message. Existing ``exit_with_code(N)`` calls inside the body
         # propagate unchanged — handle_errors does not intercept SystemExit.
         with handle_errors():
             # NOTEBOOKLM_AUTH_JSON has no writable backing store, so a keepalive
@@ -1652,7 +1658,7 @@ def register_session_commands(cli):
                     "the env var to be refreshed externally.",
                     err=True,
                 )
-                raise SystemExit(1)
+                exit_with_code(1)
 
             include_domains = _parse_include_domains(include_domains_raw)
             if include_domains and browser_cookies is None:
@@ -1661,7 +1667,7 @@ def register_session_commands(cli):
                     "is also set (the keepalive-only path does not re-extract cookies).",
                     err=True,
                 )
-                raise SystemExit(1)
+                exit_with_code(1)
 
             profile = ctx.obj.get("profile") if ctx.obj else None
             storage_path = get_storage_path(profile=profile)

--- a/src/notebooklm/cli/skill.py
+++ b/src/notebooklm/cli/skill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 
 from .agent_templates import get_agent_source_content
+from .error_handler import exit_with_code
 from .rendering import console
 
 
@@ -129,7 +130,7 @@ def install(scope: str, target_name: str):
         console.print("[red]Error:[/red] Skill source not found in package data.")
         console.print("This may indicate an incomplete or corrupted installation.")
         console.print("Try reinstalling: pip install --force-reinstall notebooklm-py")
-        raise SystemExit(1)
+        exit_with_code(1)
 
     version = get_package_version()
     stamped_content = add_version_comment(content, version)
@@ -158,7 +159,7 @@ def install(scope: str, target_name: str):
         console.print(f"[red]Failed[/red] to install {TARGETS[target].label}: {err}")
 
     if failed_targets:
-        raise SystemExit(1)
+        exit_with_code(1)
 
 
 @skill.command()
@@ -266,7 +267,7 @@ def show(scope: str, target_name: str):
         content = get_skill_source_content()
         if content is None:
             console.print("[red]Error:[/red] Skill source not found in package data.")
-            raise SystemExit(1)
+            exit_with_code(1)
         console.print(content)
         return
 

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -30,7 +30,7 @@ from rich.table import Table
 from ..client import NotebookLMClient
 from ..types import Source, source_status_to_str
 from .auth_runtime import with_client
-from .error_handler import _output_error
+from .error_handler import _output_error, current_json_output, exit_with_code
 from .input import read_stdin_text, resolve_prompt
 from .options import (
     json_option,
@@ -69,7 +69,8 @@ def _validate_upload_path(content: str, follow_symlinks: bool) -> Path:
     try:
         return source_add_service.validate_upload_path(content, follow_symlinks)
     except source_add_service.SourceAddValidationError as exc:
-        raise click.ClickException(str(exc)) from exc
+        _output_error(f"Error: {exc}", "VALIDATION_ERROR", current_json_output(), 1)
+        raise AssertionError("unreachable") from None  # pragma: no cover
 
 
 def _classify_junk_sources(sources: list[Source]) -> list[tuple[str, str, str, str]]:
@@ -148,7 +149,7 @@ def source():
     pass
 
 
-def _build_id_ambiguity_error(source_id: str, matches) -> click.ClickException:
+def _build_id_ambiguity_error(source_id: str, matches) -> str:
     """Build a consistent ambiguity error for source ID prefix matches."""
     lines = [f"Ambiguous ID '{source_id}' matches {len(matches)} sources:"]
     for item in matches[:5]:
@@ -157,7 +158,7 @@ def _build_id_ambiguity_error(source_id: str, matches) -> click.ClickException:
     if len(matches) > 5:
         lines.append(f"  ... and {len(matches) - 5} more")
     lines.append("Specify more characters to narrow down.")
-    return click.ClickException("\n".join(lines))
+    return "\n".join(lines)
 
 
 def _looks_like_full_source_id(source_id: str) -> bool:
@@ -198,7 +199,13 @@ async def _resolve_source_for_delete(
         return matches[0].id
 
     if len(matches) > 1:
-        raise _build_id_ambiguity_error(source_id, matches)
+        _output_error(
+            _build_id_ambiguity_error(source_id, matches),
+            "AMBIGUOUS_ID",
+            json_output,
+            1,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
 
     title_matches = [item for item in sources if item.title == source_id]
     if title_matches:
@@ -210,15 +217,22 @@ async def _resolve_source_for_delete(
             lines.append(f"  {item.id[:12]}... {item.title}")
         if len(title_matches) > 5:
             lines.append(f"  ... and {len(title_matches) - 5} more")
-        raise click.ClickException("\n".join(lines))
+        _output_error("\n".join(lines), "VALIDATION_ERROR", json_output, 1)
+        raise AssertionError("unreachable")  # pragma: no cover
 
-    raise click.ClickException(
+    _output_error(
         f"No source found starting with '{source_id}'. "
-        "Run 'notebooklm source list' to see available sources."
+        "Run 'notebooklm source list' to see available sources.",
+        "NOT_FOUND",
+        json_output,
+        1,
     )
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
-async def _resolve_source_by_exact_title(client, notebook_id: str, title: str):
+async def _resolve_source_by_exact_title(
+    client, notebook_id: str, title: str, *, json_output: bool = False
+):
     """Resolve a source by exact title for the explicit delete-by-title flow."""
     title = validate_id(title, "source title")
     sources = await client.sources.list(notebook_id)
@@ -233,12 +247,16 @@ async def _resolve_source_by_exact_title(client, notebook_id: str, title: str):
             lines.append(f"  {item.id[:12]}... {item.title}")
         if len(matches) > 5:
             lines.append(f"  ... and {len(matches) - 5} more")
-        raise click.ClickException("\n".join(lines))
+        _output_error("\n".join(lines), "AMBIGUOUS_TITLE", json_output, 1)
 
-    raise click.ClickException(
+    _output_error(
         f"No source found with title '{title}'. "
-        "Run 'notebooklm source list' to see available sources."
+        "Run 'notebooklm source list' to see available sources.",
+        "NOT_FOUND",
+        json_output,
+        1,
     )
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 @source.command("list")
@@ -632,7 +650,9 @@ def source_delete_by_title(ctx, title, notebook_id, yes, json_output, client_aut
 
             async def resolve_delete_by_title(client):
                 nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-                source = await _resolve_source_by_exact_title(client, nb_id_resolved, title)
+                source = await _resolve_source_by_exact_title(
+                    client, nb_id_resolved, title, json_output=json_output
+                )
 
                 # P1.T2 bug 2: same JSON-mode confirmation contract as
                 # ``source delete``. Never prompt under --json; require --yes.
@@ -959,7 +979,7 @@ def source_add_research(
             result = await client.research.start(nb_id_resolved, query, search_source, mode)
             if not result:
                 console.print("[red]Research failed to start[/red]")
-                raise SystemExit(1)
+                exit_with_code(1)
 
             task_id = result["task_id"]
             console.print(f"[dim]Task ID: {task_id}[/dim]")
@@ -994,7 +1014,7 @@ def source_add_research(
                     break
                 elif status.get("status") == "no_research":
                     console.print("[red]Research failed to start[/red]")
-                    raise SystemExit(1)
+                    exit_with_code(1)
                 await asyncio.sleep(_POLL_INTERVAL_S)
             else:
                 status = {"status": "timeout"}
@@ -1243,15 +1263,15 @@ def source_stale(ctx, source_id, notebook_id, json_output, client_auth):
                     }
                 )
                 # Exit codes remain inverted by design — see docs/cli-exit-codes.md.
-                raise SystemExit(0 if stale else 1)
+                exit_with_code(0 if stale else 1)
 
             if is_fresh:
                 console.print("[green]✓ Source is fresh[/green]")
-                raise SystemExit(1)  # Not stale
+                exit_with_code(1)  # Not stale
             else:
                 console.print("[yellow]⚠ Source is stale[/yellow]")
                 console.print("[dim]Run 'source refresh' to update[/dim]")
-                raise SystemExit(0)  # Is stale
+                exit_with_code(0)  # Is stale
 
     return _run()
 
@@ -1349,7 +1369,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                     json_output_response(data)
                 else:
                     console.print(f"[red]✗ Source not found:[/red] {e.source_id}")
-                raise SystemExit(1) from None
+                exit_with_code(1)
 
             except SourceProcessingError as e:
                 if json_output:
@@ -1362,7 +1382,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                     json_output_response(data)
                 else:
                     console.print(f"[red]✗ Source processing failed:[/red] {e.source_id}")
-                raise SystemExit(1) from None
+                exit_with_code(1)
 
             except SourceTimeoutError as e:
                 if json_output:
@@ -1377,7 +1397,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                 else:
                     console.print(f"[yellow]⚠ Timeout waiting for source:[/yellow] {e.source_id}")
                     console.print(f"[dim]Last status: {e.last_status}[/dim]")
-                raise SystemExit(2) from None
+                exit_with_code(2)
 
     return _run()
 
@@ -1478,7 +1498,7 @@ def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
                 # is still on stdout above so callers can introspect which
                 # IDs failed.
                 if result.failures:
-                    raise SystemExit(1)
+                    exit_with_code(1)
                 return
 
             if result.status == "already_clean":
@@ -1512,7 +1532,7 @@ def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
                         ctx=ctx,
                     )
                 # P1.T2 bug 8: text-mode parity with JSON-mode exit code.
-                raise SystemExit(1)
+                exit_with_code(1)
 
             cli_print(
                 f"[green]Successfully cleaned {result.deleted_count} source(s).[/green]",

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -1,0 +1,88 @@
+"""CLI exit-path allowlist enforcement."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from notebooklm.cli.error_handler import (
+    ALLOWED_CLICK_EXCEPTION_SITES,
+    ALLOWED_RAW_SYSEXIT_SITES,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
+
+AllowedSite = tuple[str, int]
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _allowed_sites(entries: list[tuple[str, int, str]]) -> set[AllowedSite]:
+    return {(path, line) for path, line, _reason in entries}
+
+
+def _format_sites(sites: set[AllowedSite]) -> str:
+    return "\n".join(f"{path}:{line}" for path, line in sorted(sites))
+
+
+def _raw_system_exit_sites() -> set[AllowedSite]:
+    sites: set[AllowedSite] = set()
+    for path in sorted(CLI_ROOT.rglob("*.py")):
+        if path.name == "error_handler.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel_path = path.relative_to(REPO_ROOT).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+                continue
+            if _call_name(node.exc.func) == "SystemExit":
+                sites.add((rel_path, node.lineno))
+    return sites
+
+
+def _click_exception_call_sites() -> set[AllowedSite]:
+    sites: set[AllowedSite] = set()
+    for path in sorted(CLI_ROOT.rglob("*.py")):
+        if path.name == "error_handler.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel_path = path.relative_to(REPO_ROOT).as_posix()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _call_name(node.func) == "click.ClickException":
+                sites.add((rel_path, node.lineno))
+    return sites
+
+
+def test_raw_system_exit_sites_are_error_handler_owned_or_allowlisted() -> None:
+    """Raw ``SystemExit`` outside ``error_handler.py`` must stay exceptional."""
+    actual = _raw_system_exit_sites()
+    allowed = _allowed_sites(ALLOWED_RAW_SYSEXIT_SITES)
+
+    assert len(actual) <= 5
+    assert actual <= allowed, "Unallowlisted raw SystemExit sites:\n" + _format_sites(
+        actual - allowed
+    )
+    assert allowed <= actual, "Stale raw SystemExit allowlist entries:\n" + _format_sites(
+        allowed - actual
+    )
+
+
+def test_click_exception_sites_match_input_validation_allowlist() -> None:
+    """``click.ClickException`` is limited to documented input-validation sites."""
+    actual = _click_exception_call_sites()
+    allowed = _allowed_sites(ALLOWED_CLICK_EXCEPTION_SITES)
+
+    assert actual <= allowed, "Unallowlisted click.ClickException sites:\n" + _format_sites(
+        actual - allowed
+    )
+    assert allowed <= actual, "Stale click.ClickException allowlist entries:\n" + _format_sites(
+        allowed - actual
+    )

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -7,8 +7,11 @@ import pytest
 
 import notebooklm.cli._encoding as encoding_module
 from notebooklm.cli.error_handler import (
+    ALLOWED_CLICK_EXCEPTION_SITES,
+    ALLOWED_RAW_SYSEXIT_SITES,
     _output_error,
     emit_cancelled_and_exit,
+    exit_with_code,
     handle_errors,
 )
 from notebooklm.exceptions import (
@@ -60,6 +63,31 @@ class TestHandleErrorsExitCodes:
         with pytest.raises(SystemExit) as exc_info, handle_errors():
             raise RuntimeError("Unexpected bug")
         assert exc_info.value.code == 2
+
+    def test_exit_with_code_is_canonical_raw_exit_path(self):
+        """Callers that already emitted output can still exit through error_handler."""
+        with pytest.raises(SystemExit) as exc_info:
+            exit_with_code(75)
+
+        assert exc_info.value.code == 75
+
+
+class TestErrorHandlerAllowlists:
+    """The allowlists are intentionally structured for lint enforcement."""
+
+    def test_raw_system_exit_allowlist_entries_have_reasons(self):
+        for rel_path, line_number, reason in ALLOWED_RAW_SYSEXIT_SITES:
+            assert rel_path.startswith("src/notebooklm/cli/")
+            assert isinstance(line_number, int)
+            assert line_number > 0
+            assert reason
+
+    def test_click_exception_allowlist_entries_have_reasons(self):
+        for rel_path, line_number, reason in ALLOWED_CLICK_EXCEPTION_SITES:
+            assert rel_path.startswith("src/notebooklm/cli/")
+            assert isinstance(line_number, int)
+            assert line_number > 0
+            assert reason
 
 
 class TestHandleErrorsJsonOutput:


### PR DESCRIPTION
## Summary

Rebased and retargeted to `main` after #938 merged.

- route raw CLI exits outside `error_handler.py` through `exit_with_code()` or `_output_error()`
- document the raw-exit and `click.ClickException` allowlists in `cli/error_handler.py`
- add AST lint coverage to keep new raw exits / ClickException constructor sites from drifting

## Verification

- `uv run pytest tests/_lint/test_error_handler_allowlist.py tests/unit/cli/test_error_handler.py -q`
- `uv run ruff check src/notebooklm/cli tests/_lint tests/unit/cli/test_error_handler.py`
- `uv run mypy src/notebooklm/cli --ignore-missing-imports`
- `uv run pytest tests/unit tests/integration -q`

## Exit-path inventory

- raw `raise SystemExit` outside `src/notebooklm/cli/error_handler.py`: 0 by grep, 0 by AST
- `click.ClickException(` constructor calls outside `error_handler.py`: 17, all documented in `ALLOWED_CLICK_EXCEPTION_SITES`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling and exit codes across all CLI commands for improved consistency.
  * Enhanced error messaging consistency, particularly in JSON output mode.

* **Tests**
  * Added comprehensive tests to validate error-handling practices across the CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->