### PR TITLE
test(cli): cover phase 3 service compliance

### DIFF
--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -91,7 +91,7 @@ def get_client(ctx) -> tuple[dict, str, str]:
     resolved_storage_path = _resolved_auth_storage_path(ctx)
     typed_storage_path = cast(Path | None, resolved_storage_path)
 
-    # Load from storage (which respects NOTEBOOKLM_AUTH_JSON if resolved path is None).
+    # Load from storage (which respects env-supplied auth if resolved path is None).
     cookies = helpers.load_auth_from_storage(resolved_storage_path)
 
     from ..auth import fetch_tokens_with_domains

--- a/src/notebooklm/cli/services/auth_diagnostics.py
+++ b/src/notebooklm/cli/services/auth_diagnostics.py
@@ -41,7 +41,7 @@ class AuthCheckPlan:
             check will read when no env-var auth is active).
         profile: Active profile name (forwarded to the token-fetch path
             so SID/SAPISID extraction targets the right account).
-        has_env_auth: ``True`` when ``NOTEBOOKLM_AUTH_JSON`` is set;
+        has_env_auth: ``True`` when env-supplied auth is active;
             short-circuits the file-read in favor of parsing the env var.
         has_home_env: ``True`` when ``NOTEBOOKLM_HOME`` is set; used in
             the ``auth_source`` display string.
@@ -128,7 +128,7 @@ def _read_storage_state(plan: AuthCheckPlan) -> tuple[dict[str, Any] | None, str
     if plan.has_env_auth:
         # Env-var auth: read the inline JSON via the consolidated
         # :func:`read_env_auth_json` accessor so this module stays out
-        # of the ``NOTEBOOKLM_AUTH_JSON`` consolidation gate's grep.
+        # of the auth-source consolidation gate's grep.
         try:
             return json.loads(read_env_auth_json()), None
         except json.JSONDecodeError as exc:

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -355,7 +355,7 @@ def validate_login_flag_conflicts(
     """Enforce ``login`` flag mutual-exclusion rules.
 
     Emits a styled error and ``exit_with_code(1)`` on the first conflict.
-    The ``NOTEBOOKLM_AUTH_JSON`` env-var check is intentionally not handled
+    The env-supplied-auth check is intentionally not handled
     here: it is an environment vs file-auth conflict, distinct from flag
     mutual-exclusion, and stays in the ``login`` orchestrator.
     """

--- a/src/notebooklm/cli/services/session_context.py
+++ b/src/notebooklm/cli/services/session_context.py
@@ -207,7 +207,7 @@ class StatusReport:
         context: The resolved notebook-context view (always present).
         paths: ``get_path_info(...)`` output when ``--paths`` was passed,
             else ``None``.
-        has_env_auth: ``True`` when ``NOTEBOOKLM_AUTH_JSON`` is set;
+        has_env_auth: ``True`` when env-supplied auth is active;
             used by the ``--paths`` renderer to print the inline-auth
             note.
     """
@@ -433,7 +433,7 @@ def run_logout(ctx: click.Context | None) -> None:
 
     Removes the resolved storage file, the cached browser profile, and
     the per-context cache file. Prints the env-still-active note when
-    ``NOTEBOOKLM_AUTH_JSON`` survives the logout. The order matters:
+    env-supplied auth survives the logout. The order matters:
 
     1. Storage file (the credential itself).
     2. Browser profile (the persistent SSO cache).

--- a/tests/_lint/test_auth_source_consolidation.py
+++ b/tests/_lint/test_auth_source_consolidation.py
@@ -1,0 +1,42 @@
+"""Auth-source consolidation guard for P3.T3.
+
+The env-var name is intentionally centralized in
+``cli/services/auth_source.py``. Other CLI modules must import
+``AUTH_JSON_ENV_NAME`` / ``has_env_auth_json`` instead of re-declaring
+the literal in source comments, docs, or logic. This keeps the original
+phase-3 grep gate enforceable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CLI_ROOTS = (
+    Path("src/notebooklm/cli"),
+    Path("src/notebooklm/notebooklm_cli.py"),
+)
+AUTH_SOURCE_PATH = Path("src/notebooklm/cli/services/auth_source.py")
+ENV_LITERAL = "NOTEBOOKLM_AUTH_JSON"
+
+
+def _source_files() -> list[Path]:
+    files: list[Path] = []
+    for root in CLI_ROOTS:
+        if root.is_file():
+            files.append(root)
+        else:
+            files.extend(sorted(root.rglob("*.py")))
+    return files
+
+
+def test_auth_json_env_literal_is_centralized() -> None:
+    offenders = [
+        path
+        for path in _source_files()
+        if path != AUTH_SOURCE_PATH and ENV_LITERAL in path.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        f"{ENV_LITERAL} must only be declared in {AUTH_SOURCE_PATH}; "
+        "other CLI modules should import AUTH_JSON_ENV_NAME or describe it generically. "
+        f"Offenders: {[str(path) for path in offenders]}"
+    )

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -1,0 +1,265 @@
+"""Direct service-layer tests for extracted ``cli/services/source_*`` modules."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm.cli.services import source_content, source_mutations, source_research, source_wait
+from notebooklm.cli.services.source_content import SourceFulltextPlan, execute_source_fulltext
+from notebooklm.cli.services.source_mutations import (
+    SourceDeletePlan,
+    SourceRenamePlan,
+    execute_source_delete,
+    execute_source_rename,
+)
+from notebooklm.cli.services.source_research import (
+    SourceAddResearchPlan,
+    execute_source_add_research,
+)
+from notebooklm.cli.services.source_wait import SourceWaitPlan, execute_source_wait
+from notebooklm.types import Source, SourceFulltext, SourceTimeoutError
+
+
+@pytest.mark.asyncio
+async def test_source_delete_json_without_yes_uses_structured_confirmation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_output_error(
+        message: str,
+        code: str,
+        json_output: bool,
+        exit_code: int,
+        *,
+        extra: dict[str, object] | None = None,
+    ) -> None:
+        calls.append(
+            {
+                "message": message,
+                "code": code,
+                "json_output": json_output,
+                "exit_code": exit_code,
+                "extra": extra,
+            }
+        )
+        raise SystemExit(exit_code)
+
+    monkeypatch.setattr(source_mutations, "output_error", fake_output_error)
+    client = SimpleNamespace(
+        sources=SimpleNamespace(
+            list=AsyncMock(return_value=[Source(id="src_abcdef", title="Paper")]),
+            delete=AsyncMock(),
+        )
+    )
+    plan = SourceDeletePlan(
+        notebook_id="nb_1",
+        source_id="src_abc",
+        yes=False,
+        json_output=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await execute_source_delete(client, plan)
+
+    assert exc_info.value.code == 1
+    assert calls == [
+        {
+            "message": "Pass --yes to confirm destructive operation in --json mode",
+            "code": "CONFIRM_REQUIRED",
+            "json_output": True,
+            "exit_code": 1,
+            "extra": {
+                "action": "delete",
+                "source_id": "src_abcdef",
+                "notebook_id": "nb_1",
+            },
+        }
+    ]
+    client.sources.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_source_rename_json_emits_service_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(source_mutations, "json_output_response", payloads.append)
+    monkeypatch.setattr(
+        source_mutations,
+        "resolve_source_id",
+        AsyncMock(return_value="src_full"),
+    )
+    client = SimpleNamespace(
+        sources=SimpleNamespace(rename=AsyncMock(return_value=Source(id="src_full", title="New")))
+    )
+
+    await execute_source_rename(
+        client,
+        SourceRenamePlan(
+            notebook_id="nb_1",
+            source_id="src",
+            new_title="New",
+            json_output=True,
+        ),
+    )
+
+    client.sources.rename.assert_awaited_once_with("nb_1", "src_full", "New")
+    assert payloads == [
+        {
+            "action": "rename",
+            "source_id": "src_full",
+            "notebook_id": "nb_1",
+            "title": "New",
+            "status": "renamed",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_fulltext_json_output_writes_file_and_emits_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(source_content, "json_output_response", payloads.append)
+    client = SimpleNamespace(
+        sources=SimpleNamespace(
+            get_fulltext=AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_1",
+                    title="Paper",
+                    content="full content",
+                    char_count=12,
+                )
+            )
+        )
+    )
+    output_path = tmp_path / "source.txt"
+
+    await execute_source_fulltext(
+        client,
+        SourceFulltextPlan(
+            notebook_id="nb_1",
+            source_id="src_1",
+            json_output=True,
+            output=str(output_path),
+            output_format="text",
+        ),
+    )
+
+    assert output_path.read_text(encoding="utf-8") == "full content"
+    assert payloads == [
+        {
+            "path": str(output_path),
+            "bytes": len(b"full content"),
+            "source_id": "src_1",
+            "title": "Paper",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_pins_task_id_and_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported = SimpleNamespace(imported=["src_1"])
+    import_research_sources = AsyncMock(return_value=imported)
+    monkeypatch.setattr(source_research, "import_research_sources", import_research_sources)
+    monkeypatch.setattr(source_research.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
+    monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            poll=AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "sources": [{"title": "Result"}],
+                    "report": "Report",
+                }
+            ),
+        )
+    )
+
+    await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="deep",
+            import_all=True,
+            cited_only=True,
+            no_wait=False,
+            timeout=30,
+        ),
+    )
+
+    client.research.start.assert_awaited_once_with("nb_1", "topic", "web", "deep")
+    client.research.poll.assert_awaited_once_with("nb_1", task_id="task_123")
+    import_research_sources.assert_awaited_once_with(
+        client,
+        "nb_1",
+        "task_123",
+        [{"title": "Result"}],
+        report="Report",
+        cited_only=True,
+        max_elapsed=30,
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_wait_timeout_maps_to_json_envelope_and_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[dict[str, object]] = []
+
+    @contextlib.asynccontextmanager
+    async def fake_status_with_elapsed(*args: object, **kwargs: object) -> AsyncIterator[None]:
+        yield
+
+    def fake_exit_with_code(code: int) -> None:
+        raise SystemExit(code)
+
+    monkeypatch.setattr(source_wait, "status_with_elapsed", fake_status_with_elapsed)
+    monkeypatch.setattr(source_wait, "json_output_response", payloads.append)
+    monkeypatch.setattr(source_wait, "exit_with_code", fake_exit_with_code)
+    client = SimpleNamespace(
+        sources=SimpleNamespace(
+            wait_until_ready=AsyncMock(side_effect=SourceTimeoutError("src_1", 10.0, 2))
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await execute_source_wait(
+            client,
+            SourceWaitPlan(
+                notebook_id="nb_1",
+                source_id="src_1",
+                timeout=10.0,
+                interval=0.5,
+                json_output=True,
+            ),
+        )
+
+    assert exc_info.value.code == 2
+    assert payloads == [
+        {
+            "source_id": "src_1",
+            "status": "timeout",
+            "last_status_code": 2,
+            "timeout_seconds": 10,
+            "error": "Source src_1 not ready after 10.0s (last status: 2)",
+        }
+    ]
+    client.sources.wait_until_ready.assert_awaited_once_with(
+        "nb_1",
+        "src_1",
+        timeout=10.0,
+        initial_interval=0.5,
+    )

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -1,0 +1,192 @@
+"""Direct service-layer tests for ``cli/services/download.py``.
+
+These cover the P3.T2 public service surface without going through
+``CliRunner`` or Click command registration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import click
+import pytest
+
+from notebooklm.cli._download_specs import DOWNLOAD_SPECS_BY_NAME
+from notebooklm.cli.services import download as download_service
+from notebooklm.cli.services.download import build_download_plan, execute_download
+from notebooklm.types import Artifact
+
+
+def _artifact(
+    artifact_id: str,
+    title: str,
+    artifact_type: int,
+    *,
+    variant: int | None = None,
+    status: int = 3,
+) -> Artifact:
+    return Artifact(
+        id=artifact_id,
+        title=title,
+        _artifact_type=artifact_type,
+        _variant=variant,
+        status=status,
+    )
+
+
+def _args(**overrides: Any) -> dict[str, Any]:
+    args: dict[str, Any] = {
+        "output_path": None,
+        "notebook_id": "nb_123",
+        "latest": False,
+        "earliest": False,
+        "download_all": False,
+        "name": None,
+        "artifact_id": None,
+        "json_output": False,
+        "dry_run": False,
+        "force": False,
+        "no_clobber": False,
+    }
+    args.update(overrides)
+    return args
+
+
+@pytest.fixture(autouse=True)
+def resolved_notebook(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        download_service,
+        "resolve_notebook_id",
+        AsyncMock(return_value="nb_resolved"),
+    )
+
+
+def test_build_download_plan_rejects_force_and_no_clobber() -> None:
+    spec = DOWNLOAD_SPECS_BY_NAME["audio"]
+
+    with pytest.raises(click.UsageError, match="Cannot specify both --force and --no-clobber"):
+        build_download_plan(spec, _args(force=True, no_clobber=True))
+
+
+def test_build_download_plan_applies_registry_format_extension_and_warning() -> None:
+    spec = DOWNLOAD_SPECS_BY_NAME["slide-deck"]
+    warnings: list[str] = []
+
+    plan = build_download_plan(
+        spec,
+        _args(output_path="deck.pdf", slide_format="pptx"),
+        Path("/workspace"),
+        warn_sink=warnings.append,
+    )
+
+    assert plan.file_extension == ".pptx"
+    assert plan.format_choice == "pptx"
+    assert warnings == [
+        "Warning: output path 'deck.pdf' does not end with '.pptx' but --format pptx was requested."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_download_all_dry_run_applies_name_filter_and_duplicate_filenames(
+    tmp_path: Path,
+) -> None:
+    spec = DOWNLOAD_SPECS_BY_NAME["audio"]
+    artifacts = SimpleNamespace(
+        list=AsyncMock(
+            return_value=[
+                _artifact("a1", "Episode", 1),
+                _artifact("a2", "Episode", 1),
+                _artifact("a3", "Trailer", 1),
+            ]
+        ),
+        download_audio=AsyncMock(),
+    )
+    facade = SimpleNamespace(artifacts=artifacts)
+    plan = build_download_plan(
+        spec,
+        _args(
+            output_path=str(tmp_path / "downloads"),
+            download_all=True,
+            name="episode",
+            dry_run=True,
+        ),
+        tmp_path,
+    )
+
+    result = await execute_download(plan, facade)
+
+    assert result == {
+        "dry_run": True,
+        "operation": "download_all",
+        "count": 2,
+        "output_dir": str(tmp_path / "downloads"),
+        "artifacts": [
+            {"id": "a1", "title": "Episode", "filename": "Episode.mp3"},
+            {"id": "a2", "title": "Episode", "filename": "Episode (2).mp3"},
+        ],
+    }
+    artifacts.download_audio.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_download_all_reports_partial_failure_and_progress(tmp_path: Path) -> None:
+    spec = DOWNLOAD_SPECS_BY_NAME["audio"]
+    artifacts = SimpleNamespace(
+        list=AsyncMock(
+            return_value=[
+                _artifact("a1", "Episode 1", 1),
+                _artifact("a2", "Episode 2", 1),
+            ]
+        ),
+        download_audio=AsyncMock(
+            side_effect=[str(tmp_path / "Episode 1.mp3"), RuntimeError("boom")]
+        ),
+    )
+    facade = SimpleNamespace(artifacts=artifacts)
+    plan = build_download_plan(
+        spec,
+        _args(output_path=str(tmp_path), download_all=True),
+        tmp_path,
+    )
+    progress: list[str] = []
+
+    result = await execute_download(plan, facade, text_progress_sink=progress.append)
+
+    assert result["error"] is True
+    assert result["succeeded_count"] == 1
+    assert result["failed_count"] == 1
+    assert result["skipped_count"] == 0
+    assert [item["status"] for item in result["artifacts"]] == ["downloaded", "failed"]
+    assert result["artifacts"][1]["error"] == "boom"
+    assert progress == [
+        "[dim]Downloading 1/2:[/dim] Episode 1",
+        "[dim]Downloading 2/2:[/dim] Episode 2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> None:
+    spec = DOWNLOAD_SPECS_BY_NAME["quiz"]
+    artifacts = SimpleNamespace(
+        list=AsyncMock(return_value=[_artifact("quiz_1", "Quiz", 4, variant=2)]),
+        download_quiz=AsyncMock(return_value=str(tmp_path / "quiz.md")),
+    )
+    facade = SimpleNamespace(artifacts=artifacts)
+    plan = build_download_plan(
+        spec,
+        _args(output_path=str(tmp_path / "quiz.md"), output_format="markdown"),
+        tmp_path,
+    )
+
+    result = await execute_download(plan, facade)
+
+    assert result["status"] == "downloaded"
+    artifacts.download_quiz.assert_awaited_once_with(
+        "nb_resolved",
+        str(tmp_path / "quiz.md"),
+        artifact_id="quiz_1",
+        output_format="markdown",
+    )


### PR DESCRIPTION
## Summary
- centralize the NOTEBOOKLM_AUTH_JSON literal back to `cli/services/auth_source.py` and add a lint guard for the P3.T3 grep gate
- add direct service-layer coverage for the P3.T2 download plan/executor surface
- add direct service-layer coverage across the P3.T5 source service modules

## Tests
- `uv run --extra dev pytest tests/_lint/test_auth_source_consolidation.py tests/unit/test_download_service.py tests/unit/test_cli_source_services.py tests/unit/cli/test_download_characterization.py tests/unit/cli/test_source_characterization.py -q`
- `uv run --extra dev pytest tests/_lint/test_no_module_shadowing.py tests/_lint/test_login_init_is_reexport_only.py tests/_lint/test_login_package_dag.py tests/unit/cli/test_session_patch_surface.py tests/_lint/test_auth_source_consolidation.py -q`
- `uv run --extra dev pytest tests/unit -q`
- `uv run --extra browser --extra dev --extra markdown pytest tests/integration -q`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy src/notebooklm/cli --ignore-missing-imports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for CLI source service operations covering delete, rename, export, import, and timeout handling.
  * Added unit tests for download service validation and execution, including dry-run and partial failure scenarios.
  * Added lint tests to enforce centralized environment configuration management.

* **Chores**
  * Updated internal documentation to reflect consolidated naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->