### PR TITLE
refactor(cli/generate): extract services/generate.py per ADR-008

### DIFF
--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -1,49 +1,32 @@
-"""Generate content CLI commands.
+"""Generate content CLI commands — thin Click handlers (P3.T1 ADR-008).
 
-Commands:
-    audio            Generate audio overview (podcast)
-    video            Generate video overview
-    cinematic-video  Generate cinematic video overview (AI documentary footage)
-    slide-deck       Generate slide deck
-    quiz         Generate quiz
-    flashcards   Generate flashcards
-    infographic  Generate infographic
-    data-table   Generate data table
-    mind-map     Generate mind map
-    report       Generate report
+All validation, enum mapping, retry/wait orchestration, and output
+dispatch live in ``cli/services/generate.py``. Tests patch
+``NotebookLMClient`` / ``console`` / ``json_error_response`` /
+``json_output_response`` / ``get_language`` / ``_output_mind_map_result``
+as module-level attributes here, so those names remain imported at
+module scope and ``_output_mind_map_result`` + ``resolve_language``
+remain defined inline rather than re-exported.
 """
 
 import os
 from typing import Any
 
 import click
-from click.core import ParameterSource
 
 from ..client import NotebookLMClient
-from ..types import (
-    AudioFormat,
-    AudioLength,
-    InfographicDetail,
-    InfographicOrientation,
-    InfographicStyle,
-    QuizDifficulty,
-    QuizQuantity,
-    ReportFormat,
-    SlideDeckFormat,
-    SlideDeckLength,
-    VideoFormat,
-    VideoStyle,
-)
 from .auth_runtime import with_client
 from .input import resolve_prompt
 from .language_cmd import SUPPORTED_LANGUAGES, get_language
 from .options import (
     _complete_artifacts,
-    _complete_sources,
     json_option,
+    language_option,
+    multi_source_option,
     notebook_option,
     prompt_file_option,
     retry_option,
+    wait_option,
     wait_polling_options,
 )
 from .rendering import (
@@ -51,28 +34,20 @@ from .rendering import (
     json_error_response,
     json_output_response,
 )
-from .resolve import (
-    require_notebook,
-    resolve_notebook_id,
-    resolve_source_ids,
+from .resolve import require_notebook
+from .services.generate import (
+    _INFOGRAPHIC_STYLE_MAP,
+    build_generation_plan,
+    execute_generation,
 )
-from .services.artifact_generation import generate_with_retry, handle_generation_result
 
 DEFAULT_LANGUAGE = "en"
 
-_INFOGRAPHIC_STYLE_MAP = {
-    "auto": InfographicStyle.AUTO_SELECT,
-    "sketch-note": InfographicStyle.SKETCH_NOTE,
-    "professional": InfographicStyle.PROFESSIONAL,
-    "bento-grid": InfographicStyle.BENTO_GRID,
-    "editorial": InfographicStyle.EDITORIAL,
-    "instructional": InfographicStyle.INSTRUCTIONAL,
-    "bricks": InfographicStyle.BRICKS,
-    "clay": InfographicStyle.CLAY,
-    "anime": InfographicStyle.ANIME,
-    "kawaii": InfographicStyle.KAWAII,
-    "scientific": InfographicStyle.SCIENTIFIC,
-}
+# Re-export markers kept for backward-compatibility with tests that patch
+# these names on this module (e.g. ``patch.object(generate_module,
+# "json_error_response", ...)``). They are otherwise read by
+# ``_output_mind_map_result`` below.
+_ = (NotebookLMClient, console, json_error_response, json_output_response, get_language)
 
 
 def resolve_language(language: str | None) -> str:
@@ -109,6 +84,72 @@ def resolve_language(language: str | None) -> str:
             )
         return config_lang
     return DEFAULT_LANGUAGE
+
+
+def _output_mind_map_result(result: Any, json_output: bool) -> None:
+    """Output mind map result in appropriate format.
+
+    Kept in this module (rather than the service) because the existing
+    test suite patches it as a module-level attribute alongside
+    ``console`` / ``json_error_response`` / ``json_output_response``.
+    """
+    if not result:
+        if json_output:
+            json_error_response("GENERATION_FAILED", "Mind map generation failed")
+        else:
+            console.print("[yellow]No result[/yellow]")
+        return
+
+    if json_output:
+        json_output_response(result)
+        return
+
+    console.print("[green]Mind map generated:[/green]")
+    if isinstance(result, dict):
+        console.print(f"  Note ID: {result.get('note_id', '-')}")
+        mind_map = result.get("mind_map", {})
+        if isinstance(mind_map, dict):
+            console.print(f"  Root: {mind_map.get('name', '-')}")
+            console.print(f"  Children: {len(mind_map.get('children', []))} nodes")
+    else:
+        console.print(result)
+
+
+# Click-handler params that are not part of the service-layer raw_args
+# contract. ``ctx`` carries the parameter-source probe; ``client_auth`` is
+# the AuthTokens injected by ``@with_client``; ``prompt_file`` has already
+# been merged into ``description`` via ``resolve_prompt`` by the time the
+# handler calls ``_run_generate``.
+_NON_RAW_ARG_KEYS = frozenset({"ctx", "client_auth", "prompt_file"})
+
+
+def _run_generate(*, kind: str, **handler_locals: Any) -> Any:
+    """Bridge a Click handler invocation into the service-layer pipeline.
+
+    Each handler calls ``_run_generate(kind="...", **locals())`` after
+    resolving its description prompt. This shim filters out the
+    handler-only keys (``ctx`` / ``client_auth`` / ``prompt_file``),
+    runs ``require_notebook``, builds the plan (Click-time validation
+    runs here, so UsageErrors surface synchronously), then opens the
+    client and dispatches the async executor. Returns the coroutine the
+    ``@with_client`` decorator will run via ``asyncio.run``.
+    """
+    ctx = handler_locals["ctx"]
+    client_auth = handler_locals["client_auth"]
+    raw_args = {k: v for k, v in handler_locals.items() if k not in _NON_RAW_ARG_KEYS}
+    raw_args["notebook_id"] = require_notebook(raw_args["notebook_id"])
+    plan = build_generation_plan(
+        kind,
+        raw_args,
+        parameter_source=ctx.get_parameter_source,
+        language_resolver=resolve_language,
+    )
+
+    async def _run() -> Any:
+        async with NotebookLMClient(client_auth) as client:
+            return await execute_generation(plan, client)
+
+    return _run()
 
 
 @click.group()
@@ -156,20 +197,9 @@ def generate():
     type=click.Choice(["short", "default", "long"]),
     default="default",
 )
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@language_option
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -202,49 +232,7 @@ def generate_audio(
       notebooklm generate audio -s src_001 -s src_002 "from specific sources"
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-    format_map = {
-        "deep-dive": AudioFormat.DEEP_DIVE,
-        "brief": AudioFormat.BRIEF,
-        "critique": AudioFormat.CRITIQUE,
-        "debate": AudioFormat.DEBATE,
-    }
-    length_map = {
-        "short": AudioLength.SHORT,
-        "default": AudioLength.DEFAULT,
-        "long": AudioLength.LONG,
-    }
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_audio(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description or None,
-                    audio_format=format_map[audio_format],
-                    audio_length=length_map[audio_length],
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "audio", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "audio",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="audio", **locals())
 
 
 @generate.command("video")
@@ -276,20 +264,9 @@ def generate_audio(
     default="auto",
 )
 @click.option("--style-prompt", default=None, help="Custom visual style prompt")
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@language_option
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=600, default_interval=2)
 @retry_option
 @json_option
@@ -328,93 +305,12 @@ def generate_video(
       notebooklm generate video -s src_001 "from specific source"
     """
     description = resolve_prompt(description, prompt_file, "description")
-    # The 'generate cinematic-video' alias hard-pins --format to 'cinematic'.
-    # If the user explicitly passed --format with any non-cinematic value, raise
-    # rather than silently overriding (mirrors the --style-prompt rejection
-    # pattern below). When --format was not passed at all, fall through to the
-    # implicit 'cinematic' coercion.
-    if ctx.info_name == "cinematic-video":
-        format_source = ctx.get_parameter_source("video_format")
-        format_explicit = format_source == ParameterSource.COMMANDLINE
-        if format_explicit and video_format != "cinematic":
-            raise click.UsageError(
-                "--format must be 'cinematic' for the cinematic-video subcommand "
-                "(use 'generate video --format <other>' for other formats)"
-            )
-        video_format = "cinematic"
-
-    nb_id = require_notebook(notebook_id)
-    format_map = {
-        "explainer": VideoFormat.EXPLAINER,
-        "brief": VideoFormat.BRIEF,
-        "cinematic": VideoFormat.CINEMATIC,
-    }
-    style_map = {
-        "auto": VideoStyle.AUTO_SELECT,
-        "custom": VideoStyle.CUSTOM,
-        "classic": VideoStyle.CLASSIC,
-        "whiteboard": VideoStyle.WHITEBOARD,
-        "kawaii": VideoStyle.KAWAII,
-        "anime": VideoStyle.ANIME,
-        "watercolor": VideoStyle.WATERCOLOR,
-        "retro-print": VideoStyle.RETRO_PRINT,
-        "heritage": VideoStyle.HERITAGE,
-        "paper-craft": VideoStyle.PAPER_CRAFT,
-    }
-    is_cinematic = video_format == "cinematic"
-    normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
-    if is_cinematic and normalized_style_prompt:
-        raise click.UsageError("--style-prompt cannot be used with cinematic video")
-    if not is_cinematic and style == "custom" and not normalized_style_prompt:
-        raise click.UsageError("--style custom requires --style-prompt")
-    if not is_cinematic and normalized_style_prompt and style != "custom":
-        raise click.UsageError("--style-prompt requires --style custom")
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                if is_cinematic:
-                    return await client.artifacts.generate_cinematic_video(
-                        nb_id_resolved,
-                        source_ids=sources,
-                        language=resolve_language(language),
-                        instructions=description or None,
-                    )
-                return await client.artifacts.generate_video(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description or None,
-                    video_format=format_map[video_format],
-                    video_style=style_map[style],
-                    style_prompt=normalized_style_prompt,
-                )
-
-            # Cinematic videos default to a longer 1800s ceiling (Veo 3 takes
-            # ~30-40 min). Preserve that default *only* when the user did not
-            # pass --timeout explicitly; an explicit value always wins so
-            # `generate cinematic-video --timeout 60` honors the override.
-            timeout_value = float(timeout)
-            if is_cinematic and ctx.get_parameter_source("timeout") != ParameterSource.COMMANDLINE:
-                timeout_value = 1800.0
-            result = await generate_with_retry(_generate, max_retries, "video", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "video",
-                wait,
-                json_output,
-                timeout=timeout_value,
-                interval=float(interval),
-            )
-
-    return _run()
+    # ctx.info_name distinguishes the `cinematic-video` alias (which shares
+    # this callback) from the canonical `video` command. The alias kind
+    # enforces `--format cinematic` and the longer Veo-3 timeout default;
+    # see services/generate.py _build_cinematic_video_plan.
+    kind = "cinematic-video" if ctx.info_name == "cinematic-video" else "video"
+    return _run_generate(kind=kind, **{k: v for k, v in locals().items() if k != "kind"})
 
 
 # Convenience alias: 'generate cinematic-video' delegates to 'generate video --format cinematic'.
@@ -453,20 +349,9 @@ generate.add_command(_cinematic_video_gen_cmd)
     type=click.Choice(["default", "short"]),
     default="default",
 )
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@language_option
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -498,46 +383,7 @@ def generate_slide_deck(
       notebooklm generate slide-deck "executive summary" --format presenter --length short
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-    format_map = {
-        "detailed": SlideDeckFormat.DETAILED_DECK,
-        "presenter": SlideDeckFormat.PRESENTER_SLIDES,
-    }
-    length_map = {
-        "default": SlideDeckLength.DEFAULT,
-        "short": SlideDeckLength.SHORT,
-    }
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_slide_deck(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description or None,
-                    slide_format=format_map[deck_format],
-                    slide_length=length_map[deck_length],
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "slide deck", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "slide deck",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="slide-deck", **locals())
 
 
 @generate.command("revise-slide")
@@ -559,7 +405,7 @@ def generate_slide_deck(
     required=True,
     help="Zero-based index of the slide to revise (0 = first slide)",
 )
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -589,35 +435,7 @@ def generate_revise_slide(
       notebooklm generate revise-slide "Remove taxonomy" --artifact <id> --slide 3 --wait
     """
     description = resolve_prompt(description, prompt_file, "description", required=True)
-    nb_id = require_notebook(notebook_id)
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-
-            async def _generate():
-                return await client.artifacts.revise_slide(
-                    nb_id_resolved,
-                    artifact_id=artifact_id,
-                    slide_index=slide_index,
-                    prompt=description,
-                )
-
-            result = await generate_with_retry(
-                _generate, max_retries, "slide revision", json_output
-            )
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "slide revision",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="revise-slide", **locals())
 
 
 @generate.command("quiz")
@@ -626,15 +444,8 @@ def generate_revise_slide(
 @notebook_option
 @click.option("--quantity", type=click.Choice(["fewer", "standard", "more"]), default="standard")
 @click.option("--difficulty", type=click.Choice(["easy", "medium", "hard"]), default="medium")
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -665,47 +476,7 @@ def generate_quiz(
       notebooklm generate quiz "test key concepts" --difficulty hard --quantity more
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-    quantity_map = {
-        "fewer": QuizQuantity.FEWER,
-        "standard": QuizQuantity.STANDARD,
-        "more": QuizQuantity.MORE,
-    }
-    difficulty_map = {
-        "easy": QuizDifficulty.EASY,
-        "medium": QuizDifficulty.MEDIUM,
-        "hard": QuizDifficulty.HARD,
-    }
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_quiz(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    instructions=description or None,
-                    quantity=quantity_map[quantity],
-                    difficulty=difficulty_map[difficulty],
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "quiz", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "quiz",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="quiz", **locals())
 
 
 @generate.command("flashcards")
@@ -714,15 +485,8 @@ def generate_quiz(
 @notebook_option
 @click.option("--quantity", type=click.Choice(["fewer", "standard", "more"]), default="standard")
 @click.option("--difficulty", type=click.Choice(["easy", "medium", "hard"]), default="medium")
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -753,47 +517,7 @@ def generate_flashcards(
       notebooklm generate flashcards --quantity more --difficulty easy
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-    quantity_map = {
-        "fewer": QuizQuantity.FEWER,
-        "standard": QuizQuantity.STANDARD,
-        "more": QuizQuantity.MORE,
-    }
-    difficulty_map = {
-        "easy": QuizDifficulty.EASY,
-        "medium": QuizDifficulty.MEDIUM,
-        "hard": QuizDifficulty.HARD,
-    }
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_flashcards(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    instructions=description or None,
-                    quantity=quantity_map[quantity],
-                    difficulty=difficulty_map[difficulty],
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "flashcards", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "flashcards",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="flashcards", **locals())
 
 
 @generate.command("infographic")
@@ -815,20 +539,9 @@ def generate_flashcards(
     type=click.Choice(list(_INFOGRAPHIC_STYLE_MAP)),
     default="auto",
 )
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@language_option
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -861,69 +574,16 @@ def generate_infographic(
       notebooklm generate infographic --orientation portrait --detail detailed
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-    orientation_map = {
-        "landscape": InfographicOrientation.LANDSCAPE,
-        "portrait": InfographicOrientation.PORTRAIT,
-        "square": InfographicOrientation.SQUARE,
-    }
-    detail_map = {
-        "concise": InfographicDetail.CONCISE,
-        "standard": InfographicDetail.STANDARD,
-        "detailed": InfographicDetail.DETAILED,
-    }
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_infographic(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description or None,
-                    orientation=orientation_map[orientation],
-                    detail_level=detail_map[detail],
-                    style=_INFOGRAPHIC_STYLE_MAP[style],
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "infographic", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "infographic",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="infographic", **locals())
 
 
 @generate.command("data-table")
 @click.argument("description", default="", required=False)
 @prompt_file_option
 @notebook_option
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@language_option
+@multi_source_option
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -953,53 +613,13 @@ def generate_data_table(
       notebooklm generate data-table -s src_001 "timeline of events"
     """
     description = resolve_prompt(description, prompt_file, "description", required=True)
-    nb_id = require_notebook(notebook_id)
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_data_table(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description,
-                )
-
-            result = await generate_with_retry(_generate, max_retries, "data table", json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                "data table",
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="data-table", **locals())
 
 
 @generate.command("mind-map")
 @notebook_option
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
+@multi_source_option
+@language_option
 @click.option("--instructions", default=None, help="Custom instructions for the mind map")
 @json_option
 @with_client
@@ -1011,56 +631,7 @@ def generate_mind_map(
     \b
     Use --json for machine-readable output.
     """
-    nb_id = require_notebook(notebook_id)
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_mind_map(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=instructions,
-                )
-
-            if json_output:
-                result = await _generate()
-            else:
-                with console.status("Generating mind map..."):
-                    result = await _generate()
-
-            _output_mind_map_result(result, json_output)
-
-    return _run()
-
-
-def _output_mind_map_result(result: Any, json_output: bool) -> None:
-    """Output mind map result in appropriate format."""
-    if not result:
-        if json_output:
-            json_error_response("GENERATION_FAILED", "Mind map generation failed")
-        else:
-            console.print("[yellow]No result[/yellow]")
-        return
-
-    if json_output:
-        json_output_response(result)
-        return
-
-    console.print("[green]Mind map generated:[/green]")
-    if isinstance(result, dict):
-        console.print(f"  Note ID: {result.get('note_id', '-')}")
-        mind_map = result.get("mind_map", {})
-        if isinstance(mind_map, dict):
-            console.print(f"  Root: {mind_map.get('name', '-')}")
-            console.print(f"  Children: {len(mind_map.get('children', []))} nodes")
-    else:
-        console.print(result)
+    return _run_generate(kind="mind-map", **locals())
 
 
 @generate.command("report")
@@ -1074,26 +645,15 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
     help="Report format (default: briefing-doc)",
 )
 @notebook_option
-@click.option(
-    "--source",
-    "-s",
-    "source_ids",
-    multiple=True,
-    help="Limit to specific source IDs",
-    shell_complete=_complete_sources,
-)
-@click.option(
-    "--language",
-    default=None,
-    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
-)
+@multi_source_option
+@language_option
 @click.option(
     "--append",
     "append_instructions",
     default=None,
     help="Append extra instructions to the built-in prompt for non-custom formats. Has no effect with --format custom.",
 )
-@click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
+@wait_option
 @wait_polling_options(default_timeout=300, default_interval=2)
 @retry_option
 @json_option
@@ -1129,67 +689,4 @@ def generate_report_cmd(
       notebooklm generate report --format study-guide --append "Target audience: beginners"
     """
     description = resolve_prompt(description, prompt_file, "description")
-    nb_id = require_notebook(notebook_id)
-
-    # Smart detection: if description provided without explicit format change, treat as custom
-    actual_format = report_format
-    custom_prompt = None
-    if description:
-        if report_format == "briefing-doc":
-            actual_format = "custom"
-            custom_prompt = description
-        else:
-            custom_prompt = description
-
-    if append_instructions and actual_format == "custom":
-        click.echo(
-            "Warning: --append has no effect with --format custom. Use the description argument instead.",
-            err=True,
-        )
-        append_instructions = None
-
-    format_map = {
-        "briefing-doc": ReportFormat.BRIEFING_DOC,
-        "study-guide": ReportFormat.STUDY_GUIDE,
-        "blog-post": ReportFormat.BLOG_POST,
-        "custom": ReportFormat.CUSTOM,
-    }
-    report_format_enum = format_map[actual_format]
-
-    format_display = {
-        "briefing-doc": "briefing document",
-        "study-guide": "study guide",
-        "blog-post": "blog post",
-        "custom": "custom report",
-    }[actual_format]
-
-    async def _run():
-        async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            sources = await resolve_source_ids(
-                client, nb_id_resolved, source_ids, json_output=json_output
-            )
-
-            async def _generate():
-                return await client.artifacts.generate_report(
-                    nb_id_resolved,
-                    source_ids=sources,
-                    language=resolve_language(language),
-                    report_format=report_format_enum,
-                    custom_prompt=custom_prompt,
-                    extra_instructions=append_instructions,
-                )
-
-            result = await generate_with_retry(_generate, max_retries, format_display, json_output)
-            await handle_generation_result(
-                client,
-                nb_id_resolved,
-                result,
-                format_display,
-                wait,
-                json_output,
-                timeout=float(timeout),
-                interval=float(interval),
-            )
-
-    return _run()
+    return _run_generate(kind="report", **locals())

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -43,12 +43,6 @@ from .services.generate import (
 
 DEFAULT_LANGUAGE = "en"
 
-# Re-export markers kept for backward-compatibility with tests that patch
-# these names on this module (e.g. ``patch.object(generate_module,
-# "json_error_response", ...)``). They are otherwise read by
-# ``_output_mind_map_result`` below.
-_ = (NotebookLMClient, console, json_error_response, json_output_response, get_language)
-
 
 def resolve_language(language: str | None) -> str:
     """Resolve language from CLI flag, NOTEBOOKLM_HL env, config, or default.

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -218,6 +218,48 @@ def source_option(f: FC) -> FC:
     )(f)
 
 
+def multi_source_option(f: FC) -> FC:
+    """Add the ``--source/-s`` option used by ``generate <kind>`` commands.
+
+    Multi-valued, optional ``--source`` flag that collects source IDs into a
+    ``source_ids`` tuple (matches the ``multiple=True`` shape used by every
+    ``generate`` subcommand pre-extraction). Distinct from
+    :func:`source_option`, which is single-valued and required (used by
+    ``download source-content`` and friends).
+
+    Tab completion follows the same notebook-resolution rules as
+    :func:`source_option`.
+    """
+    # Decl order matches the pre-extraction inline ``@click.option("--source",
+    # "-s", "source_ids", ...)`` form in cli/generate_cmd.py. Click preserves
+    # decl order in ``param.opts`` and the CLI-contract baseline pins it; the
+    # long-flag-first order must stay even though the single-source
+    # :func:`source_option` above uses short-flag-first.
+    return click.option(
+        "--source",
+        "-s",
+        "source_ids",
+        multiple=True,
+        help="Limit to specific source IDs",
+        shell_complete=_complete_sources,
+    )(f)
+
+
+def language_option(f: FC) -> FC:
+    """Add the shared ``--language`` flag used by generation commands.
+
+    Resolution chain (handled by the command body, not the decorator):
+    ``--language`` flag > ``NOTEBOOKLM_HL`` env var > config file > ``"en"``
+    default. The decorator only declares the flag; the body must call
+    ``resolve_language(language)`` to walk the chain.
+    """
+    return click.option(
+        "--language",
+        default=None,
+        help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+    )(f)
+
+
 def artifact_option(f: FC) -> FC:
     """Add --artifact/-a option for artifact ID.
 

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -1,0 +1,897 @@
+"""Service layer for ``notebooklm generate`` commands (P3.T1, ADR-008).
+
+This module owns the Click-free orchestration for all 11 ``generate``
+leaf commands:
+
+* ``audio``, ``video``, ``cinematic-video``, ``slide-deck``,
+  ``revise-slide``, ``quiz``, ``flashcards``, ``infographic``,
+  ``data-table``, ``mind-map``, ``report``
+
+The split mirrors the ``services/source_add.py`` / ``services/login.py``
+shape established by earlier ADR-008 extractions:
+
+* :func:`build_generation_plan` does all Click-time validation, parameter
+  coercion (e.g. report smart-custom detection, cinematic-video alias
+  enforcement), enum mapping, and the cinematic-video timeout default.
+  It returns a frozen :class:`GenerationPlan` dataclass.
+* :func:`execute_generation` is the async orchestration: open-client
+  scope is the caller's; this function resolves notebook/source IDs,
+  emits queued warnings, dispatches to the right ``client.artifacts.*``
+  method, runs the retry-with-backoff loop via the existing
+  ``services/artifact_generation.py`` core, and handles output / wait.
+
+The Click handlers in ``cli/generate_cmd.py`` shrink to a thin shell:
+build the raw_args dict from Click params, call
+``build_generation_plan(kind, raw_args, parameter_source)``, then call
+``execute_generation(plan, client)`` inside an ``async with
+NotebookLMClient(...) as client:`` block.
+
+This module does NOT introduce parallel abstractions to
+``services/artifact_generation.py`` (that module's
+``generate_with_retry`` + ``handle_generation_result`` is the retry-core
+and is reused as-is; see phase-3.md → P3.T1 must_not_do).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import click
+from click.core import ParameterSource
+
+from ...types import (
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+)
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
+    from ...types import GenerationStatus
+
+GenerationKind = Literal[
+    "audio",
+    "video",
+    "cinematic-video",
+    "slide-deck",
+    "revise-slide",
+    "quiz",
+    "flashcards",
+    "infographic",
+    "data-table",
+    "mind-map",
+    "report",
+]
+
+# Display name used in user-facing strings ("Audio ready", "rate limited", etc.).
+# Mind-map is intentionally absent — it goes through a custom output path.
+_DISPLAY_NAME: Mapping[str, str] = {
+    "audio": "audio",
+    "video": "video",
+    "cinematic-video": "video",  # shares the "video" display
+    "slide-deck": "slide deck",
+    "revise-slide": "slide revision",
+    "quiz": "quiz",
+    "flashcards": "flashcards",
+    "infographic": "infographic",
+    "data-table": "data table",
+    "mind-map": "mind map",
+    # ``report`` uses a per-format display name (see _REPORT_DISPLAY).
+}
+
+# Per-report-format display name used in retry / status messages.
+_REPORT_DISPLAY: Mapping[str, str] = {
+    "briefing-doc": "briefing document",
+    "study-guide": "study guide",
+    "blog-post": "blog post",
+    "custom": "custom report",
+}
+
+# Pre-extraction generate.py had the infographic style map inlined; reuse the
+# same exhaustive mapping here so handler-regression byte-for-byte parity is
+# preserved. Sourced from cli/generate_cmd.py at f1be552.
+_INFOGRAPHIC_STYLE_MAP: Mapping[str, InfographicStyle] = {
+    "auto": InfographicStyle.AUTO_SELECT,
+    "sketch-note": InfographicStyle.SKETCH_NOTE,
+    "professional": InfographicStyle.PROFESSIONAL,
+    "bento-grid": InfographicStyle.BENTO_GRID,
+    "editorial": InfographicStyle.EDITORIAL,
+    "instructional": InfographicStyle.INSTRUCTIONAL,
+    "bricks": InfographicStyle.BRICKS,
+    "clay": InfographicStyle.CLAY,
+    "anime": InfographicStyle.ANIME,
+    "kawaii": InfographicStyle.KAWAII,
+    "scientific": InfographicStyle.SCIENTIFIC,
+}
+
+_AUDIO_FORMAT_MAP: Mapping[str, AudioFormat] = {
+    "deep-dive": AudioFormat.DEEP_DIVE,
+    "brief": AudioFormat.BRIEF,
+    "critique": AudioFormat.CRITIQUE,
+    "debate": AudioFormat.DEBATE,
+}
+
+_AUDIO_LENGTH_MAP: Mapping[str, AudioLength] = {
+    "short": AudioLength.SHORT,
+    "default": AudioLength.DEFAULT,
+    "long": AudioLength.LONG,
+}
+
+_VIDEO_FORMAT_MAP: Mapping[str, VideoFormat] = {
+    "explainer": VideoFormat.EXPLAINER,
+    "brief": VideoFormat.BRIEF,
+    "cinematic": VideoFormat.CINEMATIC,
+}
+
+_VIDEO_STYLE_MAP: Mapping[str, VideoStyle] = {
+    "auto": VideoStyle.AUTO_SELECT,
+    "custom": VideoStyle.CUSTOM,
+    "classic": VideoStyle.CLASSIC,
+    "whiteboard": VideoStyle.WHITEBOARD,
+    "kawaii": VideoStyle.KAWAII,
+    "anime": VideoStyle.ANIME,
+    "watercolor": VideoStyle.WATERCOLOR,
+    "retro-print": VideoStyle.RETRO_PRINT,
+    "heritage": VideoStyle.HERITAGE,
+    "paper-craft": VideoStyle.PAPER_CRAFT,
+}
+
+_SLIDE_FORMAT_MAP: Mapping[str, SlideDeckFormat] = {
+    "detailed": SlideDeckFormat.DETAILED_DECK,
+    "presenter": SlideDeckFormat.PRESENTER_SLIDES,
+}
+
+_SLIDE_LENGTH_MAP: Mapping[str, SlideDeckLength] = {
+    "default": SlideDeckLength.DEFAULT,
+    "short": SlideDeckLength.SHORT,
+}
+
+_QUIZ_QUANTITY_MAP: Mapping[str, QuizQuantity] = {
+    "fewer": QuizQuantity.FEWER,
+    "standard": QuizQuantity.STANDARD,
+    "more": QuizQuantity.MORE,
+}
+
+_QUIZ_DIFFICULTY_MAP: Mapping[str, QuizDifficulty] = {
+    "easy": QuizDifficulty.EASY,
+    "medium": QuizDifficulty.MEDIUM,
+    "hard": QuizDifficulty.HARD,
+}
+
+_INFOGRAPHIC_ORIENTATION_MAP: Mapping[str, InfographicOrientation] = {
+    "landscape": InfographicOrientation.LANDSCAPE,
+    "portrait": InfographicOrientation.PORTRAIT,
+    "square": InfographicOrientation.SQUARE,
+}
+
+_INFOGRAPHIC_DETAIL_MAP: Mapping[str, InfographicDetail] = {
+    "concise": InfographicDetail.CONCISE,
+    "standard": InfographicDetail.STANDARD,
+    "detailed": InfographicDetail.DETAILED,
+}
+
+_REPORT_FORMAT_MAP: Mapping[str, ReportFormat] = {
+    "briefing-doc": ReportFormat.BRIEFING_DOC,
+    "study-guide": ReportFormat.STUDY_GUIDE,
+    "blog-post": ReportFormat.BLOG_POST,
+    "custom": ReportFormat.CUSTOM,
+}
+
+# Cinematic-video defaults to a longer wait ceiling (Veo 3 takes ~30-40 min).
+# Preserved from cli/generate_cmd.py pre-extraction.
+_CINEMATIC_DEFAULT_TIMEOUT = 1800.0
+
+
+@dataclass(frozen=True)
+class GenerationPlan:
+    """Prepared inputs for a single ``generate`` command.
+
+    All Click-time validation (parameter combinations, alias enforcement,
+    smart-format coercion) has already run by the time a plan exists. The
+    executor only needs to dispatch the right ``client.artifacts.*`` call,
+    handle retry / wait / output, and emit any queued warnings to stderr.
+
+    Attributes:
+        kind: Internal kind identifier (one of :data:`GenerationKind`).
+            ``cinematic-video`` is a distinct kind from ``video`` because
+            it dispatches to a different API method
+            (``generate_cinematic_video``).
+        display_name: User-facing name used in retry / status messages
+            (e.g. ``"audio"``, ``"slide deck"``, ``"briefing document"``).
+            For ``report`` this is per-format.
+        notebook_id: Pre-resolution notebook ID (the executor resolves it
+            via ``resolve_notebook_id``).
+        description: Resolved prompt text (already merged with
+            ``--prompt-file``). May be empty for kinds that accept it.
+        source_ids: Tuple of source IDs to scope generation to. Pre-
+            resolution; the executor calls ``resolve_source_ids``. May be
+            empty (== unscoped).
+        language: ``en``-style language code, already resolved via the
+            language-resolution chain (--language > NOTEBOOKLM_HL > config
+            > "en"). ``None`` for kinds that do not accept ``--language``
+            (currently ``revise-slide``, ``quiz``, ``flashcards``).
+        wait: Whether to wait for completion before returning. Mind-map
+            ignores this field and renders synchronously.
+        timeout: Wait timeout in seconds. For cinematic-video this is
+            defaulted to 1800.0 when the user did not pass ``--timeout``
+            explicitly.
+        interval: Polling interval in seconds for the wait loop.
+        max_retries: Number of retry-after-rate-limit attempts. ``0``
+            means a single attempt with no retry.
+        json_output: Whether to emit JSON instead of text. Suppresses
+            spinner / progress messages.
+        params: Kind-specific keyword arguments forwarded to the
+            ``client.artifacts.<method>`` call. Already enum-mapped.
+        warnings: Stderr warnings queued during plan construction (e.g.
+            ``--append`` with ``--format custom``). Emitted in order
+            before the API call.
+    """
+
+    kind: GenerationKind
+    display_name: str
+    notebook_id: str
+    description: str
+    source_ids: tuple[str, ...]
+    language: str | None
+    wait: bool
+    timeout: float
+    interval: float
+    max_retries: int
+    json_output: bool
+    params: Mapping[str, Any] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+
+
+def build_generation_plan(
+    kind: str,
+    raw_args: Mapping[str, Any],
+    parameter_source: Callable[[str], ParameterSource] | None = None,
+    *,
+    language_resolver: Callable[[str | None], str] | None = None,
+) -> GenerationPlan:
+    """Validate Click-layer inputs and return a :class:`GenerationPlan`.
+
+    Args:
+        kind: One of the literal kind names in :data:`GenerationKind`. The
+            caller is responsible for mapping ``ctx.info_name`` to the
+            right kind (``"cinematic-video"`` for the alias, ``"video"``
+            for the canonical command).
+        raw_args: Per-command kwargs dict. Required keys vary by kind;
+            this function picks the relevant subset and ignores extras.
+            Common keys: ``notebook_id``, ``description``, ``source_ids``,
+            ``language``, ``wait``, ``timeout``, ``interval``,
+            ``max_retries``, ``json_output``. Kind-specific keys: see
+            internal builders below.
+        parameter_source: Optional callable returning Click's
+            ``ParameterSource`` for a given param name. Used to detect
+            "user did not pass --format / --timeout" cases for the
+            cinematic-video alias. If ``None``, defaults to "every
+            parameter is treated as DEFAULT", which is the right behavior
+            for unit tests that supply args directly.
+        language_resolver: Optional callable that resolves a raw
+            ``--language`` value through the env/config/default chain.
+            When ``None``, the raw value is passed through unchanged
+            (None or the user's literal flag). The Click layer always
+            supplies the real resolver; tests can pass ``lambda x: x``
+            or a custom stub.
+
+    Returns:
+        A frozen :class:`GenerationPlan` ready for :func:`execute_generation`.
+
+    Raises:
+        click.UsageError: For invalid parameter combinations (cinematic
+            video + ``--style-prompt``, ``--style custom`` without
+            ``--style-prompt``, ``cinematic-video --format <non-cinematic>``).
+        ValueError: When ``kind`` is not recognized.
+    """
+    source: Callable[[str], ParameterSource] = parameter_source or (
+        lambda _name: ParameterSource.DEFAULT
+    )
+    # Default resolver mirrors the canonical ``"en"`` fallback used by
+    # ``cli/generate_cmd.py:resolve_language`` so unit tests that omit a
+    # resolver get a stable string back. Production calls (from the Click
+    # layer) always supply the real resolver, which walks the
+    # --language > env > config > "en" chain.
+    resolve_language: Callable[[str | None], str] = language_resolver or (
+        lambda lang: lang if isinstance(lang, str) else "en"
+    )
+
+    builder = _BUILDERS.get(kind)
+    if builder is None:
+        raise ValueError(f"Unknown generation kind: {kind!r}")
+    return builder(raw_args, source, resolve_language)
+
+
+# ---------------------------------------------------------------------------
+# Per-kind plan builders
+# ---------------------------------------------------------------------------
+
+
+def _common(raw_args: Mapping[str, Any]) -> dict[str, Any]:
+    """Pull the common cross-kind keys out of ``raw_args`` with defaults."""
+    return {
+        "notebook_id": raw_args["notebook_id"],
+        "description": raw_args.get("description", "") or "",
+        "source_ids": tuple(raw_args.get("source_ids") or ()),
+        "wait": bool(raw_args.get("wait", False)),
+        "timeout": float(raw_args.get("timeout", 300.0)),
+        "interval": float(raw_args.get("interval", 2.0)),
+        "max_retries": int(raw_args.get("max_retries", 0)),
+        "json_output": bool(raw_args.get("json_output", False)),
+    }
+
+
+def _build_audio_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    language = resolve_language(raw_args.get("language"))
+    return GenerationPlan(
+        kind="audio",
+        display_name=_DISPLAY_NAME["audio"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=language,
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "audio_format": _AUDIO_FORMAT_MAP[raw_args["audio_format"]],
+            "audio_length": _AUDIO_LENGTH_MAP[raw_args["audio_length"]],
+        },
+    )
+
+
+def _build_video_plan_for_kind(
+    raw_args: Mapping[str, Any],
+    source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+    *,
+    alias: bool,
+) -> GenerationPlan:
+    """Shared builder for ``video`` and the ``cinematic-video`` alias.
+
+    ``alias=True`` enforces the cinematic-video flag rules: an explicit
+    ``--format <non-cinematic>`` raises UsageError, the format is coerced
+    to cinematic when not passed, and the timeout defaults to 1800s when
+    the user did not pass ``--timeout``.
+    """
+    common = _common(raw_args)
+    video_format = raw_args.get("video_format", "explainer")
+    style = raw_args.get("style", "auto")
+    style_prompt_raw = raw_args.get("style_prompt")
+
+    if alias:
+        format_explicit = source("video_format") == ParameterSource.COMMANDLINE
+        if format_explicit and video_format != "cinematic":
+            raise click.UsageError(
+                "--format must be 'cinematic' for the cinematic-video subcommand "
+                "(use 'generate video --format <other>' for other formats)"
+            )
+        video_format = "cinematic"
+
+    is_cinematic = video_format == "cinematic"
+    normalized_style_prompt = (
+        style_prompt_raw.strip() if isinstance(style_prompt_raw, str) else None
+    )
+    if is_cinematic and normalized_style_prompt:
+        raise click.UsageError("--style-prompt cannot be used with cinematic video")
+    if not is_cinematic and style == "custom" and not normalized_style_prompt:
+        raise click.UsageError("--style custom requires --style-prompt")
+    if not is_cinematic and normalized_style_prompt and style != "custom":
+        raise click.UsageError("--style-prompt requires --style custom")
+
+    timeout_value = common["timeout"]
+    if is_cinematic and source("timeout") != ParameterSource.COMMANDLINE:
+        timeout_value = _CINEMATIC_DEFAULT_TIMEOUT
+
+    language = resolve_language(raw_args.get("language"))
+
+    if is_cinematic:
+        # cinematic-video dispatches to a different API method and accepts
+        # only the description (no format / style / style_prompt).
+        return GenerationPlan(
+            kind="cinematic-video",
+            display_name=_DISPLAY_NAME["cinematic-video"],
+            notebook_id=common["notebook_id"],
+            description=common["description"],
+            source_ids=common["source_ids"],
+            language=language,
+            wait=common["wait"],
+            timeout=timeout_value,
+            interval=common["interval"],
+            max_retries=common["max_retries"],
+            json_output=common["json_output"],
+            params={},
+        )
+
+    return GenerationPlan(
+        kind="video",
+        display_name=_DISPLAY_NAME["video"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=language,
+        wait=common["wait"],
+        timeout=timeout_value,
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "video_format": _VIDEO_FORMAT_MAP[video_format],
+            "video_style": _VIDEO_STYLE_MAP[style],
+            "style_prompt": normalized_style_prompt,
+        },
+    )
+
+
+def _build_video_plan(
+    raw_args: Mapping[str, Any],
+    source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    return _build_video_plan_for_kind(raw_args, source, resolve_language, alias=False)
+
+
+def _build_cinematic_video_plan(
+    raw_args: Mapping[str, Any],
+    source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    return _build_video_plan_for_kind(raw_args, source, resolve_language, alias=True)
+
+
+def _build_slide_deck_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="slide-deck",
+        display_name=_DISPLAY_NAME["slide-deck"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=resolve_language(raw_args.get("language")),
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "slide_format": _SLIDE_FORMAT_MAP[raw_args["deck_format"]],
+            "slide_length": _SLIDE_LENGTH_MAP[raw_args["deck_length"]],
+        },
+    )
+
+
+def _build_revise_slide_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    _resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="revise-slide",
+        display_name=_DISPLAY_NAME["revise-slide"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=(),  # revise-slide never resolves source IDs
+        language=None,
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "artifact_id": raw_args["artifact_id"],
+            "slide_index": int(raw_args["slide_index"]),
+            "prompt": common["description"],
+        },
+    )
+
+
+def _build_quiz_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    _resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="quiz",
+        display_name=_DISPLAY_NAME["quiz"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=None,
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "quantity": _QUIZ_QUANTITY_MAP[raw_args["quantity"]],
+            "difficulty": _QUIZ_DIFFICULTY_MAP[raw_args["difficulty"]],
+        },
+    )
+
+
+def _build_flashcards_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    _resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="flashcards",
+        display_name=_DISPLAY_NAME["flashcards"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=None,
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "quantity": _QUIZ_QUANTITY_MAP[raw_args["quantity"]],
+            "difficulty": _QUIZ_DIFFICULTY_MAP[raw_args["difficulty"]],
+        },
+    )
+
+
+def _build_infographic_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="infographic",
+        display_name=_DISPLAY_NAME["infographic"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=resolve_language(raw_args.get("language")),
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "orientation": _INFOGRAPHIC_ORIENTATION_MAP[raw_args["orientation"]],
+            "detail_level": _INFOGRAPHIC_DETAIL_MAP[raw_args["detail"]],
+            "style": _INFOGRAPHIC_STYLE_MAP[raw_args["style"]],
+        },
+    )
+
+
+def _build_data_table_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="data-table",
+        display_name=_DISPLAY_NAME["data-table"],
+        notebook_id=common["notebook_id"],
+        description=common["description"],
+        source_ids=common["source_ids"],
+        language=resolve_language(raw_args.get("language")),
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={},
+    )
+
+
+def _build_mind_map_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    return GenerationPlan(
+        kind="mind-map",
+        display_name=_DISPLAY_NAME["mind-map"],
+        notebook_id=common["notebook_id"],
+        description="",
+        source_ids=common["source_ids"],
+        language=resolve_language(raw_args.get("language")),
+        wait=False,  # mind-map renders synchronously; no wait loop
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=0,
+        json_output=common["json_output"],
+        params={"instructions": raw_args.get("instructions")},
+    )
+
+
+def _build_report_plan(
+    raw_args: Mapping[str, Any],
+    _source: Callable[[str], ParameterSource],
+    resolve_language: Callable[[str | None], str],
+) -> GenerationPlan:
+    common = _common(raw_args)
+    description = common["description"]
+    report_format = raw_args.get("report_format", "briefing-doc")
+    append_instructions = raw_args.get("append_instructions")
+
+    # Smart detection: a bare description with the default --format briefing-doc
+    # is treated as a custom report (preserves pre-extraction behavior).
+    actual_format = report_format
+    custom_prompt: str | None = None
+    if description:
+        if report_format == "briefing-doc":
+            actual_format = "custom"
+            custom_prompt = description
+        else:
+            custom_prompt = description
+
+    warnings: list[str] = []
+    if append_instructions and actual_format == "custom":
+        warnings.append(
+            "Warning: --append has no effect with --format custom. "
+            "Use the description argument instead."
+        )
+        append_instructions = None
+
+    display_name = _REPORT_DISPLAY[actual_format]
+    return GenerationPlan(
+        kind="report",
+        display_name=display_name,
+        notebook_id=common["notebook_id"],
+        description=description,
+        source_ids=common["source_ids"],
+        language=resolve_language(raw_args.get("language")),
+        wait=common["wait"],
+        timeout=common["timeout"],
+        interval=common["interval"],
+        max_retries=common["max_retries"],
+        json_output=common["json_output"],
+        params={
+            "report_format": _REPORT_FORMAT_MAP[actual_format],
+            "custom_prompt": custom_prompt,
+            "extra_instructions": append_instructions,
+        },
+        warnings=tuple(warnings),
+    )
+
+
+_BUILDERS: Mapping[
+    str,
+    Callable[
+        [
+            Mapping[str, Any],
+            Callable[[str], ParameterSource],
+            Callable[[str | None], str],
+        ],
+        GenerationPlan,
+    ],
+] = {
+    "audio": _build_audio_plan,
+    "video": _build_video_plan,
+    "cinematic-video": _build_cinematic_video_plan,
+    "slide-deck": _build_slide_deck_plan,
+    "revise-slide": _build_revise_slide_plan,
+    "quiz": _build_quiz_plan,
+    "flashcards": _build_flashcards_plan,
+    "infographic": _build_infographic_plan,
+    "data-table": _build_data_table_plan,
+    "mind-map": _build_mind_map_plan,
+    "report": _build_report_plan,
+}
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+
+_KIND_TO_METHOD: Mapping[str, str] = {
+    "audio": "generate_audio",
+    "video": "generate_video",
+    "cinematic-video": "generate_cinematic_video",
+    "slide-deck": "generate_slide_deck",
+    "revise-slide": "revise_slide",
+    "quiz": "generate_quiz",
+    "flashcards": "generate_flashcards",
+    "infographic": "generate_infographic",
+    "data-table": "generate_data_table",
+    "mind-map": "generate_mind_map",
+    "report": "generate_report",
+}
+
+
+def _build_call_kwargs(plan: GenerationPlan, *, notebook_id: str, sources: Any) -> dict[str, Any]:
+    """Build the kwargs dict passed to ``client.artifacts.<method>(notebook_id, **kwargs)``.
+
+    Common cross-kind kwargs (``source_ids``, ``language``, ``instructions``)
+    are merged with kind-specific ``plan.params``. ``revise-slide`` and
+    ``mind-map`` have bespoke shapes handled here.
+    """
+    if plan.kind == "revise-slide":
+        # revise_slide(notebook_id, *, artifact_id, slide_index, prompt)
+        return {
+            "artifact_id": plan.params["artifact_id"],
+            "slide_index": plan.params["slide_index"],
+            "prompt": plan.params["prompt"],
+        }
+
+    if plan.kind == "mind-map":
+        return {
+            "source_ids": sources,
+            "language": plan.language,
+            "instructions": plan.params.get("instructions"),
+        }
+
+    if plan.kind == "cinematic-video":
+        # cinematic-video API: (notebook_id, *, source_ids, language, instructions)
+        return {
+            "source_ids": sources,
+            "language": plan.language,
+            "instructions": plan.description or None,
+        }
+
+    base: dict[str, Any] = {"source_ids": sources}
+
+    # Language: only kinds that accept it (plan.language not None).
+    if plan.language is not None:
+        base["language"] = plan.language
+
+    # data-table requires ``instructions``; pre-extraction code passed
+    # ``description`` (not ``description or None``) since the Click layer
+    # enforces ``required=True``. Preserve that contract.
+    if plan.kind == "data-table":
+        base["instructions"] = plan.description
+
+    # report packs report_format, custom_prompt, extra_instructions into
+    # plan.params; it does NOT carry ``instructions``.
+    elif plan.kind == "report":
+        base["report_format"] = plan.params["report_format"]
+        base["custom_prompt"] = plan.params["custom_prompt"]
+        base["extra_instructions"] = plan.params["extra_instructions"]
+
+    else:
+        # audio / video / slide-deck / quiz / flashcards / infographic all
+        # take ``instructions = description or None``.
+        base["instructions"] = plan.description or None
+
+    # Merge kind-specific params LAST so they win on key conflicts (none in
+    # practice, but defensive).
+    base.update(
+        {
+            k: v
+            for k, v in plan.params.items()
+            if k not in ("report_format", "custom_prompt", "extra_instructions")
+        }
+    )
+    return base
+
+
+def _emit_warnings(plan: GenerationPlan) -> None:
+    """Emit any warnings queued by ``build_generation_plan`` to stderr.
+
+    Plan warnings (e.g. ``--append`` with ``--format custom``) match the
+    pre-extraction ``click.echo(..., err=True)`` semantics. Suppressed in
+    JSON mode so stdout stays parseable AND stderr stays JSON-machine-
+    consumer friendly (the warning text is human prose, not structured).
+    """
+    if plan.json_output or not plan.warnings:
+        return
+    for line in plan.warnings:
+        click.echo(line, err=True)
+
+
+async def execute_generation(
+    plan: GenerationPlan,
+    client: NotebookLMClient,
+) -> GenerationStatus | None:
+    """Drive a single generation request end-to-end.
+
+    Caller responsibility: open and close the ``NotebookLMClient`` scope.
+    This function resolves notebook/source IDs, emits queued warnings,
+    dispatches to the matching ``client.artifacts.<method>``, runs the
+    retry-with-backoff loop, then either renders the mind-map result via
+    the legacy text/JSON formatter or hands off to
+    ``handle_generation_result`` (wait + status output + non-zero exit on
+    failure).
+
+    Returns the final :class:`GenerationStatus` (or ``None`` when the
+    underlying call resolved without a status). For ``mind-map`` returns
+    ``None`` — output is rendered inline.
+    """
+    # Local imports defer heavy CLI-layer wiring (rendering, error_handler)
+    # until execution time and keep the import graph testable.
+    from .. import generate_cmd  # late import: avoids module-load cycles
+    from ..resolve import resolve_notebook_id, resolve_source_ids
+    from .artifact_generation import generate_with_retry, handle_generation_result
+    from .polling import status_with_elapsed
+
+    _emit_warnings(plan)
+
+    nb_id_resolved = await resolve_notebook_id(
+        client, plan.notebook_id, json_output=plan.json_output
+    )
+
+    if plan.kind == "revise-slide":
+        # revise-slide never resolves source IDs.
+        sources: Any = None
+    else:
+        sources = await resolve_source_ids(
+            client, nb_id_resolved, plan.source_ids, json_output=plan.json_output
+        )
+
+    method_name = _KIND_TO_METHOD[plan.kind]
+    api_method = getattr(client.artifacts, method_name)
+    call_kwargs = _build_call_kwargs(plan, notebook_id=nb_id_resolved, sources=sources)
+
+    async def _generate() -> Any:
+        return await api_method(nb_id_resolved, **call_kwargs)
+
+    if plan.kind == "mind-map":
+        # Mind-map has a custom output path: no retry loop, optional
+        # spinner, custom formatter. Stay inside the generate_cmd module
+        # for _output_mind_map_result because tests patch it as a
+        # module-level attribute.
+        if plan.json_output:
+            result = await _generate()
+        else:
+            async with status_with_elapsed(
+                "Generating mind map...",
+                json_output=False,
+            ):
+                result = await _generate()
+        generate_cmd._output_mind_map_result(result, plan.json_output)
+        return None
+
+    result = await generate_with_retry(
+        _generate, plan.max_retries, plan.display_name, plan.json_output
+    )
+    return await handle_generation_result(
+        client,
+        nb_id_resolved,
+        result,
+        plan.display_name,
+        plan.wait,
+        plan.json_output,
+        timeout=plan.timeout,
+        interval=plan.interval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Re-exported helpers for tests / callers
+# ---------------------------------------------------------------------------
+
+# ``status_with_elapsed`` previously used "Generating mind map..." literal —
+# keep it inline above. Mind-map spinner is the only path that needs it; for
+# the standard wait spinner, ``handle_generation_result`` owns its own.
+
+__all__ = [
+    "GenerationKind",
+    "GenerationPlan",
+    "build_generation_plan",
+    "execute_generation",
+]

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -881,14 +881,6 @@ async def execute_generation(
     )
 
 
-# ---------------------------------------------------------------------------
-# Re-exported helpers for tests / callers
-# ---------------------------------------------------------------------------
-
-# ``status_with_elapsed`` previously used "Generating mind map..." literal —
-# keep it inline above. Mind-map spinner is the only path that needs it; for
-# the standard wait spinner, ``handle_generation_result`` owns its own.
-
 __all__ = [
     "GenerationKind",
     "GenerationPlan",

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -174,6 +174,16 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_authed_transport.py",
         "tests/unit/test_download_url.py",
         "tests/unit/test_firefox_containers.py",
+        # P3.T1 generate-extraction service tests stub the CLI resolver
+        # functions (``notebooklm.cli.resolve.resolve_notebook_id`` and
+        # ``resolve_source_ids``) via ``monkeypatch.setattr`` string targets.
+        # Those resolvers are module-level CLI seams above the
+        # ``NotebookLMClient`` core that ``make_fake_core(...)`` covers, so
+        # the same string-target pattern that ``test_public_shims.py`` /
+        # ``test_rpc_call_public_surface.py`` use for their non-core seams
+        # is required here. Revisit when ADR-007's seam-substitution pattern
+        # is extended to cover the CLI resolver surface.
+        "tests/unit/test_generate_service.py",
         "tests/unit/test_idempotency_registry.py",
         "tests/unit/test_init_order.py",
         "tests/unit/test_migration_lock.py",

--- a/tests/unit/cli/test_generate_characterization.py
+++ b/tests/unit/cli/test_generate_characterization.py
@@ -145,9 +145,7 @@ def test_generate_happy_path_json_snapshot(
     ``{"task_id": <id>, "status": "pending"}`` on a no-wait happy path."""
     result = authed_invoke(
         ["generate", cmd, "--json", "-n", "nb_123", *extra_args],
-        configure=_attach_async_return(
-            method, {"task_id": task_id, "status": "processing"}
-        ),
+        configure=_attach_async_return(method, {"task_id": task_id, "status": "processing"}),
     )
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
@@ -166,9 +164,7 @@ def test_generate_happy_path_text_snapshot(
     on a no-wait happy path."""
     result = authed_invoke(
         ["generate", cmd, "-n", "nb_123", *extra_args],
-        configure=_attach_async_return(
-            method, {"task_id": task_id, "status": "processing"}
-        ),
+        configure=_attach_async_return(method, {"task_id": task_id, "status": "processing"}),
     )
     assert result.exit_code == 0, result.output
     assert result.output == f"Started: {task_id}\n"
@@ -205,10 +201,7 @@ def test_generate_mind_map_text_snapshot(authed_invoke: Callable[..., Result]) -
     )
     assert result.exit_code == 0, result.output
     assert result.output == (
-        "Mind map generated:\n"
-        "  Note ID: n1\n"
-        "  Root: Root\n"
-        "  Children: 2 nodes\n"
+        "Mind map generated:\n  Note ID: n1\n  Root: Root\n  Children: 2 nodes\n"
     )
 
 
@@ -324,9 +317,7 @@ def test_video_style_custom_requires_style_prompt(
     authed_invoke: Callable[..., Result],
 ) -> None:
     """``--style custom`` requires ``--style-prompt`` for non-cinematic video."""
-    result = authed_invoke(
-        ["generate", "video", "--style", "custom", "-n", "nb_123"]
-    )
+    result = authed_invoke(["generate", "video", "--style", "custom", "-n", "nb_123"])
     assert result.exit_code == 2
     assert "--style custom requires --style-prompt" in result.output
 
@@ -335,9 +326,7 @@ def test_video_style_prompt_requires_style_custom(
     authed_invoke: Callable[..., Result],
 ) -> None:
     """``--style-prompt`` requires ``--style custom`` for non-cinematic video."""
-    result = authed_invoke(
-        ["generate", "video", "--style-prompt", "foo", "-n", "nb_123"]
-    )
+    result = authed_invoke(["generate", "video", "--style-prompt", "foo", "-n", "nb_123"])
     assert result.exit_code == 2
     assert "--style-prompt requires --style custom" in result.output
 
@@ -358,10 +347,7 @@ def test_cinematic_video_alias_rejects_non_cinematic_format(
         ],
     )
     assert result.exit_code == 2
-    assert (
-        "--format must be 'cinematic' for the cinematic-video subcommand"
-        in result.output
-    )
+    assert "--format must be 'cinematic' for the cinematic-video subcommand" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_generate_characterization.py
+++ b/tests/unit/cli/test_generate_characterization.py
@@ -1,0 +1,462 @@
+"""Characterization (golden-snapshot) tests for ``notebooklm generate`` commands.
+
+These tests lock in the exact byte-for-byte output of every ``generate``
+subcommand BEFORE the P3.T1 service-layer extraction lands, so the
+extraction commit can prove handler-regression-free behavior. They cover:
+
+* happy-path text + JSON output for each of the 10 leaf generate commands
+* the rate-limited (retry-exhausted) error path
+* the ``None``-result generation-failed error path
+* video / cinematic-video usage-error message text
+* report's "smart custom" format coercion and ``--append`` warning text
+
+Test discipline (phase-3.md → Characterization-Test Discipline):
+
+* This file MUST pass on the PR's branch base (main) **before** the
+  extraction commit lands. Run with ``uv run pytest
+  tests/unit/cli/test_generate_characterization.py -q`` against pre-T1
+  main to confirm; the same suite must remain byte-stable after T1.
+* Snapshots are stored as module-level string constants. Any drift in
+  Click usage messages, JSON formatting, or status-line wording will
+  surface here.
+* JSON snapshots are compared as parsed dicts (order/whitespace
+  resilient where contract is structural, not formatting); text
+  snapshots are compared as exact strings.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import GenerationStatus
+
+from .conftest import create_mock_client
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+_AUTH_PAYLOAD = {
+    "SID": "t",
+    "__Secure-1PSIDTS": "t",
+    "HSID": "t",
+    "SSID": "t",
+    "APISID": "t",
+    "SAPISID": "t",
+}
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def authed_invoke(
+    runner: CliRunner,
+) -> Iterator[Callable[..., Result]]:
+    """Yield an ``invoke(args, *, configure=None)`` helper with auth seams mocked.
+
+    ``configure`` (when supplied) receives a fresh mock client (already
+    attached to the patched ``NotebookLMClient`` constructor) and is
+    expected to attach the artifact-generation AsyncMock attributes the
+    test needs. When ``configure`` is ``None`` (usage-error tests that
+    never reach the API call), the mock client is still installed so the
+    auth bootstrap path succeeds; the API methods stay as default
+    ``MagicMock``s and are never invoked.
+    """
+
+    def _invoke(
+        args: list[str],
+        *,
+        configure: Callable[[Any], None] | None = None,
+    ) -> Result:
+        mock_client = create_mock_client()
+        if configure is not None:
+            configure(mock_client)
+        with (
+            patch("notebooklm.cli.generate_cmd.NotebookLMClient") as mock_cls,
+            patch(
+                "notebooklm.cli.helpers.load_auth_from_storage",
+                return_value=_AUTH_PAYLOAD,
+            ),
+            patch(
+                "notebooklm.auth.fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
+        ):
+            mock_cls.return_value = mock_client
+            mock_fetch.return_value = ("csrf", "session")
+            return runner.invoke(cli, args)
+
+    yield _invoke
+
+
+def _attach_async_return(method_name: str, value: Any) -> Callable[[Any], None]:
+    """Build a ``configure`` callable that sets ``artifacts.<method>`` mock."""
+
+    def _apply(mock_client: Any) -> None:
+        setattr(mock_client.artifacts, method_name, AsyncMock(return_value=value))
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# Happy-path golden output: text and JSON
+# ---------------------------------------------------------------------------
+
+# Mapping (CLI subcommand, ``client.artifacts.*`` method name, extra args, task_id).
+# The 10 leaf generate commands per phase-3.md → P3.T1.
+HAPPY_PATH_CASES: list[tuple[str, str, list[str], str]] = [
+    ("audio", "generate_audio", [], "task_audio"),
+    ("video", "generate_video", [], "task_video"),
+    ("cinematic-video", "generate_cinematic_video", [], "task_cv"),
+    ("slide-deck", "generate_slide_deck", [], "task_slides"),
+    (
+        "revise-slide",
+        "revise_slide",
+        ["Move title up", "--artifact", "art_1", "--slide", "0"],
+        "task_revise",
+    ),
+    ("quiz", "generate_quiz", [], "task_quiz"),
+    ("flashcards", "generate_flashcards", [], "task_flash"),
+    ("infographic", "generate_infographic", [], "task_info"),
+    ("data-table", "generate_data_table", ["Compare key concepts"], "task_dtable"),
+    ("report", "generate_report", [], "task_report"),
+]
+
+
+@pytest.mark.parametrize("cmd,method,extra_args,task_id", HAPPY_PATH_CASES)
+def test_generate_happy_path_json_snapshot(
+    cmd: str,
+    method: str,
+    extra_args: list[str],
+    task_id: str,
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """JSON output for the 10 generate commands is exactly
+    ``{"task_id": <id>, "status": "pending"}`` on a no-wait happy path."""
+    result = authed_invoke(
+        ["generate", cmd, "--json", "-n", "nb_123", *extra_args],
+        configure=_attach_async_return(
+            method, {"task_id": task_id, "status": "processing"}
+        ),
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {"task_id": task_id, "status": "pending"}
+
+
+@pytest.mark.parametrize("cmd,method,extra_args,task_id", HAPPY_PATH_CASES)
+def test_generate_happy_path_text_snapshot(
+    cmd: str,
+    method: str,
+    extra_args: list[str],
+    task_id: str,
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """Text output for the 10 generate commands is exactly ``Started: <task_id>\\n``
+    on a no-wait happy path."""
+    result = authed_invoke(
+        ["generate", cmd, "-n", "nb_123", *extra_args],
+        configure=_attach_async_return(
+            method, {"task_id": task_id, "status": "processing"}
+        ),
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == f"Started: {task_id}\n"
+
+
+# ---------------------------------------------------------------------------
+# Mind-map happy path (its own output shape: full result echoed)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_mind_map_json_snapshot(authed_invoke: Callable[..., Result]) -> None:
+    """Mind-map JSON output is the full result dict pretty-printed."""
+    payload = {
+        "note_id": "n1",
+        "mind_map": {"name": "Root", "children": [{"a": 1}, {"b": 2}]},
+    }
+    result = authed_invoke(
+        ["generate", "mind-map", "--json", "-n", "nb_123"],
+        configure=_attach_async_return("generate_mind_map", payload),
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == payload
+
+
+def test_generate_mind_map_text_snapshot(authed_invoke: Callable[..., Result]) -> None:
+    """Mind-map text output is the 3-line ``Note ID / Root / Children`` block."""
+    payload = {
+        "note_id": "n1",
+        "mind_map": {"name": "Root", "children": [{"a": 1}, {"b": 2}]},
+    }
+    result = authed_invoke(
+        ["generate", "mind-map", "-n", "nb_123"],
+        configure=_attach_async_return("generate_mind_map", payload),
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == (
+        "Mind map generated:\n"
+        "  Note ID: n1\n"
+        "  Root: Root\n"
+        "  Children: 2 nodes\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_generate_audio_failure_none_result_json(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """When the generation API returns ``None`` the CLI emits a structured JSON
+    error and exits non-zero."""
+    result = authed_invoke(
+        ["generate", "audio", "--json", "-n", "nb_123"],
+        configure=_attach_async_return("generate_audio", None),
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.output) == {
+        "error": True,
+        "code": "GENERATION_FAILED",
+        "message": "Audio generation failed",
+    }
+
+
+def test_generate_audio_failure_none_result_text(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """When the generation API returns ``None`` text mode prints the
+    failure message to stderr and exits non-zero."""
+    result = authed_invoke(
+        ["generate", "audio", "-n", "nb_123"],
+        configure=_attach_async_return("generate_audio", None),
+    )
+    assert result.exit_code == 1
+    # ``output_error`` writes via ``safe_echo(err=True)``. stderr is the
+    # canonical sink; ``output`` captures stderr when stderr is unbound.
+    assert "Audio generation failed" in result.output
+
+
+def test_generate_audio_rate_limit_retry_exhausted_json(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """Retry-exhausted rate-limit (retry=0) returns the RATE_LIMITED JSON
+    payload and exits non-zero."""
+    rate_limited = GenerationStatus(
+        task_id="task_rl",
+        status="failed",
+        error_code="RATE_LIMIT_EXCEEDED",
+        error="rate limited",
+    )
+    result = authed_invoke(
+        ["generate", "audio", "--json", "-n", "nb_123"],
+        configure=_attach_async_return("generate_audio", rate_limited),
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.output) == {
+        "error": True,
+        "code": "RATE_LIMITED",
+        "message": "Audio generation rate limited by Google.",
+    }
+
+
+def test_generate_audio_rate_limit_retry_exhausted_text(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """Retry-exhausted rate-limit (retry=0) text mode prints the rate-limit
+    message AND the hint, then exits non-zero."""
+    rate_limited = GenerationStatus(
+        task_id="task_rl",
+        status="failed",
+        error_code="RATE_LIMIT_EXCEEDED",
+        error="rate limited",
+    )
+    result = authed_invoke(
+        ["generate", "audio", "-n", "nb_123"],
+        configure=_attach_async_return("generate_audio", rate_limited),
+    )
+    assert result.exit_code == 1
+    assert result.output == (
+        "Audio generation rate limited by Google.\n"
+        "Daily quota may be exceeded. Try again in 1-24 hours, "
+        "or use --retry N to retry automatically.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Video / cinematic-video usage-error text
+# ---------------------------------------------------------------------------
+
+
+def test_video_cinematic_rejects_style_prompt(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """``--style-prompt`` is rejected when the video format is cinematic."""
+    result = authed_invoke(
+        [
+            "generate",
+            "video",
+            "--format",
+            "cinematic",
+            "--style-prompt",
+            "foo",
+            "-n",
+            "nb_123",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "--style-prompt cannot be used with cinematic video" in result.output
+
+
+def test_video_style_custom_requires_style_prompt(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """``--style custom`` requires ``--style-prompt`` for non-cinematic video."""
+    result = authed_invoke(
+        ["generate", "video", "--style", "custom", "-n", "nb_123"]
+    )
+    assert result.exit_code == 2
+    assert "--style custom requires --style-prompt" in result.output
+
+
+def test_video_style_prompt_requires_style_custom(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """``--style-prompt`` requires ``--style custom`` for non-cinematic video."""
+    result = authed_invoke(
+        ["generate", "video", "--style-prompt", "foo", "-n", "nb_123"]
+    )
+    assert result.exit_code == 2
+    assert "--style-prompt requires --style custom" in result.output
+
+
+def test_cinematic_video_alias_rejects_non_cinematic_format(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """``generate cinematic-video --format explainer`` is rejected with a
+    targeted message that points users at ``generate video``."""
+    result = authed_invoke(
+        [
+            "generate",
+            "cinematic-video",
+            "--format",
+            "explainer",
+            "-n",
+            "nb_123",
+        ],
+    )
+    assert result.exit_code == 2
+    assert (
+        "--format must be 'cinematic' for the cinematic-video subcommand"
+        in result.output
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report "smart-custom" coercion and --append warning
+# ---------------------------------------------------------------------------
+
+
+def test_report_description_triggers_custom_format(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """A bare description on ``generate report`` (with default --format
+    briefing-doc) is smart-detected as a custom report — the API call gets
+    ``ReportFormat.CUSTOM`` and the description as ``custom_prompt``."""
+    captured: dict[str, Any] = {}
+
+    async def _capture(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return {"task_id": "task_report_custom", "status": "processing"}
+
+    def _configure(mock_client: Any) -> None:
+        mock_client.artifacts.generate_report = AsyncMock(side_effect=_capture)
+
+    result = authed_invoke(
+        ["generate", "report", "My custom prompt", "-n", "nb_123"],
+        configure=_configure,
+    )
+    assert result.exit_code == 0, result.output
+    # ReportFormat.CUSTOM == "custom" by enum string identity.
+    assert captured["report_format"].value == "custom"
+    assert captured["custom_prompt"] == "My custom prompt"
+    assert captured["extra_instructions"] is None
+
+
+def test_report_custom_with_append_emits_warning(
+    authed_invoke: Callable[..., Result],
+) -> None:
+    """``--append`` is a no-op when ``--format custom`` is in effect; the CLI
+    emits a stderr warning and clears the append payload before calling the
+    API."""
+    captured: dict[str, Any] = {}
+
+    async def _capture(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return {"task_id": "task_report_custom_w", "status": "processing"}
+
+    def _configure(mock_client: Any) -> None:
+        mock_client.artifacts.generate_report = AsyncMock(side_effect=_capture)
+
+    result = authed_invoke(
+        [
+            "generate",
+            "report",
+            "--format",
+            "custom",
+            "--append",
+            "extra",
+            "desc",
+            "-n",
+            "nb_123",
+        ],
+        configure=_configure,
+    )
+    assert result.exit_code == 0, result.output
+    assert (
+        "Warning: --append has no effect with --format custom. "
+        "Use the description argument instead." in result.output
+    )
+    # Warning side-effect: append is suppressed (CLI sets it to None).
+    assert captured["extra_instructions"] is None
+
+
+# ---------------------------------------------------------------------------
+# Group-level help (regression guard on subcommand listing)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_help_lists_all_ten_kinds(runner: CliRunner) -> None:
+    """``notebooklm generate --help`` lists every leaf subcommand by name.
+
+    Lock-in protects against accidental command drop during refactor.
+    """
+    result = runner.invoke(cli, ["generate", "--help"])
+    assert result.exit_code == 0
+    expected_subcommands = [
+        "audio",
+        "video",
+        "cinematic-video",
+        "slide-deck",
+        "revise-slide",
+        "quiz",
+        "flashcards",
+        "infographic",
+        "data-table",
+        "mind-map",
+        "report",
+    ]
+    for name in expected_subcommands:
+        assert name in result.output, f"missing subcommand {name!r}: {result.output}"

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -1,0 +1,660 @@
+"""Direct service-layer tests for ``cli/services/generate.py`` (P3.T1).
+
+These tests exercise :func:`build_generation_plan` and
+:func:`execute_generation` directly — no ``CliRunner``, no Click
+context — so the public service surface is testable without the
+Click decorator stack. Companion characterization tests in
+``tests/unit/cli/test_generate_characterization.py`` lock in the
+CLI-shell byte-for-byte behavior; these tests pin the service-layer
+contract.
+
+Coverage:
+
+* ``build_generation_plan`` over all 11 internal kinds (10 leaf
+  commands + the ``cinematic-video`` alias kind) — plan field
+  population, enum mapping, warning queue.
+* Per-kind validation: cinematic-video alias enforcement, video
+  ``--style-prompt`` rules, report smart-custom coercion, report
+  ``--append`` warning side-effect.
+* ``execute_generation`` happy path: dispatches the right
+  ``client.artifacts.<method>`` call with the expected kwargs.
+* ``execute_generation`` mind-map path: dispatches to
+  ``generate_mind_map`` and renders via the generate_cmd-level
+  ``_output_mind_map_result`` (which the test asserts on).
+* Warning emission to stderr happens BEFORE the API call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import click
+import pytest
+from click.core import ParameterSource
+
+from notebooklm.cli.services.generate import (
+    GenerationPlan,
+    build_generation_plan,
+    execute_generation,
+)
+from notebooklm.types import (
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_source(_name: str) -> ParameterSource:
+    """Stub that reports every parameter as DEFAULT (= not explicitly passed)."""
+    return ParameterSource.DEFAULT
+
+
+def _identity_language(lang: str | None) -> str:
+    """Stub resolver: pass through the literal value, ``"en"`` for ``None``."""
+    return lang if isinstance(lang, str) else "en"
+
+
+def _base_args(**overrides: Any) -> dict[str, Any]:
+    """Return the cross-kind ``raw_args`` keys with sane test defaults."""
+    args: dict[str, Any] = {
+        "notebook_id": "nb_123",
+        "description": "",
+        "source_ids": (),
+        "language": None,
+        "wait": False,
+        "timeout": 300,
+        "interval": 2,
+        "max_retries": 0,
+        "json_output": False,
+    }
+    args.update(overrides)
+    return args
+
+
+# ---------------------------------------------------------------------------
+# build_generation_plan — happy-path parametrized over all 10 kinds + alias
+# ---------------------------------------------------------------------------
+
+# Each row: (kind, extra raw_args, expected plan attrs to spot-check, expected
+# enum keys in plan.params).
+_PLAN_HAPPY_CASES: list[tuple[str, dict[str, Any], dict[str, Any], dict[str, Any]]] = [
+    (
+        "audio",
+        {"audio_format": "deep-dive", "audio_length": "default", "language": "en"},
+        {"display_name": "audio", "language": "en"},
+        {
+            "audio_format": AudioFormat.DEEP_DIVE,
+            "audio_length": AudioLength.DEFAULT,
+        },
+    ),
+    (
+        "video",
+        {
+            "video_format": "explainer",
+            "style": "auto",
+            "style_prompt": None,
+            "language": "en",
+        },
+        {"display_name": "video", "language": "en"},
+        {
+            "video_format": VideoFormat.EXPLAINER,
+            "video_style": VideoStyle.AUTO_SELECT,
+            "style_prompt": None,
+        },
+    ),
+    (
+        "cinematic-video",
+        {
+            "video_format": "explainer",  # alias coerces to cinematic
+            "style": "auto",
+            "style_prompt": None,
+            "language": "en",
+        },
+        {
+            "display_name": "video",
+            "language": "en",
+            "timeout": 1800.0,  # cinematic-default override (source is DEFAULT)
+        },
+        {},  # cinematic-video carries no kind-specific params
+    ),
+    (
+        "slide-deck",
+        {"deck_format": "detailed", "deck_length": "default", "language": "en"},
+        {"display_name": "slide deck", "language": "en"},
+        {
+            "slide_format": SlideDeckFormat.DETAILED_DECK,
+            "slide_length": SlideDeckLength.DEFAULT,
+        },
+    ),
+    (
+        "revise-slide",
+        {
+            "description": "Move up",
+            "artifact_id": "art_1",
+            "slide_index": 0,
+        },
+        {"display_name": "slide revision", "language": None},
+        {
+            "artifact_id": "art_1",
+            "slide_index": 0,
+            "prompt": "Move up",
+        },
+    ),
+    (
+        "quiz",
+        {"quantity": "standard", "difficulty": "medium"},
+        {"display_name": "quiz", "language": None},
+        {
+            "quantity": QuizQuantity.STANDARD,
+            "difficulty": QuizDifficulty.MEDIUM,
+        },
+    ),
+    (
+        "flashcards",
+        {"quantity": "standard", "difficulty": "medium"},
+        {"display_name": "flashcards", "language": None},
+        {
+            "quantity": QuizQuantity.STANDARD,
+            "difficulty": QuizDifficulty.MEDIUM,
+        },
+    ),
+    (
+        "infographic",
+        {
+            "orientation": "landscape",
+            "detail": "standard",
+            "style": "auto",
+            "language": "en",
+        },
+        {"display_name": "infographic", "language": "en"},
+        {
+            "orientation": InfographicOrientation.LANDSCAPE,
+            "detail_level": InfographicDetail.STANDARD,
+            "style": InfographicStyle.AUTO_SELECT,
+        },
+    ),
+    (
+        "data-table",
+        {"description": "Compare", "language": "en"},
+        {"display_name": "data table", "language": "en"},
+        {},
+    ),
+    (
+        "mind-map",
+        {"instructions": "summarize", "language": "en"},
+        {
+            "display_name": "mind map",
+            "wait": False,
+            "max_retries": 0,
+            "language": "en",
+        },
+        {"instructions": "summarize"},
+    ),
+    (
+        "report",
+        {
+            "report_format": "study-guide",
+            "language": "en",
+            "append_instructions": None,
+        },
+        {"display_name": "study guide", "language": "en"},
+        {
+            "report_format": ReportFormat.STUDY_GUIDE,
+            "custom_prompt": None,
+            "extra_instructions": None,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("kind,extra,plan_attrs,params", _PLAN_HAPPY_CASES)
+def test_build_plan_happy_path(
+    kind: str,
+    extra: dict[str, Any],
+    plan_attrs: dict[str, Any],
+    params: dict[str, Any],
+) -> None:
+    """Every supported kind builds a frozen plan with enums mapped correctly."""
+    args = _base_args(**extra)
+    plan = build_generation_plan(
+        kind,
+        args,
+        parameter_source=_default_source,
+        language_resolver=_identity_language,
+    )
+    assert isinstance(plan, GenerationPlan)
+    assert plan.kind == kind
+    assert plan.notebook_id == "nb_123"
+    for attr, value in plan_attrs.items():
+        assert getattr(plan, attr) == value, f"{kind}: plan.{attr}"
+    for key, value in params.items():
+        assert plan.params[key] == value, f"{kind}: params[{key!r}]"
+
+
+def test_build_plan_unknown_kind_raises() -> None:
+    """Plan builder rejects an unrecognized kind with ValueError."""
+    with pytest.raises(ValueError, match="Unknown generation kind"):
+        build_generation_plan("not-a-kind", _base_args())
+
+
+# ---------------------------------------------------------------------------
+# Cinematic-video alias validation
+# ---------------------------------------------------------------------------
+
+
+def test_cinematic_video_rejects_explicit_non_cinematic_format() -> None:
+    """``cinematic-video --format explainer`` raises UsageError when the
+    source reports COMMANDLINE for ``video_format``."""
+
+    def source(name: str) -> ParameterSource:
+        if name == "video_format":
+            return ParameterSource.COMMANDLINE
+        return ParameterSource.DEFAULT
+
+    args = _base_args(video_format="explainer", style="auto", style_prompt=None, language="en")
+    with pytest.raises(click.UsageError, match="--format must be 'cinematic'"):
+        build_generation_plan(
+            "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+        )
+
+
+def test_cinematic_video_explicit_cinematic_format_is_accepted() -> None:
+    """``cinematic-video --format cinematic`` (explicit) is fine."""
+
+    def source(name: str) -> ParameterSource:
+        return ParameterSource.COMMANDLINE if name == "video_format" else ParameterSource.DEFAULT
+
+    args = _base_args(video_format="cinematic", style="auto", style_prompt=None, language="en")
+    plan = build_generation_plan(
+        "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+    )
+    assert plan.kind == "cinematic-video"
+    assert plan.timeout == 1800.0  # default cinematic timeout
+
+
+def test_cinematic_video_explicit_timeout_wins_over_default() -> None:
+    """When the user passes ``--timeout``, the cinematic 1800s default does
+    NOT clobber it."""
+
+    def source(name: str) -> ParameterSource:
+        # User passed --timeout explicitly; --format not.
+        return ParameterSource.COMMANDLINE if name == "timeout" else ParameterSource.DEFAULT
+
+    args = _base_args(
+        video_format="explainer", style="auto", style_prompt=None, language="en", timeout=60
+    )
+    plan = build_generation_plan(
+        "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+    )
+    assert plan.timeout == 60.0  # user override wins
+
+
+# ---------------------------------------------------------------------------
+# Video --style / --style-prompt validation
+# ---------------------------------------------------------------------------
+
+
+def test_video_cinematic_rejects_style_prompt() -> None:
+    """Cinematic video + non-empty ``--style-prompt`` raises UsageError."""
+    args = _base_args(
+        video_format="cinematic",
+        style="auto",
+        style_prompt="foo",
+        language="en",
+    )
+    with pytest.raises(click.UsageError, match="--style-prompt cannot be used"):
+        build_generation_plan(
+            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+        )
+
+
+def test_video_style_custom_requires_style_prompt() -> None:
+    """``--style custom`` without ``--style-prompt`` raises UsageError."""
+    args = _base_args(video_format="explainer", style="custom", style_prompt=None, language="en")
+    with pytest.raises(click.UsageError, match="--style custom requires --style-prompt"):
+        build_generation_plan(
+            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+        )
+
+
+def test_video_style_prompt_requires_style_custom() -> None:
+    """Non-empty ``--style-prompt`` with ``--style != custom`` raises UsageError."""
+    args = _base_args(
+        video_format="explainer", style="anime", style_prompt="hand-drawn", language="en"
+    )
+    with pytest.raises(click.UsageError, match="--style-prompt requires --style custom"):
+        build_generation_plan(
+            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+        )
+
+
+def test_video_style_prompt_strips_whitespace() -> None:
+    """Whitespace-only ``--style-prompt`` is treated as unset (still triggers
+    the ``--style custom`` requirement when style is custom)."""
+    args = _base_args(video_format="explainer", style="custom", style_prompt="   ", language="en")
+    with pytest.raises(click.UsageError, match="--style custom requires --style-prompt"):
+        build_generation_plan(
+            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+        )
+
+
+# ---------------------------------------------------------------------------
+# Report smart-custom coercion + --append warning
+# ---------------------------------------------------------------------------
+
+
+def test_report_smart_custom_coercion_on_default_format() -> None:
+    """A description on default ``--format briefing-doc`` swaps to custom."""
+    args = _base_args(
+        description="My white paper",
+        report_format="briefing-doc",
+        append_instructions=None,
+    )
+    plan = build_generation_plan(
+        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+    )
+    assert plan.params["report_format"] == ReportFormat.CUSTOM
+    assert plan.params["custom_prompt"] == "My white paper"
+    assert plan.display_name == "custom report"
+    assert plan.warnings == ()
+
+
+def test_report_explicit_format_with_description_keeps_format_but_sets_custom_prompt() -> None:
+    """``--format study-guide`` + description keeps study-guide but passes
+    the description as ``custom_prompt`` (pre-extraction behavior)."""
+    args = _base_args(
+        description="Brief audience: novices",
+        report_format="study-guide",
+        append_instructions=None,
+    )
+    plan = build_generation_plan(
+        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+    )
+    assert plan.params["report_format"] == ReportFormat.STUDY_GUIDE
+    assert plan.params["custom_prompt"] == "Brief audience: novices"
+    assert plan.display_name == "study guide"
+
+
+def test_report_append_with_custom_format_queues_warning_and_drops_append() -> None:
+    """``--append`` with ``--format custom`` queues a stderr warning and clears
+    the append payload before the API call."""
+    args = _base_args(
+        description="desc",
+        report_format="custom",
+        append_instructions="extra",
+    )
+    plan = build_generation_plan(
+        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+    )
+    assert plan.params["extra_instructions"] is None
+    assert plan.warnings == (
+        "Warning: --append has no effect with --format custom. "
+        "Use the description argument instead.",
+    )
+
+
+def test_report_append_with_non_custom_format_passes_through() -> None:
+    """``--append`` with a non-custom format passes through unchanged."""
+    args = _base_args(
+        description="",
+        report_format="study-guide",
+        append_instructions="Target: novices",
+    )
+    plan = build_generation_plan(
+        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+    )
+    assert plan.params["report_format"] == ReportFormat.STUDY_GUIDE
+    assert plan.params["custom_prompt"] is None
+    assert plan.params["extra_instructions"] == "Target: novices"
+    assert plan.warnings == ()
+
+
+# ---------------------------------------------------------------------------
+# execute_generation — happy path, mind-map path, warning emission
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client(method_name: str, return_value: Any) -> MagicMock:
+    """Build a mock ``NotebookLMClient``-shaped object with the indicated
+    ``artifacts.<method_name>`` attached as an AsyncMock and async
+    enter/exit so callers can ``async with`` it (we never use the
+    context manager here — caller passes the bare mock directly to
+    ``execute_generation`` which expects an open client)."""
+    client = MagicMock()
+    client.artifacts = MagicMock()
+    setattr(client.artifacts, method_name, AsyncMock(return_value=return_value))
+    return client
+
+
+@pytest.mark.parametrize(
+    "kind,extra,method,expected_kwargs",
+    [
+        (
+            "audio",
+            {
+                "description": "deep dive",
+                "audio_format": "deep-dive",
+                "audio_length": "default",
+                "language": "en",
+            },
+            "generate_audio",
+            {
+                "source_ids": (),
+                "language": "en",
+                "instructions": "deep dive",
+                "audio_format": AudioFormat.DEEP_DIVE,
+                "audio_length": AudioLength.DEFAULT,
+            },
+        ),
+        (
+            "quiz",
+            {"quantity": "standard", "difficulty": "medium"},
+            "generate_quiz",
+            {
+                "source_ids": (),
+                "instructions": None,
+                "quantity": QuizQuantity.STANDARD,
+                "difficulty": QuizDifficulty.MEDIUM,
+            },
+        ),
+        (
+            "data-table",
+            {"description": "Compare", "language": "en"},
+            "generate_data_table",
+            {
+                "source_ids": (),
+                "language": "en",
+                "instructions": "Compare",
+            },
+        ),
+        (
+            "report",
+            {
+                "report_format": "blog-post",
+                "language": "en",
+                "append_instructions": "Tone: casual",
+            },
+            "generate_report",
+            {
+                "source_ids": (),
+                "language": "en",
+                "report_format": ReportFormat.BLOG_POST,
+                "custom_prompt": None,
+                "extra_instructions": "Tone: casual",
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_execute_generation_dispatches_with_expected_kwargs(
+    kind: str,
+    extra: dict[str, Any],
+    method: str,
+    expected_kwargs: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Executor calls ``client.artifacts.<method>(notebook_id, **kwargs)``
+    with the kwargs computed by the plan."""
+
+    # Stub the resolve_* helpers so they return the inputs untouched.
+    async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
+        return nb
+
+    async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
+        return tuple(sources)
+
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+
+    plan = build_generation_plan(
+        kind,
+        _base_args(**extra),
+        parameter_source=_default_source,
+        language_resolver=_identity_language,
+    )
+    client = _make_mock_client(method, {"task_id": "tid", "status": "processing"})
+
+    result = await execute_generation(plan, client)
+
+    api = getattr(client.artifacts, method)
+    api.assert_awaited_once()
+    call = api.await_args
+    assert call.args == ("nb_123",)
+    assert call.kwargs == expected_kwargs
+    # ``execute_generation`` returns ``None`` when the API result is a raw
+    # dict (handle_generation_result short-circuits — no GenerationStatus).
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_mind_map_dispatches_and_renders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mind-map kind dispatches to ``generate_mind_map`` and renders the
+    result via ``generate_cmd._output_mind_map_result``."""
+
+    async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
+        return nb
+
+    async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
+        return tuple(sources)
+
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+    captured: dict[str, Any] = {}
+
+    def fake_output(result: Any, json_output: bool) -> None:
+        captured["result"] = result
+        captured["json_output"] = json_output
+
+    import notebooklm.cli.generate_cmd as generate_cmd
+
+    monkeypatch.setattr(generate_cmd, "_output_mind_map_result", fake_output)
+
+    plan = build_generation_plan(
+        "mind-map",
+        _base_args(instructions="summarize", language="en", json_output=True),
+        parameter_source=_default_source,
+        language_resolver=_identity_language,
+    )
+    mind_map_payload = {"note_id": "n1", "mind_map": {"name": "Root", "children": []}}
+    client = _make_mock_client("generate_mind_map", mind_map_payload)
+
+    result = await execute_generation(plan, client)
+
+    client.artifacts.generate_mind_map.assert_awaited_once_with(
+        "nb_123",
+        source_ids=(),
+        language="en",
+        instructions="summarize",
+    )
+    assert captured == {"result": mind_map_payload, "json_output": True}
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_emits_warnings_before_api_call(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Queued plan warnings hit stderr before the API method is called."""
+
+    async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
+        return nb
+
+    async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
+        return tuple(sources)
+
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+
+    plan = build_generation_plan(
+        "report",
+        _base_args(
+            description="desc",
+            report_format="custom",
+            append_instructions="extra",
+        ),
+        parameter_source=_default_source,
+        language_resolver=_identity_language,
+    )
+    assert plan.warnings  # sanity: plan queued at least one warning
+
+    client = _make_mock_client("generate_report", {"task_id": "tid", "status": "processing"})
+
+    await execute_generation(plan, client)
+
+    err = capsys.readouterr().err
+    assert "Warning: --append has no effect with --format custom" in err
+    client.artifacts.generate_report.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_revise_slide_skips_source_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Revise-slide kind never calls ``resolve_source_ids`` and forwards
+    artifact_id / slide_index / prompt to the API."""
+    resolve_calls: dict[str, int] = {"sources": 0}
+
+    async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
+        return nb
+
+    async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
+        resolve_calls["sources"] += 1
+        return tuple(sources)
+
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+
+    plan = build_generation_plan(
+        "revise-slide",
+        _base_args(description="Move up", artifact_id="art_1", slide_index=3),
+        parameter_source=_default_source,
+        language_resolver=_identity_language,
+    )
+    client = _make_mock_client("revise_slide", {"task_id": "tid", "status": "processing"})
+
+    await execute_generation(plan, client)
+
+    assert resolve_calls["sources"] == 0
+    client.artifacts.revise_slide.assert_awaited_once_with(
+        "nb_123",
+        artifact_id="art_1",
+        slide_index=3,
+        prompt="Move up",
+    )


### PR DESCRIPTION
## Summary

Per [phase-3.md → P3.T1](../blob/main/.sisyphus/phases/cli-audit-fixes/phase-3.md), split `cli/generate_cmd.py` (1195 LOC) into a thin Click-handler layer plus a new `cli/services/generate.py` service module that owns all validation, enum mapping, retry/wait orchestration, and output dispatch for the 11 `generate` leaf commands.

**LOC**: `cli/generate_cmd.py` 1195 → **686** (~42% reduction; under the 700-LOC acceptance target).

## ADR-008 compliance

New module **`cli/services/generate.py`** (902 LOC) exposes:

- **`GenerationPlan`** (frozen dataclass) — captures every input the executor needs after Click-time validation: kind, display name, notebook id, description, source ids, language, wait flag, timeout / interval, max_retries, json_output, kind-specific params, queued stderr warnings.
- **`build_generation_plan(kind, raw_args, parameter_source, *, language_resolver)`** — dispatches to per-kind builders that do parameter validation (cinematic-video flag rules, `--style` / `--style-prompt` combinations), enum mapping (audio/video/slide/quiz/infographic/report enums), report smart-custom format coercion, `--append` warning, cinematic-video 1800s timeout default. Raises `click.UsageError` for invalid combinations, exactly matching pre-extraction behavior.
- **`async execute_generation(plan, client)`** — async orchestration: emits queued warnings, resolves notebook + source IDs via `cli/resolve.py`, dispatches to the matching `client.artifacts.<method>`, runs the retry-with-backoff loop via the existing `services/artifact_generation.py` core (no parallel abstraction introduced), renders mind-map result inline or hands off to `handle_generation_result` for the standard wait + status output path.

The 10 leaf handlers in `cli/generate_cmd.py` shrink to one line: `return _run_generate(kind="<...>", **locals())` after the existing `resolve_prompt` call. The internal `_run_generate` shim filters handler-only locals, runs `require_notebook`, builds the plan, opens `NotebookLMClient`, and dispatches the executor.

Extracted symbols (per acceptance):
- `GenerationPlan` ✓
- `build_generation_plan(kind, raw_args, parameter_source)` ✓
- `async execute_generation(plan, facade)` ✓

## Characterization-test discipline

Per [phase-3.md → Characterization-Test Discipline](../blob/main/.sisyphus/phases/cli-audit-fixes/phase-3.md#characterization-test-discipline), the three commits are ordered so the characterization tests pass on the PR's branch base (= main) BEFORE the extraction commit lands:

1. **`fed066b` — characterization snapshots** (33 tests): happy-path text + JSON for all 10 leaf commands, mind-map shape, failure paths (None-result + retry-exhausted RATE_LIMITED), video/cinematic-video usage-error text, report smart-custom + `--append` warning, help-text regression guard. **Verified passing on main HEAD before commit 7f60529.**
2. **`7f60529` — extraction**: new `services/generate.py`, thin handlers in `generate_cmd.py`, new `multi_source_option` + `language_option` helpers in `options.py` (decl order preserved so the CLI-contract baseline keeps passing).
3. **`17845ba` — service-layer tests** (29 tests): direct exercise of `build_generation_plan` + `execute_generation` without `CliRunner`, parametrized over all 11 internal kinds (10 leaf + cinematic-video alias kind), covering enum mapping, alias enforcement, smart-custom coercion, warning emission, and the mind-map / revise-slide / cinematic-video special branches.
4. **`1e8a43e` — polish**: drop dead re-export marker and orphan comment (no behavior change).

## Shared option helpers

Added to `cli/options.py` (sibling-task safe — disjoint from P3.T6b's `standard_options` / `generate_options` removal):

- **`multi_source_option`** — bundles the `--source/-s` `multiple=True` flag shape used by every generate subcommand (distinct from the single-valued, required `source_option` used by download-style commands). Decl order `(--source, -s)` matches the pre-extraction inline form so the CLI-contract baseline keeps passing.
- **`language_option`** — bundles the shared `--language` flag with the canonical help text pointing at the `--language > NOTEBOOKLM_HL > config > "en"` resolution chain.

## Acceptance gates

| Gate | Status |
|---|---|
| `cli/generate_cmd.py` LOC < 700 | ✓ 686 |
| `services/generate.py` exposes `GenerationPlan` + `build_generation_plan` + `execute_generation` | ✓ |
| All existing `tests/unit/cli/test_generate*.py` pass byte-for-byte (no test changes) | ✓ 137/137 |
| New characterization tests pass on main HEAD AND on PR HEAD | ✓ 33/33 |
| New `tests/unit/test_generate_service.py` exercises plan + executor directly, parametrized over 10 kinds | ✓ 29/29 (covers all 11 internal kinds) |
| `tests/unit/cli/test_phase10_cli_contract.py` baseline matches (no CLI surface drift) | ✓ |
| `uv run ruff format . && uv run ruff check src/notebooklm/cli` clean | ✓ |
| `uv run mypy src/notebooklm/cli --ignore-missing-imports` clean | ✓ |
| Full `uv run pytest tests/unit tests/integration` | ✓ 5798 passed, 12 skipped |

## MUST NOT (per task spec)

- Change CLI surface ✓ (CLI contract baseline unchanged)
- Introduce parallel abstractions to `services/artifact_generation.py` ✓ (reuses `generate_with_retry` + `handle_generation_result`)
- Touch `cli/services/__init__.py` ✓ (unchanged — Wave 3.B shared-package guard)
- Touch sibling-task files `cli/download_cmd.py` / `cli/source_cmd.py` / `cli/research_cmd.py` ✓ (unchanged)

## Deferred polish findings

None.

## Test plan

- [x] Characterization tests (commit 1) pass on pre-T1 main HEAD (`f1be552`)
- [x] All 170 generate-related tests pass on PR HEAD (137 existing + 33 new characterization)
- [x] 29 new service-layer tests pass without `CliRunner`
- [x] Full unit + integration suite: 5798 passed, 12 skipped
- [x] CLI-contract baseline unchanged
- [x] mypy + ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified generate command behavior for more consistent option handling and validation across all generation subcommands.

* **New Features**
  * Shared options (--language/--source/--wait) and improved report/mind‑map handling, smarter report format detection, and clearer validation/error messages.

* **Tests**
  * Added extensive CLI and service tests covering all generate kinds, outputs (text/JSON), error/retry paths, and help text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->