### PR TITLE
ci(publish): polish publish workflow operations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-test:
     name: Build wheel and run release smoke
@@ -57,9 +61,11 @@ jobs:
       # the publish job receives.
       uses: actions/upload-artifact@v7
       with:
-        name: python-distribution
+        name: notebooklm-py-dist
         path: dist/
         if-no-files-found: error
+        # One-day retention is intentional: publish consumes this artifact
+        # immediately. See issue #829 for the recovery trade-off.
         retention-days: 1
 
     - name: Install built wheel + canonical contributor extras in a clean venv
@@ -102,7 +108,7 @@ jobs:
     - name: Download distribution artifacts
       uses: actions/download-artifact@v7
       with:
-        name: python-distribution
+        name: notebooklm-py-dist
         path: dist/
 
     - name: Publish to PyPI

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -3,6 +3,10 @@ name: Publish to TestPyPI
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-test:
     name: Build wheel and run release smoke
@@ -53,9 +57,11 @@ jobs:
       # the publish job receives.
       uses: actions/upload-artifact@v7
       with:
-        name: python-distribution
+        name: notebooklm-py-dist
         path: dist/
         if-no-files-found: error
+        # One-day retention is intentional: publish consumes this artifact
+        # immediately. See issue #829 for the recovery trade-off.
         retention-days: 1
 
     - name: Install built wheel + canonical contributor extras in a clean venv
@@ -97,7 +103,7 @@ jobs:
     - name: Download distribution artifacts
       uses: actions/download-artifact@v7
       with:
-        name: python-distribution
+        name: notebooklm-py-dist
         path: dist/
 
     - name: Upload to TestPyPI


### PR DESCRIPTION
## Summary

Adds the small release-operations polish items for the PyPI and TestPyPI publish workflows.

## Related Issue

Closes #829

## Changes

- Adds non-canceling workflow concurrency keyed by workflow and ref.
- Renames the publish artifact from `python-distribution` to `notebooklm-py-dist` in both upload and download steps.
- Keeps `retention-days: 1` and documents the intentional recovery trade-off near the setting.

## Test Plan

- [x] `uv run python scripts/check_workflow_permissions.py`
- [x] `uv run python scripts/check_workflow_secret_gates.py`
- [x] `uv run python scripts/check_action_pinning.py`
- [x] `actionlint .github/workflows/publish.yml .github/workflows/testpypi-publish.yml`
- [x] `rg -n "python-distribution" .github scripts docs tests pyproject.toml README.md CONTRIBUTING.md AGENTS.md CLAUDE.md`

## Notes

The concurrency group intentionally includes `github.ref` to queue duplicate runs for the same tag or manual dispatch ref while allowing independent release refs to proceed separately. `cancel-in-progress: false` is intentional for publish safety.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD workflows to improve release reliability by preventing concurrent build cancellations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->