### PR TITLE
feat(public): add __all__ to paths/migration/cli + fix _chat docstring (closes I2, I11)

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -48,10 +48,17 @@ def _extract_next_turn_content(next_turn: Any) -> str | None:
 
     The ``khqZz`` (``GET_CONVERSATION_TURNS``) response packs each AI answer
     as ``turn[4][0][0]`` — three nested wrappers around the answer text. This
-    helper delegates the inner-most descent to :func:`safe_index` so soft-mode
-    shape drift (``NOTEBOOKLM_STRICT_DECODE`` unset) logs a structured warning
-    and returns ``None`` instead of raising; strict-decode mode still lets
-    :func:`safe_index` raise ``UnknownRPCMethodError`` so callers fail fast.
+    helper delegates the inner-most descent to :func:`safe_index`, which
+    consults the strict-decode policy defined in :mod:`notebooklm._env`
+    (``is_strict_decode_enabled``). Strict-decode is the default when
+    ``NOTEBOOKLM_STRICT_DECODE`` is unset (or set to ``"1" / "true" / "True"``):
+    descent failures raise :class:`~notebooklm.exceptions.UnknownRPCMethodError`
+    so callers fail fast on Google-side shape drift. Setting
+    ``NOTEBOOKLM_STRICT_DECODE=0`` (or any other non-truthy value) opts back
+    into legacy soft-mode behavior — :func:`safe_index` logs a structured
+    warning and returns ``None`` instead of raising. See ADR-011
+    (``docs/adr/0011-schema-validation-policy.md``) for the rationale and
+    the opt-out retirement timeline.
 
     Args:
         next_turn: The candidate answer turn (a ``turn[2] == 2`` row from the

--- a/src/notebooklm/migration.py
+++ b/src/notebooklm/migration.py
@@ -24,6 +24,17 @@ from .paths import get_config_path, get_home_dir
 
 logger = logging.getLogger(__name__)
 
+# Public surface (ADR-012). Underscore-prefixed constants such as
+# ``_MIGRATION_LOCK``, ``_MIGRATION_MARKER``, and ``_MIGRATION_LOCK_TIMEOUT``
+# remain importable / monkeypatch-able for tests via direct attribute
+# lookup; ``__all__`` only governs ``from notebooklm.migration import *``
+# and documents the intended public API.
+__all__ = [
+    "MigrationLockTimeoutError",
+    "ensure_profiles_dir",
+    "migrate_to_profiles",
+]
+
 _MIGRATION_MARKER = ".migration_complete"
 _MIGRATION_LOCK = ".migration.lock"
 _MIGRATION_LOCK_TIMEOUT = 30.0

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -113,7 +113,13 @@ from .cli import (
 )
 from .cli.grouped import SectionedGroup
 
-# Import helpers needed for backward compatibility with tests
+# Public surface (ADR-012). ``main`` is the ``[project.scripts]`` entry
+# point and ``src/notebooklm/__main__.py`` shim; ``cli`` is the root
+# ``click.Group`` imported by tests to drive ``CliRunner`` invocations.
+# The underscore-prefixed helpers in this module (``_reconfigure_output_stream``,
+# ``_configure_windows_runtime``) stay importable for tests but are not part
+# of the documented public API.
+__all__ = ["cli", "main"]
 
 
 # =============================================================================

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -43,6 +43,27 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Public surface (ADR-012). Underscore-prefixed helpers like
+# ``_read_default_profile`` and ``_reset_config_cache`` remain importable for
+# test fixtures via the standard ``from notebooklm.paths import _foo`` syntax
+# (Python attribute lookup is unaffected by ``__all__``); ``__all__`` only
+# governs ``from notebooklm.paths import *`` and documents the intended
+# public API.
+__all__ = [
+    "get_active_profile",
+    "get_browser_profile_dir",
+    "get_config_path",
+    "get_context_path",
+    "get_home_dir",
+    "get_path_info",
+    "get_profile_dir",
+    "get_storage_path",
+    "list_profiles",
+    "read_default_profile",
+    "resolve_profile",
+    "set_active_profile",
+]
+
 # Module-level active profile, set once at CLI startup via set_active_profile().
 # Library users should pass profile= explicitly to path functions instead.
 _active_profile: str | None = None


### PR DESCRIPTION
## Summary

- **I2 (ADR-012 surface convention)**: adds `__all__` to the three public modules that audit finding I2 flagged as missing it — `paths.py`, `migration.py`, `notebooklm_cli.py`. ADR-012 mandates `__all__` on every public-surface module; this closes the last three gaps. Each `__all__` is derived from non-underscore external import usage (rg over `src/ docs/ tests/`), so the declared surface matches actual public usage; underscore-prefixed test helpers (`_reset_config_cache`, `_read_default_profile`, `_MIGRATION_LOCK`, `_MIGRATION_MARKER`, `_MIGRATION_LOCK_TIMEOUT`) remain importable via direct attribute lookup (Python attribute access is unaffected by `__all__`).
- **I11 (`_chat.py` docstring)**: rewrites the `_extract_next_turn_content` docstring whose strict/soft-mode polarity was inverted. The actual policy in `_env.is_strict_decode_enabled()` and `rpc/_safe_index.py` makes strict the default (unset = raise); `NOTEBOOKLM_STRICT_DECODE=0` opts back into legacy soft-mode (warn + return `None`). Cross-references `notebooklm._env` and ADR-011.

## Surface added to `__all__`

| Module | Names |
|---|---|
| `paths.py` | `get_active_profile`, `get_browser_profile_dir`, `get_config_path`, `get_context_path`, `get_home_dir`, `get_path_info`, `get_profile_dir`, `get_storage_path`, `list_profiles`, `read_default_profile`, `resolve_profile`, `set_active_profile` (12) |
| `migration.py` | `MigrationLockTimeoutError`, `ensure_profiles_dir`, `migrate_to_profiles` (3) |
| `notebooklm_cli.py` | `cli`, `main` (2) — `cli` is the root `click.Group` imported by 50+ test files; `main` is the `[project.scripts]` + `__main__.py` console-script entry |

## Task

Phase 2 PR-F of `.sisyphus/plans/architecture-audit-fixes.md` (TODOs item 6); closes audit items I2 and I11 from `.sisyphus/plans/architecture-audit.md`.

## Test plan

- [x] `python -c "import notebooklm.paths; assert all(not n.startswith('_') for n in notebooklm.paths.__all__)"` (and migration / notebooklm_cli) — passes for each.
- [x] Private symbols (`_reset_config_cache`, `_MIGRATION_LOCK`, etc.) still importable via direct attribute lookup.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (160 files).
- [x] `uv run pytest tests/unit -q` — green (5228 passed, 44 skipped).
- [x] Verified all 14 ADR-012 public modules now declare `__all__`.

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal documentation for strict-decode behavior in chat processing.

* **Chores**
  * Clarified internal module API structure by defining explicit public export surfaces across core modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->