### PR TITLE
ci(publish): pin artifact handoff tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        python -m pip install build==1.5.0
 
     - name: Build package
       run: |
@@ -55,7 +55,7 @@ jobs:
       # touched the runner. Smoke install/test below still runs against
       # `dist/` for behavior validation but can no longer influence what
       # the publish job receives.
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # @ v7
       with:
         name: python-distribution
         path: dist/
@@ -100,7 +100,7 @@ jobs:
 
     steps:
     - name: Download distribution artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # @ v7
       with:
         name: python-distribution
         path: dist/

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        python -m pip install build==1.5.0
 
     - name: Build package
       run: python -m build
@@ -51,7 +51,7 @@ jobs:
       # touched the runner. Smoke install/test below still runs against
       # `dist/` for behavior validation but can no longer influence what
       # the publish job receives.
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # @ v7
       with:
         name: python-distribution
         path: dist/
@@ -95,7 +95,7 @@ jobs:
 
     steps:
     - name: Download distribution artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # @ v7
       with:
         name: python-distribution
         path: dist/


### PR DESCRIPTION
## Summary

Pins the build and artifact-handoff tooling used by the publish workflows.

## Related Issue

Closes #828

## Changes

- Pins `build` to the current PyPI release, `1.5.0`, and installs it with `python -m pip`.
- SHA-pins `actions/upload-artifact@v7` in both publish workflows.
- SHA-pins `actions/download-artifact@v7` in both publish workflows.

## Test Plan

- [x] `git ls-remote --tags https://github.com/actions/upload-artifact.git refs/tags/v7`
- [x] `git ls-remote --tags https://github.com/actions/download-artifact.git refs/tags/v7`
- [x] PyPI JSON check for current `build` version (`1.5.0`)
- [x] `uv run python scripts/check_workflow_permissions.py`
- [x] `uv run python scripts/check_workflow_secret_gates.py`
- [x] `uv run python scripts/check_action_pinning.py`
- [x] `actionlint .github/workflows/publish.yml .github/workflows/testpypi-publish.yml`

## Notes

Deferred hardening, matching the issue scope: hash-pinning `build` transitive dependencies and broader SHA-pinning of `checkout` / `setup-python` can be separate follow-ups. `python -m pip install --upgrade pip` remains intentionally out of scope for this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use pinned action versions for consistent build and publish processes.
  * Pinned build dependencies to specific versions for reproducible TestPyPI publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->