### PR TITLE
chore: post-merge review follow-ups for #929/#932/#934/#935

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -677,7 +677,7 @@ class Session:
         3. Saves cookies one last time through ``save_cookies``.
         4. Calls ``aclose()`` under :func:`asyncio.shield` so cancellation
            arriving mid-close cannot leak the underlying httpx transport.
-        5. Nulls out ``_http_client``, ``_authed_transport`` and
+        5. Nulls out ``_kernel._http_client``, ``_authed_transport`` and
            ``_rpc_executor`` so a follow-up :meth:`open` rebuilds the
            transport collaborators against the new ``httpx.AsyncClient``.
         """

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -58,10 +58,15 @@ Design constraints (load-bearing — see ``tests/unit/test_client_keepalive.py``
 
 Field names (``_http_client``, ``_bound_loop``, ``_keepalive_task``,
 ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``,
-``_connect_timeout``, ``_limits``) deliberately mirror the legacy
-``Session`` ivars so the compat ``@property`` bridges on ``Session``
-can stay readable for reviewers grepping the codebase. ``_http_client`` is now
-a property bridge to the Kernel rather than lifecycle-owned storage.
+``_connect_timeout``, ``_limits``) historically mirrored the legacy
+``Session`` ivars when ``Session`` still held ``@property`` bridges that
+forwarded to them. Those bridges were retired in the session-shrink arc
+(see ``tests/_lint/test_no_session_compat_bridges.py`` and the
+"closed for the property-shim debt" note in ``docs/architecture.md``);
+the names are kept verbatim now for grep discoverability across the test
+suite — callers reach the storage directly via ``session._lifecycle.<attr>``
+or the public ``session.bound_loop`` property. ``_http_client`` is a thin
+accessor returning the live ``httpx.AsyncClient`` from the concrete Kernel.
 """
 
 from __future__ import annotations
@@ -194,9 +199,11 @@ class _LifecycleHost(Protocol):
 class ClientLifecycle:
     """Owns HTTP-client open/close, keepalive, cookie persistence on close.
 
-    Field names mirror the legacy ``Session`` ivars so the compat
-    ``@property`` bridges on ``Session`` can delegate with
-    ``return self._lifecycle._<attr>`` and stay readable.
+    Field names mirror the legacy ``Session`` ivars for grep discoverability
+    across the test suite. The ``@property`` bridges that historically
+    delegated with ``return self._lifecycle._<attr>`` were retired in the
+    session-shrink arc; callers now reach these fields directly via
+    ``session._lifecycle.<attr>``.
 
     Construction is event-loop-agnostic — only plain values and ``None``
     placeholders are stored. The ``httpx.AsyncClient`` and the keepalive

--- a/src/notebooklm/cli/download_helpers.py
+++ b/src/notebooklm/cli/download_helpers.py
@@ -62,6 +62,7 @@ def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str)
             title_of=lambda a: a["title"],
             error_factory=ValueError,
             emit_match_status=False,
+            allow_full_id_passthrough=False,
         )
     except ValueError as e:
         # Re-shape the canonical "No artifact found starting with..." /

--- a/src/notebooklm/cli/download_helpers.py
+++ b/src/notebooklm/cli/download_helpers.py
@@ -20,11 +20,15 @@ class ArtifactDict(TypedDict):
 def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str) -> str:
     """Resolve a partial artifact ID to a full ID.
 
-    Full UUID-shaped IDs (canonical 8-4-4-4-12 hex layout, case-insensitive -
-    see :data:`notebooklm.cli.resolve.FULL_ID_PATTERN`) are returned as-is.
-    Anything else - including a 25-char prefix of a 36-char UUID - is matched
-    as a case-insensitive prefix against the artifact list, so unique prefixes
-    resolve locally rather than reaching the backend as truncated IDs.
+    UUID-shaped IDs (canonical 8-4-4-4-12 hex layout, case-insensitive -
+    see :data:`notebooklm.cli.resolve.FULL_ID_PATTERN`) are validated against
+    the pre-fetched ``artifacts`` list (full-ID passthrough is disabled for
+    this path via ``allow_full_id_passthrough=False``). A UUID not present
+    in ``artifacts`` raises the canonical local "not found" error instead
+    of passing through to a backend 404. Anything else - including a 25-char
+    prefix of a 36-char UUID - is matched as a case-insensitive prefix
+    against the artifact list, so unique prefixes resolve locally rather
+    than reaching the backend as truncated IDs.
 
     The matching logic is delegated to
     :func:`notebooklm.cli.resolve.resolve_partial_id_in_items` (the canonical

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -188,6 +188,7 @@ def research_wait(
             async with status_with_elapsed(
                 "Waiting for research to complete...",
                 json_output=json_output,
+                resume_hint="notebooklm research status",
             ):
                 poll_result = await poll_until(
                     _fetch_status,

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -199,6 +199,7 @@ def resolve_partial_id_in_items(
     json_output: bool = False,
     stdout_console: Console | None = None,
     stderr_output_console: Console | None = None,
+    allow_full_id_passthrough: bool = True,
 ) -> str:
     """Resolve a partial ID against a **pre-fetched** item list.
 
@@ -247,6 +248,13 @@ def resolve_partial_id_in_items(
             so stdout stays parseable JSON.
         stdout_console: Console for human-mode diagnostics.
         stderr_output_console: Console for JSON-mode diagnostics.
+        allow_full_id_passthrough: When true (default), a canonical
+            8-4-4-4-12 UUID is returned verbatim without scanning
+            ``items``. Callers that have already fetched the
+            authoritative item list (e.g. download helpers) pass
+            ``False`` so a full-shape ID that isn't in the list raises
+            the canonical "not found" error instead of silently
+            propagating to a backend 404.
 
     Returns:
         Full ID of the matched item.
@@ -266,8 +274,12 @@ def resolve_partial_id_in_items(
     partial_id = partial_id.strip()
 
     # Concrete IDs are passed through so direct get/delete commands can hit
-    # the backend by ID without forcing an extra list RPC first.
-    if _is_full_id_candidate(partial_id):
+    # the backend by ID without forcing an extra list RPC first. Callers
+    # that already hold an authoritative item list (download helpers) opt
+    # out via ``allow_full_id_passthrough=False`` so a full-shape ID that
+    # isn't in the list falls through to the membership check below and
+    # surfaces the canonical "not found" error rather than a silent 404.
+    if allow_full_id_passthrough and _is_full_id_candidate(partial_id):
         return partial_id
 
     partial_id_lower = partial_id.lower()

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -49,9 +49,6 @@ def _format_status_message(artifact_type: str, elapsed: float | None = None) -> 
     return f"{base} [{int(elapsed)}s elapsed]"
 
 
-_status_with_elapsed = status_with_elapsed
-
-
 def calculate_backoff_delay(
     attempt: int,
     initial_delay: float = RETRY_INITIAL_DELAY,

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -52,7 +52,12 @@ FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
     {
         # ClientLifecycle bridges retired in session-shrink PR 6 — readers now
         # go straight to ``session._kernel`` / ``session._lifecycle`` or use
-        # the public ``session.bound_loop`` property.
+        # the public ``session.bound_loop`` property. Lifecycle bridge names
+        # (``_http_client``, ``_bound_loop``, ``_timeout``, ``_connect_timeout``,
+        # ``_limits``, ``_keepalive_interval``, ``_keepalive_task``) are
+        # intentionally NOT listed below: ``Session`` no longer defines them,
+        # so any stray reference raises ``AttributeError`` at access time —
+        # no lint guard required.
         # AuthRefreshCoordinator bridges retired in session-shrink PR 5 —
         # readers (and the two ``_refresh_callback`` writers in
         # ``tests/integration/test_session_integration.py``) now go straight

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -11,10 +11,10 @@ from click.testing import CliRunner
 from notebooklm.cli.services.artifact_generation import (
     RETRY_MAX_DELAY,
     _format_status_message,
-    _status_with_elapsed,
     calculate_backoff_delay,
     generate_with_retry,
 )
+from notebooklm.cli.services.polling import status_with_elapsed
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc.types import ReportFormat
 
@@ -2292,7 +2292,7 @@ class TestStatusWithElapsed:
 
         async def _exercise() -> None:
             with patch.object(artifact_generation_module.console, "status") as mock_status:
-                async with _status_with_elapsed("audio", json_output=True):
+                async with status_with_elapsed("audio", json_output=True):
                     pass
                 assert not mock_status.called, "console.status must not be invoked under --json"
 
@@ -2409,7 +2409,7 @@ class TestGenerateWaitSigintResumeHint:
                 mock_status.return_value.__enter__ = MagicMock(return_value=MagicMock())
                 mock_status.return_value.__exit__ = MagicMock(return_value=False)
                 with pytest.raises(KeyboardInterrupt):
-                    async with _status_with_elapsed("audio", resume_hint=None):
+                    async with status_with_elapsed("audio", resume_hint=None):
                         raise KeyboardInterrupt
 
         asyncio.run(_exercise())

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -808,6 +808,27 @@ class TestResolvePartialIdInItems:
         )
         assert result == full
 
+    def test_full_uuid_no_passthrough_when_disabled(self):
+        """``allow_full_id_passthrough=False`` forces membership validation.
+
+        Callers that already hold the authoritative item list (download
+        helpers) opt out of the fast-path so a valid-shape UUID that isn't
+        in the list surfaces the canonical "not found" error instead of
+        being passed through and yielding a silent backend 404.
+        """
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        full = "abc12345-6789-4abc-def0-1234567890ab"
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_partial_id_in_items(
+                full,
+                [],
+                entity_name="artifact",
+                list_command="artifact list",
+                allow_full_id_passthrough=False,
+            )
+        assert "No artifact found starting with" in str(exc_info.value.message)
+
     def test_partial_unique_match_with_attr_accessor(self):
         from notebooklm.cli.resolve import resolve_partial_id_in_items
 

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -1065,3 +1065,24 @@ class TestEntitySpecificPartialArtifactId:
         with pytest.raises(ValueError) as exc:
             resolve_partial_artifact_id([], "abc")
         assert not isinstance(exc.value, _click.ClickException)
+
+    def test_full_uuid_not_in_list_preserves_not_found_contract(self):
+        """``resolve_partial_artifact_id`` keeps ``allow_full_id_passthrough=False``.
+
+        A canonical-shape UUID absent from ``artifacts`` MUST raise the
+        historical "Artifact '<id>' not found" wording rather than passing
+        through and silently 404-ing at the backend. Pins the wrapper-level
+        integration contract that the core-level
+        :class:`TestResolvePartialIdInItems` test exercises in isolation.
+        """
+        from notebooklm.cli.download_helpers import resolve_partial_artifact_id
+
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        artifacts = [
+            {"id": "xyz22222-aaaa-4abc-def0-000000000002", "title": "Only", "created_at": 1}
+        ]
+
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_artifact_id(artifacts, full_uuid)
+
+        assert str(exc.value) == f"Artifact '{full_uuid}' not found"

--- a/tests/unit/cli/test_resolver_characterization.py
+++ b/tests/unit/cli/test_resolver_characterization.py
@@ -332,12 +332,14 @@ class TestDownloadNotebookResolution:
                 ],
             )
 
-        # The ambiguity must show up in the output (either as an error
-        # envelope or as a non-zero exit). The current implementation
-        # returns the {"error": ...} envelope from ``_download()``.
-        out = result.output
-        # Either branch is acceptable; pin both so neither shape regresses.
-        assert "Ambiguous" in out or "ambiguous" in out
+        # Full contract: --json failure exits 1 (post-#925 exit-code parity)
+        # with a {"error": ...} envelope on stdout, and the download_audio
+        # mock MUST NOT be awaited because the resolver short-circuited
+        # before dispatch.
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert "Ambiguous" in payload["error"] or "ambiguous" in payload["error"]
+        mock_client.artifacts.download_audio.assert_not_awaited()
 
     def test_unknown_partial_artifact_id_surfaces_error(
         self, runner, mock_auth, mock_fetch, tmp_path
@@ -364,7 +366,13 @@ class TestDownloadNotebookResolution:
                 ],
             )
 
-        assert "not found" in result.output.lower()
+        # Full contract: --json failure exits 1 (post-#925 exit-code parity)
+        # with {"error": "Artifact 'zzz' not found"} on stdout, and
+        # download_audio MUST NOT be awaited.
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload == {"error": "Artifact 'zzz' not found"}
+        mock_client.artifacts.download_audio.assert_not_awaited()
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit/cli/test_resolver_characterization.py
+++ b/tests/unit/cli/test_resolver_characterization.py
@@ -338,7 +338,7 @@ class TestDownloadNotebookResolution:
         # before dispatch.
         assert result.exit_code == 1, result.output
         payload = json.loads(result.stdout)
-        assert "Ambiguous" in payload["error"] or "ambiguous" in payload["error"]
+        assert "Ambiguous partial ID" in payload["error"]
         mock_client.artifacts.download_audio.assert_not_awaited()
 
     def test_unknown_partial_artifact_id_surfaces_error(


### PR DESCRIPTION
## Summary

Bundles 7 small follow-ups surfaced by Claude reviews of four merged PRs (#929, #932, #934, #935). Each finding is a single-file touch-up — bundling avoids 4 redundant CI cycles.

## Changes

| ID | File(s) | What |
|----|---------|------|
| 929-a | `cli/resolve.py`, `cli/download_helpers.py`, `tests/unit/cli/test_resolve.py` | Add `allow_full_id_passthrough=True` kwarg to `resolve_partial_id_in_items`; download helpers pass `False` so a valid-shape UUID not in the pre-fetched list raises canonical "not found" instead of silent 404. New sibling test pins the gated behavior. |
| 929-b | `tests/unit/cli/test_resolver_characterization.py` | Strengthen ambiguous + unknown partial-artifact-ID tests: pin `exit_code == 1` (post-#925 `--json` failure contract), parse stdout as JSON, assert `download_audio.assert_not_awaited()`. (Note: the original Claude review suggested `exit_code == 0` — that was wrong post-#925; corrected here.) |
| 932-a | `_session_lifecycle.py` | Update 2 docstring blocks (module + `ClientLifecycle` class) that still claimed the `@property` bridges on `Session` were live. Those bridges were retired in the session-shrink arc. |
| 932-b | `tests/_lint/test_no_session_compat_bridges.py` | Add "names intentionally NOT listed" rationale to the ClientLifecycle block of `FORBIDDEN_PROPERTIES`, parallel to the existing auth/observability blocks. |
| 934-a | `cli/research.py` | Add `resume_hint="notebooklm research status"` so Ctrl-C during `research wait` emits the structured cancellation message instead of a raw KeyboardInterrupt. |
| 934-b | `cli/services/artifact_generation.py`, `tests/unit/cli/test_generate.py` | Remove `_status_with_elapsed = status_with_elapsed` re-export alias; migrate test imports + call-sites to import `status_with_elapsed` directly from `cli.services.polling`. |
| 935 | `_session.py` | Single-line `close()` docstring fix: `_http_client` → `_kernel._http_client` (field moved to `Kernel` in the session-shrink arc). |

## Source review comments

- #929 review: https://github.com/teng-lin/notebooklm-py/pull/929#issuecomment-4512915739
- #932 review: https://github.com/teng-lin/notebooklm-py/pull/932#issuecomment-4512916006
- #934 review: https://github.com/teng-lin/notebooklm-py/pull/934#issuecomment-4512916577
- #935 review: https://github.com/teng-lin/notebooklm-py/pull/935#issuecomment-4512916831

## Why bundled

Seven changes across already-merged PRs, each a one-or-two-line touch-up. Bundling into one PR saves 4 review/CI cycles and keeps the trail readable (every commit references its source review). After merge, each source PR gets a reply pointing here.

## Verification

- ✅ `uv run ruff format src tests` — clean (460 files unchanged)
- ✅ `uv run ruff check src tests` — clean
- ✅ `uv run mypy src/notebooklm --ignore-missing-imports` — clean (141 source files)
- ✅ `uv run pytest` — 5710 passed, 49 skipped, 0 failed

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Research wait command now shows a hint pointing users to the research status command.

* **Bug Fixes**
  * Artifact ID resolution tightened: full-form IDs are validated locally and now yield clearer "not found" errors when absent.

* **Documentation**
  * Updated lifecycle and shutdown documentation and a docstring for clarity.

* **Tests**
  * Added and adjusted tests validating artifact resolution behavior, CLI error outputs, and spinner/status handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->