### PR TITLE
docs: fix 4 doc-drift findings from #945 retroactive review

### DIFF
--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -9,11 +9,10 @@ in `docs/refactor-history.md` (revision 5, dated 2026-05-20). It supersedes
 [ADR-010](0010-session-kernel-split.md) (Session/Kernel split), which
 was re-statused to `Superseded by ADR-013 (#866)` when this ADR landed.
 
-The 11-step migration described in `docs/refactor-history.md` §Migration Plan
-landed in full across Phases 1–7 of the capability refactor arc; the
-broad `Session` protocol was deleted in Phase 7 (refactor-history.md step 10),
-so this ADR is now a plain `Accepted` record with no outstanding
-sunset clause.
+The 11-step migration originally drafted alongside this ADR landed in
+full across Phases 1–7 of the capability refactor arc; the broad
+`Session` protocol was deleted in Phase 7, so this ADR is now a plain
+`Accepted` record with no outstanding sunset clause.
 
 ## Context
 
@@ -119,7 +118,8 @@ runtimes. Concretely:
    - `ArtifactsRuntime` and `DrainHookRegistration` in `_artifacts.py`
      (composes `RpcCaller + AsyncWorkRuntime + DrainHookRegistration`).
    - `UploadRuntime` in `_source_upload.py` (composes `RpcCaller +
-     OperationScopeProvider` plus `kernel` + `auth` constructor args).
+     OperationScopeProvider + LoopGuard` plus `kernel` + `auth`
+     constructor args).
 
 4. **Each feature constructor names its dependency by capability**, not
    by the broad `Session`:
@@ -205,13 +205,11 @@ runtimes. Concretely:
   saved-chat ownership move) and they would not be coherent if split
   across multiple ADRs.
 
-The 11-step incremental migration that realizes this decision is
-detailed in `docs/refactor-history.md` §Migration Plan. It is intentionally
-**not duplicated here**: this ADR records the architectural intent, not
-the step sequence. Step ordering may evolve as the migration progresses
-(e.g. when test fixture changes reveal a needed prior step), and the
-authoritative ordering lives in `docs/refactor-history.md` until the cutover
-lands.
+The incremental migration that realized this decision shipped across
+Phases 1–7 of the capability refactor arc and is now complete; this ADR
+records the architectural intent rather than the step sequence. See
+`docs/refactor-history.md` for the as-shipped module map and the
+narrative of how the cutover landed.
 
 ### Composed Runtime Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ not exported from `_session_contracts.py`):
 |----------|--------|----------------|
 | `ChatRuntime` | [`_chat.py`](../src/notebooklm/_chat.py) | Chat-feature capability union — composes `RpcCaller` + `LoopGuard` and adds chat-specific `transport_post()` + `next_reqid()` methods. (The `ConversationCache` lives on `ChatAPI`, not the Protocol.) |
 | `ArtifactsRuntime` | [`_artifacts.py`](../src/notebooklm/_artifacts.py) | Artifact-feature capability union — composes `RpcCaller` + `AsyncWorkRuntime` + `DrainHookRegistration`. No own members; used by `ArtifactsAPI` for RPC dispatch, loop affinity, operation scopes, and close-time drain-hook registration. The `PollRegistry` lives on `ArtifactsAPI`, not the Protocol. |
-| `UploadRuntime` | [`_source_upload.py`](../src/notebooklm/_source_upload.py) | Upload-pipeline capability union — composes `RpcCaller` + `OperationScopeProvider`. The upload semaphore is internal to `SourceUploadPipeline`, not the Protocol. |
+| `UploadRuntime` | [`_source_upload.py`](../src/notebooklm/_source_upload.py) | Upload-pipeline capability union — composes `RpcCaller` + `OperationScopeProvider` + `LoopGuard`. The upload semaphore is internal to `SourceUploadPipeline`, not the Protocol. |
 | `DrainHookRegistration` | [`_artifacts.py`](../src/notebooklm/_artifacts.py) | Exposes `register_drain_hook(name, hook)` for close-time cleanup. Sole `DrainHookRegistration` after the broad-`Session` Protocol was deleted from `_session_contracts.py` (see the `_session_contracts.py` module docstring). |
 
 Production satisfies the shared Protocols via `Session`; tests substitute

--- a/docs/refactor-history.md
+++ b/docs/refactor-history.md
@@ -157,7 +157,7 @@ These modules did not exist before Tier 12 began:
 |---|---|
 | `notebooklm._session_contracts` | `AuthMetadata`, `Kernel`, and the four shared capability Protocols (`RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime`) added in the capability refactor (ADR-013). The originally-shipped broad `Session` Protocol and the standalone `DrainHookRegistration` Protocol were deleted in the final phase; feature-local runtimes (`ChatRuntime`, `ArtifactsRuntime`, `UploadRuntime`) now live in their owning feature modules, and the canonical `DrainHookRegistration` is local to `_artifacts.py`. |
 | `notebooklm._kernel` | Concrete `Kernel` transport core (owns the `httpx.AsyncClient`, exposes `post` / `cookies` / `aclose`). Located at root (`src/notebooklm/_kernel.py`), not nested. |
-| `notebooklm._middleware` | Middleware chain primitives (`AuthedHttpClient` Protocol, `Middleware` Protocol, `RequestContext`, chain composition). |
+| `notebooklm._middleware` | Middleware chain primitives (`Middleware` Protocol, `NextCall` callable type, `RpcRequest` / `RpcResponse` envelope dataclasses, `build_chain` composer). |
 | `notebooklm._middleware_tracing` | Tier 12 PR 12.3 — request tracing middleware. |
 | `notebooklm._middleware_metrics` | Tier 12 PR 12.4 — metrics collection middleware. |
 | `notebooklm._middleware_drain` | Tier 12 PR 12.5 — drain bookkeeping middleware. |
@@ -272,7 +272,7 @@ that slice was declared as a Protocol in the feature's own module:
   AsyncWorkRuntime + DrainHookRegistration`. Artifact polling owns
   the only close-time cleanup hook in the codebase today.
 - `UploadRuntime` in `_source_upload.py` — `RpcCaller +
-  OperationScopeProvider`. The upload pipeline also receives
+  OperationScopeProvider + LoopGuard`. The upload pipeline also receives
   `kernel` and `auth` as constructor args, since uploads need
   upload-specific auth routing and live cookies — but those wires
   are explicit, not implicit through a god-object.
@@ -335,7 +335,7 @@ NotebooksAPI(rpc, *, sources_api=sources)
 ChatAPI(runtime, *, notebooks=notebooks)
 ArtifactsAPI(runtime, *, notebooks=notebooks, mind_maps=mind_maps,
              note_service=note_service)
-NotesAPI(rpc, *, notes=note_service, mind_maps=mind_maps,
+NotesAPI(*, notes=note_service, mind_maps=mind_maps,
          save_chat_answer=...)
 ```
 


### PR DESCRIPTION
## Summary

Fixes 4 doc-drift findings surfaced by the retroactive `@claude review` on #945
(trigger comment: [#945 (comment)](https://github.com/teng-lin/notebooklm-py/pull/945#issuecomment-4514752433)):

1. **`docs/refactor-history.md:160`** — the `_middleware` row referenced
   non-existent type names (`AuthedHttpClient` Protocol, `RequestContext`).
   Replaced with the actual `__all__` of `src/notebooklm/_middleware.py`:
   `Middleware`, `NextCall`, `RpcRequest`, `RpcResponse`, `build_chain`.
2. **`docs/refactor-history.md:275` + `docs/architecture.md:83` +
   `docs/adr/0013-composable-session-capabilities.md:121`** — added
   `LoopGuard` to the `UploadRuntime` capability list. The actual class at
   `src/notebooklm/_source_upload.py:74` is
   `class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol)`,
   and the inclusion is load-bearing (Audit C1: lets `add_file` short-circuit
   cross-loop misuse before entering `operation_scope`).
3. **`docs/refactor-history.md:338`** — removed the phantom `rpc` positional
   arg from the `NotesAPI` constructor table. The actual signature at
   `src/notebooklm/_notes.py:67` is all keyword-only with no `rpc` parameter:
   `__init__(self, *, notes, mind_maps, save_chat_answer)`.
4. **`docs/adr/0013-composable-session-capabilities.md` lines 12 and 208-212**
   — removed forward-references to `docs/refactor-history.md` §Migration Plan,
   a section that was deliberately dropped after the cutover landed. Rewrote
   both paragraphs to describe the migration as completed rather than
   in-flight.

## Test plan

- [x] Visually inspected diffs against the cited files/line numbers.
- [x] Verified `src/notebooklm/_middleware.py` `__all__` matches the new
      `_middleware` row description.
- [x] Verified `src/notebooklm/_source_upload.py:74` includes `LoopGuard` in
      the `UploadRuntime` Protocol base list.
- [x] Verified `src/notebooklm/_notes.py:67` `NotesAPI.__init__` is
      kwargs-only with no `rpc` parameter.
- [x] Confirmed no remaining "Migration Plan" references in `docs/` after
      the rewrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision records documenting completion of multi-phase system migrations
  * Clarified capability component composition in upload runtime architecture
  * Updated refactor history with current middleware chain implementations and API construction details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->