### PR TITLE
ci(rpc-health): classify ReadTimeout as transient

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -16,9 +16,12 @@ Priority order when multiple statuses are present:
 
 Transient errors that still exit 0 are limited to rate-limit signals
 (HTTP 429, gRPC ``RESOURCE_EXHAUSTED``, and the decoder's user-displayable
-``API rate limit`` / quota messages raised as ``RateLimitError``).
-Everything else is treated as a real failure so the nightly canary can
-flag silent breakage.
+``API rate limit`` / quota messages raised as ``RateLimitError``) plus
+``httpx.ReadTimeout`` against Google's RPC endpoints — those are almost
+always server-side slowness, not an RPC contract change, and they
+consistently pass on retry (see #1004). Everything else (parse failures,
+unexpected HTTP status codes, schema mismatches) is still treated as a
+real failure so the nightly canary can flag silent breakage.
 
 Environment variables:
     NOTEBOOKLM_AUTH_JSON - Playwright storage state JSON (required)
@@ -1034,31 +1037,48 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
     return results
 
 
-# Substrings that mark an ERROR as a transient rate-limit signal.
-# These are the ONLY errors that count as transient — everything else
-# (timeouts, parse failures, unexpected HTTP errors) is treated as a real
-# failure so the nightly canary can flag silent breakage. Keep this list
+# Substrings that mark an ERROR as a transient signal. Keep this list
 # narrow on purpose: broadening it would mask real RPC drift.
 #
-# ``API rate limit`` catches the decoder's user-displayable messages
-# raised as ``RateLimitError`` ("API rate limit exceeded..." and
-# "API rate limit or quota exceeded..."). These reach the canary via the
-# ``except RPCError`` parse-error branch in ``test_rpc_method_with_data``
-# and were previously misclassified as non-transient.
+# Currently classified as transient:
+#   * ``HTTP 429`` and gRPC ``RESOURCE_EXHAUSTED`` — explicit rate-limit
+#     signals from the backend.
+#   * ``API rate limit`` — catches the decoder's user-displayable messages
+#     raised as ``RateLimitError`` ("API rate limit exceeded..." and
+#     "API rate limit or quota exceeded..."). These reach the canary via
+#     the ``except RPCError`` parse-error branch in
+#     ``test_rpc_method_with_data`` and were previously misclassified.
+#   * ``ReadTimeout`` — ``httpx.ReadTimeout`` against Google's RPC
+#     endpoints is almost always server-side slowness, not an RPC
+#     contract change. It consistently passes on retry (see #1004 and
+#     prior occurrences on 2026-05-20). Only the ``httpx.ReadTimeout``
+#     class name is treated as transient — ``ConnectTimeout`` /
+#     ``WriteTimeout`` / ``PoolTimeout`` stay non-transient because they
+#     point at client- or network-side problems worth surfacing.
+#
+# Everything else (other timeouts, parse failures, unexpected HTTP
+# status codes, schema mismatches) is still treated as a real failure
+# so the nightly canary can flag silent breakage.
 TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
     "HTTP 429",
     "RESOURCE_EXHAUSTED",
     "API rate limit",
+    "ReadTimeout",
 )
 
 
 def is_transient_error(error_message: str | None) -> bool:
-    """Return True if an ERROR result is a transient rate-limit signal.
+    """Return True if an ERROR result is a transient signal.
 
-    Rate-limit responses (HTTP 429, gRPC ``RESOURCE_EXHAUSTED``) are the
-    only errors classified as transient. They are expected on throttled
-    days and should not trip the canary. Anything else — timeouts, parse
-    failures, unexpected HTTP errors — is treated as a real failure.
+    Transient signals (filtered out of the auto-open path):
+      * Rate-limit responses (HTTP 429, gRPC ``RESOURCE_EXHAUSTED``,
+        decoder ``RateLimitError`` messages).
+      * ``httpx.ReadTimeout`` against Google's RPC endpoints — these
+        are server-side flakes that pass on retry (issue #1004).
+
+    Anything else — other timeouts, parse failures, unexpected HTTP
+    status codes — is treated as a real failure that warrants
+    investigation.
     """
     if not error_message:
         return False

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -5,7 +5,7 @@ This script makes minimal API calls to exercise RPC methods and verify
 that the method IDs in rpc/types.py still match what the API returns.
 
 Exit codes:
-    0 - All RPC methods OK (or only transient rate-limit errors)
+    0 - All RPC methods OK (or only transient errors: rate-limits / ReadTimeouts)
     1 - One or more RPC methods have mismatched IDs
     2 - Authentication or infrastructure failure (not an RPC problem)
     3 - One or more RPC methods returned a non-transient ERROR
@@ -1187,7 +1187,7 @@ def print_summary(results: list[CheckResult]) -> int:
         print("       These are real failures (not rate-limit transients).")
         return 3
     if transient_errors:
-        print("RESULT: PASS - Only transient rate-limit errors observed")
+        print("RESULT: PASS - Only transient errors observed (rate-limits / ReadTimeouts)")
         print("       Review ERROR DETAILS above for affected methods.")
         return 0
     print("RESULT: PASS - All tested RPC methods OK")

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -96,6 +96,12 @@ def _result(
         # issues. Pin both phrasings (decoder.py:117 and :470).
         "Parse error: API rate limit exceeded. Please wait before retrying.",
         "Parse error: API rate limit or quota exceeded. Please wait before retrying.",
+        # ``httpx.ReadTimeout`` with an empty message stringifies to the
+        # class name (see issue #864 fallback in make_rpc_request) and is
+        # a Google-side flake that passes on retry — see #1004 and the
+        # 2026-05-20 occurrence. Classifying it as transient prevents
+        # auto-opening dup issues for single-run timeouts.
+        "ReadTimeout",
     ],
 )
 def test_transient_markers_match(message: str) -> None:
@@ -118,6 +124,22 @@ def test_non_transient_markers_do_not_match(message: str | None) -> None:
     assert is_transient_error(message) is False
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Only ``httpx.ReadTimeout`` is treated as a Google-side flake.
+        # Connect/Write/Pool timeouts point at client- or network-side
+        # problems (DNS, broken proxy, exhausted connection pool) and
+        # should keep tripping the canary so they get investigated.
+        "ConnectTimeout",
+        "WriteTimeout",
+        "PoolTimeout",
+    ],
+)
+def test_non_readtimeout_timeouts_stay_non_transient(message: str) -> None:
+    assert is_transient_error(message) is False
+
+
 # ---------------------------------------------------------------------------
 # partition_errors
 # ---------------------------------------------------------------------------
@@ -137,11 +159,21 @@ def test_partition_errors_separates_transient_from_real() -> None:
             CheckStatus.ERROR,
             error="Parse error: API rate limit or quota exceeded. Please wait before retrying.",
         ),
+        # ``httpx.ReadTimeout("")`` surfaces as the bare class name via the
+        # str-or-classname fallback in make_rpc_request (issue #864).
+        # Treated as transient per issue #1004 — a single-run Google-side
+        # timeout should not auto-open a non-transient issue.
+        _result("read_timeout", CheckStatus.ERROR, error="ReadTimeout"),
         _result("mismatch", CheckStatus.MISMATCH),
     ]
     non_transient, transient = partition_errors(results)
     assert [r.method.name for r in non_transient] == ["timeout", "parse"]
-    assert [r.method.name for r in transient] == ["rate", "quota", "ratelimit_leak"]
+    assert [r.method.name for r in transient] == [
+        "rate",
+        "quota",
+        "ratelimit_leak",
+        "read_timeout",
+    ]
 
 
 @pytest.mark.asyncio
@@ -305,13 +337,15 @@ async def test_check_method_propagates_empty_message_errors(
     assert result.error == "ReadTimeout"
 
 
-def test_is_transient_error_pins_readtimeout_as_non_transient() -> None:
+def test_is_transient_error_classifies_readtimeout_as_transient() -> None:
     # Pinned policy (see scripts/check_rpc_health.py docstring + the
-    # comment on TRANSIENT_ERROR_MARKERS): transport timeouts are
-    # treated as real failures so the canary can flag silent breakage.
-    # If this policy ever changes, update this test deliberately —
-    # don't drop it. See #864 for the discussion.
-    assert is_transient_error("ReadTimeout") is False
+    # comment on TRANSIENT_ERROR_MARKERS): ``httpx.ReadTimeout`` against
+    # Google's RPC endpoints is a server-side flake that passes on retry,
+    # so it is filtered out of the auto-open issue path (#1004). Other
+    # timeouts (Connect/Write/Pool) stay non-transient because they
+    # point at client- or network-side problems worth surfacing. If this
+    # policy ever changes, update this test deliberately — don't drop it.
+    assert is_transient_error("ReadTimeout") is True
     assert is_transient_error("ConnectTimeout") is False
     assert is_transient_error("WriteTimeout") is False
     assert is_transient_error("PoolTimeout") is False


### PR DESCRIPTION
## Summary

- Add `ReadTimeout` to `TRANSIENT_ERROR_MARKERS` in `scripts/check_rpc_health.py` so single-run `httpx.ReadTimeout` errors against Google's RPC endpoints stop tripping the non-transient exit-code-3 path and farming auto-opened GitHub issues.
- Keep the classification deliberately narrow: only `ReadTimeout` is added. `ConnectTimeout` / `WriteTimeout` / `PoolTimeout` stay non-transient because they point at client- or network-side problems worth surfacing, and parse failures / unexpected HTTP status codes / schema mismatches remain non-transient so real RPC drift still trips the canary.
- Update tests to flip the previously-pinned `ReadTimeout-is-non-transient` policy, add new coverage for the non-`ReadTimeout` timeout family, and extend `partition_errors` regression coverage.

## Motivation

Issue #1004 was auto-opened by the RPC Health Check workflow on the v0.5.0 release run because `GET_SUGGESTED_REPORTS (ciyUvf)` returned `ReadTimeout` on a single call. The same method has timed out / returned empty on prior runs (e.g. 2026-05-20) and consistently passes on retry. The very next RPC Health run on the same `release/v0.5.0` branch ([run 26349395697](https://github.com/teng-lin/notebooklm-py/actions/runs/26349395697)) passed all 39 methods, confirming the timeout was Google-side slowness rather than a contract change.

The workflow's issue-creation step keys off the same classification (`exit_code == 3`), so genuine non-transient findings still auto-open an issue — only single-run `ReadTimeout` flakes are now filtered out.

Closes #1004

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest tests/unit -q` (5405 passed)
- [x] Targeted: `uv run pytest tests/unit/test_check_rpc_health.py tests/unit/test_rpc_health_coverage.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RPC health checks now treat read timeout errors from RPC endpoints as transient (temporary) issues, improving exit-code accuracy and retry behavior.

* **Tests**
  * Updated and added tests to verify read timeouts are classified as transient and other timeout types remain non-transient to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->