### PR TITLE
refactor(error-injection): inject builder instead of dynamic-loading test fixture

### DIFF
--- a/src/notebooklm/_error_injection.py
+++ b/src/notebooklm/_error_injection.py
@@ -1,13 +1,24 @@
 """Synthetic HTTP error injection for VCR cassette playback (test-only).
 
 When ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to ``429`` / ``5xx`` /
-``expired_csrf``, :class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
-short-circuits each chain invocation with the synthetic response built
-by ``tests/cassette_patterns.py:build_synthetic_error_response`` so the
-client's exception-mapping branches (429 → ``RateLimitError``, 5xx →
-``ServerError``, 400-CSRF → ``AuthError``) fire end-to-end.
+``expired_csrf`` AND
+:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
+has been constructed with an injected ``builder`` callable (canonical:
+``tests/cassette_patterns.py:build_synthetic_error_response``), the
+middleware short-circuits each chain invocation with the synthetic
+response so the client's exception-mapping branches (429 →
+``RateLimitError``, 5xx → ``ServerError``, 400-CSRF → ``AuthError``) fire
+end-to-end.
 
-**Production behavior is unchanged when the env var is unset.** The
+**The env var is a no-op without an injected builder.** Production code
+(``MiddlewareChainBuilder`` in ``_middleware_chain.py``) instantiates
+``ErrorInjectionMiddleware()`` with no builder argument, so a leaked
+``NOTEBOOKLM_VCR_RECORD_ERRORS`` env var on a user install cannot trigger
+any synthetic substitution — the middleware passes through. Tests that
+exercise the substitution path construct the middleware directly with an
+explicit ``builder=`` argument (issue #1005).
+
+**Production behavior is also unchanged when the env var is unset.** The
 middleware delegates straight to ``next_call``; the chain leaf
 (``AuthedTransport.perform_authed_post``) runs exactly as it would
 without the middleware in the chain.
@@ -63,6 +74,15 @@ def _get_error_injection_mode() -> str | None:
     unrecognized value (we deliberately fail open rather than crash a
     cassette-recording run on a typo — the unit tests catch the typo path,
     and the VCR config validates the value separately).
+
+    Returning a non-``None`` mode does NOT by itself activate any synthetic
+    substitution: the production ``ErrorInjectionMiddleware`` is
+    constructed without a builder (see
+    :class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`),
+    which makes the middleware a pass-through regardless of this mode.
+    Tests that exercise the substitution wire a builder explicitly. Issue
+    #1005 closes the prior dynamic-load attack surface where a leaked env
+    var would trigger an ``importlib`` walk of ``tests/cassette_patterns.py``.
 
     The valid-mode set is hardcoded here (rather than imported from
     ``tests.cassette_patterns``) so production import time never reaches into

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -9,16 +9,28 @@ the interim 4-middleware chain ``[Drain, Metrics, ErrorInjection, Tracing]``;
 PRs 12.7–12.8 insert ``Retry`` and ``AuthRefresh`` BETWEEN ``Metrics`` and
 ``ErrorInjection`` so the ordering rationale holds at every step.
 
-Test-only path. Production behavior is unchanged when ``NOTEBOOKLM_VCR_RECORD_ERRORS``
-is unset — the middleware delegates straight to ``next_call``. When the env var
-resolves to ``"429"`` / ``"5xx"`` / ``"expired_csrf"`` (via
-:func:`_error_injection._get_error_injection_mode`), every chain invocation
-short-circuits with a synthetic :class:`httpx.Response` built by
-``tests/cassette_patterns.build_synthetic_error_response`` — the chain leaf
+Test-only path. Production behavior is unchanged when no builder is wired
+into the middleware — the constructor's default ``builder=None`` makes
+``__call__`` a pass-through even if ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set.
+Production code paths (``MiddlewareChainBuilder`` in ``_middleware_chain.py``)
+construct ``ErrorInjectionMiddleware()`` with no builder, so the substitution
+path can never fire from a production install. Tests that want the
+substitution to fire construct the middleware directly with an explicit
+``builder=`` argument (issue #1005 — replaces the previous filesystem-walking
+``_load_builder()`` that called ``importlib.util.spec_from_file_location`` on
+``tests/cassette_patterns.py`` at runtime, which broke wheel installs and
+exposed an arbitrary-code-exec path keyed off the env var).
+
+When a builder IS wired AND the env var resolves to ``"429"`` / ``"5xx"`` /
+``"expired_csrf"`` (via :func:`_error_injection._get_error_injection_mode`),
+every chain invocation short-circuits with a synthetic :class:`httpx.Response`
+built by the injected callable (canonical implementation:
+``tests/cassette_patterns.build_synthetic_error_response``) — the chain leaf
 (``_perform_authed_post``) is NOT called. The same env-var startup guard
 (:func:`_error_injection._refuse_synthetic_error_outside_test_context`)
 still fires at ``Session`` construction so a leaked deploy env never reaches
-this code path in production.
+``Session.__init__`` in production; the builder-not-wired default is the
+second line of defense closing the issue-#1005 attack surface.
 
 Tier-12 history: PR 12.6 lifted the substitution from the pre-Tier-12
 httpx transport (``_error_injection._SyntheticErrorTransport``,
@@ -28,17 +40,22 @@ middleware is now the only production substitution surface.
 
 Behavior contract:
 
-- Env var unset → ``await next_call(request)`` unchanged (pass-through).
-- Env var set, mode ``"429"`` → raise :class:`TransportRateLimited` so the
-  OUTER ``RetryMiddleware`` retries (restoring ADR-009 §"ErrorInjection
-  inside Retry — synthetic transient failures trigger retry"; codex iter-1
-  catch on PR 12.7). The raised exception carries the synthetic
-  ``Retry-After`` header so the retry honors the rate-limit timing.
-- Env var set, mode ``"5xx"`` → raise :class:`TransportServerError` so
-  ``RetryMiddleware`` retries with exponential backoff.
-- Env var set, mode ``"expired_csrf"`` (HTTP 400) → raise the raw
-  :class:`httpx.HTTPStatusError` so ``AuthRefreshMiddleware`` (outside
-  this middleware in the final chain ordering) catches it via
+- ``builder`` is ``None`` (production default) → ``await next_call(request)``
+  unchanged (pass-through), regardless of env var.
+- Env var unset → ``await next_call(request)`` unchanged (pass-through),
+  regardless of builder.
+- Env var set, builder wired, mode ``"429"`` → raise
+  :class:`TransportRateLimited` so the OUTER ``RetryMiddleware`` retries
+  (restoring ADR-009 §"ErrorInjection inside Retry — synthetic transient
+  failures trigger retry"; codex iter-1 catch on PR 12.7). The raised
+  exception carries the synthetic ``Retry-After`` header so the retry
+  honors the rate-limit timing.
+- Env var set, builder wired, mode ``"5xx"`` → raise
+  :class:`TransportServerError` so ``RetryMiddleware`` retries with
+  exponential backoff.
+- Env var set, builder wired, mode ``"expired_csrf"`` (HTTP 400) → raise
+  the raw :class:`httpx.HTTPStatusError` so ``AuthRefreshMiddleware``
+  (outside this middleware in the final chain ordering) catches it via
   ``is_auth_error`` and drives the refresh-then-retry flow. Pre-PR-12.6
   this happened naturally because the legacy ``_SyntheticErrorTransport``
   returned the synthetic 400 below httpx, the leaf's ``raise_for_status``
@@ -68,11 +85,8 @@ for the PR sequence.
 
 from __future__ import annotations
 
-import importlib.util
 import logging
 from collections.abc import Callable
-from pathlib import Path
-from typing import cast
 
 import httpx
 
@@ -101,14 +115,36 @@ class ErrorInjectionMiddleware:
     matches the Protocol so instances are assignable into a
     ``Sequence[Middleware]``.
 
-    Holds no shared state. The lazily-loaded synthetic-response builder is
-    cached on the instance after first activation so a long-running test
-    suite doesn't pay the ``importlib`` cost per chain call.
+    Holds no shared state. The synthetic-response builder is injected by
+    the caller (default ``None``); production wiring in
+    :class:`notebooklm._middleware_chain.MiddlewareChainBuilder` never
+    passes a builder, so the substitution path stays inaccessible from
+    installed packages. Tests pass an explicit builder (typically
+    ``tests.cassette_patterns.build_synthetic_error_response``) when they
+    want the substitution to fire.
+
+    Args:
+        builder: Optional callable that maps a mode string (``"429"`` /
+            ``"5xx"`` / ``"expired_csrf"``) to a
+            ``(status_code, body, headers)`` triple used to build the
+            synthetic :class:`httpx.Response`. When ``None`` (production
+            default), ``__call__`` is a pass-through even with the env var
+            set — this closes issue #1005's attack surface (a leaked env
+            var on a user install can no longer trigger any synthetic
+            substitution, because the production chain never injects a
+            builder).
     """
 
-    def __init__(self) -> None:
-        # Cached after first ``_load_builder`` call; ``None`` means "not yet loaded".
-        self._builder: _SyntheticBuilder | None = None
+    def __init__(self, builder: _SyntheticBuilder | None = None) -> None:
+        # Production default: no builder wired → middleware is a pass-through
+        # regardless of env var state. Tests that want substitution must pass
+        # ``builder=tests.cassette_patterns.build_synthetic_error_response``
+        # (or any compatible callable) explicitly. See module docstring and
+        # issue #1005 for the rationale (the prior implementation walked the
+        # filesystem at runtime to ``importlib``-load
+        # ``tests/cassette_patterns.py``, which broke wheel installs AND
+        # exposed an arbitrary-code-exec path keyed off the env var).
+        self._builder: _SyntheticBuilder | None = builder
         # Gates the one-shot "injection enabled" log line — preserves the
         # pre-PR-12.6 ``_session_lifecycle`` log signal that operators running
         # cassette-recording flows rely on to confirm their env var was picked up.
@@ -119,7 +155,7 @@ class ErrorInjectionMiddleware:
         request: RpcRequest,
         next_call: NextCall,
     ) -> RpcResponse:
-        """Substitute a synthetic error response when the env var is set.
+        """Substitute a synthetic error response when env var AND builder are set.
 
         Reads the env var via
         :func:`_error_injection._get_error_injection_mode` at call
@@ -131,9 +167,16 @@ class ErrorInjectionMiddleware:
         :func:`monkeypatch.setattr` seam live: a value-import would freeze
         the binding at module-load time and silently dead-letter any
         function swap.
+
+        Pass-through (``await next_call(request)``) happens when EITHER
+        gate is open:
+
+        - ``mode is None`` (env var unset / empty / unknown value), OR
+        - ``self._builder is None`` (no builder injected — production
+          default per issue #1005).
         """
         mode = _error_injection._get_error_injection_mode()
-        if mode is None:
+        if mode is None or self._builder is None:
             return await next_call(request)
 
         if not self._logged_activation:
@@ -145,7 +188,7 @@ class ErrorInjectionMiddleware:
             )
             self._logged_activation = True
 
-        status_code, body, headers = self._load_builder()(mode)
+        status_code, body, headers = self._builder(mode)
         # Anchor the synthetic response to the original method/URL/body/headers
         # so callers that inspect ``response.request`` see what the leaf would
         # have sent.
@@ -204,66 +247,6 @@ class ErrorInjectionMiddleware:
         # ``HTTPStatusError`` so ``AuthRefreshMiddleware`` can drive the
         # refresh-then-retry flow.
         raise original
-
-    def _load_builder(self) -> _SyntheticBuilder:
-        """Lazy importlib-load of ``tests.cassette_patterns.build_synthetic_error_response``.
-
-        Production code must not import from ``tests/`` at module load —
-        installed-package layouts don't ship ``tests/``. The env var that
-        gates this whole path is test-only, so this import only ever runs
-        in recording / unit-test contexts where ``tests/`` is on disk
-        relative to ``src/notebooklm/``.
-
-        This was previously duplicated in the (now-deleted)
-        ``_error_injection._SyntheticErrorTransport._load_builder``;
-        PR 12.9 removed that class so the chain middleware is the single
-        source of truth for synthetic-response loading.
-        """
-        if self._builder is not None:
-            return self._builder
-        # Search candidates in order:
-        # 1. ``tests/cassette_patterns.py`` under the test-process CWD — works
-        #    for wheel-installed smoke runs that invoke pytest from a checkout
-        #    where ``notebooklm`` lives in ``site-packages`` rather than
-        #    ``src/``.
-        # 2. ``src/notebooklm/_middleware_error_injection.py``'s grandparent —
-        #    the editable-install path used by ``uv sync`` development setups.
-        candidates = [
-            Path.cwd() / "tests" / "cassette_patterns.py",
-            Path(__file__).resolve().parent.parent.parent / "tests" / "cassette_patterns.py",
-        ]
-        target = next((c for c in candidates if c.exists()), candidates[-1])
-        if not target.exists():
-            raise RuntimeError(
-                f"{ERROR_INJECT_ENV_VAR} is set but tests/cassette_patterns.py "
-                f"is not available. Tried: {[str(c) for c in candidates]}. "
-                f"This plumbing is test-only — unset {ERROR_INJECT_ENV_VAR} "
-                f"to restore normal behavior."
-            )
-        spec = importlib.util.spec_from_file_location("_notebooklm_cassette_patterns", target)
-        # NOT ``assert`` — runtime invariant must survive ``python -O``.
-        if spec is None or spec.loader is None:
-            raise RuntimeError(
-                f"Failed to load module spec for {target}. "
-                f"Unset {ERROR_INJECT_ENV_VAR} to restore normal behavior."
-            )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        builder = getattr(mod, "build_synthetic_error_response", None)
-        if builder is None:
-            # Explicit guard so a renamed/removed symbol in
-            # tests/cassette_patterns.py surfaces with the same actionable
-            # remediation as the missing-file path above — without this,
-            # ``cast`` is type-only and the failure would be a bare
-            # ``AttributeError`` on the next call to ``builder(mode)``.
-            raise RuntimeError(
-                f"tests/cassette_patterns.py at {target} does not export "
-                f"``build_synthetic_error_response`` — the synthetic-error "
-                f"plumbing is misaligned. Unset {ERROR_INJECT_ENV_VAR} to "
-                f"restore normal behavior."
-            )
-        self._builder = cast(_SyntheticBuilder, builder)
-        return self._builder
 
 
 __all__ = ["ErrorInjectionMiddleware"]

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -171,12 +171,17 @@ class ErrorInjectionMiddleware:
         Pass-through (``await next_call(request)``) happens when EITHER
         gate is open:
 
-        - ``mode is None`` (env var unset / empty / unknown value), OR
         - ``self._builder is None`` (no builder injected — production
-          default per issue #1005).
+          default per issue #1005), OR
+        - ``mode is None`` (env var unset / empty / unknown value).
+
+        Builder is checked first to skip the env-var lookup on every RPC
+        in production (where ``self._builder`` is always ``None``).
         """
+        if self._builder is None:
+            return await next_call(request)
         mode = _error_injection._get_error_injection_mode()
-        if mode is None or self._builder is None:
+        if mode is None:
             return await next_call(request)
 
         if not self._logged_activation:

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -5,8 +5,12 @@ and ADR-009 §"Chain ordering":
 
 - **Pass-through when env var is unset.** The middleware delegates straight
   to ``next_call``; production behavior is byte-for-byte unchanged.
+- **Pass-through when no builder is wired (issue #1005).** Even with the
+  env var set to a valid mode, the production default ``builder=None``
+  makes ``__call__`` a pass-through. Tests that exercise substitution
+  must construct the middleware with an explicit ``builder=`` argument.
 - **Raise transport exceptions for 429 / 5xx (PR 12.7).** When the env var
-  resolves to ``"429"`` the middleware raises
+  resolves to ``"429"`` AND a builder is wired, the middleware raises
   :class:`TransportRateLimited` (carrying the synthetic ``Retry-After``);
   ``"5xx"`` raises :class:`TransportServerError`. This is the contract
   that lets the OUTER ``RetryMiddleware`` retry, restoring ADR-009
@@ -20,8 +24,6 @@ and ADR-009 §"Chain ordering":
   exception) has a ``response.request`` attached whose
   ``method`` / ``url`` / ``body`` mirror the incoming
   :class:`RpcRequest`.
-- **Builder cached on the instance** so a long-running test suite pays
-  the ``importlib`` cost exactly once per middleware.
 
 The tests use a real :class:`ErrorInjectionMiddleware` instance plus the
 canonical chain fixtures (``make_request`` and a one-shot terminal stub)
@@ -29,7 +31,11 @@ rather than mocking the substitution logic. Activation is flipped via
 :func:`monkeypatch.setenv` against ``NOTEBOOKLM_VCR_RECORD_ERRORS`` so the
 production env-var resolution code path
 (:func:`notebooklm._error_injection._get_error_injection_mode`) is
-exercised end-to-end.
+exercised end-to-end. Tests that need substitution to fire pass
+``builder=build_synthetic_error_response`` from
+``tests.cassette_patterns`` explicitly into the middleware constructor —
+that's the post-#1005 wiring that replaces the previous filesystem-load
+implementation.
 """
 
 from __future__ import annotations
@@ -40,6 +46,7 @@ import pytest
 # pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
+from cassette_patterns import build_synthetic_error_response
 from notebooklm._authed_transport import TransportRateLimited, TransportServerError
 from notebooklm._error_injection import ERROR_INJECT_ENV_VAR
 from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
@@ -139,7 +146,7 @@ async def test_429_mode_raises_transport_rate_limited(
     """
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
     terminal, calls = _recording_terminal()
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], terminal)
 
     with pytest.raises(TransportRateLimited) as excinfo:
@@ -159,7 +166,7 @@ async def test_429_response_carries_synthetic_request_url_and_body(
 ) -> None:
     """The synthetic ``httpx.Response.request`` mirrors the chain request."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
@@ -186,7 +193,7 @@ async def test_5xx_mode_raises_transport_server_error(
     """``5xx`` mode raises :class:`TransportServerError` for ``RetryMiddleware``."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
     terminal, calls = _recording_terminal()
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], terminal)
 
     with pytest.raises(TransportServerError) as excinfo:
@@ -221,7 +228,7 @@ async def test_expired_csrf_mode_raises_http_status_error(
     """
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
     terminal, calls = _recording_terminal()
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], terminal)
 
     with pytest.raises(httpx.HTTPStatusError) as excinfo:
@@ -239,7 +246,7 @@ async def test_expired_csrf_response_carries_synthetic_request_url(
     """The raised HTTPStatusError wraps a synthetic ``httpx.Response`` whose
     ``.request`` mirrors the chain envelope."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
@@ -276,7 +283,7 @@ async def test_retry_outside_error_injection_retries_synthetic_429(
     async def fake_sleep(seconds: float) -> None:
         slept.append(seconds)
 
-    error_injection = ErrorInjectionMiddleware()
+    error_injection = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     retry = RetryMiddleware(
         rate_limit_max_retries=2,
         server_error_max_retries=2,
@@ -308,7 +315,7 @@ async def test_retry_outside_error_injection_retries_synthetic_5xx(
     async def fake_sleep(seconds: float) -> None:
         slept.append(seconds)
 
-    error_injection = ErrorInjectionMiddleware()
+    error_injection = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     retry = RetryMiddleware(
         rate_limit_max_retries=2,
         server_error_max_retries=1,
@@ -368,7 +375,7 @@ async def test_auth_refresh_outside_error_injection_triggers_refresh_on_expired_
         refresh_callback_enabled=lambda: True,
         refresh_retry_delay=lambda: 0.0,
     )
-    error_injection = ErrorInjectionMiddleware()
+    error_injection = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain(
         [auth_refresh, error_injection],
         _static_terminal(httpx.Response(200, content=b"unreached-because-env-is-on")),
@@ -416,7 +423,7 @@ async def test_auth_refresh_outside_error_injection_completes_when_env_flips_off
         refresh_callback_enabled=lambda: True,
         refresh_retry_delay=lambda: 0.0,
     )
-    error_injection = ErrorInjectionMiddleware()
+    error_injection = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain(
         [auth_refresh, error_injection],
         _static_terminal(httpx.Response(200, content=b"after-refresh-success")),
@@ -430,28 +437,66 @@ async def test_auth_refresh_outside_error_injection_completes_when_env_flips_off
 
 
 # ---------------------------------------------------------------------------
-# Builder caching
+# Builder injection (issue #1005)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_builder_loaded_once_across_calls(
+async def test_default_constructor_has_no_builder_and_passes_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``_load_builder`` caches its result on the instance."""
+    """Default ``ErrorInjectionMiddleware()`` (no builder arg) is a pass-through.
+
+    Issue #1005 hardening: even with the env var set to a valid mode, a
+    middleware constructed without an injected builder must NOT short-circuit.
+    Production code (``MiddlewareChainBuilder``) constructs the middleware
+    this way, so this test pins the "leaked env var on a user install can
+    never trigger synthetic substitution" invariant.
+    """
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
-    middleware = ErrorInjectionMiddleware()
-    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()  # no builder → pass-through
 
     assert middleware._builder is None
-    with pytest.raises(TransportRateLimited):
-        await chain(make_request())
-    first = middleware._builder
-    assert first is not None
+    chain = build_chain([middleware], terminal)
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # Leaf was reached — middleware did NOT raise / short-circuit.
+    assert len(calls) == 1
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_explicit_builder_is_used_on_every_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The injected ``builder`` callable is invoked on every chain call.
+
+    Replaces the legacy ``_load_builder`` caching test: now the builder is
+    supplied at construction time so there's no lazy-load to cache. We
+    verify the SAME injected callable is what produces the synthetic
+    response on each call by counting invocations.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
+    invocations: list[str] = []
+
+    def counting_builder(mode: str) -> tuple[int, bytes, dict[str, str]]:
+        invocations.append(mode)
+        return build_synthetic_error_response(mode)
+
+    middleware = ErrorInjectionMiddleware(builder=counting_builder)
+    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     with pytest.raises(TransportRateLimited):
         await chain(make_request())
-    assert middleware._builder is first  # same object — no re-load
+    with pytest.raises(TransportRateLimited):
+        await chain(make_request())
+
+    # Injected builder was invoked on each chain call (the synthetic
+    # response object is built fresh per call — there's no instance cache
+    # of the response itself, only the builder is held).
+    assert invocations == ["429", "429"]
+    assert middleware._builder is counting_builder
 
 
 # ---------------------------------------------------------------------------
@@ -466,7 +511,7 @@ async def test_activation_flip_between_calls_is_observed(
     """Flipping the env var between two chain calls observes both modes."""
     monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
     terminal, calls = _recording_terminal()
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], terminal)
 
     # Call 1: pass-through, leaf reached.
@@ -514,7 +559,7 @@ async def test_monkeypatch_setattr_on_get_error_injection_mode_is_live(
     monkeypatch.setattr(_eim_module, "_get_error_injection_mode", lambda: "5xx")
 
     terminal, calls = _recording_terminal()
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], terminal)
 
     with pytest.raises(TransportServerError):
@@ -530,7 +575,7 @@ async def test_activation_log_fires_once_per_instance(
 ) -> None:
     """The "synthetic-error injection enabled" log line fires exactly once."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
-    middleware = ErrorInjectionMiddleware()
+    middleware = ErrorInjectionMiddleware(builder=build_synthetic_error_response)
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"x")))
 
     with caplog.at_level("INFO", logger="notebooklm._core"):


### PR DESCRIPTION
## Summary

Closes #1005.

`ErrorInjectionMiddleware._load_builder()` walked the filesystem at runtime to find `tests/cassette_patterns.py`, then used `importlib.util.spec_from_file_location(...)` + `spec.loader.exec_module(mod)` to dynamically execute it. The path-walking workaround landed in `67df2be` (v0.5.0 release, squashed into #998) papered over a TestPyPI wheel-install smoke failure — but the right fix is to inject the builder explicitly.

## Changes

- **`src/notebooklm/_middleware_error_injection.py`**: added `builder: _SyntheticBuilder | None = None` constructor arg; `__call__` is pass-through when `mode is None OR self._builder is None`; deleted `_load_builder()` and the entire `Path` / `importlib.util` / `exec_module` code path (~50 lines removed).
- **`src/notebooklm/_error_injection.py`**: tightened the module + `_get_mode` docstrings to note that the env var is a no-op without an injected builder.
- **`tests/unit/test_error_injection_middleware.py`**: tests that previously set `NOTEBOOKLM_VCR_RECORD_ERRORS` now also wire `builder=build_synthetic_error_response` from `tests.cassette_patterns` explicitly. New `test_default_constructor_has_no_builder_and_passes_through` pins the production-default safety invariant. The obsolete `_load_builder` caching test was replaced with one that verifies the injected builder is invoked per call.

## Why this is safer

Production code (`MiddlewareChainBuilder` in `_middleware_chain.py`) still constructs `ErrorInjectionMiddleware()` with no builder argument, so a leaked `NOTEBOOKLM_VCR_RECORD_ERRORS` env var on a user install cannot trigger any synthetic substitution — the middleware short-circuits to pass-through. The arbitrary-code-exec attack surface is closed entirely (a leaked env var no longer triggers an `importlib` walk of `tests/cassette_patterns.py`).

The startup guard `_refuse_synthetic_error_outside_test_context` in `_error_injection.py` remains as the first line of defense; the builder-not-wired default is the second.

ADR-009 chain ordering is unchanged: `[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]`.

## Test plan

- [x] `uv run pre-commit run --all-files` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest` — **6186 passed, 12 skipped** (full suite)
- [x] **Wheel-install smoke** (the failure mode that originally caught the install-layout dependency in #998's TestPyPI smoke): built the wheel with `uv build --wheel`, installed into a clean venv with only the wheel + test deps, ran `pytest tests/unit -q` — **5402 passed, 49 skipped**. This proves the refactor actually removes the install-layout dependency that 67df2be's CWD fallback was working around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified internal test-only error-injection plumbing; no changes to production behavior or user-facing functionality.
* **Tests**
  * Updated and expanded tests for synthetic error scenarios to use explicit builder wiring and to verify pass-through behavior when not injected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->