### PR TITLE
ci(nightly): skip --extra markdown when pyproject lacks it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,7 +119,21 @@ jobs:
       # (same as the contributor workflow in docs/installation.md). Extras
       # cover the full E2E surface: `browser` = playwright, `dev` = pytest +
       # plugins, `markdown` = markdownify (used by source-conversion tests).
-      run: uv sync --frozen --extra browser --extra dev --extra markdown
+      #
+      # The `markdown` extra was added on `main` (v0.5.0); the older
+      # `develop` branch pre-dates it and does not define `markdown` in
+      # its pyproject.toml. Scheduled workflow runs always load this file
+      # from the default branch (`main`) and then check out the resolved
+      # target branch above — so the install step has to cope with both
+      # pyproject layouts under one workflow file. Probe the checked-out
+      # tree and only request the extra when it's defined.
+      shell: bash
+      run: |
+        EXTRAS=(--extra browser --extra dev)
+        if grep -qE '^markdown\s*=' pyproject.toml; then
+          EXTRAS+=(--extra markdown)
+        fi
+        uv sync --frozen "${EXTRAS[@]}"
 
     - name: Get Playwright version
       id: playwright-version


### PR DESCRIPTION
The nightly E2E workflow checks out the branch resolved by
``resolve-branch`` (``main`` or ``develop``) but the workflow file
itself is always loaded from the default branch on scheduled triggers.
``develop`` pre-dates the ``markdown`` extra introduced on ``main``
(v0.5.0), so ``uv sync --frozen --extra markdown`` aborts there with
``Extra `markdown` is not defined in the project's `optional-dependencies` table``.

Probe the checked-out ``pyproject.toml`` and only request ``--extra
markdown`` when it's actually defined. ``main`` continues to install the
full E2E surface (browser + dev + markdown); ``develop`` installs
browser + dev only — matching what its own pyproject defines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly workflow to handle varying project configurations and ensure compatibility across branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->