### PR TITLE
test(e2e): extend deep research timeout

### DIFF
--- a/tests/e2e/test_research_import_verification.py
+++ b/tests/e2e/test_research_import_verification.py
@@ -118,6 +118,7 @@ class TestResearchImportVerification:
             f"new sources appear in notebook after waiting."
         )
 
+    @pytest.mark.timeout(2400)
     @pytest.mark.asyncio
     async def test_deep_research_import_count_matches(self, client, temp_notebook):
         """Regression for #315: deep research import actually adds sources.


### PR DESCRIPTION
## Summary
- add a pytest-timeout override for the deep research import E2E regression test
- keep the repo-wide 60s timeout for normal tests while allowing this documented 10-20+ minute path to run

## Validation
- uv run --frozen --extra dev pytest tests/e2e/test_research_import_verification.py::TestResearchImportVerification::test_deep_research_import_count_matches --collect-only -q
- uv run --frozen ruff check tests/e2e/test_research_import_verification.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite reliability by adding execution time constraints to deep research verification test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->