### PR TITLE
test: speed up audit-heavy unit checks

### DIFF
--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -52,6 +52,13 @@ from urllib.parse import parse_qs, unquote, urlparse
 import pytest
 import yaml
 
+# Prefer libyaml for the cassette-shape lint. The top-level cassette set is
+# large enough that pure-Python SafeLoader dominates unit-suite runtime.
+try:
+    from yaml import CSafeLoader as _YamlSafeLoader
+except ImportError:  # pragma: no cover - libyaml ships with PyYAML wheels
+    from yaml import SafeLoader as _YamlSafeLoader  # type: ignore[assignment]
+
 # ---------------------------------------------------------------------------
 # Cassette discovery
 # ---------------------------------------------------------------------------
@@ -350,7 +357,7 @@ def _load_cassette(path: Path) -> tuple[dict[str, Any], str]:
     # (cp1252 on Windows), which can't decode the 4-byte UTF-8 emoji
     # sequences.
     raw = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(raw) or {}
+    data = yaml.load(raw, Loader=_YamlSafeLoader) or {}
     return data, raw
 
 

--- a/tests/unit/test_migration_lock.py
+++ b/tests/unit/test_migration_lock.py
@@ -178,8 +178,8 @@ def test_lock_does_not_block_subsequent_runs(tmp_path: Path) -> None:
 def test_held_lock_surfaces_timeout_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A held lock causes :class:`MigrationLockTimeoutError` to surface.
 
-    A separate thread holds the lock for the duration of the call under
-    test; we shrink the timeout to 1s so the test runs quickly. The
+    The test pre-acquires the lock for the duration of the call under
+    test, then uses filelock's non-blocking timeout path so the test runs quickly. The
     expected outcome is the new wrapper exception, NOT a raw
     :class:`filelock.Timeout` (callers should see a domain-specific
     error).
@@ -192,8 +192,8 @@ def test_held_lock_surfaces_timeout_error(tmp_path: Path, monkeypatch: pytest.Mo
     holder = FileLock(str(lock_path))
     holder.acquire()
 
-    # Shrink the migration timeout so the assertion runs in ~1 second.
-    monkeypatch.setattr("notebooklm.migration._MIGRATION_LOCK_TIMEOUT", 1.0, raising=True)
+    # Non-blocking acquire exercises the same wrapper branch without a real wait.
+    monkeypatch.setattr("notebooklm.migration._MIGRATION_LOCK_TIMEOUT", 0.0, raising=True)
 
     try:
         with (

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -408,6 +408,11 @@ def _iter_types_private_helper_import_files() -> list[Path]:
     return sorted(paths)
 
 
+def _may_reference_private_types_seam(text: str) -> bool:
+    """Cheap prefilter before AST parsing the private ``notebooklm.types`` audit."""
+    return "types" in text and "_" in text
+
+
 @pytest.mark.parametrize("enum_name", _REEXPORTED_RPC_ENUMS)
 def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
     """notebooklm.types.<Enum> is the same object as notebooklm.rpc.types.<Enum>."""
@@ -523,7 +528,10 @@ def test_types_private_helper_seam_manifest_matches_first_party_imports() -> Non
 
     imported_private_names: set[str] = set()
     for path in _iter_types_private_helper_import_files():
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        if not _may_reference_private_types_seam(text):
+            continue
+        tree = ast.parse(text)
         type_module_aliases: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -212,19 +212,15 @@ def _collect_external_imports_by_module() -> dict[str, frozenset[str]]:
                     if alias.name == "*" or alias.name.startswith("_"):
                         continue
                     imports_by_module.setdefault(module_basename, set()).add(alias.name)
-    return {module: frozenset(names) for module, names in imports_by_module.items()}
+    return {name: frozenset(names) for name, names in imports_by_module.items()}
 
 
 def _collect_external_imports(module_basename: str) -> set[str]:
     """Return the set of public names imported from ``notebooklm.<module_basename>``.
 
-    Walks every ``.py`` file under ``src/``, ``tests/``, ``docs/`` and collects
-    names from any ``ImportFrom`` that resolves to ``notebooklm.<module>``
-    (absolute) or ``..<module>`` / ``.<module>`` (relative). Filters out
-    underscore-prefixed names and the bare ``*`` star-import marker.
-
-    Defensive on parse errors — a malformed file in the tree must not block
-    this audit.
+    Reads from the cached repo-wide scan in
+    :func:`_collect_external_imports_by_module`, which walks every ``.py``
+    file under ``src/``, ``tests/``, ``docs/`` once per process.
     """
     return set(_collect_external_imports_by_module().get(module_basename, frozenset()))
 

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
+from functools import lru_cache
 
 import notebooklm.auth as auth_module
 import notebooklm.client as client_module
@@ -179,6 +180,41 @@ def test_auth_all_excludes_private_names() -> None:
     assert not private, f"underscore-prefixed names must not appear in auth.__all__: {private}"
 
 
+@lru_cache(maxsize=1)
+def _collect_external_imports_by_module() -> dict[str, frozenset[str]]:
+    """Return public names imported from ``notebooklm.<module>`` by module.
+
+    The auth/client audit tests both walk the same tree. Cache the scan so
+    adding a second audited module does not double the unit-suite cost.
+    """
+    imports_by_module: dict[str, set[str]] = {}
+    for root in _SCAN_ROOTS:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                module = node.module or ""
+                module_basename: str | None = None
+                if module.startswith("notebooklm.") and module.count(".") == 1:
+                    module_basename = module.rsplit(".", 1)[1]
+                # Relative matching covers `from .auth import X` / `from ..auth`.
+                # The scan roots do not contain same-named non-notebooklm packages,
+                # so the module basename is sufficient for this audit.
+                elif node.level > 0 and module:
+                    module_basename = module
+                if module_basename is None:
+                    continue
+                for alias in node.names:
+                    if alias.name == "*" or alias.name.startswith("_"):
+                        continue
+                    imports_by_module.setdefault(module_basename, set()).add(alias.name)
+    return {module: frozenset(names) for module, names in imports_by_module.items()}
+
+
 def _collect_external_imports(module_basename: str) -> set[str]:
     """Return the set of public names imported from ``notebooklm.<module_basename>``.
 
@@ -190,30 +226,7 @@ def _collect_external_imports(module_basename: str) -> set[str]:
     Defensive on parse errors — a malformed file in the tree must not block
     this audit.
     """
-    names: set[str] = set()
-    for root in _SCAN_ROOTS:
-        for path in (_REPO_ROOT / root).rglob("*.py"):
-            try:
-                tree = ast.parse(path.read_text())
-            except (SyntaxError, UnicodeDecodeError):
-                continue
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.ImportFrom):
-                    continue
-                module = node.module or ""
-                # Relative matching covers `from .auth import X` / `from ..auth`.
-                # The scan roots do not contain same-named non-notebooklm packages,
-                # so the module basename is sufficient for this audit.
-                resolves_to_target = module == f"notebooklm.{module_basename}" or (
-                    node.level > 0 and module == module_basename
-                )
-                if not resolves_to_target:
-                    continue
-                for alias in node.names:
-                    if alias.name == "*" or alias.name.startswith("_"):
-                        continue
-                    names.add(alias.name)
-    return names
+    return set(_collect_external_imports_by_module().get(module_basename, frozenset()))
 
 
 def test_auth_all_matches_external_imports_audit() -> None:


### PR DESCRIPTION
## Summary

- Use libyaml's `CSafeLoader` for cassette-shape YAML parsing, with `SafeLoader` fallback.
- Cache the public-surface import audit scan across auth/client checks.
- Skip AST parsing files that cannot reference private `notebooklm.types` seams.
- Exercise migration lock timeout wrapping through filelock's non-blocking path instead of waiting one real second.

## Runtime Notes

- Original measured `tests/unit tests/integration`: `132.70s` pytest time / `134.47s` wall.
- After these optimizations: `100.92s` pytest time / `102.75s` wall on the final PR run.
- `tests/unit/test_cassette_shapes.py` targeted run dropped from about `30.59s` to about `1.98s` in the investigation pass.

Follow-up larger fast-local-loop work is tracked in #1001.

## Reviews

- Codex pass: OK; checked old/new import-scan and private seam audit results matched; targeted tests passed.
- AGY pass: OK; scoped to test runtime and aligned with repo conventions.
- Claude pass: requested docstring wording fix in `test_migration_lock.py`; applied.

## Tests

- `uv run pytest tests/unit/test_cassette_shapes.py tests/unit/test_public_surface.py tests/unit/test_public_shims.py tests/unit/test_migration_lock.py -q` (`362 passed in 4.89s`)
- `uv run ruff check tests/unit/test_cassette_shapes.py tests/unit/test_public_surface.py tests/unit/test_public_shims.py tests/unit/test_migration_lock.py`
- `uv run ruff check .`
- `uv run pytest tests/unit tests/integration -q --durations=80 --durations-min=0.05` (`6130 passed, 12 skipped in 100.92s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved YAML cassette deserialization by preferring faster native loaders when available, increasing reliability.
  * Reduced test runtime with repo-wide AST scan caching and a lightweight prefilter to avoid unnecessary parsing.
  * Made lock-timeout tests non-blocking and immediate to speed up execution while preserving error handling assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->