### PR TITLE
refactor(cli/source): extract services/source_{listing,mutations,research,content,wait}.py

### DIFF
--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from ...types import Source
 from ...urls import is_youtube_url
+
+if TYPE_CHECKING:
+    import click
+
+    from ...client import NotebookLMClient
 
 SourceAddType = Literal["url", "text", "file", "youtube"]
 
@@ -162,3 +168,66 @@ async def add_source(
     # Do not forward the deprecated mime_type flag: the CLI emits the user
     # warning, while add_file() would also emit a library-level warning.
     return await sources.add_file(notebook_id, str(plan.upload_path), title=plan.title)
+
+
+@dataclass(frozen=True)
+class SourceAddExecutionPlan:
+    """Click-shaped inputs for ``execute_source_add``.
+
+    Distinct from :class:`SourceAddPlan` (which captures the detected source
+    type + warnings produced by :func:`build_source_add_plan`). This wraps
+    the resolved-notebook id + the prepared add-plan so the executor has a
+    single argument matching the other ``cli/services/source_*`` pairs.
+    """
+
+    notebook_id: str
+    plan: SourceAddPlan
+    json_output: bool
+
+
+async def execute_source_add(
+    client: NotebookLMClient,
+    plan: SourceAddExecutionPlan,
+    *,
+    ctx: click.Context | None = None,
+) -> None:
+    """Run the ``source add`` workflow with spinner + JSON / text rendering.
+
+    P1.T2 bug 5: ``rich.console.Console.status`` is a SYNCHRONOUS context
+    manager. The pre-fix shape ``with console.status(...): return _run()``
+    exited the spinner as soon as ``_run()`` returned the coroutine — BEFORE
+    ``with_client`` awaited it — so the spinner was effectively invisible
+    during the actual upload. The ``with`` block here lives inside the
+    awaited coroutine so the spinner spans the real I/O. JSON mode still
+    suppresses the spinner so stdout stays pure JSON.
+    """
+    # Local imports keep this service module free of CLI-only top-level deps
+    # so importing it does not pull in click for non-CLI consumers.
+    from ..rendering import cli_print, console, json_output_response
+
+    spinner = (
+        contextlib.nullcontext()
+        if plan.json_output
+        else console.status(f"Adding {plan.plan.detected_type} source...")
+    )
+    with spinner:
+        src = await add_source(
+            client.sources,
+            notebook_id=plan.notebook_id,
+            plan=plan.plan,
+        )
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "source": {
+                    "id": src.id,
+                    "title": src.title,
+                    "type": str(src.kind),
+                    "url": src.url,
+                }
+            }
+        )
+        return
+
+    cli_print(f"[green]Added source:[/green] {src.id}", ctx=ctx)

--- a/src/notebooklm/cli/services/source_clean.py
+++ b/src/notebooklm/cli/services/source_clean.py
@@ -6,10 +6,15 @@ import asyncio
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse, urlunparse
 
 from ...types import Source, source_status_to_str
+
+if TYPE_CHECKING:
+    import click
+
+    from ...client import NotebookLMClient
 
 CleanCandidate = tuple[str, str, str, str]
 CleanFailure = tuple[str, str]
@@ -167,4 +172,151 @@ async def run_source_clean(
         candidates=tuple(candidates),
         deleted_count=deleted,
         failures=tuple(failures),
+    )
+
+
+@dataclass(frozen=True)
+class SourceCleanPlan:
+    """Click-shaped inputs for ``execute_source_clean``."""
+
+    notebook_id: str
+    dry_run: bool
+    yes: bool
+    json_output: bool
+    quiet_mode: bool
+
+
+async def execute_source_clean(
+    client: NotebookLMClient,
+    plan: SourceCleanPlan,
+    *,
+    ctx: click.Context | None = None,
+    classify_sources: Callable[[list[Source]], list[CleanCandidate]] = classify_junk_sources,
+    on_candidates: Callable[[list[CleanCandidate]], None] | None = None,
+) -> None:
+    """Run the ``source clean`` workflow with progress + JSON / text rendering.
+
+    Caller may pass ``classify_sources`` and ``on_candidates`` callbacks so
+    tests that patch the source-cmd compatibility wrappers (e.g.
+    ``_classify_junk_sources``, ``_print_clean_candidates``) continue to see
+    their patched implementations exercised end-to-end. Defaults are the
+    canonical service-layer implementations.
+    """
+    # Local imports keep this service module light at import time and avoid
+    # pulling click / rendering into non-CLI callers of ``run_source_clean``.
+    import click as _click
+
+    from ..error_handler import exit_with_code
+    from ..rendering import cli_print, cli_status, json_output_response
+    from .source_mutations import require_yes_in_json
+
+    async def _list_sources(notebook_id: str) -> list[Source]:
+        if plan.json_output:
+            return await client.sources.list(notebook_id)
+        with cli_status("Fetching sources for cleanup...", ctx=ctx):
+            return await client.sources.list(notebook_id)
+
+    # P1.T2 bug 3: in --json mode, never prompt — automation cannot answer
+    # the question. Pass a non-interactive ``confirm_delete`` that always
+    # declines; once the service returns ``cancelled`` we synthesize a
+    # structured ``CONFIRM_REQUIRED`` error below.
+    confirm_delete: Callable[[int], bool] = (
+        (lambda count: False)
+        if plan.json_output
+        else (lambda count: _click.confirm(f"Delete {count} source(s)?"))
+    )
+
+    suppress_status = plan.json_output or plan.quiet_mode
+    cb_candidates = None if suppress_status else on_candidates
+    cb_delete_start: Callable[[int], None] | None = (
+        None
+        if suppress_status
+        else lambda count: cli_print(
+            f"[dim]Cleaning {count} source(s) (in chunks of 10)...[/dim]",
+            ctx=ctx,
+        )
+    )
+
+    result = await run_source_clean(
+        notebook_id=plan.notebook_id,
+        dry_run=plan.dry_run,
+        yes=plan.yes,
+        list_sources=_list_sources,
+        delete_source=client.sources.delete,
+        confirm_delete=confirm_delete,
+        on_candidates=cb_candidates,
+        on_delete_start=cb_delete_start,
+        classify_sources=classify_sources,
+    )
+
+    candidate_payload = candidates_payload(result.candidates)
+
+    if plan.json_output:
+        # P1.T2 bug 3: synthesize structured error when --json + no --yes
+        # left candidates uncleaned.
+        if result.status == "cancelled" and not plan.yes:
+            require_yes_in_json(
+                action="clean",
+                extra={
+                    "notebook_id": result.notebook_id,
+                    "candidate_count": result.candidate_count,
+                    "candidates": candidate_payload,
+                },
+            )
+
+        payload: dict[str, Any] = {
+            "action": "clean",
+            "notebook_id": result.notebook_id,
+            "status": result.status,
+            "candidates": candidate_payload,
+            "deleted_count": result.deleted_count,
+            "failure_count": result.failure_count,
+        }
+        if result.status != "already_clean":
+            payload["candidate_count"] = result.candidate_count
+        if result.status == "completed":
+            payload["failures"] = [{"id": sid, "error": err} for sid, err in result.failures]
+        json_output_response(payload)
+        # P1.T2 bug 8: partial-failure exits non-zero so shell automation
+        # (set -e, CI) sees the failure.
+        if result.failures:
+            exit_with_code(1)
+        return
+
+    if result.status == "already_clean":
+        cli_print(
+            "[green]Notebook is already clean. No junk sources found.[/green]",
+            ctx=ctx,
+        )
+        return
+
+    if result.status == "dry_run":
+        cli_print(
+            f"[yellow]Dry run: would delete {result.candidate_count} source(s).[/yellow]",
+            ctx=ctx,
+        )
+        return
+
+    if result.status == "cancelled":
+        return
+
+    if result.failures:
+        cli_print(
+            f"[yellow]Cleaned {result.deleted_count} source(s). "
+            f"{len(result.failures)} deletion(s) failed.[/yellow]",
+            ctx=ctx,
+        )
+        for sid, err in result.failures[:5]:
+            cli_print(f"  [red]{sid}:[/red] {err}", ctx=ctx)
+        if len(result.failures) > 5:
+            cli_print(
+                f"  [dim]...and {len(result.failures) - 5} more[/dim]",
+                ctx=ctx,
+            )
+        # P1.T2 bug 8: text-mode parity with JSON-mode exit code.
+        exit_with_code(1)
+
+    cli_print(
+        f"[green]Successfully cleaned {result.deleted_count} source(s).[/green]",
+        ctx=ctx,
     )

--- a/src/notebooklm/cli/services/source_content.py
+++ b/src/notebooklm/cli/services/source_content.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from ...client import NotebookLMClient
 from ...types import source_status_to_str
 from ..error_handler import exit_with_code, output_error
 from ..rendering import console, get_source_type_display, json_output_response
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 FulltextFormat = Literal["text", "markdown"]
 

--- a/src/notebooklm/cli/services/source_content.py
+++ b/src/notebooklm/cli/services/source_content.py
@@ -1,0 +1,269 @@
+"""Services for read-only source-content commands: get, fulltext, guide, stale.
+
+Each command has its own plan + executor pair so the ``cli/source_cmd.py``
+Click handler collapses to a one-call wrapper. Output rendering stays in
+the executors (rather than returning a result object the handler renders)
+because the pre-extraction handlers thread text-mode console.print calls
+inline with the fetch — preserving that order is what keeps the
+characterization-test snapshots byte-for-byte stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+from ...client import NotebookLMClient
+from ...types import source_status_to_str
+from ..error_handler import exit_with_code, output_error
+from ..rendering import console, get_source_type_display, json_output_response
+
+FulltextFormat = Literal["text", "markdown"]
+
+
+# ---------------------------------------------------------------------------
+# source get
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceGetPlan:
+    """Prepared inputs for ``execute_source_get``."""
+
+    notebook_id: str
+    source_id: str
+    json_output: bool
+
+
+async def execute_source_get(client: NotebookLMClient, plan: SourceGetPlan) -> None:
+    """Fetch + render a single source.
+
+    Exit-code contract: 0 on success, 1 if the source is not found.
+    """
+    src = await client.sources.get(plan.notebook_id, plan.source_id)
+
+    # BREAKING (P1.T2): not-found exits 1 with a typed error instead of
+    # the previous exit-0 ``found: false`` placeholder. See
+    # ``docs/cli-exit-codes.md`` and the BREAKING entry in CHANGELOG.md
+    # (Unreleased → Changed). The trailing ``raise AssertionError``
+    # unreachable narrows the ``Source | None`` for mypy.
+    if src is None:
+        output_error(
+            "Source not found",
+            code="NOT_FOUND",
+            json_output=plan.json_output,
+            exit_code=1,
+            extra={"source_id": plan.source_id, "notebook_id": plan.notebook_id},
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "source": {
+                    "id": src.id,
+                    "title": src.title,
+                    "type": str(src.kind),
+                    "url": src.url,
+                    "status": source_status_to_str(src.status),
+                    "status_id": src.status,
+                    "created_at": (src.created_at.isoformat() if src.created_at else None),
+                },
+                "found": True,
+            }
+        )
+        return
+
+    console.print(f"[bold cyan]Source:[/bold cyan] {src.id}")
+    console.print(f"[bold]Title:[/bold] {src.title}")
+    console.print(f"[bold]Type:[/bold] {get_source_type_display(src.kind)}")
+    if src.url:
+        console.print(f"[bold]URL:[/bold] {src.url}")
+    if src.created_at:
+        console.print(f"[bold]Created:[/bold] {src.created_at.strftime('%Y-%m-%d %H:%M')}")
+
+
+# ---------------------------------------------------------------------------
+# source fulltext
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceFulltextPlan:
+    """Prepared inputs for ``execute_source_fulltext``."""
+
+    notebook_id: str
+    source_id: str
+    json_output: bool
+    output: str | None
+    output_format: FulltextFormat
+
+
+async def execute_source_fulltext(client: NotebookLMClient, plan: SourceFulltextPlan) -> None:
+    """Fetch + render (or save) a source's full indexed text content."""
+
+    async def _fetch():
+        return await client.sources.get_fulltext(
+            plan.notebook_id, plan.source_id, output_format=plan.output_format
+        )
+
+    if plan.json_output:
+        fulltext = await _fetch()
+    else:
+        with console.status("Fetching fulltext content..."):
+            fulltext = await _fetch()
+
+    if plan.json_output:
+        # P1.T2 bug 4: when both --json and -o are given, write the
+        # (potentially multi-MB) content to disk and emit a small
+        # metadata envelope on stdout — not the full content twice.
+        if plan.output:
+            content_bytes = fulltext.content.encode("utf-8")
+            Path(plan.output).write_bytes(content_bytes)
+            json_output_response(
+                {
+                    "path": str(plan.output),
+                    "bytes": len(content_bytes),
+                    "source_id": fulltext.source_id,
+                    "title": fulltext.title,
+                }
+            )
+            return
+
+        json_output_response(asdict(fulltext))
+        return
+
+    if plan.output:
+        Path(plan.output).write_text(fulltext.content, encoding="utf-8")
+        console.print(f"[green]Saved {fulltext.char_count} chars to {plan.output}[/green]")
+        return
+
+    console.print(f"[bold cyan]Source:[/bold cyan] {fulltext.source_id}")
+    console.print(f"[bold]Title:[/bold] {fulltext.title}")
+    console.print(f"[bold]Characters:[/bold] {fulltext.char_count:,}")
+    if fulltext.url:
+        console.print(f"[bold]URL:[/bold] {fulltext.url}")
+    console.print()
+    console.print("[bold cyan]Content:[/bold cyan]")
+    # ``markup=False`` so markdown links like ``[text](url)`` are not
+    # eaten by Rich's tag parser.
+    if len(fulltext.content) > 2000:
+        console.print(fulltext.content[:2000], markup=False, highlight=False)
+        console.print(
+            f"\n[dim]... ({fulltext.char_count - 2000:,} more chars, "
+            "use -o to save full content)[/dim]"
+        )
+    else:
+        console.print(fulltext.content, markup=False, highlight=False)
+
+
+# ---------------------------------------------------------------------------
+# source guide
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceGuidePlan:
+    """Prepared inputs for ``execute_source_guide``."""
+
+    notebook_id: str
+    source_id: str
+    json_output: bool
+
+
+async def execute_source_guide(client: NotebookLMClient, plan: SourceGuidePlan) -> None:
+    """Fetch + render an AI-generated source summary and keywords."""
+
+    async def _fetch_guide():
+        return await client.sources.get_guide(plan.notebook_id, plan.source_id)
+
+    if plan.json_output:
+        guide = await _fetch_guide()
+    else:
+        with console.status("Generating source guide..."):
+            guide = await _fetch_guide()
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "source_id": plan.source_id,
+                "summary": guide.get("summary", ""),
+                "keywords": guide.get("keywords", []),
+            }
+        )
+        return
+
+    summary = guide.get("summary", "").strip()
+    keywords = guide.get("keywords", [])
+
+    if not summary and not keywords:
+        console.print("[yellow]No guide available for this source[/yellow]")
+        return
+
+    if summary:
+        console.print("[bold cyan]Summary:[/bold cyan]")
+        console.print(summary)
+        console.print()
+
+    if keywords:
+        console.print("[bold cyan]Keywords:[/bold cyan]")
+        console.print(", ".join(keywords))
+
+
+# ---------------------------------------------------------------------------
+# source stale
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceStalePlan:
+    """Prepared inputs for ``execute_source_stale``."""
+
+    notebook_id: str
+    source_id: str
+    json_output: bool
+
+
+async def execute_source_stale(client: NotebookLMClient, plan: SourceStalePlan) -> None:
+    """Check if a URL/Drive source needs refresh; exit 0 if stale, 1 if fresh.
+
+    Inverted exit-code semantics are intentional — see
+    ``docs/cli-exit-codes.md``. The JSON body carries an explicit
+    ``stale`` boolean so callers who prefer to branch on a field rather
+    than the exit code can do so.
+    """
+    is_fresh = await client.sources.check_freshness(plan.notebook_id, plan.source_id)
+    stale = not is_fresh
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "source_id": plan.source_id,
+                "notebook_id": plan.notebook_id,
+                "stale": stale,
+                "fresh": is_fresh,
+            }
+        )
+        # Inverted exit codes preserved by design.
+        exit_with_code(0 if stale else 1)
+
+    if is_fresh:
+        console.print("[green]✓ Source is fresh[/green]")
+        exit_with_code(1)
+    else:
+        console.print("[yellow]⚠ Source is stale[/yellow]")
+        console.print("[dim]Run 'source refresh' to update[/dim]")
+        exit_with_code(0)
+
+
+__all__ = [
+    "SourceFulltextPlan",
+    "SourceGetPlan",
+    "SourceGuidePlan",
+    "SourceStalePlan",
+    "execute_source_fulltext",
+    "execute_source_get",
+    "execute_source_guide",
+    "execute_source_stale",
+]

--- a/src/notebooklm/cli/services/source_listing.py
+++ b/src/notebooklm/cli/services/source_listing.py
@@ -10,11 +10,14 @@ need to know how Rich tables or JSON envelopes are assembled.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from ...client import NotebookLMClient
 from ...types import Source, source_status_to_str
 from ..rendering import get_source_type_display
 from .listing import ListResult, ListSpec, run_list
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/cli/services/source_listing.py
+++ b/src/notebooklm/cli/services/source_listing.py
@@ -1,0 +1,80 @@
+"""Service for ``source list`` — fetch + render the source table.
+
+Composes :class:`~notebooklm.cli.services.listing.ListSpec` so the Click
+handler in ``cli/source_cmd.py`` collapses to a one-call wrapper. The
+extracted executor stays a thin facade over the shared listing pipeline —
+all envelope-extras and column logic live here so the handler does not
+need to know how Rich tables or JSON envelopes are assembled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...client import NotebookLMClient
+from ...types import Source, source_status_to_str
+from ..rendering import get_source_type_display
+from .listing import ListResult, ListSpec, run_list
+
+
+@dataclass(frozen=True)
+class SourceListPlan:
+    """Prepared inputs for ``execute_source_list``."""
+
+    notebook_id: str
+    json_output: bool
+    limit: int | None
+    no_truncate: bool
+
+
+def _build_spec() -> ListSpec[Source]:
+    """Build the ``ListSpec`` for ``source list``.
+
+    Factored out of ``execute_source_list`` so unit tests can introspect
+    the column / serialize shape directly without running the full
+    pipeline.
+    """
+
+    async def envelope_extras(client: NotebookLMClient, notebook_id: str) -> dict[str, str | None]:
+        nb = await client.notebooks.get(notebook_id)
+        return {"notebook_id": notebook_id, "notebook_title": nb.title if nb else None}
+
+    return ListSpec(
+        title="Sources in {notebook_id}",
+        items_key="sources",
+        fetch=lambda client, notebook_id: client.sources.list(notebook_id),
+        serialize=lambda src: {
+            "id": src.id,
+            "title": src.title,
+            "type": str(src.kind),
+            "url": src.url,
+            "status": source_status_to_str(src.status),
+            "status_id": src.status,
+            "created_at": src.created_at.isoformat() if src.created_at else None,
+        },
+        columns=["ID", "Title", "Type", "Created", "Status"],
+        row=lambda src: [
+            src.id,
+            src.title or "-",
+            get_source_type_display(src.kind),
+            src.created_at.strftime("%Y-%m-%d %H:%M") if src.created_at else "-",
+            source_status_to_str(src.status),
+        ],
+        envelope_extras=envelope_extras,
+    )
+
+
+async def execute_source_list(client: NotebookLMClient, plan: SourceListPlan) -> ListResult[Source]:
+    """Fetch + render the source list per the prepared plan."""
+    spec = _build_spec()
+    return await run_list(
+        spec,
+        client,
+        notebook_id=plan.notebook_id,
+        limit=plan.limit,
+        json_output=plan.json_output,
+        no_truncate=plan.no_truncate,
+    )
+
+
+__all__ = ["SourceListPlan", "execute_source_list"]

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -1,0 +1,538 @@
+"""Services for source-mutation commands: delete, delete-by-title, rename, refresh, add-drive.
+
+Each command has its own plan + executor pair. The shared resolver
+helpers (``resolve_source_for_delete``, ``resolve_source_by_exact_title``,
+``require_yes_in_json``) also live here because they are mutation-specific
+and were previously private helpers on ``cli/source_cmd.py``. The
+:class:`MutationPlan` pipeline from
+``cli/services/confirming_mutation.py`` handles the resolve → confirm →
+execute → serialize flow for the destructive paths.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import click
+
+from ...client import NotebookLMClient
+from ...types import DriveMimeType
+from ..error_handler import output_error
+from ..rendering import (
+    cli_print,
+    cli_status,
+    console,
+    emit_status,
+    json_output_response,
+)
+from ..resolve import resolve_source_id, validate_id
+from .confirming_mutation import MutationPlan, run_confirmed_mutation
+
+DriveMimeChoice = Literal["google-doc", "google-slides", "google-sheets", "pdf"]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for source-id resolution (moved out of cli/source_cmd.py)
+# ---------------------------------------------------------------------------
+
+
+def build_id_ambiguity_error(source_id: str, matches) -> str:
+    """Build a consistent ambiguity error for source ID prefix matches."""
+    lines = [f"Ambiguous ID '{source_id}' matches {len(matches)} sources:"]
+    for item in matches[:5]:
+        title = item.title or "(untitled)"
+        lines.append(f"  {item.id[:12]}... {title}")
+    if len(matches) > 5:
+        lines.append(f"  ... and {len(matches) - 5} more")
+    lines.append("Specify more characters to narrow down.")
+    return "\n".join(lines)
+
+
+def looks_like_full_source_id(source_id: str) -> bool:
+    """Return True for UUID-shaped source IDs that can skip list-based resolution."""
+    return bool(
+        re.fullmatch(
+            r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+            source_id,
+        )
+    )
+
+
+async def resolve_source_for_delete(
+    client, notebook_id: str, source_id: str, *, json_output: bool = False
+) -> str:
+    """Resolve a source ID for delete, returning the full source ID string.
+
+    Canonical UUIDs take a fast path and skip the live source list
+    lookup. Partial IDs are resolved against the live list. When
+    ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
+    """
+    source_id = validate_id(source_id, "source")
+    if looks_like_full_source_id(source_id):
+        return source_id
+
+    sources = await client.sources.list(notebook_id)
+    matches = [item for item in sources if item.id.lower().startswith(source_id.lower())]
+
+    if len(matches) == 1:
+        if matches[0].id != source_id:
+            title = matches[0].title or "(untitled)"
+            emit_status(
+                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
+                json_output=json_output,
+            )
+        return matches[0].id
+
+    if len(matches) > 1:
+        output_error(
+            build_id_ambiguity_error(source_id, matches),
+            "AMBIGUOUS_ID",
+            json_output,
+            1,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    title_matches = [item for item in sources if item.title == source_id]
+    if title_matches:
+        lines = [
+            f"'{source_id}' matches {len(title_matches)} source title(s), not source IDs.",
+            f"Use 'notebooklm source delete-by-title \"{source_id}\"' or delete by ID:",
+        ]
+        for item in title_matches[:5]:
+            lines.append(f"  {item.id[:12]}... {item.title}")
+        if len(title_matches) > 5:
+            lines.append(f"  ... and {len(title_matches) - 5} more")
+        output_error("\n".join(lines), "VALIDATION_ERROR", json_output, 1)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    output_error(
+        f"No source found starting with '{source_id}'. "
+        "Run 'notebooklm source list' to see available sources.",
+        "NOT_FOUND",
+        json_output,
+        1,
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+async def resolve_source_by_exact_title(
+    client, notebook_id: str, title: str, *, json_output: bool = False
+):
+    """Resolve a source by exact title for the explicit delete-by-title flow."""
+    title = validate_id(title, "source title")
+    sources = await client.sources.list(notebook_id)
+    matches = [item for item in sources if item.title == title]
+
+    if len(matches) == 1:
+        return matches[0]
+
+    if len(matches) > 1:
+        lines = [f"Title '{title}' matches {len(matches)} sources. Delete by ID instead:"]
+        for item in matches[:5]:
+            lines.append(f"  {item.id[:12]}... {item.title}")
+        if len(matches) > 5:
+            lines.append(f"  ... and {len(matches) - 5} more")
+        output_error("\n".join(lines), "AMBIGUOUS_TITLE", json_output, 1)
+
+    output_error(
+        f"No source found with title '{title}'. "
+        "Run 'notebooklm source list' to see available sources.",
+        "NOT_FOUND",
+        json_output,
+        1,
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+def require_yes_in_json(*, action: str, extra: dict[str, Any] | None = None) -> None:
+    """Emit a structured ``CONFIRM_REQUIRED`` error and exit non-zero.
+
+    Centralises the JSON-mode confirmation gate used by destructive
+    commands (``source delete``, ``source delete-by-title``, ``source
+    clean``). Calling this helper always raises ``SystemExit(1)`` via
+    :func:`output_error` — it never returns normally.
+    """
+    payload: dict[str, Any] = {"action": action}
+    if extra:
+        payload.update(extra)
+    output_error(
+        "Pass --yes to confirm destructive operation in --json mode",
+        code="CONFIRM_REQUIRED",
+        json_output=True,
+        exit_code=1,
+        extra=payload,
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# source delete
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceDeletePlan:
+    """Prepared inputs for ``execute_source_delete``."""
+
+    notebook_id: str
+    source_id: str
+    yes: bool
+    json_output: bool
+
+
+async def execute_source_delete(
+    client: NotebookLMClient, plan: SourceDeletePlan, *, ctx: click.Context | None = None
+) -> None:
+    """Resolve + confirm + delete a single source by id or partial id."""
+
+    async def resolve_delete(client):
+        resolved_id = await resolve_source_for_delete(
+            client, plan.notebook_id, plan.source_id, json_output=plan.json_output
+        )
+        # P1.T2 bug 1: In --json mode, never prompt — automation cannot
+        # answer an interactive confirmation. Require --yes and emit a
+        # structured JSON error otherwise.
+        if plan.json_output and not plan.yes:
+            require_yes_in_json(
+                action="delete",
+                extra={
+                    "source_id": resolved_id,
+                    "notebook_id": plan.notebook_id,
+                },
+            )
+        return {
+            "notebook_id": plan.notebook_id,
+            "source_id": resolved_id,
+            "success": False,
+        }
+
+    async def execute_delete(client, resolved):
+        resolved["success"] = bool(
+            await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
+        )
+
+    def serialize_success(resolved):
+        return {
+            "action": "delete",
+            "source_id": resolved["source_id"],
+            "notebook_id": resolved["notebook_id"],
+            "success": bool(resolved["success"]),
+            "status": "deleted" if resolved["success"] else "unknown",
+        }
+
+    mutation = MutationPlan(
+        entity_label="source",
+        resolve=resolve_delete,
+        confirm_message="Delete source {resolved[source_id]}?",
+        execute=execute_delete,
+        serialize_success=serialize_success,
+        serialize_cancel=lambda resolved: {
+            "action": "delete",
+            "source_id": resolved["source_id"],
+            "notebook_id": resolved["notebook_id"],
+            "success": False,
+            "status": "cancelled",
+        },
+    )
+    result = await run_confirmed_mutation(
+        mutation,
+        client,
+        yes=plan.yes,
+        json_output=plan.json_output,
+        confirmer=click.confirm,
+    )
+    if result.status == "cancelled" or plan.json_output:
+        return
+
+    resolved_id = result.resolved["source_id"]
+    success = bool(result.resolved["success"])
+    if success:
+        cli_print(f"[green]Deleted source:[/green] {resolved_id}", ctx=ctx)
+    else:
+        cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
+# source delete-by-title
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceDeleteByTitlePlan:
+    """Prepared inputs for ``execute_source_delete_by_title``."""
+
+    notebook_id: str
+    title: str
+    yes: bool
+    json_output: bool
+
+
+async def execute_source_delete_by_title(
+    client: NotebookLMClient,
+    plan: SourceDeleteByTitlePlan,
+    *,
+    ctx: click.Context | None = None,
+) -> None:
+    """Resolve + confirm + delete a source by exact title."""
+
+    async def resolve_delete_by_title(client):
+        source = await resolve_source_by_exact_title(
+            client, plan.notebook_id, plan.title, json_output=plan.json_output
+        )
+        # P1.T2 bug 2: same JSON-mode confirmation contract as ``source delete``.
+        if plan.json_output and not plan.yes:
+            require_yes_in_json(
+                action="delete-by-title",
+                extra={
+                    "source_id": source.id,
+                    "title": source.title,
+                    "notebook_id": plan.notebook_id,
+                },
+            )
+        return {
+            "notebook_id": plan.notebook_id,
+            "source_id": source.id,
+            "title": source.title,
+            "success": False,
+        }
+
+    async def execute_delete_by_title(client, resolved):
+        resolved["success"] = bool(
+            await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
+        )
+
+    def serialize_success(resolved):
+        return {
+            "action": "delete-by-title",
+            "source_id": resolved["source_id"],
+            "title": resolved["title"],
+            "notebook_id": resolved["notebook_id"],
+            "success": bool(resolved["success"]),
+            "status": "deleted" if resolved["success"] else "unknown",
+        }
+
+    mutation = MutationPlan(
+        entity_label="source",
+        resolve=resolve_delete_by_title,
+        confirm_message="Delete source '{resolved[title]}' ({resolved[source_id]})?",
+        execute=execute_delete_by_title,
+        serialize_success=serialize_success,
+        serialize_cancel=lambda resolved: {
+            "action": "delete-by-title",
+            "source_id": resolved["source_id"],
+            "title": resolved["title"],
+            "notebook_id": resolved["notebook_id"],
+            "success": False,
+            "status": "cancelled",
+        },
+    )
+    result = await run_confirmed_mutation(
+        mutation,
+        client,
+        yes=plan.yes,
+        json_output=plan.json_output,
+        confirmer=click.confirm,
+    )
+    if result.status == "cancelled" or plan.json_output:
+        return
+
+    source_id = result.resolved["source_id"]
+    success = bool(result.resolved["success"])
+    if success:
+        cli_print(f"[green]Deleted source:[/green] {source_id}", ctx=ctx)
+    else:
+        cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
+# source rename
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceRenamePlan:
+    """Prepared inputs for ``execute_source_rename``."""
+
+    notebook_id: str
+    source_id: str
+    new_title: str
+    json_output: bool
+
+
+async def execute_source_rename(
+    client: NotebookLMClient,
+    plan: SourceRenamePlan,
+    *,
+    ctx: click.Context | None = None,
+) -> None:
+    """Resolve + rename a single source."""
+    resolved_id = await resolve_source_id(
+        client, plan.notebook_id, plan.source_id, json_output=plan.json_output
+    )
+    src = await client.sources.rename(plan.notebook_id, resolved_id, plan.new_title)
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "action": "rename",
+                "source_id": src.id,
+                "notebook_id": plan.notebook_id,
+                "title": src.title,
+                "status": "renamed",
+            }
+        )
+        return
+
+    cli_print(f"[green]Renamed source:[/green] {src.id}", ctx=ctx)
+    cli_print(f"[bold]New title:[/bold] {src.title}", ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
+# source refresh
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceRefreshPlan:
+    """Prepared inputs for ``execute_source_refresh``."""
+
+    notebook_id: str
+    source_id: str
+    json_output: bool
+
+
+async def execute_source_refresh(
+    client: NotebookLMClient,
+    plan: SourceRefreshPlan,
+    *,
+    ctx: click.Context | None = None,
+) -> None:
+    """Resolve + refresh a URL/Drive source."""
+    resolved_id = await resolve_source_id(
+        client, plan.notebook_id, plan.source_id, json_output=plan.json_output
+    )
+
+    if plan.json_output:
+        src = await client.sources.refresh(plan.notebook_id, resolved_id)
+    else:
+        with cli_status("Refreshing source...", ctx=ctx):
+            src = await client.sources.refresh(plan.notebook_id, resolved_id)
+
+    if plan.json_output:
+        # ``refresh`` may return a Source dataclass, ``True``, or
+        # falsy/None. Surface the same three states in JSON so
+        # automation can branch on ``status`` without scraping text.
+        if src and src is not True:
+            data = {
+                "action": "refresh",
+                "source_id": src.id,
+                "notebook_id": plan.notebook_id,
+                "title": src.title,
+                "status": "refreshed",
+            }
+        elif src is True:
+            data = {
+                "action": "refresh",
+                "source_id": resolved_id,
+                "notebook_id": plan.notebook_id,
+                "status": "refreshed",
+            }
+        else:
+            data = {
+                "action": "refresh",
+                "source_id": resolved_id,
+                "notebook_id": plan.notebook_id,
+                "status": "no_result",
+            }
+        json_output_response(data)
+        return
+
+    if src and src is not True:
+        cli_print(f"[green]Source refreshed:[/green] {src.id}", ctx=ctx)
+        cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
+    elif src is True:
+        cli_print(f"[green]Source refreshed:[/green] {resolved_id}", ctx=ctx)
+    else:
+        cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
+# source add-drive
+# ---------------------------------------------------------------------------
+
+
+_DRIVE_MIME_MAP: dict[DriveMimeChoice, str] = {
+    "google-doc": DriveMimeType.GOOGLE_DOC.value,
+    "google-slides": DriveMimeType.GOOGLE_SLIDES.value,
+    "google-sheets": DriveMimeType.GOOGLE_SHEETS.value,
+    "pdf": DriveMimeType.PDF.value,
+}
+
+
+@dataclass(frozen=True)
+class SourceAddDrivePlan:
+    """Prepared inputs for ``execute_source_add_drive``."""
+
+    notebook_id: str
+    file_id: str
+    title: str
+    mime_type: DriveMimeChoice
+    json_output: bool
+
+
+async def execute_source_add_drive(
+    client: NotebookLMClient,
+    plan: SourceAddDrivePlan,
+    *,
+    ctx: click.Context | None = None,
+) -> None:
+    """Add a Google Drive document as a source."""
+    mime = _DRIVE_MIME_MAP[plan.mime_type]
+
+    if plan.json_output:
+        src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
+    else:
+        with console.status("Adding Drive source..."):
+            src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "action": "add-drive",
+                "source": {
+                    "id": src.id,
+                    "title": src.title,
+                    "type": str(src.kind),
+                    "url": src.url,
+                    "drive_file_id": plan.file_id,
+                    "mime_type": plan.mime_type,
+                },
+                "notebook_id": plan.notebook_id,
+            }
+        )
+        return
+
+    cli_print(f"[green]Added Drive source:[/green] {src.id}", ctx=ctx)
+    cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
+
+
+__all__ = [
+    "SourceAddDrivePlan",
+    "SourceDeleteByTitlePlan",
+    "SourceDeletePlan",
+    "SourceRefreshPlan",
+    "SourceRenamePlan",
+    "build_id_ambiguity_error",
+    "execute_source_add_drive",
+    "execute_source_delete",
+    "execute_source_delete_by_title",
+    "execute_source_refresh",
+    "execute_source_rename",
+    "looks_like_full_source_id",
+    "require_yes_in_json",
+    "resolve_source_by_exact_title",
+    "resolve_source_for_delete",
+]

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import click
 
-from ...client import NotebookLMClient
 from ...types import DriveMimeType
 from ..error_handler import output_error
 from ..rendering import (
@@ -29,6 +28,9 @@ from ..rendering import (
 )
 from ..resolve import resolve_source_id, validate_id
 from .confirming_mutation import MutationPlan, run_confirmed_mutation
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 DriveMimeChoice = Literal["google-doc", "google-slides", "google-sheets", "pdf"]
 

--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from ...client import NotebookLMClient
 from ..error_handler import exit_with_code
 from ..rendering import console, display_report, display_research_sources
 from ..research_import import import_research_sources
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 SearchSource = Literal["web", "drive"]
 SearchMode = Literal["fast", "deep"]

--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -1,0 +1,123 @@
+"""Service for ``source add-research`` — research start + poll + import.
+
+Owns the polling loop (task-id-pinned per P1.T2 bug 6) and the optional
+``--import-all`` step. Stays in service-layer territory: imports the
+rendering helpers + ``import_research_sources`` directly rather than
+threading display callbacks through the executor — the resulting code
+matches the pre-extraction Click handler line-for-line so the
+characterization-test snapshots survive byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+from ...client import NotebookLMClient
+from ..error_handler import exit_with_code
+from ..rendering import console, display_report, display_research_sources
+from ..research_import import import_research_sources
+
+SearchSource = Literal["web", "drive"]
+SearchMode = Literal["fast", "deep"]
+
+# Pinned at 5 seconds to match the legacy ``cli/source.py`` poll cadence
+# and the explanatory comment in the original ``source add-research``
+# handler. ``timeout`` is divided by this value to compute the per-task
+# iteration budget; see :func:`execute_source_add_research`.
+_POLL_INTERVAL_S = 5
+
+
+@dataclass(frozen=True)
+class SourceAddResearchPlan:
+    """Prepared inputs for ``execute_source_add_research``."""
+
+    notebook_id: str
+    query: str
+    search_source: SearchSource
+    mode: SearchMode
+    import_all: bool
+    cited_only: bool
+    no_wait: bool
+    timeout: int
+
+
+async def execute_source_add_research(
+    client: NotebookLMClient, plan: SourceAddResearchPlan
+) -> None:
+    """Start research, poll until completion, and optionally import sources.
+
+    Exit-code contract (matches the pre-extraction handler):
+        * 0 — research started + completed (or ``--no-wait`` returned early).
+        * 1 — research failed to start (``no_research`` from the server).
+
+    The polling loop is pinned to the ``task_id`` returned by
+    ``research.start`` so a second research task started mid-wait (e.g.
+    concurrent caller, web UI, or retry) cannot cross-wire its sources
+    into this task's import branch (P1.T2 bug 6).
+    """
+    console.print(f"[yellow]Starting {plan.mode} research on {plan.search_source}...[/yellow]")
+    result = await client.research.start(
+        plan.notebook_id, plan.query, plan.search_source, plan.mode
+    )
+    if not result:
+        console.print("[red]Research failed to start[/red]")
+        exit_with_code(1)
+
+    task_id = result["task_id"]
+    console.print(f"[dim]Task ID: {task_id}[/dim]")
+
+    # Non-blocking mode: return immediately. Research will keep running
+    # server-side; until something fires IMPORT_RESEARCH the NotebookLM
+    # web UI will show an "Add sources?" modal (issue #315).
+    if plan.no_wait:
+        console.print(
+            "[green]Research started.[/green] "
+            "Run 'notebooklm research wait --import-all' to commit "
+            "sources once it completes, otherwise the NotebookLM web "
+            "UI will keep an 'Add sources?' modal open."
+        )
+        return
+
+    # Poll budget mirrors ``research wait --timeout``: total seconds
+    # divided by the 5 s interval. The legacy hardcoded 60-iteration cap
+    # stranded deep research (#315) because the import branch below is
+    # gated on ``status == "completed"``.
+    status: dict | None = None
+    for _ in range(max(1, plan.timeout // _POLL_INTERVAL_S)):
+        status = await client.research.poll(plan.notebook_id, task_id=task_id)
+        if status.get("status") == "completed":
+            break
+        elif status.get("status") == "no_research":
+            console.print("[red]Research failed to start[/red]")
+            exit_with_code(1)
+        await asyncio.sleep(_POLL_INTERVAL_S)
+    else:
+        status = {"status": "timeout"}
+
+    assert status is not None  # for mypy — loop above always assigns
+
+    if status.get("status") == "completed":
+        sources = status.get("sources", [])
+        console.print()
+        display_research_sources(sources)
+
+        display_report(status.get("report", ""), json_hint=False)
+
+        if plan.import_all and sources and task_id:
+            import_result = await import_research_sources(
+                client,
+                plan.notebook_id,
+                task_id,
+                sources,
+                report=status.get("report", ""),
+                cited_only=plan.cited_only,
+                max_elapsed=plan.timeout,
+            )
+            console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
+    else:
+        console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
+
+
+__all__ = ["SourceAddResearchPlan", "execute_source_add_research"]

--- a/src/notebooklm/cli/services/source_wait.py
+++ b/src/notebooklm/cli/services/source_wait.py
@@ -1,0 +1,139 @@
+"""Service for ``source wait`` — long-running source-readiness poll.
+
+Owns the dataclass + executor pair so ``cli/source_cmd.py`` stays a thin
+Click handler. The executor wraps the underlying
+``client.sources.wait_until_ready`` call in a transient
+``status_with_elapsed`` spinner (suppressed under JSON) and translates the
+three ``SourceWaitError`` subclasses into the documented exit-code +
+envelope contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...client import NotebookLMClient
+from ...types import (
+    Source,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceTimeoutError,
+)
+from ..error_handler import exit_with_code
+from ..rendering import console, json_output_response
+from .polling import status_with_elapsed
+
+WaitStatus = Literal["ready", "not_found", "error", "timeout"]
+
+
+@dataclass(frozen=True)
+class SourceWaitPlan:
+    """Prepared inputs for ``execute_source_wait``."""
+
+    notebook_id: str
+    source_id: str
+    timeout: float
+    interval: float
+    json_output: bool
+
+
+def _emit_ready_payload(source: Source, *, json_output: bool) -> None:
+    if json_output:
+        json_output_response(
+            {
+                "source_id": source.id,
+                "title": source.title,
+                "status": "ready",
+                "status_code": source.status,
+            }
+        )
+        return
+    console.print(f"[green]✓ Source ready:[/green] {source.id}")
+    if source.title:
+        console.print(f"[bold]Title:[/bold] {source.title}")
+
+
+def _emit_not_found(exc: SourceNotFoundError, *, json_output: bool) -> None:
+    if json_output:
+        json_output_response(
+            {
+                "source_id": exc.source_id,
+                "status": "not_found",
+                "error": str(exc),
+            }
+        )
+    else:
+        console.print(f"[red]✗ Source not found:[/red] {exc.source_id}")
+
+
+def _emit_processing_error(exc: SourceProcessingError, *, json_output: bool) -> None:
+    if json_output:
+        json_output_response(
+            {
+                "source_id": exc.source_id,
+                "status": "error",
+                "status_code": exc.status,
+                "error": str(exc),
+            }
+        )
+    else:
+        console.print(f"[red]✗ Source processing failed:[/red] {exc.source_id}")
+
+
+def _emit_timeout(exc: SourceTimeoutError, *, json_output: bool) -> None:
+    if json_output:
+        json_output_response(
+            {
+                "source_id": exc.source_id,
+                "status": "timeout",
+                "last_status_code": exc.last_status,
+                "timeout_seconds": int(exc.timeout),
+                "error": str(exc),
+            }
+        )
+    else:
+        console.print(f"[yellow]⚠ Timeout waiting for source:[/yellow] {exc.source_id}")
+        console.print(f"[dim]Last status: {exc.last_status}[/dim]")
+
+
+async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) -> None:
+    """Run the ``source wait`` workflow with status spinner + error mapping.
+
+    Exit-code contract (matches ``source_cmd.source_wait`` pre-extraction):
+        * 0 — source reached READY before timeout.
+        * 1 — :class:`SourceNotFoundError` or :class:`SourceProcessingError`.
+        * 2 — :class:`SourceTimeoutError`.
+
+    Caller is responsible for resolving ``plan.source_id`` to a full UUID
+    BEFORE calling this executor (so the spinner message and JSON envelope
+    carry the resolved id consistently).
+    """
+    try:
+        async with status_with_elapsed(
+            f"Waiting for source {plan.source_id} to finish processing...",
+            json_output=plan.json_output,
+            # Parallel hint: ``source wait`` has no separate ``source
+            # poll`` command, so the resume IS re-running the same wait.
+            resume_hint=f"notebooklm source wait {plan.source_id}",
+        ):
+            source = await client.sources.wait_until_ready(
+                plan.notebook_id,
+                plan.source_id,
+                timeout=plan.timeout,
+                initial_interval=plan.interval,
+            )
+    except SourceNotFoundError as exc:
+        _emit_not_found(exc, json_output=plan.json_output)
+        exit_with_code(1)
+    except SourceProcessingError as exc:
+        _emit_processing_error(exc, json_output=plan.json_output)
+        exit_with_code(1)
+    except SourceTimeoutError as exc:
+        _emit_timeout(exc, json_output=plan.json_output)
+        exit_with_code(2)
+    else:
+        _emit_ready_payload(source, json_output=plan.json_output)
+
+
+__all__ = ["SourceWaitPlan", "execute_source_wait"]

--- a/src/notebooklm/cli/services/source_wait.py
+++ b/src/notebooklm/cli/services/source_wait.py
@@ -11,9 +11,8 @@ envelope contract.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING
 
-from ...client import NotebookLMClient
 from ...types import (
     Source,
     SourceNotFoundError,
@@ -24,7 +23,8 @@ from ..error_handler import exit_with_code
 from ..rendering import console, json_output_response
 from .polling import status_with_elapsed
 
-WaitStatus = Literal["ready", "not_found", "error", "timeout"]
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -1,36 +1,32 @@
-"""Source management CLI commands.
+"""Source management CLI commands — thin Click-handler layer (ADR-008).
 
-Commands:
-    list             List sources in a notebook
-    add              Add a source (url, text, file, youtube)
-    add-drive        Add a Google Drive document
-    add-research     Search web/drive and add sources from results
-    get              Get source details
-    fulltext         Get full indexed text content of a source
-    guide            Get AI-generated source summary and keywords
-    stale            Check if a URL/Drive source needs refresh
-    wait             Wait for a source to finish processing
-    clean            Remove duplicate, error, and access-blocked sources
-    delete           Delete a source
-    delete-by-title  Delete a source by exact title
-    rename           Rename a source
-    refresh          Refresh a URL/Drive source
+Each command builds a ``cli/services/source_*`` plan dataclass and delegates
+to its executor:
+
+* ``services/source_listing.py``   — list
+* ``services/source_mutations.py`` — delete, delete-by-title, rename,
+  refresh, add-drive
+* ``services/source_content.py``   — get, fulltext, guide, stale
+* ``services/source_research.py``  — add-research
+* ``services/source_wait.py``      — wait
+* ``services/source_add.py``       — add  (pre-T5; T5 added the executor)
+* ``services/source_clean.py``     — clean (pre-T5; T5 added the executor)
+
+The full per-command listing lives in the ``source`` click group docstring
+below (it is what ``notebooklm source --help`` shows).
 """
 
-import asyncio
-import contextlib
+import asyncio  # noqa: F401 — re-exported for P1.T2 regression tests that patch source_cmd.asyncio.sleep
 import os
-import re
 from pathlib import Path
-from typing import Any
 
 import click
 from rich.table import Table
 
 from ..client import NotebookLMClient
-from ..types import Source, source_status_to_str
+from ..types import Source
 from .auth_runtime import with_client
-from .error_handler import _output_error, current_json_output, exit_with_code
+from .error_handler import _output_error, current_json_output
 from .input import read_stdin_text, resolve_prompt
 from .options import (
     json_option,
@@ -39,24 +35,41 @@ from .options import (
     prompt_file_option,
     wait_polling_options,
 )
-from .rendering import (
-    cli_print,
-    cli_status,
-    console,
-    display_report,
-    display_research_sources,
-    emit_status,
-    get_source_type_display,
-    json_output_response,
-)
-from .research_import import import_research_sources
-from .resolve import require_notebook, resolve_notebook_id, resolve_source_id, validate_id
+from .rendering import console
+from .resolve import require_notebook, resolve_notebook_id, resolve_source_id
 from .runtime import is_quiet
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
-from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
-from .services.listing import ListSpec, run_list
-from .services.polling import status_with_elapsed
+from .services.source_add import SourceAddExecutionPlan, execute_source_add
+from .services.source_clean import SourceCleanPlan, execute_source_clean
+from .services.source_content import (
+    SourceFulltextPlan,
+    SourceGetPlan,
+    SourceGuidePlan,
+    SourceStalePlan,
+    execute_source_fulltext,
+    execute_source_get,
+    execute_source_guide,
+    execute_source_stale,
+)
+from .services.source_listing import SourceListPlan, execute_source_list
+from .services.source_mutations import (
+    SourceAddDrivePlan,
+    SourceDeleteByTitlePlan,
+    SourceDeletePlan,
+    SourceRefreshPlan,
+    SourceRenamePlan,
+    execute_source_add_drive,
+    execute_source_delete,
+    execute_source_delete_by_title,
+    execute_source_refresh,
+    execute_source_rename,
+)
+from .services.source_research import SourceAddResearchPlan, execute_source_add_research
+from .services.source_wait import SourceWaitPlan, execute_source_wait
+
+# Compatibility wrappers — tests patch these names on this module. Each
+# one is a one-liner forwarder to the canonical service-layer home.
 
 
 def _looks_like_path(content: str) -> bool:
@@ -91,35 +104,6 @@ def _print_clean_candidates(candidates: list[tuple[str, str, str, str]]) -> None
     console.print(table)
 
 
-def _require_yes_in_json(*, action: str, extra: dict[str, Any] | None = None) -> None:
-    """Emit a structured ``CONFIRM_REQUIRED`` error and exit non-zero.
-
-    Centralises the JSON-mode confirmation gate used by destructive commands
-    (``source delete``, ``source delete-by-title``, ``source clean``). Calling
-    this helper always raises ``SystemExit(1)`` via :func:`_output_error` — it
-    never returns normally.
-
-    Args:
-        action: Short verb identifying the command (``"delete"``,
-            ``"delete-by-title"``, ``"clean"``) so callers can match the
-            envelope to the originating command.
-        extra: Additional command-specific fields (e.g. ``source_id``,
-            ``notebook_id``, ``candidates``) merged into the JSON envelope so
-            automation has full context about what was refused.
-    """
-    payload: dict[str, Any] = {"action": action}
-    if extra:
-        payload.update(extra)
-    _output_error(
-        "Pass --yes to confirm destructive operation in --json mode",
-        code="CONFIRM_REQUIRED",
-        json_output=True,
-        exit_code=1,
-        extra=payload,
-    )
-    raise AssertionError("unreachable")  # pragma: no cover
-
-
 @click.group()
 def source():
     """Source management commands.
@@ -141,122 +125,9 @@ def source():
       rename           Rename a source
       refresh          Refresh a URL/Drive source
 
-    \b
-    Partial ID Support:
-      SOURCE_ID arguments support partial matching. Instead of typing the full
-      UUID, you can use a prefix (e.g., 'abc' matches 'abc123def456...').
+    Partial ID Support: SOURCE_ID arguments support partial-prefix matching
+    (e.g. 'abc' matches 'abc123def456...').
     """
-    pass
-
-
-def _build_id_ambiguity_error(source_id: str, matches) -> str:
-    """Build a consistent ambiguity error for source ID prefix matches."""
-    lines = [f"Ambiguous ID '{source_id}' matches {len(matches)} sources:"]
-    for item in matches[:5]:
-        title = item.title or "(untitled)"
-        lines.append(f"  {item.id[:12]}... {title}")
-    if len(matches) > 5:
-        lines.append(f"  ... and {len(matches) - 5} more")
-    lines.append("Specify more characters to narrow down.")
-    return "\n".join(lines)
-
-
-def _looks_like_full_source_id(source_id: str) -> bool:
-    """Return True for UUID-shaped source IDs that can skip list-based resolution."""
-    return bool(
-        re.fullmatch(
-            r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-            source_id,
-        )
-    )
-
-
-async def _resolve_source_for_delete(
-    client, notebook_id: str, source_id: str, *, json_output: bool = False
-) -> str:
-    """Resolve a source ID for delete, returning the full source ID string.
-
-    Canonical UUIDs take a fast path and skip the live source list lookup.
-    Partial IDs are resolved against the live list.
-
-    When ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
-    """
-    source_id = validate_id(source_id, "source")
-    if _looks_like_full_source_id(source_id):
-        return source_id
-
-    sources = await client.sources.list(notebook_id)
-    matches = [item for item in sources if item.id.lower().startswith(source_id.lower())]
-
-    if len(matches) == 1:
-        if matches[0].id != source_id:
-            title = matches[0].title or "(untitled)"
-            emit_status(
-                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
-                json_output=json_output,
-            )
-        return matches[0].id
-
-    if len(matches) > 1:
-        _output_error(
-            _build_id_ambiguity_error(source_id, matches),
-            "AMBIGUOUS_ID",
-            json_output,
-            1,
-        )
-        raise AssertionError("unreachable")  # pragma: no cover
-
-    title_matches = [item for item in sources if item.title == source_id]
-    if title_matches:
-        lines = [
-            f"'{source_id}' matches {len(title_matches)} source title(s), not source IDs.",
-            f"Use 'notebooklm source delete-by-title \"{source_id}\"' or delete by ID:",
-        ]
-        for item in title_matches[:5]:
-            lines.append(f"  {item.id[:12]}... {item.title}")
-        if len(title_matches) > 5:
-            lines.append(f"  ... and {len(title_matches) - 5} more")
-        _output_error("\n".join(lines), "VALIDATION_ERROR", json_output, 1)
-        raise AssertionError("unreachable")  # pragma: no cover
-
-    _output_error(
-        f"No source found starting with '{source_id}'. "
-        "Run 'notebooklm source list' to see available sources.",
-        "NOT_FOUND",
-        json_output,
-        1,
-    )
-    raise AssertionError("unreachable")  # pragma: no cover
-
-
-async def _resolve_source_by_exact_title(
-    client, notebook_id: str, title: str, *, json_output: bool = False
-):
-    """Resolve a source by exact title for the explicit delete-by-title flow."""
-    title = validate_id(title, "source title")
-    sources = await client.sources.list(notebook_id)
-    matches = [item for item in sources if item.title == title]
-
-    if len(matches) == 1:
-        return matches[0]
-
-    if len(matches) > 1:
-        lines = [f"Title '{title}' matches {len(matches)} sources. Delete by ID instead:"]
-        for item in matches[:5]:
-            lines.append(f"  {item.id[:12]}... {item.title}")
-        if len(matches) > 5:
-            lines.append(f"  ... and {len(matches) - 5} more")
-        _output_error("\n".join(lines), "AMBIGUOUS_TITLE", json_output, 1)
-
-    _output_error(
-        f"No source found with title '{title}'. "
-        "Run 'notebooklm source list' to see available sources.",
-        "NOT_FOUND",
-        json_output,
-        1,
-    )
-    raise AssertionError("unreachable")  # pragma: no cover
 
 
 @source.command("list")
@@ -277,44 +148,13 @@ def source_list(ctx, notebook_id, json_output, limit, no_truncate, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-
-            async def envelope_extras(
-                client: NotebookLMClient, notebook_id: str
-            ) -> dict[str, str | None]:
-                nb = await client.notebooks.get(notebook_id)
-                return {"notebook_id": notebook_id, "notebook_title": nb.title if nb else None}
-
-            spec = ListSpec(
-                title="Sources in {notebook_id}",
-                items_key="sources",
-                fetch=lambda client, notebook_id: client.sources.list(notebook_id),
-                serialize=lambda src: {
-                    "id": src.id,
-                    "title": src.title,
-                    "type": str(src.kind),
-                    "url": src.url,
-                    "status": source_status_to_str(src.status),
-                    "status_id": src.status,
-                    "created_at": src.created_at.isoformat() if src.created_at else None,
-                },
-                columns=["ID", "Title", "Type", "Created", "Status"],
-                row=lambda src: [
-                    src.id,
-                    src.title or "-",
-                    get_source_type_display(src.kind),
-                    src.created_at.strftime("%Y-%m-%d %H:%M") if src.created_at else "-",
-                    source_status_to_str(src.status),
-                ],
-                envelope_extras=envelope_extras,
-            )
-            await run_list(
-                spec,
-                client,
+            plan = SourceListPlan(
                 notebook_id=nb_id_resolved,
-                limit=limit,
                 json_output=json_output,
+                limit=limit,
                 no_truncate=no_truncate,
             )
+            await execute_source_list(client, plan)
 
     return _run()
 
@@ -330,11 +170,7 @@ def source_list(ctx, notebook_id, json_output, limit, no_truncate, client_auth):
     help="Source type (auto-detected if not specified)",
 )
 @click.option("--title", help="Custom title for text and uploaded-file sources")
-# DEPRECATION-REMOVAL: v0.6.0 — ``--mime-type`` on the file-source path is a
-# no-op (the upload pipeline ignores it; the server derives the MIME type from
-# the filename extension). A deprecation note is echoed to stderr when the flag
-# is used with a file source. The separate Drive-source ``--mime-type`` on the
-# ``add-drive`` command remains live and IS NOT affected by this deprecation.
+# DEPRECATION-REMOVAL v0.6.0: see services/source_add.py for the rationale.
 @click.option(
     "--mime-type",
     help=(
@@ -378,37 +214,14 @@ def source_add(
 ):
     """Add a source to a notebook.
 
-    \b
-    Source type is auto-detected:
-      - URLs (http/https) -> url or youtube
-      - Existing files (.pdf, .md, .txt, etc.) -> file (uploaded)
-      - Other content -> text (inline)
-      - Use --type to override
-
-    \b
-    Examples:
-      notebooklm source add https://example.com             # URL
-      notebooklm source add ./doc.pdf                       # Existing file uploaded
-      notebooklm source add https://youtube.com/...         # YouTube video
-      notebooklm source add "My notes here"                 # Inline text
-      notebooklm source add "My notes" --title "Research"   # Text with custom title
-
-    \b
-    Note: a path-shaped argument (contains '/' or ends in a known document
-    extension) that does not exist on disk is still ingested as inline text,
-    but a stderr warning is emitted so a typo (e.g. ``./missin.md``) cannot
-    silently masquerade as a successful upload. Pass ``--type text`` to suppress
-    the warning when the input is genuinely text content that happens to look
-    path-shaped.
+    Source type is auto-detected (URL/file/youtube/text) — see ``--type`` to
+    override. A path-shaped argument that does not exist on disk is still
+    ingested as inline text but a stderr warning is emitted; pass
+    ``--type text`` to suppress.
     """
-    # Unix ``-`` convention: ``source add -`` reads inline text
-    # from stdin and forces the text-source path. Intercepted here BEFORE
-    # the URL / file / path-shaped auto-detection branches so a single dash
-    # never falls into the path-shaped warning ("'-' looks like a path...")
-    # and so an explicit ``--type file -`` does not try to open a file
-    # literally named ``-``. We always route through the text branch — URL
-    # / file / YouTube would be nonsensical for piped text and the
-    # ``--type`` override is silently coerced for the same reason.
+    # Unix ``-`` convention: ``source add -`` reads inline text from stdin and
+    # forces the text-source path. Intercepted BEFORE auto-detection so a
+    # single dash never falls into the path-shaped warning.
     if content == "-":
         content = read_stdin_text(source_label="source content")
         source_type = "text"
@@ -435,39 +248,15 @@ def source_add(
     async def _run():
         async with NotebookLMClient(client_auth, **client_kwargs) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            # P1.T2 bug 5: ``rich.console.Console.status`` is a SYNCHRONOUS
-            # context manager. The old shape ``with console.status(...): return
-            # _run()`` exited the spinner as soon as ``_run()`` returned the
-            # coroutine — BEFORE ``with_client`` awaited it — so the spinner
-            # was effectively invisible during the actual upload. Moving the
-            # ``with`` block inside the awaited coroutine makes the spinner
-            # span the real I/O. JSON mode still suppresses the spinner so
-            # stdout stays pure JSON.
-            spinner = (
-                contextlib.nullcontext()
-                if json_output
-                else console.status(f"Adding {plan.detected_type} source...")
-            )
-            with spinner:
-                src = await source_add_service.add_source(
-                    client.sources,
+            await execute_source_add(
+                client,
+                SourceAddExecutionPlan(
                     notebook_id=nb_id_resolved,
                     plan=plan,
-                )
-
-            if json_output:
-                data = {
-                    "source": {
-                        "id": src.id,
-                        "title": src.title,
-                        "type": str(src.kind),
-                        "url": src.url,
-                    }
-                }
-                json_output_response(data)
-                return
-
-            cli_print(f"[green]Added source:[/green] {src.id}", ctx=ctx)
+                    json_output=json_output,
+                ),
+                ctx=ctx,
+            )
 
     return _run()
 
@@ -478,67 +267,23 @@ def source_add(
 @json_option
 @with_client
 def source_get(ctx, source_id, notebook_id, json_output, client_auth):
-    """Get source details.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-    """
+    """Get source details."""
     nb_id = require_notebook(notebook_id)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            # Resolve partial ID to full ID
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-            src = await client.sources.get(nb_id_resolved, resolved_id)
-
-            # BREAKING: not-found exits 1 with a typed error instead of
-            # the previous exit-0 ``found: false`` placeholder. The
-            # ``_output_error`` helper writes the message to stderr (text mode)
-            # or emits ``{error, code, message, source_id}`` to stdout (json
-            # mode) and raises ``SystemExit(1)``. See ``docs/cli-exit-codes.md``
-            # and the BREAKING entry in ``CHANGELOG.md`` (Unreleased → Changed).
-            #
-            # The trailing ``raise AssertionError`` is unreachable at runtime
-            # (``_output_error`` always raises) — it exists solely to narrow
-            # ``src`` from ``Source | None`` to ``Source`` for mypy without
-            # forcing a ``NoReturn`` annotation onto
-            # ``error_handler._output_error`` (which would change the shared
-            # error helper's typing contract).
-            if src is None:
-                _output_error(
-                    "Source not found",
-                    code="NOT_FOUND",
+            await execute_source_get(
+                client,
+                SourceGetPlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=resolved_id,
                     json_output=json_output,
-                    exit_code=1,
-                    extra={"source_id": resolved_id, "notebook_id": nb_id_resolved},
-                )
-                raise AssertionError("unreachable")  # pragma: no cover
-
-            if json_output:
-                data = {
-                    "source": {
-                        "id": src.id,
-                        "title": src.title,
-                        "type": str(src.kind),
-                        "url": src.url,
-                        "status": source_status_to_str(src.status),
-                        "status_id": src.status,
-                        "created_at": (src.created_at.isoformat() if src.created_at else None),
-                    },
-                    "found": True,
-                }
-                json_output_response(data)
-                return
-
-            console.print(f"[bold cyan]Source:[/bold cyan] {src.id}")
-            console.print(f"[bold]Title:[/bold] {src.title}")
-            console.print(f"[bold]Type:[/bold] {get_source_type_display(src.kind)}")
-            if src.url:
-                console.print(f"[bold]URL:[/bold] {src.url}")
-            if src.created_at:
-                console.print(f"[bold]Created:[/bold] {src.created_at.strftime('%Y-%m-%d %H:%M')}")
+                ),
+            )
 
     return _run()
 
@@ -550,87 +295,22 @@ def source_get(ctx, source_id, notebook_id, json_output, client_auth):
 @json_option
 @with_client
 def source_delete(ctx, source_id, notebook_id, yes, json_output, client_auth):
-    """Delete a source.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-    """
+    """Delete a source."""
     nb_id = require_notebook(notebook_id)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-
-            async def resolve_delete(client):
-                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-                resolved_id = await _resolve_source_for_delete(
-                    client, nb_id_resolved, source_id, json_output=json_output
-                )
-
-                # P1.T2 bug 1: In --json mode, never prompt — automation cannot
-                # answer an interactive confirmation and a hanging prompt is
-                # indistinguishable from a stuck command. Require --yes and emit a
-                # structured JSON error otherwise.
-                if json_output and not yes:
-                    _require_yes_in_json(
-                        action="delete",
-                        extra={
-                            "source_id": resolved_id,
-                            "notebook_id": nb_id_resolved,
-                        },
-                    )
-
-                return {
-                    "notebook_id": nb_id_resolved,
-                    "source_id": resolved_id,
-                    "success": False,
-                }
-
-            async def execute_delete(client, resolved):
-                resolved["success"] = bool(
-                    await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
-                )
-
-            def serialize_success(resolved):
-                return {
-                    "action": "delete",
-                    "source_id": resolved["source_id"],
-                    "notebook_id": resolved["notebook_id"],
-                    "success": bool(resolved["success"]),
-                    "status": "deleted" if resolved["success"] else "unknown",
-                }
-
-            plan = MutationPlan(
-                entity_label="source",
-                resolve=resolve_delete,
-                confirm_message="Delete source {resolved[source_id]}?",
-                execute=execute_delete,
-                serialize_success=serialize_success,
-                serialize_cancel=lambda resolved: {
-                    "action": "delete",
-                    "source_id": resolved["source_id"],
-                    "notebook_id": resolved["notebook_id"],
-                    "success": False,
-                    "status": "cancelled",
-                },
-            )
-            result = await run_confirmed_mutation(
-                plan,
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            await execute_source_delete(
                 client,
-                yes=yes,
-                json_output=json_output,
-                confirmer=click.confirm,
+                SourceDeletePlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=source_id,
+                    yes=yes,
+                    json_output=json_output,
+                ),
+                ctx=ctx,
             )
-            if result.status == "cancelled":
-                return
-
-            if json_output:
-                return
-
-            resolved_id = result.resolved["source_id"]
-            success = bool(result.resolved["success"])
-            if success:
-                cli_print(f"[green]Deleted source:[/green] {resolved_id}", ctx=ctx)
-            else:
-                cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
 
     return _run()
 
@@ -647,81 +327,17 @@ def source_delete_by_title(ctx, title, notebook_id, yes, json_output, client_aut
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-
-            async def resolve_delete_by_title(client):
-                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-                source = await _resolve_source_by_exact_title(
-                    client, nb_id_resolved, title, json_output=json_output
-                )
-
-                # P1.T2 bug 2: same JSON-mode confirmation contract as
-                # ``source delete``. Never prompt under --json; require --yes.
-                if json_output and not yes:
-                    _require_yes_in_json(
-                        action="delete-by-title",
-                        extra={
-                            "source_id": source.id,
-                            "title": source.title,
-                            "notebook_id": nb_id_resolved,
-                        },
-                    )
-
-                return {
-                    "notebook_id": nb_id_resolved,
-                    "source_id": source.id,
-                    "title": source.title,
-                    "success": False,
-                }
-
-            async def execute_delete_by_title(client, resolved):
-                resolved["success"] = bool(
-                    await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
-                )
-
-            def serialize_success(resolved):
-                return {
-                    "action": "delete-by-title",
-                    "source_id": resolved["source_id"],
-                    "title": resolved["title"],
-                    "notebook_id": resolved["notebook_id"],
-                    "success": bool(resolved["success"]),
-                    "status": "deleted" if resolved["success"] else "unknown",
-                }
-
-            plan = MutationPlan(
-                entity_label="source",
-                resolve=resolve_delete_by_title,
-                confirm_message="Delete source '{resolved[title]}' ({resolved[source_id]})?",
-                execute=execute_delete_by_title,
-                serialize_success=serialize_success,
-                serialize_cancel=lambda resolved: {
-                    "action": "delete-by-title",
-                    "source_id": resolved["source_id"],
-                    "title": resolved["title"],
-                    "notebook_id": resolved["notebook_id"],
-                    "success": False,
-                    "status": "cancelled",
-                },
-            )
-            result = await run_confirmed_mutation(
-                plan,
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            await execute_source_delete_by_title(
                 client,
-                yes=yes,
-                json_output=json_output,
-                confirmer=click.confirm,
+                SourceDeleteByTitlePlan(
+                    notebook_id=nb_id_resolved,
+                    title=title,
+                    yes=yes,
+                    json_output=json_output,
+                ),
+                ctx=ctx,
             )
-            if result.status == "cancelled":
-                return
-
-            if json_output:
-                return
-
-            source_id = result.resolved["source_id"]
-            success = bool(result.resolved["success"])
-            if success:
-                cli_print(f"[green]Deleted source:[/green] {source_id}", ctx=ctx)
-            else:
-                cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
 
     return _run()
 
@@ -733,35 +349,22 @@ def source_delete_by_title(ctx, title, notebook_id, yes, json_output, client_aut
 @json_option
 @with_client
 def source_rename(ctx, source_id, new_title, notebook_id, json_output, client_auth):
-    """Rename a source.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-    """
+    """Rename a source."""
     nb_id = require_notebook(notebook_id)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            # Resolve partial ID to full ID
-            resolved_id = await resolve_source_id(
-                client, nb_id_resolved, source_id, json_output=json_output
+            await execute_source_rename(
+                client,
+                SourceRenamePlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=source_id,
+                    new_title=new_title,
+                    json_output=json_output,
+                ),
+                ctx=ctx,
             )
-            src = await client.sources.rename(nb_id_resolved, resolved_id, new_title)
-
-            if json_output:
-                json_output_response(
-                    {
-                        "action": "rename",
-                        "source_id": src.id,
-                        "notebook_id": nb_id_resolved,
-                        "title": src.title,
-                        "status": "renamed",
-                    }
-                )
-                return
-
-            cli_print(f"[green]Renamed source:[/green] {src.id}", ctx=ctx)
-            cli_print(f"[bold]New title:[/bold] {src.title}", ctx=ctx)
 
     return _run()
 
@@ -772,62 +375,21 @@ def source_rename(ctx, source_id, new_title, notebook_id, json_output, client_au
 @json_option
 @with_client
 def source_refresh(ctx, source_id, notebook_id, json_output, client_auth):
-    """Refresh a URL/Drive source.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-    """
+    """Refresh a URL/Drive source."""
     nb_id = require_notebook(notebook_id)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            # Resolve partial ID to full ID
-            resolved_id = await resolve_source_id(
-                client, nb_id_resolved, source_id, json_output=json_output
+            await execute_source_refresh(
+                client,
+                SourceRefreshPlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=source_id,
+                    json_output=json_output,
+                ),
+                ctx=ctx,
             )
-
-            if json_output:
-                src = await client.sources.refresh(nb_id_resolved, resolved_id)
-            else:
-                with cli_status("Refreshing source...", ctx=ctx):
-                    src = await client.sources.refresh(nb_id_resolved, resolved_id)
-
-            if json_output:
-                # ``refresh`` may return a Source dataclass, ``True``, or
-                # falsy/None. Surface the same three states in JSON so
-                # automation can branch on ``status`` without scraping text.
-                if src and src is not True:
-                    data = {
-                        "action": "refresh",
-                        "source_id": src.id,
-                        "notebook_id": nb_id_resolved,
-                        "title": src.title,
-                        "status": "refreshed",
-                    }
-                elif src is True:
-                    data = {
-                        "action": "refresh",
-                        "source_id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                        "status": "refreshed",
-                    }
-                else:
-                    data = {
-                        "action": "refresh",
-                        "source_id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                        "status": "no_result",
-                    }
-                json_output_response(data)
-                return
-
-            if src and src is not True:
-                cli_print(f"[green]Source refreshed:[/green] {src.id}", ctx=ctx)
-                cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
-            elif src is True:
-                cli_print(f"[green]Source refreshed:[/green] {resolved_id}", ctx=ctx)
-            else:
-                cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
 
     return _run()
 
@@ -846,46 +408,22 @@ def source_refresh(ctx, source_id, notebook_id, json_output, client_auth):
 @with_client
 def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, client_auth):
     """Add a Google Drive document as a source."""
-    from ..types import DriveMimeType
-
     nb_id = require_notebook(notebook_id)
-    mime_map = {
-        "google-doc": DriveMimeType.GOOGLE_DOC.value,
-        "google-slides": DriveMimeType.GOOGLE_SLIDES.value,
-        "google-sheets": DriveMimeType.GOOGLE_SHEETS.value,
-        "pdf": DriveMimeType.PDF.value,
-    }
-    mime = mime_map[mime_type]
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-
-            if json_output:
-                src = await client.sources.add_drive(nb_id_resolved, file_id, title, mime)
-            else:
-                with console.status("Adding Drive source..."):
-                    src = await client.sources.add_drive(nb_id_resolved, file_id, title, mime)
-
-            if json_output:
-                json_output_response(
-                    {
-                        "action": "add-drive",
-                        "source": {
-                            "id": src.id,
-                            "title": src.title,
-                            "type": str(src.kind),
-                            "url": src.url,
-                            "drive_file_id": file_id,
-                            "mime_type": mime_type,
-                        },
-                        "notebook_id": nb_id_resolved,
-                    }
-                )
-                return
-
-            cli_print(f"[green]Added Drive source:[/green] {src.id}", ctx=ctx)
-            cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
+            await execute_source_add_drive(
+                client,
+                SourceAddDrivePlan(
+                    notebook_id=nb_id_resolved,
+                    file_id=file_id,
+                    title=title,
+                    mime_type=mime_type,
+                    json_output=json_output,
+                ),
+                ctx=ctx,
+            )
 
     return _run()
 
@@ -919,14 +457,14 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
     default=1800,
     type=int,
     help=(
-        "Per-phase seconds budget for (a) the research-completion poll loop "
-        "and (b) the --import-all retry loop (default: 1800). Each phase "
-        "gets the full budget independently, so worst-case total wall time "
-        "is up to 2× this value. Matches 'research wait --timeout' "
-        "semantics. Bumping this is required for deep research that runs "
-        "longer than the legacy 5-minute cap — otherwise the CLI gives up "
-        "before IMPORT_RESEARCH fires and the NotebookLM web UI is left "
-        "showing an 'Add sources?' modal."
+        "Per-phase seconds budget for (a) the research-completion poll "
+        "loop and (b) the --import-all retry loop (default: 1800). Each "
+        "phase gets the full budget independently, so worst-case total "
+        "wall time is up to 2× this value. Matches 'research wait "
+        "--timeout' semantics. Bumping this is required for deep "
+        "research that runs longer than the legacy 5-minute cap — "
+        "otherwise the CLI gives up before IMPORT_RESEARCH fires and "
+        "the NotebookLM web UI is left showing an 'Add sources?' modal."
     ),
 )
 @with_client
@@ -945,25 +483,14 @@ def source_add_research(
 ):
     """Search web or drive and add sources from results.
 
-    \b
-    Examples:
-      notebooklm source add-research "machine learning"              # Search web
-      notebooklm source add-research "project docs" --from drive     # Search Google Drive
-      notebooklm source add-research "AI papers" --mode deep         # Deep search
-      notebooklm source add-research "tutorials" --import-all        # Auto-import all results
-      notebooklm source add-research "topic" --import-all --cited-only
-      notebooklm source add-research "topic" --mode deep --no-wait   # Non-blocking deep search
-      notebooklm source add-research --prompt-file query.txt --mode deep   # Read query from file
+    See ``--from``, ``--mode``, ``--import-all``, ``--cited-only``,
+    ``--no-wait``, and ``--timeout``. Read the query from a file with
+    ``--prompt-file``.
     """
     query = resolve_prompt(query, prompt_file, "query", required=True)
     if cited_only and not import_all:
         raise click.UsageError("--cited-only requires --import-all")
-    # P1.T2 bug 7: --no-wait returns immediately without polling, so
-    # --import-all would have no completed results to import. Silently
-    # ignoring --import-all is the worst failure mode (user assumes import
-    # happened); refuse the combination instead. Callers that want
-    # deferred imports must explicitly run ``research wait --import-all``
-    # after start (the message in --no-wait already hints at this).
+    # P1.T2 bug 7: --no-wait + --import-all is silently broken — refuse it.
     if no_wait and import_all:
         raise click.UsageError(
             "--import-all requires --wait (the default) or a separate "
@@ -975,70 +502,19 @@ def source_add_research(
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            console.print(f"[yellow]Starting {mode} research on {search_source}...[/yellow]")
-            result = await client.research.start(nb_id_resolved, query, search_source, mode)
-            if not result:
-                console.print("[red]Research failed to start[/red]")
-                exit_with_code(1)
-
-            task_id = result["task_id"]
-            console.print(f"[dim]Task ID: {task_id}[/dim]")
-
-            # Non-blocking mode: return immediately. Research will keep
-            # running server-side; until something fires IMPORT_RESEARCH the
-            # NotebookLM web UI will show an "Add sources?" modal (#315).
-            if no_wait:
-                console.print(
-                    "[green]Research started.[/green] "
-                    "Run 'notebooklm research wait --import-all' to commit "
-                    "sources once it completes, otherwise the NotebookLM web "
-                    "UI will keep an 'Add sources?' modal open."
-                )
-                return
-
-            # Poll budget mirrors `research wait --timeout`: total seconds
-            # divided by the 5 s interval. The legacy hardcoded 60-iteration
-            # cap stranded deep research (#315) because the import branch
-            # below is gated on `status == "completed"`.
-            #
-            # P1.T2 bug 6: pin every poll to the ``task_id`` we received from
-            # ``research.start`` so a second research task started mid-wait
-            # (e.g. by a concurrent caller, web UI, or retry) cannot
-            # cross-wire its sources / report into this task's import branch.
-            # Matches the pattern in ``cli/research.py:155-189``.
-            _POLL_INTERVAL_S = 5
-            status = None
-            for _ in range(max(1, timeout // _POLL_INTERVAL_S)):
-                status = await client.research.poll(nb_id_resolved, task_id=task_id)
-                if status.get("status") == "completed":
-                    break
-                elif status.get("status") == "no_research":
-                    console.print("[red]Research failed to start[/red]")
-                    exit_with_code(1)
-                await asyncio.sleep(_POLL_INTERVAL_S)
-            else:
-                status = {"status": "timeout"}
-
-            if status.get("status") == "completed":
-                sources = status.get("sources", [])
-                console.print()
-                display_research_sources(sources)
-
-                display_report(status.get("report", ""), json_hint=False)
-
-                if import_all and sources and task_id:
-                    import_result = await import_research_sources(
-                        client,
-                        nb_id_resolved,
-                        task_id,
-                        sources,
-                        report=status.get("report", ""),
-                        cited_only=cited_only,
-                        max_elapsed=timeout,
-                    )
-                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
-            else:
-                console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
+            await execute_source_add_research(
+                client,
+                SourceAddResearchPlan(
+                    notebook_id=nb_id_resolved,
+                    query=query,
+                    search_source=search_source,
+                    mode=mode,
+                    import_all=import_all,
+                    cited_only=cited_only,
+                    no_wait=no_wait,
+                    timeout=timeout,
+                ),
+            )
 
     return _run()
 
@@ -1060,30 +536,11 @@ def source_add_research(
 def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_format, client_auth):
     """Get full content of a source.
 
-    Retrieves the complete content from NotebookLM. Use --format markdown to get
-    a rich version with headings, tables, links, and emphasis preserved.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-
-    \b
-    Output shapes:
-      Text mode (default):
-        - No ``-o``: full content rendered to the terminal (truncated at 2000 chars).
-        - With ``-o``: full content written to FILE; stderr/stdout shows a brief saved-N-chars line.
-      JSON mode (``--json``):
-        - No ``-o``: full ``asdict(SourceFulltext)`` payload on stdout
-          (``{source_id, title, content, char_count, url, ...}``).
-        - With ``-o``: full content written to FILE; a *metadata envelope*
-          on stdout — ``{path, bytes, source_id, title}``. This avoids
-          duplicating multi-MB fulltext to both stdout and disk while still
-          giving automation a parseable stdout payload that names the file.
-
-    \b
-    Examples:
-      notebooklm source fulltext abc123                        # Show plaintext in terminal
-      notebooklm source fulltext abc123 -f markdown -o out.md  # Save markdown to file
-      notebooklm source fulltext abc123 --json                 # Full JSON payload to stdout
-      notebooklm source fulltext abc123 --json -o out.txt      # File + metadata envelope on stdout
+    Use ``--format markdown`` for a rich version with headings/tables/links.
+    Text mode truncates at 2000 chars; ``-o FILE`` writes the full content.
+    JSON mode emits the full ``SourceFulltext`` payload, or with ``-o`` a
+    ``{path, bytes, source_id, title}`` envelope (content goes to the file
+    only, not duplicated to stdout).
     """
     nb_id = require_notebook(notebook_id)
 
@@ -1093,60 +550,16 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_for
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-
-            async def _fetch():
-                return await client.sources.get_fulltext(
-                    nb_id_resolved, resolved_id, output_format=output_format
-                )
-
-            if json_output:
-                fulltext = await _fetch()
-            else:
-                with console.status("Fetching fulltext content..."):
-                    fulltext = await _fetch()
-
-            if json_output:
-                # P1.T2 bug 4: when both --json and -o are given, write the
-                # (potentially multi-MB) content to disk and emit a small
-                # metadata envelope on stdout — not the full content twice.
-                if output:
-                    content_bytes = fulltext.content.encode("utf-8")
-                    Path(output).write_bytes(content_bytes)
-                    json_output_response(
-                        {
-                            "path": str(output),
-                            "bytes": len(content_bytes),
-                            "source_id": fulltext.source_id,
-                            "title": fulltext.title,
-                        }
-                    )
-                    return
-
-                from dataclasses import asdict
-
-                json_output_response(asdict(fulltext))
-                return
-
-            if output:
-                Path(output).write_text(fulltext.content, encoding="utf-8")
-                console.print(f"[green]Saved {fulltext.char_count} chars to {output}[/green]")
-                return
-
-            console.print(f"[bold cyan]Source:[/bold cyan] {fulltext.source_id}")
-            console.print(f"[bold]Title:[/bold] {fulltext.title}")
-            console.print(f"[bold]Characters:[/bold] {fulltext.char_count:,}")
-            if fulltext.url:
-                console.print(f"[bold]URL:[/bold] {fulltext.url}")
-            console.print()
-            console.print("[bold cyan]Content:[/bold cyan]")
-            # markup=False so markdown links like `[text](url)` are not eaten by Rich's tag parser
-            if len(fulltext.content) > 2000:
-                console.print(fulltext.content[:2000], markup=False, highlight=False)
-                console.print(
-                    f"\n[dim]... ({fulltext.char_count - 2000:,} more chars, use -o to save full content)[/dim]"
-                )
-            else:
-                console.print(fulltext.content, markup=False, highlight=False)
+            await execute_source_fulltext(
+                client,
+                SourceFulltextPlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=resolved_id,
+                    json_output=json_output,
+                    output=output,
+                    output_format=output_format,
+                ),
+            )
 
     return _run()
 
@@ -1159,15 +572,8 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_for
 def source_guide(ctx, source_id, notebook_id, json_output, client_auth):
     """Get AI-generated source summary and keywords.
 
-    Shows the "Source Guide" - an AI-generated overview of what a source contains,
-    including a summary with highlighted keywords and topic tags.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-
-    \b
-    Examples:
-      notebooklm source guide abc123                    # Get guide for source
-      notebooklm source guide abc123 --json             # Output as JSON
+    Shows the "Source Guide" — an AI-generated overview with a summary,
+    highlighted keywords, and topic tags.
     """
     nb_id = require_notebook(notebook_id)
 
@@ -1177,40 +583,14 @@ def source_guide(ctx, source_id, notebook_id, json_output, client_auth):
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-
-            async def _fetch_guide():
-                return await client.sources.get_guide(nb_id_resolved, resolved_id)
-
-            if json_output:
-                guide = await _fetch_guide()
-            else:
-                with console.status("Generating source guide..."):
-                    guide = await _fetch_guide()
-
-            if json_output:
-                data = {
-                    "source_id": resolved_id,
-                    "summary": guide.get("summary", ""),
-                    "keywords": guide.get("keywords", []),
-                }
-                json_output_response(data)
-                return
-
-            summary = guide.get("summary", "").strip()
-            keywords = guide.get("keywords", [])
-
-            if not summary and not keywords:
-                console.print("[yellow]No guide available for this source[/yellow]")
-                return
-
-            if summary:
-                console.print("[bold cyan]Summary:[/bold cyan]")
-                console.print(summary)
-                console.print()
-
-            if keywords:
-                console.print("[bold cyan]Keywords:[/bold cyan]")
-                console.print(", ".join(keywords))
+            await execute_source_guide(
+                client,
+                SourceGuidePlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=resolved_id,
+                    json_output=json_output,
+                ),
+            )
 
     return _run()
 
@@ -1223,19 +603,11 @@ def source_guide(ctx, source_id, notebook_id, json_output, client_auth):
 def source_stale(ctx, source_id, notebook_id, json_output, client_auth):
     """Check if a URL/Drive source needs refresh.
 
-    Returns exit code 0 if stale (needs refresh), 1 if fresh.
-    This enables shell scripting: if notebooklm source stale ID; then refresh; fi
-
-    The inverted exit-code semantics are intentional and apply to ``--json``
-    too — see docs/cli-exit-codes.md. Branch on the JSON ``stale`` field
-    when the predicate-style exit code is awkward.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-
-    \b
-    Examples:
-      notebooklm source stale abc123              # Check if stale
-      notebooklm source stale abc123 --json       # Same exit codes; JSON body
+    Exit 0 if stale (needs refresh), 1 if fresh — enables shell scripting
+    ``if notebooklm source stale ID; then refresh; fi``. Inverted exit-code
+    semantics are intentional and apply to ``--json`` too (see
+    docs/cli-exit-codes.md). Branch on the JSON ``stale`` field when the
+    predicate-style exit code is awkward.
     """
     nb_id = require_notebook(notebook_id)
 
@@ -1245,33 +617,14 @@ def source_stale(ctx, source_id, notebook_id, json_output, client_auth):
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-            is_fresh = await client.sources.check_freshness(nb_id_resolved, resolved_id)
-            stale = not is_fresh
-
-            if json_output:
-                # PRESERVE INVERTED EXIT-CODE SEMANTICS: ``source stale`` is the
-                # only command that exits 0 on a "true predicate" and 1 on a
-                # "false predicate". The JSON body carries the boolean
-                # explicitly so callers who would prefer to branch on a field
-                # rather than the exit code can do so.
-                json_output_response(
-                    {
-                        "source_id": resolved_id,
-                        "notebook_id": nb_id_resolved,
-                        "stale": stale,
-                        "fresh": is_fresh,
-                    }
-                )
-                # Exit codes remain inverted by design — see docs/cli-exit-codes.md.
-                exit_with_code(0 if stale else 1)
-
-            if is_fresh:
-                console.print("[green]✓ Source is fresh[/green]")
-                exit_with_code(1)  # Not stale
-            else:
-                console.print("[yellow]⚠ Source is stale[/yellow]")
-                console.print("[dim]Run 'source refresh' to update[/dim]")
-                exit_with_code(0)  # Is stale
+            await execute_source_stale(
+                client,
+                SourceStalePlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=resolved_id,
+                    json_output=json_output,
+                ),
+            )
 
     return _run()
 
@@ -1285,33 +638,10 @@ def source_stale(ctx, source_id, notebook_id, json_output, client_auth):
 def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, client_auth):
     """Wait for a source to finish processing.
 
-    After adding a source, it needs to be processed before it can be used
-    for chat or artifact generation. This command polls until the source
-    is ready or fails.
-
-    SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
-
-    \b
-    Exit codes:
-      0 - Source is ready
-      1 - Source not found or processing failed
-      2 - Timeout reached
-
-    \b
-    Examples:
-      notebooklm source wait abc123                          # Wait for source to be ready
-      notebooklm source wait abc123 --timeout 300            # Wait up to 5 minutes
-      notebooklm source wait abc123 --interval 5             # Poll every 5 seconds
-      notebooklm source wait abc123 --json                   # Output status as JSON
-
-    \b
-    Subagent pattern for long-running operations:
-      # In main conversation, add source then spawn subagent to wait:
-      notebooklm source add https://example.com
-      # Subagent runs: notebooklm source wait <source_id>
+    Polls until the source is ready or fails. Exit code 0=ready, 1=missing or
+    processing failed, 2=timeout. Spawn this in a subagent after ``source
+    add`` returns so the main conversation can continue.
     """
-    from ..types import SourceNotFoundError, SourceProcessingError, SourceTimeoutError
-
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -1320,84 +650,16 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-
-            try:
-                # Wrap the blocking poll in a transient spinner so interactive
-                # Users see progress feedback during the wait.
-                # Replaces the prior static "[dim]Waiting for source ...[/dim]"
-                # print — the spinner conveys the same information AND a live
-                # elapsed-seconds counter, then disappears so the final
-                # ready / failure / timeout line stands alone. No-op under
-                # --json so stdout stays pure JSON.
-                async with status_with_elapsed(
-                    f"Waiting for source {resolved_id} to finish processing...",
+            await execute_source_wait(
+                client,
+                SourceWaitPlan(
+                    notebook_id=nb_id_resolved,
+                    source_id=resolved_id,
+                    timeout=float(timeout),
+                    interval=float(interval),
                     json_output=json_output,
-                    # Parallel hint for ``source wait``: there is
-                    # no separate ``source poll`` command, so the resume IS
-                    # re-running the same wait. Keeps the ``Cancelled. Resume
-                    # with: ...`` phrasing consistent across the three
-                    # long-running paths.
-                    resume_hint=f"notebooklm source wait {resolved_id}",
-                ):
-                    source = await client.sources.wait_until_ready(
-                        nb_id_resolved,
-                        resolved_id,
-                        timeout=float(timeout),
-                        initial_interval=float(interval),
-                    )
-
-                if json_output:
-                    data = {
-                        "source_id": source.id,
-                        "title": source.title,
-                        "status": "ready",
-                        "status_code": source.status,
-                    }
-                    json_output_response(data)
-                else:
-                    console.print(f"[green]✓ Source ready:[/green] {source.id}")
-                    if source.title:
-                        console.print(f"[bold]Title:[/bold] {source.title}")
-
-            except SourceNotFoundError as e:
-                if json_output:
-                    data = {
-                        "source_id": e.source_id,
-                        "status": "not_found",
-                        "error": str(e),
-                    }
-                    json_output_response(data)
-                else:
-                    console.print(f"[red]✗ Source not found:[/red] {e.source_id}")
-                exit_with_code(1)
-
-            except SourceProcessingError as e:
-                if json_output:
-                    data = {
-                        "source_id": e.source_id,
-                        "status": "error",
-                        "status_code": e.status,
-                        "error": str(e),
-                    }
-                    json_output_response(data)
-                else:
-                    console.print(f"[red]✗ Source processing failed:[/red] {e.source_id}")
-                exit_with_code(1)
-
-            except SourceTimeoutError as e:
-                if json_output:
-                    data = {
-                        "source_id": e.source_id,
-                        "status": "timeout",
-                        "last_status_code": e.last_status,
-                        "timeout_seconds": int(e.timeout),
-                        "error": str(e),
-                    }
-                    json_output_response(data)
-                else:
-                    console.print(f"[yellow]⚠ Timeout waiting for source:[/yellow] {e.source_id}")
-                    console.print(f"[dim]Last status: {e.last_status}[/dim]")
-                exit_with_code(2)
+                ),
+            )
 
     return _run()
 
@@ -1413,130 +675,23 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
 def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
     """Automatically remove duplicate, error, and access-blocked sources."""
     nb_id = require_notebook(notebook_id)
-
     quiet_mode = is_quiet(ctx)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-
-            async def _list_sources(notebook_id: str) -> list[Source]:
-                if json_output:
-                    return await client.sources.list(notebook_id)
-                with cli_status("Fetching sources for cleanup...", ctx=ctx):
-                    return await client.sources.list(notebook_id)
-
-            # P1.T2 bug 3: in --json mode, never prompt — automation cannot
-            # answer the question. Pass a non-interactive ``confirm_delete``
-            # that always declines; once the service returns ``cancelled`` we
-            # synthesize a structured ``CONFIRM_REQUIRED`` error below
-            # (only when there were candidates — empty notebooks short-circuit
-            # to ``already_clean`` before ``confirm_delete`` is ever called).
-            confirm_delete = (
-                (lambda count: False)
-                if json_output
-                else (lambda count: click.confirm(f"Delete {count} source(s)?"))
-            )
-
-            # Candidate tables and progress lines are status prose; JSON and
-            # quiet modes both suppress them.
-            on_candidates = None if (json_output or quiet_mode) else _print_clean_candidates
-            on_delete_start = (
-                None
-                if (json_output or quiet_mode)
-                else lambda count: cli_print(
-                    f"[dim]Cleaning {count} source(s) (in chunks of 10)...[/dim]",
-                    ctx=ctx,
-                )
-            )
-
-            result = await source_clean_service.run_source_clean(
-                notebook_id=nb_id_resolved,
-                dry_run=dry_run,
-                yes=yes,
-                list_sources=_list_sources,
-                delete_source=client.sources.delete,
-                confirm_delete=confirm_delete,
-                on_candidates=on_candidates,
-                on_delete_start=on_delete_start,
-                classify_sources=_classify_junk_sources,
-            )
-
-            candidate_payload = source_clean_service.candidates_payload(result.candidates)
-
-            if json_output:
-                # P1.T2 bug 3: synthesize structured error when --json + no
-                # --yes left candidates uncleaned (the silent
-                # ``status=cancelled`` form would be invisible to automation).
-                if result.status == "cancelled" and not yes:
-                    _require_yes_in_json(
-                        action="clean",
-                        extra={
-                            "notebook_id": result.notebook_id,
-                            "candidate_count": result.candidate_count,
-                            "candidates": candidate_payload,
-                        },
-                    )
-
-                payload = {
-                    "action": "clean",
-                    "notebook_id": result.notebook_id,
-                    "status": result.status,
-                    "candidates": candidate_payload,
-                    "deleted_count": result.deleted_count,
-                    "failure_count": result.failure_count,
-                }
-                if result.status != "already_clean":
-                    payload["candidate_count"] = result.candidate_count
-                if result.status == "completed":
-                    payload["failures"] = [
-                        {"id": sid, "error": err} for sid, err in result.failures
-                    ]
-                json_output_response(payload)
-                # P1.T2 bug 8: partial-failure must exit non-zero so shell
-                # automation (set -e, CI) sees the failure. The full report
-                # is still on stdout above so callers can introspect which
-                # IDs failed.
-                if result.failures:
-                    exit_with_code(1)
-                return
-
-            if result.status == "already_clean":
-                cli_print(
-                    "[green]Notebook is already clean. No junk sources found.[/green]",
-                    ctx=ctx,
-                )
-                return
-
-            if result.status == "dry_run":
-                cli_print(
-                    f"[yellow]Dry run: would delete {result.candidate_count} source(s).[/yellow]",
-                    ctx=ctx,
-                )
-                return
-
-            if result.status == "cancelled":
-                return
-
-            if result.failures:
-                cli_print(
-                    f"[yellow]Cleaned {result.deleted_count} source(s). "
-                    f"{len(result.failures)} deletion(s) failed.[/yellow]",
-                    ctx=ctx,
-                )
-                for sid, err in result.failures[:5]:
-                    cli_print(f"  [red]{sid}:[/red] {err}", ctx=ctx)
-                if len(result.failures) > 5:
-                    cli_print(
-                        f"  [dim]...and {len(result.failures) - 5} more[/dim]",
-                        ctx=ctx,
-                    )
-                # P1.T2 bug 8: text-mode parity with JSON-mode exit code.
-                exit_with_code(1)
-
-            cli_print(
-                f"[green]Successfully cleaned {result.deleted_count} source(s).[/green]",
+            await execute_source_clean(
+                client,
+                SourceCleanPlan(
+                    notebook_id=nb_id_resolved,
+                    dry_run=dry_run,
+                    yes=yes,
+                    json_output=json_output,
+                    quiet_mode=quiet_mode,
+                ),
                 ctx=ctx,
+                classify_sources=_classify_junk_sources,
+                on_candidates=_print_clean_candidates,
             )
 
     return _run()

--- a/tests/unit/cli/test_source_characterization.py
+++ b/tests/unit/cli/test_source_characterization.py
@@ -1,0 +1,568 @@
+"""Characterization tests for ``notebooklm source ...`` CLI commands.
+
+These tests pin observable CLI behavior across the ``source`` command surface
+BEFORE the P3.T5 service extraction. They are end-to-end at the ``CliRunner``
+level so they capture exit codes, stdout/stderr structure, and JSON envelope
+shape that lower-level service-unit tests in ``test_source.py`` do not cover
+holistically.
+
+They MUST pass identically on ``main`` HEAD before the extraction commit
+lands, and they MUST continue to pass byte-for-byte after the extraction.
+Any divergence is a behavior regression — not an opportunity to "fix" the
+old behavior.
+
+Coverage matrix (commands × output modes from the P3.T5 spec):
+
+| Command                  | text | json |
+|--------------------------|------|------|
+| source add               | yes  | yes  |
+| source list              | yes  | yes  |
+| source get               | yes  | yes  |
+| source delete            | yes  | yes  |
+| source delete-by-title   | yes  | yes  |
+| source clean             | yes  | yes  |
+| source fulltext          | yes  | yes  |
+| source guide             | yes  | yes  |
+| source add-research      | yes  | yes  |
+| source wait              | yes  | yes  |
+
+Each test pins one (command, mode) cell of the matrix to a specific
+expected-text fragment or JSON envelope. The fragments are intentionally
+narrow (one or two structural lines) so the snapshots survive cosmetic
+changes (e.g. Rich color codes) while still catching shape regressions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import (
+    Source,
+    SourceFulltext,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceStatus,
+    SourceTimeoutError,
+)
+
+from .conftest import create_mock_client
+
+pytestmark = pytest.mark.characterization
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    with patch("notebooklm.cli.helpers.load_auth_from_storage") as m:
+        m.return_value = {
+            "SID": "test",
+            "__Secure-1PSIDTS": "test_1psidts",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        yield m
+
+
+@pytest.fixture
+def patched_fetch_tokens():
+    with patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as fetch:
+        fetch.return_value = ("csrf", "session")
+        yield fetch
+
+
+# ----------------------------------------------------------------------------
+# source add
+# ----------------------------------------------------------------------------
+
+
+class TestSourceAddCharacterization:
+    def test_add_url_text_mode_prints_added_source_line(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.add_url = AsyncMock(
+                return_value=Source(id="src_new_url", title="URL Source", url="https://x")
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "add", "https://example.com", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "Added source:" in result.output
+        assert "src_new_url" in result.output
+
+    def test_add_url_json_mode_emits_source_envelope(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.add_url = AsyncMock(
+                return_value=Source(id="src_new", title="T", url="https://x")
+            )
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                ["source", "add", "https://example.com", "-n", "nb_123", "--json"],
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["source"]["id"] == "src_new"
+        assert payload["source"]["title"] == "T"
+        assert payload["source"]["url"] == "https://x"
+
+
+# ----------------------------------------------------------------------------
+# source list
+# ----------------------------------------------------------------------------
+
+
+class TestSourceListCharacterization:
+    def test_list_text_mode_renders_rich_table(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[Source(id="src_1", title="One")])
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "list", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "Sources in nb_123" in result.output
+        assert "src_1" in result.output
+        assert "One" in result.output
+
+    def test_list_json_mode_emits_array_with_count(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(
+                return_value=[
+                    Source(
+                        id="src_1",
+                        title="One",
+                        url=None,
+                        status=SourceStatus.READY,
+                        created_at=datetime(2025, 1, 1, 12, 0, 0),
+                    )
+                ]
+            )
+            client.notebooks.get = AsyncMock(return_value=type("N", (), {"title": "NB"})())
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "list", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["notebook_id"] == "nb_123"
+        assert payload["count"] == 1
+        assert payload["sources"][0]["id"] == "src_1"
+        assert payload["sources"][0]["title"] == "One"
+
+
+# ----------------------------------------------------------------------------
+# source get
+# ----------------------------------------------------------------------------
+
+
+class TestSourceGetCharacterization:
+    def test_get_text_mode_prints_title_and_type(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get = AsyncMock(
+                return_value=Source(id="src_1", title="My Source", url=None)
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "get", "src_1", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "Source:" in result.output
+        assert "src_1" in result.output
+        assert "My Source" in result.output
+
+    def test_get_json_mode_emits_source_envelope(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get = AsyncMock(
+                return_value=Source(
+                    id="src_1",
+                    title="My Source",
+                    url="https://x",
+                    status=SourceStatus.READY,
+                )
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "get", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["found"] is True
+        assert payload["source"]["id"] == "src_1"
+        assert payload["source"]["url"] == "https://x"
+
+    def test_get_not_found_exits_1_text_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get = AsyncMock(return_value=None)
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "get",
+                    "11111111-2222-3333-4444-555555555555",
+                    "-n",
+                    "nb_123",
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_get_not_found_exits_1_json_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get = AsyncMock(return_value=None)
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "get",
+                    "11111111-2222-3333-4444-555555555555",
+                    "-n",
+                    "nb_123",
+                    "--json",
+                ],
+            )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["error"] is True
+        assert payload["code"] == "NOT_FOUND"
+
+
+# ----------------------------------------------------------------------------
+# source delete
+# ----------------------------------------------------------------------------
+
+
+class TestSourceDeleteCharacterization:
+    def test_delete_text_mode_with_yes_prints_deleted(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.delete = AsyncMock(return_value=True)
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "delete", "src_1", "-n", "nb_123", "-y"])
+        assert result.exit_code == 0
+        assert "Deleted source:" in result.output
+
+    def test_delete_json_mode_with_yes_emits_envelope(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.delete = AsyncMock(return_value=True)
+            cls.return_value = client
+            result = runner.invoke(
+                cli, ["source", "delete", "src_1", "-n", "nb_123", "-y", "--json"]
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["action"] == "delete"
+        assert payload["source_id"] == "src_1"
+        assert payload["success"] is True
+        assert payload["status"] == "deleted"
+
+
+# ----------------------------------------------------------------------------
+# source delete-by-title
+# ----------------------------------------------------------------------------
+
+
+class TestSourceDeleteByTitleCharacterization:
+    def test_delete_by_title_text_mode_with_yes(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(
+                return_value=[Source(id="src_999", title="Exact Title")]
+            )
+            client.sources.delete = AsyncMock(return_value=True)
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "delete-by-title",
+                    "Exact Title",
+                    "-n",
+                    "nb_123",
+                    "-y",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Deleted source:" in result.output
+
+    def test_delete_by_title_json_mode_with_yes(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(
+                return_value=[Source(id="src_999", title="Exact Title")]
+            )
+            client.sources.delete = AsyncMock(return_value=True)
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "delete-by-title",
+                    "Exact Title",
+                    "-n",
+                    "nb_123",
+                    "-y",
+                    "--json",
+                ],
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["action"] == "delete-by-title"
+        assert payload["source_id"] == "src_999"
+        assert payload["title"] == "Exact Title"
+
+
+# ----------------------------------------------------------------------------
+# source clean
+# ----------------------------------------------------------------------------
+
+
+class TestSourceCleanCharacterization:
+    def test_clean_already_clean_text_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[])
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "already clean" in result.output.lower()
+
+    def test_clean_already_clean_json_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[])
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["action"] == "clean"
+        assert payload["status"] == "already_clean"
+        assert payload["deleted_count"] == 0
+
+
+# ----------------------------------------------------------------------------
+# source fulltext
+# ----------------------------------------------------------------------------
+
+
+class TestSourceFulltextCharacterization:
+    def test_fulltext_text_mode_prints_content(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_1",
+                    title="T",
+                    content="hello world",
+                    char_count=11,
+                    url=None,
+                )
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "fulltext", "src_1", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "hello world" in result.output
+
+    def test_fulltext_json_mode_emits_dataclass_payload(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_1",
+                    title="T",
+                    content="hi",
+                    char_count=2,
+                    url=None,
+                )
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "fulltext", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["source_id"] == "src_1"
+        assert payload["content"] == "hi"
+        assert payload["char_count"] == 2
+
+
+# ----------------------------------------------------------------------------
+# source guide
+# ----------------------------------------------------------------------------
+
+
+class TestSourceGuideCharacterization:
+    def test_guide_text_mode_prints_summary_and_keywords(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get_guide = AsyncMock(
+                return_value={"summary": "summary text", "keywords": ["a", "b"]}
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "guide", "src_1", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "summary text" in result.output
+        assert "Keywords:" in result.output
+        assert "a, b" in result.output
+
+    def test_guide_json_mode_emits_summary_and_keywords(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.get_guide = AsyncMock(return_value={"summary": "s", "keywords": ["k1"]})
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "guide", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["source_id"] == "src_1"
+        assert payload["summary"] == "s"
+        assert payload["keywords"] == ["k1"]
+
+
+# ----------------------------------------------------------------------------
+# source add-research
+# ----------------------------------------------------------------------------
+
+
+class TestSourceAddResearchCharacterization:
+    def test_add_research_no_wait_returns_after_start(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "add-research",
+                    "machine learning",
+                    "-n",
+                    "nb_123",
+                    "--no-wait",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Task ID:" in result.output
+        assert "Research started" in result.output
+
+    def test_add_research_no_wait_with_import_all_is_usage_error(
+        self, runner, mock_auth, patched_fetch_tokens
+    ):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "add-research",
+                    "ml",
+                    "-n",
+                    "nb_123",
+                    "--no-wait",
+                    "--import-all",
+                ],
+            )
+        assert result.exit_code == 2
+        assert "--import-all requires" in result.output
+
+
+# ----------------------------------------------------------------------------
+# source wait
+# ----------------------------------------------------------------------------
+
+
+class TestSourceWaitCharacterization:
+    def test_wait_success_text_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.wait_until_ready = AsyncMock(
+                return_value=Source(id="src_1", title="Ready One")
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "wait", "src_1", "-n", "nb_123"])
+        assert result.exit_code == 0
+        assert "Source ready:" in result.output
+        assert "src_1" in result.output
+
+    def test_wait_success_json_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.wait_until_ready = AsyncMock(
+                return_value=Source(id="src_1", title="Ready", status=2)
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "wait", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "ready"
+        assert payload["source_id"] == "src_1"
+
+    def test_wait_not_found_exits_1_json_mode(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[Source(id="src_1", title="One")])
+            client.sources.wait_until_ready = AsyncMock(side_effect=SourceNotFoundError("src_1"))
+            cls.return_value = client
+            result = runner.invoke(
+                cli,
+                ["source", "wait", "src_1", "-n", "nb_123", "--json"],
+            )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "not_found"
+
+    def test_wait_processing_error_exits_1(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[Source(id="src_1", title="One")])
+            client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceProcessingError("src_1", status=4)
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "wait", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "error"
+        assert payload["status_code"] == 4
+
+    def test_wait_timeout_exits_2(self, runner, mock_auth, patched_fetch_tokens):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
+            client = create_mock_client()
+            client.sources.list = AsyncMock(return_value=[Source(id="src_1", title="One")])
+            client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceTimeoutError("src_1", timeout=5.0, last_status=3)
+            )
+            cls.return_value = client
+            result = runner.invoke(cli, ["source", "wait", "src_1", "-n", "nb_123", "--json"])
+        assert result.exit_code == 2
+        payload = json.loads(result.output)
+        assert payload["status"] == "timeout"
+        assert payload["last_status_code"] == 3


### PR DESCRIPTION
## Summary

Implements **P3.T5** (Phase 3 Wave 3.B). Splits `cli/source_cmd.py`
(1542 LOC) into thin Click handlers + 5 new `cli/services/source_*` modules
per **ADR-008**, with two pre-existing service modules extended for
symmetry.

**Before → after**:

| File | Before | After | Δ |
|---|---:|---:|---:|
| `src/notebooklm/cli/source_cmd.py` | 1542 | **697** | −55 % |

`source_cmd.py` is now under the **<700 LOC** target the phase artifact
specifies (which was framed against the pre-T0 baseline of 1457).

## 5 new service files

| Module | Plan dataclass | Executor | Builds on |
|---|---|---|---|
| `services/source_listing.py` | `SourceListPlan` | `execute_source_list` | `services/listing.py` |
| `services/source_mutations.py` | `SourceDeletePlan`, `SourceDeleteByTitlePlan`, `SourceRenamePlan`, `SourceRefreshPlan`, `SourceAddDrivePlan` | five executors + shared `resolve_source_for_delete`, `resolve_source_by_exact_title`, `require_yes_in_json` | `services/confirming_mutation.py` |
| `services/source_content.py` | `SourceGetPlan`, `SourceFulltextPlan`, `SourceGuidePlan`, `SourceStalePlan` | four executors |  |
| `services/source_research.py` | `SourceAddResearchPlan` | `execute_source_add_research` (task-id-pinned poll + optional import-all) |  |
| `services/source_wait.py` | `SourceWaitPlan` | `execute_source_wait` | `services/polling.py` |

Plus **extensions** to the two pre-T5 service files:

* `services/source_add.py` — added `SourceAddExecutionPlan` + `execute_source_add` (spinner brackets the awaited upload, P1.T2 bug 5).
* `services/source_clean.py` — added `SourceCleanPlan` + `execute_source_clean` (resolve-callbacks + JSON/text rendering).

## P1.T2 regression lockdown (8 bug-fix tests survive unchanged)

All P1.T2 regression tests pass **without modification** after the
extraction:

1. `source delete --json` without `--yes` → typed `CONFIRM_REQUIRED`, no prompt.
2. `source delete-by-title --json` without `--yes` → same typed error.
3. `source clean --json` with candidates and without `--yes` → same.
4. `source fulltext --json -o FILE` → metadata envelope on stdout, not duplicated content.
5. `source add` spinner brackets the actual upload (not the coroutine factory).
6. `source add-research` polling pins `task_id` from `research.start`.
7. `source add-research --no-wait --import-all` is a `click.UsageError`.
8. `source clean` partial-failure exits non-zero in both text and JSON modes.

## P2.T1 `require_notebook` lockdown

`source_cmd.py` does **not** touch `AuthSource` directly — every command
goes through `cli/resolve.py:require_notebook` (consolidated in **P2.T1**).
This is what keeps Wave 3.B parallel-safe (no symbol-flow dependency on
P3.T3's session split, which runs later in Wave 3.D).

## Characterization tests (commit 1)

`tests/unit/cli/test_source_characterization.py` — 25 golden CLI-runner
snapshots for the 10 commands listed in the P3.T5 spec
(`add/list/get/delete/delete-by-title/clean/fulltext/guide/add-research/wait`)
in **both text and JSON modes**. Passed on main HEAD `f1be552` before the
extraction landed (commit `96ea990`) and pass on the PR HEAD.

## Commit sequence

1. `96ea990` — characterization tests (must pass on main HEAD before extraction).
2. `0fb8098` — extraction (5 new service files + thinned source_cmd.py).

## Test plan

- [x] `uv run pytest tests/unit tests/integration` → 5760 passed, 12 skipped, 0 failed.
- [x] `uv run ruff format src/notebooklm/cli tests/unit/cli/test_source_characterization.py` → clean.
- [x] `uv run ruff check src/notebooklm/cli` → clean.
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` → clean.
- [x] `wc -l src/notebooklm/cli/source_cmd.py` → **697** (target <700).
- [x] Phase 10 CLI contract baseline (`tests/unit/cli/test_phase10_cli_contract.py`) matches byte-for-byte.
- [x] CLI boundary tests pass (`tests/unit/test_cli_boundary.py`) — service modules only use the public `output_error` alias, not `_output_error`.

Refs: `.sisyphus/phases/cli-audit-fixes/phase-3.md` § P3.T5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer source commands: add (including Drive), add-research (polling/import), fulltext (file output), guide, stale check, wait, clean, list, rename, refresh, and delete-by-title with improved JSON and human output.

* **Refactor**
  * CLI now delegates execution to unified service planners, improving consistent JSON envelopes, exit codes, confirmations, and user-facing messages (spinners suppressed in JSON).

* **Tests**
  * Added end-to-end tests validating text and --json outputs, exit codes, and key command flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->