### PR TITLE
fix(sources): hint source cap on status 3 upload rejection

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -71,6 +71,9 @@ class RpcCallback(Protocol):
     ) -> Any: ...
 
 
+GetSourceLimit = Callable[[], Awaitable[int | None]]
+
+
 class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
     """Runtime capabilities required by source upload.
 
@@ -85,6 +88,63 @@ class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
     ``operation_scope`` or lazily allocating the per-loop upload semaphore.
     Mirrors the ``ChatRuntime`` / ``ArtifactsRuntime`` pattern.
     """
+
+
+_INVALID_ARGUMENT_RPC_CODE = 3
+_SOURCE_LIMIT_HINT_FLOOR = 50
+_TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
+
+
+async def _build_invalid_argument_source_limit_hint(
+    *,
+    source_count: int | None,
+    get_source_limit: GetSourceLimit | None,
+    logger: Any,
+) -> str:
+    """Build a best-effort hint for ADD_SOURCE_FILE status code 3 failures."""
+    source_limit: int | None = None
+    if get_source_limit is not None:
+        try:
+            source_limit = await get_source_limit()
+        except Exception:  # noqa: BLE001 - hint lookup must not mask the upload error.
+            logger.debug(
+                "register_file_source: source-limit lookup failed; continuing without limit hint",
+                exc_info=True,
+            )
+
+    if source_limit is not None and source_limit <= 0:
+        source_limit = None
+
+    if source_count is not None and source_limit is not None:
+        if source_count >= source_limit:
+            return (
+                f" Notebook currently has {source_count}/{source_limit} sources, "
+                "so this likely means the notebook has reached its tier-specific "
+                "per-notebook source limit. Delete sources or try a fresh notebook, "
+                "then retry."
+            )
+        return (
+            f" Notebook currently has {source_count}/{source_limit} sources, below "
+            "the advertised account limit. If the file is valid, try the same add "
+            "in a fresh notebook to distinguish file rejection from notebook state."
+        )
+
+    if source_count is not None and source_count >= _SOURCE_LIMIT_HINT_FLOOR:
+        return (
+            f" Notebook currently has {source_count} sources; status code 3 can "
+            "indicate the notebook is at or near the tier-specific per-notebook "
+            f"source limit ({_TIER_SOURCE_LIMITS_SUMMARY}). Delete sources or "
+            "try a fresh notebook, then retry."
+        )
+
+    if source_limit is not None:
+        return (
+            f" Advertised source limit for this tier is {source_limit}; compare "
+            "it with this notebook's source count. Status code 3 can indicate a "
+            "per-notebook source-limit rejection."
+        )
+
+    return ""
 
 
 class RegisterFileSource(Protocol):
@@ -380,6 +440,7 @@ class SourceUploadPipeline:
         *,
         list_sources: ListSources,
         logger: Any,
+        get_source_limit: GetSourceLimit | None = None,
         rpc_call: RpcCallback | None = None,
     ) -> str:
         """Register a file source intent and get SOURCE_ID.
@@ -423,14 +484,18 @@ class SourceUploadPipeline:
         # same-name source would otherwise direct the subsequent upload
         # stream to the wrong source.
         baseline_ids: set[str] | None
+        baseline_source_count: int | None
         try:
-            baseline_ids = {source.id for source in await list_sources(notebook_id)}
+            baseline_sources = await list_sources(notebook_id)
+            baseline_ids = {source.id for source in baseline_sources}
+            baseline_source_count = len(baseline_sources)
         except Exception:
             logger.debug(
                 "register_file_source: baseline list() failed; baseline unavailable",
                 exc_info=True,
             )
             baseline_ids = None
+            baseline_source_count = None
 
         async def _probe() -> str | None:
             try:
@@ -491,10 +556,17 @@ class SourceUploadPipeline:
                 # can catch them and run the probe before retrying.
                 raise
             except RPCError as exc:
+                hint = ""
+                if getattr(exc, "rpc_code", None) == _INVALID_ARGUMENT_RPC_CODE:
+                    hint = await _build_invalid_argument_source_limit_hint(
+                        source_count=baseline_source_count,
+                        get_source_limit=get_source_limit,
+                        logger=logger,
+                    )
                 raise SourceAddError(
                     filename,
                     cause=exc,
-                    message=f"Failed to register file source for {filename}: {exc}",
+                    message=f"Failed to register file source for {filename}: {exc}{hint}",
                 ) from exc
 
             source_id = _extract_register_file_source_id(result, filename)

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -14,6 +14,7 @@ import httpx
 from . import _source_upload
 from ._session_config import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._session_contracts import RpcCaller
+from ._settings import build_get_user_settings_params, extract_account_limits
 from ._source_add import SourceAddService
 from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
@@ -799,8 +800,18 @@ class SourcesAPI:
             notebook_id,
             filename,
             list_sources=self.list,
+            get_source_limit=self._get_source_limit,
             logger=logger,
         )
+
+    async def _get_source_limit(self) -> int | None:
+        """Return the current account's per-notebook source limit when advertised."""
+        result = await self._rpc_call(
+            RPCMethod.GET_USER_SETTINGS,
+            build_get_user_settings_params(),
+            source_path="/",
+        )
+        return extract_account_limits(result).source_limit
 
     async def _start_resumable_upload(
         self,

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -304,6 +304,40 @@ async def test_register_file_source_uses_rpc_shape_and_wraps_rpc_error(
 
 
 @pytest.mark.asyncio
+async def test_register_file_source_status3_includes_source_limit_context(
+    service: SourceUploadPipeline,
+) -> None:
+    rpc_error = RPCError(
+        "RPC o4cbdc returned null result with status code 3 (Invalid argument).",
+        method_id="o4cbdc",
+        rpc_code=3,
+    )
+    rpc = RecordingRpc(rpc_error)
+    existing_sources = [
+        Source(id=f"source_{index}", title=f"Source {index}") for index in range(56)
+    ]
+    get_source_limit = AsyncMock(return_value=50)
+
+    with pytest.raises(SourceAddError) as exc_info:
+        await service.register_file_source(
+            "nb_123",
+            "report.pdf",
+            rpc_call=rpc,
+            list_sources=AsyncMock(return_value=existing_sources),
+            get_source_limit=get_source_limit,
+            logger=MagicMock(),
+        )
+
+    assert exc_info.value.cause is rpc_error
+    message = str(exc_info.value)
+    assert "56/50 sources" in message
+    assert "tier-specific" in message
+    assert "per-notebook source limit" in message
+    assert "fresh notebook" in message
+    get_source_limit.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_register_file_source_truncates_large_string_response_preview(
     service: SourceUploadPipeline,
 ) -> None:


### PR DESCRIPTION
## Summary

- add a best-effort status-code-3 diagnostic for file source registration failures
- include the baseline notebook source count and advertised source limit when available
- mention NotebookLM's tier-specific per-notebook source limits (50/100/300/600) when the exact limit lookup is unavailable
- wire the source-limit lookup through the existing source upload pipeline seam

Closes #474.

## Tests

- `uv run pytest tests/unit/test_source_add_service.py tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py -q`
- `uv run ruff check src/notebooklm/_source_upload.py src/notebooklm/_sources.py tests/unit/test_source_upload_pipeline.py`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pre-commit run --all-files`
- `uv run pytest`
- after wording polish: `uv run pytest tests/unit/test_source_upload_pipeline.py::test_register_file_source_status3_includes_source_limit_context -q`
- after wording polish: `uv run ruff check src/notebooklm/_source_upload.py tests/unit/test_source_upload_pipeline.py`
- after wording polish: `uv run ruff format src/notebooklm/_source_upload.py tests/unit/test_source_upload_pipeline.py --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when file source registration fails with an invalid-argument error — now include source-limit context (e.g., "56/50 sources") and a best-effort hint to clarify capacity/tier limits.

* **Tests**
  * Added a unit test to verify the enhanced error message includes source-limit context and preserves the original error as the cause.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->