### PR TITLE
fix(cli): defer playwright account metadata repair

### DIFF
--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -636,6 +636,9 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
     console.print(f"[yellow]Opening {browser_label} for Google login...[/yellow]")
     console.print(f"[dim]Using persistent profile: {browser_profile}[/dim]")
 
+    account_metadata_page_html: str | None = None
+    should_repair_account_metadata = False
+
     # Use context manager to restore ProactorEventLoop for Playwright on Windows
     # (fixes #89: NotImplementedError on Windows Python 3.12)
     with windows_playwright_event_loop(), sync_playwright() as p:
@@ -796,7 +799,8 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
                 dict(playwright_state), include_domains=include_domains
             )
             atomic_write_json(storage_path, filtered_state)
-            repair_playwright_account_metadata(storage_path, page_html=active_page_html)
+            account_metadata_page_html = active_page_html
+            should_repair_account_metadata = True
 
         except Exception as e:
             # Handle browser launch errors specially (context will be None if launch failed)
@@ -828,6 +832,9 @@ def run_playwright_login(plan: PlaywrightLoginPlan) -> None:
         finally:
             if context:
                 context.close()
+
+    if should_repair_account_metadata:
+        repair_playwright_account_metadata(storage_path, page_html=account_metadata_page_html)
 
 
 __all__ = [

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -708,6 +708,76 @@ class TestLoginCommand:
         }
 
     @pytest.mark.requires_playwright
+    def test_playwright_login_repairs_metadata_after_sync_context_exits(self, tmp_path):
+        """Metadata repair must not run while Playwright's sync loop is active."""
+        from notebooklm.cli.services import playwright_login
+
+        storage_file = tmp_path / "storage.json"
+        browser_dir = tmp_path / "profile"
+        context_active = False
+        repair_calls = []
+
+        # Issue #1000: account repair calls run_async(), so it must happen
+        # after Playwright's sync context has torn down its event loop.
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+        mock_page.url = "https://notebooklm.google.com/"
+        mock_page.content.return_value = "<html></html>"
+        mock_context.pages = [mock_page]
+        mock_context.storage_state.return_value = _required_cookie_state()
+        mock_playwright = MagicMock()
+        mock_playwright.chromium.launch_persistent_context.return_value = mock_context
+
+        class FakeSyncPlaywright:
+            def __enter__(self):
+                nonlocal context_active
+                context_active = True
+                return mock_playwright
+
+            def __exit__(self, exc_type, exc, tb):
+                nonlocal context_active
+                context_active = False
+                return False
+
+        def fake_sync_playwright():
+            return FakeSyncPlaywright()
+
+        def fake_repair(storage_path, *, page_html=None, quiet=False):
+            repair_calls.append(
+                {
+                    "storage_path": storage_path,
+                    "page_html": page_html,
+                    "quiet": quiet,
+                    "context_active": context_active,
+                }
+            )
+
+        with (
+            patch("notebooklm.cli.session_cmd._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright", side_effect=fake_sync_playwright),
+            patch(
+                "notebooklm.cli.services.playwright_login.repair_playwright_account_metadata",
+                side_effect=fake_repair,
+            ),
+        ):
+            playwright_login.run_playwright_login(
+                playwright_login.PlaywrightLoginPlan(
+                    browser="chromium",
+                    browser_profile=browser_dir,
+                    storage_path=storage_file,
+                )
+            )
+
+        assert repair_calls == [
+            {
+                "storage_path": storage_file,
+                "page_html": "<html></html>",
+                "quiet": False,
+                "context_active": False,
+            }
+        ]
+
+    @pytest.mark.requires_playwright
     def test_playwright_login_writes_account_matched_by_page_email(self, runner, tmp_path):
         """When multiple accounts are visible, the current page email selects the route."""
         from notebooklm.auth import Account


### PR DESCRIPTION
## Summary

Defer Playwright login account metadata repair until after `sync_playwright()` exits so `repair_playwright_account_metadata()` no longer calls `run_async()` while Playwright's sync event loop is active.

## Related Issue

Closes #1000

## Changes

- Capture the active NotebookLM page HTML during the Playwright login flow, but postpone account metadata repair until the Playwright context has closed.
- Add a regression test proving metadata repair runs after the sync context exits while still receiving the saved storage path and captured page HTML.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest tests/unit/cli/test_login.py -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Formatting passes (`uv run ruff format --check .`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated. Not applicable; this is a narrow call-order fix.

## Notes

Polished with Codex, AGY, and Claude review passes before opening. Codex and AGY found no blocking issues; Codex suggested tightening the regression assertion, which is included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced login robustness by ensuring account metadata repair operations occur only after the storage state has been successfully synchronized and the session has terminated, improving data consistency and preventing synchronization issues.

* **Tests**
  * Added test verification for proper metadata repair execution timing within the login workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->