### PR TITLE
refactor: retire audit-confirmed dead seam-manifest entries

### DIFF
--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -9,8 +9,7 @@ from enum import Enum
 from typing import Any
 
 from ..rpc.types import ArtifactStatus, ArtifactTypeCode, artifact_status_to_str
-from .common import UnknownTypeWarning
-from .common import _datetime_from_timestamp as _common_datetime_from_timestamp
+from .common import UnknownTypeWarning, _datetime_from_timestamp
 
 
 class ArtifactType(str, Enum):
@@ -91,11 +90,6 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
             )
         return ArtifactType.UNKNOWN
     return result
-
-
-def _datetime_from_timestamp(value: Any) -> datetime | None:
-    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
-    return _common_datetime_from_timestamp(value, datetime_type=datetime)
 
 
 def _is_valid_artifact_url(value: Any) -> bool:

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -117,11 +117,9 @@ class CitedSourceSelection:
     used_fallback: bool = False
 
 
-def _datetime_from_timestamp(
-    value: Any, *, datetime_type: type[datetime] = datetime
-) -> datetime | None:
+def _datetime_from_timestamp(value: Any) -> datetime | None:
     """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
     try:
-        return datetime_type.fromtimestamp(value)
+        return datetime.fromtimestamp(value)
     except (TypeError, ValueError, OSError, OverflowError):
         return None

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -55,7 +55,7 @@ class Notebook:
         if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 5:
             ts_data = data[5][5]
             if isinstance(ts_data, list) and len(ts_data) > 0:
-                created_at = _datetime_from_timestamp(ts_data[0], datetime_type=datetime)
+                created_at = _datetime_from_timestamp(ts_data[0])
 
         is_owner = True
         if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 1:

--- a/src/notebooklm/_types/notes.py
+++ b/src/notebooklm/_types/notes.py
@@ -6,12 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from .common import _datetime_from_timestamp as _common_datetime_from_timestamp
-
-
-def _datetime_from_timestamp(value: Any) -> datetime | None:
-    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
-    return _common_datetime_from_timestamp(value, datetime_type=datetime)
+from .common import _datetime_from_timestamp
 
 
 @dataclass

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -127,7 +127,7 @@ def _extract_source_created_at(metadata: Any) -> datetime | None:
     if not isinstance(timestamp_list, list) or not timestamp_list:
         return None
 
-    return _datetime_from_timestamp(timestamp_list[0], datetime_type=datetime)
+    return _datetime_from_timestamp(timestamp_list[0])
 
 
 @dataclass

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -52,33 +52,32 @@ from .rendering import console, json_output_response
 from .resolve import resolve_notebook_id
 from .runtime import run_async
 
-# Direct imports replace the D1-PR-3-retired forwarding wrappers; see
-# ADR-008. Some of these bindings (notably ``_sync_server_language_to_config``)
-# double as session-level monkeypatch surfaces for tests pre-dating ADR-008's
-# services-side patching convention.
+# Direct imports replace the D1-PR-3-retired forwarding wrappers; see ADR-008.
+# Several of these names also serve as ``notebooklm.cli.session.*`` monkeypatch
+# surfaces for tests that pre-date ADR-008's services-side patching convention
+# (e.g. ``_sync_server_language_to_config``, ``_login_browser_cookies_single``,
+# ``_refresh_from_browser_cookies``, ``_enumerate_browser_accounts``).
+#
+# The names tagged ``F401`` below are *only* patch surfaces — they are not
+# called from this module's body, but tests bind them on the
+# ``notebooklm.cli.session`` namespace either via direct import
+# (``test_cookie_domain_split.py``, ``test_auth_subcommands.py``) or via the
+# dual-patch fixture in ``tests/_fixtures/cli_session.py`` (whose
+# ``patch_session_login_dual`` requires the name to exist on both modules).
 from .services.login import (
     _build_google_cookie_domains,
     _enumerate_browser_accounts,
+    _enumerate_one_jar,  # noqa: F401 — patch surface only
     _login_all_accounts_from_browser,
     _login_browser_cookies_single,
+    _login_with_browser_cookies,  # noqa: F401 — patch surface only
     _parse_include_domains,
     _refresh_from_browser_cookies,
+    _resolve_optional_cookie_domains,  # noqa: F401 — patch surface only
+    _select_account,  # noqa: F401 — patch surface only
     _sync_server_language_to_config,
     _warn_missing_optional_domains,
-)
-
-# Re-exports kept solely for tests that bind these helpers on the
-# ``notebooklm.cli.session`` namespace — either via direct import
-# (``test_cookie_domain_split.py``, ``test_auth_subcommands.py``) or via
-# the dual-patch fixture in ``tests/_fixtures/cli_session.py`` (whose
-# ``patch_session_login_dual`` requires the name to exist on both modules).
-# These are not referenced in this module's body.
-from .services.login import (  # noqa: F401
-    _enumerate_one_jar,
-    _login_with_browser_cookies,
-    _resolve_optional_cookie_domains,
-    _select_account,
-    _write_extracted_cookies,
+    _write_extracted_cookies,  # noqa: F401 — patch surface only
 )
 
 logger = logging.getLogger(__name__)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -52,36 +52,32 @@ from .rendering import console, json_output_response
 from .resolve import resolve_notebook_id
 from .runtime import run_async
 
-# Direct re-imports replace the D1-PR-3-retired forwarding wrappers; see
-# ADR-008. Symbols not referenced in this module remain as patch-surface
-# re-exports for legacy ``patch("notebooklm.cli.session.X")`` test sites.
-from .services.login import (  # noqa: F401
-    _INCLUDE_DOMAINS_ALL,
-    _ROOKIEPY_BROWSER_ALIASES,
+# Direct imports replace the D1-PR-3-retired forwarding wrappers; see
+# ADR-008. Some of these bindings (notably ``_sync_server_language_to_config``)
+# double as session-level monkeypatch surfaces for tests pre-dating ADR-008's
+# services-side patching convention.
+from .services.login import (
     _build_google_cookie_domains,
     _enumerate_browser_accounts,
-    _enumerate_chromium_profiles_fanout,
-    _enumerate_one_jar,
-    _handle_rookiepy_error,
     _login_all_accounts_from_browser,
     _login_browser_cookies_single,
-    _login_with_browser_cookies,
-    _maybe_warn_firefox_containers_in_use,
-    _next_available_profile_name,
     _parse_include_domains,
-    _profile_account_email,
-    _profiles_by_account_email,
-    _read_browser_cookies,
-    _read_chromium_profile_cookies_from_selector,
-    _read_firefox_container_cookies,
     _refresh_from_browser_cookies,
-    _resolve_all_accounts_target,
-    _resolve_optional_cookie_domains,
-    _select_account,
-    _select_refresh_account,
-    _split_chromium_profile_browser_spec,
     _sync_server_language_to_config,
     _warn_missing_optional_domains,
+)
+
+# Re-exports kept solely for tests that bind these helpers on the
+# ``notebooklm.cli.session`` namespace — either via direct import
+# (``test_cookie_domain_split.py``, ``test_auth_subcommands.py``) or via
+# the dual-patch fixture in ``tests/_fixtures/cli_session.py`` (whose
+# ``patch_session_login_dual`` requires the name to exist on both modules).
+# These are not referenced in this module's body.
+from .services.login import (  # noqa: F401
+    _enumerate_one_jar,
+    _login_with_browser_cookies,
+    _resolve_optional_cookie_domains,
+    _select_account,
     _write_extracted_cookies,
 )
 

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -9,9 +9,6 @@ Usage:
     from notebooklm.types import SourceType, ArtifactType  # str enums for .kind
 """
 
-from datetime import datetime
-from typing import Any
-
 from ._types import artifacts as _artifact_types
 from ._types import sources as _source_types
 from ._types.artifacts import (
@@ -35,9 +32,7 @@ from ._types.common import (
     RpcTelemetryEvent,
     UnknownTypeWarning,
 )
-from ._types.common import (
-    _datetime_from_timestamp as _common_datetime_from_timestamp,
-)
+from ._types.common import _datetime_from_timestamp
 from ._types.notebooks import (
     Notebook,
     NotebookDescription,
@@ -114,11 +109,6 @@ _warned_source_types = _source_types._warned_source_types
 # Imported for the historical ``notebooklm.types.ArtifactTypeCode`` attribute,
 # but intentionally absent from ``__all__``.
 ArtifactTypeCode = _ArtifactTypeCode
-
-
-def _datetime_from_timestamp(value: Any) -> datetime | None:
-    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
-    return _common_datetime_from_timestamp(value, datetime_type=datetime)
 
 
 __all__ = [

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 from ._types import artifacts as _artifact_types
+from ._types import common as _common_types
 from ._types import sources as _source_types
 from ._types.artifacts import (
     Artifact,
@@ -32,7 +33,6 @@ from ._types.common import (
     RpcTelemetryEvent,
     UnknownTypeWarning,
 )
-from ._types.common import _datetime_from_timestamp
 from ._types.notebooks import (
     Notebook,
     NotebookDescription,
@@ -95,6 +95,7 @@ from .rpc.types import (
 # Keep private facade names that first-party tests and external callers have
 # historically imported while the implementation moves into _types modules.
 _SOURCE_TYPE_COMPAT_MAP = _source_types._SOURCE_TYPE_COMPAT_MAP
+_datetime_from_timestamp = _common_types._datetime_from_timestamp
 _extract_artifact_url = _artifact_types._extract_artifact_url
 _extract_audio_artifact_url = _artifact_types._extract_audio_artifact_url
 _extract_infographic_artifact_url = _artifact_types._extract_infographic_artifact_url

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Any
 
 from ._types import artifacts as _artifact_types
-from ._types import notebooks as _notebook_types
 from ._types import sources as _source_types
 from ._types.artifacts import (
     Artifact,
@@ -100,20 +99,15 @@ from .rpc.types import (
 
 # Keep private facade names that first-party tests and external callers have
 # historically imported while the implementation moves into _types modules.
-_ARTIFACT_TYPE_CODE_MAP = _artifact_types._ARTIFACT_TYPE_CODE_MAP
-_SOURCE_TYPE_CODE_MAP = _source_types._SOURCE_TYPE_CODE_MAP
 _SOURCE_TYPE_COMPAT_MAP = _source_types._SOURCE_TYPE_COMPAT_MAP
 _extract_artifact_url = _artifact_types._extract_artifact_url
 _extract_audio_artifact_url = _artifact_types._extract_audio_artifact_url
 _extract_infographic_artifact_url = _artifact_types._extract_infographic_artifact_url
-_extract_notebook_sources_count = _notebook_types._extract_notebook_sources_count
 _extract_slide_deck_artifact_url = _artifact_types._extract_slide_deck_artifact_url
 _extract_source_created_at = _source_types._extract_source_created_at
 _extract_source_url = _source_types._extract_source_url
 _extract_video_artifact_url = _artifact_types._extract_video_artifact_url
 _is_valid_artifact_url = _artifact_types._is_valid_artifact_url
-_map_artifact_kind = _artifact_types._map_artifact_kind
-_safe_source_type = _source_types._safe_source_type
 _warned_artifact_types = _artifact_types._warned_artifact_types
 _warned_source_types = _source_types._warned_source_types
 

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -376,7 +376,6 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
 ]
 
 _TYPES_PRIVATE_HELPER_SEAMS = [
-    "_ARTIFACT_TYPE_CODE_MAP",
     "_SOURCE_TYPE_COMPAT_MAP",
     "_datetime_from_timestamp",
     "_extract_artifact_url",
@@ -387,16 +386,11 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
     "_extract_source_url",
     "_extract_video_artifact_url",
     "_is_valid_artifact_url",
-    "_map_artifact_kind",
     "_warned_artifact_types",
     "_warned_source_types",
 ]
 
-_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS = [
-    "_SOURCE_TYPE_CODE_MAP",
-    "_extract_notebook_sources_count",
-    "_safe_source_type",
-]
+_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS: list[str] = []
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -591,7 +591,7 @@ def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPa
     artifact_warnings: set[tuple[int | None, int | None]] = set()
     # ADR-007 seam-aliased object-target form: patch the canonical owners in
     # ``_types/{sources,artifacts}`` directly. ``notebooklm.types._warned_*``
-    # is a re-export (see ``types.py:117-118``), so the test must target the
+    # are re-exports of those canonical objects, so the test must target the
     # canonical home — patching the public facade would rebind only the
     # facade alias and not the module-global the parser reads.
     monkeypatch.setattr(_source_types_seam, "_warned_source_types", source_warnings)

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -28,7 +28,7 @@ INTERNAL_ARCHITECTURE_DOCS = {
 
 # Add names here only for explicit facade wrappers that must keep a public
 # monkeypatch seam while delegating implementation to a private _types module.
-ALLOWED_TYPES_WRAPPER_BODIES = {"_datetime_from_timestamp"}
+ALLOWED_TYPES_WRAPPER_BODIES: set[str] = set()
 PRIVATE_NOTEBOOKLM_IMPORT_RE = re.compile(
     r"\b(?:from\s+notebooklm(?:\._(?!_)\w+(?:\.\w+)*|\s+import\s+_(?!_)\w+)\b"
     r"|import\s+notebooklm\._(?!_)\w+(?:\.\w+)*\b)"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -135,9 +135,7 @@ def test_artifact_private_helper_seams_are_facade_reexports():
     import notebooklm.types as public_types
     from notebooklm._types import artifacts
 
-    assert public_types._ARTIFACT_TYPE_CODE_MAP is artifacts._ARTIFACT_TYPE_CODE_MAP
     assert public_types._warned_artifact_types is artifacts._warned_artifact_types
-    assert public_types._map_artifact_kind is artifacts._map_artifact_kind
     assert public_types._is_valid_artifact_url is artifacts._is_valid_artifact_url
     assert public_types._extract_artifact_url is artifacts._extract_artifact_url
     assert public_types._extract_audio_artifact_url is artifacts._extract_audio_artifact_url

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -61,7 +61,7 @@ class TestTimestampParsing:
         """Platform-specific timestamp errors should normalize to None."""
         from notebooklm.types import _datetime_from_timestamp
 
-        with patch("notebooklm.types.datetime") as mock_datetime:
+        with patch("notebooklm._types.common.datetime") as mock_datetime:
             mock_datetime.fromtimestamp.side_effect = OSError("timestamp out of range")
             parsed = _datetime_from_timestamp(1704067200)
 


### PR DESCRIPTION
## Summary

Retires three classes of dead "seam manifest" entries that an audit confirmed had zero first-party consumers. Net: **10 files, +28/−69**.

- **5 dead `notebooklm.types._<name>` re-exports**: `_SOURCE_TYPE_CODE_MAP`, `_extract_notebook_sources_count`, `_safe_source_type`, `_ARTIFACT_TYPE_CODE_MAP`, `_map_artifact_kind`. Pruned matching entries from `_TYPES_PRIVATE_HELPER_SEAMS` / `_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS`. Removed 2 redundant identity-assertion tests in `test_types.py`.
- **14 dead `cli/session.py` F401 re-exports** trimmed (audit's initial "19 dead" had 5 false positives that failing tests surfaced; those 5 — `_enumerate_one_jar`, `_login_with_browser_cookies`, `_resolve_optional_cookie_domains`, `_select_account`, `_write_extracted_cookies` — were restored under a small `# noqa: F401 — patch surface only` block with a header comment naming the specific test files and dual-patch fixture that depend on them). Demoted 8 names to normal imports.
- **3 `_datetime_from_timestamp` wrapper functions** retired (each was a 2-line passthrough whose only job was filling in `datetime_type=datetime`, already the default). Dropped the unused `datetime_type` kwarg from the canonical `_types/common.py:_datetime_from_timestamp`. Repointed the OSError-branch test patch target from `notebooklm.types.datetime` to `notebooklm._types.common.datetime`.

## Audit methodology

For each "seam manifest" entry, looked for first-party consumers via:
1. `from notebooklm.types import _foo` (single-line + multi-line) AST scan
2. `notebooklm.types._foo` / `cli.session._foo` string-form `patch(...)` targets
3. `patch_session_login_dual("_foo", ...)` multi-line argument scan
4. Direct attribute access on imported module objects

Entries with zero consumers got deleted. The 5 false positives in the cli.session block came from access patterns the initial AST scan missed (multi-line patch context managers + direct test imports of session-level bindings); failing tests surfaced them, they were restored under the noqa block.

## Test plan
- [x] `uv run pytest tests/unit tests/integration/cli_vcr` (5,079 passed, 44 skipped)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (clean)
- [x] `uv run ruff check src tests` + `uv run ruff format --check src tests` (clean)
- [ ] CI gate green on this PR

## Deferred polish findings
The following two micro-cleanups are now possible but were deferred as out-of-scope for this PR:
- `ALLOWED_TYPES_WRAPPER_BODIES` in `tests/unit/test_type_boundaries.py` is now an empty set; the allowlist mechanism could be retired entirely.
- `_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS` in `tests/unit/test_public_shims.py` is now an empty list; could be inlined or removed.

Both are leaving capacity for future seam additions; happy to bundle into a follow-up if anyone wants the room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal helper functions across modules to reduce code duplication and improve maintainability.
  * Streamlined module exports to expose only actively used APIs.

* **Tests**
  * Updated internal test coverage to reflect refactored helper consolidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->