### PR TITLE
docs(cli/services/login): clarify allowed-but-unused DAG edges (follow-up to #954)

### DIFF
--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -10,9 +10,11 @@ name → rookiepy function-name map (referenced by
 :mod:`.browser_accounts._read_browser_cookies` for the named-browser
 dispatch path).
 
-Imports from :mod:`.rookiepy_errors` only (used implicitly via the
-shared error printing in caller modules; this module itself relies on
-the auth-side helpers for cookie shape conversion).
+No in-package imports today. The DAG (``test_login_package_dag.py``)
+allows an edge to :mod:`.rookiepy_errors` for future use, but
+``_enumerate_one_jar`` currently formats its own error messages and does
+not call :func:`.rookiepy_errors._handle_rookiepy_error`. This module
+relies on the auth-side helpers for cookie shape conversion.
 """
 
 from __future__ import annotations

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -5,9 +5,12 @@ Owns the path that persists extracted cookies to ``storage_state.json``
 (``_select_account`` for the ``--browser-cookies``-driven targeted
 extraction, ``_select_refresh_account`` for the refresh-from-cached path).
 
-Imports from :mod:`.browser_accounts` (allowed-but-not-required per
-the DAG; the writer itself does not call into the browser-account
-discovery dispatchers) and :mod:`.cookie_domains` (likewise).
+No in-package imports today. The DAG
+(``test_login_package_dag.py``) allows edges to :mod:`.browser_accounts`
+and :mod:`.cookie_domains` for future use, but neither is currently
+needed: ``_write_extracted_cookies`` and the selectors operate on
+already-loaded cookie data + already-discovered accounts, and the
+selectors do not need to query the cookie-domain policy themselves.
 """
 
 from __future__ import annotations

--- a/tests/_lint/test_login_package_dag.py
+++ b/tests/_lint/test_login_package_dag.py
@@ -18,12 +18,31 @@ PKG_PATH = Path("src/notebooklm/cli/services/login")
 # guard (test_login_init_is_reexport_only) covers it. The DAG check below skips
 # `__init__` from edge iteration to avoid flagging legitimate sibling re-exports
 # (`from .cookie_domains import …`) as DAG violations.
+# ``ALLOWED_EDGES`` is an UPPER BOUND, not an equality check — the DAG test
+# verifies ``actual_edges ⊆ allowed_edges``. Edges marked "allowed but
+# currently unused" below are pre-declared room for likely future imports
+# (per the phase-3.md DAG diagram); the implementation modules don't take
+# them today. If you remove an "unused" entry, the test will still pass —
+# but you also remove the documented design intent that says "this edge is
+# legitimate when needed". Keep the entry; add a comment when you start
+# using it.
 ALLOWED_EDGES: dict[str, set[str]] = {
     "cookie_domains": set(),
     "rookiepy_errors": set(),
-    "cookie_jar": {"rookiepy_errors"},
+    "cookie_jar": {
+        # allowed but currently unused — _enumerate_one_jar formats its own
+        # rookiepy error messages and does not call _handle_rookiepy_error.
+        "rookiepy_errors",
+    },
     "chromium_accounts": {"cookie_jar", "rookiepy_errors", "cookie_domains"},
-    "firefox_accounts": {"cookie_jar", "rookiepy_errors", "cookie_domains"},
+    "firefox_accounts": {
+        # allowed but currently unused — the firefox helpers hand raw cookies
+        # back to the caller (browser_accounts) which then routes through
+        # _enumerate_one_jar; this module does not import it directly.
+        "cookie_jar",
+        "rookiepy_errors",
+        "cookie_domains",
+    },
     "browser_accounts": {
         "chromium_accounts",
         "firefox_accounts",
@@ -38,7 +57,12 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         "cookie_domains",
     },
     "profile_targets": set(),
-    "cookie_writes": {"browser_accounts", "cookie_domains"},
+    "cookie_writes": {
+        # allowed but currently unused — the writer operates on already-loaded
+        # cookie data and the selectors don't query the cookie-domain policy.
+        "browser_accounts",
+        "cookie_domains",
+    },
     "refresh": {"browser_accounts", "cookie_writes", "profile_targets"},
 }
 


### PR DESCRIPTION
## Summary

Three small documentation fixes from the [claude[bot] review on #954](https://github.com/teng-lin/notebooklm-py/pull/954) that landed before this follow-up could be tacked onto the original PR — the original was squash-merged the moment its CI went green.

- `cookie_jar.py` module docstring said "Imports from `.rookiepy_errors` only", but the module has zero in-package imports. Reworded to "No in-package imports today; DAG allows an edge to `.rookiepy_errors` for future use, currently unused."
- `cookie_writes.py` module docstring said "Imports from `.browser_accounts` ... and `.cookie_domains`", but the module also has zero in-package imports. Same fix.
- `tests/_lint/test_login_package_dag.py::ALLOWED_EDGES` now explicitly annotates each pre-declared-but-currently-unused edge with an inline `# allowed but currently unused — …` comment, plus a header comment explaining that `ALLOWED_EDGES` is an UPPER BOUND (the DAG test verifies `actual_edges ⊆ allowed_edges`, not equality) so future readers don't wonder whether the test is missing a strictness check.

Pure docstrings / test-comment changes — no production code paths touched.

Originating review thread: claude[bot] follow-up review on #954.

## Test plan

- [x] `tests/_lint/test_login_package_dag.py` passes.
- [x] `tests/_lint/test_login_init_is_reexport_only.py` passes.
- [x] `tests/unit/cli/test_session_patch_surface.py` (27 assertions) passes.
- [x] `uv run ruff format` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal documentation and test infrastructure to clarify the current module dependency structure and align configuration with actual code behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->