### PR TITLE
refactor(client): reuse auth storage path in from_storage

### DIFF
--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import os
 import warnings
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -766,15 +765,8 @@ class _FromStorageContext:
         path = kwargs["path"]
         profile = kwargs["profile"]
 
-        storage_path = Path(path) if path else None
-        auth = await AuthTokens.from_storage(storage_path, profile=profile)
-        # Always resolve the storage path so downstream cookie loading
-        # (e.g. artifact downloads) uses the correct file, whether the
-        # caller provided an explicit path, a named profile, or neither.
-        if storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
-            from .paths import get_storage_path
-
-            storage_path = get_storage_path(profile)
+        auth = await AuthTokens.from_storage(Path(path) if path else None, profile=profile)
+        storage_path = auth.storage_path
 
         self._client = self._cls(
             auth,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -92,6 +92,23 @@ class TestClientContextManager:
 
 
 class TestFromStorage:
+    @staticmethod
+    def _auth(storage_path):
+        return AuthTokens(
+            cookies={
+                ("SID", ".google.com", "/"): "test_sid",
+                ("__Secure-1PSIDTS", ".google.com", "/"): "test_1psidts",
+            },
+            csrf_token="test_csrf",
+            session_id="test_session",
+            storage_path=storage_path,
+        )
+
+    class CapturingClient(NotebookLMClient):
+        def __init__(self, auth, **kwargs):
+            self.captured_auth = auth
+            self.captured_kwargs = kwargs
+
     @pytest.mark.asyncio
     async def test_from_storage_success(self, tmp_path, httpx_mock: HTTPXMock):
         """Test creating client from storage file."""
@@ -178,6 +195,82 @@ class TestFromStorage:
                 assert not real_storage_path.exists()
             else:
                 assert real_storage_path.stat().st_mtime_ns == real_storage_mtime
+
+    @pytest.mark.asyncio
+    async def test_from_storage_uses_auth_storage_path_for_explicit_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Explicit paths keep the AuthTokens storage path unchanged."""
+        import notebooklm.paths as paths_mod
+
+        monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+        explicit_path = tmp_path / "storage_state.json"
+        calls = []
+
+        async def fake_from_storage(path=None, profile=None):
+            calls.append((path, profile))
+            return self._auth(path)
+
+        def fail_get_storage_path(*args, **kwargs):
+            raise AssertionError("from_storage should use auth.storage_path")
+
+        monkeypatch.setattr(AuthTokens, "from_storage", staticmethod(fake_from_storage))
+        monkeypatch.setattr(paths_mod, "get_storage_path", fail_get_storage_path)
+
+        client = await self.CapturingClient.from_storage(str(explicit_path))._build()
+
+        assert calls == [(explicit_path, None)]
+        assert client.captured_auth.storage_path == explicit_path
+        assert client.captured_kwargs["storage_path"] == explicit_path
+
+    @pytest.mark.asyncio
+    async def test_from_storage_uses_auth_storage_path_for_profile(self, tmp_path, monkeypatch):
+        """Profile resolution is owned by AuthTokens.from_storage."""
+        import notebooklm.paths as paths_mod
+
+        monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+        profile_storage_path = tmp_path / "profiles" / "work" / "storage_state.json"
+        calls = []
+
+        async def fake_from_storage(path=None, profile=None):
+            calls.append((path, profile))
+            return self._auth(profile_storage_path)
+
+        def fail_get_storage_path(*args, **kwargs):
+            raise AssertionError("from_storage should not re-resolve profile storage")
+
+        monkeypatch.setattr(AuthTokens, "from_storage", staticmethod(fake_from_storage))
+        monkeypatch.setattr(paths_mod, "get_storage_path", fail_get_storage_path)
+
+        client = await self.CapturingClient.from_storage(profile="work")._build()
+
+        assert calls == [(None, "work")]
+        assert client.captured_auth.storage_path == profile_storage_path
+        assert client.captured_kwargs["storage_path"] == profile_storage_path
+
+    @pytest.mark.asyncio
+    async def test_from_storage_preserves_none_storage_path_for_auth_json(self, monkeypatch):
+        """Inline auth JSON remains fileless."""
+        import notebooklm.paths as paths_mod
+
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", '{"cookies": []}')
+        calls = []
+
+        async def fake_from_storage(path=None, profile=None):
+            calls.append((path, profile))
+            return self._auth(None)
+
+        def fail_get_storage_path(*args, **kwargs):
+            raise AssertionError("from_storage should not resolve file paths for auth JSON")
+
+        monkeypatch.setattr(AuthTokens, "from_storage", staticmethod(fake_from_storage))
+        monkeypatch.setattr(paths_mod, "get_storage_path", fail_get_storage_path)
+
+        client = await self.CapturingClient.from_storage()._build()
+
+        assert calls == [(None, None)]
+        assert client.captured_auth.storage_path is None
+        assert client.captured_kwargs["storage_path"] is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Use `AuthTokens.from_storage(...).storage_path` in `_FromStorageContext._build` instead of re-resolving paths in the client wrapper.
- Add regression coverage for explicit paths, named profiles, and `NOTEBOOKLM_AUTH_JSON` fileless auth.

Closes #979

## Tests
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication storage path resolution by removing implicit fallback mechanisms, making path handling more explicit and predictable.

* **Tests**
  * Added comprehensive unit tests validating storage path behavior across explicit paths, profile-based configurations, and inline authentication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->