### PR TITLE
fix(close): prevent httpx leak if close() is cancelled during drain (closes I12)

### DIFF
--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -427,13 +427,21 @@ class NotebookLMClient:
         - **Normal-success and drain-timeout paths**: on return,
           ``is_connected is False`` and the underlying
           ``httpx.AsyncClient`` is closed synchronously.
-        - **Cancel-during-drain path**: ``CancelledError`` is re-raised
-          immediately, but the shielded ``Session.close()`` Task
-          continues running in the background and closes the transport
-          to completion. Callers needing a synchronous teardown signal
-          on the cancel path can ``await asyncio.sleep(0)`` (or poll
-          ``is_connected``) after observing the cancel — the inner
-          Task is already scheduled at the point the cancel surfaces.
+        - **Cancel-during-drain path** (single cancellation): the
+          shielded ``Session.close()`` runs to completion synchronously
+          before ``CancelledError`` is re-raised — Python does not
+          re-raise ``CancelledError`` to the same task without an
+          explicit re-cancel, so the await on the shielded Task
+          blocks normally. On return, ``is_connected is False`` and
+          the transport is closed.
+        - **Cancel-during-drain path** (re-cancellation while awaiting
+          the shielded close): the shielded ``Session.close()`` Task is
+          isolated from the second cancel by ``asyncio.shield`` and
+          continues running in the background; the second cancel
+          surfaces in the awaiter, is suppressed, and the *original*
+          ``CancelledError`` is re-raised. ``is_connected`` settles to
+          ``False`` once the background Task lands (callers can
+          ``await asyncio.sleep(0)`` or poll to observe it).
 
         There is no path that leaves a live transport behind.
         """
@@ -451,18 +459,23 @@ class NotebookLMClient:
                 # the caller's task is cancelled while drain() is
                 # waiting (e.g. ``asyncio.wait_for`` deadline, manual
                 # ``task.cancel()``), we MUST still tear down the
-                # transport before letting the cancel propagate.
-                # ``asyncio.shield`` schedules ``Session.close()`` as a
-                # Task that survives the outer cancellation — the
-                # await here re-raises CancelledError to us, but the
-                # inner Task keeps running and drives ``Kernel.aclose()``
-                # to completion.
+                # transport before letting the cancel propagate. On a
+                # single cancellation this shielded await runs to
+                # completion synchronously (Python does not re-raise
+                # CancelledError without an explicit re-cancel). If a
+                # SECOND cancel arrives while we're parked here,
+                # ``asyncio.shield`` isolates the inner Session.close()
+                # Task so it continues in the background; the second
+                # cancel hits the awaiter and is swallowed below so the
+                # original CancelledError surfaces unchanged.
                 try:
                     await asyncio.shield(self._session.close())
                 except BaseException:
-                    # Swallow any error (including the CancelledError
-                    # propagated through the shield await) so the
-                    # original CancelledError surfaces unchanged below.
+                    # Swallow ANY exception from the shielded close
+                    # (close errors, or a re-cancel propagated through
+                    # the shield await) so the original CancelledError
+                    # below is the one that reaches the caller. The
+                    # inner shielded Task continues to run regardless.
                     pass
                 raise
             # Any other exception from drain (e.g. ``ValueError`` for a

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -470,12 +470,17 @@ class NotebookLMClient:
                 # original CancelledError surfaces unchanged.
                 try:
                     await asyncio.shield(self._session.close())
-                except BaseException:
-                    # Swallow ANY exception from the shielded close
-                    # (close errors, or a re-cancel propagated through
-                    # the shield await) so the original CancelledError
-                    # below is the one that reaches the caller. The
-                    # inner shielded Task continues to run regardless.
+                except (Exception, asyncio.CancelledError):
+                    # Swallow regular close failures and any re-cancel
+                    # propagated through the shield await so the
+                    # original CancelledError below is the one that
+                    # reaches the caller. The inner shielded Task
+                    # continues to run regardless.
+                    # NOTE: deliberately NOT catching ``BaseException`` —
+                    # ``KeyboardInterrupt`` and ``SystemExit`` are
+                    # process-exit signals that must propagate unchanged
+                    # (per CodeRabbit feedback on PR #950, comment
+                    # 3285205066).
                     pass
                 raise
             # Any other exception from drain (e.g. ``ValueError`` for a

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -21,6 +21,7 @@ Example:
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import logging
 import os
@@ -403,24 +404,87 @@ class NotebookLMClient:
         relying on fire-and-forget close semantics (e.g. via
         ``__aexit__``) will now block briefly on the drain step; pass
         ``drain=False`` explicitly to restore the old behavior.
+
+        Cancellation-safety contract (audit finding I12):
+
+        If the caller's task is cancelled while ``close(drain=True)`` is
+        still waiting on ``drain()`` (e.g. ``asyncio.wait_for`` deadline,
+        manual ``task.cancel()``), the underlying transport is STILL torn
+        down before the cancellation propagates. The drain await
+        explicitly catches ``CancelledError`` and schedules
+        ``Session.close()`` through ``asyncio.shield`` — the shield wraps
+        the inner close in a ``Task`` that survives the outer
+        cancellation, so the ``Kernel.aclose()`` it drives runs to
+        completion in the background. On the normal-success and
+        ``TimeoutError`` paths the same shielded close call runs inline.
+        ``ValueError`` (and any other unexpected exception) from
+        ``drain()`` propagates without an implicit close, matching the
+        pre-I12 caller-error semantics asserted by
+        ``test_close_with_invalid_drain_does_not_close_transport``.
+
+        Practical guarantee:
+
+        - **Normal-success and drain-timeout paths**: on return,
+          ``is_connected is False`` and the underlying
+          ``httpx.AsyncClient`` is closed synchronously.
+        - **Cancel-during-drain path**: ``CancelledError`` is re-raised
+          immediately, but the shielded ``Session.close()`` Task
+          continues running in the background and closes the transport
+          to completion. Callers needing a synchronous teardown signal
+          on the cancel path can ``await asyncio.sleep(0)`` (or poll
+          ``is_connected``) after observing the cancel — the inner
+          Task is already scheduled at the point the cancel surfaces.
+
+        There is no path that leaves a live transport behind.
         """
         if drain:
+            drain_timeout_exc: TimeoutError | None = None
             try:
                 await self.drain(timeout=drain_timeout)
-            except TimeoutError as drain_exc:
+            except TimeoutError as exc:
+                # Drain deadline missed. Hold onto the exception and
+                # fall through to the shielded close below so callers
+                # see both the timeout signal AND a torn-down transport.
+                drain_timeout_exc = exc
+            except asyncio.CancelledError:
+                # Cancellation-safety contract (audit finding I12): if
+                # the caller's task is cancelled while drain() is
+                # waiting (e.g. ``asyncio.wait_for`` deadline, manual
+                # ``task.cancel()``), we MUST still tear down the
+                # transport before letting the cancel propagate.
+                # ``asyncio.shield`` schedules ``Session.close()`` as a
+                # Task that survives the outer cancellation — the
+                # await here re-raises CancelledError to us, but the
+                # inner Task keeps running and drives ``Kernel.aclose()``
+                # to completion.
                 try:
-                    await self._session.close()
-                except Exception as close_exc:
+                    await asyncio.shield(self._session.close())
+                except BaseException:
+                    # Swallow any error (including the CancelledError
+                    # propagated through the shield await) so the
+                    # original CancelledError surfaces unchanged below.
+                    pass
+                raise
+            # Any other exception from drain (e.g. ``ValueError`` for a
+            # caller-provided invalid deadline) propagates here without
+            # an implicit close — matches pre-I12 caller-error semantics
+            # asserted by
+            # ``test_close_with_invalid_drain_does_not_close_transport``.
+
+            try:
+                await asyncio.shield(self._session.close())
+            except Exception as close_exc:
+                if drain_timeout_exc is not None:
                     logger.warning(
-                        "Suppressing close() error after drain timeout to preserve timeout "
-                        "signal: %s",
+                        "Suppressing close() error after drain timeout to "
+                        "preserve timeout signal: %s",
                         close_exc,
                     )
-                    raise drain_exc from close_exc
+                    raise drain_timeout_exc from close_exc
                 raise
-            else:
-                await self._session.close()
-                return
+            if drain_timeout_exc is not None:
+                raise drain_timeout_exc
+            return
         await self._session.close()
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -234,3 +234,135 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
         # Release the patched hang so any still-pending keepalive task
         # can exit cleanly before pytest-asyncio's loop teardown runs.
         hang_event.set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_drain_in_close_does_not_leak_transport(
+    keepalive_auth: AuthTokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel arriving DURING ``client.close(drain=True)``'s drain must not leak.
+
+    Sibling test to ``test_close_during_keepalive_cancel_does_not_leak_transport``
+    above. That test covers the shielded inner-close path (cancel lands
+    *inside* ``aclose`` while ``Session.close`` is already running). This
+    test covers the **outer-wrapper** path (cancel lands while
+    ``NotebookLMClient.close()`` is still awaiting ``self.drain(...)``,
+    i.e. BEFORE ``self._session.close()`` is reached). Audit finding I12
+    (``architecture-audit.md``) flagged that the public wrapper at
+    ``client.py:close()`` awaits ``self.drain(...)`` *before* calling
+    ``self._session.close()`` with no protection; if the caller task is
+    cancelled while drain is parked on an in-flight operation,
+    ``CancelledError`` propagates out of ``close()`` and the shielded
+    ``Session.close()`` / ``Kernel.aclose()`` never runs — leaking the
+    live ``httpx.AsyncClient``.
+
+    Repro setup:
+
+    - Open the client.
+    - Capture ``http_client_ref`` BEFORE the cancel (successful close
+      nulls the kernel's transport attribute).
+    - Monkeypatch ``client._session.drain`` to park on an unset
+      ``asyncio.Event`` so drain() blocks indefinitely; the only exit is
+      the ``CancelledError`` injected by the outer ``wait_for`` deadline.
+    - Drive ``close(drain=True)`` through ``asyncio.wait_for(timeout=0.1)``
+      so the cancel reliably lands while ``drain`` is parked.
+
+    Expected invariant (regression assertion):
+
+    - After the cancel, ``client.is_connected`` must be ``False`` AND
+      ``http_client_ref.is_closed`` must be ``True`` — proving the outer
+      wrapper drove ``Session.close()`` to completion despite the cancel
+      that fired mid-drain. Pre-fix this assertion fails: cancel exits
+      ``NotebookLMClient.close()`` before ``self._session.close()`` is
+      reached and the transport stays open.
+    """
+    client = NotebookLMClient(keepalive_auth)
+    await client.__aenter__()
+    # Track whether close() managed to enter the failing-test side branch
+    # cleanly; if the worktree finally is reached without close having
+    # been started, ``aexit_failed`` stays False and we let the regular
+    # __aexit__ run in the finally.
+    aexit_succeeded = False
+    try:
+        # Capture the transport ref BEFORE the cancel — successful close
+        # nulls ``_kernel.http_client``, so we'd lose the handle.
+        http_client_ref = client._session._kernel.get_http_client()
+        assert http_client_ref is not None, "open() must have installed a transport"
+
+        # Park ``drain`` on an unset event. The only way out is the
+        # ``CancelledError`` that the outer ``wait_for`` injects when
+        # its 0.1 s deadline fires. This reproduces the production case
+        # where ``drain()`` is awaiting an in-flight operation that
+        # outlives the caller's cancel.
+        drain_entered = asyncio.Event()
+        hang_event = asyncio.Event()
+
+        async def _hanging_drain(*_args: object, **_kwargs: object) -> None:
+            drain_entered.set()
+            await hang_event.wait()
+
+        monkeypatch.setattr(client._session, "drain", _hanging_drain)
+
+        # Drive ``close(drain=True)`` through a short ``wait_for`` so a
+        # cancel lands while ``drain`` is parked. The cancel propagates
+        # out of ``wait_for`` as ``TimeoutError``; pre-fix it also
+        # exits ``NotebookLMClient.close()`` before reaching
+        # ``self._session.close()``, leaking the transport.
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await asyncio.wait_for(
+                client.close(drain=True),
+                timeout=0.1,
+            )
+
+        # Confirm the cancel actually landed mid-drain (test invariant).
+        # If drain_entered never fired, the cancel arrived before we
+        # reached the drain await and the test wouldn't be exercising
+        # the outer-wrapper bug.
+        assert drain_entered.is_set(), (
+            "test invariant: ``drain`` must have been entered before the "
+            "outer wait_for cancel fired; otherwise the cancel didn't land "
+            "during drain and the bug surface isn't being exercised"
+        )
+
+        # Release the patched drain hang so any pending shielded close
+        # task (post-fix) can make progress; pre-fix this is a no-op
+        # because close() already abandoned.
+        hang_event.set()
+
+        # Bounded poll: the shielded ``Session.close()`` runs as a
+        # background task; give it up to ~1 s to complete on slow CI.
+        for _ in range(100):
+            if not client.is_connected and http_client_ref.is_closed:
+                break
+            await asyncio.sleep(0.01)
+
+        # The regression assertions. Pre-fix both fail (is_connected
+        # stays True, is_closed stays False) because the cancel skipped
+        # ``self._session.close()`` entirely. Post-fix both hold because
+        # the ``finally: await asyncio.shield(self._session.close())``
+        # in ``NotebookLMClient.close()`` drives the shielded cleanup
+        # regardless of the cancel.
+        assert not client.is_connected, (
+            "transport leaked: cancel during drain() left client.is_connected "
+            "= True — NotebookLMClient.close() abandoned cleanup before "
+            "self._session.close() was reached (audit finding I12)"
+        )
+        assert http_client_ref.is_closed, (
+            "transport leaked: cancel during drain() left the httpx "
+            "AsyncClient open — NotebookLMClient.close() abandoned cleanup "
+            "before Session.close()/Kernel.aclose() were reached (audit "
+            "finding I12)"
+        )
+        aexit_succeeded = True
+    finally:
+        # If the test path above did not drive close() to completion
+        # (e.g. an assertion fired before the post-cancel poll), make a
+        # best-effort cleanup so pytest-asyncio's loop teardown doesn't
+        # surface a "transport not closed" warning. The drain monkeypatch
+        # is auto-reverted by pytest.MonkeyPatch on test exit.
+        if not aexit_succeeded:
+            try:
+                await client.close(drain=False)
+            except Exception:
+                pass

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -340,9 +340,9 @@ async def test_cancel_during_drain_in_close_does_not_leak_transport(
         # The regression assertions. Pre-fix both fail (is_connected
         # stays True, is_closed stays False) because the cancel skipped
         # ``self._session.close()`` entirely. Post-fix both hold because
-        # the ``finally: await asyncio.shield(self._session.close())``
-        # in ``NotebookLMClient.close()`` drives the shielded cleanup
-        # regardless of the cancel.
+        # the ``except asyncio.CancelledError:`` branch in
+        # ``NotebookLMClient.close()`` drives ``asyncio.shield(self._session.close())``
+        # before re-raising the cancel.
         assert not client.is_connected, (
             "transport leaked: cancel during drain() left client.is_connected "
             "= True — NotebookLMClient.close() abandoned cleanup before "


### PR DESCRIPTION
## Summary

- **Audit fix**: closes I12 from `.sisyphus/plans/architecture-audit.md` — the public `NotebookLMClient.close(drain=True)` wrapper leaked the underlying `httpx.AsyncClient` if the caller task was cancelled while `drain()` was waiting on an in-flight operation, because `CancelledError` propagated out of `close()` before `self._session.close()` (the shielded inner cleanup) was ever reached.
- **Fix**: refactored `close(drain=True)` into an explicit four-branch decision tree — drain success, `TimeoutError`, `CancelledError` (the I12 case), and other exceptions — wrapping the inner close in `asyncio.shield` so the `Session.close()` Task completes in the background even when the outer await is cancelled.
- **TDD**: added sibling test `test_cancel_during_drain_in_close_does_not_leak_transport` (verified red-first against the unmodified `close()`, green after the fix) alongside the existing inner-close-shielding regression test.

## Task

- Phase plan: `.sisyphus/phases/architecture-audit-fixes/phase-1.md` — Task PR-B (Wave 1).
- Source plan: `.sisyphus/plans/architecture-audit-fixes.md` (TODOs item 2).
- Finding: `.sisyphus/plans/architecture-audit.md` I12.

## Test plan

- [x] `uv run ruff format --check .` (482 files formatted)
- [x] `uv run ruff check .` (all checks passed)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (142 files, 0 issues)
- [x] `uv run pytest tests/unit -q` (5023 passed, 44 skipped — full unit suite)
- [x] New TDD test `test_cancel_during_drain_in_close_does_not_leak_transport` red against unmodified `close()`, green after fix
- [x] Existing tests preserved: `test_close_during_keepalive_cancel_does_not_leak_transport` (inner-close shield), `test_close_drains_when_drain_true_and_drain_times_out` (drain timeout → still close, then raise TimeoutError), `test_close_with_invalid_drain_does_not_close_transport` (caller-error → no implicit close)

## Behavior contract (now documented in the `close()` docstring)

| drain outcome | `Session.close()` runs? | Raises |
|---|---|---|
| success | yes (shielded, synchronous) | — |
| `TimeoutError` | yes (shielded, synchronous) | `TimeoutError` (close error suppressed in favor of timeout signal) |
| `CancelledError` (NEW — I12) | yes (shielded, **background**) | `CancelledError` re-raised immediately; inner Task finishes in background |
| `ValueError` etc. (caller error) | no | original exception (pre-I12 semantics preserved) |

## Files

- `src/notebooklm/client.py` — added `import asyncio`; refactored `NotebookLMClient.close()` with the four-branch shape; added cancellation-safety contract section to the docstring.
- `tests/unit/concurrency/test_close_cancellation_leak.py` — added `test_cancel_during_drain_in_close_does_not_leak_transport` as a sibling to the existing inner-close-shielding test.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown now reliably completes underlying connection teardown even if the caller is cancelled or a timeout occurs while shutdown is in progress, preventing transport/resource leaks.

* **Tests**
  * Added a regression test that simulates cancellation during shutdown and verifies transports and connections are fully cleaned up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->