### PR TITLE
refactor(middleware): extract resolve_sleep helper (closes CC1)

### DIFF
--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -69,7 +69,6 @@ PR sequence.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
@@ -79,6 +78,7 @@ import httpx
 from ._authed_transport import TransportAuthExpired
 from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._session_config import CORE_LOGGER_NAME
+from ._session_helpers import resolve_sleep
 
 if TYPE_CHECKING:
     from ._client_metrics import ClientMetrics
@@ -118,8 +118,8 @@ class AuthRefreshMiddleware:
       attr on the live client still takes effect (matches the live-binding
       contract preserved for retry budgets in PR 12.7).
     - ``sleep``: optional sleep injection (defaults to :func:`asyncio.sleep`
-      resolved at call time). Same lazy-resolve pattern as
-      :class:`RetryMiddleware`.
+      resolved at call time via :func:`_session_helpers.resolve_sleep` —
+      the same shared helper :class:`RetryMiddleware` uses).
     - ``logger``: structured logger for the "auth error detected" /
       "refresh successful" / "refresh failed" info / warning lines.
       Defaults to the project-canonical ``notebooklm._core`` logger so
@@ -144,13 +144,10 @@ class AuthRefreshMiddleware:
         self._is_auth_error = is_auth_error
         self._refresh_callback_enabled = refresh_callback_enabled
         self._refresh_retry_delay = refresh_retry_delay
-        # See ``RetryMiddleware._resolve_sleep`` for the lazy-binding rationale.
+        # Late-binding rationale lives on ``_session_helpers.resolve_sleep``.
         self._sleep = sleep
         self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
         self._metrics = metrics
-
-    def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:
-        return self._sleep if self._sleep is not None else asyncio.sleep
 
     async def __call__(
         self,
@@ -223,7 +220,7 @@ class AuthRefreshMiddleware:
 
             delay = self._refresh_retry_delay()
             if delay > 0:
-                await self._resolve_sleep()(delay)
+                await resolve_sleep(self._sleep)(delay)
             self._logger.info("Token refresh successful, retrying %s", log_label)
             if self._metrics is not None:
                 self._metrics.increment(rpc_auth_retries=1)

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -64,7 +64,6 @@ PR sequence.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
@@ -73,6 +72,7 @@ from ._authed_transport import TransportRateLimited, TransportServerError, parse
 from ._backoff import compute_backoff_delay
 from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._session_config import CORE_LOGGER_NAME
+from ._session_helpers import resolve_sleep
 
 if TYPE_CHECKING:
     from ._client_metrics import ClientMetrics
@@ -135,19 +135,12 @@ class RetryMiddleware:
         # the int form.
         self._rate_limit_max = rate_limit_max_retries
         self._server_error_max = server_error_max_retries
-        # ``None`` defers resolution to call time so a test that
-        # ``monkeypatch.setattr("asyncio.sleep", ...)`` (or anywhere
-        # asyncio.sleep is exposed) observes the fake. Capturing
-        # ``asyncio.sleep`` at construction would freeze the binding to
-        # whatever was imported when the middleware was instantiated,
-        # silently bypassing later monkeypatches.
+        # Late-binding rationale lives on ``_session_helpers.resolve_sleep``;
+        # see that helper for why we resolve at call time instead of capturing
+        # the callable at construction.
         self._sleep = sleep
         self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
         self._metrics = metrics
-
-    def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:
-        """Return the call-time sleep function — fake-or-real."""
-        return self._sleep if self._sleep is not None else asyncio.sleep
 
     def _resolve_rate_limit_max(self) -> int:
         v = self._rate_limit_max
@@ -251,7 +244,7 @@ class RetryMiddleware:
             attempt + 1,
             rate_limit_max,
         )
-        await self._resolve_sleep()(sleep_seconds)
+        await resolve_sleep(self._sleep)(sleep_seconds)
 
     async def _wait_for_server_error(
         self,
@@ -287,7 +280,7 @@ class RetryMiddleware:
             attempt + 1,
             server_error_max,
         )
-        await self._resolve_sleep()(backoff)
+        await resolve_sleep(self._sleep)(backoff)
 
 
 __all__ = ["RetryMiddleware"]

--- a/src/notebooklm/_session_helpers.py
+++ b/src/notebooklm/_session_helpers.py
@@ -16,9 +16,12 @@ __all__ = [
     "AUTH_ERROR_PATTERNS",
     "_resolve_keepalive_interval",
     "is_auth_error",
+    "resolve_sleep",
 ]
 
+import asyncio
 import math
+from collections.abc import Awaitable, Callable
 
 import httpx
 
@@ -58,6 +61,26 @@ def _resolve_keepalive_interval(keepalive: float | None, min_interval: float) ->
     if not (math.isfinite(keepalive) and keepalive > 0):
         raise ValueError(f"keepalive must be None or a positive finite number, got {keepalive!r}")
     return max(keepalive, min_interval)
+
+
+def resolve_sleep(
+    injected: Callable[[float], Awaitable[object]] | None,
+) -> Callable[[float], Awaitable[object]]:
+    """Return the call-time sleep function — injected fake-or-real ``asyncio.sleep``.
+
+    Used by ``RetryMiddleware`` and ``AuthRefreshMiddleware`` to honor a
+    constructor-time fake while still resolving the real ``asyncio.sleep`` at
+    call time. Resolving via the ``asyncio`` module global on each call (rather
+    than capturing the callable at construction) is what preserves test
+    late-binding: a ``monkeypatch.setattr('asyncio.sleep', ...)`` (which mutates
+    the singleton ``asyncio`` module's ``sleep`` attribute) is observed by every
+    caller that hits this helper, because ``asyncio.sleep`` is re-read from the
+    module's ``__dict__`` on every invocation of ``resolve_sleep``. Capturing
+    ``asyncio.sleep`` at module-import or middleware-construction time would
+    freeze the binding to whatever was imported then and silently bypass later
+    monkeypatches — that's the bug this helper exists to prevent.
+    """
+    return injected if injected is not None else asyncio.sleep
 
 
 def is_auth_error(error: Exception) -> bool:

--- a/tests/unit/test_session_helpers.py
+++ b/tests/unit/test_session_helpers.py
@@ -1,0 +1,200 @@
+"""Unit tests for :mod:`notebooklm._session_helpers`.
+
+Currently focused on :func:`resolve_sleep` — the shared helper that
+replaces the duplicated ``_resolve_sleep`` methods previously defined on
+both :class:`RetryMiddleware` and :class:`AuthRefreshMiddleware` (audit
+finding CC1).
+
+The contract pinned here:
+
+- **Injected callable wins** — ``resolve_sleep(injected)`` returns the
+  injected callable verbatim when it is not ``None``.
+- **None resolves to ``asyncio.sleep`` at call time** — capturing the
+  module-level attribute on each invocation rather than at import time.
+- **Late binding through middlewares** — both ``RetryMiddleware`` and
+  ``AuthRefreshMiddleware`` observe a ``monkeypatch.setattr`` of
+  ``asyncio.sleep`` because they call ``resolve_sleep(self._sleep)``
+  per backoff/retry, and ``resolve_sleep`` re-reads the ``asyncio``
+  module attribute every time.
+
+This is the regression test for the audit-CC1 extraction: the duplicated
+helper is gone, but the late-binding semantics tests previously relied
+on (``monkeypatch.setattr("asyncio.sleep", ...)``) still work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+
+import httpx
+import pytest
+
+from _fixtures.chain import make_request
+from notebooklm._authed_transport import TransportServerError
+from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
+from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
+from notebooklm._middleware_retry import RetryMiddleware
+from notebooklm._session_helpers import is_auth_error, resolve_sleep
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for resolve_sleep
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sleep_returns_injected_when_provided() -> None:
+    """A non-``None`` injection is returned verbatim — no proxying."""
+
+    async def fake(_seconds: float) -> None:
+        return None
+
+    assert resolve_sleep(fake) is fake
+
+
+def test_resolve_sleep_returns_asyncio_sleep_when_none() -> None:
+    """``None`` resolves to the canonical ``asyncio.sleep``."""
+
+    assert resolve_sleep(None) is asyncio.sleep
+
+
+def test_resolve_sleep_late_binds_asyncio_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``monkeypatch.setattr('asyncio.sleep', ...)`` is observed at call time.
+
+    The helper re-reads ``asyncio.sleep`` from the ``asyncio`` module global
+    on every invocation, so patches that mutate the singleton ``asyncio``
+    module's ``sleep`` attribute reach every caller. Capturing
+    ``asyncio.sleep`` at import or construction time would freeze the binding
+    and silently bypass the patch — that's the bug this helper exists to
+    prevent.
+    """
+
+    async def fake(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", fake)
+    assert resolve_sleep(None) is fake
+
+
+# ---------------------------------------------------------------------------
+# End-to-end late-binding through both middlewares
+# ---------------------------------------------------------------------------
+
+
+def _server_error(status: int = 503) -> TransportServerError:
+    request = httpx.Request("POST", "https://example.test/x")
+    response = httpx.Response(status, request=request)
+    original = httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+    return TransportServerError(
+        f"server error (HTTP {status})",
+        original=original,
+        response=response,
+        status_code=status,
+    )
+
+
+def _auth_error_http(status: int = 401) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://example.test/x")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def _ok() -> httpx.Response:
+    request = httpx.Request("POST", "https://example.test/x")
+    return httpx.Response(200, request=request, content=b"ok")
+
+
+def _scripted_terminal(behaviors: list[object]) -> NextCall:
+    iterator = iter(behaviors)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        nxt = next(iterator)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        assert isinstance(nxt, httpx.Response)
+        return RpcResponse(response=nxt, context=request.context)
+
+    return terminal
+
+
+@pytest.mark.asyncio
+async def test_retry_middleware_observes_monkeypatched_asyncio_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RetryMiddleware honors a ``monkeypatch.setattr('asyncio.sleep', ...)``.
+
+    The middleware is constructed without a ``sleep=`` injection, so the
+    no-jitter / no-real-time backoff comes from late-binding to the
+    monkeypatched ``asyncio.sleep`` instead of the real coroutine.
+    """
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    # No ``sleep=`` injection — the middleware must resolve ``asyncio.sleep``
+    # at call time via the shared helper.
+    middleware = RetryMiddleware(rate_limit_max_retries=0, server_error_max_retries=1)
+    chain = build_chain([middleware], _scripted_terminal([_server_error(), _ok()]))
+
+    response = await chain(make_request())
+
+    assert response.response.status_code == 200
+    assert len(sleeps) == 1, "expected exactly one backoff sleep before retry"
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_middleware_observes_monkeypatched_asyncio_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AuthRefreshMiddleware honors a ``monkeypatch.setattr('asyncio.sleep', ...)``.
+
+    Forces a post-refresh sleep by setting ``refresh_retry_delay`` > 0 and
+    asserts the patched ``asyncio.sleep`` (not the real one) is invoked.
+    """
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    refresh_calls: list[int] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(1)
+
+    def _live_delay() -> float:
+        return 0.25
+
+    middleware = AuthRefreshMiddleware(
+        refresh_callable=refresh,
+        is_auth_error=is_auth_error,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=_live_delay,
+        # No ``sleep=`` injection — must late-bind to monkeypatched
+        # ``asyncio.sleep`` via the shared helper.
+    )
+    chain = build_chain([middleware], _scripted_terminal([_auth_error_http(401), _ok()]))
+
+    response = await chain(make_request())
+
+    assert response.response.status_code == 200
+    assert refresh_calls == [1]
+    assert sleeps == [pytest.approx(0.25)], (
+        "expected exactly one post-refresh sleep at the configured delay, "
+        "routed through the monkeypatched asyncio.sleep"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_sleep_directly_invokable_is_awaitable() -> None:
+    """Sanity-check that ``resolve_sleep(None)(0)`` is awaitable.
+
+    Guards against accidentally returning a non-coroutine callable from the
+    helper. We pass ``0`` so the test runs instantly with no real sleep.
+    """
+    result = resolve_sleep(None)(0)
+    assert isinstance(result, Awaitable)
+    await result


### PR DESCRIPTION
## Summary

- Lifts the duplicated `_resolve_sleep` method out of `RetryMiddleware` and `AuthRefreshMiddleware` into a shared `resolve_sleep` top-level function in `_session_helpers.py` (audit finding **CC1**).
- Both middlewares now call `await resolve_sleep(self._sleep)(seconds)` so semantics are bit-for-bit equivalent to the prior `await self._resolve_sleep()(seconds)`.
- Adds `tests/unit/test_session_helpers.py` pinning the late-binding contract directly and end-to-end through both middlewares.

## Why it's safe

- **No behavior change.** `resolve_sleep(injected)` returns `injected` when not `None`, otherwise the module-global `asyncio.sleep`. Late binding to `asyncio.sleep` is preserved because the helper re-reads the `asyncio` module global on every call rather than capturing at construction.
- **Tests cover the seam.** New tests assert `monkeypatch.setattr('asyncio.sleep', ...)` is observed by the helper directly and end-to-end through `RetryMiddleware` (server-error retry backoff) and `AuthRefreshMiddleware` (post-refresh sleep).
- **Audit closure.** Closes CC1 (`.sisyphus/plans/architecture-audit.md`).

## Task

Wave-1 PR-G of `.sisyphus/phases/architecture-audit-fixes/phase-1.md` — extracts duplicated `_resolve_sleep` per `.sisyphus/plans/architecture-audit-fixes.md` TODO item 7.

## Test plan

- [x] `uv run ruff format --check .` clean (483 files).
- [x] `uv run ruff check .` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (142 source files).
- [x] `uv run pytest tests/unit -q` green (5028 passed, 44 skipped) — includes 5 new `test_session_helpers.py` tests covering injection wins, none→`asyncio.sleep`, monkeypatch late-binding directly, and monkeypatch late-binding through each middleware.
- [x] `rg '_resolve_sleep' src/notebooklm/_middleware_*.py` returns zero matches.
- [x] `resolve_sleep` defined once in `_session_helpers.py` and listed in `__all__`.

## Deferred polish findings

- `__all__` in `_session_helpers.py` mixes underscore (`_resolve_keepalive_interval`) with no-underscore (`is_auth_error`, new `resolve_sleep`) entries. Pre-existing convention; out of scope for CC1.
- `tests/unit/test_session_helpers.py::test_resolve_sleep_directly_invokable_is_awaitable` is belt-and-suspenders next to `test_resolve_sleep_returns_asyncio_sleep_when_none`. Kept — costs nothing.

## Polish

- Code-simplifier: no findings.
- Triple code review (claude + codex; agy excluded per local config): 0 critical, 0 important, 3 nits. Nit #2 (docstring cross-reference in `_middleware_auth_refresh.py`) applied in this PR. Both reviewers verdict: `READY-TO-SHIP`.
- Ultrathink: no concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating shared sleep function handling across middleware components, reducing code duplication.

* **Tests**
  * Added comprehensive unit tests covering sleep resolution behavior and middleware interaction patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->