### PR TITLE
test: split slow audit checks behind 'repo_lint' marker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,25 @@ uv run pytest tests/integration
 uv run pytest tests/e2e -m e2e        # requires auth
 ```
 
+#### Fast local loop (skip repo-wide audit checks)
+
+A subset of unit tests are repo-wide audit / release-gate checks (cassette
+shape lint, public-surface scans, CI-script audits, doc-sync guards) that scan
+many files and add ~30–45s to the local `tests/unit tests/integration` loop.
+They're marked `@pytest.mark.repo_lint` so you can opt out while iterating:
+
+```bash
+# Fast feedback loop — drops repo_lint audits (~40s savings).
+uv run pytest tests/unit tests/integration -m "not repo_lint"
+
+# Run only the repo_lint audits (what you'd typically skip above).
+uv run pytest tests/unit tests/integration -m "repo_lint"
+```
+
+Run the full suite (including `repo_lint`) before pushing — CI runs everything
+by default, so `repo_lint` failures still block merge. The default
+`uv run pytest` invocation does not filter the marker out.
+
 Quick guidance:
 
 - Reach for `httpx_mock` when you need to assert on outgoing request shape (headers, body, cookies, URL) or stub a small response — put the test under `tests/unit/`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -295,6 +295,10 @@ lock sibling and the two invocations never contend.
 # Unit + integration tests (no auth needed)
 uv run pytest
 
+# Fast local loop — skip repo-wide audit / release-gate checks (~40s saved).
+# CI still runs these; the marker just lets you iterate quickly.
+uv run pytest tests/unit tests/integration -m "not repo_lint"
+
 # E2E tests (requires auth + test notebook)
 uv run pytest tests/e2e -m readonly        # Read-only tests only
 uv run pytest tests/e2e -m "not variants"  # Skip parameter variants
@@ -303,6 +307,12 @@ uv run pytest tests/e2e --include-variants # All tests including variants
 # Select a profile for E2E tests
 uv run pytest tests/e2e -m e2e --profile work
 ```
+
+The `repo_lint` marker tags cassette-shape lint, public-surface scans,
+docstring/install-doc drift guards, version-sync, and CI-script audits.
+These are valuable release/CI guardrails but cost ~30–45s locally. See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#fast-local-loop-skip-repo-wide-audit-checks)
+for the canonical fast-loop guidance.
 
 ### Selecting a profile for E2E tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ markers = [
     "no_keepalive_disable: opt a VCR test out of the global NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1 autouse fixture in tests/integration/conftest.py",
     "allow_no_vcr: opt a tests/integration/ test out of the integration-tree enforcement hook; use for mock-only tests that legitimately live under tests/integration/",
     "characterization: behavior-pinning unit tests that lock in current observable contracts and would be too synthetic to cassette-back",
+    "repo_lint: repo-wide audit/compat checks (cassette shapes, public surface, release gates, doc-sync, CI script audits). Slow; skip locally with `-m \"not repo_lint\"`. CI still runs them by default.",
 ]
 
 [tool.coverage.run]

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TESTS_DIR = REPO_ROOT / "tests"
 # ``tests/vcr_config.py`` lives directly under ``tests/`` (not in a package).

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -52,6 +52,8 @@ from urllib.parse import parse_qs, unquote, urlparse
 import pytest
 import yaml
 
+pytestmark = pytest.mark.repo_lint
+
 # Prefer libyaml for the cassette-shape lint. The top-level cassette set is
 # large enough that pure-Python SafeLoader dominates unit-suite runtime.
 try:

--- a/tests/unit/test_check_action_pinning.py
+++ b/tests/unit/test_check_action_pinning.py
@@ -28,6 +28,8 @@ from textwrap import dedent
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "check_action_pinning.py"
 

--- a/tests/unit/test_check_coverage_thresholds.py
+++ b/tests/unit/test_check_coverage_thresholds.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "check_coverage_thresholds.py"
 

--- a/tests/unit/test_check_workflow_secret_gates.py
+++ b/tests/unit/test_check_workflow_secret_gates.py
@@ -22,6 +22,8 @@ from textwrap import dedent
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "check_workflow_secret_gates.py"
 

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO_ROOT / "scripts"
 

--- a/tests/unit/test_ci_install_parity.py
+++ b/tests/unit/test_ci_install_parity.py
@@ -10,6 +10,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "check_ci_install_parity.py"
 

--- a/tests/unit/test_claude_md_freshness.py
+++ b/tests/unit/test_claude_md_freshness.py
@@ -1,10 +1,14 @@
 import os
 import sys
 
+import pytest
+
 # Add project root to sys.path so we can import scripts
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from scripts.check_claude_md_freshness import _extract_paths, main
+
+pytestmark = pytest.mark.repo_lint
 
 
 def test_extract_paths():

--- a/tests/unit/test_docstrings.py
+++ b/tests/unit/test_docstrings.py
@@ -30,6 +30,8 @@ from pytest_httpx import HTTPXMock
 
 from notebooklm.client import NotebookLMClient
 
+pytestmark = pytest.mark.repo_lint
+
 # Files whose docstrings should not contain the broken example. We parse
 # each file's AST and walk every docstring (module + class + function).
 DOCSTRING_TARGETS = [

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -23,6 +23,8 @@ from notebooklm._notes import NotesAPI
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 
+pytestmark = pytest.mark.repo_lint
+
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 
 # Feature APIs should not reach into Session private state directly.

--- a/tests/unit/test_install_docs.py
+++ b/tests/unit/test_install_docs.py
@@ -20,6 +20,8 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover -- only hit on Python 3.10
     import tomli as tomllib  # transitive via uv.lock; declared in [dev] for safety
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALLATION_MD = REPO_ROOT / "docs" / "installation.md"
 PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "audit_public_api_compat.py"
 

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+pytestmark = pytest.mark.repo_lint
+
 # ---------------------------------------------------------------------------
 # Documented public import manifest (stability spec)
 #

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -29,8 +29,12 @@ import ast
 import pathlib
 from functools import lru_cache
 
+import pytest
+
 import notebooklm.auth as auth_module
 import notebooklm.client as client_module
+
+pytestmark = pytest.mark.repo_lint
 
 # Repository root, derived from this test file's location:
 # tests/unit/test_public_surface.py -> parents[2] == repo root.

--- a/tests/unit/test_version_pyproject_sync.py
+++ b/tests/unit/test_version_pyproject_sync.py
@@ -15,7 +15,11 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - exercised on Python <3.11
     import tomli as tomllib
 
+import pytest
+
 import notebooklm
+
+pytestmark = pytest.mark.repo_lint
 
 
 def test_version_matches_pyproject() -> None:


### PR DESCRIPTION
## Summary

Add a `repo_lint` pytest marker so contributors can opt out of repo-wide
audit / release-gate tests during local iteration, without changing what
CI runs.

- Registered `repo_lint` in `pyproject.toml [tool.pytest.ini_options] markers`.
- Tagged 15 audit/compat modules with `pytestmark = pytest.mark.repo_lint`.
  These are the tests that scan many files (cassette shapes, public-surface
  scans, doc-sync guards) or test scripts under `scripts/` rather than
  `src/notebooklm/` behavior directly.
- Documented the fast loop in `CONTRIBUTING.md` (new "Fast local loop" subsection
  under "Test tiers") and added a pointer in `docs/development.md`.

CI is unchanged: `.github/workflows/test.yml` runs `uv run pytest --cov=...`
with no `-m` filter, so `repo_lint`-marked tests still execute and still
block merge on failure.

Closes #1001 (follow-up to #1003, which landed the mechanical perf fixes).

## Marker scope

Tests now flagged `repo_lint` (all from the issue's enumerated list, plus
the closely-aligned CI/audit-script and doc-freshness tests that match the
same intent):

- `tests/unit/test_cassette_shapes.py`
- `tests/unit/test_cassette_sanitizer.py`
- `tests/unit/test_public_surface.py`
- `tests/unit/test_public_shims.py`
- `tests/unit/test_public_api_compat_audit.py`
- `tests/unit/test_docstrings.py`
- `tests/unit/test_init_order.py`
- `tests/unit/test_install_docs.py`
- `tests/unit/test_version_pyproject_sync.py`
- `tests/unit/test_check_coverage_thresholds.py`
- `tests/unit/test_check_workflow_secret_gates.py`
- `tests/unit/test_check_action_pinning.py`
- `tests/unit/test_ci_audit_scripts.py`
- `tests/unit/test_ci_install_parity.py`
- `tests/unit/test_claude_md_freshness.py`

I deliberately did **not** mark architecture/boundary tests
(`test_cli_boundary.py`, `test_type_boundaries.py`, etc.) — they're fast
(<0.5s) and exercise real `src/` invariants worth seeing on every iteration.

## Before/After runtime (this branch, Python 3.12)

Measured with `/usr/bin/time` on the local checkout:

| Run                                                  | pytest time |
|------------------------------------------------------|-------------|
| `uv run pytest tests/unit tests/integration` (full)  |     119.90s |
| `... -m "not repo_lint"` (fast loop)                 |      79.72s |
| `... -m "repo_lint"` (the audits)                    |      38.80s |

Fast loop saves ~40s (~33%) on local iterations. Numbers add up
(79.72 + 38.80 ≈ 118.5s vs the 119.90s combined run) — the marker doesn't
add overhead.

Test counts:

- Full: 6131 passed, 12 skipped
- Fast loop: 5546 passed, 12 skipped, **585 deselected**
- repo_lint only: 585 passed

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → clean (165 files)
- [x] `uv run pre-commit run --all-files` → ruff format + check pass
- [x] `uv run pytest tests/unit tests/integration` → 6131 passed (full)
- [x] `uv run pytest tests/unit tests/integration -m "not repo_lint"` → 5546 passed
- [x] `uv run pytest tests/unit tests/integration -m "repo_lint"` → 585 passed
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "fast local loop" testing workflow to docs, showing how to run quick unit/integration checks and how to run the full repository audit suite.

* **Tests**
  * Introduced a repo-wide audit marker and applied it across audit/compatibility tests so those checks can be selectively skipped for faster local iteration while remaining enforced in CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->