### PR TITLE
fix(cli): write Playwright account metadata

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -589,7 +589,7 @@ notebooklm auth check --json
 
 ### Authentication: `auth refresh`
 
-One-shot keepalive: open a session, trigger the layer-1 SIDTS rotation poke against `accounts.google.com`, persist the rotated cookies to `storage_state.json`, and exit. Designed to be invoked by the OS scheduler (launchd / systemd / cron / Task Scheduler / k8s CronJob) so an otherwise-idle profile does not stale out between user-driven calls.
+One-shot keepalive: open a session, trigger the layer-1 SIDTS rotation poke against `accounts.google.com`, persist the rotated cookies to `storage_state.json`, and exit. When a file-backed Playwright storage state has cookies but lacks in-band `notebooklm.account` metadata, `auth refresh` also repairs that metadata if account discovery is unambiguous. It does not replace existing metadata; use `login --browser-cookies <browser> --account EMAIL` to re-bind a profile that already points at the wrong account. Designed to be invoked by the OS scheduler (launchd / systemd / cron / Task Scheduler / k8s CronJob) so an otherwise-idle profile does not stale out between user-driven calls.
 
 ```bash
 notebooklm auth refresh [OPTIONS]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,14 @@ Contains the authentication data extracted from your browser session:
     },
     ...
   ],
-  "origins": []
+  "origins": [],
+  "notebooklm": {
+    "version": 1,
+    "account": {
+      "authuser": 0,
+      "email": "you@example.com"
+    }
+  }
 }
 ```
 
@@ -69,6 +76,16 @@ Contains the authentication data extracted from your browser session:
 
 In practice: extract the full cookie set via `notebooklm login` and don't try to subset it. Partial extractions (a known failure mode of browser-cookies tooling under Chrome 127+ App-Bound Encryption) are the leading suspect for "auth expires immediately" reports — see [#371](https://github.com/teng-lin/notebooklm-py/issues/371).
 
+The optional `notebooklm.account` block records the Google account route for
+multi-account sessions. New `notebooklm login` runs write it when the active
+account can be discovered safely. Older Playwright-created files can be repaired
+with `notebooklm auth refresh` when the storage state maps to one visible
+account; if several accounts are visible, use
+`notebooklm login --browser-cookies <browser> --account EMAIL` to bind the
+intended account explicitly. `auth refresh` only repairs absent metadata; if
+metadata exists but points at the wrong account, re-bind explicitly with the
+browser-cookie login path.
+
 **Override location:**
 ```bash
 notebooklm --storage /path/to/storage_state.json list
@@ -76,19 +93,14 @@ notebooklm --storage /path/to/storage_state.json list
 
 ### Context File (`context.json`)
 
-Stores the current CLI context (active notebook plus optional metadata)
-and the multi-account routing payload used by `auth`:
+Stores the current CLI context, such as the active notebook:
 
 ```json
 {
   "notebook_id": "abc123def456",
   "title": "Quarterly review notes",
   "is_owner": true,
-  "created_at": "2026-05-01T17:43:21Z",
-  "account": {
-    "authuser": 0,
-    "email": "you@example.com"
-  }
+  "created_at": "2026-05-01T17:43:21Z"
 }
 ```
 
@@ -96,7 +108,6 @@ Field summary:
 
 - `notebook_id` — currently selected notebook, written by `notebooklm use` and read by every command that takes `-n/--notebook`.
 - `title`, `is_owner`, `created_at` — optional notebook metadata captured at selection time so `status` / display commands don't need an extra round-trip. Omitted when the CLI didn't have the values to write (see `src/notebooklm/cli/helpers.py:623-651`).
-- `account` — preserved across `notebooklm use` / `notebooklm clear` (only `notebooklm auth logout` removes it). Records `authuser` (Google account index, default `0`) and optional `email` so the client routes batchexecute requests to the same account that minted the cookies (see `src/notebooklm/auth.py:1168-1283`).
 
 This file is managed automatically by `notebooklm use`, `notebooklm clear`, and the `auth` commands.
 
@@ -454,13 +465,10 @@ they are NOT the same file:
   see `paths.get_context_path`). Two `--storage` invocations against different
   files cannot see each other's selected notebook, and neither pollutes the
   default profile context.
-- **Account-routing metadata** (the `account` object — `authuser` index and
-  optional `email`) lives at a *sibling* file `context.json` next to the
-  storage file (`storage_path.with_name("context.json")`, see
-  `auth._account_context_path`). The split is deliberate: account metadata is
-  shared across CLI tooling that resolves the storage file by directory
-  (e.g., interactive `auth check`) while notebook context belongs to the
-  specific storage payload.
+- **Account-routing metadata** (the `notebooklm.account` object — `authuser`
+  index and optional `email`) lives in-band inside the selected
+  `storage_state.json`. This keeps copied files and `NOTEBOOKLM_AUTH_JSON`
+  secrets bound to the same Google account route as the original profile.
 
 Run `notebooklm --storage <path> status --paths` to see exactly which
 context file is being used for notebook selection.
@@ -509,8 +517,9 @@ jobs:
 ### Obtaining the Secret Value
 
 1. Run `notebooklm login` locally
-2. Copy the contents of `~/.notebooklm/profiles/default/storage_state.json` (the canonical write location; the legacy `~/.notebooklm/storage_state.json` is only read as a fallback)
-3. Add as a GitHub repository secret named `NOTEBOOKLM_AUTH_JSON` (see [installation.md#d-headless-server-or-ci](installation.md#d-headless-server-or-ci) for trailing-newline + ephemeral-runner refresh notes)
+2. If the file was created by an older Playwright login and lacks `notebooklm.account`, run `notebooklm auth refresh` to repair single-account states or re-login with `notebooklm login --browser-cookies <browser> --account EMAIL` for multi-account states
+3. Copy the contents of `~/.notebooklm/profiles/default/storage_state.json` (the canonical write location; the legacy `~/.notebooklm/storage_state.json` is only read as a fallback)
+4. Add as a GitHub repository secret named `NOTEBOOKLM_AUTH_JSON` (see [installation.md#d-headless-server-or-ci](installation.md#d-headless-server-or-ci) for trailing-newline + ephemeral-runner refresh notes)
 
 ### Alternative: File-Based Auth
 

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -40,11 +40,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+import httpx
+
 from ...config import get_base_host, get_base_url
 from ...io import atomic_write_json
 from ...paths import get_browser_profile_dir, get_storage_path
 from ..error_handler import exit_with_code
 from ..rendering import console
+from ..runtime import run_async
 
 # Capture the original function references at module-import time so the
 # ``_resolve_paths_helper`` precedence chain can compare each lookup
@@ -114,6 +117,10 @@ BROWSER_CLOSED_HELP = (
     "Try:\n"
     "  1. Run: notebooklm login --fresh\n"
     "  2. Or run: notebooklm auth logout && notebooklm login"
+)
+ACCOUNT_METADATA_REMEDIATION = (
+    "Run [cyan]notebooklm auth inspect --browser chrome -v[/cyan] "
+    "or [cyan]notebooklm login --browser-cookies chrome --account EMAIL[/cyan]."
 )
 
 # Browsers launched via Playwright's ``channel`` parameter (system-installed,
@@ -192,6 +199,109 @@ def filter_storage_state_cookies_by_domain_policy(
         "cookies": filtered_cookies,
         "origins": list(state.get("origins", [])),
     }
+
+
+# ---------------------------------------------------------------------------
+# Playwright account metadata repair
+# ---------------------------------------------------------------------------
+
+
+def _select_playwright_account(
+    accounts: list[Any],
+    *,
+    active_email: str | None,
+) -> tuple[Any | None, str | None]:
+    """Select the account Playwright just logged into, or return an ambiguity reason."""
+    if active_email:
+        normalized = active_email.casefold()
+        matches = [
+            account
+            for account in accounts
+            if isinstance(getattr(account, "email", None), str)
+            and account.email.casefold() == normalized
+        ]
+        if len(matches) == 1:
+            return matches[0], None
+        if matches:
+            return None, f"multiple discovered accounts matched {active_email}"
+        return None, f"current NotebookLM page email {active_email} was not discovered"
+
+    if len(accounts) == 1:
+        return accounts[0], None
+    if accounts:
+        return (
+            None,
+            "multiple Google accounts were discovered but the active page email was unavailable",
+        )
+    return None, "no Google accounts were discovered"
+
+
+def repair_playwright_account_metadata(
+    storage_path: Path,
+    *,
+    page_html: str | None = None,
+    quiet: bool = False,
+) -> bool:
+    """Populate ``notebooklm.account`` from Playwright storage when unambiguous.
+
+    This is used immediately after interactive Playwright login and by
+    file-backed ``auth refresh`` as a repair path for older Playwright-created
+    storage states. Ambiguous multi-account states are deliberately left
+    unbound after clearing any stale metadata.
+
+    Returns:
+        ``True`` when metadata was written, ``False`` when it was cleared or
+        left absent.
+    """
+    from ...auth import (
+        build_httpx_cookies_from_storage,
+        clear_account_metadata,
+        enumerate_accounts,
+        extract_email_from_html,
+        write_account_metadata,
+    )
+
+    active_email = extract_email_from_html(page_html) if isinstance(page_html, str) else None
+    try:
+        if not quiet:
+            console.print("[dim]Identifying Google account...[/dim]")
+        jar = build_httpx_cookies_from_storage(storage_path)
+        accounts = run_async(enumerate_accounts(jar))
+        selected, reason = _select_playwright_account(accounts, active_email=active_email)
+        if selected is None:
+            clear_account_metadata(storage_path)
+            if not quiet:
+                console.print(
+                    "[yellow]Warning: account metadata was not written; "
+                    f"{reason}. {ACCOUNT_METADATA_REMEDIATION}[/yellow]"
+                )
+            return False
+        write_account_metadata(
+            storage_path,
+            authuser=selected.authuser,
+            email=selected.email,
+        )
+    except (OSError, ValueError, RuntimeError, httpx.HTTPError) as exc:
+        try:
+            clear_account_metadata(storage_path)
+        except Exception as clear_exc:
+            logger.warning(
+                "Failed to clear stale account metadata for %s: %s",
+                storage_path,
+                clear_exc,
+            )
+        if not quiet:
+            console.print(
+                "[yellow]Warning: account metadata was not written. "
+                "NotebookLM auth still saved, but multi-account routing may "
+                "fall back to authuser=0. "
+                f"{ACCOUNT_METADATA_REMEDIATION} Details: {exc}[/yellow]"
+            )
+        return False
+
+    if not quiet:
+        console.print(f"[green]Account:[/green] {selected.email}")
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -469,7 +579,8 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
     selected, opens a persistent context, retries navigation on transient
     connection errors, waits for login completion, pins ``.google.com``
     cookies, applies the cookie-domain allowlist filter (P1-17), atomically
-    writes ``storage_state.json``, and clears stale account metadata.
+    writes ``storage_state.json``, and writes account metadata when the active
+    Google account can be identified safely.
     """
     browser = plan.browser
     browser_profile = plan.browser_profile
@@ -507,6 +618,14 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
             else ensure_chromium_installed
         )
         _ensure()
+
+    def _capture_page_html(page: Any) -> str | None:
+        try:
+            content = page.content()
+        except PlaywrightError as exc:
+            logger.debug("Could not read Playwright page content for account metadata: %s", exc)
+            return None
+        return content if isinstance(content, str) else None
 
     from ...paths import resolve_profile
 
@@ -619,10 +738,13 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
                     raise
                 console.print("[green]Login detected.[/green]")
 
+            active_page_html = _capture_page_html(page)
+
             # Force .google.com cookies for regional users (e.g. UK lands on
             # .google.co.uk). Use "commit" to resolve once response headers
             # (including Set-Cookie) are processed, before any client-side
             # JS redirect can interrupt. See #214.
+            recovered_during_cookie_forcing = False
             for url in [GOOGLE_ACCOUNTS_URL, f"{get_base_url()}/"]:
                 try:
                     page.goto(url, wait_until="commit")
@@ -631,6 +753,7 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
                     if TARGET_CLOSED_ERROR in error_str:
                         # Page was destroyed (e.g. user switched accounts) -- get fresh page
                         page = recover_page(context, console)
+                        recovered_during_cookie_forcing = True
                         try:
                             page.goto(url, wait_until="commit")
                         except PlaywrightError as inner_exc:
@@ -656,6 +779,9 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
                 )
                 exit_with_code(1)
 
+            if recovered_during_cookie_forcing:
+                active_page_html = _capture_page_html(page)
+
             # Atomic write with chmod 0o600 — Playwright's path= argument
             # writes directly (non-atomic + world-readable window).
             #
@@ -670,16 +796,7 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
                 dict(playwright_state), include_domains=include_domains
             )
             atomic_write_json(storage_path, filtered_state)
-            from ...auth import clear_account_metadata
-
-            try:
-                clear_account_metadata(storage_path)
-            except OSError as exc:
-                logger.warning(
-                    "Failed to clear stale account metadata for %s: %s",
-                    storage_path,
-                    exc,
-                )
+            repair_playwright_account_metadata(storage_path, page_html=active_page_html)
 
         except Exception as e:
             # Handle browser launch errors specially (context will be None if launch failed)
@@ -727,6 +844,7 @@ __all__ = [
     "is_navigation_interrupted_error",
     "prepare_login_paths",
     "recover_page",
+    "repair_playwright_account_metadata",
     "run_playwright_login",
     "url_matches_base_host",
     "validate_login_flag_conflicts",

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -142,6 +142,16 @@ async def fetch_tokens_with_domains(*args: Any, **kwargs: Any) -> Any:
     return await auth_fetch_tokens_with_domains(*args, **kwargs)
 
 
+def _is_valid_account_metadata(metadata: dict[str, Any]) -> bool:
+    raw_authuser = metadata.get("authuser")
+    if not isinstance(raw_authuser, int) or raw_authuser < 0:
+        return False
+    raw_email = metadata.get("email")
+    if raw_email is None:
+        return True
+    return isinstance(raw_email, str) and bool(raw_email.strip())
+
+
 # Legacy thin alias kept for the small set of session-cmd-internal helpers
 # below. The Playwright login flow now lives in
 # :mod:`notebooklm.cli.services.playwright_login`; this thunk preserves the
@@ -716,8 +726,10 @@ def register_session_commands(cli):
 
             from ..auth import read_account_metadata
 
-            if storage_path.exists() and not read_account_metadata(storage_path):
-                _repair_playwright_account_metadata(storage_path, quiet=quiet)
+            if storage_path.exists():
+                metadata = read_account_metadata(storage_path)
+                if not _is_valid_account_metadata(metadata):
+                    _repair_playwright_account_metadata(storage_path, quiet=quiet)
 
             if not quiet:
                 console.print(f"[green]ok[/green] refreshed: {storage_path}")

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -116,6 +116,9 @@ from .services.playwright_login import (
     recover_page as _recover_page,  # noqa: F401 — patch surface
 )
 from .services.playwright_login import (
+    repair_playwright_account_metadata as _repair_playwright_account_metadata,
+)
+from .services.playwright_login import (
     url_matches_base_host as _url_matches_base_host,  # noqa: F401 — patch surface
 )
 from .services.playwright_login import (
@@ -710,6 +713,11 @@ def register_session_commands(cli):
                 return
 
             run_async(fetch_tokens_with_domains(storage_path, profile))
+
+            from ..auth import read_account_metadata
+
+            if storage_path.exists() and not read_account_metadata(storage_path):
+                _repair_playwright_account_metadata(storage_path, quiet=quiet)
 
             if not quiet:
                 console.print(f"[green]ok[/green] refreshed: {storage_path}")

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -144,7 +144,7 @@ async def fetch_tokens_with_domains(*args: Any, **kwargs: Any) -> Any:
 
 def _is_valid_account_metadata(metadata: dict[str, Any]) -> bool:
     raw_authuser = metadata.get("authuser")
-    if not isinstance(raw_authuser, int) or raw_authuser < 0:
+    if type(raw_authuser) is not int or raw_authuser < 0:
         return False
     raw_email = metadata.get("email")
     if raw_email is None:

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -894,7 +894,10 @@ class TestLoginCommand:
             "email": "alice@example.com",
         }
 
-    def test_auth_refresh_repairs_malformed_playwright_account_metadata(self, runner, tmp_path):
+    @pytest.mark.parametrize("authuser", ["1", True])
+    def test_auth_refresh_repairs_malformed_playwright_account_metadata(
+        self, runner, tmp_path, authuser
+    ):
         """Non-empty but malformed metadata must not block Playwright repair."""
         from notebooklm.auth import Account
 
@@ -902,7 +905,7 @@ class TestLoginCommand:
         original_state = _required_cookie_state()
         original_state["notebooklm"] = {
             "version": 1,
-            "account": {"authuser": "1", "email": "wrong@example.com"},
+            "account": {"authuser": authuser, "email": "wrong@example.com"},
         }
         storage_file.write_text(json.dumps(original_state), encoding="utf-8")
 

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -34,6 +34,26 @@ def _make_from_storage_cm(client):
     return _cm()
 
 
+def _required_cookie_state() -> dict:
+    return {
+        "cookies": [
+            {"name": "SID", "value": "sid", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "psidts",
+                "domain": ".google.com",
+                "path": "/",
+            },
+        ],
+        "origins": [{"origin": "https://notebooklm.google.com", "localStorage": []}],
+    }
+
+
+def _storage_account(storage_file):
+    data = json.loads(storage_file.read_text())
+    return data.get("notebooklm", {}).get("account")
+
+
 class TestLoginUrlValidation:
     def test_url_matches_default_base_host(self, monkeypatch):
         monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
@@ -645,6 +665,261 @@ class TestLoginCommand:
 
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
+
+    @pytest.mark.requires_playwright
+    def test_playwright_login_writes_single_account_metadata(self, runner, tmp_path):
+        """Playwright login records account metadata when discovery has one account."""
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        browser_dir = tmp_path / "profile"
+
+        async def _enum(*args, **kwargs):
+            return [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+        with (
+            patch("notebooklm.cli.session_cmd._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session_cmd.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch("notebooklm.cli.session_cmd._sync_server_language_to_config"),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+        ):
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            mock_page.url = "https://notebooklm.google.com/"
+            mock_page.content.return_value = "<html></html>"
+            mock_context.pages = [mock_page]
+            mock_context.storage_state.return_value = _required_cookie_state()
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0, result.output
+        assert _storage_account(storage_file) == {
+            "authuser": 0,
+            "email": "alice@example.com",
+        }
+
+    @pytest.mark.requires_playwright
+    def test_playwright_login_writes_account_matched_by_page_email(self, runner, tmp_path):
+        """When multiple accounts are visible, the current page email selects the route."""
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        browser_dir = tmp_path / "profile"
+
+        async def _enum(*args, **kwargs):
+            return [
+                Account(authuser=0, email="alice@example.com", is_default=True),
+                Account(authuser=1, email="bob@example.com", is_default=False),
+            ]
+
+        with (
+            patch("notebooklm.cli.session_cmd._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session_cmd.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch("notebooklm.cli.session_cmd._sync_server_language_to_config"),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+        ):
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            mock_page.url = "https://notebooklm.google.com/"
+            mock_page.content.return_value = '<script>"bob@example.com"</script>'
+            mock_context.pages = [mock_page]
+            mock_context.storage_state.return_value = _required_cookie_state()
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0, result.output
+        assert _storage_account(storage_file) == {
+            "authuser": 1,
+            "email": "bob@example.com",
+        }
+
+    @pytest.mark.requires_playwright
+    def test_playwright_login_uses_recovered_page_email_for_metadata(self, runner, tmp_path):
+        """If cookie-forcing recovers a page, stale pre-recovery HTML is ignored."""
+        from playwright.sync_api import Error as PlaywrightError
+
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        browser_dir = tmp_path / "profile"
+
+        async def _enum(*args, **kwargs):
+            return [
+                Account(authuser=0, email="alice@example.com", is_default=True),
+                Account(authuser=1, email="bob@example.com", is_default=False),
+            ]
+
+        with (
+            patch("notebooklm.cli.session_cmd._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session_cmd.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch("notebooklm.cli.session_cmd._sync_server_language_to_config"),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+        ):
+            mock_context = MagicMock()
+            mock_page_stale = MagicMock()
+            mock_page_stale.url = "https://notebooklm.google.com/"
+            mock_page_stale.content.return_value = '<script>"alice@example.com"</script>'
+            goto_count = 0
+
+            def stale_goto(url, **kwargs):
+                nonlocal goto_count
+                goto_count += 1
+                if goto_count == 1:
+                    return None
+                raise PlaywrightError("Page.goto: Target page, context or browser has been closed")
+
+            mock_page_stale.goto.side_effect = stale_goto
+            mock_page_recovered = MagicMock()
+            mock_page_recovered.url = "https://notebooklm.google.com/"
+            mock_page_recovered.content.return_value = '<script>"bob@example.com"</script>'
+            mock_context.pages = [mock_page_stale]
+            mock_context.new_page.return_value = mock_page_recovered
+            mock_context.storage_state.return_value = _required_cookie_state()
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0, result.output
+        assert _storage_account(storage_file) == {
+            "authuser": 1,
+            "email": "bob@example.com",
+        }
+
+    @pytest.mark.requires_playwright
+    def test_playwright_login_clears_metadata_when_account_ambiguous(self, runner, tmp_path):
+        """Multiple discovered accounts without a page email must not pick silently."""
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        context_file = tmp_path / "context.json"
+        context_file.write_text(
+            json.dumps(
+                {
+                    "notebook_id": "nb_existing",
+                    "account": {"authuser": 1, "email": "old@example.com"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        browser_dir = tmp_path / "profile"
+
+        async def _enum(*args, **kwargs):
+            return [
+                Account(authuser=0, email="alice@example.com", is_default=True),
+                Account(authuser=1, email="bob@example.com", is_default=False),
+            ]
+
+        with (
+            patch("notebooklm.cli.session_cmd._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session_cmd.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch("notebooklm.cli.session_cmd._sync_server_language_to_config"),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+        ):
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            mock_page.url = "https://notebooklm.google.com/"
+            mock_page.content.return_value = "<html></html>"
+            mock_context.pages = [mock_page]
+            mock_context.storage_state.return_value = _required_cookie_state()
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0, result.output
+        assert _storage_account(storage_file) is None
+        assert json.loads(context_file.read_text()) == {"notebook_id": "nb_existing"}
+        assert "account metadata was not written" in result.output
+
+    def test_auth_refresh_repairs_missing_playwright_account_metadata(self, runner, tmp_path):
+        """File-backed auth refresh can migrate a Playwright state missing metadata."""
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        original_state = _required_cookie_state()
+        storage_file.write_text(json.dumps(original_state), encoding="utf-8")
+
+        async def _enum(*args, **kwargs):
+            return [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+        with (
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+            patch(
+                "notebooklm.cli.session_cmd.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh"])
+
+        assert result.exit_code == 0, result.output
+        repaired_state = json.loads(storage_file.read_text())
+        assert repaired_state["cookies"] == original_state["cookies"]
+        assert repaired_state["origins"] == original_state["origins"]
+        assert repaired_state["notebooklm"]["account"] == {
+            "authuser": 0,
+            "email": "alice@example.com",
+        }
+
+    def test_auth_refresh_skips_repair_when_account_metadata_exists(self, runner, tmp_path):
+        """Existing account metadata is an explicit binding; keepalive must not replace it."""
+        storage_file = tmp_path / "storage.json"
+        state = _required_cookie_state()
+        state["notebooklm"] = {
+            "version": 1,
+            "account": {"authuser": 1, "email": "bob@example.com"},
+        }
+        storage_file.write_text(json.dumps(state), encoding="utf-8")
+
+        with (
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session_cmd.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch("notebooklm.cli.session_cmd._repair_playwright_account_metadata") as mock_repair,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh"])
+
+        assert result.exit_code == 0, result.output
+        mock_repair.assert_not_called()
+        assert _storage_account(storage_file) == {
+            "authuser": 1,
+            "email": "bob@example.com",
+        }
 
     @pytest.mark.requires_playwright
     def test_playwright_login_clears_stale_account_metadata(self, runner, tmp_path):

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -894,6 +894,40 @@ class TestLoginCommand:
             "email": "alice@example.com",
         }
 
+    def test_auth_refresh_repairs_malformed_playwright_account_metadata(self, runner, tmp_path):
+        """Non-empty but malformed metadata must not block Playwright repair."""
+        from notebooklm.auth import Account
+
+        storage_file = tmp_path / "storage.json"
+        original_state = _required_cookie_state()
+        original_state["notebooklm"] = {
+            "version": 1,
+            "account": {"authuser": "1", "email": "wrong@example.com"},
+        }
+        storage_file.write_text(json.dumps(original_state), encoding="utf-8")
+
+        async def _enum(*args, **kwargs):
+            return [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+        with (
+            patch_session_login_dual("get_storage_path", return_value=storage_file),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+            patch(
+                "notebooklm.cli.session_cmd.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh"])
+
+        assert result.exit_code == 0, result.output
+        repaired_state = json.loads(storage_file.read_text())
+        assert repaired_state["cookies"] == original_state["cookies"]
+        assert repaired_state["origins"] == original_state["origins"]
+        assert repaired_state["notebooklm"]["account"] == {
+            "authuser": 0,
+            "email": "alice@example.com",
+        }
+
     def test_auth_refresh_skips_repair_when_account_metadata_exists(self, runner, tmp_path):
         """Existing account metadata is an explicit binding; keepalive must not replace it."""
         storage_file = tmp_path / "storage.json"


### PR DESCRIPTION
## Summary
- write `notebooklm.account` metadata after Playwright login when account discovery is unambiguous
- repair older file-backed Playwright storage states during `auth refresh` when metadata is absent and account discovery is unambiguous
- document in-band account metadata and CI `NOTEBOOKLM_AUTH_JSON` refresh guidance

## Task
Fixes #986

## Test plan
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Optional: add a narrowly targeted unit test for metadata repair exception warning output.
- Optional: revisit runtime authuser-index remapping; current request routing already prefers stored email when present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `notebooklm auth refresh` and configuration docs: account-routing metadata now lives inside storage files; added guidance to repair older storage states and re-bind profiles to a specific account.

* **Bug Fixes**
  * Login and refresh flows repair missing or malformed account metadata when a single account is unambiguous, and no longer overwrite valid existing metadata.

* **Tests**
  * Expanded tests for account-repair, recovery flows, and metadata-preservation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->