### PR TITLE
ci: retire develop canaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # Main branch: 6 AM UTC (10 PM PST / 1 AM EST)
     - cron: '0 6 * * *'
-    # Develop branch: 11 AM UTC (3 AM PST / 6 AM EST) - 5 hours later
-    - cron: '0 11 * * *'
   workflow_dispatch:
     inputs:
       test_filter:
@@ -37,18 +35,13 @@ jobs:
         # is set automatically by the runner.
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_SCHEDULE: ${{ github.event.schedule }}
           CUSTOM_BRANCH: ${{ inputs.custom_branch }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           if [ "$EVENT_NAME" = "schedule" ]; then
-            # Scheduled: determine from cron expression
-            if [ "$EVENT_SCHEDULE" = "0 6 * * *" ]; then
-              echo "branch=main" >> "$GITHUB_OUTPUT"
-            else
-              echo "branch=develop" >> "$GITHUB_OUTPUT"
-            fi
-            echo "is_standard=true" >> "$GITHUB_OUTPUT"
+            # Scheduled runs test main only. Release branches are manual.
+            TARGET="main"
           else
             # Manual: use custom_branch if set, otherwise use triggering branch
             if [ -n "$CUSTOM_BRANCH" ]; then
@@ -56,26 +49,30 @@ jobs:
             else
               TARGET="$REF_NAME"
             fi
-            echo "branch=$TARGET" >> "$GITHUB_OUTPUT"
-            # Check if it's main or develop
-            if [ "$TARGET" = "main" ] || [ "$TARGET" = "develop" ]; then
-              echo "is_standard=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "is_standard=false" >> "$GITHUB_OUTPUT"
-            fi
           fi
-          echo "Resolved branch: $(grep branch= "$GITHUB_OUTPUT" | cut -d= -f2)"
+          echo "branch=$TARGET" >> "$GITHUB_OUTPUT"
+          # Check if it's main or a release branch
+          case "$TARGET" in
+            main|release/*)
+              echo "is_standard=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "is_standard=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "Resolved branch: $TARGET"
 
   # Run E2E tests on the resolved branch
   e2e:
     name: E2E Tests (${{ needs.resolve-branch.outputs.branch }}/${{ matrix.os }})
     needs: resolve-branch
+    if: needs.resolve-branch.outputs.is_standard == 'true'
     runs-on: ${{ matrix.os }}
     # Secret-bearing job. Two-layer gating:
     #
     # 1. ``needs.resolve-branch.outputs.is_standard`` — set by the upstream
-    #    ``resolve-branch`` job. Only ``main`` and ``develop`` (or scheduled
-    #    cron triggers, which resolve to one of those) flip this to ``true``;
+    #    ``resolve-branch`` job. Only ``main`` and ``release/*`` branches
+    #    (or scheduled cron triggers, which resolve to one of those) flip this to ``true``;
     #    any other branch keeps it ``false`` and the secret-using steps below
     #    skip outright (no secret values land in the runner env).
     # 2. ``environment: protected-readonly`` (workflow_dispatch only) —
@@ -151,7 +148,7 @@ jobs:
 
     - name: Run E2E tests
       id: e2e
-      # Hard gate: only standard branches (main/develop, or scheduled cron
+      # Hard gate: only standard branches (main/release/*, or scheduled cron
       # runs which resolve to one of those) expose credentials. Any other
       # branch — including ad-hoc workflow_dispatch on a feature branch —
       # gets ``is_standard == 'false'`` from resolve-branch and skips here

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   # Determine which branch to test
@@ -58,6 +57,9 @@ jobs:
     needs: resolve-branch
     if: needs.resolve-branch.outputs.is_standard == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     concurrency:
       group: rpc-health-${{ needs.resolve-branch.outputs.branch }}
       cancel-in-progress: true

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -2,22 +2,65 @@ name: RPC Health Check
 
 on:
   schedule:
-    # Run at 7 AM UTC daily (1 hour after nightly E2E tests)
+    # Main branch: 7 AM UTC daily (1 hour after main nightly E2E tests)
     - cron: '0 7 * * *'
-  workflow_dispatch:  # Allow manual trigger
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_dispatch:
+    inputs:
+      custom_branch:
+        description: 'Override branch to test (leave empty to test the branch you triggered from)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
   issues: write
 
 jobs:
-  health-check:
-    name: RPC Health Check
+  # Determine which branch to test
+  resolve-branch:
     runs-on: ubuntu-latest
+    if: github.repository == 'teng-lin/notebooklm-py'
+    outputs:
+      branch: ${{ steps.resolve.outputs.branch }}
+      is_standard: ${{ steps.resolve.outputs.is_standard }}
+    steps:
+      - name: Resolve target branch
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CUSTOM_BRANCH: ${{ inputs.custom_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # Scheduled runs test main only. Release branches are manual.
+            TARGET="main"
+          else
+            if [ -n "$CUSTOM_BRANCH" ]; then
+              TARGET="$CUSTOM_BRANCH"
+            else
+              TARGET="$REF_NAME"
+            fi
+          fi
+          echo "branch=$TARGET" >> "$GITHUB_OUTPUT"
+          case "$TARGET" in
+            main|release/*)
+              echo "is_standard=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "is_standard=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "Resolved branch: $TARGET"
+
+  health-check:
+    name: RPC Health Check (${{ needs.resolve-branch.outputs.branch }})
+    needs: resolve-branch
+    if: needs.resolve-branch.outputs.is_standard == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: rpc-health-${{ needs.resolve-branch.outputs.branch }}
+      cancel-in-progress: true
     # Secret-bearing job. The scheduled cron canary must keep running without
     # human-in-the-loop approval (it's the whole point of the canary), but
     # `workflow_dispatch` runs are human-initiated and may originate from
@@ -30,6 +73,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ needs.resolve-branch.outputs.branch }}
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -54,7 +99,9 @@ jobs:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
+        TARGET_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
       run: |
+        echo "Testing branch: $TARGET_BRANCH"
         set +e
         uv run python scripts/check_rpc_health.py --full 2>&1 | tee health-report.txt
         exit_code=${PIPESTATUS[0]}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 # Contributing Guide
 
 **Status:** Active
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-23
 
 This guide covers everything you need to contribute to `notebooklm-py`: architecture overview, testing, and releasing.
 
@@ -650,8 +650,8 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `test.yml` | Push/PR | Unit tests, linting, type checking |
-| `nightly.yml` | Daily 6 AM UTC | E2E tests with real API |
-| `rpc-health.yml` | Daily 7 AM UTC | RPC method ID monitoring (see [stability.md](stability.md#automated-rpc-health-check)) |
+| `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch for `release/*` | E2E tests with real API |
+| `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch for `release/*` | RPC method ID monitoring (see [stability.md](stability.md#automated-rpc-health-check)) |
 | `testpypi-publish.yml` | Manual dispatch | Publish to TestPyPI |
 | `verify-package.yml` | Manual dispatch | Verify TestPyPI or PyPI install + E2E |
 | `publish.yml` | Tag push | Publish to PyPI |
@@ -662,6 +662,9 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 2. Add GitHub secrets:
    - `NOTEBOOKLM_AUTH_JSON`: Storage state JSON
    - `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`: Your test notebook ID
+
+Scheduled canaries target `main` only. Release canaries are manual: dispatch
+`nightly.yml` or `rpc-health.yml` with `custom_branch=release/vX.Y.Z`.
 
 ### Maintaining Secrets
 
@@ -680,7 +683,7 @@ credentials by dispatching a workflow on a feature branch:
 | Gate | Where | Mechanism |
 |------|-------|-----------|
 | `environment: protected-readonly` | Job-level | GitHub Environment with a required reviewer — secrets do not resolve until the maintainer approves the run. Use `${{ github.event_name == 'workflow_dispatch' && 'protected-readonly' \|\| '' }}` to require approval only on manual dispatch while leaving scheduled cron canaries unattended. |
-| `needs.<job>.outputs.is_standard == 'true'` | Step-level `if:` | Pin secret-using steps to standard branches (`main` / `develop` / scheduled cron). Non-standard branches skip the step outright — no secret values land in the runner env. |
+| `needs.<job>.outputs.is_standard == 'true'` | Job/step-level `if:` | Pin secret-using jobs or steps to standard branches (`main` / `release/*` / scheduled cron). Non-standard branches skip outright — no secret values land in the runner env. |
 | `github.event.sender.login == 'teng-lin'` | Job-level `if:` | Pin webhook-triggered workflows (e.g. `claude.yml`) to a specific maintainer actor. Any other actor's trigger never reaches the secret-bearing steps. |
 
 `scripts/check_workflow_secret_gates.py` (wired into the `test.yml` quality job)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 **Status:** Active
-**Last Updated:** 2026-05-17
+**Last Updated:** 2026-05-23
 
 Checklist for releasing a new version of `notebooklm-py`.
 
@@ -28,7 +28,7 @@ Release Plan for vX.Y.Z:
 4. Commit changes
 5. ⏸️ CONFIRM: Create PR to main?
 6. Wait for CI to pass on PR
-7. Run E2E tests on release branch
+7. Run E2E and RPC health checks on release branch
 8. ⏸️ CONFIRM: Publish to TestPyPI?
 9. Verify TestPyPI package
 10. Merge PR to main
@@ -183,12 +183,22 @@ Proceed with release preparation?
 ### E2E Tests on Release Branch
 
 - [ ] Go to **Actions** → **Nightly E2E**
-- [ ] Click **Run workflow**, select the `release/vX.Y.Z` branch
+- [ ] Click **Run workflow**, set **custom_branch** to `release/vX.Y.Z`
 - [ ] Wait for E2E tests to pass
 - [ ] If E2E tests fail:
   1. Fix issues in the release worktree
   2. Commit and push
   3. Re-run E2E tests
+
+### RPC Health Check on Release Branch
+
+- [ ] Go to **Actions** → **RPC Health Check**
+- [ ] Click **Run workflow**, set **custom_branch** to `release/vX.Y.Z`
+- [ ] Wait for RPC health check to pass
+- [ ] If RPC health check fails:
+  1. Fix issues in the release worktree
+  2. Commit and push
+  3. Re-run RPC health check
 
 ---
 

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -1,7 +1,7 @@
 # RPC Development Guide
 
 **Status:** Active
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-23
 
 This guide covers everything about NotebookLM's RPC protocol: capturing calls, debugging issues, and implementing new methods.
 
@@ -482,8 +482,10 @@ async def validate_rpc_call(rpc_id: str, params: list, expected_action: str):
 
 ## RPC Health Check Triage Policy
 
-The `rpc-health.yml` workflow runs daily (07:00 UTC) and opens an issue on any
-detected RPC ID mismatch, auth failure, or non-transient RPC error:
+The `rpc-health.yml` workflow runs daily for `main` (07:00 UTC). Release branch
+health checks are manual via `custom_branch=release/vX.Y.Z`. The workflow opens
+an issue on any detected RPC ID mismatch, auth failure, or non-transient RPC
+error:
 
 - **RPC ID mismatch** issues (exit code 1): labeled `bug, rpc-breakage, automated`.
 - **Auth failure** issues (exit code 2): labeled `bug, automated` (no `rpc-breakage`
@@ -493,7 +495,8 @@ detected RPC ID mismatch, auth failure, or non-transient RPC error:
   the rate-limit / `RESOURCE_EXHAUSTED` filter (timeouts, parse failures,
   unexpected HTTP errors). The issue body lists the affected method IDs
   extracted from the report, so triage can start without re-running the check.
-  See `.github/workflows/rpc-health.yml:76-109` for the body-assembly step.
+  See the `Extract failing methods for ERROR issue` step in
+  `.github/workflows/rpc-health.yml` for the body-assembly logic.
 
 Routing:
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,7 +1,7 @@
 # API Stability and Versioning
 
 **Status:** Active
-**Last Updated:** 2026-05-15
+**Last Updated:** 2026-05-23
 
 This document describes the stability guarantees and versioning policy for `notebooklm-py`.
 
@@ -330,14 +330,17 @@ if artifact.is_flashcards:
 
 When Google changes their internal APIs:
 
-1. **Detection**: Automated RPC health check runs nightly (see below)
+1. **Detection**: Automated RPC health check runs nightly for `main`; release
+   branch checks run manually during release prep (see below)
 2. **Investigation**: Identify changed method IDs using browser devtools
 3. **Fix**: Update `rpc/types.py` with new method IDs
 4. **Release**: Push patch release as soon as possible
 
 ### Automated RPC Health Check
 
-A nightly GitHub Action (`rpc-health.yml`) monitors all 35+ RPC methods for ID changes.
+A nightly GitHub Action (`rpc-health.yml`) monitors all 35+ RPC methods for ID
+changes on `main`. Release branches use the same workflow through manual
+dispatch.
 
 **What it verifies:**
 - The RPC method ID we send matches the ID returned in the response envelope
@@ -357,7 +360,7 @@ A nightly GitHub Action (`rpc-health.yml`) monitors all 35+ RPC methods for ID c
 - GitHub Issue auto-created with `bug`, `rpc-breakage`, and `automated` labels
 - Report shows expected vs actual IDs and which `RPCMethod` entries need updating
 
-**Manual trigger:** `gh workflow run rpc-health.yml`
+**Manual trigger:** `gh workflow run rpc-health.yml -f custom_branch=release/vX.Y.Z`
 
 ### How to Report API Breakage
 

--- a/scripts/check_workflow_permissions.py
+++ b/scripts/check_workflow_permissions.py
@@ -22,11 +22,9 @@ from pathlib import Path
 # Workflows that intentionally rely on job-level permissions or default scopes.
 # codeql.yml: needs `security-events: write` (job-scoped is the standard).
 # publish.yml / testpypi-publish.yml: write to PyPI; permissions live at job level.
-# rpc-health.yml: opens issues on failure (already has its own permissions block).
 ALLOWLIST = {
     "codeql.yml",
     "publish.yml",
-    "rpc-health.yml",
     "testpypi-publish.yml",
 }
 

--- a/scripts/check_workflow_secret_gates.py
+++ b/scripts/check_workflow_secret_gates.py
@@ -14,7 +14,7 @@ runs that have at least one of:
 * a step-level ``if:`` guard whose expression references an ``is_standard``
   output (the convention from ``nightly.yml`` where the ``resolve-branch``
   job sets ``outputs.is_standard`` to ``true`` only for ``main`` /
-  ``develop`` / scheduled cron triggers).
+  ``release/*`` / scheduled cron triggers).
 
 ``secrets.GITHUB_TOKEN`` is *not* counted as a user-provided secret — it's
 the auto-provisioned token whose scopes are bounded by the top-level
@@ -148,7 +148,7 @@ _COMMENT_RE = re.compile(r"^\s*#")
 #
 # Tokens:
 #   * ``needs.<job>.outputs.is_standard == 'true'`` — branch-class pin
-#     (nightly.yml's ``resolve-branch`` job sets this for main/develop +
+#     (nightly.yml's ``resolve-branch`` job sets this for main/release/* +
 #     scheduled triggers).
 #   * ``github.event.sender.login == '<actor>'`` /
 #     ``github.actor == '<actor>'`` — actor pin (claude.yml's


### PR DESCRIPTION
## Summary

Retires `develop` as a canary target while keeping nightly E2E and RPC health coverage for `main` and manual release-branch validation.

## Related Issue

N/A

## Changes

- Remove the scheduled `develop` E2E run from `nightly.yml`; scheduled E2E now targets `main` only.
- Add `release/*` as the trusted manual target set for Nightly E2E and RPC Health Check.
- Add branch resolution to `rpc-health.yml` so manual runs can checkout `custom_branch=release/vX.Y.Z`.
- Update release/development/RPC docs and the secret-gate checker comments to replace `develop` with `release/*`.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`pytest`): `uv run pytest` (6146 passed, 12 skipped)
- [x] Linting passes (`ruff check .`): `uv run pre-commit run --all-files`
- [x] Formatting passes (`ruff format --check .`): `uv run pre-commit run --all-files`
- [x] Type checking passes (`mypy src/notebooklm --ignore-missing-imports`): `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] Workflow gates pass: `uv run python scripts/check_workflow_secret_gates.py`
- [x] Workflow action pinning passes: `uv run python scripts/check_action_pinning.py`
- [x] Workflow permissions pass: `uv run python scripts/check_workflow_permissions.py`
- [x] Workflow YAML parses with PyYAML
- [x] If this PR changes architectural shape, an ADR has been added or updated. N/A

## Notes

`origin/develop` was deleted separately after removing its branch protection. `git ls-remote --heads origin develop` now returns no ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly and RPC health workflows now resolve and target branches (main or release/*) and support manual runs on release branches.

* **Chores**
  * Health workflow permissions narrowed and moved to the health job; concurrency scoped per-target-branch.
  * Automated branch-resolution outputs added to support gating.

* **Documentation**
  * CI/CD, release checklist, and RPC/stability docs updated with new schedules, manual-trigger guidance, and secret-gate behavior.

* **Maintenance**
  * Workflow validation allowlist adjusted and helper script docs aligned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->