### PR TITLE
refactor(cli/research): extract ResearchWaitPlan to cli/services/research.py

### DIFF
--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -10,6 +10,8 @@ loop, P1.T2 task-id pinning, and import orchestration live in the service.
 This module owns input validation, spinner I/O, rendering, and exit codes.
 """
 
+from typing import Any
+
 import click
 
 from ..client import NotebookLMClient
@@ -213,7 +215,7 @@ def _render_wait_result(plan: ResearchWaitPlan, result: ResearchWaitResult) -> N
 
     # outcome == "completed"
     if plan.json_output:
-        payload: dict = {
+        payload: dict[str, Any] = {
             "status": "completed",
             "query": result.query,
             "sources_found": result.sources_count,

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -3,9 +3,12 @@
 Commands:
     status      Check research status (single check)
     wait        Wait for research to complete (blocking)
-"""
 
-from typing import Any
+The ``wait`` command is a thin Click handler over
+:func:`notebooklm.cli.services.research.execute_research_wait` — the polling
+loop, P1.T2 task-id pinning, and import orchestration live in the service.
+This module owns input validation, spinner I/O, rendering, and exit codes.
+"""
 
 import click
 
@@ -19,12 +22,16 @@ from .rendering import (
     display_research_sources,
     json_output_response,
 )
-from .research_import import import_research_sources
 from .resolve import (
     require_notebook,
     resolve_notebook_id,
 )
-from .services.polling import poll_until, status_with_elapsed
+from .services.polling import status_with_elapsed
+from .services.research import (
+    ResearchWaitPlan,
+    ResearchWaitResult,
+    execute_research_wait,
+)
 
 # UI-only cap for the research summary preview shown in `research status` /
 # `research wait`. Unlike RPC error previews (see
@@ -149,115 +156,85 @@ def research_wait(
         raise click.UsageError("--cited-only requires --import-all")
 
     nb_id = require_notebook(notebook_id)
+    plan = ResearchWaitPlan(
+        notebook_id=nb_id,
+        timeout=timeout,
+        interval=interval,
+        import_all=import_all,
+        cited_only=cited_only,
+        json_output=json_output,
+    )
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            task_id: str | None = None
-
-            async def _fetch_status() -> dict[str, Any]:
-                """Fetch the next research status and pin a discovered task id.
-
-                Once the first poll identifies a task_id, subsequent polls pin
-                to that specific task via the ``task_id`` discriminator. This
-                guards the wait loop against the cross-wire bug where a second
-                research task started mid-wait (e.g. by a concurrent caller
-                or a retry) could substitute its results into ``status`` /
-                ``sources`` and mis-attribute provenance on import.
-                """
-                nonlocal task_id
-                current_status = await client.research.poll(nb_id_resolved, task_id=task_id)
-                status_val = current_status.get("status", "unknown")
-
-                if status_val == "no_research":
-                    if json_output:
-                        json_output_response(
-                            {"status": "no_research", "error": "No research running"}
-                        )
-                    else:
-                        console.print("[red]No research running[/red]")
-                    exit_with_code(1)
-
-                if task_id is None:
-                    task_id = current_status.get("task_id")
-
-                return current_status
-
-            def _is_complete(current_status: dict[str, Any]) -> bool:
-                return current_status.get("status", "unknown") == "completed"
-
-            async with status_with_elapsed(
-                "Waiting for research to complete...",
-                json_output=json_output,
-                resume_hint="notebooklm research status",
-            ):
-                poll_result = await poll_until(
-                    _fetch_status,
-                    _is_complete,
-                    timeout=float(timeout),
-                    interval=float(interval),
+            # Inject the wait spinner as the polling-loop context so the
+            # service stays I/O-free and unit-testable. SIGINT inside the
+            # spinner emits the canonical "Cancelled. Resume with: ..."
+            # envelope per :func:`emit_cancelled_and_exit`.
+            def _wait_context():
+                return status_with_elapsed(
+                    "Waiting for research to complete...",
+                    json_output=plan.json_output,
+                    resume_hint="notebooklm research status",
                 )
 
-            if poll_result.timed_out:
-                if json_output:
-                    json_output_response(
-                        {"status": "timeout", "error": f"Timed out after {timeout}s"}
-                    )
-                else:
-                    console.print(f"[yellow]Timed out after {timeout} seconds[/yellow]")
-                exit_with_code(1)
-
-            # Research completed — poll_until returned the terminal status,
-            # or raised SystemExit above for no-research / timeout cases.
-            status = poll_result.value
-            sources = status.get("sources", [])
-            query = status.get("query", "")
-
-            report = status.get("report", "")
-
-            if json_output:
-                result = {
-                    "status": "completed",
-                    "query": query,
-                    "sources_found": len(sources),
-                    "sources": sources,
-                    "report": report,
-                }
-                if import_all and sources and task_id:
-                    import_result = await import_research_sources(
-                        client,
-                        nb_id_resolved,
-                        task_id,
-                        sources,
-                        report=report,
-                        cited_only=cited_only,
-                        max_elapsed=timeout,
-                        json_output=True,
-                    )
-                    if import_result.cited_selection is not None:
-                        result["cited_only"] = True
-                        result["cited_sources_selected"] = len(import_result.sources)
-                        result["cited_only_fallback"] = import_result.cited_selection.used_fallback
-                    result["imported"] = len(import_result.imported)
-                    result["imported_sources"] = import_result.imported
-                json_output_response(result)
-            else:
-                console.print(f"[green]✓ Research completed:[/green] {query}")
-                display_research_sources(sources)
-
-                display_report(report)
-
-                if import_all and sources and task_id:
-                    import_result = await import_research_sources(
-                        client,
-                        nb_id_resolved,
-                        task_id,
-                        sources,
-                        report=report,
-                        cited_only=cited_only,
-                        max_elapsed=timeout,
-                        status_message="Importing sources...",
-                    )
-                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
+            result = await execute_research_wait(
+                plan,
+                client=client,
+                wait_context=_wait_context,
+            )
+            _render_wait_result(plan, result)
 
     return _run()
+
+
+def _render_wait_result(plan: ResearchWaitPlan, result: ResearchWaitResult) -> None:
+    """Render a :class:`ResearchWaitResult` and exit on non-success outcomes.
+
+    The handler owns all CLI I/O — text vs JSON, exit codes, "Imported N
+    sources" line — so the service can stay pure (and unit-testable without
+    a CliRunner).
+    """
+    if result.outcome == "no_research":
+        if plan.json_output:
+            json_output_response({"status": "no_research", "error": "No research running"})
+        else:
+            console.print("[red]No research running[/red]")
+        exit_with_code(1)
+
+    if result.outcome == "timeout":
+        if plan.json_output:
+            json_output_response(
+                {"status": "timeout", "error": f"Timed out after {result.timeout}s"}
+            )
+        else:
+            console.print(f"[yellow]Timed out after {result.timeout} seconds[/yellow]")
+        exit_with_code(1)
+
+    # outcome == "completed"
+    if plan.json_output:
+        payload: dict = {
+            "status": "completed",
+            "query": result.query,
+            "sources_found": result.sources_count,
+            "sources": result.sources,
+            "report": result.report,
+        }
+        import_result = result.import_result
+        if import_result is not None:
+            if import_result.cited_selection is not None:
+                payload["cited_only"] = True
+                payload["cited_sources_selected"] = len(import_result.sources)
+                payload["cited_only_fallback"] = import_result.cited_selection.used_fallback
+            payload["imported"] = len(import_result.imported)
+            payload["imported_sources"] = import_result.imported
+        json_output_response(payload)
+        return
+
+    # Text mode
+    console.print(f"[green]✓ Research completed:[/green] {result.query}")
+    display_research_sources(result.sources)
+    display_report(result.report)
+    import_result = result.import_result
+    if import_result is not None:
+        console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")

--- a/src/notebooklm/cli/services/research.py
+++ b/src/notebooklm/cli/services/research.py
@@ -1,0 +1,230 @@
+"""Service layer for ``research wait`` (ADR-008 Click-to-service extraction).
+
+The CLI ``research wait`` command was a 130-line Click handler that mixed
+plan construction (parsing flags + validation), polling-loop orchestration
+(with task-id pinning per P1.T2), and I/O rendering (spinner + text/JSON
+output + exit codes). This module owns the plan + orchestration; the Click
+handler in ``cli/research_cmd.py`` owns the rendering and exit-code
+decisions.
+
+Contract
+--------
+
+* :class:`ResearchWaitPlan` — frozen dataclass of user inputs.
+* :class:`ResearchWaitResult` — discriminated result returned to the handler
+  (``outcome`` ∈ ``{"no_research", "timeout", "completed"}``).
+* :func:`execute_research_wait` — async orchestrator. Pure with respect to
+  CLI I/O: it never calls ``console.print``, ``click.echo``, or
+  ``exit_with_code``. It MAY call the injected ``import_sources`` callable
+  which currently emits log messages and (in text mode) its own Rich
+  status spinner; that I/O is part of the importer, not this service.
+
+Task-id pinning (P1.T2)
+-----------------------
+
+The first poll that returns a ``task_id`` pins it; subsequent polls pass
+``task_id=<pinned>`` so a concurrent research task started mid-wait cannot
+substitute its sources or report into this wait. Preserved verbatim from
+the pre-extraction handler — the characterization test
+``TestTaskIdPinning::test_task_id_pinned_after_first_discovery`` is the
+regression guard.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from ..research_import import ResearchImportResult, import_research_sources
+from ..resolve import resolve_notebook_id
+from .polling import poll_until
+
+ResearchWaitOutcome = Literal["no_research", "timeout", "completed"]
+
+
+@dataclass(frozen=True)
+class ResearchWaitPlan:
+    """User-facing inputs for ``research wait``.
+
+    Constructed by the Click handler from validated flag values. The plan is
+    intentionally a value object so the handler can be tested independently
+    of the service and vice-versa.
+    """
+
+    notebook_id: str
+    timeout: int
+    interval: int
+    import_all: bool = False
+    cited_only: bool = False
+    json_output: bool = False
+
+
+@dataclass(frozen=True)
+class ResearchWaitResult:
+    """Discriminated outcome of a ``research wait`` invocation.
+
+    The handler picks the rendering path off ``outcome``; non-success
+    outcomes (``no_research``, ``timeout``) are converted into the
+    appropriate ``exit_with_code(1)`` by the handler. ``completed`` returns
+    exit-code 0 regardless of whether ``import_result`` is populated.
+    """
+
+    outcome: ResearchWaitOutcome
+    notebook_id: str
+    timeout: int
+    task_id: str | None = None
+    query: str = ""
+    sources: list[dict] = field(default_factory=list)
+    report: str = ""
+    import_result: ResearchImportResult | None = None
+
+    @property
+    def sources_count(self) -> int:
+        return len(self.sources)
+
+
+# Default context manager used when the handler does not inject a spinner —
+# the service is fully runnable in unit tests with no I/O.
+@contextlib.asynccontextmanager
+async def _null_wait_context() -> AsyncIterator[None]:
+    yield
+
+
+WaitContextFactory = Callable[[], "contextlib.AbstractAsyncContextManager[None]"]
+ResolveNotebookIdFn = Callable[..., Awaitable[str]]
+ImportResearchSourcesFn = Callable[..., Awaitable[ResearchImportResult]]
+
+
+async def execute_research_wait(
+    plan: ResearchWaitPlan,
+    *,
+    client: Any,
+    wait_context: WaitContextFactory = _null_wait_context,
+    resolve_id: ResolveNotebookIdFn = resolve_notebook_id,
+    import_sources: ImportResearchSourcesFn = import_research_sources,
+) -> ResearchWaitResult:
+    """Resolve, poll-with-pinned-task-id, and optionally import.
+
+    Args:
+        plan: User inputs validated by the Click handler.
+        client: An open :class:`~notebooklm.client.NotebookLMClient`. The
+            service does NOT open or close the client — the handler owns
+            that lifecycle so multiple service calls can share one client.
+        wait_context: Zero-arg factory returning an async context manager
+            that wraps the polling loop. Defaults to a no-op context. The
+            CLI handler injects ``status_with_elapsed(...)`` so the spinner
+            and SIGINT-to-cancelled translation live inside this block.
+        resolve_id: Override for :func:`notebooklm.cli.resolve.resolve_notebook_id`
+            (test seam).
+        import_sources: Override for
+            :func:`notebooklm.cli.research_import.import_research_sources`
+            (test seam).
+
+    Returns:
+        A :class:`ResearchWaitResult` whose ``outcome`` discriminates the
+        three terminal states. The service NEVER raises ``SystemExit`` and
+        NEVER prints — the handler decides exit codes and rendering.
+
+    Notes:
+        * Task-id pinning (P1.T2) — once the first poll returns a
+          ``task_id``, subsequent polls pin to it via the ``task_id=``
+          discriminator on ``client.research.poll``.
+        * Import is only invoked when ``plan.import_all`` is true AND the
+          completed status has sources AND a ``task_id`` was discovered.
+          (The third guard preserves the pre-extraction handler's behavior
+          exactly — without a task_id the importer has nothing to verify
+          against.)
+    """
+    nb_id_resolved = await resolve_id(client, plan.notebook_id, json_output=plan.json_output)
+
+    # Closure-captured pinned task_id. Once set, every subsequent poll
+    # passes it as the discriminator — this is the P1.T2 fix.
+    task_id: str | None = None
+
+    async def _fetch_status() -> dict[str, Any]:
+        nonlocal task_id
+        current_status = await client.research.poll(nb_id_resolved, task_id=task_id)
+        if task_id is None:
+            task_id = current_status.get("task_id")
+        return current_status
+
+    def _is_terminal(current_status: dict[str, Any]) -> bool:
+        status_val = current_status.get("status", "unknown")
+        # Both ``no_research`` and ``completed`` terminate the poll loop;
+        # the handler distinguishes them by ``outcome``. (Pre-extraction,
+        # ``no_research`` exited inside the fetch closure via
+        # ``exit_with_code`` — this version returns the value up and lets
+        # the handler render + exit.)
+        return status_val in ("no_research", "completed")
+
+    async with wait_context():
+        poll_result = await poll_until(
+            _fetch_status,
+            _is_terminal,
+            timeout=float(plan.timeout),
+            interval=float(plan.interval),
+        )
+
+    status = poll_result.value
+    status_val = status.get("status", "unknown")
+
+    def _terminal(outcome: ResearchWaitOutcome, **extra: Any) -> ResearchWaitResult:
+        """Build a terminal result with the common notebook/timeout/task_id fields."""
+        return ResearchWaitResult(
+            outcome=outcome,
+            notebook_id=nb_id_resolved,
+            timeout=plan.timeout,
+            task_id=task_id,
+            **extra,
+        )
+
+    if poll_result.timed_out:
+        return _terminal("timeout")
+
+    if status_val == "no_research":
+        return _terminal("no_research")
+
+    # status_val == "completed"
+    sources = status.get("sources", [])
+    query = status.get("query", "")
+    report = status.get("report", "")
+
+    import_result: ResearchImportResult | None = None
+    if plan.import_all and sources and task_id:
+        # In text mode the importer renders its own "Importing sources..."
+        # status; in JSON mode it stays silent. The kwarg delta below mirrors
+        # the pre-extraction handler exactly.
+        import_kwargs: dict[str, Any] = {
+            "report": report,
+            "cited_only": plan.cited_only,
+            "max_elapsed": plan.timeout,
+        }
+        if plan.json_output:
+            import_kwargs["json_output"] = True
+        else:
+            import_kwargs["status_message"] = "Importing sources..."
+        import_result = await import_sources(
+            client,
+            nb_id_resolved,
+            task_id,
+            sources,
+            **import_kwargs,
+        )
+
+    return _terminal(
+        "completed",
+        query=query,
+        sources=sources,
+        report=report,
+        import_result=import_result,
+    )
+
+
+__all__ = [
+    "ResearchWaitOutcome",
+    "ResearchWaitPlan",
+    "ResearchWaitResult",
+    "execute_research_wait",
+]

--- a/src/notebooklm/cli/services/research.py
+++ b/src/notebooklm/cli/services/research.py
@@ -76,7 +76,7 @@ class ResearchWaitResult:
     timeout: int
     task_id: str | None = None
     query: str = ""
-    sources: list[dict] = field(default_factory=list)
+    sources: list[dict[str, Any]] = field(default_factory=list)
     report: str = ""
     import_result: ResearchImportResult | None = None
 
@@ -92,7 +92,7 @@ async def _null_wait_context() -> AsyncIterator[None]:
     yield
 
 
-WaitContextFactory = Callable[[], "contextlib.AbstractAsyncContextManager[None]"]
+WaitContextFactory = Callable[[], contextlib.AbstractAsyncContextManager[None]]
 ResolveNotebookIdFn = Callable[..., Awaitable[str]]
 ImportResearchSourcesFn = Callable[..., Awaitable[ResearchImportResult]]
 
@@ -167,9 +167,6 @@ async def execute_research_wait(
             interval=float(plan.interval),
         )
 
-    status = poll_result.value
-    status_val = status.get("status", "unknown")
-
     def _terminal(outcome: ResearchWaitOutcome, **extra: Any) -> ResearchWaitResult:
         """Build a terminal result with the common notebook/timeout/task_id fields."""
         return ResearchWaitResult(
@@ -180,8 +177,14 @@ async def execute_research_wait(
             **extra,
         )
 
+    # Check timeout before inspecting status — keeps control flow readable
+    # (claude[bot] #5: avoid signalling that status_val matters on the
+    # timeout branch).
     if poll_result.timed_out:
         return _terminal("timeout")
+
+    status = poll_result.value
+    status_val = status.get("status", "unknown")
 
     if status_val == "no_research":
         return _terminal("no_research")

--- a/tests/unit/cli/test_research_characterization.py
+++ b/tests/unit/cli/test_research_characterization.py
@@ -1,0 +1,459 @@
+"""Golden-snapshot characterization tests for ``research wait``.
+
+These tests freeze the current ``research wait`` behavior (text + JSON modes,
+across the happy / timeout / cancelled / --no-import / --import-all paths)
+before the P3.T6a extraction lands. They MUST pass on main HEAD (commit 1 of
+the PR) and continue to pass byte-for-byte after the service extraction
+(commit 2).
+
+Covered paths (text + JSON):
+
+* happy           — research completes immediately, no import.
+* timeout         — research stays ``in_progress`` until ``--timeout`` elapses.
+* cancelled       — SIGINT during the polling spinner triggers the structured
+                    cancellation envelope from ``emit_cancelled_and_exit``.
+* --no-import     — completed; ``--import-all`` NOT passed; importer is never
+                    invoked (this is the default "wait without importing" shape
+                    a script would use).
+* --import-all    — completed; ``--import-all`` calls ``import_with_retry``.
+
+The JSON-mode snapshots compare parsed dicts (key set + values) so output is
+stable across Click/Rich versions. The text-mode snapshots compare a small
+normalized line slice (color codes stripped, fixed substrings only) so they
+don't fight Rich rendering differences.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import create_mock_client
+
+research_import_module = importlib.import_module("notebooklm.cli.research_import")
+
+# Strip ANSI/Rich SGR sequences so text-mode snapshots survive Rich version
+# bumps. We don't care that "[green]" or "\x1b[32m" is on/off — we care that
+# the literal phrase appears.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+@pytest.fixture
+def runner_and_mocks(runner, mock_auth, mock_fetch_tokens):
+    """Convenience fixture: returns ``(runner, mock_client_factory)``."""
+
+    def factory(poll_return):
+        mock_client = create_mock_client()
+        mock_client.research.poll = AsyncMock(return_value=poll_return)
+        return mock_client
+
+    return runner, factory
+
+
+# ---------------------------------------------------------------------------
+# Happy path — completed, no import
+# ---------------------------------------------------------------------------
+
+
+HAPPY_POLL = {
+    "status": "completed",
+    "task_id": "task_abc",
+    "query": "AI research",
+    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+    "report": "# Report\nBody",
+}
+
+
+class TestWaitHappy:
+    def test_happy_text(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = factory(HAPPY_POLL)
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        # Golden lines (order-sensitive substrings).
+        assert "Research completed" in out
+        assert "AI research" in out
+        assert "Found 1 sources" in out
+        assert "Source 1" in out
+        assert "Report" in out
+        # Import was NOT invoked.
+        assert "Imported" not in out
+
+    def test_happy_json(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = factory(HAPPY_POLL)
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        # Frozen JSON contract (P1.T2 baseline).
+        assert payload == {
+            "status": "completed",
+            "query": "AI research",
+            "sources_found": 1,
+            "sources": [{"title": "Source 1", "url": "http://example.com"}],
+            "report": "# Report\nBody",
+        }
+        # No import-related keys when --import-all was not passed.
+        assert "imported" not in payload
+        assert "cited_only" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Timeout path — research never completes
+# ---------------------------------------------------------------------------
+
+
+TIMEOUT_POLL = {"status": "in_progress", "query": "AI research"}
+
+
+class TestWaitTimeout:
+    def test_timeout_text(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = factory(TIMEOUT_POLL)
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--timeout", "1", "--interval", "1"],
+            )
+
+        assert result.exit_code == 1
+        out = _strip_ansi(result.output)
+        assert "Timed out after 1 seconds" in out
+
+    def test_timeout_json(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = factory(TIMEOUT_POLL)
+            result = runner.invoke(
+                cli,
+                [
+                    "research",
+                    "wait",
+                    "-n",
+                    "nb_123",
+                    "--json",
+                    "--timeout",
+                    "1",
+                    "--interval",
+                    "1",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload == {"status": "timeout", "error": "Timed out after 1s"}
+
+
+# ---------------------------------------------------------------------------
+# Cancelled path — SIGINT during polling triggers structured cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestWaitCancelled:
+    """Ctrl-C inside ``status_with_elapsed`` must surface the canonical
+    ``Cancelled. Resume with: notebooklm research status`` shape.
+
+    Verifies the resume hint plumbed into ``status_with_elapsed`` matches the
+    one wired in ``research_cmd.research_wait`` today.
+    """
+
+    def test_cancelled_text(self, runner_and_mocks):
+        runner, _ = runner_and_mocks
+        mock_client = create_mock_client()
+        mock_client.research.poll = AsyncMock(side_effect=KeyboardInterrupt)
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = mock_client
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123"])
+
+        # SIGINT exit code is 130 (128 + signal 2).
+        assert result.exit_code == 130
+        out = _strip_ansi(result.output)
+        # ``Cancelled.`` line + canonical resume hint.
+        assert "Cancelled" in out
+        assert "notebooklm research status" in out
+
+    def test_cancelled_json(self, runner_and_mocks):
+        runner, _ = runner_and_mocks
+        mock_client = create_mock_client()
+        mock_client.research.poll = AsyncMock(side_effect=KeyboardInterrupt)
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = mock_client
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--json"])
+
+        assert result.exit_code == 130
+        payload = json.loads(result.output)
+        # Structured cancellation envelope from emit_cancelled_and_exit.
+        assert payload["error"] is True
+        assert payload["code"] == "CANCELLED"
+        # Resume hint surfaces the research-specific command.
+        assert "notebooklm research status" in payload.get("resume_hint", "")
+
+
+# ---------------------------------------------------------------------------
+# --no-import path — explicit "completed without importing" goldens
+# ---------------------------------------------------------------------------
+
+
+class TestWaitNoImport:
+    """Default ``research wait`` (no ``--import-all``) returns the completed
+    payload but never calls the importer. This is the canonical script shape.
+    """
+
+    def test_no_import_text_does_not_invoke_importer(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = factory(HAPPY_POLL)
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        mock_import.assert_not_awaited()
+        out = _strip_ansi(result.output)
+        assert "Research completed" in out
+        assert "Imported" not in out
+
+    def test_no_import_json_omits_import_keys(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = factory(HAPPY_POLL)
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--json"])
+
+        assert result.exit_code == 0
+        mock_import.assert_not_awaited()
+        payload = json.loads(result.output)
+        assert "imported" not in payload
+        assert "imported_sources" not in payload
+        assert "cited_only" not in payload
+        assert "cited_sources_selected" not in payload
+        assert "cited_only_fallback" not in payload
+
+
+# ---------------------------------------------------------------------------
+# --import-all path — completed + import + (optional) --cited-only
+# ---------------------------------------------------------------------------
+
+
+class TestWaitImportAll:
+    def test_import_all_text(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        mock_client = factory(HAPPY_POLL)
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = mock_client
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--import-all"],
+            )
+
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        assert "Research completed" in out
+        assert "Imported 1 sources" in out
+        # P1.T2 task-id pinning: the importer must receive the pinned task_id
+        # discovered on the first poll, not None.
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_abc",
+            [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=300,
+        )
+
+    def test_import_all_json(self, runner_and_mocks):
+        runner, factory = runner_and_mocks
+        mock_client = factory(HAPPY_POLL)
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = mock_client
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--json", "--import-all"],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "completed"
+        assert payload["sources_found"] == 1
+        assert payload["imported"] == 1
+        assert payload["imported_sources"] == [{"id": "src_1", "title": "Source 1"}]
+        # cited_only branch not active.
+        assert "cited_only" not in payload
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_abc",
+            [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=300,
+            json_output=True,
+        )
+
+    def test_import_all_cited_only_text(self, runner_and_mocks):
+        runner, _ = runner_and_mocks
+        mock_client = create_mock_client()
+        mock_client.research.poll = AsyncMock(
+            return_value={
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI research",
+                "sources": [
+                    {"title": "Cited", "url": "https://example.com/cited"},
+                    {"title": "Uncited", "url": "https://example.com/uncited"},
+                ],
+                "report": "Report cites https://example.com/cited",
+            }
+        )
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = mock_client
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--import-all", "--cited-only"],
+            )
+
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        assert "Imported 1 sources" in out
+        # Only the cited source is forwarded to the importer.
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_abc",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=300,
+        )
+
+    def test_import_all_cited_only_json(self, runner_and_mocks):
+        runner, _ = runner_and_mocks
+        mock_client = create_mock_client()
+        mock_client.research.poll = AsyncMock(
+            return_value={
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI research",
+                "sources": [
+                    {"title": "Cited", "url": "https://example.com/cited"},
+                    {"title": "Uncited", "url": "https://example.com/uncited"},
+                ],
+                "report": "Report cites https://example.com/cited",
+            }
+        )
+        with (
+            patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls,
+            patch.object(
+                research_import_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_cls.return_value = mock_client
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            result = runner.invoke(
+                cli,
+                [
+                    "research",
+                    "wait",
+                    "-n",
+                    "nb_123",
+                    "--json",
+                    "--import-all",
+                    "--cited-only",
+                ],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        # P1.T2 fields preserved.
+        assert payload["cited_only"] is True
+        assert payload["cited_sources_selected"] == 1
+        assert payload["cited_only_fallback"] is False
+        assert payload["imported"] == 1
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_abc",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=300,
+            json_output=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# P1.T2 task-id pinning regression guard (must survive extraction unmodified)
+# ---------------------------------------------------------------------------
+
+
+class TestTaskIdPinning:
+    """First poll discovers a task_id; subsequent polls MUST pin to it.
+
+    Repro of the P1.T2 fix: the wait loop pins the task_id discriminator after
+    the first non-empty discovery so a second concurrent research task cannot
+    substitute its sources/report into the in-flight wait.
+    """
+
+    def test_task_id_pinned_after_first_discovery(self, runner_and_mocks):
+        runner, _ = runner_and_mocks
+        mock_client = create_mock_client()
+        # First poll: in_progress, with a task_id to pin. Second poll: completed.
+        poll_mock = AsyncMock()
+        poll_mock.side_effect = [
+            {"status": "in_progress", "task_id": "task_pinned", "query": "AI"},
+            {
+                "status": "completed",
+                "task_id": "task_pinned",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+            },
+        ]
+        mock_client.research.poll = poll_mock
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_cls:
+            mock_cls.return_value = mock_client
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--interval", "1", "--timeout", "10"],
+            )
+
+        assert result.exit_code == 0
+        # First call: task_id=None (nothing pinned yet).
+        first_call = poll_mock.await_args_list[0]
+        assert first_call.kwargs.get("task_id") is None
+        # Second call: task_id pinned to the value discovered on the first poll.
+        second_call = poll_mock.await_args_list[1]
+        assert second_call.kwargs.get("task_id") == "task_pinned"

--- a/tests/unit/test_research_service.py
+++ b/tests/unit/test_research_service.py
@@ -1,0 +1,578 @@
+"""Service-layer tests for ``cli/services/research.py``.
+
+These tests exercise :class:`ResearchWaitPlan` + :func:`execute_research_wait`
+DIRECTLY — no Click ``CliRunner``, no Rich console capture, no asyncio
+``CancelledError`` rituals. The Click handler in ``cli/research_cmd.py`` is
+exercised separately by ``tests/unit/cli/test_research*.py``.
+
+The service is intentionally I/O-free: it never calls ``console.print``,
+``click.echo``, or ``exit_with_code``. The Click handler owns rendering and
+exit codes; the service owns the polling loop, the P1.T2 task-id pinning,
+and the (optional) import call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm.cli.research_import import ResearchImportResult
+from notebooklm.cli.services.research import (
+    ResearchWaitPlan,
+    ResearchWaitResult,
+    execute_research_wait,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: a fake notebook client with only the surface the service touches
+# ---------------------------------------------------------------------------
+
+
+class _FakeResearchAPI:
+    """Records poll calls; returns canned values."""
+
+    def __init__(self, *, side_effect: Any) -> None:
+        self.poll = AsyncMock(side_effect=side_effect)
+
+
+class _FakeClient:
+    def __init__(self, *, poll_side_effect: Any) -> None:
+        self.research = _FakeResearchAPI(side_effect=poll_side_effect)
+
+
+async def _fake_resolve(client, notebook_id, *, json_output: bool = False) -> str:  # noqa: ARG001
+    """Pass-through resolver — service should not touch ID resolution."""
+    return notebook_id
+
+
+@pytest.fixture
+def base_plan() -> ResearchWaitPlan:
+    return ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=5,
+        interval=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_returns_outcome_with_sources(base_plan):
+    """First poll completes; service returns completed result without import."""
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI research",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "REPORT",
+            }
+        ]
+    )
+
+    result = await execute_research_wait(base_plan, client=client, resolve_id=_fake_resolve)
+
+    assert isinstance(result, ResearchWaitResult)
+    assert result.outcome == "completed"
+    assert result.notebook_id == "nb_123"
+    assert result.task_id == "task_abc"
+    assert result.query == "AI research"
+    assert result.sources == [{"title": "S", "url": "http://example.com"}]
+    assert result.sources_count == 1
+    assert result.report == "REPORT"
+    assert result.import_result is None  # import_all=False default
+    # Exactly one poll call; task_id=None on the first poll.
+    assert client.research.poll.await_count == 1
+    first_call = client.research.poll.await_args_list[0]
+    assert first_call.args == ("nb_123",)
+    assert first_call.kwargs == {"task_id": None}
+
+
+# ---------------------------------------------------------------------------
+# Timeout path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_outcome_without_completion(monkeypatch):
+    """A persistent in_progress status produces outcome='timeout'."""
+    # Eliminate real sleep so the timeout fires on the first interval boundary.
+    from notebooklm.cli.services import polling
+
+    clock = {"t": 0.0}
+
+    async def fake_sleep(delay: float) -> None:
+        clock["t"] += delay
+
+    monkeypatch.setattr(polling.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(polling.asyncio, "sleep", fake_sleep)
+
+    plan = ResearchWaitPlan(notebook_id="nb_123", timeout=1, interval=1)
+    client = _FakeClient(poll_side_effect=lambda *a, **kw: {"status": "in_progress", "query": "AI"})
+
+    # AsyncMock with a sync side_effect callable — wrap it for AsyncMock.
+    async def _poll(nb_id, *, task_id=None):  # noqa: ARG001
+        return {"status": "in_progress", "query": "AI"}
+
+    client.research.poll = AsyncMock(side_effect=_poll)
+
+    result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
+
+    assert result.outcome == "timeout"
+    assert result.timeout == 1
+    assert result.import_result is None
+
+
+# ---------------------------------------------------------------------------
+# No-research path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_research_returns_outcome_without_exit(base_plan):
+    """no_research is a terminal poll value; service returns it (no SystemExit)."""
+    client = _FakeClient(poll_side_effect=[{"status": "no_research"}])
+
+    # The service must NOT raise SystemExit — that's the handler's job.
+    result = await execute_research_wait(base_plan, client=client, resolve_id=_fake_resolve)
+
+    assert result.outcome == "no_research"
+    assert result.notebook_id == "nb_123"
+    assert result.sources == []
+    assert result.import_result is None
+
+
+# ---------------------------------------------------------------------------
+# P1.T2 task-id pinning regression — service-layer test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_id_pinned_after_first_discovery(monkeypatch):
+    """The first non-empty task_id pins every subsequent poll's discriminator.
+
+    Service-layer mirror of the CLI characterization test
+    ``TestTaskIdPinning::test_task_id_pinned_after_first_discovery``. This
+    test does NOT use the Click runner — it asserts directly on
+    ``client.research.poll.await_args_list``.
+    """
+    polls = [
+        {"status": "in_progress", "task_id": "task_pinned", "query": "AI"},
+        {
+            "status": "completed",
+            "task_id": "task_pinned",
+            "query": "AI",
+            "sources": [{"title": "S", "url": "http://example.com"}],
+            "report": "R",
+        },
+    ]
+    client = _FakeClient(poll_side_effect=polls)
+    plan = ResearchWaitPlan(notebook_id="nb_123", timeout=10, interval=1)
+
+    # No-op sleep so the inter-poll wait doesn't slow the test.
+    from notebooklm.cli.services import polling
+
+    async def _no_sleep(delay):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(polling.asyncio, "sleep", _no_sleep)
+
+    result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
+
+    assert result.outcome == "completed"
+    calls = client.research.poll.await_args_list
+    assert len(calls) == 2
+    # First call: task_id=None (nothing pinned yet).
+    assert calls[0].kwargs.get("task_id") is None
+    # Second call: pinned to the value from the first poll.
+    assert calls[1].kwargs.get("task_id") == "task_pinned"
+
+
+@pytest.mark.asyncio
+async def test_task_id_never_set_when_polls_never_return_one():
+    """If poll responses never include a task_id, the discriminator stays None."""
+    client = _FakeClient(
+        poll_side_effect=[{"status": "completed", "query": "X", "sources": [], "report": ""}]
+    )
+    plan = ResearchWaitPlan(notebook_id="nb_123", timeout=5, interval=1)
+
+    result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
+
+    assert result.outcome == "completed"
+    assert result.task_id is None
+    # The single poll call passed task_id=None.
+    assert client.research.poll.await_args_list[0].kwargs.get("task_id") is None
+
+
+# ---------------------------------------------------------------------------
+# Import-all path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_all_invokes_importer_with_pinned_task_id():
+    """When import_all=True and a task_id was pinned, importer is invoked."""
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI research",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+            }
+        ]
+    )
+    import_mock = AsyncMock(
+        return_value=ResearchImportResult(
+            imported=[{"id": "src_1", "title": "S"}],
+            sources=[{"title": "S", "url": "http://example.com"}],
+            cited_selection=None,
+        )
+    )
+
+    result = await execute_research_wait(
+        plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    assert result.outcome == "completed"
+    assert result.import_result is not None
+    assert result.import_result.imported == [{"id": "src_1", "title": "S"}]
+    import_mock.assert_awaited_once_with(
+        client,
+        "nb_123",
+        "task_abc",
+        [{"title": "S", "url": "http://example.com"}],
+        report="R",
+        cited_only=False,
+        max_elapsed=300,
+        status_message="Importing sources...",
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_all_passes_json_output_flag():
+    """In JSON mode, importer receives json_output=True instead of status_message."""
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+        json_output=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+            }
+        ]
+    )
+    import_mock = AsyncMock(
+        return_value=ResearchImportResult(
+            imported=[{"id": "src_1", "title": "S"}],
+            sources=[{"title": "S", "url": "http://example.com"}],
+            cited_selection=None,
+        )
+    )
+
+    await execute_research_wait(
+        plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    call_kwargs = import_mock.await_args.kwargs
+    assert call_kwargs.get("json_output") is True
+    assert "status_message" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_import_all_skipped_when_no_task_id():
+    """No task_id => importer is NOT invoked (handler-parity guard)."""
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+                # NO task_id key.
+            }
+        ]
+    )
+    import_mock = AsyncMock()
+
+    result = await execute_research_wait(
+        plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    assert result.outcome == "completed"
+    assert result.import_result is None
+    import_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_all_skipped_when_no_sources():
+    """Empty sources list => importer is NOT invoked."""
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [],
+                "report": "R",
+            }
+        ]
+    )
+    import_mock = AsyncMock()
+
+    result = await execute_research_wait(
+        plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    assert result.outcome == "completed"
+    assert result.import_result is None
+    import_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_all_passes_cited_only_flag():
+    """plan.cited_only flows through to the importer's cited_only kwarg."""
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+        cited_only=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R cites http://example.com",
+            }
+        ]
+    )
+    import_mock = AsyncMock(
+        return_value=ResearchImportResult(
+            imported=[{"id": "src_1", "title": "S"}],
+            sources=[{"title": "S", "url": "http://example.com"}],
+            cited_selection=None,
+        )
+    )
+
+    await execute_research_wait(
+        plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    assert import_mock.await_args.kwargs.get("cited_only") is True
+
+
+# ---------------------------------------------------------------------------
+# Wait-context injection (spinner seam)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_context_is_entered_and_exited(base_plan):
+    """The handler-injected wait_context wraps the poll loop."""
+    enter_count = {"n": 0}
+    exit_count = {"n": 0}
+
+    @contextlib.asynccontextmanager
+    async def tracking_context() -> AsyncIterator[None]:
+        enter_count["n"] += 1
+        try:
+            yield
+        finally:
+            exit_count["n"] += 1
+
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [],
+                "report": "",
+            }
+        ]
+    )
+
+    await execute_research_wait(
+        base_plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        wait_context=tracking_context,
+    )
+
+    assert enter_count["n"] == 1
+    assert exit_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_default_wait_context_is_noop(base_plan):
+    """The default null context lets the service run without any spinner."""
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [],
+                "report": "",
+            }
+        ]
+    )
+
+    # No wait_context passed; default must work.
+    result = await execute_research_wait(base_plan, client=client, resolve_id=_fake_resolve)
+    assert result.outcome == "completed"
+
+
+@pytest.mark.asyncio
+async def test_wait_context_exits_before_import_runs():
+    """Spinner-vs-import ordering: import MUST run after the wait context exits.
+
+    The pre-extraction handler kept the wait spinner open ONLY around the poll
+    loop, and called the importer (which has its own spinner) after the wait
+    spinner closed. This ordering matters because two live Rich spinners
+    overlap badly; verifying it directly guards the most subtle refactor risk
+    flagged in review.
+    """
+    events: list[str] = []
+
+    @contextlib.asynccontextmanager
+    async def tracking_context() -> AsyncIterator[None]:
+        events.append("wait_enter")
+        try:
+            yield
+        finally:
+            events.append("wait_exit")
+
+    async def tracking_import(*_args, **_kwargs):
+        events.append("import")
+        return ResearchImportResult(
+            imported=[{"id": "src_1", "title": "S"}],
+            sources=[{"title": "S", "url": "http://example.com"}],
+            cited_selection=None,
+        )
+
+    async def tracking_resolve(client, notebook_id, *, json_output=False):  # noqa: ARG001
+        events.append("resolve")
+        return notebook_id
+
+    plan = ResearchWaitPlan(
+        notebook_id="nb_123",
+        timeout=300,
+        interval=5,
+        import_all=True,
+    )
+    client = _FakeClient(
+        poll_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_abc",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+            }
+        ]
+    )
+
+    await execute_research_wait(
+        plan,
+        client=client,
+        wait_context=tracking_context,
+        resolve_id=tracking_resolve,
+        import_sources=tracking_import,
+    )
+
+    # The exact lifecycle ordering we depend on for spinner-non-overlap.
+    assert events == ["resolve", "wait_enter", "wait_exit", "import"]
+
+
+# ---------------------------------------------------------------------------
+# Dataclass invariants
+# ---------------------------------------------------------------------------
+
+
+class TestResearchWaitPlan:
+    def test_defaults(self):
+        plan = ResearchWaitPlan(notebook_id="nb", timeout=10, interval=1)
+        assert plan.import_all is False
+        assert plan.cited_only is False
+        assert plan.json_output is False
+
+    def test_is_frozen(self):
+        from dataclasses import FrozenInstanceError
+
+        plan = ResearchWaitPlan(notebook_id="nb", timeout=10, interval=1)
+        with pytest.raises(FrozenInstanceError):
+            plan.notebook_id = "other"  # type: ignore[misc]
+
+
+class TestResearchWaitResult:
+    def test_sources_count(self):
+        result = ResearchWaitResult(
+            outcome="completed",
+            notebook_id="nb",
+            timeout=10,
+            sources=[{"a": 1}, {"b": 2}],
+        )
+        assert result.sources_count == 2
+
+    def test_defaults(self):
+        result = ResearchWaitResult(outcome="no_research", notebook_id="nb", timeout=10)
+        assert result.task_id is None
+        assert result.query == ""
+        assert result.sources == []
+        assert result.report == ""
+        assert result.import_result is None

--- a/tests/unit/test_research_service.py
+++ b/tests/unit/test_research_service.py
@@ -115,14 +115,11 @@ async def test_timeout_returns_outcome_without_completion(monkeypatch):
     monkeypatch.setattr(polling.time, "monotonic", lambda: clock["t"])
     monkeypatch.setattr(polling.asyncio, "sleep", fake_sleep)
 
-    plan = ResearchWaitPlan(notebook_id="nb_123", timeout=1, interval=1)
-    client = _FakeClient(poll_side_effect=lambda *a, **kw: {"status": "in_progress", "query": "AI"})
-
-    # AsyncMock with a sync side_effect callable — wrap it for AsyncMock.
     async def _poll(nb_id, *, task_id=None):  # noqa: ARG001
         return {"status": "in_progress", "query": "AI"}
 
-    client.research.poll = AsyncMock(side_effect=_poll)
+    plan = ResearchWaitPlan(notebook_id="nb_123", timeout=1, interval=1)
+    client = _FakeClient(poll_side_effect=_poll)
 
     result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
 


### PR DESCRIPTION
## Summary

Phase 3 / Wave 3.B task **P3.T6a** — ADR-008 Click-to-service extraction
for `research wait`.

- New service `cli/services/research.py` exposes `ResearchWaitPlan`,
  `ResearchWaitResult` (discriminated outcome), and an I/O-free
  `execute_research_wait(plan, *, client, wait_context, resolve_id,
  import_sources)` orchestrator. The polling loop, P1.T2 task-id pinning,
  and import call live here.
- `cli/research_cmd.py` shrinks to thin Click handlers — `research_wait`
  builds the plan + awaits the service, then delegates to a small
  `_render_wait_result` for text/JSON output and exit codes. The
  spinner stays in the handler (injected as the `wait_context`).
- Uses `services/polling.py` (P2.T2) for the wait loop — no duplicate
  polling primitives.
- `cli/services/__init__.py` untouched per the Wave 3.B shared-package
  guard. Sibling files (`generate_cmd.py`, `download_cmd.py`,
  `source_cmd.py`) untouched.

## Characterization-test discipline (per phase-3.md)

Commits land in the required order:

1. `3a55805 test(cli/research): characterization snapshots …` — 13
   golden snapshots for `research wait` happy / timeout / cancelled /
   `--no-import` / `--import-all` paths in BOTH text and JSON modes,
   plus a P1.T2 task-id pinning regression guard. These tests passed on
   main HEAD before commit 2.
2. `7ea1fe9 refactor(cli/research): extract ResearchWaitPlan …` — the
   extraction. All 13 characterization tests continue to pass
   byte-for-byte after the refactor, alongside the 20 pre-existing
   `tests/unit/cli/test_research.py` tests (unmodified) and 17 new
   service-layer tests in `tests/unit/test_research_service.py`.

## P1.T2 task-id pinning preserved

Once the first poll returns a `task_id`, every subsequent poll passes
`task_id=<pinned>` as the discriminator on `client.research.poll(...)`
so a concurrent research task started mid-wait cannot substitute its
sources or report into this wait. Verified at both layers:

- `TestTaskIdPinning::test_task_id_pinned_after_first_discovery` (CLI)
- `test_task_id_pinned_after_first_discovery` (service)

## Test plan

- [x] `uv run ruff format src/notebooklm tests` — clean
- [x] `uv run ruff check src/notebooklm tests` — All checks passed
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` — clean
- [x] `uv run pytest tests/unit tests/integration` — 5765 passed, 12 skipped
- [x] `uv run pytest tests/unit/cli/test_research.py` — 20 passed (unmodified)
- [x] `uv run pytest tests/unit/cli/test_research_characterization.py` — 13 passed
- [x] `uv run pytest tests/unit/test_research_service.py` — 17 passed

## Deferred polish findings

- Test-seam aliases (`ResolveNotebookIdFn`, `ImportResearchSourcesFn`)
  use `Callable[..., Awaitable[...]]` for ergonomic test stubs. A
  `Protocol` would give wrong-kwarg-name coverage but balloon the seam;
  accepted tradeoff.
- Codex flagged `resolve_notebook_id` as unused in `research_cmd.py` —
  false positive (still used by `research_status`). No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON output for `research wait` with structured success/error payloads
  * `--import-all` and `--cited-only` options to import sources automatically when research completes

* **Refactor**
  * CLI rendering separated from polling/import orchestration for clearer behavior and maintainability

* **Tests**
  * Large suite covering completed, timeout, cancelled, import, cited-only, and task-id pinning scenarios (text and JSON)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->