### PR TITLE
docs: align CLAUDE.md, ADRs, and python-api with current code (closes I1, I3-I9, I13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ RPC Layer (rpc/)
 | `_session_auth.py` | `AuthRefreshCoordinator` — refresh task + auth-snapshot lock |
 | `_session_lifecycle.py` | `ClientLifecycle` — loop-affinity guard + keepalive task |
 | `_rpc_executor.py` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols |
-| `_authed_transport.py` | Authed POST path, retry loops, `_AuthedTransportHost` Protocol |
+| `_authed_transport.py` | Authed POST leaf raising `TransportRateLimited` / `TransportServerError` / `TransportAuthExpired` for `RetryMiddleware` (in `_middleware_retry.py`) to act on; hosts the `_AuthedTransportHost` Protocol. |
 | `_conversation_cache.py` | Per-instance LRU conversation cache for `ChatAPI` |
 | `_polling_registry.py` | Pending-poll registry for long-running artifact generations |
 | `_cookie_persistence.py` | Cookie-jar persistence + `__Secure-1PSIDTS` rotation |
@@ -130,7 +130,7 @@ RPC Layer (rpc/)
 | `_middleware_chain.py` | Constructs the middleware chain in the canonical ADR-009 order |
 | `_middleware*.py` | Modular middleware implementations (drain, metrics, semaphore, retry, auth, error injection, tracing) |
 | `rpc/types.py` | RPC method IDs (source of truth) |
-| `auth.py` | Authentication facade — flat re-exports from `_auth/*` seams (Superseded by [arch-d1-auth-side](https://github.com/teng-lin/notebooklm-py/pull/834) (#834); `_AuthFacadeModule` retired; tests patch the canonical home in `_auth.<module>` directly) |
+| `auth.py` | Authentication facade and host for retained surface. Still owns `AuthTokens`, `load_auth_from_storage()`, and the `_validate_required_cookies()` write-through that propagates `auth.py`-level policy rebindings into `_auth.cookie_policy` (and mirrors `_SECONDARY_BINDING_WARNED` back). Tests still pin `notebooklm.auth.<name>` monkeypatch behavior (see `tests/unit/test_public_shims.py`); `_AuthFacadeModule` itself was retired in [arch-d1-auth-side](https://github.com/teng-lin/notebooklm-py/pull/834) (#834), but the flat re-export goal in ADR-003 is **deferred** — full retirement of `AuthTokens` / `load_auth_from_storage` to `_auth/` has not happened. |
 | `_auth/paths.py` | Storage paths and filesystem helpers |
 | `_auth/extraction.py` | Cookie/token extraction from browser sessions |
 | `_auth/headers.py` | HTTP header construction |
@@ -143,14 +143,14 @@ RPC Layer (rpc/)
 src/notebooklm/
 ├── __init__.py                  # Public exports
 ├── client.py                    # NotebookLMClient
-├── auth.py                      # Authentication facade — flat re-exports from _auth/* (Superseded by arch-d1-auth-side (#834))
+├── auth.py                      # Authentication facade hosting `AuthTokens`, `load_auth_from_storage()`, and `_validate_required_cookies()` write-through into `_auth.cookie_policy` (ADR-003 flat re-export goal deferred; `_AuthFacadeModule` retired in #834)
 ├── types.py                     # Dataclasses
 ├── _session.py                  # Concrete Session orchestration (NotebookLMClient internals)
 ├── _kernel.py                   # Concrete Kernel transport core
 ├── _session_config.py           # DEFAULT_* knobs + module-level constants
 ├── _session_helpers.py          # is_auth_error / AUTH_ERROR_PATTERNS / keepalive helpers
 ├── _error_injection.py          # Synthetic-error env-var resolver + startup guard
-├── _authed_transport.py         # Authed POST path + retry loops
+├── _authed_transport.py         # Authed POST leaf — raises TransportRateLimited / TransportServerError / TransportAuthExpired for RetryMiddleware (_middleware_retry.py) to act on
 ├── _rpc_executor.py             # RPC dispatch executor
 ├── _session_auth.py             # AuthRefreshCoordinator (refresh task + auth-snapshot lock)
 ├── _client_metrics.py           # Telemetry / metrics seam
@@ -196,7 +196,7 @@ src/notebooklm/
 │   ├── cookies.py               # Cookie maps + _update_cookie_input
 │   ├── cookie_policy.py         # Domain allowlist and cookie policy
 │   ├── account.py               # Account profile + multi-account switching
-│   ├── session.py               # Session-level dataclasses
+│   ├── session.py               # Auth-session refresh implementation (`RefreshAuthCore` Protocol + `refresh_auth_session()`)
 │   ├── storage.py               # Profile/state persistence on disk
 │   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
 │   ├── psidts_recovery.py       # Inline PSIDTS recovery for cold-start (issue #865)

--- a/docs/adr/0003-auth-facade-write-through.md
+++ b/docs/adr/0003-auth-facade-write-through.md
@@ -2,22 +2,40 @@
 
 ## Status
 
-Superseded by `arch-d1-auth-side` (D1 PR-2).
+Partially completed — flat re-export goal deferred.
 
-The write-through facade (`_AuthFacadeModule` + the 5 `_AUTH_*_FACADE_NAMES` /
-`_REFRESH_DEP_MIRROR_NAMES` / `_KEEPALIVE_DEP_MIRROR_NAMES` mirror tables)
-was deleted from `src/notebooklm/auth.py` in D1 PR-2. The remediation
-moved test-side mirroring into a small `tests/_fixtures/auth_seam.py`
-helper (`patch_auth_seam(monkeypatch, name, value)`), which walked the
-known `_auth/*` seam modules and patched every one that already bound
-the name. **That helper was itself retired in the post-v0.5.0 audit
-cleanup** (`docs/test-suite-audit.md` §3): the ~50 call sites migrated
-to targeted `monkeypatch.setattr(<canonical module>, name, value)`
-against the consumer-side import, and the fixture was deleted. New
-tests should prefer constructor injection via
-`tests._fixtures.make_fake_core` (ADR-007); where module-level seam
-state (file locks, refresh-retry registries) makes injection awkward,
-patch the canonical home directly.
+The write-through facade mechanism (`_AuthFacadeModule` + the 5
+`_AUTH_*_FACADE_NAMES` / `_REFRESH_DEP_MIRROR_NAMES` /
+`_KEEPALIVE_DEP_MIRROR_NAMES` mirror tables) was deleted from
+`src/notebooklm/auth.py` in D1 PR-2 ([arch-d1-auth-side / #834](https://github.com/teng-lin/notebooklm-py/pull/834)).
+The remediation moved test-side mirroring into a small
+`tests/_fixtures/auth_seam.py` helper (`patch_auth_seam(monkeypatch, name, value)`),
+which walked the known `_auth/*` seam modules and patched every one that
+already bound the name. **That helper was itself retired in the post-v0.5.0
+audit cleanup** (`docs/test-suite-audit.md` §3): the ~50 call sites migrated
+to targeted `monkeypatch.setattr(<canonical module>, name, value)` against the
+consumer-side import, and the fixture was deleted. New tests should prefer
+constructor injection via `tests._fixtures.make_fake_core` (ADR-007); where
+module-level seam state (file locks, refresh-retry registries) makes
+injection awkward, patch the canonical home directly.
+
+**Deferred.** The original D1 plan also called for `auth.py` to be reduced
+to a flat re-export module — i.e. moving `AuthTokens`,
+`load_auth_from_storage()`, and the `_validate_required_cookies()` write-through
+into `_auth/*` and leaving `auth.py` as a thin facade. That second half was
+not shipped. At HEAD, `auth.py` still owns `AuthTokens` (`src/notebooklm/auth.py`,
+symbol `AuthTokens`), still owns the active load/recovery logic
+(`load_auth_from_storage()`), and still installs
+`_validate_required_cookies()` into `_auth.cookies` to propagate
+`auth.py`-level policy rebindings into `_auth.cookie_policy` (and mirror
+`_SECONDARY_BINDING_WARNED` back). Tests still pin
+`notebooklm.auth.<name>` monkeypatch behavior
+(`tests/unit/test_public_shims.py`).
+
+CLAUDE.md and this ADR are pinned to that current reality. Completing the
+retirement (moving `AuthTokens` / `load_auth_from_storage` to `_auth/` and
+demoting `auth.py` to flat re-exports) remains the long-term direction but
+is not scheduled.
 
 The rest of this ADR is preserved as the historical record of why the
 facade existed at all.
@@ -87,7 +105,7 @@ The mechanism is *Accepted* today because:
 - The `_REFRESH_DEP_MIRROR_NAMES` / `_KEEPALIVE_DEP_MIRROR_NAMES` cross-module mirror sets encode an even subtler invariant — names that are owned by one seam but aliased into another at import time. A reader has to trace the `from … import …` chains to verify the mirror is complete.
 - The whole apparatus exists to make tests pass under a pattern (`monkeypatch.setattr("notebooklm.auth.X", …)`) that the audit (`.sisyphus/plans/arch-biggest-problem-audit.md`, disease D1) wants to retire entirely.
 
-The retirement path was completed in the D1 auth-side PR ([#834](https://github.com/teng-lin/notebooklm-py/pull/834)): the monolithic `tests/unit/test_auth.py` was split into concern-aligned files (`test_auth_storage.py`, `test_auth_account.py`, `test_auth_refresh.py` etc.), monkeypatches were migrated to constructor injection, `_AuthFacadeModule` was deleted, and `auth.py` was reduced to a flat re-export module.
+The retirement path was **partially completed** in the D1 auth-side PR ([#834](https://github.com/teng-lin/notebooklm-py/pull/834)): the monolithic `tests/unit/test_auth.py` was split into concern-aligned files (`test_auth_storage.py`, `test_auth_account.py`, `test_auth_refresh.py` etc.), monkeypatches were migrated to constructor injection, and `_AuthFacadeModule` itself was deleted. The second half — reducing `auth.py` to a flat re-export module — is **deferred**: at HEAD, `auth.py` still owns `AuthTokens`, `load_auth_from_storage()`, and a `_validate_required_cookies()` policy write-through (see the **Status** block above for the current contract).
 
 ## Alternatives considered
 

--- a/docs/adr/0004-loop-affinity-contract.md
+++ b/docs/adr/0004-loop-affinity-contract.md
@@ -21,7 +21,7 @@ The contract is enforced at two layers:
 - `src/notebooklm/_loop_affinity.py` exposes `assert_bound_loop(bound_loop)` which compares the current loop to the captured one and raises `RuntimeError` with an actionable diagnostic if they differ.
 - `src/notebooklm/_session_lifecycle.py::ClientLifecycle.open()` captures the loop with `asyncio.get_running_loop()` and exposes it as `get_bound_loop()`. Every authed POST path forwards the captured loop into `assert_bound_loop()` before touching any loop-bound primitive.
 
-`SessionCapabilities.bound_loop` (`_capabilities.py:248-274`) defensively returns `None` when `_lifecycle` is missing or returns a non-loop value, so `MagicMock`-backed test fixtures fall through to the silent no-op path instead of misclassifying a mock as a cross-loop call.
+`Session.bound_loop()` (`src/notebooklm/_session.py`, symbol `bound_loop`) defensively returns `None` when `_lifecycle` is missing or returns a non-loop value, so `MagicMock`-backed test fixtures fall through to the silent no-op path instead of misclassifying a mock as a cross-loop call. The capability-Protocol surface that feature APIs depend on lives in `src/notebooklm/_session_contracts.py` (symbols `AuthMetadata`, `Kernel`, `RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime`); per ADR-013 the broad `SessionCapabilities` adapter and its `_capabilities.py` home were retired in favor of these narrow shared Protocols plus feature-local runtimes.
 
 ## Decision
 
@@ -46,7 +46,7 @@ The contract is enforced via `assert_bound_loop()` (raises `RuntimeError`) rathe
 **Unwanted:**
 
 - Callers that *want* multi-loop / multi-thread reuse must construct multiple clients. For test code this is mildly verbose; for production code this is the right design (each loop owns its own connection pool) so the tax is paid in tests only.
-- The loop-affinity bridge in `_capabilities.py:248-274` has to defensively handle `MagicMock`-shaped fixtures. The defensive code is small but it is a reminder that the contract is enforced via Protocol forwarding, not via a hard constructor invariant.
+- The loop-affinity bridge on `Session.bound_loop()` (in `_session.py`) has to defensively handle `MagicMock`-shaped fixtures. The defensive code is small but it is a reminder that the contract is enforced via Protocol forwarding through the capability surface in `_session_contracts.py`, not via a hard constructor invariant.
 - The contract is *advisory* to multi-process callers. Processes do not share Python objects, so the contract is trivially satisfied across fork/spawn boundaries — but the diagnostic message says "loop", not "loop or process", so a reader of an error report has to know that processes are out of scope.
 
 ## Alternatives considered

--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -200,7 +200,6 @@ Per-position rationale:
 | Key | Type | Set by | Read by |
 |---|---|---|---|
 | `rpc_method` | `RPCMethod \| None` | `Session.rpc_call` | metrics, tracing |
-| `operation_variant` | `str \| None` | `Session.rpc_call` | `AuthRefreshMiddleware` (passes back to `resolve_effective_disable_internal_retries` on retry) |
 | `disable_internal_retries` | `bool` | `Session.rpc_call` (post-resolution from `_idempotency.resolve_effective_disable_internal_retries`) | `RetryMiddleware` |
 | `build_request` | `BuildRequest` | `Session.rpc_call` / `Session.transport_post` | chain leaf (adapter into `AuthedTransport.perform_authed_post`) |
 | `log_label` | `str` | `Session.rpc_call` / `Session.transport_post` | chain leaf, `DrainMiddleware`, `TracingMiddleware` |
@@ -210,6 +209,14 @@ Per-position rationale:
 Middlewares are forbidden from inventing new keys without an ADR update.
 The dict is mutable by reference (deliberately, per master plan
 §"Per-request behavior") but read-mostly in practice.
+
+> **Note on `operation_variant`.** Idempotency policy is resolved
+> **before chain entry** in `RpcExecutor.execute()` via
+> `_idempotency.resolve_effective_disable_internal_retries(...)`; the
+> resolved boolean is what flows through the chain as
+> `disable_internal_retries`. The chain itself never needs the
+> per-request `operation_variant` selector, so it is intentionally
+> absent from this vocabulary.
 
 ### AuthRefreshMiddleware constructor signature (Tier-13 target, NOT shipped in Tier-12)
 

--- a/docs/adr/0012-implementation-surface-convention.md
+++ b/docs/adr/0012-implementation-surface-convention.md
@@ -12,7 +12,7 @@ the time of this ADR, `src/notebooklm/` contains 13 public-named modules
 (`auth.py`, `client.py`, `config.py`, `exceptions.py`, `io.py`, `log.py`,
 `migration.py`, `notebooklm_cli.py`, `paths.py`, `research.py`,
 `types.py`, `urls.py`, `utils.py`) and roughly 50 underscore-prefixed
-seam modules (`_core.py`, `_session.py`, `_kernel.py`,
+seam modules (`_session.py`, `_kernel.py`,
 `_session_contracts.py`, `_session_*`, `_authed_transport.py`,
 `_rpc_executor.py`, `_artifacts.py`, `_artifact_*.py`, `_chat.py`,
 `_chat_*.py`, `_middleware_*.py`, the `_auth/` subpackage, etc.).
@@ -123,7 +123,6 @@ but internal contents) MUST be added to this list before merging.
 ```text
 src/notebooklm/
 ├── _session.py                  # Session concrete orchestrator
-├── _core.py                     # legacy compatibility shim
 ├── _session_contracts.py        # Session/Kernel Protocols (Tier-13)
 ├── _kernel.py                   # Kernel concrete (Tier-13)
 ├── _session_*.py                # session helpers/config/lifecycle/auth

--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -25,27 +25,29 @@ ADR-010 (Tier 13 PR 13.1) pinned a deliberately narrow feature-facing
 converge on one semantic orchestration contract, while transport stayed
 isolated and Artifacts received a dedicated drain-hook seam.
 
-That narrow contract did not hold. Today, at
-`src/notebooklm/_session_contracts.py:50`, the broad `Session` protocol
-exposes **eight members**:
+That narrow contract did not hold. At the time this ADR was written, the
+broad `Session` Protocol in `src/notebooklm/_session_contracts.py` had
+grown to **eight members**:
 
-1. `auth` (`AuthMetadata` property; `_session_contracts.py:54`)
-2. `kernel` (`Kernel` property; `_session_contracts.py:57`)
-3. `rpc_call(...)` (`_session_contracts.py:59`)
-4. `transport_post(...)` (`_session_contracts.py:71`)
-5. `next_reqid(...)` (`_session_contracts.py:79`)
-6. `assert_bound_loop()` (`_session_contracts.py:81`)
-7. `operation_scope(...)` (`_session_contracts.py:83`)
-8. `register_drain_hook(...)` (`_session_contracts.py:85`)
+1. `auth` (an `AuthMetadata` property)
+2. `kernel` (a `Kernel` property)
+3. `rpc_call(...)`
+4. `transport_post(...)`
+5. `next_reqid(...)`
+6. `assert_bound_loop()`
+7. `operation_scope(...)`
+8. `register_drain_hook(...)`
 
-The five-member intent of ADR-010 is gone. `auth` and `kernel` were
+The five-member intent of ADR-010 was gone. `auth` and `kernel` had been
 promoted as members for upload-flow convenience; `register_drain_hook`
-was added to the general contract despite the standalone
-`DrainHookRegistration` Protocol at `_session_contracts.py:92` covering
-the same shape — leaving two redundant protocols carrying the same
-single-member surface. `transport_post` and `next_reqid` are used by
-exactly one feature (chat), but every feature that types against
-`Session` is now coupled to them.
+had been added to the general contract despite a standalone
+`DrainHookRegistration` Protocol covering the same shape — leaving two
+redundant protocols carrying the same single-member surface.
+`transport_post` and `next_reqid` were used by exactly one feature
+(chat), but every feature that typed against `Session` was coupled to
+them. (Post-this-ADR, Phase 7 deleted the broad `Session` Protocol
+entirely; the current `_session_contracts.py` exposes only the four
+shared capability Protocols below plus `AuthMetadata` and `Kernel`.)
 
 Re-reading the codebase against ADR-010's original constraint, the audit
 identified two categories of capability:
@@ -102,9 +104,9 @@ runtimes. Concretely:
    `LoopGuard + OperationScopeProvider`). The promotion criterion is
    **shared by ≥2 features**. No capability is promoted on speculation.
 
-2. **Retain `AuthMetadata` (`_session_contracts.py:24`) and `Kernel`
-   (`_session_contracts.py:34`)** as standalone Protocols in
-   `_session_contracts.py` — they are **NOT** members of any
+2. **Retain `AuthMetadata` and `Kernel`** (both in
+   `_session_contracts.py`, symbols `AuthMetadata` and `Kernel`) as
+   standalone Protocols — they are **NOT** members of any
    feature-facing Session Protocol. Only `SourceUploadPipeline`
    consumes them, but the upload pipeline still depends on Session-owned
    objects (the authenticated account snapshot and the transport
@@ -185,17 +187,17 @@ runtimes. Concretely:
   the new keyword-only collaborator arguments. The migration steps in
   `docs/refactor-history.md` pair each feature retyping with its same-commit
   test fixture update so the build stays green.
-- The `_core.py` compatibility shim was removed in Phase 4 ([#889](https://github.com/teng-lin/notebooklm-py/pull/889)); see `tests/unit/test_public_shims.py:1166` for the removal pin.
+- The `_core.py` compatibility shim was removed in Phase 4 ([#889](https://github.com/teng-lin/notebooklm-py/pull/889)); see `tests/unit/test_public_shims.py` (search for `Tier-10 PR-A re-export identity pins for ``notebooklm._core`` were deleted`) for the removal pin.
 - Two `RpcCaller` Protocols coexist briefly: the shared *object*
-  protocol in `_session_contracts.py` (used by every feature API) and a
-  pre-existing local *callable* protocol in `_source_upload.py:43-56`
-  (used as the `register_file_source(rpc_call=...)` callback at
-  `_source_upload.py:345`). They are structurally distinct (one is an
-  object with an `rpc_call` method; the other is a callable). To avoid
-  the name collision, the local callable protocol is **renamed** to
-  `RpcCallback` in the same commit that introduces the shared
-  `RpcCaller`. The local protocol is not deleted because the callback
-  shape is a real seam the upload pipeline depends on.
+  protocol in `_session_contracts.py` (symbol `RpcCaller`, used by every
+  feature API) and a pre-existing local *callable* protocol in
+  `_source_upload.py` (symbol `RpcCallback`, used as the
+  `register_file_source(rpc_call=...)` callback). They are structurally
+  distinct (one is an object with an `rpc_call` method; the other is a
+  callable). To avoid the name collision, the local callable protocol is
+  **renamed** to `RpcCallback` in the same commit that introduces the
+  shared `RpcCaller`. The local protocol is not deleted because the
+  callback shape is a real seam the upload pipeline depends on.
 - This ADR exceeds the 250-line soft cap by user direction; the hard
   cap remains 500 lines. The expanded length is load-bearing: the
   decision shipping in this PR is the simultaneous adoption of three
@@ -222,13 +224,14 @@ lands.
 ## Alternatives considered
 
 1. **Keep the broad `Session` contract and let it continue to grow.**
-   Rejected. The drift evidence is already visible at
-   `_session_contracts.py:50`: ADR-010 specified five members, and the
-   current contract has eight. Without an explicit promotion criterion
-   (shared by ≥2 features), every future single-consumer capability is
-   a candidate for promotion, and the contract is one PR away from
-   nine members. The "narrow Session" intent of ADR-010 is not
-   recoverable by exhortation; it requires a structural rule.
+   Rejected. At ADR-write time the drift was already visible in
+   `_session_contracts.py`'s broad `Session` Protocol: ADR-010 specified
+   five members, and the contract had grown to eight. Without an
+   explicit promotion criterion (shared by ≥2 features), every future
+   single-consumer capability is a candidate for promotion, and the
+   contract is one PR away from nine members. The "narrow Session"
+   intent of ADR-010 is not recoverable by exhortation; it requires a
+   structural rule.
 
 2. **Per-sub-client narrow Protocols only, no feature-local runtimes**
    (the post-D2 replacement from the ADR-002 lineage). Rejected.
@@ -245,8 +248,8 @@ lands.
    on speculation is exactly the drift pattern this ADR fights:
    `auth`/`kernel`/`register_drain_hook` were promoted to the broad
    `Session` for "convenience" without a second-consumer trigger, and
-   the result is the eight-member contract documented in
-   `_session_contracts.py:50`. The promotion criterion in Decision §1
+   the result was the eight-member contract enumerated in the Context
+   section above. The promotion criterion in Decision §1
    (shared by ≥2 features) exists precisely to block this path. If a
    future feature genuinely needs chat's transport slice, the
    capability is promoted at that point with the second consumer as

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -1562,9 +1562,20 @@ the parent process, and a per-loop / per-resolved-storage-path asyncio
 lock registry (`_get_refresh_lock`, mirroring the keepalive
 `_get_poke_lock` pattern) combined with `_REFRESH_GENERATIONS` guarded
 by `_REFRESH_STATE_LOCK` (a sync `threading.Lock`) ensures that a fan-out
-of N concurrent failing requests — even across event loops or worker
-threads sharing the same storage path — triggers exactly one refresh,
-not N.
+of N concurrent failing requests triggers **exactly one refresh per
+loop**, and **at-most-twice across loops** sharing the same storage path
+— not N. The cross-loop guarantee is best-effort coalescing: two loops
+can both capture the same `_REFRESH_GENERATIONS` value and pass the
+`should_run_refresh` check before either bumps it, so a worst-case race
+between two loops can run the refresh command twice. The contract is
+encoded by `tests/unit/test_refresh_lock_registry.py` as
+`1 <= run_count <= 2`. Cross-loop client reuse is unsupported anyway
+per [ADR-004](adr/0004-loop-affinity-contract.md) (one
+`NotebookLMClient` per event loop), so this race is only reachable when
+two independently-constructed clients in different loops share a
+storage path; filesystem-level locking on the storage path was
+considered and deferred (Windows-compat + stale-lock complexity for a
+worst-case "auth flow runs twice" outcome).
 
 This is **orthogonal** to L1–L3:
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -251,7 +251,7 @@ except NonIdempotentRetryError:
     ...
 ```
 
-`client.sources.add_file(...)` and `client.sources.add_drive(...)` are not yet covered by the probe-then-retry wrapper — a transport failure during these calls may produce a duplicate source on retry. Tracked as a separate fix.
+`client.sources.add_file(...)` and `client.sources.add_drive(...)` are now also covered by the probe-then-create wrapper: the create RPC runs with `disable_internal_retries=True` and, on transport failure, the wrapper probes the server-side source list (via `idempotent_create`) before deciding whether to retry — so transient failures no longer produce duplicate sources. See `_source_add.py` (`SourceAddService.add_drive`) and `_source_upload.py` (`SourceUploadPipeline.register_file_source`) for the implementation.
 
 ---
 
@@ -551,9 +551,14 @@ floor checks). All raise `ValueError`:
 
 ## Internal module map
 
-`Session` (in `src/notebooklm/_session.py`) is the orchestrator that owns
-the `httpx.AsyncClient`, glues the authed transport to RPC dispatch, and
-holds the `AuthTokens` for the running session. The supporting state
+Kernel owns the `httpx.AsyncClient`; Session constructs and exposes the
+Kernel. Per the [ADR-010](adr/0010-session-kernel-split.md) split,
+`Kernel.__init__` in `src/notebooklm/_kernel.py` constructs the
+`httpx.AsyncClient` and is responsible for closing it on `aclose()`;
+`Session` (in `src/notebooklm/_session.py`) is the orchestrator that
+constructs a `Kernel`, exposes it via `get_http_client()` delegation,
+glues the authed transport to RPC dispatch, and holds the `AuthTokens`
+for the running session. The supporting state
 (metrics, drain bookkeeping, request-id counter, transport plumbing,
 conversation cache, etc.) is split across single-responsibility session
 and kernel collaborator modules such as `notebooklm._authed_transport`,
@@ -565,7 +570,8 @@ historical `notebooklm._core` compatibility shim was removed in v0.5.0.
 
 | Module | Owns | Notes |
 |---|---|---|
-| `_session` | Concrete `Session` orchestrator; HTTP client lifecycle. | Concrete implementation. |
+| `_session` | Concrete `Session` orchestrator. Constructs and exposes a `Kernel`; the `httpx.AsyncClient` lifecycle is owned by `Kernel`. | Concrete implementation. |
+| `_kernel` | Concrete `Kernel` transport core; owns the `httpx.AsyncClient` (constructed in `Kernel.__init__`, closed in `Kernel.aclose()`) and the cookie jar. | Pure transport surface (see `Kernel` Protocol in `_session_contracts`). |
 | `_session_config` | Module-level constants: `DEFAULT_TIMEOUT`, `DEFAULT_KEEPALIVE_MIN_INTERVAL`, `DEFAULT_MAX_CONCURRENT_RPCS`, `DEFAULT_MAX_CONCURRENT_UPLOADS`, `CORE_LOGGER_NAME`, `normalize_max_concurrent_uploads`. | Pure constants; importable without side effects. |
 | `_session_helpers` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval`. | Cross-seam pure helpers; behaviour-bearing (and therefore unit-tested). |
 | `_error_injection` | `ERROR_INJECT_ENV_VAR`, `_get_error_injection_mode`, `_refuse_synthetic_error_outside_test_context`. | Env-var resolver + startup guard for the synthetic-error harness. |
@@ -578,7 +584,7 @@ historical `notebooklm._core` compatibility shim was removed in v0.5.0.
 | `_polling_registry` | Pending-poll registry shared by long-running artifact generations. | Used by artifacts and the legacy `Session._pending_polls` compatibility bridge. |
 | `_reqid_counter` | `ReqidCounter`: monotonic `_reqid` for the chat backend, lazy `asyncio.Lock` for concurrent `ChatAPI.ask` callers. | Baseline `_value=100000`, default `step=100000` — both are chat-API contract values; do not change. |
 | `_rpc_executor` | RPC dispatch executor; exposes `DecodeResponse` and `RpcOwner` Protocols so callers can be unit-tested against a stub. | `Session.rpc_call` delegates here. |
-| `_authed_transport` | Authed HTTP POST path, retry loops (429 + 5xx), `_AuthedTransportHost` Protocol. | Owns `TransportAuthExpired` / `TransportRateLimited` / `TransportServerError` transport-level exceptions. |
+| `_authed_transport` | Authed HTTP POST leaf and `_AuthedTransportHost` Protocol. Raises `TransportRateLimited` / `TransportServerError` for `RetryMiddleware` (in `_middleware_retry.py`) to act on; raises `TransportAuthExpired` for `AuthRefreshMiddleware`. | Owns the `TransportAuthExpired` / `TransportRateLimited` / `TransportServerError` transport-level exceptions; retry loops (429 + 5xx) live in `RetryMiddleware`. |
 
 Feature APIs depend on narrow per-capability Protocols defined in
 `notebooklm._session_contracts` (and feature-local runtime Protocols
@@ -624,8 +630,8 @@ class NotebookLMClient:
         rate_limit_max_retries: int = 3,
         server_error_max_retries: int = 3,
         limits: ConnectionLimits | None = None,
-        max_concurrent_uploads: int | None = None,
-        max_concurrent_rpcs: int | None = None,
+        max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,  # 4
+        max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,        # 16
         upload_timeout: httpx.Timeout | None = None,
         on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
     ) -> "NotebookLMClient":
@@ -638,8 +644,8 @@ class NotebookLMClient:
         rate_limit_max_retries: int = 3,
         server_error_max_retries: int = 3,
         limits: ConnectionLimits | None = None,
-        max_concurrent_uploads: int | None = None,
-        max_concurrent_rpcs: int | None = None,
+        max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,  # 4
+        max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,        # 16
         upload_timeout: httpx.Timeout | None = None,
         on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
         cookie_saver: CookieSaver | None = None,
@@ -791,7 +797,7 @@ print(url)
 | `add_url(notebook_id, url, wait=False, wait_timeout=120.0)` | `str, str, bool, float` | `Source` | Add URL source (autodetects YouTube URLs and routes them appropriately) |
 | `add_text(notebook_id, title, content, wait=False, wait_timeout=120.0, idempotent=False)` | `str, str, str, bool, float, bool` | `Source` | Add text content |
 | `add_file(notebook_id, file_path, mime_type=None, wait=False, wait_timeout=120.0, *, title=None, on_progress=None)` | `str, str \| Path, str \| None, bool, float, *, str \| None, Callable \| None` | `Source` | Upload file. `mime_type` is **deprecated** and ignored (server infers from filename); passing non-`None` emits `DeprecationWarning` and is scheduled for removal in v0.6.0. `title` (keyword-only) sets the display name via a post-upload `UPDATE_SOURCE` and forces a brief registration wait even when `wait=False`. `on_progress(bytes_sent, total_bytes)` may be sync or async. |
-| `add_drive(notebook_id, file_id, title, mime_type=None, wait=False, wait_timeout=120.0)` | `str, str, str, str \| None, bool, float` | `Source` | Add Google Drive doc |
+| `add_drive(notebook_id, file_id, title, mime_type="application/vnd.google-apps.document", *, wait=False, wait_timeout=120.0)` | `str, str, str, str, *, bool, float` | `Source` | Add Google Drive doc. `mime_type` defaults to Google Docs; override for Slides/Sheets/PDF via `DriveMimeType` (see `notebooklm.types`). `wait` and `wait_timeout` are keyword-only. |
 | `rename(notebook_id, source_id, new_title)` | `str, str, str` | `Source` | Rename source |
 | `refresh(notebook_id, source_id)` | `str, str` | `bool` | Refresh URL/Drive source |
 | `check_freshness(notebook_id, source_id)` | `str, str` | `bool` | Check if source needs refresh |


### PR DESCRIPTION
## Summary

Doc-only sweep aligning 8 files with current code (PR-D of the
architecture-audit-fixes Phase 2 wave). Every audit-cited claim
re-verified by symbol grep at HEAD — the audit was captured at
`3ed0a4eb` and its line refs have drifted, so the updates use
symbol-based references where possible.

## Files touched

| File | Findings |
|---|---|
| `CLAUDE.md` | I1, I7 |
| `docs/adr/0003-auth-facade-write-through.md` | I1 (Status + body) |
| `docs/adr/0004-loop-affinity-contract.md` | I4 |
| `docs/adr/0009-middleware-chain.md` | I3 |
| `docs/adr/0012-implementation-surface-convention.md` | I5 (drop `_core.py` shim subsection) |
| `docs/adr/0013-composable-session-capabilities.md` | I5 (line-ref cleanup) |
| `docs/auth-cookie-lifecycle.md` | I13 |
| `docs/python-api.md` | I6, I7, I8, I9 |

Plus a one-line `## Notes` block appended to `.sisyphus/plans/architecture-audit.md` closing CC4 (the `.sisyphus/` tree is gitignored, so the closure note lives outside this commit but inside the orchestrator's working copy).

## Highlights

- **I1**: ADR-003 Status changed from "Superseded" to "Partially completed — flat re-export goal deferred". CLAUDE.md `auth.py` row now honestly describes the surface (`AuthTokens`, `load_auth_from_storage()`, `_validate_required_cookies()` write-through). `_auth/session.py` row corrected from "Session-level dataclasses" to "Auth-session refresh implementation".
- **I3**: `operation_variant` row removed from ADR-009's `RpcRequest.context` vocabulary table; appendix note added explaining pre-chain idempotency resolution.
- **I7**: "retry loops (429 + 5xx)" attribution moved off `_authed_transport.py` and onto `RetryMiddleware` (`_middleware_retry.py`) in CLAUDE.md + `docs/python-api.md`.
- **I8**: `docs/python-api.md` Internal module map now says "Kernel owns the `httpx.AsyncClient`; Session constructs and exposes the Kernel" (per [ADR-010](docs/adr/0010-session-kernel-split.md)); added a dedicated `_kernel` table row.
- **I9**: Documented defaults fixed — `max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS  # 4`, `max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS  # 16`. `add_drive(...)` now shows `mime_type="application/vnd.google-apps.document"` with `wait` / `wait_timeout` keyword-only.
- **I13**: Cross-loop single-flight contract loosened from "exactly one refresh even across event loops" to "exactly one refresh per loop; at-most-twice across loops". Cites `tests/unit/test_refresh_lock_registry.py` (`1 <= run_count <= 2`) and [ADR-004](docs/adr/0004-loop-affinity-contract.md).

## Test plan

- [x] No `src/notebooklm/` files modified (`git diff --stat src/` empty).
- [x] `rg 'at-most-twice' docs/auth-cookie-lifecycle.md` matches.
- [x] `rg 'Kernel owns' docs/python-api.md` matches.
- [x] ADR-003 Status field reflects deferred retirement.
- [x] `uv run pytest tests/unit/test_public_shims.py -q` green (251 passed).
- [x] `uv run ruff format --check .` clean; `uv run ruff check .` clean.

## Out of scope (per the audit's chosen directions)

- Does **NOT** retire `auth.py` to a flat facade (I1 chose the doc-update direction).
- Does **NOT** add filesystem locking for refresh (I13 chose the doc-loosening direction).
- Does **NOT** touch ADR-001/002/005/006/007/008/010/011.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records (ADRs) to reflect recent auth and session contract refinements.
  * Clarified refresh coalescing guarantees in auth cookie lifecycle documentation.
  * Updated API guidance for file and drive source operations with improved idempotency and retry behavior.

* **API Changes**
  * Changed default values for `max_concurrent_uploads` (now 4) and `max_concurrent_rpcs` (now 16) in `NotebookLMClient`.
  * Updated `SourcesAPI.add_drive()` to default MIME type to Google Docs format and made `wait`/`wait_timeout` parameters keyword-only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->