### PR TITLE
feat(artifacts): surface generation rate-limit retry

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1077,6 +1077,20 @@ status = await client.artifacts.generate_quiz(
 )
 ```
 
+**Rate-limit retry for generation:**
+
+```python
+from notebooklm.artifacts import with_rate_limit_retry
+
+status = await with_rate_limit_retry(
+    lambda: client.artifacts.generate_audio(
+        notebook_id,
+        instructions="focus on the counterarguments",
+    ),
+    max_retries=3,
+)
+```
+
 **Waiting for Completion:**
 
 ```python
@@ -2016,20 +2030,15 @@ async with await NotebookLMClient.from_storage() as client:
 
 Google rate limits aggressive API usage:
 
-```python
-import asyncio
-from notebooklm import RPCError
+For artifact-generation methods, use the shared generation retry helper:
 
-async def safe_create_notebooks(client, titles):
-    for title in titles:
-        try:
-            await client.notebooks.create(title)
-        except RPCError:
-            # Wait and retry on rate limit
-            await asyncio.sleep(10)
-            await client.notebooks.create(title)
-        # Add delay between operations
-        await asyncio.sleep(2)
+```python
+from notebooklm.artifacts import with_rate_limit_retry
+
+status = await with_rate_limit_retry(
+    lambda: client.artifacts.generate_audio(notebook_id),
+    max_retries=3,
+)
 ```
 
 ### Streaming Chat Responses
@@ -2078,6 +2087,35 @@ passage = await resolve_chat_reference_passage(
     client, notebook_id, first_ref, context_chars=150
 )
 print(f"Context: {passage}")
+```
+
+### Artifact Generation Helpers
+
+These helpers live in `notebooklm.artifacts` and can be used with any
+artifact-generation callable that returns `GenerationStatus`.
+
+#### `notebooklm.artifacts.with_rate_limit_retry`
+
+```python
+async def with_rate_limit_retry(
+    generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
+    *,
+    max_retries: int,
+    initial_delay: float = 60.0,
+    max_delay: float = 300.0,
+    multiplier: float = 2.0,
+) -> GenerationStatus | None:
+    """Run an artifact-generation callable with rate-limit retry."""
+```
+
+Example:
+```python
+from notebooklm.artifacts import with_rate_limit_retry
+
+status = await with_rate_limit_retry(
+    lambda: client.artifacts.generate_video(notebook_id),
+    max_retries=3,
+)
 ```
 
 ### Research Extraction and Citation Filtering

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2104,9 +2104,14 @@ async def with_rate_limit_retry(
     initial_delay: float = 60.0,
     max_delay: float = 300.0,
     multiplier: float = 2.0,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+    on_retry: Callable[[RateLimitRetryEvent], object | Awaitable[object]] | None = None,
 ) -> GenerationStatus | None:
     """Run an artifact-generation callable with rate-limit retry."""
 ```
+
+`sleep` lets tests or schedulers provide their own async wait function.
+`on_retry` receives a `RateLimitRetryEvent` before each retry sleep.
 
 Example:
 ```python

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -381,6 +381,7 @@ notebooklm generate video --retry 5   # Works with most generate commands
 **Python:**
 ```python
 import asyncio
+from notebooklm import RPCError
 from notebooklm.artifacts import with_rate_limit_retry
 
 # Add delays between intensive operations
@@ -393,6 +394,18 @@ status = await with_rate_limit_retry(
     lambda: client.artifacts.generate_audio(nb_id),
     max_retries=3,
 )
+
+# For non-artifact RPC calls, retry by passing a fresh callable each attempt
+async def retry_rpc_call(make_call, max_retries=3):
+    for attempt in range(max_retries + 1):
+        try:
+            return await make_call()
+        except RPCError:
+            if attempt >= max_retries:
+                raise
+            await asyncio.sleep(2**attempt)
+
+notebook = await retry_rpc_call(lambda: client.notebooks.create("Research Notes"))
 ```
 
 ### Starting a brand-new conversation (resolves the older issue #659 workaround)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -381,21 +381,18 @@ notebooklm generate video --retry 5   # Works with most generate commands
 **Python:**
 ```python
 import asyncio
+from notebooklm.artifacts import with_rate_limit_retry
 
 # Add delays between intensive operations
 for url in urls:
     await client.sources.add_url(nb_id, url)
     await asyncio.sleep(2)  # 2 second delay
 
-# Use exponential backoff on failures
-async def retry_with_backoff(coro, max_retries=3):
-    for attempt in range(max_retries):
-        try:
-            return await coro
-        except RPCError:
-            wait = 2 ** attempt  # 1, 2, 4 seconds
-            await asyncio.sleep(wait)
-    raise Exception("Max retries exceeded")
+# Use the shared generation retry policy when starting artifacts
+status = await with_rate_limit_retry(
+    lambda: client.artifacts.generate_audio(nb_id),
+    max_retries=3,
+)
 ```
 
 ### Starting a brand-new conversation (resolves the older issue #659 workaround)

--- a/src/notebooklm/artifacts.py
+++ b/src/notebooklm/artifacts.py
@@ -26,10 +26,14 @@ _RetrySleep = Callable[[float], Awaitable[Any]]
 
 @dataclass(frozen=True)
 class RateLimitRetryEvent:
-    """Details passed to ``with_rate_limit_retry`` retry callbacks."""
+    """Details passed to ``with_rate_limit_retry`` retry callbacks.
+
+    ``retry_number`` is the 1-based retry being scheduled.
+    ``next_attempt_number`` is the 1-based generation attempt after the
+    callback and sleep complete.
+    """
 
     result: GenerationStatus
-    attempt_number: int
     next_attempt_number: int
     total_attempts: int
     retry_number: int
@@ -51,6 +55,9 @@ def calculate_backoff_delay(
     ``attempt`` is zero-indexed, so ``attempt=0`` yields ``initial_delay``.
     The delay grows by ``multiplier`` until capped at ``max_delay``.
     """
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 0:
+        raise ValueError("attempt must be a non-negative integer")
+
     delay = initial_delay * (multiplier**attempt)
     return min(delay, max_delay)
 
@@ -99,7 +106,8 @@ async def with_rate_limit_retry(
 
     sleep_func = asyncio.sleep if sleep is None else sleep
 
-    for attempt in range(max_retries + 1):
+    attempt = 0
+    while True:
         result = await generate_fn()
 
         if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
@@ -117,7 +125,6 @@ async def with_rate_limit_retry(
         if on_retry is not None:
             event = RateLimitRetryEvent(
                 result=result,
-                attempt_number=attempt + 1,
                 next_attempt_number=attempt + 2,
                 total_attempts=max_retries + 1,
                 retry_number=attempt + 1,
@@ -128,8 +135,7 @@ async def with_rate_limit_retry(
             if inspect.isawaitable(callback_result):
                 await callback_result
         await sleep_func(delay)
-
-    return None
+        attempt += 1
 
 
 __all__ = [

--- a/src/notebooklm/artifacts.py
+++ b/src/notebooklm/artifacts.py
@@ -1,0 +1,142 @@
+"""Public artifact-generation helpers.
+
+The client methods on ``client.artifacts`` return ``GenerationStatus`` objects
+directly when Google rejects generation with a user-displayable rate-limit or
+quota error. This module provides the same retry policy used by the CLI so
+Python API callers do not need to duplicate the backoff loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .types import GenerationStatus
+
+RATE_LIMIT_RETRY_INITIAL_DELAY = 60.0
+RATE_LIMIT_RETRY_MAX_DELAY = 300.0
+RATE_LIMIT_RETRY_BACKOFF_MULTIPLIER = 2.0
+
+_GenerationCallable = Callable[[], Awaitable[GenerationStatus | None]]
+_RetrySleep = Callable[[float], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class RateLimitRetryEvent:
+    """Details passed to ``with_rate_limit_retry`` retry callbacks."""
+
+    result: GenerationStatus
+    attempt_number: int
+    next_attempt_number: int
+    total_attempts: int
+    retry_number: int
+    max_retries: int
+    delay: float
+
+
+_RetryCallback = Callable[[RateLimitRetryEvent], object | Awaitable[object]]
+
+
+def calculate_backoff_delay(
+    attempt: int,
+    initial_delay: float = RATE_LIMIT_RETRY_INITIAL_DELAY,
+    max_delay: float = RATE_LIMIT_RETRY_MAX_DELAY,
+    multiplier: float = RATE_LIMIT_RETRY_BACKOFF_MULTIPLIER,
+) -> float:
+    """Calculate the capped exponential delay for a retry attempt.
+
+    ``attempt`` is zero-indexed, so ``attempt=0`` yields ``initial_delay``.
+    The delay grows by ``multiplier`` until capped at ``max_delay``.
+    """
+    delay = initial_delay * (multiplier**attempt)
+    return min(delay, max_delay)
+
+
+async def with_rate_limit_retry(
+    generate_fn: _GenerationCallable,
+    *,
+    max_retries: int,
+    initial_delay: float = RATE_LIMIT_RETRY_INITIAL_DELAY,
+    max_delay: float = RATE_LIMIT_RETRY_MAX_DELAY,
+    multiplier: float = RATE_LIMIT_RETRY_BACKOFF_MULTIPLIER,
+    sleep: _RetrySleep | None = None,
+    on_retry: _RetryCallback | None = None,
+) -> GenerationStatus | None:
+    """Run an artifact-generation callable with rate-limit retry.
+
+    The callable is always invoked at least once. Retries happen only when the
+    result is a ``GenerationStatus`` whose ``is_rate_limited`` property is
+    true. Successful statuses, non-rate-limit failures, and ``None`` return
+    immediately.
+
+    Args:
+        generate_fn: Async callable that starts an artifact-generation request.
+        max_retries: Number of retries after the initial attempt.
+        initial_delay: Delay before the first retry, in seconds.
+        max_delay: Maximum delay cap, in seconds.
+        multiplier: Exponential backoff multiplier.
+        sleep: Async sleep function. Defaults to ``asyncio.sleep``.
+        on_retry: Optional callback invoked before each retry sleep.
+
+    Returns:
+        The first non-rate-limited result, or the final rate-limited result
+        when the retry budget is exhausted.
+
+    Raises:
+        ValueError: If retry or delay parameters are invalid.
+    """
+    if max_retries < 0:
+        raise ValueError("max_retries must be non-negative")
+    if initial_delay < 0:
+        raise ValueError("initial_delay must be non-negative")
+    if max_delay < 0:
+        raise ValueError("max_delay must be non-negative")
+    if multiplier <= 0:
+        raise ValueError("multiplier must be positive")
+
+    sleep_func = asyncio.sleep if sleep is None else sleep
+
+    for attempt in range(max_retries + 1):
+        result = await generate_fn()
+
+        if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
+            return result
+
+        if attempt >= max_retries:
+            return result
+
+        delay = calculate_backoff_delay(
+            attempt,
+            initial_delay=initial_delay,
+            max_delay=max_delay,
+            multiplier=multiplier,
+        )
+        if on_retry is not None:
+            event = RateLimitRetryEvent(
+                result=result,
+                attempt_number=attempt + 1,
+                next_attempt_number=attempt + 2,
+                total_attempts=max_retries + 1,
+                retry_number=attempt + 1,
+                max_retries=max_retries,
+                delay=delay,
+            )
+            callback_result = on_retry(event)
+            if inspect.isawaitable(callback_result):
+                await callback_result
+        await sleep_func(delay)
+
+    return None
+
+
+__all__ = [
+    "RATE_LIMIT_RETRY_BACKOFF_MULTIPLIER",
+    "RATE_LIMIT_RETRY_INITIAL_DELAY",
+    "RATE_LIMIT_RETRY_MAX_DELAY",
+    "RateLimitRetryEvent",
+    "calculate_backoff_delay",
+    "with_rate_limit_retry",
+]

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -1,9 +1,9 @@
 """CLI-internal services for artifact generation commands."""
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from ... import artifacts as artifact_retry
 from ...client import NotebookLMClient
 from ...types import GenerationStatus
 from ..error_handler import output_error
@@ -11,9 +11,12 @@ from ..rendering import console, json_output_response
 from .polling import status_with_elapsed
 
 # Retry constants
-RETRY_INITIAL_DELAY = 60.0  # seconds
-RETRY_MAX_DELAY = 300.0  # 5 minutes
-RETRY_BACKOFF_MULTIPLIER = 2.0
+RETRY_INITIAL_DELAY = artifact_retry.RATE_LIMIT_RETRY_INITIAL_DELAY
+RETRY_MAX_DELAY = artifact_retry.RATE_LIMIT_RETRY_MAX_DELAY
+RETRY_BACKOFF_MULTIPLIER = artifact_retry.RATE_LIMIT_RETRY_BACKOFF_MULTIPLIER
+
+# Compatibility export for callers that imported the old CLI-local helper.
+calculate_backoff_delay = artifact_retry.calculate_backoff_delay
 
 
 # Typical-duration hints for the spinner status line.
@@ -49,27 +52,6 @@ def _format_status_message(artifact_type: str, elapsed: float | None = None) -> 
     return f"{base} [{int(elapsed)}s elapsed]"
 
 
-def calculate_backoff_delay(
-    attempt: int,
-    initial_delay: float = RETRY_INITIAL_DELAY,
-    max_delay: float = RETRY_MAX_DELAY,
-    multiplier: float = RETRY_BACKOFF_MULTIPLIER,
-) -> float:
-    """Calculate exponential backoff delay for a retry attempt.
-
-    Args:
-        attempt: The current attempt number (0-indexed).
-        initial_delay: Initial delay in seconds.
-        max_delay: Maximum delay cap in seconds.
-        multiplier: Backoff multiplier.
-
-    Returns:
-        Delay in seconds for this attempt.
-    """
-    delay = initial_delay * (multiplier**attempt)
-    return min(delay, max_delay)
-
-
 async def generate_with_retry(
     generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
     max_retries: int,
@@ -90,28 +72,20 @@ async def generate_with_retry(
     Returns:
         GenerationStatus or None if generation failed.
     """
-    for attempt in range(max_retries + 1):
-        result = await generate_fn()
 
-        # Return immediately if not rate limited (success or other failure)
-        if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
-            return result
-
-        # Rate limited with no retries left
-        if attempt >= max_retries:
-            return result
-
-        # Wait before retry
-        delay = calculate_backoff_delay(attempt)
+    def _show_retry(event: artifact_retry.RateLimitRetryEvent) -> None:
         if not json_output:
             console.print(
                 f"[yellow]{artifact_type.title()} rate limited. "
-                f"Retrying in {int(delay)}s (attempt {attempt + 2}/{max_retries + 1})...[/yellow]"
+                f"Retrying in {int(event.delay)}s "
+                f"(attempt {event.next_attempt_number}/{event.total_attempts})...[/yellow]"
             )
-        await asyncio.sleep(delay)
 
-    # Unreachable, but satisfies type checker
-    return None
+    return await artifact_retry.with_rate_limit_retry(
+        generate_fn,
+        max_retries=max_retries,
+        on_retry=_show_retry,
+    )
 
 
 async def handle_generation_result(

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -1,0 +1,132 @@
+"""Unit tests for public artifact-generation rate-limit retry helpers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from notebooklm.artifacts import (
+    RATE_LIMIT_RETRY_MAX_DELAY,
+    RateLimitRetryEvent,
+    calculate_backoff_delay,
+    with_rate_limit_retry,
+)
+from notebooklm.types import GenerationStatus
+
+
+def _rate_limited_status() -> GenerationStatus:
+    return GenerationStatus(
+        task_id="",
+        status="failed",
+        error="Rate limited",
+        error_code="USER_DISPLAYABLE_ERROR",
+    )
+
+
+class TestCalculateBackoffDelay:
+    def test_exponential_backoff_with_cap(self) -> None:
+        assert calculate_backoff_delay(0, initial_delay=60.0) == 60.0
+        assert calculate_backoff_delay(1, initial_delay=60.0) == 120.0
+        assert calculate_backoff_delay(2, initial_delay=60.0) == 240.0
+        assert (
+            calculate_backoff_delay(10, initial_delay=60.0, max_delay=RATE_LIMIT_RETRY_MAX_DELAY)
+            == RATE_LIMIT_RETRY_MAX_DELAY
+        )
+
+    def test_custom_multiplier(self) -> None:
+        assert calculate_backoff_delay(1, initial_delay=10.0, multiplier=3.0) == 30.0
+
+
+class TestWithRateLimitRetry:
+    @pytest.mark.asyncio
+    async def test_returns_success_without_retry(self) -> None:
+        success = GenerationStatus(task_id="task_123", status="pending")
+        generate_fn = AsyncMock(return_value=success)
+
+        result = await with_rate_limit_retry(generate_fn, max_retries=3)
+
+        assert result == success
+        assert generate_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_rate_limited_status_then_returns_success(self) -> None:
+        rate_limited = _rate_limited_status()
+        success = GenerationStatus(task_id="task_123", status="pending")
+        generate_fn = AsyncMock(side_effect=[rate_limited, success])
+        events: list[RateLimitRetryEvent] = []
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await with_rate_limit_retry(
+                generate_fn,
+                max_retries=3,
+                on_retry=events.append,
+            )
+
+        assert result == success
+        assert generate_fn.call_count == 2
+        mock_sleep.assert_awaited_once_with(60.0)
+        assert events == [
+            RateLimitRetryEvent(
+                result=rate_limited,
+                attempt_number=1,
+                next_attempt_number=2,
+                total_attempts=4,
+                retry_number=1,
+                max_retries=3,
+                delay=60.0,
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retry_budget_and_returns_last_rate_limited_status(self) -> None:
+        rate_limited = _rate_limited_status()
+        generate_fn = AsyncMock(return_value=rate_limited)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await with_rate_limit_retry(generate_fn, max_retries=2)
+
+        assert result == rate_limited
+        assert generate_fn.call_count == 3
+        assert [call.args[0] for call in mock_sleep.await_args_list] == [60.0, 120.0]
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_rate_limit_failure(self) -> None:
+        failed = GenerationStatus(task_id="", status="failed", error="Bad request")
+        generate_fn = AsyncMock(return_value=failed)
+
+        result = await with_rate_limit_retry(generate_fn, max_retries=3)
+
+        assert result == failed
+        assert generate_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_supports_async_retry_callback_and_custom_sleep(self) -> None:
+        rate_limited = _rate_limited_status()
+        success = GenerationStatus(task_id="task_123", status="pending")
+        generate_fn = AsyncMock(side_effect=[rate_limited, success])
+        on_retry = AsyncMock()
+        sleep = AsyncMock()
+
+        result = await with_rate_limit_retry(
+            generate_fn,
+            max_retries=1,
+            initial_delay=2.0,
+            sleep=sleep,
+            on_retry=on_retry,
+        )
+
+        assert result == success
+        sleep.assert_awaited_once_with(2.0)
+        on_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_validates_retry_parameters(self) -> None:
+        generate_fn = AsyncMock()
+
+        with pytest.raises(ValueError, match="max_retries"):
+            await with_rate_limit_retry(generate_fn, max_retries=-1)
+        with pytest.raises(ValueError, match="initial_delay"):
+            await with_rate_limit_retry(generate_fn, max_retries=0, initial_delay=-1.0)
+        with pytest.raises(ValueError, match="max_delay"):
+            await with_rate_limit_retry(generate_fn, max_retries=0, max_delay=-1.0)
+        with pytest.raises(ValueError, match="multiplier"):
+            await with_rate_limit_retry(generate_fn, max_retries=0, multiplier=0.0)

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -1,5 +1,6 @@
 """Unit tests for public artifact-generation rate-limit retry helpers."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -35,6 +36,11 @@ class TestCalculateBackoffDelay:
     def test_custom_multiplier(self) -> None:
         assert calculate_backoff_delay(1, initial_delay=10.0, multiplier=3.0) == 30.0
 
+    @pytest.mark.parametrize("attempt", [-1, 1.5, True])
+    def test_rejects_invalid_attempt(self, attempt: Any) -> None:
+        with pytest.raises(ValueError, match="attempt must be a non-negative integer"):
+            calculate_backoff_delay(attempt)
+
 
 class TestWithRateLimitRetry:
     @pytest.mark.asyncio
@@ -67,7 +73,6 @@ class TestWithRateLimitRetry:
         assert events == [
             RateLimitRetryEvent(
                 result=rate_limited,
-                attempt_number=1,
                 next_attempt_number=2,
                 total_attempts=4,
                 retry_number=1,


### PR DESCRIPTION
## Summary
- Add public notebooklm.artifacts.with_rate_limit_retry helper with the CLI backoff policy and retry event callbacks.
- Delegate the CLI generation retry loop to the library helper while preserving CLI messages and compatibility constants.
- Document Python API and troubleshooting usage for artifact-generation retries.

Fixes #887

## Tests
- uv run pytest
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/notebooklm
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable rate-limit retry helper for artifact-generation calls with exponential backoff and retry callbacks.
  * CLI artifact generation now delegates to the shared retry helper and shows user-facing "retrying in Xs" messages (suppressed in JSON mode).

* **Documentation**
  * Updated Python API docs and troubleshooting guide with examples demonstrating the shared retry helper.

* **Tests**
  * Added unit tests covering backoff behavior, retry flows, and input validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->