### PR TITLE
feat(auth): recover __Secure-1PSIDTS during browser-cookies extraction (#990)

### DIFF
--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -109,6 +109,83 @@ def _validate_required_cookies(
             )
 
 
+def missing_cookies_hint(
+    cookie_names: set[str],
+    *,
+    browser_label: str | None = None,
+) -> str:
+    """Return an actionable recovery hint for the missing-cookies failure mode.
+
+    The browser-extraction CLI calls this after a ``ValueError`` from
+    :func:`extract_cookies_from_storage` to replace the generic "Make sure you
+    are logged into Google in your browser" tail with a scenario-specific
+    message. Branches on which Tier-1 / Tier-2 cookies are actually missing.
+
+    Scenarios (issue #990):
+
+    - ``SID`` missing: user is not signed in to Google at all in this browser.
+      Recovery is impossible without a fresh login.
+    - ``__Secure-1PSIDTS`` missing + secondary binding present: typically a
+      cold browser session. The in-memory ``RotateCookies`` recovery should
+      have already attempted to mint it; reaching this hint means Google
+      declined the POST (4xx / 5xx / withheld the Set-Cookie). Suggest
+      visiting NotebookLM in-browser to refresh.
+    - ``__Secure-1PSIDTS`` missing + secondary binding missing: ``RotateCookies``
+      cannot help because Google rejects requests without the binding cookies.
+      User must visit NotebookLM in-browser to populate ``OSID``.
+    - Secondary binding missing (Tier-2 warning case): the session works for
+      now but is fragile. Visiting NotebookLM populates the missing cookies.
+
+    Args:
+        cookie_names: Names of cookies that survived extraction.
+        browser_label: Optional browser label for the message
+            (``"chrome"``, ``"firefox"``). When omitted, defaults to
+            ``"your browser"``.
+
+    Returns:
+        A multi-line human-readable hint. The caller is responsible for any
+        formatting (rich tags, indentation) — this returns plain text.
+    """
+    browser_phrase = browser_label or "your browser"
+
+    if "SID" not in cookie_names:
+        return (
+            f"You are not signed in to Google in {browser_phrase}.\n"
+            f"Sign in to a Google account (Gmail, Drive, NotebookLM, ...) "
+            f"in {browser_phrase} and re-run this command."
+        )
+
+    psidts_missing = "__Secure-1PSIDTS" not in cookie_names
+    has_secondary = _has_valid_secondary_binding(cookie_names)
+
+    if psidts_missing and not has_secondary:
+        return (
+            f"Your {browser_phrase} session is signed in to Google but is missing "
+            f"the cookies NotebookLM needs (OSID or APISID+SAPISID, plus "
+            f"__Secure-1PSIDTS).\n"
+            f"Open https://notebooklm.google.com in {browser_phrase} (sign in if "
+            f"prompted), reload the page, then re-run this command."
+        )
+
+    if psidts_missing:
+        return (
+            f"__Secure-1PSIDTS is missing and the automatic RotateCookies recovery "
+            f"did not succeed.\n"
+            f"Open https://notebooklm.google.com in {browser_phrase} (this triggers "
+            f"Google to refresh the cookie), then re-run this command."
+        )
+
+    if not has_secondary:
+        return (
+            f"Your {browser_phrase} cookies are missing the NotebookLM binding "
+            f"(OSID, or APISID+SAPISID).\n"
+            f"Open https://notebooklm.google.com in {browser_phrase} (sign in if "
+            f"prompted), reload the page, then re-run this command."
+        )
+
+    return _EXTRACTION_HINT
+
+
 # Cookie domains we extract / accept by default.
 #
 # Empirical justification: traced cassettes

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -3,8 +3,23 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 logger = logging.getLogger("notebooklm.auth")
+
+
+def cookie_names_from_storage(storage_state: Mapping[str, Any]) -> set[str]:
+    """Return the set of cookie names present in a Playwright storage_state.
+
+    Centralizes the ``{entry["name"] for entry in storage_state["cookies"]}``
+    pattern that the CLI extraction paths use to feed
+    :func:`missing_cookies_hint` after a failed extraction. Defensive against
+    non-dict entries (rookiepy can return malformed rows) and missing keys.
+    """
+    cookies = storage_state.get("cookies", [])
+    return {entry.get("name", "") for entry in cookies if isinstance(entry, dict)}
+
 
 # Tier 1: cookies whose absence Google rejects deterministically.
 #

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -15,10 +15,15 @@ def cookie_names_from_storage(storage_state: Mapping[str, Any]) -> set[str]:
     Centralizes the ``{entry["name"] for entry in storage_state["cookies"]}``
     pattern that the CLI extraction paths use to feed
     :func:`missing_cookies_hint` after a failed extraction. Defensive against
-    non-dict entries (rookiepy can return malformed rows) and missing keys.
+    non-dict entries (rookiepy can return malformed rows), missing keys, and
+    ``None`` / empty-string names (so the returned set never contains ``""``).
     """
     cookies = storage_state.get("cookies", [])
-    return {entry.get("name", "") for entry in cookies if isinstance(entry, dict)}
+    return {
+        name
+        for entry in cookies
+        if isinstance(entry, dict) and isinstance(name := entry.get("name"), str) and name
+    }
 
 
 # Tier 1: cookies whose absence Google rejects deterministically.

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -31,10 +31,12 @@ for this fix.
 
 from __future__ import annotations
 
+import http.cookiejar
 import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -329,3 +331,189 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
         storage_path,
     )
     return True
+
+
+def _rookiepy_entry_to_cookie(entry: dict[str, Any]) -> http.cookiejar.Cookie:
+    """Build an ``http.cookiejar.Cookie`` from a rookiepy cookie dict.
+
+    Rookiepy returns cookies with snake_case field names (``http_only``); the
+    Playwright storage_state mirror (:func:`notebooklm._auth.cookies._storage_entry_to_cookie`)
+    uses camelCase (``httpOnly``). We need a parallel converter so the
+    in-memory recovery path can build an ``httpx.Cookies`` jar straight from
+    the rookiepy list — without first round-tripping through
+    ``convert_rookiepy_cookies_to_storage_state`` (which would silently drop
+    entries on domains we don't allowlist).
+    """
+    domain = entry.get("domain", "") or ""
+    expires = entry.get("expires")
+    expires_value = None if expires in (None, -1) else expires
+    rest: dict[str, str] = {"HttpOnly": ""} if entry.get("http_only") else {}
+    return http.cookiejar.Cookie(
+        version=0,
+        name=entry.get("name", "") or "",
+        value=entry.get("value", "") or "",
+        port=None,
+        port_specified=False,
+        domain=domain,
+        domain_specified=bool(domain),
+        domain_initial_dot=domain.startswith("."),
+        path=entry.get("path") or "/",
+        path_specified=True,
+        secure=bool(entry.get("secure", False)),
+        expires=expires_value,
+        discard=expires_value is None,
+        comment=None,
+        comment_url=None,
+        rest=rest,
+    )
+
+
+def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
+    """In-memory ``__Secure-1PSIDTS`` recovery for the browser-extraction path.
+
+    Variant of :func:`_recover_psidts_inline` for the CLI ``--browser-cookies``
+    flows (``_enumerate_one_jar``, ``_write_extracted_cookies``) that operate
+    on rookiepy cookie lists before any persistence. The file-based recovery
+    is unreachable here because nothing has been written to disk yet — the
+    cookies live only in the caller's in-memory list.
+
+    Preconditions match the file-based recovery (see
+    :func:`_recover_psidts_inline`):
+
+    1. ``SID`` present.
+    2. ``__Secure-1PSIDTS`` absent.
+    3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``).
+
+    On success, mutates ``rookiepy_cookies`` to append the rotated
+    ``__Secure-1PSIDTS`` (and ``__Secure-3PSIDTS``) entries in rookiepy's
+    snake_case format. Downstream
+    :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
+    picks them up on re-conversion.
+
+    No file lock and no in-process throttle: the browser-extraction path is a
+    one-shot CLI invocation that runs before any persistence. Concurrent CLI
+    processes would each be operating on their own in-memory list — the
+    cross-process flock in the file-based recovery exists to coordinate
+    writes to a shared ``storage_state.json``, which doesn't apply here.
+
+    Returns ``True`` if the rotation succeeded and the in-memory list now
+    contains ``__Secure-1PSIDTS``; ``False`` otherwise.
+    """
+    cookie_names: set[str] = {
+        name
+        for entry in rookiepy_cookies
+        if isinstance(entry, dict)
+        and isinstance(name := entry.get("name"), str)
+        and name
+        and entry.get("value")
+    }
+
+    if "SID" not in cookie_names:
+        logger.debug("In-memory PSIDTS recovery skipped: SID missing")
+        return False
+    if _PSIDTS_COOKIE in cookie_names:
+        return False
+    if not _has_valid_secondary_binding(cookie_names):
+        logger.debug(
+            "In-memory PSIDTS recovery skipped: secondary binding incomplete "
+            "(need OSID, or both APISID and SAPISID)"
+        )
+        return False
+
+    jar = httpx.Cookies()
+    for entry in rookiepy_cookies:
+        if not isinstance(entry, dict):
+            continue
+        if not entry.get("name") or not entry.get("value"):
+            continue
+        if not _is_allowed_auth_domain(entry.get("domain", "")):
+            continue
+        jar.jar.set_cookie(_rookiepy_entry_to_cookie(entry))
+
+    try:
+        with httpx.Client(
+            cookies=jar,
+            follow_redirects=True,
+            timeout=_KEEPALIVE_POKE_TIMEOUT,
+        ) as client:
+            response = client.post(
+                _keepalive.KEEPALIVE_ROTATE_URL,
+                headers=_KEEPALIVE_ROTATE_HEADERS,
+                content=_KEEPALIVE_ROTATE_BODY,
+            )
+            response.raise_for_status()
+            rotated_cookies = list(client.cookies.jar)
+    except httpx.HTTPError as exc:
+        logger.debug("In-memory PSIDTS recovery POST failed (non-fatal): %s", exc)
+        return False
+
+    psidts_present = any(c.name == _PSIDTS_COOKIE for c in rotated_cookies)
+    if not psidts_present:
+        logger.debug(
+            "In-memory PSIDTS recovery: RotateCookies returned 2xx but did not "
+            "include %s — Google may be withholding the rotation",
+            _PSIDTS_COOKIE,
+        )
+        return False
+
+    for cookie in rotated_cookies:
+        if cookie.name not in {_PSIDTS_COOKIE, "__Secure-3PSIDTS"}:
+            continue
+        if not cookie.value or not cookie.domain:
+            continue
+        rookiepy_cookies.append(
+            {
+                "name": cookie.name,
+                "value": cookie.value,
+                "domain": cookie.domain,
+                "path": cookie.path or "/",
+                "expires": cookie.expires,
+                "secure": True,
+                "http_only": True,
+            }
+        )
+
+    logger.info(
+        "Recovered %s via in-memory RotateCookies POST (browser-cookies extraction)",
+        _PSIDTS_COOKIE,
+    )
+    return True
+
+
+def validate_with_recovery(
+    rookiepy_cookies: list[dict[str, Any]],
+) -> tuple[dict[str, Any], ValueError | None]:
+    """Convert + validate rookiepy cookies, attempting recovery on failure.
+
+    Shared helper for the two CLI browser-extraction entry points
+    (:func:`notebooklm.cli.services.login.cookie_jar._enumerate_one_jar` and
+    :func:`notebooklm.cli.services.login.cookie_writes._write_extracted_cookies`).
+    Wraps :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
+    plus :func:`notebooklm._auth.cookies.extract_cookies_from_storage` with one
+    retry through :func:`recover_psidts_in_memory` (issue #990). When the
+    recovery preconditions hold (SID present, PSIDTS absent, secondary
+    binding intact), the rotated cookies are appended to ``rookiepy_cookies``
+    in place so downstream persistence picks them up.
+
+    Lives in the auth subpackage rather than the CLI login package so both
+    CLI call sites can route through ``notebooklm.auth`` without adding a
+    new sibling-import edge to the login-package DAG.
+
+    Returns:
+        ``(storage_state, error)``. When ``error`` is ``None`` the validation
+        succeeded (possibly after recovery); when not, ``error`` is the final
+        ``ValueError`` and ``storage_state`` is the latest extraction attempt.
+    """
+    storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
+    try:
+        _auth_cookies.extract_cookies_from_storage(storage_state)
+        return storage_state, None
+    except ValueError as initial:
+        if not recover_psidts_in_memory(rookiepy_cookies):
+            return storage_state, initial
+        storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
+        try:
+            _auth_cookies.extract_cookies_from_storage(storage_state)
+            return storage_state, None
+        except ValueError as final:
+            return storage_state, final

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -485,9 +485,10 @@ def validate_with_recovery(
 ) -> tuple[dict[str, Any], ValueError | None]:
     """Convert + validate rookiepy cookies, attempting recovery on failure.
 
-    Shared helper for the two CLI browser-extraction entry points
-    (:func:`notebooklm.cli.services.login.cookie_jar._enumerate_one_jar` and
-    :func:`notebooklm.cli.services.login.cookie_writes._write_extracted_cookies`).
+    Shared helper for the three CLI browser-extraction entry points:
+    :func:`notebooklm.cli.services.login.cookie_jar._enumerate_one_jar`,
+    :func:`notebooklm.cli.services.login.cookie_writes._write_extracted_cookies`,
+    and :func:`notebooklm.cli.services.login.refresh._login_with_browser_cookies`.
     Wraps :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
     plus :func:`notebooklm._auth.cookies.extract_cookies_from_storage` with one
     retry through :func:`recover_psidts_in_memory` (issue #990). When the

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -148,6 +148,7 @@ __all__ = [
     "load_auth_from_storage",
     "load_httpx_cookies",
     "MINIMUM_REQUIRED_COOKIES",
+    "missing_cookies_hint",
     "normalize_cookie_map",
     "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
     "NOTEBOOKLM_REFRESH_CMD_ENV",
@@ -155,9 +156,11 @@ __all__ = [
     "OPTIONAL_COOKIE_DOMAINS",
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "read_account_metadata",
+    "recover_psidts_in_memory",
     "REQUIRED_COOKIE_DOMAINS",
     "save_cookies_to_storage",
     "snapshot_cookie_jar",
+    "validate_with_recovery",
     "write_account_metadata",
 ]
 
@@ -557,6 +560,19 @@ _rotate_cookies = _auth_keepalive._rotate_cookies
 # behavior. Tests that need to substitute the recovery body should patch
 # ``notebooklm._auth.psidts_recovery._recover_psidts_inline``.
 _recover_psidts_inline = _auth_psidts_recovery._recover_psidts_inline
+# In-memory variant for the browser-cookies extraction path (issue #990).
+# Public because CLI services (which must not import underscore-prefixed names
+# from notebooklm public modules) need access. Mutates the caller's rookiepy
+# cookie list in place; no file lock / throttle.
+recover_psidts_in_memory = _auth_psidts_recovery.recover_psidts_in_memory
+# Validate-with-recovery convenience: convert + validate rookiepy cookies and
+# transparently retry through ``recover_psidts_in_memory`` on the recoverable
+# PSIDTS-missing case (issue #990). Used by the CLI browser-extraction paths.
+validate_with_recovery = _auth_psidts_recovery.validate_with_recovery
+# Missing-cookies diagnostic hint (issue #990). Inspects which Tier-1/Tier-2
+# cookies are missing and returns a scenario-specific recovery message that
+# the CLI uses in place of the generic "Make sure you are logged in" tail.
+missing_cookies_hint = _cookie_policy.missing_cookies_hint
 # Rotation sentinel path lives in ``_auth.paths``; the keepalive module also
 # aliases it locally. Re-exported here for white-box callers that resolve it
 # against ``notebooklm.auth``.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -127,6 +127,7 @@ __all__ = [
     "build_httpx_cookies_from_storage",
     "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
+    "cookie_names_from_storage",
     "CookieSaveResult",
     "CookieSnapshot",
     "CookieSnapshotKey",
@@ -573,6 +574,9 @@ validate_with_recovery = _auth_psidts_recovery.validate_with_recovery
 # cookies are missing and returns a scenario-specific recovery message that
 # the CLI uses in place of the generic "Make sure you are logged in" tail.
 missing_cookies_hint = _cookie_policy.missing_cookies_hint
+# Helper: extract cookie names from a Playwright storage_state. Shared by
+# all three CLI browser-extraction paths to feed ``missing_cookies_hint``.
+cookie_names_from_storage = _cookie_policy.cookie_names_from_storage
 # Rotation sentinel path lives in ``_auth.paths``; the keepalive module also
 # aliases it locally. Re-exported here for white-box callers that resolve it
 # against ``notebooklm.auth``.

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -25,8 +25,8 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ....auth import (
-    convert_rookiepy_cookies_to_storage_state,
-    extract_cookies_from_storage,
+    missing_cookies_hint,
+    validate_with_recovery,
 )
 from ...error_handler import exit_with_code
 from ...rendering import console
@@ -102,15 +102,19 @@ def _enumerate_one_jar(
         extract_cookies_with_domains,
     )
 
-    storage_state = convert_rookiepy_cookies_to_storage_state(raw_cookies)
-    try:
-        extract_cookies_from_storage(storage_state)
-    except ValueError as e:
+    storage_state, validation_error = validate_with_recovery(raw_cookies)
+    if validation_error is not None:
         if not quiet:
+            cookie_names = {
+                entry.get("name", "")
+                for entry in storage_state.get("cookies", [])
+                if isinstance(entry, dict)
+            }
+            hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
             console.print(
                 "[red]No valid Google authentication cookies found.[/red]\n"
-                f"{e}\n\n"
-                "Make sure you are logged into Google in your browser."
+                f"{validation_error}\n\n"
+                f"{hint}"
             )
         exit_with_code(1)
 

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ....auth import (
+    cookie_names_from_storage,
     missing_cookies_hint,
     validate_with_recovery,
 )
@@ -105,11 +106,7 @@ def _enumerate_one_jar(
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
         if not quiet:
-            cookie_names = {
-                entry.get("name", "")
-                for entry in storage_state.get("cookies", [])
-                if isinstance(entry, dict)
-            }
+            cookie_names = cookie_names_from_storage(storage_state)
             hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
             console.print(
                 "[red]No valid Google authentication cookies found.[/red]\n"

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -23,9 +23,9 @@ from typing import Any
 import httpx
 
 from ....auth import (
-    convert_rookiepy_cookies_to_storage_state,
-    extract_cookies_from_storage,
     fetch_tokens_with_domains,
+    missing_cookies_hint,
+    validate_with_recovery,
 )
 from ....io import atomic_write_json
 from ...error_handler import exit_with_code
@@ -135,14 +135,18 @@ def _write_extracted_cookies(
     Bypasses :func:`_read_browser_cookies` because the caller already has the
     cookies in hand (e.g. ``--all-accounts`` reads once and writes N profiles).
     """
-    storage_state = convert_rookiepy_cookies_to_storage_state(raw_cookies)
-    try:
-        extract_cookies_from_storage(storage_state)
-    except ValueError as e:
+    storage_state, validation_error = validate_with_recovery(raw_cookies)
+    if validation_error is not None:
+        cookie_names = {
+            entry.get("name", "")
+            for entry in storage_state.get("cookies", [])
+            if isinstance(entry, dict)
+        }
+        hint = missing_cookies_hint(cookie_names)
         console.print(
             "[red]No valid Google authentication cookies found.[/red]\n"
-            f"{e}\n\n"
-            "Make sure you are logged into Google in your browser."
+            f"{validation_error}\n\n"
+            f"{hint}"
         )
         exit_with_code(1)
 

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -23,6 +23,7 @@ from typing import Any
 import httpx
 
 from ....auth import (
+    cookie_names_from_storage,
     fetch_tokens_with_domains,
     missing_cookies_hint,
     validate_with_recovery,
@@ -137,11 +138,7 @@ def _write_extracted_cookies(
     """
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
-        cookie_names = {
-            entry.get("name", "")
-            for entry in storage_state.get("cookies", [])
-            if isinstance(entry, dict)
-        }
+        cookie_names = cookie_names_from_storage(storage_state)
         hint = missing_cookies_hint(cookie_names)
         console.print(
             "[red]No valid Google authentication cookies found.[/red]\n"

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -276,7 +276,11 @@ def _login_with_browser_cookies(
         include_domains: Optional ``--include-domains`` label set forwarded
             to :func:`_read_browser_cookies`.
     """
-    from ....auth import missing_cookies_hint, validate_with_recovery
+    from ....auth import (
+        cookie_names_from_storage,
+        missing_cookies_hint,
+        validate_with_recovery,
+    )
 
     raw_cookies = _read_browser_cookies(browser_name, include_domains=include_domains)
 
@@ -285,11 +289,7 @@ def _login_with_browser_cookies(
     # ``storage_state`` returned here already includes the rotated PSIDTS.
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
-        cookie_names = {
-            entry.get("name", "")
-            for entry in storage_state.get("cookies", [])
-            if isinstance(entry, dict)
-        }
+        cookie_names = cookie_names_from_storage(storage_state)
         hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
         console.print(
             "[red]No valid Google authentication cookies found.[/red]\n"

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -26,8 +26,6 @@ import click
 import httpx
 
 from ....auth import (
-    convert_rookiepy_cookies_to_storage_state,
-    extract_cookies_from_storage,
     fetch_tokens_with_domains,
     read_account_metadata,
 )
@@ -278,16 +276,25 @@ def _login_with_browser_cookies(
         include_domains: Optional ``--include-domains`` label set forwarded
             to :func:`_read_browser_cookies`.
     """
+    from ....auth import missing_cookies_hint, validate_with_recovery
+
     raw_cookies = _read_browser_cookies(browser_name, include_domains=include_domains)
 
-    storage_state = convert_rookiepy_cookies_to_storage_state(raw_cookies)
-    try:
-        extract_cookies_from_storage(storage_state)  # validates SID is present
-    except ValueError as e:
+    # ``validate_with_recovery`` mutates ``raw_cookies`` in place if the
+    # in-memory ``RotateCookies`` recovery succeeds (issue #990), so the
+    # ``storage_state`` returned here already includes the rotated PSIDTS.
+    storage_state, validation_error = validate_with_recovery(raw_cookies)
+    if validation_error is not None:
+        cookie_names = {
+            entry.get("name", "")
+            for entry in storage_state.get("cookies", [])
+            if isinstance(entry, dict)
+        }
+        hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
         console.print(
             "[red]No valid Google authentication cookies found.[/red]\n"
-            f"{e}\n\n"
-            "Make sure you are logged into Google in your browser."
+            f"{validation_error}\n\n"
+            f"{hint}"
         )
         exit_with_code(1)
 

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -26,8 +26,11 @@ import click
 import httpx
 
 from ....auth import (
+    cookie_names_from_storage,
     fetch_tokens_with_domains,
+    missing_cookies_hint,
     read_account_metadata,
+    validate_with_recovery,
 )
 from ....client import NotebookLMClient
 from ....io import atomic_write_json
@@ -276,12 +279,6 @@ def _login_with_browser_cookies(
         include_domains: Optional ``--include-domains`` label set forwarded
             to :func:`_read_browser_cookies`.
     """
-    from ....auth import (
-        cookie_names_from_storage,
-        missing_cookies_hint,
-        validate_with_recovery,
-    )
-
     raw_cookies = _read_browser_cookies(browser_name, include_domains=include_domains)
 
     # ``validate_with_recovery`` mutates ``raw_cookies`` in place if the

--- a/tests/unit/cli/test_login_cookie_recovery.py
+++ b/tests/unit/cli/test_login_cookie_recovery.py
@@ -205,7 +205,7 @@ class TestMissingCookiesDiagnostics:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
 
         assert result.exit_code == 1
-        assert "notebooklm.google.com" in result.output
+        assert "https://notebooklm.google.com" in result.output
 
         # No POST: recovery short-circuits on the secondary-binding precondition.
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -230,7 +230,7 @@ class TestMissingCookiesDiagnostics:
         assert result.exit_code == 1
         # The 4xx-recovery-failed hint mentions notebooklm.google.com so the
         # user knows the remediation step.
-        assert "notebooklm.google.com" in result.output
+        assert "https://notebooklm.google.com" in result.output
 
         # POST was attempted exactly once (and declined).
         rotate_calls = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]

--- a/tests/unit/cli/test_login_cookie_recovery.py
+++ b/tests/unit/cli/test_login_cookie_recovery.py
@@ -1,0 +1,237 @@
+"""Tests for browser-cookies extraction edge cases (issue #990).
+
+Covers the in-memory ``__Secure-1PSIDTS`` recovery wired into
+``_enumerate_one_jar`` and ``_write_extracted_cookies``, plus the
+scenario-specific diagnostic hints emitted when recovery declines.
+
+Scenarios:
+
+- Browser cookies arrive with ``SID`` + secondary binding but no PSIDTS
+  (cold session, RotateCookies not yet fired): in-memory recovery should
+  mint PSIDTS so ``notebooklm login --browser-cookies`` succeeds.
+- No ``SID`` at all: user isn't signed in to Google. CLI emits the
+  "Sign in to a Google account" hint without firing RotateCookies.
+- No secondary binding (no ``OSID``, no ``APISID+SAPISID``): RotateCookies
+  would 401. CLI emits the "Open https://notebooklm.google.com" hint.
+- RotateCookies POST returns 4xx: recovery declines, hint surfaces.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from _fixtures import patch_session_login_dual
+from notebooklm.notebooklm_cli import cli
+
+_ROTATE_URL_RE = re.compile(r"^https://accounts\.google\.com/RotateCookies$")
+
+
+def _rookiepy_mock(cookies: list[dict]) -> MagicMock:
+    mock = MagicMock()
+    mock.chrome = MagicMock(return_value=cookies)
+    mock.load = MagicMock(return_value=cookies)
+    return mock
+
+
+def _account_enum(email: str = "alice@example.com"):
+    async def _enum(*args, **kwargs):
+        from notebooklm.auth import Account
+
+        return [Account(authuser=0, email=email, is_default=True)]
+
+    return _enum
+
+
+def _profile_storage_path(target_root):
+    def fake_get_storage_path(profile=None):
+        return target_root / (profile or "default") / "storage_state.json"
+
+    return fake_get_storage_path
+
+
+def _make_rotate_response(*, with_psidts: bool = True, status_code: int = 200):
+    headers: list[tuple[str, str]] = []
+    if with_psidts:
+        headers.append(
+            (
+                "Set-Cookie",
+                "__Secure-1PSIDTS=fresh_psidts; Domain=.google.com; Path=/; "
+                "Secure; HttpOnly; SameSite=Lax",
+            )
+        )
+    return {
+        "status_code": status_code,
+        "headers": headers,
+        "content": b'["identity.hfcr",600]',
+    }
+
+
+# Rookiepy cookies that have everything Google needs EXCEPT the rotating
+# PSIDTS — the in-memory recovery should be able to mint it via RotateCookies.
+_RECOVERABLE_BROWSER_COOKIES = [
+    {
+        "domain": ".google.com",
+        "name": "SID",
+        "value": "browser_sid",
+        "path": "/",
+        "secure": True,
+        "http_only": False,
+    },
+    {
+        "domain": ".google.com",
+        "name": "HSID",
+        "value": "browser_hsid",
+        "path": "/",
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "SSID",
+        "value": "browser_ssid",
+        "path": "/",
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "APISID",
+        "value": "browser_apisid",
+        "path": "/",
+        "secure": False,
+        "http_only": False,
+    },
+    {
+        "domain": ".google.com",
+        "name": "SAPISID",
+        "value": "browser_sapisid",
+        "path": "/",
+        "secure": True,
+        "http_only": True,
+    },
+]
+
+
+@pytest.mark.no_default_keepalive_mock
+class TestPsidtsRecoveryDuringExtraction:
+    """``login --browser-cookies`` recovers PSIDTS when Google can mint it."""
+
+    def test_recovers_missing_psidts_and_completes_login(self, runner, tmp_path, httpx_mock):
+        """SID + secondary binding present, no PSIDTS → RotateCookies + persist."""
+        mock_rk = _rookiepy_mock(list(_RECOVERABLE_BROWSER_COOKIES))
+        target_root = tmp_path / "profiles"
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_rotate_response())
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch_session_login_dual(
+                "get_storage_path",
+                side_effect=_profile_storage_path(target_root),
+            ),
+            patch_session_login_dual("_sync_server_language_to_config"),
+            patch("notebooklm.auth.enumerate_accounts", new=_account_enum()),
+            patch_session_login_dual(
+                "fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+                return_value=("csrf", "sess"),
+            ),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
+
+        assert result.exit_code == 0, result.output
+
+        # RotateCookies must have been called exactly once (in-memory recovery).
+        rotate_calls = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        assert len(rotate_calls) == 1
+
+        # And the persisted storage_state must include the rotated PSIDTS.
+        import json
+
+        storage_file = target_root / "default" / "storage_state.json"
+        saved = json.loads(storage_file.read_text())
+        names = {c["name"] for c in saved["cookies"]}
+        assert "__Secure-1PSIDTS" in names
+        psidts = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
+        assert psidts["value"] == "fresh_psidts"
+
+
+@pytest.mark.no_default_keepalive_mock
+class TestMissingCookiesDiagnostics:
+    """When recovery cannot help, the CLI emits a scenario-specific hint."""
+
+    def test_no_sid_emits_signin_hint(self, runner, tmp_path, httpx_mock):
+        """No SID → recovery declines → "not signed in to Google" hint."""
+        cookies = [c for c in _RECOVERABLE_BROWSER_COOKIES if c["name"] != "SID"]
+        mock_rk = _rookiepy_mock(cookies)
+        target_root = tmp_path / "profiles"
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch_session_login_dual(
+                "get_storage_path",
+                side_effect=_profile_storage_path(target_root),
+            ),
+            patch_session_login_dual("_sync_server_language_to_config"),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
+
+        assert result.exit_code == 1
+        assert "not signed in" in result.output
+        assert "chrome" in result.output
+
+        # Crucially: no RotateCookies POST (recovery preconditions failed).
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    def test_missing_secondary_binding_emits_visit_notebooklm_hint(
+        self, runner, tmp_path, httpx_mock
+    ):
+        """No OSID / no APISID+SAPISID → RotateCookies would 401 → visit-page hint."""
+        # SID alone — no binding at all.
+        cookies = [c for c in _RECOVERABLE_BROWSER_COOKIES if c["name"] == "SID"]
+        mock_rk = _rookiepy_mock(cookies)
+        target_root = tmp_path / "profiles"
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch_session_login_dual(
+                "get_storage_path",
+                side_effect=_profile_storage_path(target_root),
+            ),
+            patch_session_login_dual("_sync_server_language_to_config"),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
+
+        assert result.exit_code == 1
+        assert "notebooklm.google.com" in result.output
+
+        # No POST: recovery short-circuits on the secondary-binding precondition.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    def test_rotate_cookies_4xx_emits_recovery_failed_hint(self, runner, tmp_path, httpx_mock):
+        """Recovery attempts the POST but Google returns 401 → visit-page hint."""
+        mock_rk = _rookiepy_mock(list(_RECOVERABLE_BROWSER_COOKIES))
+        target_root = tmp_path / "profiles"
+        # 401 means recovery declines (psidts_present check fails).
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=401)
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch_session_login_dual(
+                "get_storage_path",
+                side_effect=_profile_storage_path(target_root),
+            ),
+            patch_session_login_dual("_sync_server_language_to_config"),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
+
+        assert result.exit_code == 1
+        # The 4xx-recovery-failed hint mentions notebooklm.google.com so the
+        # user knows the remediation step.
+        assert "notebooklm.google.com" in result.output
+
+        # POST was attempted exactly once (and declined).
+        rotate_calls = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        assert len(rotate_calls) == 1

--- a/tests/unit/cli/test_login_cookie_recovery.py
+++ b/tests/unit/cli/test_login_cookie_recovery.py
@@ -205,7 +205,12 @@ class TestMissingCookiesDiagnostics:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
 
         assert result.exit_code == 1
-        assert "https://notebooklm.google.com" in result.output
+        # Hint nudges the user to open NotebookLM. We assert on a non-URL
+        # substring so CodeQL doesn't flag this as incomplete URL sanitization
+        # (the hint itself contains the canonical URL). Rich line-wraps the
+        # output, so we normalize whitespace before checking.
+        output_normalized = " ".join(result.output.split())
+        assert "reload the page" in output_normalized
 
         # No POST: recovery short-circuits on the secondary-binding precondition.
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -228,9 +233,11 @@ class TestMissingCookiesDiagnostics:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
 
         assert result.exit_code == 1
-        # The 4xx-recovery-failed hint mentions notebooklm.google.com so the
-        # user knows the remediation step.
-        assert "https://notebooklm.google.com" in result.output
+        # The 4xx-recovery-failed hint surfaces the rotation diagnosis. Checked
+        # on a non-URL substring to keep CodeQL's URL-sanitization rule happy.
+        # Normalize whitespace because Rich may line-wrap the message.
+        output_normalized = " ".join(result.output.split())
+        assert "RotateCookies recovery" in output_normalized
 
         # POST was attempted exactly once (and declined).
         rotate_calls = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -559,19 +559,23 @@ class TestMissingCookiesHint:
         assert "not signed in" in hint
         assert "chrome" in hint
 
+    # NOTE: We assert on non-URL hint phrases rather than the
+    # ``https://notebooklm.google.com`` literal so CodeQL's
+    # ``py/incomplete-url-substring-sanitization`` rule doesn't flag these
+    # checks (the hint itself contains the canonical URL).
     def test_missing_psidts_with_binding_suggests_rotation_or_visit(self):
         from notebooklm._auth.cookie_policy import missing_cookies_hint
 
         hint = missing_cookies_hint({"SID", "APISID", "SAPISID"}, browser_label="firefox")
         assert "__Secure-1PSIDTS" in hint
-        assert "https://notebooklm.google.com" in hint
+        assert "RotateCookies recovery" in hint
         assert "firefox" in hint
 
     def test_missing_psidts_and_binding_suggests_visit(self):
         from notebooklm._auth.cookie_policy import missing_cookies_hint
 
         hint = missing_cookies_hint({"SID"}, browser_label="chrome")
-        assert "https://notebooklm.google.com" in hint
+        assert "reload the page" in hint
         assert ("OSID" in hint) or ("binding" in hint.lower())
 
     def test_missing_binding_only_suggests_visit(self):
@@ -579,7 +583,7 @@ class TestMissingCookiesHint:
 
         # SID + PSIDTS present, but no secondary binding.
         hint = missing_cookies_hint({"SID", "__Secure-1PSIDTS"}, browser_label="chrome")
-        assert "https://notebooklm.google.com" in hint
+        assert "reload the page" in hint
         assert "binding" in hint.lower() or "OSID" in hint
 
     def test_default_browser_label_when_unspecified(self):

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -520,7 +520,7 @@ class TestInMemoryRecovery:
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
 
     @pytest.mark.no_default_keepalive_mock
-    def testvalidate_with_recovery_heals_partial_jar(self, httpx_mock: HTTPXMock):
+    def test_validate_with_recovery_heals_partial_jar(self, httpx_mock: HTTPXMock):
         """End-to-end: validate-with-recovery returns (storage_state, None) after rotation."""
         cookies = self._rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
@@ -534,7 +534,7 @@ class TestInMemoryRecovery:
         assert "__Secure-1PSIDTS" in {c["name"] for c in cookies}
 
     @pytest.mark.no_default_keepalive_mock
-    def testvalidate_with_recovery_returns_error_on_unrecoverable(self, httpx_mock: HTTPXMock):
+    def test_validate_with_recovery_returns_error_on_unrecoverable(self, httpx_mock: HTTPXMock):
         """When recovery declines, the original ValueError is surfaced."""
         # No SID → recovery declines → original ValueError propagates.
         cookies = [c for c in self._rookiepy_recoverable() if c["name"] != "SID"]

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -373,6 +373,222 @@ class TestBuildHttpxCookiesFromStorageIntegration:
             build_httpx_cookies_from_storage(storage_path)
 
 
+class TestInMemoryRecovery:
+    """In-memory recovery for the browser-extraction path (issue #990).
+
+    Mirrors the file-based ``_recover_psidts_inline`` contract: same precondition
+    gate, same failure modes return ``False`` without raising, but operates on
+    a rookiepy cookie list in memory instead of a storage_state file. No file
+    lock / throttle because the extraction path is a single one-shot CLI run.
+    """
+
+    # Rookiepy uses snake_case field names; mirror that shape here so the
+    # in-memory recovery exercises the real format produced by rookiepy.load().
+    # ``expires`` omitted = session cookie; an explicit ``int`` would be epoch
+    # seconds — small values like 9999 land in 1970 and get filtered as expired
+    # before reaching the wire.
+    @staticmethod
+    def _rookiepy_recoverable() -> list[dict]:
+        return [
+            {
+                "name": "SID",
+                "value": "test_sid",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": False,
+            },
+            {
+                "name": "APISID",
+                "value": "test_apisid",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": False,
+                "http_only": False,
+            },
+            {
+                "name": "SAPISID",
+                "value": "test_sapisid",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+            },
+        ]
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_recovers_psidts_and_mutates_list_in_place(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+
+        names = {c["name"] for c in cookies}
+        assert "__Secure-1PSIDTS" in names
+        psidts = next(c for c in cookies if c["name"] == "__Secure-1PSIDTS")
+        assert psidts["value"] == "fresh_psidts_value"
+        assert psidts["domain"] == ".google.com"
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_post_carries_existing_cookies(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_recovery.recover_psidts_in_memory(cookies)
+
+        requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        assert len(requests) == 1
+        header = requests[0].headers.get("cookie", "")
+        assert "SID=test_sid" in header
+        assert "APISID=test_apisid" in header
+        assert "SAPISID=test_sapisid" in header
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_no_sid_returns_false_without_post(self, httpx_mock: HTTPXMock):
+        cookies = [c for c in self._rookiepy_recoverable() if c["name"] != "SID"]
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_psidts_already_present_returns_false_without_post(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable() + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "already_there",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+            }
+        ]
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_missing_secondary_binding_returns_false_without_post(self, httpx_mock: HTTPXMock):
+        cookies = [
+            c for c in self._rookiepy_recoverable() if c["name"] not in {"APISID", "SAPISID"}
+        ]
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_osid_satisfies_secondary_binding(self, httpx_mock: HTTPXMock):
+        cookies = [
+            {
+                "name": "SID",
+                "value": "test_sid",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": False,
+            },
+            {
+                "name": "OSID",
+                "value": "test_osid",
+                "domain": "notebooklm.google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+            },
+        ]
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_4xx_response_returns_false(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=401)
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert "__Secure-1PSIDTS" not in {c["name"] for c in cookies}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_200_without_psidts_returns_false(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response(include_psidts=False))
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert "__Secure-1PSIDTS" not in {c["name"] for c in cookies}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_network_error_returns_false(self, httpx_mock: HTTPXMock):
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_exception(httpx.ConnectError("simulated network failure"))
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def testvalidate_with_recovery_heals_partial_jar(self, httpx_mock: HTTPXMock):
+        """End-to-end: validate-with-recovery returns (storage_state, None) after rotation."""
+        cookies = self._rookiepy_recoverable()
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        storage_state, error = psidts_recovery.validate_with_recovery(cookies)
+
+        assert error is None
+        names = {c["name"] for c in storage_state["cookies"]}
+        assert "__Secure-1PSIDTS" in names
+        # Caller's list is also healed (so downstream persistence picks it up).
+        assert "__Secure-1PSIDTS" in {c["name"] for c in cookies}
+
+    @pytest.mark.no_default_keepalive_mock
+    def testvalidate_with_recovery_returns_error_on_unrecoverable(self, httpx_mock: HTTPXMock):
+        """When recovery declines, the original ValueError is surfaced."""
+        # No SID → recovery declines → original ValueError propagates.
+        cookies = [c for c in self._rookiepy_recoverable() if c["name"] != "SID"]
+
+        storage_state, error = psidts_recovery.validate_with_recovery(cookies)
+
+        assert error is not None
+        assert "SID" in str(error)
+        # No POST fired (recovery preconditions failed early).
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        # storage_state still reflects the (incomplete) extraction attempt.
+        assert isinstance(storage_state, dict)
+
+
+class TestMissingCookiesHint:
+    """Diagnostic helper that branches on which cookies are missing (issue #990)."""
+
+    def test_no_sid_suggests_signing_in(self):
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint(set(), browser_label="chrome")
+        assert "not signed in" in hint
+        assert "chrome" in hint
+
+    def test_missing_psidts_with_binding_suggests_rotation_or_visit(self):
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint({"SID", "APISID", "SAPISID"}, browser_label="firefox")
+        assert "__Secure-1PSIDTS" in hint
+        assert "notebooklm.google.com" in hint
+        assert "firefox" in hint
+
+    def test_missing_psidts_and_binding_suggests_visit(self):
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint({"SID"}, browser_label="chrome")
+        assert "notebooklm.google.com" in hint
+        assert ("OSID" in hint) or ("binding" in hint.lower())
+
+    def test_missing_binding_only_suggests_visit(self):
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        # SID + PSIDTS present, but no secondary binding.
+        hint = missing_cookies_hint({"SID", "__Secure-1PSIDTS"}, browser_label="chrome")
+        assert "notebooklm.google.com" in hint
+        assert "binding" in hint.lower() or "OSID" in hint
+
+    def test_default_browser_label_when_unspecified(self):
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint(set())
+        assert "your browser" in hint
+
+
 class TestEdgeCases:
     """Hardening tests for the precondition gate and post-POST persistence."""
 

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -564,14 +564,14 @@ class TestMissingCookiesHint:
 
         hint = missing_cookies_hint({"SID", "APISID", "SAPISID"}, browser_label="firefox")
         assert "__Secure-1PSIDTS" in hint
-        assert "notebooklm.google.com" in hint
+        assert "https://notebooklm.google.com" in hint
         assert "firefox" in hint
 
     def test_missing_psidts_and_binding_suggests_visit(self):
         from notebooklm._auth.cookie_policy import missing_cookies_hint
 
         hint = missing_cookies_hint({"SID"}, browser_label="chrome")
-        assert "notebooklm.google.com" in hint
+        assert "https://notebooklm.google.com" in hint
         assert ("OSID" in hint) or ("binding" in hint.lower())
 
     def test_missing_binding_only_suggests_visit(self):
@@ -579,7 +579,7 @@ class TestMissingCookiesHint:
 
         # SID + PSIDTS present, but no secondary binding.
         hint = missing_cookies_hint({"SID", "__Secure-1PSIDTS"}, browser_label="chrome")
-        assert "notebooklm.google.com" in hint
+        assert "https://notebooklm.google.com" in hint
         assert "binding" in hint.lower() or "OSID" in hint
 
     def test_default_browser_label_when_unspecified(self):

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -54,6 +54,7 @@ EXPECTED_AUTH_ALL: list[str] = [
     "build_httpx_cookies_from_storage",
     "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
+    "cookie_names_from_storage",
     "CookieSaveResult",
     "CookieSnapshot",
     "CookieSnapshotKey",

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -75,6 +75,7 @@ EXPECTED_AUTH_ALL: list[str] = [
     "load_auth_from_storage",
     "load_httpx_cookies",
     "MINIMUM_REQUIRED_COOKIES",
+    "missing_cookies_hint",
     "normalize_cookie_map",
     "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
     "NOTEBOOKLM_REFRESH_CMD_ENV",
@@ -82,9 +83,11 @@ EXPECTED_AUTH_ALL: list[str] = [
     "OPTIONAL_COOKIE_DOMAINS",
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "read_account_metadata",
+    "recover_psidts_in_memory",
     "REQUIRED_COOKIE_DOMAINS",
     "save_cookies_to_storage",
     "snapshot_cookie_jar",
+    "validate_with_recovery",
     "write_account_metadata",
 ]
 


### PR DESCRIPTION
The CLI ``--browser-cookies`` extraction path previously failed with a
generic "No valid Google authentication cookies found" when rookiepy
returned a partial cookie set — most often when ``__Secure-1PSIDTS`` was
absent because Google hadn't rotated it on the browser side yet.

Adds ``recover_psidts_in_memory`` (in-memory variant of
``_recover_psidts_inline``) that fires one ``RotateCookies`` POST against
the existing browser cookies and appends the rotated PSIDTS entries to the
rookiepy list before persistence. The CLI extraction paths
(``_enumerate_one_jar``, ``_write_extracted_cookies``,
``_login_with_browser_cookies``) now route through
``validate_with_recovery``, which attempts recovery transparently before
surfacing an error.

When recovery declines or fails, ``missing_cookies_hint`` emits a
scenario-specific message based on which Tier-1 / Tier-2 cookies are
missing:

- No SID → "You are not signed in to Google in <browser>"
- PSIDTS missing + secondary binding intact → "RotateCookies recovery
  did not succeed. Open https://notebooklm.google.com in <browser>"
- PSIDTS missing + binding missing → "missing the cookies NotebookLM
  needs. Open https://notebooklm.google.com"
- Binding missing only → "missing the NotebookLM binding"

Includes unit tests for the new in-memory recovery, the diagnostic helper,
and CLI integration tests covering each scenario.

https://claude.ai/code/session_01Xbpk9TQzwkyrz2vibpp8uh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory automatic recovery for missing auth cookies during browser-cookies login flows.
  * Cookie-name extraction and scenario-specific multi-line hints to guide remediation; new public diagnostics and validation helpers.

* **Bug Fixes**
  * Validation now retries with recovered cookie state and surfaces clearer, actionable CLI errors when recovery fails.

* **Tests**
  * Added unit tests covering recovery success/failure paths, retry behavior, and diagnostic message variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->