### PR TITLE
ci(publish): add TestPyPI environment attestations

### DIFF
--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -85,6 +85,7 @@ jobs:
     name: Publish to TestPyPI
     needs: build-and-test
     runs-on: ubuntu-latest
+    environment: testpypi
     # Minimum-scope publish job: only the trusted PyPA action runs here. No
     # `actions/checkout`, no Python install, no third-party dependencies in
     # the runner environment — so the OIDC token request that `id-token:
@@ -104,6 +105,10 @@ jobs:
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
+        # PEP 740 attestations: pypa/gh-action-pypi-publish generates an
+        # in-toto attestation for the uploaded artifacts and publishes it
+        # via PyPI's Trusted Publishing flow (OIDC, no API token).
+        attestations: true
 
     - name: Summary
       run: |


### PR DESCRIPTION
## Summary

Adds TestPyPI publish parity with the production publish job.

## Related Issue

Closes #827

## Changes

- Adds `environment: testpypi` to the TestPyPI publish job so OIDC minting can be environment-scoped.
- Enables explicit PEP 740 attestations on the TestPyPI upload path.
- Mirrors the production attestation comment for maintainability.

## Test Plan

- [x] `uv run python scripts/check_workflow_permissions.py`
- [x] `uv run python scripts/check_workflow_secret_gates.py`
- [x] `uv run python scripts/check_action_pinning.py`
- [x] `actionlint .github/workflows/testpypi-publish.yml`
- [ ] `workflow_dispatch` on TestPyPI after the out-of-band setup below

## Notes

Before dispatching this workflow, maintainers need to confirm the GitHub Environment named `testpypi` exists with the intended protection rules and update the TestPyPI Trusted Publisher configuration to require environment `testpypi`. The final live verification is a TestPyPI dispatch that confirms the upload succeeds and attestations are published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TestPyPI publishing workflow configuration
  * Enabled artifact attestations for enhanced package verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->