### PR TITLE
fix(cli): sync all-accounts language once

### DIFF
--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -146,6 +146,9 @@ def _login_all_accounts_from_browser(
     profiles_by_email = _profiles_by_account_email(existing_profiles)
     unavailable: set[str] = set(existing_profiles)
     claimed: set[str] = set()
+    # Server language is persisted as one CLI-wide preference, so syncing once
+    # avoids a network request and config write per discovered account.
+    language_sync_target: tuple[Path, str] | None = None
     for account in accounts:
         base_name = email_to_profile_name(account.email)
         target_profile = profiles_by_email.get(account.email.casefold())
@@ -169,6 +172,10 @@ def _login_all_accounts_from_browser(
             authuser=account.authuser,
             email=account.email,
         )
+        language_sync_target = (target_storage, target_profile)
+
+    if language_sync_target is not None:
+        target_storage, target_profile = language_sync_target
         _sync_server_language_to_config(storage_path=target_storage, profile=target_profile)
 
 

--- a/tests/unit/cli/test_login_multi_account.py
+++ b/tests/unit/cli/test_login_multi_account.py
@@ -147,16 +147,10 @@ class TestLoginMultiAccount:
         bob_meta = _read_account(target_root / "bob" / "storage_state.json")
         assert alice_meta == {"authuser": 0, "email": "alice@example.com"}
         assert bob_meta == {"authuser": 1, "email": "bob@gmail.com"}
-        assert [call.kwargs for call in mock_sync.call_args_list] == [
-            {
-                "storage_path": target_root / "alice" / "storage_state.json",
-                "profile": "alice",
-            },
-            {
-                "storage_path": target_root / "bob" / "storage_state.json",
-                "profile": "bob",
-            },
-        ]
+        mock_sync.assert_called_once_with(
+            storage_path=target_root / "bob" / "storage_state.json",
+            profile="bob",
+        )
 
     def test_all_accounts_rerun_reuses_profiles_by_email(self, runner, tmp_path):
         mock_rk = _multiaccount_rookiepy_mock()


### PR DESCRIPTION
## Summary
- Address the #974 post-merge review finding by syncing server language only once after `login --browser-cookies ... --all-accounts` writes profiles.
- Preserve multi-account routing by syncing through the selected profile storage, which already contains the account metadata.
- Update the multi-account CLI test to assert one global language-sync call.

## Tests
- `uv run pre-commit run --all-files`
- `uv run mypy src/notebooklm`
- `uv run pytest`
- `uv run pytest tests/unit/cli/test_login_multi_account.py tests/unit/cli/test_login_chromium_fanout.py tests/unit/cli/test_auth_subcommands.py tests/unit/test_artifact_rate_limit_retry.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized multi-account login process by consolidating language settings synchronization, improving efficiency during bulk account login operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->