### PR TITLE
fix(loop-affinity): guard upload + drain admission paths (closes C1)

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -724,6 +724,7 @@ IDEMPOTENCY_REGISTRY.register(
 # won't drown in WARN spam. The choice of 30s mirrors the cadence of
 # similar advisory-log throttles elsewhere in the codebase.
 _AT_LEAST_ONCE_LOG_INTERVAL: float = 30.0
+# Audit CC6: single-loop-per-client invariant per ADR-004; not safe for multi-loop fan-out.
 _at_least_once_last_logged: dict[tuple[RPCMethod, str | None], float] = {}
 
 

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 # Task storage from GC-ing them mid-flight. Sharing one set across all
 # ``NoteService`` instances is correct and simpler than per-instance
 # bookkeeping — there is no per-instance state on the tasks themselves.
+# Audit CC6: single-loop-per-client invariant per ADR-004; not safe for multi-loop fan-out.
 _cleanup_tasks: set[asyncio.Task[Any]] = set()
 
 

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -25,6 +25,7 @@ from ._session_config import (
 from ._session_contracts import (
     AuthMetadata,
     Kernel,
+    LoopGuard,
     OperationScopeProvider,
     RpcCaller,
 )
@@ -70,13 +71,19 @@ class RpcCallback(Protocol):
     ) -> Any: ...
 
 
-class UploadRuntime(RpcCaller, OperationScopeProvider, Protocol):
+class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
     """Runtime capabilities required by source upload.
 
-    Combines :class:`RpcCaller` (``rpc_call`` method) and
+    Combines :class:`RpcCaller` (``rpc_call`` method),
     :class:`OperationScopeProvider` (``operation_scope`` async-context
-    manager) — the only ``Session`` surfaces the pipeline needs at runtime.
-    A concrete :class:`Session` structurally satisfies this Protocol.
+    manager), and :class:`LoopGuard` (``assert_bound_loop`` method) — the
+    only ``Session`` surfaces the pipeline needs at runtime. A concrete
+    :class:`Session` structurally satisfies this Protocol.
+
+    Audit C1: ``LoopGuard`` is included so :meth:`SourceUploadPipeline.add_file`
+    can short-circuit cross-loop misuse *before* entering
+    ``operation_scope`` or lazily allocating the per-loop upload semaphore.
+    Mirrors the ``ChatRuntime`` / ``ArtifactsRuntime`` pattern.
     """
 
 
@@ -144,6 +151,7 @@ ListSources = Callable[[str], Awaitable[list[Source]]]
 QueueWaitRecorder = Callable[[float], None]
 
 
+# Audit CC6: single-loop-per-client invariant per ADR-004; not safe for multi-loop fan-out.
 _BACKGROUND_CANCEL_TASKS: set[asyncio.Task[None]] = set()
 
 
@@ -282,6 +290,12 @@ class SourceUploadPipeline:
         logger: Any,
     ) -> Source:
         """Add a file source to a notebook using resumable upload."""
+        # Audit C1: catch cross-loop add_file *before* touching
+        # ``operation_scope`` or lazily allocating the upload semaphore.
+        # Both are loop-bound on first use, so a cross-loop call would
+        # otherwise attach a primitive to the wrong loop before the
+        # documented ``RuntimeError`` guard fires (ADR-004).
+        self._runtime.assert_bound_loop()
         logger.debug("Adding file source to notebook %s: %s", notebook_id, file_path)
         if mime_type is not None:
             warnings.warn(

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -143,7 +143,16 @@ class TransportDrainTracker:
         is what lets an in-flight source upload finish its sub-RPCs after
         ``drain()`` starts. See
         ``tests/unit/test_observability.py::test_drain_allows_nested_work_inside_accepted_operation``.
+
+        Audit C1: catch cross-loop admission *before* touching the lazy
+        ``_drain_condition``. The condition is loop-bound on first
+        ``get_drain_condition`` — a cross-loop call would either silently
+        bind it to the wrong loop or hang on ``async with condition``
+        against a primitive belonging to the originally-bound loop.
+        Mirrors the existing guard in :meth:`drain` so both admission
+        and shutdown paths surface the same diagnostic.
         """
+        assert_bound_loop(self._bound_loop)
         condition = self.get_drain_condition()
         task = asyncio.current_task()
         depth = self.current_operation_depth(task)

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -212,3 +212,61 @@ def test_chat_ask_guards_against_cross_loop_call() -> None:
             asyncio.run(inner())
     finally:
         other_loop.close()
+
+
+def test_add_file_guards_against_cross_loop_call() -> None:
+    """``SourceUploadPipeline.add_file`` must raise on cross-loop misuse.
+
+    Regression guard for audit finding C1: previously the upload pipeline
+    entered ``operation_scope`` and acquired the lazy upload
+    ``asyncio.Semaphore`` *before* any loop check, so a cross-loop
+    ``client.sources.add_file(...)`` could attach the semaphore to the
+    wrong loop before the documented ``RuntimeError`` guard fired.
+
+    The new contract: ``add_file`` calls ``runtime.assert_bound_loop()`` as
+    its first statement (mirroring ``ArtifactPollingService.wait_for_completion``
+    and ``ChatAPI.ask``) so cross-loop misuse surfaces a clean
+    ``RuntimeError`` before any loop-bound primitive is touched. The
+    ``UploadRuntime`` Protocol must declare ``LoopGuard`` so the
+    structural type check covers the new attribute.
+    """
+    from notebooklm._source_upload import SourceUploadPipeline
+
+    runtime = MagicMock()
+    runtime.assert_bound_loop = MagicMock(
+        side_effect=RuntimeError("NotebookLM client used from a different event loop")
+    )
+    kernel = MagicMock()
+    auth = MagicMock()
+
+    # Construct the pipeline outside any running loop — its ``__init__`` is
+    # event-loop-agnostic; the cross-loop guard fires inside ``add_file``.
+    pipeline = SourceUploadPipeline(runtime, kernel, auth)
+
+    async def _unused(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - guard fires first
+        raise AssertionError("upload collaborator should not run on cross-loop call")
+
+    async def inner() -> None:
+        await pipeline.add_file(
+            "nb-id",
+            "/nonexistent/path/should-never-be-touched.pdf",
+            register_file_source=_unused,
+            start_resumable_upload=_unused,
+            upload_file_streaming=_unused,
+            wait_until_ready=_unused,
+            wait_until_registered=_unused,
+            rename=_unused,
+            logger=MagicMock(),
+        )
+
+    with pytest.raises(RuntimeError, match="different event loop"):
+        asyncio.run(inner())
+
+    # Confirm the cross-loop guard fired *before* any collaborator was
+    # touched. Three independent witnesses to the contract: the guard
+    # was called once, ``operation_scope`` (the loop-bound async-context
+    # manager the audit specifically calls out) was never entered, and
+    # the lazy upload semaphore was never allocated.
+    runtime.assert_bound_loop.assert_called_once()
+    runtime.operation_scope.assert_not_called()
+    assert pipeline._upload_semaphore is None

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -66,6 +66,11 @@ def mock_core():
 
     core.operation_scope.side_effect = operation_scope
     core.record_upload_queue_wait = MagicMock()
+    # Audit C1: ``UploadRuntime`` now includes ``LoopGuard`` so
+    # :meth:`SourceUploadPipeline.add_file` short-circuits cross-loop
+    # misuse. MagicMock blocks ``assert``-prefixed attribute access as a
+    # foot-gun guard, so the no-op stub must be installed explicitly.
+    core.assert_bound_loop = MagicMock()
     return core
 
 

--- a/tests/unit/test_transport_drain.py
+++ b/tests/unit/test_transport_drain.py
@@ -296,3 +296,40 @@ def test_token_is_frozen_dataclass() -> None:
     token = _TransportOperationToken(task=None)
     with pytest.raises(FrozenInstanceError):
         token.task = None  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Cross-loop affinity guard on the admission entry-point (audit C1)
+# ---------------------------------------------------------------------------
+
+
+def test_begin_transport_post_guards_against_cross_loop_call() -> None:
+    """``begin_transport_post`` must raise on cross-loop misuse.
+
+    Regression guard for audit finding C1: ``drain()`` already calls
+    :func:`assert_bound_loop` before touching the lazy ``asyncio.Condition``,
+    but the admission entry-point ``begin_transport_post`` previously did
+    not — so a cross-loop POST admission could either silently bind the
+    Condition to the wrong loop (if the admission won the lazy-init race)
+    or hang on ``async with condition`` against a loop-A-bound primitive
+    when called from loop B. Bind the tracker to a foreign loop, then
+    drive ``begin_transport_post`` from a fresh ``asyncio.run`` — the
+    guard must surface the cross-loop misuse with the same diagnostic
+    the transport guard uses.
+    """
+    tracker = TransportDrainTracker()
+    other_loop = asyncio.new_event_loop()
+    try:
+        tracker.set_bound_loop(other_loop)
+
+        async def inner() -> None:
+            await tracker.begin_transport_post("test")
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+        # Confirm the cross-loop guard fired *before* the lazy
+        # ``_drain_condition`` was allocated — the whole point of the
+        # guard is to prevent a foreign loop from binding the condition.
+        assert tracker._drain_condition is None
+    finally:
+        other_loop.close()


### PR DESCRIPTION
## Summary

Closes audit findings **C1** and **CC6** from `.sisyphus/plans/architecture-audit.md` (phase plan: `.sisyphus/phases/architecture-audit-fixes/phase-1.md`, Task PR-A).

- **C1 — Loop-affinity gap (correctness).** Two entry-points touched loop-bound primitives before any affinity check, violating ADR-004:
  - `SourceUploadPipeline.add_file` entered `operation_scope` and lazily allocated the upload `asyncio.Semaphore` before checking the bound loop. A cross-loop `client.sources.add_file(...)` could attach those primitives to the wrong loop before the documented `RuntimeError` guard fired.
  - `TransportDrainTracker.begin_transport_post` touched the lazy `asyncio.Condition` before any loop check. The sibling `drain()` already had the guard; admission was left inconsistent.

  Fix: extend `UploadRuntime` Protocol with `LoopGuard` and call `self._runtime.assert_bound_loop()` at the top of `add_file`. Add `assert_bound_loop(self._bound_loop)` to `begin_transport_post` before `get_drain_condition`. Mirrors the existing `ChatRuntime` / `ArtifactsRuntime` patterns (`_chat.py:255`, `_artifact_polling.py:149`).

- **CC6 — Module-level mutables (doc-only).** Three module-level mutable singletons were flagged as architecturally fragile under multi-loop fan-out. Add a uniform one-line invariant comment to each (grep-able via `single-loop-per-client invariant per ADR-004`):
  - `_BACKGROUND_CANCEL_TASKS` (`_source_upload.py`)
  - `_cleanup_tasks` (`_note_service.py`)
  - `_at_least_once_last_logged` (`_idempotency.py`)

## TDD discipline

Both cross-loop regression tests were written **red-first**, observed to fail with the expected `RuntimeError`-vs-`FileNotFoundError` mismatch, then turned green by the production change.

## Test plan

- [x] `uv run ruff format --check .` (482 files clean)
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (142 files clean)
- [x] `uv run pytest tests/unit -q` (5088 passed, 10 skipped)
- [x] Acceptance grep checks: `rg 'self._runtime.assert_bound_loop' src/notebooklm/_source_upload.py` matches at `add_file()` entry; `rg 'assert_bound_loop' src/notebooklm/_transport_drain.py` matches at both `begin_transport_post()` and `drain()`.
- [x] `UploadRuntime` Protocol declares `LoopGuard` in its base list.

## Polish — pre-PR triple review

Ran `/polish` (simplify + triple review + ultrathink) before opening:

- **code-simplifier**: no changes (diff is already minimal; CC6 audit-shibboleth comments are intentionally uniform).
- **triple review** (claude / codex / agy, ~6min wall-clock):
  - **codex IMPORTANT applied**: strengthen upload test with `runtime.operation_scope.assert_not_called()` so the contract pins all three loop-bound surfaces (guard, scope, semaphore).
  - **agy NIT applied**: strengthen drain test with `assert tracker._drain_condition is None`.
  - **consensus deferred**: do NOT add the same guard to `begin_transport_task` in this PR (scope-locked by phase-plan `must_not_do`; out-of-scope widening); do NOT convert the `mock_core` fixture to `spec=UploadRuntime` (that fixture also stands in for auth/kernel surfaces; narrow spec would churn unrelated tests).
- **ultrathink**: no architectural concerns. Pattern matches existing precedents (`drain()` guard, `ChatAPI.ask`, `ArtifactPollingService.wait_for_completion`).

## Deferred polish findings

- `begin_transport_task` cross-loop guard for symmetry — scope-locked by phase-plan; revisit if architectural symmetry becomes load-bearing.

## References

- ADR-004 (`docs/adr/0004-loop-affinity-contract.md`)
- Pattern: `src/notebooklm/_chat.py:255` (`ChatAPI.ask` guard); `src/notebooklm/_artifact_polling.py:149` (`ArtifactPollingService` guard)
- Helper: `src/notebooklm/_loop_affinity.py::assert_bound_loop`
- Audit: `.sisyphus/plans/architecture-audit.md` C1 + CC6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime validation to detect and reject operations invoked from incorrect event loop contexts in upload and transport operations, with clear error reporting.

* **Tests**
  * Added comprehensive tests verifying event loop context validation works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->