### PR TITLE
feat(research): add wait_for_completion

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -748,7 +748,7 @@ repeat across pipeline invocations), set `NOTEBOOKLM_QUIET_DEPRECATIONS=1`
 
 Perform AI-powered research and add discovered sources to the notebook.
 
-> **Python equivalent:** [`client.research.start(nb_id, query, source="web", mode="deep")`](python-api.md#researchapi-clientresearch) followed by `client.research.poll(...)` / `client.research.import_sources(...)`.
+> **Python equivalent:** [`client.research.start(nb_id, query, source="web", mode="deep")`](python-api.md#researchapi-clientresearch) followed by `client.research.wait_for_completion(...)` / `client.research.import_sources(...)`.
 
 ```bash
 notebooklm source add-research [query] [OPTIONS]
@@ -820,7 +820,7 @@ notebooklm research status --json
 
 Wait for research to complete (blocking).
 
-> **Python equivalent:** loop on [`client.research.poll(nb_id)`](python-api.md#researchapi-clientresearch) until the returned status is terminal, then optionally call `client.research.import_sources(...)` (matches the CLI's `--import-all` / `--cited-only` behavior).
+> **Python equivalent:** [`client.research.wait_for_completion(nb_id)`](python-api.md#researchapi-clientresearch), then optionally call `client.research.import_sources(...)` (matches the CLI's `--import-all` / `--cited-only` behavior).
 
 ```bash
 notebooklm research wait [OPTIONS]

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -56,6 +56,8 @@ Examples:
 - `ArtifactPollingService.wait_for_completion` — loops `poll_status` until the
   artifact is terminal or `timeout` elapses.
 - `ArtifactsAPI.wait_for_completion` — public facade over the service loop.
+- `ResearchAPI.wait_for_completion` — loops `poll` until research is terminal,
+  pinning a discovered `task_id` between iterations.
 - `SourcePoller.wait_for_sources` (and `SourcesAPI.wait_for_sources`) — batch
   wait across N source IDs with a shared deadline.
 - `RetryMiddleware._wait_for_rate_limit` / `_wait_for_server_error` — private

--- a/docs/examples/research-to-podcast.py
+++ b/docs/examples/research-to-podcast.py
@@ -37,29 +37,34 @@ async def main(topic: str):
         task_id = research.get("task_id") if research else None
         print(f"  Task ID: {task_id}\n")
 
-        # 3. Poll for completion
+        # 3. Wait for completion
         print("Waiting for research to complete...")
-        max_polls = 30
-        for i in range(max_polls):
-            status = await client.research.poll(nb.id)
-            state = status.get("status", "unknown")
-            print(f"  Poll {i + 1}/{max_polls}: {state}")
-
-            if state == "completed":
-                sources = status.get("sources", [])
-                print(f"  Found {len(sources)} sources!\n")
-                break
-
-            await asyncio.sleep(10)
-        else:
+        try:
+            status = await client.research.wait_for_completion(
+                nb.id,
+                task_id=task_id,
+                timeout=300,
+                interval=10,
+            )
+        except TimeoutError:
             print("  Research timed out\n")
             return
 
+        if status.get("status") != "completed":
+            print(f"  Research ended with status: {status.get('status', 'unknown')}\n")
+            return
+
+        task_id = status.get("task_id") or task_id
+        sources = status.get("sources", [])
+        print(f"  Found {len(sources)} sources!\n")
+
         # 4. Import discovered sources
-        if sources:
+        if sources and task_id:
             print("Importing sources...")
             await client.research.import_sources(nb.id, task_id, sources[:10])  # Limit to 10
             print(f"  Imported {min(len(sources), 10)} sources\n")
+        elif sources:
+            print("  Skipping import: research completed without a task ID\n")
 
         # 5. Generate podcast
         print("Generating podcast...")

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1223,6 +1223,7 @@ if result.references:
 |--------|------------|---------|-------------|
 | `start(notebook_id, query, source, mode)` | `str, str, str="web", str="fast"` | `dict \| None` | Start research (mode: "fast" or "deep"); raises `ValidationError` on invalid source/mode |
 | `poll(notebook_id, task_id=None)` | `str, str \| None = None` | `dict` | Check research status |
+| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls |
 | `import_sources(notebook_id, task_id, sources)` | `str, str, list` | `list[dict]` | Import findings |
 
 **Method Signatures:**
@@ -1244,7 +1245,7 @@ async def poll(notebook_id: str, task_id: str | None = None) -> dict:
     """
     Returns a dict for the selected research task. If task_id is None, selects the latest research task and raises/emits an ambiguity warning if multiple tasks are in-flight. Top-level keys:
       - task_id:   str       — task/report identifier
-      - status:    str       — "completed" | "in_progress" | "no_research"
+      - status:    str       — "completed" | "failed" | "in_progress" | "no_research"
       - query:     str       — original research query
       - sources:   list[dict]
       - summary:   str       — summary text when present
@@ -1257,6 +1258,25 @@ async def poll(notebook_id: str, task_id: str | None = None) -> dict:
       - result_type:        int — 1=web, 2=drive, 5=deep-research report entry
       - research_task_id:   str — task/report ID that produced this source
       - report_markdown:    str — deep-research report markdown (for type-5 entries)
+    """
+
+async def wait_for_completion(
+    notebook_id: str,
+    task_id: str | None = None,
+    *,
+    timeout: float = 1800,
+    interval: float = 5,
+) -> dict:
+    """
+    Loops on poll() until research returns "completed" / "failed" or the
+    timeout expires. "no_research" returns immediately only before a task_id
+    is known; when a task_id is supplied or discovered, transient
+    "no_research" polls are retried. Once a concrete task_id is returned,
+    later polls reuse it as the discriminator so concurrent research tasks in
+    the same notebook cannot cross-wire results.
+
+    Returns: final poll() dict.
+    Raises: TimeoutError on timeout; ValueError for invalid timeout/interval.
     """
 
 async def import_sources(notebook_id: str, task_id: str, sources: list[dict]) -> list[dict]:
@@ -1293,13 +1313,13 @@ task_id = result["task_id"]
 # poll resolves to the intended task. Without it, poll() returns the
 # "latest task" and emits an ambiguity warning when multiple are in flight.
 
-# Poll until complete (always pass task_id for unambiguous targeting)
-import asyncio
-while True:
-    status = await client.research.poll(nb_id, task_id=task_id)
-    if status["status"] == "completed":
-        break
-    await asyncio.sleep(10)
+# Wait until complete (always pass task_id for unambiguous targeting)
+status = await client.research.wait_for_completion(
+    nb_id,
+    task_id=task_id,
+    timeout=1800,
+    interval=5,
+)
 
 # Import discovered sources (using the same task_id discriminator)
 imported = await client.research.import_sources(nb_id, task_id, status["sources"][:5])

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -494,7 +494,7 @@ class ResearchAPI:
             Dictionary representing the parsed research task for the
             notebook. Includes:
             - ``task_id``: task/report identifier for the selected task
-            - ``status``: ``in_progress``, ``completed``, or ``no_research``
+            - ``status``: ``in_progress``, ``completed``, ``failed``, or ``no_research``
             - ``query``: original research query text
             - ``sources``: parsed source dictionaries for the selected task
             - ``summary``: summary text when present
@@ -604,10 +604,17 @@ class ResearchAPI:
                     if report and parsed_source is not None:
                         parsed_source["report_markdown"] = report
 
-            # NOTE: Research status codes differ from artifact status codes
-            # Research: 1=in_progress, 2=completed, 6=completed (deep research)
+            # NOTE: Research status codes differ from artifact status codes.
+            # Research: 1=in_progress, 2=completed, 6=completed (deep research).
+            # Unknown non-null codes are treated as terminal failures so wait
+            # loops don't spin until timeout after the backend rejects a task.
             # Artifacts: 1=in_progress, 2=pending, 3=completed
-            status = "completed" if status_code in (2, 6) else "in_progress"
+            if status_code in (2, 6):
+                status = "completed"
+            elif status_code == 1 or status_code is None:
+                status = "in_progress"
+            else:
+                status = "failed"
 
             parsed_tasks.append(
                 {
@@ -652,6 +659,74 @@ class ResearchAPI:
             }
 
         return {"status": "no_research", "tasks": []}
+
+    async def wait_for_completion(
+        self,
+        notebook_id: str,
+        task_id: str | None = None,
+        *,
+        timeout: float = 1800,
+        interval: float = 5,
+    ) -> dict[str, Any]:
+        """Poll until research reaches a terminal state or times out.
+
+        When the first poll returns a concrete ``task_id``, subsequent polls
+        pass it back through :meth:`poll` as the discriminator. This prevents a
+        later concurrent research task in the same notebook from substituting
+        its sources/report into this wait loop.
+
+        Args:
+            notebook_id: The notebook ID.
+            task_id: Optional research task discriminator. Pass the value
+                returned by :meth:`start` when available.
+            timeout: Maximum seconds to wait.
+            interval: Seconds between status checks.
+
+        Returns:
+            The final :meth:`poll` result for ``completed`` or ``failed``
+            statuses. ``no_research`` is returned immediately only when no
+            task id is known; for a known/pinned task it can be a transient
+            live-API state before the task appears in ``POLL_RESEARCH``.
+
+        Raises:
+            TimeoutError: If research does not reach a terminal status before
+                ``timeout`` elapses.
+            ValueError: If ``timeout`` is negative or ``interval`` is not
+                positive.
+        """
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        if interval <= 0:
+            raise ValueError("interval must be positive")
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        pinned_task_id = task_id
+
+        while True:
+            status = await self.poll(notebook_id, task_id=pinned_task_id)
+            if pinned_task_id is None:
+                discovered_task_id = status.get("task_id")
+                if isinstance(discovered_task_id, str) and discovered_task_id:
+                    pinned_task_id = discovered_task_id
+
+            status_val = status.get("status", "unknown")
+            if status_val in ("completed", "failed"):
+                return status
+            if status_val == "no_research" and pinned_task_id is None:
+                return status
+
+            elapsed = loop.time() - start
+            if elapsed >= timeout:
+                task_label = pinned_task_id or "unknown"
+                raise TimeoutError(
+                    f"Research task {task_label} timed out after {timeout}s "
+                    f"(last status: {status_val})"
+                )
+
+            sleep_for = min(interval, timeout - elapsed)
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
 
     async def import_sources(
         self,

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -213,6 +213,24 @@ def _render_wait_result(plan: ResearchWaitPlan, result: ResearchWaitResult) -> N
             console.print(f"[yellow]Timed out after {result.timeout} seconds[/yellow]")
         exit_with_code(1)
 
+    if result.outcome == "failed":
+        if plan.json_output:
+            failed_payload: dict[str, Any] = {"status": "failed", "error": "Research failed"}
+            if result.query:
+                failed_payload["query"] = result.query
+            if result.sources:
+                failed_payload["sources"] = result.sources
+                failed_payload["sources_found"] = result.sources_count
+            if result.report:
+                failed_payload["report"] = result.report
+            json_output_response(failed_payload)
+        else:
+            if result.query:
+                console.print(f"[red]Research failed:[/red] {result.query}")
+            else:
+                console.print("[red]Research failed[/red]")
+        exit_with_code(1)
+
     # outcome == "completed"
     if plan.json_output:
         payload: dict[str, Any] = {

--- a/src/notebooklm/cli/services/research.py
+++ b/src/notebooklm/cli/services/research.py
@@ -1,9 +1,9 @@
 """Service layer for ``research wait`` (ADR-008 Click-to-service extraction).
 
 The CLI ``research wait`` command was a 130-line Click handler that mixed
-plan construction (parsing flags + validation), polling-loop orchestration
-(with task-id pinning per P1.T2), and I/O rendering (spinner + text/JSON
-output + exit codes). This module owns the plan + orchestration; the Click
+plan construction (parsing flags + validation), wait orchestration, and I/O
+rendering (spinner + text/JSON output + exit codes). This module owns the plan
+and orchestration; the Click
 handler in ``cli/research_cmd.py`` owns the rendering and exit-code
 decisions.
 
@@ -12,7 +12,7 @@ Contract
 
 * :class:`ResearchWaitPlan` — frozen dataclass of user inputs.
 * :class:`ResearchWaitResult` — discriminated result returned to the handler
-  (``outcome`` ∈ ``{"no_research", "timeout", "completed"}``).
+  (``outcome`` ∈ ``{"no_research", "timeout", "failed", "completed"}``).
 * :func:`execute_research_wait` — async orchestrator. Pure with respect to
   CLI I/O: it never calls ``console.print``, ``click.echo``, or
   ``exit_with_code``. It MAY call the injected ``import_sources`` callable
@@ -22,12 +22,9 @@ Contract
 Task-id pinning (P1.T2)
 -----------------------
 
-The first poll that returns a ``task_id`` pins it; subsequent polls pass
-``task_id=<pinned>`` so a concurrent research task started mid-wait cannot
-substitute its sources or report into this wait. Preserved verbatim from
-the pre-extraction handler — the characterization test
-``TestTaskIdPinning::test_task_id_pinned_after_first_discovery`` is the
-regression guard.
+The protocol-level pinning invariant lives in
+``ResearchAPI.wait_for_completion``. This service delegates the wait loop to
+the Python API so CLI and library callers share the same cross-wire guard.
 """
 
 from __future__ import annotations
@@ -35,13 +32,12 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from ..research_import import ResearchImportResult, import_research_sources
 from ..resolve import resolve_notebook_id
-from .polling import poll_until
 
-ResearchWaitOutcome = Literal["no_research", "timeout", "completed"]
+ResearchWaitOutcome = Literal["no_research", "timeout", "failed", "completed"]
 
 
 @dataclass(frozen=True)
@@ -66,7 +62,7 @@ class ResearchWaitResult:
     """Discriminated outcome of a ``research wait`` invocation.
 
     The handler picks the rendering path off ``outcome``; non-success
-    outcomes (``no_research``, ``timeout``) are converted into the
+    outcomes (``no_research``, ``timeout``, ``failed``) are converted into the
     appropriate ``exit_with_code(1)`` by the handler. ``completed`` returns
     exit-code 0 regardless of whether ``import_result`` is populated.
     """
@@ -105,7 +101,7 @@ async def execute_research_wait(
     resolve_id: ResolveNotebookIdFn = resolve_notebook_id,
     import_sources: ImportResearchSourcesFn = import_research_sources,
 ) -> ResearchWaitResult:
-    """Resolve, poll-with-pinned-task-id, and optionally import.
+    """Resolve, wait for completion, and optionally import.
 
     Args:
         plan: User inputs validated by the Click handler.
@@ -124,13 +120,12 @@ async def execute_research_wait(
 
     Returns:
         A :class:`ResearchWaitResult` whose ``outcome`` discriminates the
-        three terminal states. The service NEVER raises ``SystemExit`` and
+        terminal states. The service NEVER raises ``SystemExit`` and
         NEVER prints — the handler decides exit codes and rendering.
 
     Notes:
-        * Task-id pinning (P1.T2) — once the first poll returns a
-          ``task_id``, subsequent polls pin to it via the ``task_id=``
-          discriminator on ``client.research.poll``.
+        * Task-id pinning is handled by
+          ``client.research.wait_for_completion``.
         * Import is only invoked when ``plan.import_all`` is true AND the
           completed status has sources AND a ``task_id`` was discovered.
           (The third guard preserves the pre-extraction handler's behavior
@@ -139,36 +134,24 @@ async def execute_research_wait(
     """
     nb_id_resolved = await resolve_id(client, plan.notebook_id, json_output=plan.json_output)
 
-    # Closure-captured pinned task_id. Once set, every subsequent poll
-    # passes it as the discriminator — this is the P1.T2 fix.
-    task_id: str | None = None
-
-    async def _fetch_status() -> dict[str, Any]:
-        nonlocal task_id
-        current_status = await client.research.poll(nb_id_resolved, task_id=task_id)
-        if task_id is None:
-            task_id = current_status.get("task_id")
-        return current_status
-
-    def _is_terminal(current_status: dict[str, Any]) -> bool:
-        status_val = current_status.get("status", "unknown")
-        # Both ``no_research`` and ``completed`` terminate the poll loop;
-        # the handler distinguishes them by ``outcome``. (Pre-extraction,
-        # ``no_research`` exited inside the fetch closure via
-        # ``exit_with_code`` — this version returns the value up and lets
-        # the handler render + exit.)
-        return status_val in ("no_research", "completed")
-
     async with wait_context():
-        poll_result = await poll_until(
-            _fetch_status,
-            _is_terminal,
-            timeout=float(plan.timeout),
-            interval=float(plan.interval),
-        )
+        try:
+            status = await client.research.wait_for_completion(
+                nb_id_resolved,
+                timeout=float(plan.timeout),
+                interval=float(plan.interval),
+            )
+        except TimeoutError:
+            return ResearchWaitResult(
+                outcome="timeout",
+                notebook_id=nb_id_resolved,
+                timeout=plan.timeout,
+            )
+
+    raw_task_id = status.get("task_id")
+    task_id = raw_task_id if isinstance(raw_task_id, str) else None
 
     def _terminal(outcome: ResearchWaitOutcome, **extra: Any) -> ResearchWaitResult:
-        """Build a terminal result with the common notebook/timeout/task_id fields."""
         return ResearchWaitResult(
             outcome=outcome,
             notebook_id=nb_id_resolved,
@@ -177,22 +160,31 @@ async def execute_research_wait(
             **extra,
         )
 
-    # Check timeout before inspecting status — keeps control flow readable
-    # (claude[bot] #5: avoid signalling that status_val matters on the
-    # timeout branch).
-    if poll_result.timed_out:
-        return _terminal("timeout")
+    def _as_str(value: Any) -> str:
+        return value if isinstance(value, str) else ""
 
-    status = poll_result.value
-    status_val = status.get("status", "unknown")
+    def _as_sources(value: Any) -> list[dict[str, Any]]:
+        return cast(list[dict[str, Any]], value) if isinstance(value, list) else []
+
+    status_val = _as_str(status.get("status")) or "unknown"
+    query = _as_str(status.get("query"))
+    sources = _as_sources(status.get("sources"))
+    report = _as_str(status.get("report"))
 
     if status_val == "no_research":
         return _terminal("no_research")
+    if status_val == "failed":
+        return _terminal(
+            "failed",
+            query=query,
+            sources=sources,
+            report=report,
+        )
 
-    # status_val == "completed"
-    sources = status.get("sources", [])
-    query = status.get("query", "")
-    report = status.get("report", "")
+    # wait_for_completion only returns completed/no_research/failed; keep a
+    # narrow fallback so future terminal statuses cannot be rendered as success.
+    if status_val != "completed":
+        return _terminal("failed", query=query, sources=sources, report=report)
 
     import_result: ResearchImportResult | None = None
     if plan.import_all and sources and task_id:

--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -1,16 +1,14 @@
-"""Service for ``source add-research`` — research start + poll + import.
+"""Service for ``source add-research`` — research start + wait + import.
 
-Owns the polling loop (task-id-pinned per P1.T2 bug 6) and the optional
-``--import-all`` step. Stays in service-layer territory: imports the
-rendering helpers + ``import_research_sources`` directly rather than
-threading display callbacks through the executor — the resulting code
-matches the pre-extraction Click handler line-for-line so the
-characterization-test snapshots survive byte-for-byte.
+Owns research start orchestration and the optional ``--import-all`` step.
+The protocol-level wait loop and task-id pinning live in
+``ResearchAPI.wait_for_completion``. Stays in service-layer territory:
+imports the rendering helpers + ``import_research_sources`` directly rather than
+threading display callbacks through the executor.
 """
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -52,12 +50,12 @@ async def execute_source_add_research(
 
     Exit-code contract (matches the pre-extraction handler):
         * 0 — research started + completed (or ``--no-wait`` returned early).
-        * 1 — research failed to start (``no_research`` from the server).
+        * 1 — research failed to start (``research.start`` returned empty, or
+          the wait API reports no active research before a task is known).
 
-    The polling loop is pinned to the ``task_id`` returned by
-    ``research.start`` so a second research task started mid-wait (e.g.
-    concurrent caller, web UI, or retry) cannot cross-wire its sources
-    into this task's import branch (P1.T2 bug 6).
+    The wait call passes the ``task_id`` returned by ``research.start`` so a
+    second research task started mid-wait (e.g. concurrent caller, web UI, or
+    retry) cannot cross-wire its sources into this task's import branch.
     """
     console.print(f"[yellow]Starting {plan.mode} research on {plan.search_source}...[/yellow]")
     result = await client.research.start(
@@ -82,26 +80,19 @@ async def execute_source_add_research(
         )
         return
 
-    # Poll budget mirrors ``research wait --timeout``: cover the full total
-    # seconds budget at the fixed 5 s cadence. The legacy hardcoded
-    # 60-iteration cap stranded deep research (#315) because the import
-    # branch below is gated on ``status == "completed"``.
-    status: dict | None = None
-    max_polls = max(1, (plan.timeout + _POLL_INTERVAL_S - 1) // _POLL_INTERVAL_S)
-    for _ in range(max_polls):
-        status = await client.research.poll(plan.notebook_id, task_id=task_id)
-        if status.get("status") == "completed":
-            break
-        elif status.get("status") == "no_research":
-            console.print("[red]Research failed to start[/red]")
-            exit_with_code(1)
-        await asyncio.sleep(_POLL_INTERVAL_S)
-    else:
+    try:
+        status = await client.research.wait_for_completion(
+            plan.notebook_id,
+            task_id=task_id,
+            timeout=float(plan.timeout),
+            interval=float(_POLL_INTERVAL_S),
+        )
+    except TimeoutError:
         status = {"status": "timeout"}
 
-    assert status is not None  # for mypy — loop above always assigns
+    status_val = status.get("status", "unknown")
 
-    if status.get("status") == "completed":
+    if status_val == "completed":
         sources = status.get("sources", [])
         console.print()
         display_research_sources(sources)
@@ -119,8 +110,16 @@ async def execute_source_add_research(
                 max_elapsed=plan.timeout,
             )
             console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
+    elif status_val == "no_research":
+        console.print("[red]Research failed to start[/red]")
+        exit_with_code(1)
+    elif status_val in ("failed", "timeout"):
+        message = "Research timed out" if status_val == "timeout" else "Research failed"
+        console.print(f"[red]{message}[/red]")
+        exit_with_code(1)
     else:
-        console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
+        console.print(f"[yellow]Status: {status_val}[/yellow]")
+        exit_with_code(1)
 
 
 __all__ = ["SourceAddResearchPlan", "execute_source_add_research"]

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for CLI unit tests."""
 
+import math
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -153,6 +154,37 @@ def create_mock_client():
     mock_client.research = MagicMock()
     mock_client.notes = MagicMock()
     mock_client.sharing = MagicMock()
+
+    mock_client.research.poll = AsyncMock(return_value={"status": "no_research"})
+
+    async def wait_for_research_completion(
+        notebook_id,
+        task_id=None,
+        *,
+        timeout=1800,
+        interval=5,
+    ):
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        if interval <= 0:
+            raise ValueError("interval must be positive")
+        pinned_task_id = task_id
+        attempts = max(1, math.ceil(timeout / interval) + 1)
+        status = {"status": "no_research"}
+        for _ in range(attempts):
+            status = await mock_client.research.poll(notebook_id, task_id=pinned_task_id)
+            if pinned_task_id is None:
+                discovered_task_id = status.get("task_id")
+                if isinstance(discovered_task_id, str) and discovered_task_id:
+                    pinned_task_id = discovered_task_id
+            status_val = status.get("status")
+            if status_val in ("completed", "failed"):
+                return status
+            if status_val == "no_research" and pinned_task_id is None:
+                return status
+        raise TimeoutError(f"Research task {pinned_task_id or 'unknown'} timed out")
+
+    mock_client.research.wait_for_completion = AsyncMock(side_effect=wait_for_research_completion)
 
     # Default mocks for partial ID resolution
     # These return mock objects that match common test ID patterns (nb_*, src_*, etc.)

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -160,6 +160,26 @@ class TestResearchWait:
         assert result.exit_code == 1
         assert "No research running" in result.output
 
+    def test_wait_failed(self, runner, mock_auth, mock_fetch_tokens):
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "failed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+                    "report": "# Partial",
+                }
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123"])
+
+        assert result.exit_code == 1
+        assert "Research failed" in result.output
+        assert "AI research" in result.output
+
     def test_wait_timeout(self, runner, mock_auth, mock_fetch_tokens):
         with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
@@ -364,6 +384,30 @@ class TestResearchWait:
         data = json.loads(result.output)
         assert data["status"] == "no_research"
         assert "error" in data
+
+    def test_wait_json_failed(self, runner, mock_auth, mock_fetch_tokens):
+        with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "failed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+                    "report": "# Partial",
+                }
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "failed"
+        assert data["error"] == "Research failed"
+        assert data["query"] == "AI research"
+        assert data["sources_found"] == 1
+        assert data["report"] == "# Partial"
 
     def test_wait_json_timeout(self, runner, mock_auth, mock_fetch_tokens):
         with patch("notebooklm.cli.research_cmd.NotebookLMClient") as mock_client_cls:

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -163,22 +163,22 @@ async def test_source_fulltext_json_output_writes_file_and_emits_metadata(
 
 
 @pytest.mark.asyncio
-async def test_source_add_research_pins_task_id_and_imports(
+async def test_source_add_research_waits_with_started_task_id_and_imports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     imported = SimpleNamespace(imported=["src_1"])
     import_research_sources = AsyncMock(return_value=imported)
     monkeypatch.setattr(source_research, "import_research_sources", import_research_sources)
-    monkeypatch.setattr(source_research.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
     monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
     monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
-            poll=AsyncMock(
+            wait_for_completion=AsyncMock(
                 return_value={
                     "status": "completed",
+                    "task_id": "task_123",
                     "sources": [{"title": "Result"}],
                     "report": "Report",
                 }
@@ -201,7 +201,12 @@ async def test_source_add_research_pins_task_id_and_imports(
     )
 
     client.research.start.assert_awaited_once_with("nb_1", "topic", "web", "deep")
-    client.research.poll.assert_awaited_once_with("nb_1", task_id="task_123")
+    client.research.wait_for_completion.assert_awaited_once_with(
+        "nb_1",
+        task_id="task_123",
+        timeout=30.0,
+        interval=5.0,
+    )
     import_research_sources.assert_awaited_once_with(
         client,
         "nb_1",
@@ -213,23 +218,106 @@ async def test_source_add_research_pins_task_id_and_imports(
     )
 
 
+@pytest.mark.parametrize("status", ["failed", "timeout"])
 @pytest.mark.asyncio
-async def test_source_add_research_ceil_poll_budget_covers_timeout(
+async def test_source_add_research_failed_or_timeout_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+) -> None:
+    printed: list[str] = []
+
+    def fake_exit_with_code(code: int) -> None:
+        raise SystemExit(code)
+
+    monkeypatch.setattr(
+        source_research.console, "print", lambda message, *_, **__: printed.append(message)
+    )
+    monkeypatch.setattr(source_research, "exit_with_code", fake_exit_with_code)
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            wait_for_completion=AsyncMock(return_value={"status": status, "task_id": "task_123"}),
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await execute_source_add_research(
+            client,
+            SourceAddResearchPlan(
+                notebook_id="nb_1",
+                query="topic",
+                search_source="web",
+                mode="deep",
+                import_all=False,
+                cited_only=False,
+                no_wait=False,
+                timeout=30,
+            ),
+        )
+
+    assert exc_info.value.code == 1
+    expected = "Research failed" if status == "failed" else "Research timed out"
+    assert any(expected in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_unknown_status_exits_nonzero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    sleep = AsyncMock()
-    monkeypatch.setattr(source_research.asyncio, "sleep", sleep)
+    printed: list[str] = []
+
+    def fake_exit_with_code(code: int) -> None:
+        raise SystemExit(code)
+
+    monkeypatch.setattr(
+        source_research.console, "print", lambda message, *_, **__: printed.append(message)
+    )
+    monkeypatch.setattr(source_research, "exit_with_code", fake_exit_with_code)
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            wait_for_completion=AsyncMock(
+                return_value={"status": "cancelled", "task_id": "task_123"}
+            ),
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await execute_source_add_research(
+            client,
+            SourceAddResearchPlan(
+                notebook_id="nb_1",
+                query="topic",
+                search_source="web",
+                mode="deep",
+                import_all=False,
+                cited_only=False,
+                no_wait=False,
+                timeout=30,
+            ),
+        )
+
+    assert exc_info.value.code == 1
+    assert any("Status: cancelled" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_delegates_timeout_budget_to_research_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
     monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
     monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
-            poll=AsyncMock(
-                side_effect=[
-                    {"status": "in_progress"},
-                    {"status": "completed", "sources": [], "report": ""},
-                ]
+            wait_for_completion=AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [],
+                    "report": "",
+                }
             ),
         )
     )
@@ -248,9 +336,12 @@ async def test_source_add_research_ceil_poll_budget_covers_timeout(
         ),
     )
 
-    assert client.research.poll.await_count == 2
-    client.research.poll.assert_any_await("nb_1", task_id="task_123")
-    sleep.assert_awaited_once_with(5)
+    client.research.wait_for_completion.assert_awaited_once_with(
+        "nb_1",
+        task_id="task_123",
+        timeout=6.0,
+        interval=5.0,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -13,6 +13,7 @@ that exposes a ``--json`` flag so future regressions surface immediately.
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -154,6 +155,35 @@ def _make_client(extra_setup=None) -> MagicMock:
     client.artifacts.suggest_reports = AsyncMock(return_value=[])
     client.notes.list = AsyncMock(return_value=_stub_notes())
     client.research.poll = AsyncMock(return_value={"status": "no_research"})
+
+    async def wait_for_research_completion(
+        notebook_id: str,
+        task_id: str | None = None,
+        *,
+        timeout: float = 1800,
+        interval: float = 5,
+    ) -> dict:
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        if interval <= 0:
+            raise ValueError("interval must be positive")
+        pinned_task_id = task_id
+        attempts = max(1, math.ceil(timeout / interval) + 1)
+        status = {"status": "no_research"}
+        for _ in range(attempts):
+            status = await client.research.poll(notebook_id, task_id=pinned_task_id)
+            if pinned_task_id is None:
+                discovered_task_id = status.get("task_id")
+                if isinstance(discovered_task_id, str) and discovered_task_id:
+                    pinned_task_id = discovered_task_id
+            status_val = status.get("status")
+            if status_val in ("completed", "failed"):
+                return status
+            if status_val == "no_research" and pinned_task_id is None:
+                return status
+        raise TimeoutError(f"Research task {pinned_task_id or 'unknown'} timed out")
+
+    client.research.wait_for_completion = AsyncMock(side_effect=wait_for_research_completion)
     client.sharing.get_status = AsyncMock(return_value=_stub_share_status())
     client.chat.get_conversation_id = AsyncMock(return_value=None)
     client.chat.get_history = AsyncMock(return_value=[])

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -2,10 +2,12 @@
 
 import json
 import logging
+import warnings
 from urllib.parse import parse_qs
 
 import pytest
 
+import notebooklm._research as research_module
 from notebooklm import NotebookLMClient
 from notebooklm._research import (
     ResearchAPI,
@@ -23,6 +25,18 @@ def _extract_request_params(request) -> list:
     body = parse_qs(request.content.decode())
     f_req = json.loads(body["f.req"][0])
     return json.loads(f_req[0][0][1])
+
+
+def _build_research_task_payload(
+    query: str,
+    source_url: str,
+    source_title: str,
+    *,
+    status_code: int,
+) -> list:
+    """Build one POLL_RESEARCH task_info entry for wait/poll tests."""
+    sources = [[source_url, source_title, "desc", 1]]
+    return [None, [query, 1], 1, [sources, f"{query} summary"], status_code]
 
 
 class TestParseResultType:
@@ -386,6 +400,251 @@ class TestResearch:
         assert result["tasks"][0]["task_id"] == "task_123"
 
     @pytest.mark.asyncio
+    async def test_wait_for_completion_pins_discovered_task_id(
+        self, auth_tokens, httpx_mock, build_rpc_response, monkeypatch
+    ):
+        """A discovered task_id is reused so later polls cannot cross-wire tasks."""
+
+        async def no_sleep(delay: float) -> None:  # noqa: ARG001
+            return None
+
+        monkeypatch.setattr(research_module.asyncio, "sleep", no_sleep)
+
+        first_poll = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_A",
+                        _build_research_task_payload(
+                            "query A",
+                            "https://a.example/early",
+                            "Early A",
+                            status_code=1,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        second_poll = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_B",
+                        _build_research_task_payload(
+                            "query B",
+                            "https://b.example/final",
+                            "Final B",
+                            status_code=2,
+                        ),
+                    ],
+                    [
+                        "task_A",
+                        _build_research_task_payload(
+                            "query A",
+                            "https://a.example/final",
+                            "Final A",
+                            status_code=2,
+                        ),
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=first_poll.encode(), method="POST")
+        httpx_mock.add_response(content=second_poll.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                result = await client.research.wait_for_completion(
+                    "nb_123",
+                    timeout=10,
+                    interval=1,
+                )
+
+        assert result["status"] == "completed"
+        assert result["task_id"] == "task_A"
+        assert result["query"] == "query A"
+        assert result["sources"][0]["research_task_id"] == "task_A"
+        assert result["sources"][0]["title"] == "Final A"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_accepts_initial_task_id(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """An explicit task_id filters the first poll before any discovery."""
+        response_body = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_B",
+                        _build_research_task_payload(
+                            "query B",
+                            "https://b.example",
+                            "Result B",
+                            status_code=2,
+                        ),
+                    ],
+                    [
+                        "task_A",
+                        _build_research_task_payload(
+                            "query A",
+                            "https://a.example",
+                            "Result A",
+                            status_code=2,
+                        ),
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                result = await client.research.wait_for_completion(
+                    "nb_123",
+                    task_id="task_A",
+                    timeout=10,
+                    interval=1,
+                )
+
+        assert result["status"] == "completed"
+        assert result["task_id"] == "task_A"
+        assert result["sources"][0]["title"] == "Result A"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_returns_no_research(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.wait_for_completion(
+                "nb_123",
+                timeout=10,
+                interval=1,
+            )
+
+        assert result == {"status": "no_research", "tasks": []}
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_retries_transient_no_research_for_initial_task_id(
+        self, auth_tokens, httpx_mock, build_rpc_response, monkeypatch
+    ):
+        """Live API can return no_research briefly after start() for a known task."""
+
+        async def no_sleep(delay: float) -> None:  # noqa: ARG001
+            return None
+
+        monkeypatch.setattr(research_module.asyncio, "sleep", no_sleep)
+
+        no_research = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        completed = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_123",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=2,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=no_research.encode(), method="POST")
+        httpx_mock.add_response(content=completed.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.wait_for_completion(
+                "nb_123",
+                task_id="task_123",
+                timeout=10,
+                interval=1,
+            )
+
+        assert result["status"] == "completed"
+        assert result["task_id"] == "task_123"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_returns_failed_terminal_status(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        response_body = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_123",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=3,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.wait_for_completion(
+                "nb_123",
+                task_id="task_123",
+                timeout=10,
+                interval=1,
+            )
+
+        assert result["status"] == "failed"
+        assert result["task_id"] == "task_123"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_raises_timeout(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        response_body = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_123",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=1,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(TimeoutError, match="task_123"):
+                await client.research.wait_for_completion(
+                    "nb_123",
+                    timeout=0,
+                    interval=1,
+                )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_rejects_invalid_budget(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValueError, match="timeout must be non-negative"):
+                await client.research.wait_for_completion("nb_123", timeout=-1)
+            with pytest.raises(ValueError, match="interval must be positive"):
+                await client.research.wait_for_completion("nb_123", interval=0)
+
+    @pytest.mark.asyncio
     async def test_import_research(self, auth_tokens, httpx_mock, build_rpc_response):
         response_body = build_rpc_response(
             RPCMethod.IMPORT_RESEARCH, [[[["src_new"], "Imported Title"]]]
@@ -610,6 +869,20 @@ class TestResearch:
             result = await client.research.poll("nb_123")
 
         assert result["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_unknown_non_null_status_code_failed(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """Unknown backend status codes are terminal failures, not endless progress."""
+        task_info = [None, ["query", 1], 1, [[], ""], 3]
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_import_sources_skips_result_type_5(

--- a/tests/unit/test_research_service.py
+++ b/tests/unit/test_research_service.py
@@ -7,8 +7,7 @@ exercised separately by ``tests/unit/cli/test_research*.py``.
 
 The service is intentionally I/O-free: it never calls ``console.print``,
 ``click.echo``, or ``exit_with_code``. The Click handler owns rendering and
-exit codes; the service owns the polling loop, the P1.T2 task-id pinning,
-and the (optional) import call.
+exit codes; the service owns wait orchestration and the optional import call.
 """
 
 from __future__ import annotations
@@ -33,15 +32,15 @@ from notebooklm.cli.services.research import (
 
 
 class _FakeResearchAPI:
-    """Records poll calls; returns canned values."""
+    """Records wait calls; returns canned values."""
 
     def __init__(self, *, side_effect: Any) -> None:
-        self.poll = AsyncMock(side_effect=side_effect)
+        self.wait_for_completion = AsyncMock(side_effect=side_effect)
 
 
 class _FakeClient:
-    def __init__(self, *, poll_side_effect: Any) -> None:
-        self.research = _FakeResearchAPI(side_effect=poll_side_effect)
+    def __init__(self, *, wait_side_effect: Any) -> None:
+        self.research = _FakeResearchAPI(side_effect=wait_side_effect)
 
 
 async def _fake_resolve(client, notebook_id, *, json_output: bool = False) -> str:  # noqa: ARG001
@@ -65,9 +64,9 @@ def base_plan() -> ResearchWaitPlan:
 
 @pytest.mark.asyncio
 async def test_completed_returns_outcome_with_sources(base_plan):
-    """First poll completes; service returns completed result without import."""
+    """A completed wait result is rendered into the service result."""
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -89,11 +88,11 @@ async def test_completed_returns_outcome_with_sources(base_plan):
     assert result.sources_count == 1
     assert result.report == "REPORT"
     assert result.import_result is None  # import_all=False default
-    # Exactly one poll call; task_id=None on the first poll.
-    assert client.research.poll.await_count == 1
-    first_call = client.research.poll.await_args_list[0]
-    assert first_call.args == ("nb_123",)
-    assert first_call.kwargs == {"task_id": None}
+    client.research.wait_for_completion.assert_awaited_once_with(
+        "nb_123",
+        timeout=5.0,
+        interval=1.0,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -102,24 +101,10 @@ async def test_completed_returns_outcome_with_sources(base_plan):
 
 
 @pytest.mark.asyncio
-async def test_timeout_returns_outcome_without_completion(monkeypatch):
-    """A persistent in_progress status produces outcome='timeout'."""
-    # Eliminate real sleep so the timeout fires on the first interval boundary.
-    from notebooklm.cli.services import polling
-
-    clock = {"t": 0.0}
-
-    async def fake_sleep(delay: float) -> None:
-        clock["t"] += delay
-
-    monkeypatch.setattr(polling.time, "monotonic", lambda: clock["t"])
-    monkeypatch.setattr(polling.asyncio, "sleep", fake_sleep)
-
-    async def _poll(nb_id, *, task_id=None):  # noqa: ARG001
-        return {"status": "in_progress", "query": "AI"}
-
+async def test_timeout_returns_outcome_without_completion():
+    """A library timeout is mapped to outcome='timeout'."""
     plan = ResearchWaitPlan(notebook_id="nb_123", timeout=1, interval=1)
-    client = _FakeClient(poll_side_effect=_poll)
+    client = _FakeClient(wait_side_effect=TimeoutError("timed out"))
 
     result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
 
@@ -135,8 +120,8 @@ async def test_timeout_returns_outcome_without_completion(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_no_research_returns_outcome_without_exit(base_plan):
-    """no_research is a terminal poll value; service returns it (no SystemExit)."""
-    client = _FakeClient(poll_side_effect=[{"status": "no_research"}])
+    """no_research is a terminal wait value; service returns it (no SystemExit)."""
+    client = _FakeClient(wait_side_effect=[{"status": "no_research"}])
 
     # The service must NOT raise SystemExit — that's the handler's job.
     result = await execute_research_wait(base_plan, client=client, resolve_id=_fake_resolve)
@@ -147,57 +132,110 @@ async def test_no_research_returns_outcome_without_exit(base_plan):
     assert result.import_result is None
 
 
+@pytest.mark.asyncio
+async def test_failed_returns_outcome_without_import(base_plan):
+    """failed is terminal and must not fall through to completed/import behavior."""
+    client = _FakeClient(
+        wait_side_effect=[
+            {
+                "status": "failed",
+                "task_id": "task_failed",
+                "query": "AI research",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "Partial report",
+            }
+        ]
+    )
+    import_mock = AsyncMock()
+
+    result = await execute_research_wait(
+        base_plan,
+        client=client,
+        resolve_id=_fake_resolve,
+        import_sources=import_mock,
+    )
+
+    assert result.outcome == "failed"
+    assert result.task_id == "task_failed"
+    assert result.query == "AI research"
+    assert result.sources == [{"title": "S", "url": "http://example.com"}]
+    assert result.report == "Partial report"
+    assert result.import_result is None
+    import_mock.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_outcome"),
+    [
+        ("failed", "failed"),
+        ("completed", "completed"),
+        ("cancelled", "failed"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_terminal_payload_fields_are_normalized(
+    base_plan,
+    status: str,
+    expected_outcome: str,
+):
+    """Malformed wait payload fields are coerced before CLI rendering."""
+    client = _FakeClient(
+        wait_side_effect=[
+            {
+                "status": status,
+                "task_id": "task_abc",
+                "query": 123,
+                "sources": None,
+                "report": ["not", "a", "string"],
+            }
+        ]
+    )
+
+    result = await execute_research_wait(base_plan, client=client, resolve_id=_fake_resolve)
+
+    assert result.outcome == expected_outcome
+    assert result.query == ""
+    assert result.sources == []
+    assert result.sources_count == 0
+    assert result.report == ""
+
+
 # ---------------------------------------------------------------------------
-# P1.T2 task-id pinning regression — service-layer test
+# Library wait delegation
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_task_id_pinned_after_first_discovery(monkeypatch):
-    """The first non-empty task_id pins every subsequent poll's discriminator.
-
-    Service-layer mirror of the CLI characterization test
-    ``TestTaskIdPinning::test_task_id_pinned_after_first_discovery``. This
-    test does NOT use the Click runner — it asserts directly on
-    ``client.research.poll.await_args_list``.
-    """
-    polls = [
-        {"status": "in_progress", "task_id": "task_pinned", "query": "AI"},
-        {
-            "status": "completed",
-            "task_id": "task_pinned",
-            "query": "AI",
-            "sources": [{"title": "S", "url": "http://example.com"}],
-            "report": "R",
-        },
-    ]
-    client = _FakeClient(poll_side_effect=polls)
+async def test_wait_delegates_timeout_and_interval_to_library():
+    """The service passes CLI wait budget values into the Python API."""
+    client = _FakeClient(
+        wait_side_effect=[
+            {
+                "status": "completed",
+                "task_id": "task_pinned",
+                "query": "AI",
+                "sources": [{"title": "S", "url": "http://example.com"}],
+                "report": "R",
+            }
+        ]
+    )
     plan = ResearchWaitPlan(notebook_id="nb_123", timeout=10, interval=1)
-
-    # No-op sleep so the inter-poll wait doesn't slow the test.
-    from notebooklm.cli.services import polling
-
-    async def _no_sleep(delay):  # noqa: ARG001
-        return None
-
-    monkeypatch.setattr(polling.asyncio, "sleep", _no_sleep)
 
     result = await execute_research_wait(plan, client=client, resolve_id=_fake_resolve)
 
     assert result.outcome == "completed"
-    calls = client.research.poll.await_args_list
-    assert len(calls) == 2
-    # First call: task_id=None (nothing pinned yet).
-    assert calls[0].kwargs.get("task_id") is None
-    # Second call: pinned to the value from the first poll.
-    assert calls[1].kwargs.get("task_id") == "task_pinned"
+    client.research.wait_for_completion.assert_awaited_once_with(
+        "nb_123",
+        timeout=10.0,
+        interval=1.0,
+    )
 
 
 @pytest.mark.asyncio
-async def test_task_id_never_set_when_polls_never_return_one():
-    """If poll responses never include a task_id, the discriminator stays None."""
+async def test_task_id_never_set_when_wait_result_has_none():
+    """If wait result has no task_id, the importer guard stays off."""
     client = _FakeClient(
-        poll_side_effect=[{"status": "completed", "query": "X", "sources": [], "report": ""}]
+        wait_side_effect=[{"status": "completed", "query": "X", "sources": [], "report": ""}]
     )
     plan = ResearchWaitPlan(notebook_id="nb_123", timeout=5, interval=1)
 
@@ -205,8 +243,7 @@ async def test_task_id_never_set_when_polls_never_return_one():
 
     assert result.outcome == "completed"
     assert result.task_id is None
-    # The single poll call passed task_id=None.
-    assert client.research.poll.await_args_list[0].kwargs.get("task_id") is None
+    client.research.wait_for_completion.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +261,7 @@ async def test_import_all_invokes_importer_with_pinned_task_id():
         import_all=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -275,7 +312,7 @@ async def test_import_all_passes_json_output_flag():
         json_output=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -315,7 +352,7 @@ async def test_import_all_skipped_when_no_task_id():
         import_all=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "query": "AI",
@@ -349,7 +386,7 @@ async def test_import_all_skipped_when_no_sources():
         import_all=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -384,7 +421,7 @@ async def test_import_all_passes_cited_only_flag():
         cited_only=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -419,7 +456,7 @@ async def test_import_all_passes_cited_only_flag():
 
 @pytest.mark.asyncio
 async def test_wait_context_is_entered_and_exited(base_plan):
-    """The handler-injected wait_context wraps the poll loop."""
+    """The handler-injected wait_context wraps the library wait call."""
     enter_count = {"n": 0}
     exit_count = {"n": 0}
 
@@ -432,7 +469,7 @@ async def test_wait_context_is_entered_and_exited(base_plan):
             exit_count["n"] += 1
 
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -458,7 +495,7 @@ async def test_wait_context_is_entered_and_exited(base_plan):
 async def test_default_wait_context_is_noop(base_plan):
     """The default null context lets the service run without any spinner."""
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",
@@ -478,7 +515,7 @@ async def test_default_wait_context_is_noop(base_plan):
 async def test_wait_context_exits_before_import_runs():
     """Spinner-vs-import ordering: import MUST run after the wait context exits.
 
-    The pre-extraction handler kept the wait spinner open ONLY around the poll
+    The pre-extraction handler kept the wait spinner open ONLY around the wait
     loop, and called the importer (which has its own spinner) after the wait
     spinner closed. This ordering matters because two live Rich spinners
     overlap badly; verifying it directly guards the most subtle refactor risk
@@ -513,7 +550,7 @@ async def test_wait_context_exits_before_import_runs():
         import_all=True,
     )
     client = _FakeClient(
-        poll_side_effect=[
+        wait_side_effect=[
             {
                 "status": "completed",
                 "task_id": "task_abc",


### PR DESCRIPTION
## Summary

Adds a public `ResearchAPI.wait_for_completion()` loop that pins a discovered `task_id` between polls, then migrates the CLI research wait paths to use it instead of carrying their own poll loops.

## Related Issue

Closes #886

## Changes

- Added `client.research.wait_for_completion(notebook_id, task_id=None, *, timeout=1800, interval=5)`.
- Moved `research wait` and `source add-research` onto the library wait API.
- Added library-level regression coverage for task-id pinning / cross-wire protection.
- Updated Python API docs, CLI references, conventions, and the research-to-podcast example.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest` — 6050 passed, 12 skipped)
- [x] Linting passes (`uv run ruff check .`)
- [x] Formatting passes (`uv run ruff format --check .`)
- [x] Type checking passes (`uv run mypy src/notebooklm`)
- [x] Pre-commit passes (`uv run pre-commit run --all-files`)
- [x] ADR check: no new ADR needed; this follows ADR-008 by moving protocol-level polling into the Python API.

## Notes

Authenticated live e2e was not run; it requires NotebookLM login and notebook env vars. The full local suite, including VCR/integration coverage, passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a library helper to wait for research completion with configurable timeout/interval, task-id pinning, and terminal failure handling.

* **Documentation**
  * Updated CLI reference, Python API docs, conventions, and examples to use the wait-for-completion workflow and demonstrate task-id pinning and timeout/interval semantics.

* **CLI Changes**
  * CLI delegates waiting to the helper, adds explicit "failed" outcome, adjusts exit codes and conditional import behavior, and emits structured JSON/text failure output.

* **Behavior**
  * Unknown backend status codes are treated as terminal failures.

* **Tests**
  * Expanded unit tests to cover wait behavior, failed/timeout cases, task-id pinning, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->