### PR TITLE
fix(io): move sync open off loop, single writer thread, batch policy aggregation

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -41,7 +41,11 @@ _TRUSTED_DOWNLOAD_DOMAINS = (".google.com", ".googleusercontent.com", ".googleap
 _DOWNLOAD_WRITER_QUEUE_SIZE = 8
 
 
-async def _await_writer_exit(writer_thread: threading.Thread) -> None:
+async def _await_writer_exit(
+    writer_thread: threading.Thread,
+    *,
+    re_raise_cancel: bool = False,
+) -> None:
     """Wait for a download writer thread to actually exit.
 
     Plain ``await asyncio.to_thread(thread.join)`` is unsafe under
@@ -58,20 +62,39 @@ async def _await_writer_exit(writer_thread: threading.Thread) -> None:
     actually completes. Repeated cancellations only delay our
     re-raise, never the writer's exit.
 
-    Addresses the CodeRabbit MAJOR finding on PR #981.
+    Cancellation handling:
+
+    * Only ``asyncio.CancelledError`` is caught inside the loop — any
+      other exception from the shielded join (currently none in
+      practice, since ``Thread.join`` doesn't raise) propagates
+      immediately so we don't accidentally hide a real bug.
+    * The most recent ``CancelledError`` (if any) is preserved.
+    * If ``re_raise_cancel=True``, the helper re-raises that
+      ``CancelledError`` after the writer has fully exited. Callers
+      on the success path want this so an in-flight cancellation
+      isn't lost when the writer happens to finish first. Callers on
+      a cleanup-path (the producer's ``except`` block, which already
+      has an exception to re-raise) leave it at the default
+      ``False`` so we don't mask the original error with a second
+      cancellation.
+
+    Addresses the CodeRabbit MAJOR findings on PR #981 — both the
+    original join-vs-unlink race AND the follow-up finding that the
+    initial fix silently absorbed task cancellation.
     """
     join_task = asyncio.ensure_future(asyncio.to_thread(writer_thread.join))
+    cancelled_error: asyncio.CancelledError | None = None
     while not join_task.done():
         try:
             await asyncio.shield(join_task)
-        except BaseException:
-            # Outer task was cancelled (or some other exception
-            # propagated into our await). The shielded join keeps
-            # running; loop and re-await. We deliberately swallow
-            # the cancellation here so the join can complete —
-            # the original exception is preserved on the calling
-            # frame's stack and re-raised after we return.
-            pass
+        except asyncio.CancelledError as exc:
+            # Outer task was cancelled. The shielded join keeps
+            # running; loop and re-await so the writer can still
+            # exit cleanly before we return.
+            cancelled_error = exc
+
+    if cancelled_error is not None and re_raise_cancel:
+        raise cancelled_error
 
 
 @dataclass(frozen=False)
@@ -720,14 +743,16 @@ class ArtifactDownloadService:
                                 except queue.Full:
                                     await asyncio.to_thread(chunk_q.put, None)
                             # Join surfaces any exception the writer
-                            # captured. ``to_thread(.join)`` is needed
-                            # because ``Thread.join`` is sync-blocking.
-                            # ``_await_writer_exit`` shield-loops until
-                            # the writer actually exits so the outer
-                            # cleanup never races with the still-open
-                            # file handle (CodeRabbit MAJOR finding on
-                            # PR #981).
-                            await _await_writer_exit(writer_thread)
+                            # captured. ``_await_writer_exit`` shield-
+                            # loops until the writer actually exits so
+                            # the outer cleanup never races with the
+                            # still-open file handle. ``re_raise_cancel
+                            # =True`` ensures a cancellation that
+                            # arrived while we were waiting for the
+                            # writer isn't lost when the writer happens
+                            # to finish first — CodeRabbit MAJOR
+                            # findings on PR #981.
+                            await _await_writer_exit(writer_thread, re_raise_cancel=True)
                             if writer_error:
                                 raise writer_error[0]
                         except BaseException:

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -10,6 +10,7 @@ import os
 import queue
 import sys
 import tempfile
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -577,24 +578,38 @@ class ArtifactDownloadService:
 
                         # Producer/consumer split: a single dedicated
                         # writer thread drains a bounded queue and writes
-                        # to ``temp_file``. The async chunk loop puts
-                        # bytes on the queue; ``await asyncio.to_thread(
-                        # q.put, ...)`` blocks the producer when the
-                        # queue is full, giving us back-pressure without
-                        # spawning a fresh thread call per 64 KiB chunk
-                        # (which for multi-GB downloads is thousands of
-                        # thread-pool allocations and contention).
+                        # to ``temp_file``. Compared to the legacy
+                        # per-chunk ``asyncio.to_thread(f.write, chunk)``,
+                        # this avoids thousands of thread-pool allocations
+                        # for multi-GB downloads.
+                        #
+                        # The writer runs on a dedicated ``threading.Thread``
+                        # rather than ``asyncio.to_thread`` so it does NOT
+                        # tie up a slot in asyncio's default executor pool.
+                        # With many concurrent downloads, default-executor
+                        # saturation by long-lived writers (each blocking
+                        # on ``chunk_q.get()``) could deadlock producers
+                        # trying to ``put`` via ``to_thread`` — addresses
+                        # the gemini-code-assist HIGH-severity finding on
+                        # the original PR.
+                        #
+                        # Producer puts use ``put_nowait`` first and only
+                        # fall back to ``to_thread(put, ...)`` when the
+                        # queue is full, minimizing default-executor
+                        # pressure during normal flow.
                         #
                         # End-of-stream is signalled with a ``None``
-                        # sentinel. The writer surfaces filesystem errors
-                        # by re-raising from its ``to_thread`` task; the
-                        # producer detects that path by checking
-                        # ``writer_task.done()`` before pushing each
-                        # chunk so a dead writer doesn't deadlock the
-                        # producer in ``q.put``.
+                        # sentinel. Writer-side failures are surfaced via
+                        # ``writer_error`` and an early ``writer_failed``
+                        # ``threading.Event`` so the producer can short-
+                        # circuit BEFORE the writer's drain completes,
+                        # avoiding wasted network reads — addresses the
+                        # gemini-code-assist MEDIUM-severity finding.
                         chunk_q: queue.Queue[bytes | None] = queue.Queue(
                             maxsize=_DOWNLOAD_WRITER_QUEUE_SIZE
                         )
+                        writer_failed = threading.Event()
+                        writer_error: list[BaseException] = []
 
                         def _writer_loop() -> None:
                             # If the writer raises (e.g. OSError on
@@ -604,9 +619,16 @@ class ArtifactDownloadService:
                             # hangs forever because we are the only
                             # consumer. The ``finally`` drains pending
                             # items via ``get_nowait`` so blocked puts
-                            # complete and the producer can observe
-                            # ``writer_task.done()`` on its next
-                            # iteration.
+                            # complete and the producer can observe the
+                            # failure signal on its next iteration.
+                            #
+                            # ``writer_failed`` is set in the ``except``
+                            # BEFORE the drain so the producer's
+                            # short-circuit check fires as early as
+                            # possible — the drain itself can run for a
+                            # few milliseconds clearing the queue, during
+                            # which the producer would otherwise read and
+                            # discard network bytes pointlessly.
                             try:
                                 with open(temp_file, "wb") as fh:
                                     while True:
@@ -614,6 +636,17 @@ class ArtifactDownloadService:
                                         if item is None:
                                             return
                                         fh.write(item)
+                            except BaseException as exc:
+                                # Capture-and-don't-reraise: the producer
+                                # surfaces the exception via
+                                # ``writer_error[0]`` after joining.
+                                # Re-raising here would only land in the
+                                # thread's bootstrap as
+                                # ``PytestUnhandledThreadExceptionWarning``
+                                # / sys.unraisablehook noise without
+                                # carrying any new information.
+                                writer_error.append(exc)
+                                writer_failed.set()
                             finally:
                                 while True:
                                     try:
@@ -621,24 +654,45 @@ class ArtifactDownloadService:
                                     except queue.Empty:
                                         break
 
-                        writer_task = asyncio.create_task(asyncio.to_thread(_writer_loop))
+                        writer_thread = threading.Thread(
+                            target=_writer_loop,
+                            name=f"artifact-dl-writer-{temp_file.name}",
+                            daemon=True,
+                        )
+                        writer_thread.start()
                         total_bytes = 0
                         try:
                             async for chunk in response.aiter_bytes(chunk_size=65536):
-                                if writer_task.done():
-                                    # Writer died (likely OSError). Stop
-                                    # producing and surface the failure
-                                    # via the ``await writer_task`` below.
+                                if writer_failed.is_set():
+                                    # Writer raised mid-stream. Stop
+                                    # reading — further network bytes
+                                    # would just be discarded by the
+                                    # drain. The original error is
+                                    # re-raised via ``writer_error[0]``
+                                    # below.
                                     break
-                                await asyncio.to_thread(chunk_q.put, chunk)
+                                # ``put_nowait`` avoids a ``to_thread``
+                                # round-trip when the queue has space
+                                # (the common case under balanced flow);
+                                # fall back to ``to_thread`` only when
+                                # the queue is full so the loop suspends
+                                # cleanly under back-pressure.
+                                try:
+                                    chunk_q.put_nowait(chunk)
+                                except queue.Full:
+                                    await asyncio.to_thread(chunk_q.put, chunk)
                                 total_bytes += len(chunk)
-                            # Sentinel signals clean EOF. If we broke out
-                            # of the loop because the writer died, the
-                            # ``put`` here would block forever — guard
-                            # against that.
-                            if not writer_task.done():
-                                await asyncio.to_thread(chunk_q.put, None)
-                            await writer_task
+                            if not writer_failed.is_set():
+                                try:
+                                    chunk_q.put_nowait(None)
+                                except queue.Full:
+                                    await asyncio.to_thread(chunk_q.put, None)
+                            # Join surfaces any exception the writer
+                            # captured. ``to_thread(.join)`` is needed
+                            # because ``Thread.join`` is sync-blocking.
+                            await asyncio.to_thread(writer_thread.join)
+                            if writer_error:
+                                raise writer_error[0]
                         except BaseException:
                             # On producer-side failure (network error,
                             # cancellation, HTML payload), make sure the
@@ -664,14 +718,8 @@ class ArtifactDownloadService:
                                     # get — the next put attempt will
                                     # succeed.
                                     pass
-                            # Wait for the writer to consume the sentinel
-                            # and release the temp-file handle before the
-                            # outer ``except`` unlinks it. ``shield``
-                            # plus ``suppress`` mirrors the original
-                            # cancellation-aware wait so a re-cancel
-                            # during cleanup doesn't drop the await.
                             with contextlib.suppress(BaseException):
-                                await asyncio.shield(writer_task)
+                                await asyncio.to_thread(writer_thread.join)
                             raise
 
                         if total_bytes == 0:

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -7,6 +7,7 @@ import contextlib
 import csv
 import logging
 import os
+import queue
 import sys
 import tempfile
 from dataclasses import dataclass, field
@@ -32,6 +33,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _TRUSTED_DOWNLOAD_DOMAINS = (".google.com", ".googleusercontent.com", ".googleapis.com")
+
+# Bounded queue between the async chunk producer and the single writer
+# thread. Small enough to provide back-pressure (the producer awaits when
+# the writer falls behind) but large enough to keep the writer hot across
+# a brief read stall. 8 slots × 64 KiB ≈ 512 KiB of in-flight buffering.
+_DOWNLOAD_WRITER_QUEUE_SIZE = 8
 
 
 @dataclass(frozen=False)
@@ -503,7 +510,15 @@ class ArtifactDownloadService:
                         len(response.content),
                     )
 
-                except (httpx.HTTPError, ValueError) as e:
+                except (httpx.HTTPError, ValueError, ArtifactDownloadError) as e:
+                    # ``ArtifactDownloadError`` covers the policy violations
+                    # raised earlier in this block (non-HTTPS scheme,
+                    # untrusted host, 401/403, HTML payload). Aggregating
+                    # them into ``result.failed`` lets a single bad URL
+                    # fall out of the batch instead of aborting every
+                    # remaining download in the loop. The single-URL
+                    # ``download_url`` path below intentionally still
+                    # raises — only the batch surface absorbs.
                     if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
                         reason = f"HTTP {e.response.status_code}"
                     else:
@@ -560,17 +575,104 @@ class ArtifactDownloadService:
                                 "Authentication may have expired. Run 'notebooklm login'.",
                             )
 
+                        # Producer/consumer split: a single dedicated
+                        # writer thread drains a bounded queue and writes
+                        # to ``temp_file``. The async chunk loop puts
+                        # bytes on the queue; ``await asyncio.to_thread(
+                        # q.put, ...)`` blocks the producer when the
+                        # queue is full, giving us back-pressure without
+                        # spawning a fresh thread call per 64 KiB chunk
+                        # (which for multi-GB downloads is thousands of
+                        # thread-pool allocations and contention).
+                        #
+                        # End-of-stream is signalled with a ``None``
+                        # sentinel. The writer surfaces filesystem errors
+                        # by re-raising from its ``to_thread`` task; the
+                        # producer detects that path by checking
+                        # ``writer_task.done()`` before pushing each
+                        # chunk so a dead writer doesn't deadlock the
+                        # producer in ``q.put``.
+                        chunk_q: queue.Queue[bytes | None] = queue.Queue(
+                            maxsize=_DOWNLOAD_WRITER_QUEUE_SIZE
+                        )
+
+                        def _writer_loop() -> None:
+                            # If the writer raises (e.g. OSError on
+                            # ``fh.write``), the bounded queue may have a
+                            # producer parked in ``q.put`` waiting for a
+                            # consumer. Without draining, that producer
+                            # hangs forever because we are the only
+                            # consumer. The ``finally`` drains pending
+                            # items via ``get_nowait`` so blocked puts
+                            # complete and the producer can observe
+                            # ``writer_task.done()`` on its next
+                            # iteration.
+                            try:
+                                with open(temp_file, "wb") as fh:
+                                    while True:
+                                        item = chunk_q.get()
+                                        if item is None:
+                                            return
+                                        fh.write(item)
+                            finally:
+                                while True:
+                                    try:
+                                        chunk_q.get_nowait()
+                                    except queue.Empty:
+                                        break
+
+                        writer_task = asyncio.create_task(asyncio.to_thread(_writer_loop))
                         total_bytes = 0
-                        with open(temp_file, "wb") as f:
+                        try:
                             async for chunk in response.aiter_bytes(chunk_size=65536):
-                                write_task = asyncio.create_task(asyncio.to_thread(f.write, chunk))
-                                try:
-                                    await asyncio.shield(write_task)
-                                except asyncio.CancelledError:
-                                    with contextlib.suppress(asyncio.CancelledError, Exception):
-                                        await write_task
-                                    raise
+                                if writer_task.done():
+                                    # Writer died (likely OSError). Stop
+                                    # producing and surface the failure
+                                    # via the ``await writer_task`` below.
+                                    break
+                                await asyncio.to_thread(chunk_q.put, chunk)
                                 total_bytes += len(chunk)
+                            # Sentinel signals clean EOF. If we broke out
+                            # of the loop because the writer died, the
+                            # ``put`` here would block forever — guard
+                            # against that.
+                            if not writer_task.done():
+                                await asyncio.to_thread(chunk_q.put, None)
+                            await writer_task
+                        except BaseException:
+                            # On producer-side failure (network error,
+                            # cancellation, HTML payload), make sure the
+                            # writer sees a sentinel and exits — even if
+                            # the queue is currently saturated. A bare
+                            # ``put_nowait(None)`` would raise
+                            # ``queue.Full`` and leave the writer parked
+                            # in ``q.get`` forever; instead drop one item
+                            # to make room, then put the sentinel. At
+                            # most two iterations are needed: the writer
+                            # is the only consumer, so once a slot opens
+                            # nothing else refills it.
+                            while True:
+                                try:
+                                    chunk_q.put_nowait(None)
+                                    break
+                                except queue.Full:
+                                    pass
+                                try:
+                                    chunk_q.get_nowait()
+                                except queue.Empty:
+                                    # Writer drained between our put and
+                                    # get — the next put attempt will
+                                    # succeed.
+                                    pass
+                            # Wait for the writer to consume the sentinel
+                            # and release the temp-file handle before the
+                            # outer ``except`` unlinks it. ``shield``
+                            # plus ``suppress`` mirrors the original
+                            # cancellation-aware wait so a re-cancel
+                            # during cleanup doesn't drop the await.
+                            with contextlib.suppress(BaseException):
+                                await asyncio.shield(writer_task)
+                            raise
 
                         if total_bytes == 0:
                             raise ArtifactDownloadError(

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import csv
 import logging
 import os
@@ -40,6 +39,39 @@ _TRUSTED_DOWNLOAD_DOMAINS = (".google.com", ".googleusercontent.com", ".googleap
 # the writer falls behind) but large enough to keep the writer hot across
 # a brief read stall. 8 slots × 64 KiB ≈ 512 KiB of in-flight buffering.
 _DOWNLOAD_WRITER_QUEUE_SIZE = 8
+
+
+async def _await_writer_exit(writer_thread: threading.Thread) -> None:
+    """Wait for a download writer thread to actually exit.
+
+    Plain ``await asyncio.to_thread(thread.join)`` is unsafe under
+    cancellation: if our awaiting task is cancelled, the await raises
+    ``CancelledError`` and we unwind even though the underlying
+    ``thread.join`` is still blocked on the thread. The thread keeps
+    running, which means the outer cleanup (``temp_file.unlink``)
+    races with the writer's still-open file handle.
+
+    ``asyncio.shield`` alone doesn't fix this: it keeps the *inner*
+    join task alive across cancellation, but the *await* still raises
+    ``CancelledError`` and we unwind anyway. The fix is a shield-loop
+    that keeps re-awaiting the same shielded join task until it
+    actually completes. Repeated cancellations only delay our
+    re-raise, never the writer's exit.
+
+    Addresses the CodeRabbit MAJOR finding on PR #981.
+    """
+    join_task = asyncio.ensure_future(asyncio.to_thread(writer_thread.join))
+    while not join_task.done():
+        try:
+            await asyncio.shield(join_task)
+        except BaseException:
+            # Outer task was cancelled (or some other exception
+            # propagated into our await). The shielded join keeps
+            # running; loop and re-await. We deliberately swallow
+            # the cancellation here so the join can complete —
+            # the original exception is preserved on the calling
+            # frame's stack and re-raised after we return.
+            pass
 
 
 @dataclass(frozen=False)
@@ -690,7 +722,12 @@ class ArtifactDownloadService:
                             # Join surfaces any exception the writer
                             # captured. ``to_thread(.join)`` is needed
                             # because ``Thread.join`` is sync-blocking.
-                            await asyncio.to_thread(writer_thread.join)
+                            # ``_await_writer_exit`` shield-loops until
+                            # the writer actually exits so the outer
+                            # cleanup never races with the still-open
+                            # file handle (CodeRabbit MAJOR finding on
+                            # PR #981).
+                            await _await_writer_exit(writer_thread)
                             if writer_error:
                                 raise writer_error[0]
                         except BaseException:
@@ -718,8 +755,21 @@ class ArtifactDownloadService:
                                     # get — the next put attempt will
                                     # succeed.
                                     pass
-                            with contextlib.suppress(BaseException):
-                                await asyncio.to_thread(writer_thread.join)
+                            # MUST wait for the writer to actually exit
+                            # before unwinding: the outer ``except``
+                            # unlinks ``temp_file``, which would race
+                            # with the writer's still-open file handle
+                            # otherwise. A plain
+                            # ``contextlib.suppress(BaseException) +
+                            # await to_thread(.join)`` does NOT suffice
+                            # — the await itself can be re-cancelled and
+                            # unwind before the writer finishes. The
+                            # shield-loop in ``_await_writer_exit``
+                            # keeps re-awaiting the same shielded join
+                            # task across repeated cancellations until
+                            # the writer thread is actually dead.
+                            # CodeRabbit MAJOR finding on PR #981.
+                            await _await_writer_exit(writer_thread)
                             raise
 
                         if total_bytes == 0:

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -309,11 +309,20 @@ class SourceUploadPipeline:
             if not title:
                 raise ValidationError("Title cannot be empty or whitespace-only")
 
-        file_path = Path(file_path).resolve()
-        if not file_path.exists():
-            raise FileNotFoundError(f"File not found: {file_path}")
-        if not file_path.is_file():
-            raise ValidationError(f"Not a regular file: {file_path}")
+        # ``Path.resolve()`` / ``exists()`` / ``is_file()`` all hit the
+        # filesystem (stat / readlink syscalls). On a slow network mount
+        # or a deep symlink chain these are blocking calls — same problem
+        # class as the ``open()`` + ``fstat()`` below — so they are
+        # offloaded to a worker thread too.
+        def _resolve_and_check(raw_path: str | Path) -> Path:
+            resolved = Path(raw_path).resolve()
+            if not resolved.exists():
+                raise FileNotFoundError(f"File not found: {resolved}")
+            if not resolved.is_file():
+                raise ValidationError(f"Not a regular file: {resolved}")
+            return resolved
+
+        file_path = await asyncio.to_thread(_resolve_and_check, file_path)
 
         filename = file_path.name
         async with self._runtime.operation_scope(f"upload:{upload_index}"):
@@ -322,10 +331,27 @@ class SourceUploadPipeline:
             async with upload_sem:
                 if self._record_upload_queue_wait is not None:
                     self._record_upload_queue_wait(monotonic() - upload_wait_start)
-                file_obj = open(file_path, "rb")  # noqa: SIM115
+
+                # ``open()`` and ``fstat()`` are synchronous syscalls. For
+                # network filesystems or deep directories they can block
+                # the event loop for tens of milliseconds, stalling every
+                # other concurrent task (auth refresh, sibling uploads,
+                # the cancellation watchdog) for the duration of the
+                # syscall. Run them on a worker thread so the loop keeps
+                # ticking. ``fstat`` is paired with ``open`` in the same
+                # closure so we don't pay the round-trip cost twice.
+                def _open_and_stat(path: Path) -> tuple[IO[bytes], int]:
+                    fh = open(path, "rb")  # noqa: SIM115
+                    try:
+                        size = os.fstat(fh.fileno()).st_size
+                    except BaseException:
+                        fh.close()
+                        raise
+                    return fh, size
+
+                file_obj, file_size = await asyncio.to_thread(_open_and_stat, file_path)
                 handed_off = False
                 try:
-                    file_size = os.fstat(file_obj.fileno()).st_size
                     source_id = await register_file_source(notebook_id, filename)
                     upload_url = await start_resumable_upload(
                         notebook_id,

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -444,3 +444,230 @@ async def test_download_url_cookie_load_runs_off_loop_thread(
         call_site="_download_url",
         wrap_target="load_httpx_cookies",
     )
+
+
+@pytest.mark.asyncio
+async def test_download_url_uses_single_writer_thread_for_all_chunks(
+    mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
+    tmp_path: Path,
+) -> None:
+    """``_download_url`` must drive ALL chunks through ONE writer thread.
+
+    Pre-fix the streaming loop wrapped every 64 KiB chunk in its own
+    ``asyncio.to_thread(f.write, chunk)`` call. For multi-GB downloads
+    that adds up to thousands of fresh thread-pool jobs — allocation
+    churn and contention on the default executor.
+
+    Post-fix the producer pushes chunks onto a bounded queue drained by
+    a single dedicated writer thread. We assert the property directly:
+    only ONE ``asyncio.to_thread`` call dispatches a writer body, even
+    when the stream yields many chunks.
+
+    Methodology
+    -----------
+    The fix structures the chunk loop as one ``asyncio.to_thread(
+    _writer_loop)`` (long-lived, drains a ``queue.Queue``) plus per-chunk
+    ``asyncio.to_thread(q.put, chunk)`` calls (the queue ``put`` is the
+    back-pressure await). We patch ``asyncio.to_thread`` with a recorder
+    that classifies each call:
+
+    * Calls whose first positional arg is a callable named ``_writer_loop``
+      (the closure produced inside ``_download_url``) are "writer" calls.
+    * All other calls are passthroughs (cookie load, ``queue.put``, etc.).
+
+    We require *exactly one* writer call regardless of chunk count. A
+    regression that goes back to per-chunk ``to_thread(f.write, ...)``
+    bumps the count to N.
+    """
+    api, _ = mock_artifacts_api
+    output_path = tmp_path / "many_chunks.bin"
+
+    import httpx as real_httpx
+
+    # 32 chunks of 64 KiB. Anything > ~2 demonstrates the regression
+    # signal cleanly; 32 keeps the test fast while making the
+    # per-chunk-pre-fix count visually obvious in failure output.
+    chunks = [b"x" * 65536 for _ in range(32)]
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        for chunk in chunks:
+            yield chunk
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    original_to_thread = asyncio.to_thread
+    writer_calls = 0
+
+    async def recording_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal writer_calls
+        # The writer closure is defined inside ``_download_url`` so we
+        # match on the qualified name suffix. Anything else (cookie
+        # load, ``queue.Queue.put``, etc.) passes through untouched.
+        name = getattr(func, "__qualname__", "") or getattr(func, "__name__", "")
+        if name.endswith("_writer_loop"):
+            writer_calls += 1
+        return await original_to_thread(func, *args, **kwargs)
+
+    with (
+        patch.object(real_httpx, "AsyncClient", return_value=mock_client),
+        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+        patch("notebooklm._artifact_downloads.asyncio.to_thread", new=recording_to_thread),
+    ):
+        result = await api._download_url(
+            "https://storage.googleapis.com/many_chunks.bin", str(output_path)
+        )
+
+    assert result == str(output_path)
+    assert output_path.exists()
+    assert output_path.stat().st_size == sum(len(c) for c in chunks), (
+        "The temp-file → final-file atomic replace must preserve all bytes."
+    )
+    assert writer_calls == 1, (
+        f"_download_url dispatched {writer_calls} writer thread jobs for a "
+        f"{len(chunks)}-chunk download. The fix requires exactly ONE long-lived "
+        "writer thread fed via a bounded queue, not a fresh asyncio.to_thread "
+        "per chunk."
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_url_writer_failure_does_not_deadlock_producer(
+    mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
+    tmp_path: Path,
+) -> None:
+    """A failing writer thread must not deadlock the producer.
+
+    Regression: with a bounded queue, a producer parked in ``q.put``
+    on a full queue hangs forever if the writer raises mid-stream
+    (the worker thread holding the put only releases when a consumer
+    takes, and we are the only consumer). The fix has the writer's
+    ``finally`` drain the queue so blocked puts can complete and the
+    producer can observe ``writer_task.done()`` on the next iteration.
+
+    Determinism strategy — engineer the race so the queue is GUARANTEED
+    full when the writer dies:
+
+    1. Patch ``builtins.open`` so the writer's handle defers the
+       OSError until a ``threading.Event`` is set. This holds the
+       writer at its first ``fh.write`` indefinitely, letting the
+       producer fill the queue.
+    2. The producer yields many chunks. Each ``q.put`` succeeds until
+       the bounded queue (size 8) is full; the next put parks on a
+       worker thread.
+    3. From the test we wait until the queue is observed full, then
+       set the event. The writer's first write raises OSError; with
+       the fix, the writer's ``finally`` drains the queue and the
+       parked producer wakes; without the fix, the parked producer
+       hangs and ``asyncio.wait_for`` times out.
+    """
+    import builtins  # local import keeps the module's import list lean
+    import threading
+
+    import httpx as real_httpx
+
+    api, _ = mock_artifacts_api
+    output_path = tmp_path / "doomed.bin"
+
+    # ``aiter_bytes`` yields chunks indefinitely so the queue can keep
+    # being filled regardless of how many slots the writer has cleared.
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        idx = 0
+        while True:
+            yield b"x" * 65536
+            idx += 1
+            # Yield to the loop so the producer doesn't spin without
+            # giving the writer thread CPU time.
+            await asyncio.sleep(0)
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    real_open = builtins.open
+    write_blocked = threading.Event()
+    release_writer = threading.Event()
+
+    class _DeferredExplodingHandle:
+        """File handle whose first ``write`` blocks until released, then raises."""
+
+        def write(self, data: bytes) -> int:
+            write_blocked.set()
+            release_writer.wait(timeout=5.0)
+            raise OSError("simulated disk full")
+
+        def close(self) -> None:  # noqa: D401
+            pass
+
+        def __enter__(self) -> _DeferredExplodingHandle:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+            self.close()
+
+    def _patched_open(file, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        try:
+            target = Path(file).resolve()
+            same_dir = target.parent == tmp_path.resolve()
+        except (TypeError, ValueError):
+            same_dir = False
+        if same_dir and "w" in mode and "b" in mode:
+            return _DeferredExplodingHandle()
+        return real_open(file, mode, *args, **kwargs)
+
+    async def _release_writer_after_queue_fills() -> None:
+        # Wait until the writer thread has entered its (blocked)
+        # ``write`` call. That guarantees one chunk has been
+        # dequeued, AND the writer is no longer consuming. By the
+        # time the producer's next ``q.put`` parks, we know the
+        # queue is full.
+        await asyncio.to_thread(write_blocked.wait, 2.0)
+        # Give the producer time to fill the queue and park.
+        await asyncio.sleep(0.2)
+        # Now release the writer — its ``write`` raises OSError.
+        # The post-fix ``finally`` block must drain the queue so the
+        # parked producer can wake.
+        release_writer.set()
+
+    with (
+        patch.object(real_httpx, "AsyncClient", return_value=mock_client),
+        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+        patch.object(builtins, "open", new=_patched_open),
+    ):
+        download_coro = api._download_url(
+            "https://storage.googleapis.com/doomed.bin", str(output_path)
+        )
+        release_coro = _release_writer_after_queue_fills()
+        # Run both concurrently. Pre-fix the download hangs in
+        # ``q.put`` forever and ``wait_for`` fires before either coro
+        # makes progress. Post-fix the writer's ``finally`` drains the
+        # queue, the producer unblocks, ``await writer_task`` raises
+        # OSError, the outer ``except`` cleans up the temp file, and
+        # the OSError propagates to the test.
+        with pytest.raises(OSError, match="simulated disk full"):
+            await asyncio.wait_for(
+                asyncio.gather(download_coro, release_coro),
+                timeout=5.0,
+            )
+
+    # Final file must NOT exist (atomic replace never ran).
+    assert not output_path.exists()
+    # Temp file must NOT be left behind.
+    assert list(tmp_path.glob("doomed.bin.*.tmp")) == []

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -459,25 +459,25 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
     churn and contention on the default executor.
 
     Post-fix the producer pushes chunks onto a bounded queue drained by
-    a single dedicated writer thread. We assert the property directly:
-    only ONE ``asyncio.to_thread`` call dispatches a writer body, even
-    when the stream yields many chunks.
+    a single dedicated writer thread. The writer runs on a dedicated
+    ``threading.Thread`` (NOT ``asyncio.to_thread``) so it does not tie
+    up a slot in asyncio's default executor pool — addresses the
+    gemini-code-assist HIGH-severity finding about default-executor
+    saturation under many concurrent downloads.
 
     Methodology
     -----------
-    The fix structures the chunk loop as one ``asyncio.to_thread(
-    _writer_loop)`` (long-lived, drains a ``queue.Queue``) plus per-chunk
-    ``asyncio.to_thread(q.put, chunk)`` calls (the queue ``put`` is the
-    back-pressure await). We patch ``asyncio.to_thread`` with a recorder
-    that classifies each call:
+    We patch ``threading.Thread`` with a recorder that classifies each
+    instantiation:
 
-    * Calls whose first positional arg is a callable named ``_writer_loop``
-      (the closure produced inside ``_download_url``) are "writer" calls.
-    * All other calls are passthroughs (cookie load, ``queue.put``, etc.).
+    * Threads whose ``target`` is a callable named ``_writer_loop``
+      (the closure produced inside ``_download_url``) are "writer"
+      threads.
+    * All other threads (rare on this path) are passthroughs.
 
-    We require *exactly one* writer call regardless of chunk count. A
-    regression that goes back to per-chunk ``to_thread(f.write, ...)``
-    bumps the count to N.
+    We require *exactly one* writer thread per download regardless of
+    chunk count. A regression that goes back to per-chunk
+    ``to_thread(f.write, ...)`` bumps the count to N.
     """
     api, _ = mock_artifacts_api
     output_path = tmp_path / "many_chunks.bin"
@@ -505,23 +505,24 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
-    original_to_thread = asyncio.to_thread
-    writer_calls = 0
+    import threading as real_threading
 
-    async def recording_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
-        nonlocal writer_calls
-        # The writer closure is defined inside ``_download_url`` so we
-        # match on the qualified name suffix. Anything else (cookie
-        # load, ``queue.Queue.put``, etc.) passes through untouched.
-        name = getattr(func, "__qualname__", "") or getattr(func, "__name__", "")
-        if name.endswith("_writer_loop"):
-            writer_calls += 1
-        return await original_to_thread(func, *args, **kwargs)
+    original_thread_cls = real_threading.Thread
+    writer_threads = 0
+
+    class _RecordingThread(original_thread_cls):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal writer_threads
+            target = kwargs.get("target") or (args[1] if len(args) > 1 else None)
+            name = getattr(target, "__qualname__", "") or getattr(target, "__name__", "")
+            if name.endswith("_writer_loop"):
+                writer_threads += 1
+            super().__init__(*args, **kwargs)
 
     with (
         patch.object(real_httpx, "AsyncClient", return_value=mock_client),
         patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
-        patch("notebooklm._artifact_downloads.asyncio.to_thread", new=recording_to_thread),
+        patch("notebooklm._artifact_downloads.threading.Thread", new=_RecordingThread),
     ):
         result = await api._download_url(
             "https://storage.googleapis.com/many_chunks.bin", str(output_path)
@@ -532,11 +533,10 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
     assert output_path.stat().st_size == sum(len(c) for c in chunks), (
         "The temp-file → final-file atomic replace must preserve all bytes."
     )
-    assert writer_calls == 1, (
-        f"_download_url dispatched {writer_calls} writer thread jobs for a "
+    assert writer_threads == 1, (
+        f"_download_url created {writer_threads} writer threads for a "
         f"{len(chunks)}-chunk download. The fix requires exactly ONE long-lived "
-        "writer thread fed via a bounded queue, not a fresh asyncio.to_thread "
-        "per chunk."
+        "writer thread fed via a bounded queue, not a fresh thread per chunk."
     )
 
 

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -467,20 +467,28 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
 
     Methodology
     -----------
-    We patch ``threading.Thread`` with a recorder that classifies each
-    instantiation:
+    Two layers of evidence:
 
-    * Threads whose ``target`` is a callable named ``_writer_loop``
-      (the closure produced inside ``_download_url``) are "writer"
-      threads.
-    * All other threads (rare on this path) are passthroughs.
+    1. Patch ``threading.Thread`` with a recorder that counts
+       instantiations whose ``target`` is the ``_writer_loop`` closure.
+       Exactly one writer thread must be instantiated.
 
-    We require *exactly one* writer thread per download regardless of
-    chunk count. A regression that goes back to per-chunk
-    ``to_thread(f.write, ...)`` bumps the count to N.
+    2. Patch ``builtins.open`` on the temp-file path so the returned
+       handle records ``threading.get_ident()`` for every ``write()``
+       call. All recorded ids must be identical AND must match the
+       writer thread's ``ident``. CodeRabbit nitpick on PR #981: thread
+       construction alone doesn't prove every chunk was written on
+       that thread; recording the call site closes that gap.
+
+    A regression that goes back to per-chunk ``to_thread(f.write, ...)``
+    fails layer 1 (thread count > 1) AND layer 2 (writes happen across
+    multiple thread idents).
     """
     api, _ = mock_artifacts_api
     output_path = tmp_path / "many_chunks.bin"
+
+    import builtins
+    import threading as real_threading
 
     import httpx as real_httpx
 
@@ -505,24 +513,65 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
-    import threading as real_threading
-
     original_thread_cls = real_threading.Thread
+    real_open = builtins.open
     writer_threads = 0
+    writer_thread_idents: list[int] = []
+    write_thread_ids: list[int] = []
 
     class _RecordingThread(original_thread_cls):  # type: ignore[misc, valid-type]
         def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
             nonlocal writer_threads
             target = kwargs.get("target") or (args[1] if len(args) > 1 else None)
             name = getattr(target, "__qualname__", "") or getattr(target, "__name__", "")
-            if name.endswith("_writer_loop"):
+            self._is_writer_loop_thread = name.endswith("_writer_loop")
+            if self._is_writer_loop_thread:
                 writer_threads += 1
             super().__init__(*args, **kwargs)
+
+        def start(self) -> None:
+            super().start()
+            # ``ident`` is only valid after ``start()``. Capture it
+            # here so the test can compare it against the per-write
+            # thread ids recorded by ``_RecordingFile``.
+            if self._is_writer_loop_thread:
+                writer_thread_idents.append(self.ident)  # type: ignore[arg-type]
+
+    class _RecordingFile:
+        """Forwards every attribute to the real handle but instruments
+        ``write`` to record the calling thread's ident."""
+
+        def __init__(self, fh) -> None:  # type: ignore[no-untyped-def]
+            self._fh = fh
+
+        def write(self, data: bytes) -> int:
+            write_thread_ids.append(real_threading.get_ident())
+            return self._fh.write(data)
+
+        def __enter__(self) -> _RecordingFile:
+            return self
+
+        def __exit__(self, *exc) -> None:  # type: ignore[no-untyped-def]
+            self._fh.close()
+
+        def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
+            return getattr(self._fh, name)
+
+    def _patched_open(file, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        try:
+            target_path = Path(file).resolve()
+            in_tmp_dir = target_path.parent == tmp_path.resolve()
+        except (TypeError, ValueError):
+            in_tmp_dir = False
+        if in_tmp_dir and "w" in mode and "b" in mode:
+            return _RecordingFile(real_open(file, mode, *args, **kwargs))
+        return real_open(file, mode, *args, **kwargs)
 
     with (
         patch.object(real_httpx, "AsyncClient", return_value=mock_client),
         patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
         patch("notebooklm._artifact_downloads.threading.Thread", new=_RecordingThread),
+        patch.object(builtins, "open", new=_patched_open),
     ):
         result = await api._download_url(
             "https://storage.googleapis.com/many_chunks.bin", str(output_path)
@@ -537,6 +586,26 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
         f"_download_url created {writer_threads} writer threads for a "
         f"{len(chunks)}-chunk download. The fix requires exactly ONE long-lived "
         "writer thread fed via a bounded queue, not a fresh thread per chunk."
+    )
+    # Layer 2: prove every chunk was written on the same single thread,
+    # and that thread is the dedicated writer.
+    assert len(write_thread_ids) == len(chunks), (
+        f"recorded {len(write_thread_ids)} writes for a {len(chunks)}-chunk "
+        "download — production code must call ``fh.write`` exactly once per "
+        "chunk on the writer thread."
+    )
+    distinct_write_idents = set(write_thread_ids)
+    assert len(distinct_write_idents) == 1, (
+        f"chunks were written across {len(distinct_write_idents)} distinct "
+        f"threads ({sorted(distinct_write_idents)}). A regression that mixes "
+        "the dedicated writer with per-chunk ``to_thread(f.write, ...)`` calls "
+        "would surface here."
+    )
+    assert writer_thread_idents, "writer thread ident was not captured"
+    assert distinct_write_idents == {writer_thread_idents[0]}, (
+        f"writes happened on thread {distinct_write_idents.pop()} but the "
+        f"dedicated _writer_loop thread had ident {writer_thread_idents[0]}. "
+        "Writes must run on the writer thread, not a sibling executor slot."
     )
 
 

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+import threading
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -120,6 +121,10 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
 
     core.operation_scope.side_effect = operation_scope
     core.record_upload_queue_wait = MagicMock()
+    # MagicMock blocks ``assert``-prefixed attribute access as a foot-gun
+    # guard; the no-op ``assert_bound_loop`` stub used by ``add_file``
+    # must therefore be installed explicitly.
+    core.assert_bound_loop = MagicMock()
     uploader = SourceUploadPipeline(
         core,
         core.kernel,
@@ -325,4 +330,79 @@ async def test_upload_file_streaming_path_fallback_does_not_block_event_loop(
         f"(expected >= {MIN_HEARTBEATS}). The synchronous f.read(65536) is "
         f"still running on the event-loop thread — wrap it with "
         f"asyncio.to_thread."
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_file_open_runs_off_loop_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``add_file``'s ``open()`` + ``fstat()`` must run off the event loop.
+
+    Pre-fix the ``open()`` and ``os.fstat`` calls inside ``add_file``
+    execute as synchronous syscalls directly on the loop thread. On a
+    slow network mount that stalls every other concurrent coroutine for
+    the full ``open`` latency. The fix wraps the pair in
+    ``await asyncio.to_thread(...)``.
+
+    Methodology mirrors ``test_download_blocks_loop.py``: we monkey-patch
+    ``builtins.open`` so it captures ``threading.get_ident()`` on the
+    very first call for our test file. If the wrap is in place the
+    captured id differs from the loop thread id; a regression that
+    removes the wrap leaves them equal.
+    """
+    sources_api, _core = _make_sources_api()
+    test_file = tmp_path / "to_open.bin"
+    test_file.write_bytes(b"payload")
+
+    real_open = builtins.open
+    loop_thread_id = threading.get_ident()
+    captured: list[int] = []
+
+    def _recording_open(file, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        # Only record when the open is for our test file in binary mode
+        # — log handlers, .pyc caches, etc. can also call builtins.open
+        # and would otherwise pollute the capture list.
+        try:
+            same = Path(file).resolve() == test_file.resolve()
+        except (TypeError, ValueError):
+            same = False
+        if same and "b" in mode:
+            captured.append(threading.get_ident())
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _recording_open)
+
+    # Mock the registration RPC so we never hit the wire. Two RPC calls
+    # land before ``add_file`` returns: GET_NOTEBOOK (baseline list) and
+    # ADD_SOURCE_FILE (register). The "[[[['src_t1']]]]" shape feeds the
+    # standard SOURCE_ID walker in ``_extract_register_file_source_id``.
+    _core.rpc_call.return_value = [[[["src_t1"]]]]
+
+    mock_start_response = MagicMock()
+    mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com/session"}
+    mock_upload_response = MagicMock()
+    mock_upload_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+        mock_client_cls.return_value = mock_client
+
+        await sources_api.add_file("nb_t1", str(test_file))
+
+    # The first `open` on our test file is the production ``open()``
+    # inside the upload-semaphore block. Subsequent `open`s (e.g. the
+    # finalize path) are not under test here.
+    assert captured, (
+        "builtins.open was never called for the test file — the patch target "
+        "or the production code path may have changed."
+    )
+    assert captured[0] != loop_thread_id, (
+        f"add_file's open() ran on the event-loop thread (thread id {captured[0]}). "
+        "It must be wrapped in asyncio.to_thread so a slow filesystem cannot stall "
+        "concurrent tasks."
     )

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -97,8 +97,15 @@ class TestDownloadUrlsBatch:
         assert result.failed == []
 
     @pytest.mark.asyncio
-    async def test_batch_download_html_response_rejected(self, mock_artifacts_api, tmp_path):
-        """Test that HTML responses raise ArtifactDownloadError (auth expired)."""
+    async def test_batch_download_html_response_aggregated(self, mock_artifacts_api, tmp_path):
+        """HTML-payload ``ArtifactDownloadError`` is aggregated into ``failed``.
+
+        The batch surface now treats policy violations the same as
+        transport errors: they land in ``result.failed`` so siblings can
+        still complete. The single-URL ``download_url`` path still
+        raises this error to its caller — see the pinned tests in
+        ``tests/integration/test_artifacts_integration.py``.
+        """
         api, _ = mock_artifacts_api
 
         # Mock response returning HTML instead of media
@@ -121,9 +128,14 @@ class TestDownloadUrlsBatch:
                 ("https://storage.googleapis.com/file.mp4", str(tmp_path / "file.mp4")),
             ]
 
-            # HTML response should raise ArtifactDownloadError
-            with pytest.raises(ArtifactDownloadError, match="Received HTML instead of media"):
-                await api._download_urls_batch(urls_and_paths)
+            result = await api._download_urls_batch(urls_and_paths)
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        url, exc = result.failed[0]
+        assert url == "https://storage.googleapis.com/file.mp4"
+        assert isinstance(exc, ArtifactDownloadError)
+        assert "Received HTML instead of media" in str(exc)
 
     @pytest.mark.asyncio
     async def test_batch_download_partial_failure(self, mock_artifacts_api, tmp_path):

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -165,8 +165,19 @@ async def test_download_batch_logs_warning_per_failure(mock_artifacts_api, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_html_response_still_raises(mock_artifacts_api, tmp_path):
-    """ArtifactDownloadError (security signal) propagates — NOT swallowed into failed."""
+async def test_html_response_aggregated_into_failed(mock_artifacts_api, tmp_path):
+    """``ArtifactDownloadError`` raised for an HTML payload is aggregated.
+
+    Pre-fix the batch loop only caught ``(httpx.HTTPError, ValueError)``
+    so an HTML-instead-of-media response (e.g. an auth-expired
+    redirect) aborted the entire batch. Post-fix the policy
+    ``ArtifactDownloadError`` lands in ``result.failed`` alongside any
+    sibling successes — single bad URL no longer drops the rest of
+    the batch. The single-download path (``download_url``) still
+    raises this error; see
+    ``tests/integration/test_artifacts_integration.py``'s download-URL
+    contract tests for that surface.
+    """
     from notebooklm._artifacts import ArtifactDownloadError
 
     api, _ = mock_artifacts_api
@@ -176,26 +187,35 @@ async def test_html_response_still_raises(mock_artifacts_api, tmp_path):
     with _patched_httpx_client(None) as mock_client:
         mock_client.get = AsyncMock(return_value=html_response)
 
-        with pytest.raises(ArtifactDownloadError):
-            await api._download_urls_batch(
-                [(f"{TRUSTED_URL_PREFIX}file.mp4", str(tmp_path / "file.mp4"))]
-            )
+        result = await api._download_urls_batch(
+            [(f"{TRUSTED_URL_PREFIX}file.mp4", str(tmp_path / "file.mp4"))]
+        )
+
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    failed_url, failed_exc = result.failed[0]
+    assert failed_url == f"{TRUSTED_URL_PREFIX}file.mp4"
+    assert isinstance(failed_exc, ArtifactDownloadError)
 
 
 @pytest.mark.asyncio
-async def test_untrusted_domain_still_raises(mock_artifacts_api, tmp_path):
-    """Untrusted-domain ArtifactDownloadError propagates."""
+async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_path):
+    """Untrusted-domain ``ArtifactDownloadError`` lands in ``failed``, not raised."""
     from notebooklm._artifacts import ArtifactDownloadError
 
     api, _ = mock_artifacts_api
 
-    with (
-        patch("notebooklm._artifacts.load_httpx_cookies", return_value={}),
-        pytest.raises(ArtifactDownloadError, match="Untrusted"),
-    ):
-        await api._download_urls_batch(
+    with patch("notebooklm._artifacts.load_httpx_cookies", return_value={}):
+        result = await api._download_urls_batch(
             [("https://evil.example.com/file.mp4", str(tmp_path / "x.mp4"))]
         )
+
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    failed_url, failed_exc = result.failed[0]
+    assert failed_url == "https://evil.example.com/file.mp4"
+    assert isinstance(failed_exc, ArtifactDownloadError)
+    assert "Untrusted" in str(failed_exc)
 
 
 @pytest.mark.asyncio
@@ -233,6 +253,43 @@ async def test_download_warning_log_does_not_leak_url_via_exception_str(
     joined = " ".join(warning_messages)
     assert "LEAKY" not in joined, f"capability token leaked: {joined!r}"
     assert "HTTP 503" in joined
+
+
+@pytest.mark.asyncio
+async def test_download_batch_isolates_bad_url_from_good_one(mock_artifacts_api, tmp_path):
+    """A policy violation on one URL must not abort sibling downloads.
+
+    Mixed batch: one untrusted-domain URL (raises ``ArtifactDownloadError``
+    inside the per-URL try-block) and one trusted-domain URL (succeeds).
+    Pre-fix the policy error escapes the batch loop and the good URL is
+    never attempted. Post-fix the policy error lands in ``failed`` while
+    the good URL still completes — caller can pick up the partial result
+    and retry just the failure.
+    """
+    from notebooklm._artifacts import ArtifactDownloadError
+
+    api, _ = mock_artifacts_api
+    bad_url = "https://untrusted.example/x.mp4"
+    good_url = f"{TRUSTED_URL_PREFIX}y.mp4"
+    bad_path = tmp_path / "x.mp4"
+    good_path = tmp_path / "y.mp4"
+
+    # The good URL's GET should succeed. The bad URL never reaches GET
+    # because the trusted-domain check raises before the HTTP call.
+    success = _mock_response(b"payload bytes")
+    with _patched_httpx_client([success]):
+        result = await api._download_urls_batch(
+            [(bad_url, str(bad_path)), (good_url, str(good_path))]
+        )
+
+    # Good URL completed.
+    assert result.succeeded == [str(good_path)]
+    # Bad URL ended up in failed with an ArtifactDownloadError, NOT propagated.
+    assert len(result.failed) == 1
+    failed_url, failed_exc = result.failed[0]
+    assert failed_url == bad_url
+    assert isinstance(failed_exc, ArtifactDownloadError)
+    assert result.partial
 
 
 def test_no_docs_callers():

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -257,46 +257,49 @@ class TestDownloadUrlErrorWrapping:
     async def test_cancellation_during_write_removes_temp_file(self, mock_artifacts_api, tmp_path):
         """Cancelled streaming writes must not leave the mkstemp temp file behind.
 
-        After the single-writer-thread refactor (PR T1.M.4 — issue #?),
-        the producer's per-chunk yield point is ``asyncio.to_thread(
-        chunk_q.put, chunk)`` (back-pressure into the writer queue), not
-        a direct ``to_thread(f.write, ...)``. The test gates cancellation
-        on the first queue-put rather than the first file-write so the
-        producer is reliably parked on a cancellable await when we
-        cancel the task. The invariant under test — no leftover
-        ``mkstemp`` temp file — is unchanged.
+        After the review-fix refactor (PR #981 r2: gemini findings), the
+        producer uses ``put_nowait`` whenever the bounded queue has
+        space, falling back to ``to_thread(put, ...)`` only under back-
+        pressure. For small payloads that fit in the queue, no
+        ``to_thread(put)`` call fires — so the test cannot gate on it.
+        Instead we gate on the producer's ``aiter_bytes`` await, which
+        is the canonical async-cancellable yield point inside the chunk
+        loop. The invariant under test — no leftover ``mkstemp`` temp
+        file after cancellation — is unchanged.
         """
         api = mock_artifacts_api
         output_path = tmp_path / "file.mp4"
+
+        chunk_yielded = asyncio.Event()
+        allow_finish = asyncio.Event()
+
+        async def mock_aiter_bytes(chunk_size: int = 8192):
+            # Yield one real chunk so the producer enters the chunk
+            # loop body and pushes a chunk onto the queue, then park
+            # at a cancellable ``await`` so the test can deliver
+            # ``task.cancel()`` while the producer is mid-stream.
+            yield b"partial media payload"
+            chunk_yielded.set()
+            await allow_finish.wait()
+
         response = _build_mock_response(content=b"partial media payload")
+        response.aiter_bytes = mock_aiter_bytes
         client_patch, cookies_patch = _patch_httpx_client(response)
 
-        original_to_thread = asyncio.to_thread
-        put_started = asyncio.Event()
-        release_put = asyncio.Event()
-
-        async def controlled_to_thread(func, /, *args, **kwargs):
-            # The chunk producer awaits ``to_thread(chunk_q.put, chunk)``
-            # for each yielded chunk. We gate on that to park the
-            # producer at a known cancellable await point. Other
-            # to_thread calls (cookie load, the long-lived
-            # ``_writer_loop``, the final sentinel ``put``) pass through.
-            if getattr(func, "__name__", "") == "put" and args:
-                put_started.set()
-                await release_put.wait()
-            return await original_to_thread(func, *args, **kwargs)
-
-        with (
-            client_patch,
-            cookies_patch,
-            patch("notebooklm._artifact_downloads.asyncio.to_thread", controlled_to_thread),
-        ):
+        with client_patch, cookies_patch:
             task = asyncio.create_task(
                 api._download_url("https://storage.googleapis.com/file.mp4", str(output_path))
             )
-            await asyncio.wait_for(put_started.wait(), timeout=1)
+            # Wait until the producer has yielded once and is parked
+            # on ``allow_finish.wait()`` inside the mocked
+            # ``aiter_bytes``.
+            await asyncio.wait_for(chunk_yielded.wait(), timeout=2)
             task.cancel()
-            release_put.set()
+            # Release the mock so the cancel-propagation path unwinds
+            # cleanly. Without this the awaited Event would briefly
+            # delay the cancellation visitor; asyncio still cancels,
+            # but the release makes the unwind deterministic.
+            allow_finish.set()
 
             with pytest.raises(asyncio.CancelledError):
                 await task

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -255,20 +255,35 @@ class TestDownloadUrlErrorWrapping:
 
     @pytest.mark.asyncio
     async def test_cancellation_during_write_removes_temp_file(self, mock_artifacts_api, tmp_path):
-        """Cancelled streaming writes must not leave the mkstemp temp file behind."""
+        """Cancelled streaming writes must not leave the mkstemp temp file behind.
+
+        After the single-writer-thread refactor (PR T1.M.4 — issue #?),
+        the producer's per-chunk yield point is ``asyncio.to_thread(
+        chunk_q.put, chunk)`` (back-pressure into the writer queue), not
+        a direct ``to_thread(f.write, ...)``. The test gates cancellation
+        on the first queue-put rather than the first file-write so the
+        producer is reliably parked on a cancellable await when we
+        cancel the task. The invariant under test — no leftover
+        ``mkstemp`` temp file — is unchanged.
+        """
         api = mock_artifacts_api
         output_path = tmp_path / "file.mp4"
         response = _build_mock_response(content=b"partial media payload")
         client_patch, cookies_patch = _patch_httpx_client(response)
 
         original_to_thread = asyncio.to_thread
-        write_started = asyncio.Event()
-        release_write = asyncio.Event()
+        put_started = asyncio.Event()
+        release_put = asyncio.Event()
 
         async def controlled_to_thread(func, /, *args, **kwargs):
-            if getattr(func, "__name__", "") == "write":
-                write_started.set()
-                await release_write.wait()
+            # The chunk producer awaits ``to_thread(chunk_q.put, chunk)``
+            # for each yielded chunk. We gate on that to park the
+            # producer at a known cancellable await point. Other
+            # to_thread calls (cookie load, the long-lived
+            # ``_writer_loop``, the final sentinel ``put``) pass through.
+            if getattr(func, "__name__", "") == "put" and args:
+                put_started.set()
+                await release_put.wait()
             return await original_to_thread(func, *args, **kwargs)
 
         with (
@@ -279,9 +294,9 @@ class TestDownloadUrlErrorWrapping:
             task = asyncio.create_task(
                 api._download_url("https://storage.googleapis.com/file.mp4", str(output_path))
             )
-            await asyncio.wait_for(write_started.wait(), timeout=1)
+            await asyncio.wait_for(put_started.wait(), timeout=1)
             task.cancel()
-            release_write.set()
+            release_put.set()
 
             with pytest.raises(asyncio.CancelledError):
                 await task


### PR DESCRIPTION
## Summary

Three related IO + batch-download reliability fixes, plus a regression fix for the writer-failure path.

### §2.1 — Move sync `open()` / `fstat()` / `resolve()` off the event loop

`_source_upload.py:325`. `Path.resolve()/exists()/is_file()`, `open()`, and `os.fstat()` all block on stat syscalls. Under the upload semaphore on a slow network mount they would stall every other concurrent task. Wrapped in `asyncio.to_thread(...)` closures so the loop keeps ticking.

### §2.2 — Single writer thread for chunked downloads

`_artifact_downloads.py:564-573`. Replaced per-chunk `asyncio.to_thread(f.write, chunk)` (one thread call per 64 KiB; thousands of allocations on multi-GB downloads) with a dedicated writer thread fed from a bounded `queue.Queue` (size 8 ≈ 512 KiB buffered). Producer awaits when the writer falls behind; sentinel `None` signals EOF.

### §2.7 — Batch policy errors land in `DownloadResult.failed`

`_artifact_downloads.py:506`. `download_urls_batch()` raised `ArtifactDownloadError` for invalid scheme / untrusted host / auth failure / HTML payload (lines 469-486) but the `except` clause at line 506 only caught `(httpx.HTTPError, ValueError)`, so one bad URL aborted the entire batch. Added `ArtifactDownloadError` to the except tuple so the bad URL lands in `result.failed` while the rest of the batch completes.

The single-URL `download_url()` contract is unchanged — it still raises. That contract is pinned by `tests/integration/test_artifacts_integration.py:2168, 2201`.

### Regression fix — writer-failure must not deadlock producer

With the bounded queue, a producer parked in `q.put` on a full queue hangs forever if the writer raises mid-stream (we are the only consumer). Added a `finally` to `_writer_loop` that drains the queue via `get_nowait`, so blocked puts complete and the producer can observe `writer_task.done()` on the next iteration. Pinned by `tests/integration/concurrency/test_download_blocks_loop.py::test_download_url_writer_failure_does_not_deadlock_producer`.

## Test plan

- [x] `uv run pytest tests/unit tests/integration --timeout=30` — 5992 passed, 49 skipped
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check src/notebooklm` — clean
- [x] Single-download contract preserved (test_artifacts_integration.py:2168, 2201)
- [x] Regression test `test_download_url_writer_failure_does_not_deadlock_producer` passes (was hanging beyond 15s timeout before fix; now 0.25s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch downloads now record per-URL failures (including HTML/policy/untrusted-domain errors) so one bad URL won't abort others; partial successes are returned.
  * Streaming downloads use a single writer thread with bounded buffering and back-pressure, robustly handling writer errors, cancellation, and temp-file cleanup to avoid deadlocks/races.
  * Uploads offload blocking filesystem operations to a worker thread to avoid blocking the event loop.

* **Tests**
  * Added/updated integration and unit tests covering download/upload concurrency, writer failure recovery, cancellation, and batch-failure aggregation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->