### PR TITLE
refactor(cli): promote run_client_workflow adapter

### DIFF
--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -11,6 +11,7 @@ import logging
 import os
 import time
 from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
 from functools import wraps
 from pathlib import Path
 from typing import Any, NoReturn, TypeVar, cast
@@ -181,6 +182,7 @@ def with_auth_and_errors(
     json_output: bool,
     body: Callable[[AuthTokens], Awaitable[T]],
     auth_loader: Callable[[click.Context], AuthTokens] | None = None,
+    body_error_handler: Callable[[Exception], T] | None = None,
 ) -> T:
     """Run a CLI command body with shared auth bootstrap and error handling."""
     from .error_handler import handle_errors
@@ -237,9 +239,47 @@ def with_auth_and_errors(
             result = helpers.run_async(body(auth))
         except Exception as e:
             log_result("failed", str(e))
+            if body_error_handler is not None:
+                return body_error_handler(e)
             raise
         log_result("completed")
         return result
+
+
+def run_client_workflow(
+    ctx: click.Context,
+    *,
+    command_name: str,
+    json_output: bool,
+    body: Callable[[Any], Awaitable[T]],
+    auth_loader: Callable[[click.Context], AuthTokens] | None = None,
+    client_factory: Callable[[AuthTokens], AbstractAsyncContextManager[Any]] | None = None,
+    body_error_handler: Callable[[Exception], T] | None = None,
+) -> T:
+    """Run a CLI workflow with shared auth, client lifetime, and error handling.
+
+    This is the command-level adapter for handlers that need an opened
+    ``NotebookLMClient`` rather than raw ``AuthTokens``. ``with_auth_and_errors``
+    remains the lower-level primitive for commands that intentionally manage
+    client lifetime themselves.
+    """
+    if client_factory is None:
+        from ..client import NotebookLMClient
+
+        client_factory = NotebookLMClient
+
+    async def workflow(auth: AuthTokens) -> T:
+        async with client_factory(auth) as client:
+            return await body(client)
+
+    return with_auth_and_errors(
+        ctx,
+        command_name=command_name,
+        json_output=json_output,
+        body=workflow,
+        auth_loader=auth_loader,
+        body_error_handler=body_error_handler,
+    )
 
 
 def with_client(f):

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -20,10 +20,9 @@ from typing import Any, TypedDict
 
 import click
 
-from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
-from .auth_runtime import with_auth_and_errors
+from .auth_runtime import run_client_workflow
 from .download_helpers import (
     ArtifactDict,
     artifact_title_to_filename,
@@ -126,7 +125,7 @@ async def _get_completed_artifacts_as_dicts(
 
 
 async def _download_artifacts_generic(
-    client_auth: AuthTokens,
+    client: NotebookLMClient,
     artifact_type_name: str,
     artifact_kind: ArtifactType,
     file_extension: str,
@@ -152,7 +151,7 @@ async def _download_artifacts_generic(
     with the same logic, only varying by extension and type filters.
 
     Args:
-        client_auth: Auth tokens for constructing the NotebookLM client
+        client: Open NotebookLM client
         artifact_type_name: Human-readable type name ("audio", "video", etc.)
         artifact_kind: ArtifactType enum value to filter by
         file_extension: File extension (".mp3", ".mp4", ".png", ".pdf")
@@ -204,291 +203,277 @@ async def _download_artifacts_generic(
                 err=True,
             )
 
-    async def _download() -> dict[str, Any]:
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+    nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
-            # Setup download method dispatch
-            download_methods: dict[str, _DownloadFn] = {
-                "audio": client.artifacts.download_audio,
-                "video": client.artifacts.download_video,
-                "infographic": client.artifacts.download_infographic,
-                "slide-deck": client.artifacts.download_slide_deck,
-                "report": client.artifacts.download_report,
-                "mind-map": client.artifacts.download_mind_map,
-                "data-table": client.artifacts.download_data_table,
-                "quiz": client.artifacts.download_quiz,
-                "flashcards": client.artifacts.download_flashcards,
+    # Setup download method dispatch
+    download_methods: dict[str, _DownloadFn] = {
+        "audio": client.artifacts.download_audio,
+        "video": client.artifacts.download_video,
+        "infographic": client.artifacts.download_infographic,
+        "slide-deck": client.artifacts.download_slide_deck,
+        "report": client.artifacts.download_report,
+        "mind-map": client.artifacts.download_mind_map,
+        "data-table": client.artifacts.download_data_table,
+        "quiz": client.artifacts.download_quiz,
+        "flashcards": client.artifacts.download_flashcards,
+    }
+    download_fn: _DownloadFn | None = download_methods.get(artifact_type_name)
+    if not download_fn:
+        raise ValueError(f"Unknown artifact type: {artifact_type_name}")
+
+    # For slide-deck with PPTX format, bind output_format="pptx"
+    if artifact_type_name == "slide-deck" and slide_format == "pptx":
+        download_fn = partial(client.artifacts.download_slide_deck, output_format="pptx")
+
+    # For quiz/flashcards, always bind --format so the underlying API
+    # serialises the requested representation (json/markdown/html).
+    if artifact_type_name == "quiz":
+        download_fn = partial(client.artifacts.download_quiz, output_format=output_format)
+    elif artifact_type_name == "flashcards":
+        download_fn = partial(client.artifacts.download_flashcards, output_format=output_format)
+
+    # Fetch and filter artifacts by type and completed status
+    type_artifacts = await _get_completed_artifacts_as_dicts(client, nb_id_resolved, artifact_kind)
+
+    if not type_artifacts:
+        return {
+            "error": f"No completed {artifact_type_name} artifacts found",
+            "suggestion": f"Generate one with: notebooklm generate {artifact_type_name}",
+        }
+
+    # Helper for file conflict resolution
+    def _resolve_conflict(path: Path) -> tuple[Path | None, dict | None]:
+        if not path.exists():
+            return path, None
+
+        if no_clobber:
+            return None, {
+                "status": "skipped",
+                "reason": "file exists",
+                "path": str(path),
             }
-            download_fn: _DownloadFn | None = download_methods.get(artifact_type_name)
-            if not download_fn:
-                raise ValueError(f"Unknown artifact type: {artifact_type_name}")
 
-            # For slide-deck with PPTX format, bind output_format="pptx"
-            if artifact_type_name == "slide-deck" and slide_format == "pptx":
-                download_fn = partial(client.artifacts.download_slide_deck, output_format="pptx")
+        if not force:
+            # Auto-rename
+            counter = 2
+            base_name = path.stem
+            parent = path.parent
+            ext = path.suffix
+            while path.exists():
+                path = parent / f"{base_name} ({counter}){ext}"
+                counter += 1
 
-            # For quiz/flashcards, always bind --format so the underlying API
-            # serialises the requested representation (json/markdown/html).
-            if artifact_type_name == "quiz":
-                download_fn = partial(client.artifacts.download_quiz, output_format=output_format)
-            elif artifact_type_name == "flashcards":
-                download_fn = partial(
-                    client.artifacts.download_flashcards, output_format=output_format
-                )
+        return path, None
 
-            # Fetch and filter artifacts by type and completed status
-            type_artifacts = await _get_completed_artifacts_as_dicts(
-                client, nb_id_resolved, artifact_kind
+    # Handle --all flag
+    if download_all:
+        output_dir = Path(output_path) if output_path else Path(default_output_dir)
+
+        # Apply --name filter before previewing/downloading. Match the
+        # case-insensitive substring semantics used by
+        # ``select_artifact`` for the single-artifact path so the two
+        # entry points stay consistent. If the filter excludes every
+        # artifact, return the same legacy error envelope as
+        # ``select_artifact`` does on a name miss (caller exits 1 via
+        # the top-level "error" key check in ``_run_artifact_download``).
+        if name:
+            name_lower = name.lower()
+            filtered_artifacts = [a for a in type_artifacts if name_lower in a["title"].lower()]
+            if not filtered_artifacts:
+                return {
+                    "error": (
+                        f"No artifacts matching '{name}'. "
+                        f"Available: {', '.join(a['title'] for a in type_artifacts)}"
+                    ),
+                }
+            type_artifacts = filtered_artifacts
+
+        # Pre-compute the final filename per artifact so dry-run and
+        # execution agree on duplicate-title disambiguation. The
+        # execution loop below mutates ``existing_names`` as it goes;
+        # dry-run iterates the same way so its preview reflects the
+        # ``Title (2).ext`` / ``Title (3).ext`` suffixes the execution
+        # path would write.
+        planned_filenames: list[str] = []
+        existing_names: set[str] = set()
+        for artifact in type_artifacts:
+            item_name = artifact_title_to_filename(
+                artifact["title"],
+                file_extension,
+                existing_names,
             )
+            existing_names.add(item_name)
+            planned_filenames.append(item_name)
 
-            if not type_artifacts:
-                return {
-                    "error": f"No completed {artifact_type_name} artifacts found",
-                    "suggestion": f"Generate one with: notebooklm generate {artifact_type_name}",
-                }
-
-            # Helper for file conflict resolution
-            def _resolve_conflict(path: Path) -> tuple[Path | None, dict | None]:
-                if not path.exists():
-                    return path, None
-
-                if no_clobber:
-                    return None, {
-                        "status": "skipped",
-                        "reason": "file exists",
-                        "path": str(path),
+        if dry_run:
+            return {
+                "dry_run": True,
+                "operation": "download_all",
+                "count": len(type_artifacts),
+                "output_dir": str(output_dir),
+                "artifacts": [
+                    {
+                        "id": a["id"],
+                        "title": a["title"],
+                        "filename": item_name,
                     }
+                    for a, item_name in zip(type_artifacts, planned_filenames, strict=True)
+                ],
+            }
 
-                if not force:
-                    # Auto-rename
-                    counter = 2
-                    base_name = path.stem
-                    parent = path.parent
-                    ext = path.suffix
-                    while path.exists():
-                        path = parent / f"{base_name} ({counter}){ext}"
-                        counter += 1
+        output_dir.mkdir(parents=True, exist_ok=True)
 
-                return path, None
+        artifacts_results: list[dict[str, Any]] = []
+        total = len(type_artifacts)
+        succeeded_count = 0
+        failed_count = 0
+        skipped_count = 0
 
-            # Handle --all flag
-            if download_all:
-                output_dir = Path(output_path) if output_path else Path(default_output_dir)
+        for i, (artifact, item_name) in enumerate(
+            zip(type_artifacts, planned_filenames, strict=True), 1
+        ):
+            # Progress indicator
+            if not json_output:
+                console.print(f"[dim]Downloading {i}/{total}:[/dim] {artifact['title']}")
 
-                # Apply --name filter before previewing/downloading. Match the
-                # case-insensitive substring semantics used by
-                # ``select_artifact`` for the single-artifact path so the two
-                # entry points stay consistent. If the filter excludes every
-                # artifact, return the same legacy error envelope as
-                # ``select_artifact`` does on a name miss (caller exits 1 via
-                # the top-level "error" key check in ``_run_artifact_download``).
-                if name:
-                    name_lower = name.lower()
-                    filtered_artifacts = [
-                        a for a in type_artifacts if name_lower in a["title"].lower()
-                    ]
-                    if not filtered_artifacts:
-                        return {
-                            "error": (
-                                f"No artifacts matching '{name}'. "
-                                f"Available: {', '.join(a['title'] for a in type_artifacts)}"
-                            ),
-                        }
-                    type_artifacts = filtered_artifacts
-
-                # Pre-compute the final filename per artifact so dry-run and
-                # execution agree on duplicate-title disambiguation. The
-                # execution loop below mutates ``existing_names`` as it goes;
-                # dry-run iterates the same way so its preview reflects the
-                # ``Title (2).ext`` / ``Title (3).ext`` suffixes the execution
-                # path would write.
-                planned_filenames: list[str] = []
-                existing_names: set[str] = set()
-                for artifact in type_artifacts:
-                    item_name = artifact_title_to_filename(
-                        artifact["title"],
-                        file_extension,
-                        existing_names,
-                    )
-                    existing_names.add(item_name)
-                    planned_filenames.append(item_name)
-
-                if dry_run:
-                    return {
-                        "dry_run": True,
-                        "operation": "download_all",
-                        "count": len(type_artifacts),
-                        "output_dir": str(output_dir),
-                        "artifacts": [
-                            {
-                                "id": a["id"],
-                                "title": a["title"],
-                                "filename": item_name,
-                            }
-                            for a, item_name in zip(type_artifacts, planned_filenames, strict=True)
-                        ],
-                    }
-
-                output_dir.mkdir(parents=True, exist_ok=True)
-
-                artifacts_results: list[dict[str, Any]] = []
-                total = len(type_artifacts)
-                succeeded_count = 0
-                failed_count = 0
-                skipped_count = 0
-
-                for i, (artifact, item_name) in enumerate(
-                    zip(type_artifacts, planned_filenames, strict=True), 1
-                ):
-                    # Progress indicator
-                    if not json_output:
-                        console.print(f"[dim]Downloading {i}/{total}:[/dim] {artifact['title']}")
-
-                    item_path = output_dir / item_name
-
-                    # Resolve conflicts
-                    resolved_path, skip_info = _resolve_conflict(item_path)
-                    if skip_info or resolved_path is None:
-                        artifacts_results.append(
-                            {
-                                "id": artifact["id"],
-                                "title": artifact["title"],
-                                "filename": item_name,
-                                **(
-                                    skip_info
-                                    or {"status": "skipped", "reason": "conflict resolution failed"}
-                                ),
-                            }
-                        )
-                        skipped_count += 1
-                        continue
-
-                    # Update if auto-renamed
-                    item_path = resolved_path
-                    item_name = item_path.name
-
-                    # Download
-                    try:
-                        # Download using dispatch
-                        await download_fn(
-                            nb_id_resolved, str(item_path), artifact_id=str(artifact["id"])
-                        )
-
-                        artifacts_results.append(
-                            {
-                                "id": artifact["id"],
-                                "title": artifact["title"],
-                                "filename": item_name,
-                                "path": str(item_path),
-                                "status": "downloaded",
-                            }
-                        )
-                        succeeded_count += 1
-                    except Exception as e:
-                        artifacts_results.append(
-                            {
-                                "id": artifact["id"],
-                                "title": artifact["title"],
-                                "filename": item_name,
-                                "status": "failed",
-                                "error": str(e),
-                            }
-                        )
-                        failed_count += 1
-
-                # Per P1.T4: ANY per-item failure must surface to a non-zero
-                # exit code. ``_run_artifact_download`` keys exit-code policy
-                # on the presence of the top-level ``"error"`` field, so we
-                # only add it when there are failures — keeping the all-success
-                # envelope exit-0-clean while making partial / total failure
-                # automation-friendly via the documented counts.
-                envelope: dict[str, Any] = {
-                    "operation": "download_all",
-                    "output_dir": str(output_dir),
-                    "total": total,
-                    "succeeded_count": succeeded_count,
-                    "failed_count": failed_count,
-                    "skipped_count": skipped_count,
-                    "artifacts": artifacts_results,
-                }
-                if failed_count > 0:
-                    envelope["error"] = True
-                return envelope
-
-            # Single artifact selection
-            try:
-                resolved_artifact_id = (
-                    resolve_partial_artifact_id(type_artifacts, artifact_id)
-                    if artifact_id
-                    else None
-                )
-                selected, reason = select_artifact(
-                    type_artifacts,
-                    latest=latest,
-                    earliest=earliest,
-                    name=name,
-                    artifact_id=resolved_artifact_id,
-                )
-            except ValueError as e:
-                return {"error": str(e)}
-
-            # Determine output path
-            if not output_path:
-                safe_name = artifact_title_to_filename(
-                    str(selected["title"]),
-                    file_extension,
-                    set(),
-                )
-                final_path = Path.cwd() / safe_name
-            else:
-                final_path = Path(output_path)
-
-            # Dry run
-            if dry_run:
-                return {
-                    "dry_run": True,
-                    "operation": "download_single",
-                    "artifact": {
-                        "id": selected["id"],
-                        "title": selected["title"],
-                        "selection_reason": reason,
-                    },
-                    "output_path": str(final_path),
-                }
+            item_path = output_dir / item_name
 
             # Resolve conflicts
-            resolved_path, skip_error = _resolve_conflict(final_path)
-            if skip_error or resolved_path is None:
-                return {
-                    "error": f"File exists: {final_path}",
-                    "artifact": selected,
-                    "suggestion": "Use --force to overwrite or choose a different path",
-                }
+            resolved_path, skip_info = _resolve_conflict(item_path)
+            if skip_info or resolved_path is None:
+                artifacts_results.append(
+                    {
+                        "id": artifact["id"],
+                        "title": artifact["title"],
+                        "filename": item_name,
+                        **(
+                            skip_info
+                            or {"status": "skipped", "reason": "conflict resolution failed"}
+                        ),
+                    }
+                )
+                skipped_count += 1
+                continue
 
-            final_path = resolved_path
+            # Update if auto-renamed
+            item_path = resolved_path
+            item_name = item_path.name
 
             # Download
             try:
                 # Download using dispatch
-                result_path = await download_fn(
-                    nb_id_resolved, str(final_path), artifact_id=str(selected["id"])
+                await download_fn(nb_id_resolved, str(item_path), artifact_id=str(artifact["id"]))
+
+                artifacts_results.append(
+                    {
+                        "id": artifact["id"],
+                        "title": artifact["title"],
+                        "filename": item_name,
+                        "path": str(item_path),
+                        "status": "downloaded",
+                    }
                 )
-
-                return {
-                    "operation": "download_single",
-                    "artifact": {
-                        "id": selected["id"],
-                        "title": selected["title"],
-                        "selection_reason": reason,
-                    },
-                    "output_path": result_path or str(final_path),
-                    "status": "downloaded",
-                }
+                succeeded_count += 1
             except Exception as e:
-                return {"error": str(e), "artifact": selected}
+                artifacts_results.append(
+                    {
+                        "id": artifact["id"],
+                        "title": artifact["title"],
+                        "filename": item_name,
+                        "status": "failed",
+                        "error": str(e),
+                    }
+                )
+                failed_count += 1
 
-    return await _download()
+        # Per P1.T4: ANY per-item failure must surface to a non-zero
+        # exit code. ``_run_artifact_download`` keys exit-code policy
+        # on the presence of the top-level ``"error"`` field, so we
+        # only add it when there are failures — keeping the all-success
+        # envelope exit-0-clean while making partial / total failure
+        # automation-friendly via the documented counts.
+        envelope: dict[str, Any] = {
+            "operation": "download_all",
+            "output_dir": str(output_dir),
+            "total": total,
+            "succeeded_count": succeeded_count,
+            "failed_count": failed_count,
+            "skipped_count": skipped_count,
+            "artifacts": artifacts_results,
+        }
+        if failed_count > 0:
+            envelope["error"] = True
+        return envelope
+
+    # Single artifact selection
+    try:
+        resolved_artifact_id = (
+            resolve_partial_artifact_id(type_artifacts, artifact_id) if artifact_id else None
+        )
+        selected, reason = select_artifact(
+            type_artifacts,
+            latest=latest,
+            earliest=earliest,
+            name=name,
+            artifact_id=resolved_artifact_id,
+        )
+    except ValueError as e:
+        return {"error": str(e)}
+
+    # Determine output path
+    if not output_path:
+        safe_name = artifact_title_to_filename(
+            str(selected["title"]),
+            file_extension,
+            set(),
+        )
+        final_path = Path.cwd() / safe_name
+    else:
+        final_path = Path(output_path)
+
+    # Dry run
+    if dry_run:
+        return {
+            "dry_run": True,
+            "operation": "download_single",
+            "artifact": {
+                "id": selected["id"],
+                "title": selected["title"],
+                "selection_reason": reason,
+            },
+            "output_path": str(final_path),
+        }
+
+    # Resolve conflicts
+    resolved_path, skip_error = _resolve_conflict(final_path)
+    if skip_error or resolved_path is None:
+        return {
+            "error": f"File exists: {final_path}",
+            "artifact": selected,
+            "suggestion": "Use --force to overwrite or choose a different path",
+        }
+
+    final_path = resolved_path
+
+    # Download
+    try:
+        # Download using dispatch
+        result_path = await download_fn(
+            nb_id_resolved, str(final_path), artifact_id=str(selected["id"])
+        )
+
+        return {
+            "operation": "download_single",
+            "artifact": {
+                "id": selected["id"],
+                "title": selected["title"],
+                "selection_reason": reason,
+            },
+            "output_path": result_path or str(final_path),
+            "status": "downloaded",
+        }
+    except Exception as e:
+        return {"error": str(e), "artifact": selected}
 
 
 def _display_download_result(result: dict, artifact_type: str) -> None:
@@ -761,7 +746,7 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     Handles the common pattern across all artifact download commands.
 
     Exception and auth-bootstrap paths are routed through the shared
-    ``with_auth_and_errors`` runtime so download commands match decorator-based
+    ``run_client_workflow`` runtime so download commands match decorator-based
     commands for ``--json`` error envelopes, auth-required UX, verbose logging,
     and exit-code policy.
 
@@ -771,16 +756,16 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     typed handler — it preserves the legacy `{"error": "<msg>"}` JSON shape
     that scripts already depend on, and exits 1 directly.
 
-    Missing storage files are handled inside ``with_auth_and_errors`` before
+    Missing storage files are handled inside ``run_client_workflow`` before
     the command body runs. ``FileNotFoundError`` raised by the download body
     still reaches the typed error handler as an unexpected command failure.
     """
     config = ARTIFACT_CONFIGS[artifact_type]
     json_output = kwargs.get("json_output", False)
 
-    async def body(client_auth: AuthTokens) -> dict[str, Any]:
+    async def body(client: NotebookLMClient) -> dict[str, Any]:
         return await _download_artifacts_generic(
-            client_auth=client_auth,
+            client=client,
             artifact_type_name=artifact_type,
             artifact_kind=config["kind"],
             file_extension=config["extension"],
@@ -788,11 +773,12 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
             **kwargs,
         )
 
-    result = with_auth_and_errors(
+    result = run_client_workflow(
         ctx,
         command_name=f"download_{artifact_type.replace('-', '_')}",
         json_output=json_output,
         body=body,
+        client_factory=NotebookLMClient,
     )
 
     if json_output:

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -40,7 +40,7 @@ from ..paths import (
     get_path_info,
     get_storage_path,
 )
-from .auth_runtime import get_auth_tokens, handle_auth_error
+from .auth_runtime import handle_auth_error, run_client_workflow
 from .context import (
     _current_storage_override,
     clear_context,
@@ -931,62 +931,42 @@ def register_session_commands(cli):
             console.print(table)
             return
 
-        try:
-            auth = get_auth_tokens(ctx)
-        except FileNotFoundError:
-            # No auth file on disk — fail closed (don't poison context.json
-            # with an unverified ID) and route through the typed
-            # ``handle_auth_error`` UX so JSON callers get the standard
-            # ``AUTH_REQUIRED`` envelope and text callers get the rich
-            # multi-line "Run notebooklm login" walkthrough.
-            handle_auth_error(json_output)
-            return  # unreachable — handle_auth_error raises SystemExit
-        except click.ClickException:
-            raise
+        async def _get(client: NotebookLMClient):
+            # Resolve partial ID to full ID. Forward ``json_output`` so the
+            # resolver's "Matched: …" partial-ID diagnostic routes to stderr
+            # in --json mode and stdout stays pure parseable JSON for scripted
+            # callers.
+            resolved_id = await resolve_notebook_id(client, notebook_id, json_output=json_output)
+            nb = await client.notebooks.get(resolved_id)
+            return nb, resolved_id
 
-        async def _get():
-            async with NotebookLMClient(auth) as client:
-                # Resolve partial ID to full ID. Forward ``json_output`` so
-                # the resolver's "Matched: …" partial-ID diagnostic routes
-                # to stderr in --json mode and stdout stays pure parseable
-                # JSON for scripted callers.
-                resolved_id = await resolve_notebook_id(
-                    client, notebook_id, json_output=json_output
+        def _handle_use_verification_error(exc: Exception):
+            if isinstance(exc, click.ClickException):
+                # Re-raise click exceptions (from resolve_notebook_id —
+                # partial-id ambiguity or "no match"). These already exit
+                # non-zero with a clear message and never reach persistence.
+                raise exc
+            if isinstance(exc, NotebookNotFoundError):
+                # Server confirmed the notebook does not exist. Fail closed:
+                # do not persist anything to context.json.
+                _output_error(
+                    f"Error: Notebook {notebook_id!r} not found. "
+                    "Run 'notebooklm list' to see available notebooks, "
+                    "or pass --force to bypass verification.",
+                    "NOT_FOUND",
+                    json_output,
+                    1,
                 )
-                nb = await client.notebooks.get(resolved_id)
-                return nb, resolved_id
+                raise AssertionError("unreachable")
+            if isinstance(exc, AuthError):
+                # Auth expired (e.g. SID/SSID cookies stale). Route through
+                # the canonical "Run notebooklm login" UX instead of the
+                # generic verification-failed fallback.
+                handle_auth_error(json_output)
 
-        try:
-            nb, resolved_id = run_async(_get())
-        except click.ClickException:
-            # Re-raise click exceptions (from resolve_notebook_id — partial-id
-            # ambiguity or "no match"). These already exit non-zero with a
-            # clear message and never reach the persistence branch.
-            raise
-        except NotebookNotFoundError:
-            # Server confirmed the notebook does not exist. Fail closed: do
-            # not persist anything to context.json, and exit 1 with a clear
-            # error.
-            _output_error(
-                f"Error: Notebook {notebook_id!r} not found. "
-                "Run 'notebooklm list' to see available notebooks, "
-                "or pass --force to bypass verification.",
-                "NOT_FOUND",
-                json_output,
-                1,
-            )
-        except AuthError:
-            # Auth expired (e.g. SID/SSID cookies stale). Route through the
-            # typed UX so the user sees "Run notebooklm login" instead of
-            # the generic "Pass --force to persist without verification"
-            # catch-all that previously hid the real remediation.
-            # See ``helpers.handle_auth_error`` for the canonical message.
-            handle_auth_error(json_output)
-            return  # unreachable — handle_auth_error raises SystemExit
-        except Exception as exc:
-            # All other failures (network errors, RPC errors, etc.) also
-            # fail closed — we cannot confirm the notebook exists, so refuse
-            # to persist. --force is the documented escape hatch.
+            # All other failures (network errors, RPC errors, etc.) also fail
+            # closed — we cannot confirm the notebook exists, so refuse to
+            # persist. --force is the documented escape hatch.
             _output_error(
                 f"Error: Could not verify notebook {notebook_id!r}: {exc}. "
                 "Pass --force to persist without verification.",
@@ -994,6 +974,16 @@ def register_session_commands(cli):
                 json_output,
                 1,
             )
+            raise AssertionError("unreachable")
+
+        nb, resolved_id = run_client_workflow(
+            ctx,
+            command_name="session_use",
+            json_output=json_output,
+            body=_get,
+            client_factory=NotebookLMClient,
+            body_error_handler=_handle_use_verification_error,
+        )
 
         created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
         set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -963,6 +963,7 @@ def register_session_commands(cli):
                 # the canonical "Run notebooklm login" UX instead of the
                 # generic verification-failed fallback.
                 handle_auth_error(json_output)
+                raise AssertionError("unreachable")
 
             # All other failures (network errors, RPC errors, etc.) also fail
             # closed — we cannot confirm the notebook exists, so refuse to

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -94,6 +94,21 @@ def _make_click_context(verbose: int = 0) -> click.Context:
     return click.Context(run, parent=root_ctx)
 
 
+class _FakeClientManager:
+    def __init__(self, client):
+        self.client = client
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Shared primitive behavior
 # ---------------------------------------------------------------------------
@@ -160,6 +175,71 @@ def test_auth_runtime_default_auth_loader_preserves_helpers_patch_seam() -> None
 
     loader.assert_called_once_with(ctx)
     assert result is sentinel_auth
+
+
+def test_run_client_workflow_opens_client_with_loaded_auth() -> None:
+    sentinel_auth = MagicMock(name="auth")
+    sentinel_client = MagicMock(name="client")
+    manager = _FakeClientManager(sentinel_client)
+    seen: dict[str, object] = {}
+    ctx = _make_click_context()
+
+    def _loader(loader_ctx: click.Context):
+        seen["ctx"] = loader_ctx
+        return sentinel_auth
+
+    def _client_factory(auth):
+        seen["factory_auth"] = auth
+        return manager
+
+    async def _body(client):
+        seen["client"] = client
+        return "ok"
+
+    result = auth_runtime.run_client_workflow(
+        ctx,
+        command_name="run",
+        json_output=False,
+        body=_body,
+        auth_loader=_loader,
+        client_factory=_client_factory,
+    )
+
+    assert result == "ok"
+    assert seen == {
+        "ctx": ctx,
+        "factory_auth": sentinel_auth,
+        "client": sentinel_client,
+    }
+    assert manager.entered is True
+    assert manager.exited is True
+
+
+def test_run_client_workflow_body_error_handler_can_handle_body_exception() -> None:
+    sentinel_auth = MagicMock(name="auth")
+    sentinel_client = MagicMock(name="client")
+    manager = _FakeClientManager(sentinel_client)
+    ctx = _make_click_context()
+
+    async def _body(_client):
+        raise RuntimeError("body failed")
+
+    def _handle(exc: Exception) -> str:
+        return f"handled: {exc}"
+
+    result = auth_runtime.run_client_workflow(
+        ctx,
+        command_name="run",
+        json_output=False,
+        body=_body,
+        auth_loader=lambda _ctx: sentinel_auth,
+        client_factory=lambda _auth: manager,
+        body_error_handler=_handle,
+    )
+
+    assert result == "handled: body failed"
+    assert manager.entered is True
+    assert manager.exited is True
 
 
 def test_with_auth_and_errors_passes_verbose_json_to_current_handle_errors() -> None:


### PR DESCRIPTION
## Summary

Rebased and retargeted to `main` after #940 merged.

- promote `run_client_workflow()` in `cli/auth_runtime.py` as the shared adapter for command workflows that need an opened `NotebookLMClient`
- migrate artifact downloads and `session use` verification onto the adapter while preserving existing module-local `NotebookLMClient` patch seams
- keep `language.py` on its existing best-effort helpers because those paths intentionally swallow auth/RPC failures and return `None` instead of behaving like command workflows
- add coverage for client lifetime wiring and the body-error hook used by `session use`

## Verification

- `uv run pytest tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_download.py tests/unit/cli/test_session_edge_cases.py tests/unit/test_session_lifecycle.py tests/unit/test_session_auth.py tests/unit/test_session_contracts.py tests/unit/test_session_close.py -q`
- `uv run ruff check src/notebooklm/cli/auth_runtime.py src/notebooklm/cli/download.py src/notebooklm/cli/session.py tests/unit/test_with_client_handle_errors.py`
- `uv run ruff format --check src/notebooklm/cli/auth_runtime.py src/notebooklm/cli/download.py src/notebooklm/cli/session.py tests/unit/test_with_client_handle_errors.py`
- `uv run mypy src/notebooklm/cli/auth_runtime.py src/notebooklm/cli/download.py src/notebooklm/cli/session.py --ignore-missing-imports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified CLI workflows to run with a managed client context and improved error routing, consolidating download and session command behavior.

* **Bug Fixes**
  * Better handling of exceptions raised during command execution via an optional body-level error handler to surface structured errors without leaking internal state.

* **Tests**
  * Added tests verifying client lifecycle management and the new body-error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->