### PR TITLE
test: convert leaking safe_index DeprecationWarning to explicit pytest.warns

### DIFF
--- a/tests/integration/test_artifacts_drift.py
+++ b/tests/integration/test_artifacts_drift.py
@@ -103,9 +103,10 @@ class TestParseGenerationResultSoftDrift:
         # contract this class pins requires an explicit `"0"` opt-out.
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
 
-        status = artifacts_api._parse_generation_result(
-            None, method_id=RPCMethod.CREATE_ARTIFACT.value
-        )
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            status = artifacts_api._parse_generation_result(
+                None, method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
 
         assert status.status == "failed"
         assert status.task_id == ""
@@ -114,9 +115,10 @@ class TestParseGenerationResultSoftDrift:
     def test_empty_list_returns_failed(self, artifacts_api, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
 
-        status = artifacts_api._parse_generation_result(
-            [], method_id=RPCMethod.CREATE_ARTIFACT.value
-        )
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            status = artifacts_api._parse_generation_result(
+                [], method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
 
         assert status.status == "failed"
         assert status.task_id == ""
@@ -126,9 +128,10 @@ class TestParseGenerationResultSoftDrift:
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
 
         # Inner list missing both task_id and status_code positions.
-        status = artifacts_api._parse_generation_result(
-            [[]], method_id=RPCMethod.REVISE_SLIDE.value
-        )
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            status = artifacts_api._parse_generation_result(
+                [[]], method_id=RPCMethod.REVISE_SLIDE.value
+            )
 
         assert status.status == "failed"
         assert status.task_id == ""
@@ -142,9 +145,10 @@ class TestParseGenerationResultSoftDrift:
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
 
         # task_id present, status_code position absent.
-        status = artifacts_api._parse_generation_result(
-            [["task_short"]], method_id=RPCMethod.CREATE_ARTIFACT.value
-        )
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            status = artifacts_api._parse_generation_result(
+                [["task_short"]], method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
 
         assert status.task_id == "task_short"
         assert status.status == "pending"

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -1541,12 +1541,13 @@ class TestReviseSlide:
         httpx_mock.add_response(content=null_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.artifacts.revise_slide(
-                notebook_id="nb_123",
-                artifact_id="artifact_456",
-                slide_index=0,
-                prompt="Remove taxonomy section",
-            )
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.artifacts.revise_slide(
+                    notebook_id="nb_123",
+                    artifact_id="artifact_456",
+                    slide_index=0,
+                    prompt="Remove taxonomy section",
+                )
 
         assert result is not None
         assert result.status == "failed"
@@ -2238,7 +2239,8 @@ class TestParseGenerationResult:
         httpx_mock.add_response(content=empty_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.artifacts.generate_audio("nb_123")
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.artifacts.generate_audio("nb_123")
 
         assert result.status == "failed"
         assert result.task_id == ""
@@ -2274,7 +2276,8 @@ class TestParseGenerationResult:
         httpx_mock.add_response(content=null_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.artifacts.generate_audio("nb_123")
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.artifacts.generate_audio("nb_123")
 
         assert result.status == "failed"
 

--- a/tests/integration/test_get_summary_drift.py
+++ b/tests/integration/test_get_summary_drift.py
@@ -79,7 +79,10 @@ async def test_get_summary_drift_soft_mode_returns_empty_with_warning(monkeypatc
     # result[0] is an empty list → result[0][0] raises IndexError.
     api = _make_api([[]])
 
-    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+    with (
+        caplog.at_level(logging.WARNING, logger="notebooklm"),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         summary = await api.get_summary("nb_drift_soft")
 
     assert summary == ""

--- a/tests/integration/test_notebooks_integration.py
+++ b/tests/integration/test_notebooks_integration.py
@@ -598,7 +598,8 @@ class TestNotebookEdgeCases:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.notebooks.get_summary("nb_123")
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.notebooks.get_summary("nb_123")
 
         assert result == ""
 

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -330,7 +330,8 @@ class TestParseGenerationResult:
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result(None, method_id="R7cb6c")
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            result = api._parse_generation_result(None, method_id="R7cb6c")
 
         assert result.status == "failed"
         assert result.task_id == ""
@@ -341,7 +342,8 @@ class TestParseGenerationResult:
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result([], method_id="R7cb6c")
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            result = api._parse_generation_result([], method_id="R7cb6c")
 
         assert result.status == "failed"
         assert result.task_id == ""

--- a/tests/unit/test_artifacts_helpers.py
+++ b/tests/unit/test_artifacts_helpers.py
@@ -59,7 +59,10 @@ def test_extract_data_table_rows_missing_inner_list(
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
     raw_data = [[[[[0, 100, None, None, [6, 7]]]]]]
 
-    with caplog.at_level(logging.WARNING):
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         result = _extract_data_table_rows(raw_data)
 
     assert result == []
@@ -76,7 +79,8 @@ def test_extract_data_table_rows_wrong_type_at_one_level(
     # Replace the third wrapper layer with a non-indexable string.
     raw_data = [[[["not-a-list", [[0, 100, None, None, [6, 7, []]]]]]]]
 
-    result = _extract_data_table_rows(raw_data)
+    with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+        result = _extract_data_table_rows(raw_data)
 
     assert result == []
 
@@ -88,7 +92,8 @@ def test_extract_data_table_rows_truncated_structure(
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
     raw_data: list = [[[]]]
 
-    result = _extract_data_table_rows(raw_data)
+    with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+        result = _extract_data_table_rows(raw_data)
 
     assert result == []
 
@@ -133,7 +138,10 @@ def test_parse_data_table_raises_artifact_parse_error_on_drift(
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
     truncated: list = [[[]]]  # same shape as drift test above
 
-    with pytest.raises(ArtifactParseError):
+    with (
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        pytest.raises(ArtifactParseError),
+    ):
         _parse_data_table(truncated)
 
 

--- a/tests/unit/test_chat_helpers.py
+++ b/tests/unit/test_chat_helpers.py
@@ -47,7 +47,10 @@ def test_extract_next_turn_content_missing_inner_list(
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
     next_turn = [None, None, 2, None, []]
 
-    with caplog.at_level(logging.WARNING):
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         result = _extract_next_turn_content(next_turn)
 
     assert result is None
@@ -70,7 +73,10 @@ def test_extract_next_turn_content_wrong_type_at_level(
     # non-string non-list scalar to force the safe_index drift path.
     next_turn = [None, None, 2, None, [42]]
 
-    with caplog.at_level(logging.WARNING):
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         result = _extract_next_turn_content(next_turn)
 
     assert result is None
@@ -112,6 +118,7 @@ def test_parse_turns_to_qa_pairs_drift_yields_empty_answer(
         ]
     ]
 
-    result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+    with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+        result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
 
     assert result == [("Question?", "")]

--- a/tests/unit/test_chat_history.py
+++ b/tests/unit/test_chat_history.py
@@ -139,7 +139,8 @@ class TestParseTurnsToQaPairs:
                 [None, None, 2, None, []],  # empty nested list
             ]
         ]
-        result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+        with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+            result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
         assert result == [("Question?", "")]
 
     def test_answer_with_none_text(self):

--- a/tests/unit/test_notebooks_extractors.py
+++ b/tests/unit/test_notebooks_extractors.py
@@ -36,7 +36,10 @@ class TestExtractSummary:
         # outer[0] is an empty list — outer[0][0] would IndexError.
         outer: list = [[], [[["Q", "P"]]]]
 
-        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+        with (
+            caplog.at_level(logging.WARNING, logger="notebooklm"),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             result = _extract_summary(outer)
 
         assert result == ""
@@ -61,7 +64,10 @@ class TestExtractSummary:
         # outer[0] is an int — outer[0][0] raises TypeError.
         outer = [42, [[["Q", "P"]]]]
 
-        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+        with (
+            caplog.at_level(logging.WARNING, logger="notebooklm"),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             result = _extract_summary(outer)
 
         assert result == ""

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -223,7 +223,10 @@ class TestExtractTaskId:
         # Post-PR 13.9a default is strict; pin soft mode to keep asserting
         # the warn-and-return-None contract these helpers expose.
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             assert _extract_task_id([]) is None
         assert "safe_index drift" in caplog.text
 
@@ -237,7 +240,10 @@ class TestExtractTaskId:
         # invoking safe_index; the descent path under strict mode would
         # otherwise surface UnknownRPCMethodError for the inner safe_index hop.
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             assert _extract_task_id(None) is None
 
 
@@ -250,7 +256,10 @@ class TestExtractTaskInfo:
 
     def test_missing_index_returns_none(self, caplog, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             assert _extract_task_info(["only_id"]) is None
         assert "safe_index drift" in caplog.text
 
@@ -269,7 +278,10 @@ class TestExtractQueryText:
 
     def test_missing_query_info_returns_none(self, caplog, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             # task_info[1] missing entirely
             assert _extract_query_text([None]) is None
         assert "safe_index drift" in caplog.text
@@ -294,7 +306,10 @@ class TestExtractStatusCode:
 
     def test_missing_index_returns_none(self, caplog, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             assert _extract_status_code([None, ["q"], None, []]) is None
         assert "safe_index drift" in caplog.text
 
@@ -332,7 +347,10 @@ class TestExtractSourcesAndSummary:
 
     def test_missing_bundle_returns_empty(self, caplog, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        with caplog.at_level(logging.WARNING):
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+        ):
             sources, summary = _extract_sources_and_summary([None, ["q"], None])
         assert sources == []
         assert summary is None

--- a/tests/unit/test_research_api.py
+++ b/tests/unit/test_research_api.py
@@ -301,7 +301,8 @@ class TestPollEdgeCases:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.research.poll("nb_123")
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.research.poll("nb_123")
 
         assert result["status"] == "no_research"
 
@@ -601,7 +602,8 @@ class TestPollEdgeCases:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.research.poll("nb_123")
+            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
+                result = await client.research.poll("nb_123")
 
         assert result["status"] == "no_research"
 

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -98,7 +98,10 @@ def test_qa_pairs_warns_on_unguarded_shape(caplog, monkeypatch):
     ]
 
     chat = ChatAPI.__new__(ChatAPI)
-    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+    with (
+        caplog.at_level(logging.WARNING, logger="notebooklm"),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         # Direct call to the private parser
         pairs = chat._parse_turns_to_qa_pairs(turns_data)  # type: ignore[arg-type]
 
@@ -138,7 +141,10 @@ async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
     mock_core.rpc_call = AsyncMock(return_value=[[]])
     api._rpc = mock_core
 
-    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+    with (
+        caplog.at_level(logging.WARNING, logger="notebooklm"),
+        pytest.warns(DeprecationWarning, match="safe_index soft-mode"),
+    ):
         summary = await api.get_summary("nb_summary")
 
     assert summary == ""


### PR DESCRIPTION
## Summary

Wrap soft-mode `safe_index` call sites in tests with `pytest.warns(DeprecationWarning, match="safe_index soft-mode")` so the `DeprecationWarning` emitted by `notebooklm.rpc._safe_index` (when `NOTEBOOKLM_STRICT_DECODE=0`) is explicitly asserted rather than leaking into test output.

- 12 test modules touched across `tests/unit/` and `tests/integration/`
- Every wrap site already pinned soft mode via `monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")`; the new `pytest.warns` block converts the previously-silent warning into a captured expectation
- No production code changed

## Scope (all sites use `pytest.warns`, not `STRICT_DECODE=1` workaround)

Every leaking test in scope was already intentionally exercising the soft-mode fallback (each had `monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")`). The right fix was therefore `pytest.warns` everywhere — using `STRICT_DECODE=1` instead would have flipped these tests onto a different code path (strict raises `UnknownRPCMethodError`) and broken their intent.

| File | Sites |
|---|---|
| `tests/unit/test_research.py` | 6 (`_extract_task_id`, `_extract_task_info`, `_extract_query_text`, `_extract_status_code`, `_extract_sources_and_summary` drift cases) |
| `tests/unit/test_research_api.py` | 2 (`poll` skip / all-invalid edge cases) |
| `tests/unit/test_notebooks_extractors.py` | 2 (`_extract_summary` drift cases) |
| `tests/unit/test_artifacts_coverage.py` | 2 (`_parse_generation_result` null / empty) |
| `tests/unit/test_artifacts_helpers.py` | 4 (data-table drift shapes + parser fallback) |
| `tests/unit/test_chat_helpers.py` | 3 (`_extract_next_turn_content` + `_parse_turns_to_qa_pairs` drift) |
| `tests/unit/test_chat_history.py` | 1 (`_parse_turns_to_qa_pairs` index-error path) |
| `tests/unit/test_swallow_observability.py` | 2 (QA-pair + summary drift) |
| `tests/integration/test_artifacts_drift.py` | 4 (soft-drift `_parse_generation_result` cases) |
| `tests/integration/test_artifacts_integration.py` | 3 (`revise_slide` null + `generate_audio` failure parsing) |
| `tests/integration/test_get_summary_drift.py` | 1 (soft-mode summary drift) |
| `tests/integration/test_notebooks_integration.py` | 1 (`get_summary` empty) |

Where the new `pytest.warns` had to coexist with `caplog.at_level(...)` or `pytest.raises(...)`, the contexts are combined via parenthesized `with (...)` syntax to satisfy ruff `SIM117`.

## Test plan

- [x] `uv run pytest -W error::DeprecationWarning` on the changed modules passes — 375/375 tests
- [x] `uv run pytest tests/unit tests/integration` stays green — 5988 pass, 49 skip
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (165 source files)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test suites across multiple modules to validate deprecation warning behavior for soft-mode operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->