### PR TITLE
refactor(cli): decorator cleanup + alias_command helper

### DIFF
--- a/src/notebooklm/cli/__init__.py
+++ b/src/notebooklm/cli/__init__.py
@@ -65,14 +65,11 @@ from .note_cmd import note
 from .notebook_cmd import register_notebook_commands
 from .options import (
     artifact_option,
-    generate_options,
     json_option,
     # Individual option decorators
     notebook_option,
     output_option,
     source_option,
-    # Composite decorators
-    standard_options,
     wait_option,
 )
 from .profile_cmd import profile
@@ -133,8 +130,6 @@ __all__ = [
     "source_option",
     "artifact_option",
     "output_option",
-    "standard_options",
-    "generate_options",
     # Output
     "json_output_response",
     "json_error_response",

--- a/src/notebooklm/cli/download_cmd.py
+++ b/src/notebooklm/cli/download_cmd.py
@@ -33,7 +33,7 @@ from ..client import NotebookLMClient
 from ._download_specs import DOWNLOAD_SPECS, DownloadTypeSpec
 from .auth_runtime import run_client_workflow
 from .error_handler import exit_with_code
-from .options import _complete_artifacts, notebook_option
+from .options import _complete_artifacts, alias_command, notebook_option
 from .rendering import console, json_output_response
 from .services.download import build_download_plan, execute_download
 
@@ -240,15 +240,13 @@ for _spec in DOWNLOAD_SPECS:
 # 'download cinematic-video' is a thin alias re-using download_video's
 # params + callback. Kept out of the registry to make the alias contract
 # explicit in code.
-_video_cmd = download.commands["video"]
-_cinematic_video_cmd = click.Command(
+alias_command(
+    download,
+    download.commands["video"],
     name="cinematic-video",
-    callback=_video_cmd.callback,
-    params=list(_video_cmd.params),
     help=(
         "Download cinematic video overview(s) to file.\n\n"
         "Alias for 'download video' — cinematic and standard videos share\n"
         "the same artifact type."
     ),
 )
-download.add_command(_cinematic_video_cmd)

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -20,6 +20,7 @@ from .input import resolve_prompt
 from .language_cmd import SUPPORTED_LANGUAGES, get_language
 from .options import (
     _complete_artifacts,
+    alias_command,
     json_option,
     language_option,
     multi_source_option,
@@ -309,10 +310,10 @@ def generate_video(
 
 # Convenience alias: 'generate cinematic-video' delegates to 'generate video --format cinematic'.
 # Reuses generate_video's callback/params so changes stay in sync automatically.
-_cinematic_video_gen_cmd = click.Command(
+alias_command(
+    generate,
+    generate_video,
     name="cinematic-video",
-    callback=generate_video.callback,
-    params=list(generate_video.params),
     help=(
         "Generate cinematic video overview (AI-generated documentary footage).\n\n"
         "Alias for 'generate video --format cinematic'. Uses Veo 3 AI to create\n"
@@ -324,7 +325,6 @@ _cinematic_video_gen_cmd = click.Command(
         '  notebooklm generate cinematic-video "documentary about quantum physics"'
     ),
 )
-generate.add_command(_cinematic_video_gen_cmd)
 
 
 @generate.command("slide-deck")

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -146,13 +146,12 @@ def wait_polling_options(
     defaults without diverging on flag name or help text.
 
     The ``--wait`` flag is intentionally NOT bundled here. It is a *trigger*
-    flag on ``generate <kind>`` (paired with ``wait_option`` /
-    ``generate_options``) and is implicit on ``artifact wait`` /
-    ``source wait`` (those subcommands ARE the wait). Bundling ``--wait``
-    here would either force-add it to commands that don't need it, or
-    interact awkwardly with ``--wait/--no-wait``'s tri-state default on
-    ``generate``. Keeping the trigger separate makes the surface uniform
-    and honest about intent.
+    flag on ``generate <kind>`` (paired with ``wait_option``) and is implicit
+    on ``artifact wait`` / ``source wait`` (those subcommands ARE the wait).
+    Bundling ``--wait`` here would either force-add it to commands that don't
+    need it, or interact awkwardly with ``--wait/--no-wait``'s tri-state
+    default on ``generate``. Keeping the trigger separate makes the surface
+    uniform and honest about intent.
 
     Args:
         default_timeout: Default value for ``--timeout`` in seconds. Each
@@ -394,14 +393,60 @@ def list_options(f: FC) -> FC:
     return f
 
 
-# Composite decorators for common patterns
+# =============================================================================
+# COMMAND ALIASING
+# =============================================================================
+#
+# ``alias_command`` lives here rather than in ``cli.helpers`` because
+# ``cli.helpers`` is constrained to a compatibility-facade surface (see
+# ``tests/unit/test_cli_boundary.py::test_helpers_remains_compatibility_facade``);
+# new implementations must own their module. ``options.py`` is the closest
+# fit: it is already the shared Click-surface utility module that command
+# modules import (for ``notebook_option``, ``json_option``, etc.), so adding
+# an alias-builder here keeps Click-surface concerns colocated without
+# inventing a one-function module.
 
 
-def standard_options(f: FC) -> FC:
-    """Apply notebook + json options (most common pattern)."""
-    return notebook_option(json_option(f))
+def alias_command(
+    group: click.Group,
+    source_command: click.Command,
+    name: str,
+    help: str,
+) -> click.Command:
+    """Register ``name`` on ``group`` as a thin alias for ``source_command``.
 
+    The alias shares the source command's callback and parameters, so flag and
+    behavior changes on the source command propagate automatically. Only the
+    visible ``name`` and ``help`` text are overridden, which is the entire
+    point of an alias: same behavior, different surface.
 
-def generate_options(f: FC) -> FC:
-    """Apply notebook + json + wait + retry options for generation commands."""
-    return notebook_option(json_option(wait_option(retry_option(f))))
+    The source command's ``params`` list is *copied*
+    (``list(source_command.params)``) so post-registration mutation on the
+    source list cannot retroactively change the alias. The
+    :class:`click.Parameter` instances inside are still shared by reference —
+    that is the desired contract for an alias and matches the previous
+    hand-written wiring for ``download cinematic-video`` and ``generate
+    cinematic-video``.
+
+    Args:
+        group: The Click group to register the alias under (e.g. ``download``
+            or ``generate``).
+        source_command: The already-built :class:`click.Command` whose
+            behavior the alias should mirror. Callers typically pass either a
+            module-level command symbol or ``group.commands["<name>"]``.
+        name: The subcommand name the alias is registered under.
+        help: The help text shown for the alias in ``--help`` output. Usually
+            states "Alias for ..." so users understand the relationship.
+
+    Returns:
+        The newly registered :class:`click.Command`, so callers can introspect
+        or further customize if needed.
+    """
+    alias = click.Command(
+        name=name,
+        callback=source_command.callback,
+        params=list(source_command.params),
+        help=help,
+    )
+    group.add_command(alias)
+    return alias

--- a/tests/unit/cli/test_options_validation.py
+++ b/tests/unit/cli/test_options_validation.py
@@ -142,3 +142,148 @@ class TestLimitRange:
         collapsed = " ".join(result.output.split())
         assert "0 = show no rows" in collapsed
         assert "Omit for unlimited" in collapsed
+
+
+# ---------------------------------------------------------------------------
+# alias_command (P3.T6b) — Click command-alias builder
+# ---------------------------------------------------------------------------
+#
+# ``alias_command`` lives in ``cli/options.py`` because ``cli/helpers.py`` is
+# constrained to a compatibility-facade surface (see
+# ``tests/unit/test_cli_boundary.py``). These tests use direct construction
+# (no monkeypatching, per task spec) — they build a tiny throwaway group +
+# source command and verify static and runtime properties via Click's
+# ``CliRunner``. The cinematic-video aliases on the real ``generate`` and
+# ``download`` groups are covered by the existing characterization tests
+# (``tests/unit/cli/test_download_characterization.py``,
+# ``tests/unit/cli/test_generate.py``) — those would have regressed if the
+# helper's contract had drifted.
+
+
+class TestAliasCommand:
+    def test_alias_command_registers_under_new_name(self) -> None:
+        """The alias appears in the group's command registry under ``name``."""
+        import click
+
+        from notebooklm.cli.options import alias_command
+
+        @click.group()
+        def grp() -> None:
+            """Test group."""
+
+        @grp.command("orig")
+        def orig() -> None:
+            """Original command."""
+            click.echo("orig-called")
+
+        alias = alias_command(grp, orig, name="alias", help="Alias of orig.")
+
+        assert "alias" in grp.commands
+        assert grp.commands["alias"] is alias
+        assert alias.name == "alias"
+
+    def test_alias_command_overrides_help_text(self) -> None:
+        """The alias renders the override help, not the source command's help."""
+        import click
+
+        from notebooklm.cli.options import alias_command
+
+        @click.group()
+        def grp() -> None:
+            """Group."""
+
+        @grp.command("orig", help="Original help text.")
+        def orig() -> None:
+            click.echo("ok")
+
+        alias_command(grp, orig, name="alias", help="Alias help text.")
+
+        runner = CliRunner()
+        result = runner.invoke(grp, ["alias", "--help"])
+        assert result.exit_code == 0
+        assert "Alias help text." in result.output
+        assert "Original help text." not in result.output
+
+    def test_alias_command_shares_callback_and_params(self) -> None:
+        """Invoking the alias runs the source command's callback with its params."""
+        import click
+
+        from notebooklm.cli.options import alias_command
+
+        captured: dict[str, object] = {}
+
+        @click.group()
+        def grp() -> None:
+            """Group."""
+
+        @grp.command("orig")
+        @click.option("--count", type=int, default=1)
+        @click.argument("target")
+        def orig(count: int, target: str) -> None:
+            captured["count"] = count
+            captured["target"] = target
+            click.echo(f"{target}x{count}")
+
+        alias_command(grp, orig, name="alias", help="Alias.")
+
+        runner = CliRunner()
+
+        # Source command still works.
+        captured.clear()
+        result = runner.invoke(grp, ["orig", "--count", "3", "foo"])
+        assert result.exit_code == 0, result.output
+        assert captured == {"count": 3, "target": "foo"}
+        assert "foox3" in result.output
+
+        # Alias runs the same callback with the same params.
+        captured.clear()
+        result = runner.invoke(grp, ["alias", "--count", "5", "bar"])
+        assert result.exit_code == 0, result.output
+        assert captured == {"count": 5, "target": "bar"}
+        assert "barx5" in result.output
+
+    def test_alias_command_params_list_is_copied(self) -> None:
+        """Mutating the source command's params after aliasing does not leak in.
+
+        The alias holds its own list (``list(source_command.params)``) so a
+        later ``source_command.params.append(...)`` cannot retroactively
+        change the alias's accepted flags. The ``Parameter`` instances inside
+        are still shared by reference — that's the desired alias contract.
+        """
+        import click
+
+        from notebooklm.cli.options import alias_command
+
+        @click.group()
+        def grp() -> None:
+            """Group."""
+
+        @grp.command("orig")
+        @click.option("--flag-a", is_flag=True)
+        def orig(flag_a: bool) -> None:
+            click.echo("ok")
+
+        alias = alias_command(grp, orig, name="alias", help="Alias.")
+
+        alias_param_count_before = len(alias.params)
+        orig.params.append(click.Option(["--injected"], is_flag=True))
+
+        assert len(alias.params) == alias_param_count_before
+
+    def test_alias_command_returns_registered_command(self) -> None:
+        """The helper returns the same ``click.Command`` it just registered."""
+        import click
+
+        from notebooklm.cli.options import alias_command
+
+        @click.group()
+        def grp() -> None:
+            """Group."""
+
+        @grp.command("orig")
+        def orig() -> None:
+            pass
+
+        alias = alias_command(grp, orig, name="alias", help="Alias.")
+        assert isinstance(alias, click.Command)
+        assert alias is grp.commands["alias"]


### PR DESCRIPTION
## Summary

Phase 3 / Wave 3.E (P3.T6b) of the CLI audit-fixes plan. Two pieces of cleanup, plus a new aliasing helper:

1. **Delete two orphaned composite option decorators** in `cli/options.py` — `standard_options` and `generate_options`. Both had zero call sites left after the Wave 3.B `*_cmd.py` extractions; nothing in `src/`, `tests/`, or `docs/` referenced them. Confirmed via `grep -rn`.
2. **Add `alias_command(group, source_command, name, help) -> click.Command`** helper in `cli/options.py`. Builds a `click.Command` that mirrors the source command's callback + params under a new name/help, and registers it on `group`.
3. **Convert both `cinematic-video` Click aliases** (`download cinematic-video`, `generate cinematic-video`) to use the helper. Behavior is byte-equivalent — same callback, same params, same help text rendering.

## Stacking

> This PR is **stacked on #962** (`cli-audit-fixes/p3t3-session-split`). Its diff base is that branch, not `main`. When #962 merges, this branch may need a rebase onto `main` before merge — orchestrator-aware. No new test failures vs the stacked base (42 pre-existing in p3t3 are unaffected).

## Why `cli/options.py` instead of `cli/helpers.py`

The task spec authorized either location. `cli/helpers.py` is constrained by `tests/unit/test_cli_boundary.py::test_helpers_remains_compatibility_facade` to a compatibility-facade surface — no new function definitions. Concrete helpers must live in an owning module. `cli/options.py` is the closest fit because it is already the shared Click-surface utility module that the command modules import (for `notebook_option`, `json_option`, etc.). A new banner comment in `options.py` documents this rationale inline so future readers don't re-litigate the choice.

## Before / after — `download cinematic-video`

```python
# Before
_video_cmd = download.commands["video"]
_cinematic_video_cmd = click.Command(
    name="cinematic-video",
    callback=_video_cmd.callback,
    params=list(_video_cmd.params),
    help=(
        "Download cinematic video overview(s) to file.\n\n"
        "Alias for 'download video' — cinematic and standard videos share\n"
        "the same artifact type."
    ),
)
download.add_command(_cinematic_video_cmd)

# After
alias_command(
    download,
    download.commands["video"],
    name="cinematic-video",
    help=(
        "Download cinematic video overview(s) to file.\n\n"
        "Alias for 'download video' — cinematic and standard videos share\n"
        "the same artifact type."
    ),
)
```

`generate cinematic-video` follows the same shape; source command is the module-level `generate_video` symbol rather than a `group.commands[...]` lookup.

## Acceptance

- [x] `grep -rn "standard_options\|generate_options" src/notebooklm/cli/` returns zero hits.
- [x] `alias_command(group, source_command, name, help)` helper exists at `src/notebooklm/cli/options.py:410`.
- [x] Both `cinematic-video` aliases use `alias_command`.
- [x] `uv run ruff format .` clean.
- [x] `uv run ruff check src/notebooklm/cli` clean.
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` clean (63 files).
- [x] `uv run pytest tests/unit/cli tests/unit` — zero new failures vs the stacked base; 5 new `alias_command` tests pass; cinematic-video characterization tests still pass.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_options_validation.py::TestAliasCommand` — 5 new direct unit tests cover registration, help-text override, callback + params sharing, copy semantics, returned command identity. No monkeypatching, per task `MUST NOT`.
- [x] `uv run pytest tests/unit/cli/test_download_characterization.py tests/unit/cli/test_download.py tests/unit/cli/test_generate.py` — existing characterization tests for `download cinematic-video` and `generate cinematic-video` still pass byte-for-byte.
- [x] `uv run pytest tests/unit/test_cli_boundary.py` — boundary invariants honored (helpers-as-facade + no cross-module helpers imports).
- [x] CLI smoke: `notebooklm download cinematic-video --help` and `notebooklm generate cinematic-video --help` render the override help text and full option list.

## Deferred polish findings

None.

## Out of scope (must-not-do honored)

- `cli/services/__init__.py` not touched (Phase-3-wide guard).
- Sibling-task files (`session_cmd.py`, `source_cmd.py`, etc.) not touched — only `options.py`, `__init__.py`, `download_cmd.py`, `generate_cmd.py`, plus the new tests in `test_options_validation.py`.
- `cinematic-video` command behavior and visibility unchanged (same callback, same params, same help text, same group registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)