### PR TITLE
fix(cli): cover source research poll timeout

### DIFF
--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -82,12 +82,13 @@ async def execute_source_add_research(
         )
         return
 
-    # Poll budget mirrors ``research wait --timeout``: total seconds
-    # divided by the 5 s interval. The legacy hardcoded 60-iteration cap
-    # stranded deep research (#315) because the import branch below is
-    # gated on ``status == "completed"``.
+    # Poll budget mirrors ``research wait --timeout``: cover the full total
+    # seconds budget at the fixed 5 s cadence. The legacy hardcoded
+    # 60-iteration cap stranded deep research (#315) because the import
+    # branch below is gated on ``status == "completed"``.
     status: dict | None = None
-    for _ in range(max(1, plan.timeout // _POLL_INTERVAL_S)):
+    max_polls = max(1, (plan.timeout + _POLL_INTERVAL_S - 1) // _POLL_INTERVAL_S)
+    for _ in range(max_polls):
         status = await client.research.poll(plan.notebook_id, task_id=task_id)
         if status.get("status") == "completed":
             break

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -214,6 +214,46 @@ async def test_source_add_research_pins_task_id_and_imports(
 
 
 @pytest.mark.asyncio
+async def test_source_add_research_ceil_poll_budget_covers_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep = AsyncMock()
+    monkeypatch.setattr(source_research.asyncio, "sleep", sleep)
+    monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
+    monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            poll=AsyncMock(
+                side_effect=[
+                    {"status": "in_progress"},
+                    {"status": "completed", "sources": [], "report": ""},
+                ]
+            ),
+        )
+    )
+
+    await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="fast",
+            import_all=False,
+            cited_only=False,
+            no_wait=False,
+            timeout=6,
+        ),
+    )
+
+    assert client.research.poll.await_count == 2
+    client.research.poll.assert_any_await("nb_1", task_id="task_123")
+    sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.asyncio
 async def test_source_wait_timeout_maps_to_json_envelope_and_exit_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Use ceil-style budgeting for source add-research polling so non-multiple timeouts cover the full requested budget.
- Add a service regression test for a 6s timeout at the 5s poll cadence.

## Tests
- `uv run pytest tests/unit/test_cli_source_services.py -q`
- `uv run ruff format --check src/notebooklm/cli/services/source_research.py tests/unit/test_cli_source_services.py`
- `uv run ruff check src/notebooklm/cli/services/source_research.py tests/unit/test_cli_source_services.py`
- `uv run pre-commit run --all-files`
- `uv run mypy src/notebooklm`

Fixes #963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved source research polling to properly utilize the complete timeout budget at fixed intervals, ensuring more consistent and reliable research completion detection during source addition operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->