### PR TITLE
refactor(architecture): remove facade backreferences

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import csv
+import json
 import logging
 import os
 import queue
-import sys
 import tempfile
 import threading
 from dataclasses import dataclass, field
@@ -17,6 +17,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ._artifact_formatters import _extract_app_data, _parse_data_table
+from .auth import load_httpx_cookies
 from .exceptions import ValidationError
 from .rpc import ArtifactTypeCode
 from .types import (
@@ -24,6 +26,7 @@ from .types import (
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
+    _extract_artifact_url,
 )
 
 if TYPE_CHECKING:
@@ -121,21 +124,8 @@ class DownloadResult:
         return bool(self.succeeded) and bool(self.failed)
 
 
-def _artifact_seams() -> Any:
-    """Return the facade module that legacy tests patch.
-
-    Download code deliberately resolves selected dependencies through
-    ``notebooklm._artifacts`` at call time so existing private monkeypatch
-    targets keep working after the extraction.
-    """
-    try:
-        return sys.modules["notebooklm._artifacts"]
-    except KeyError as e:
-        raise RuntimeError("notebooklm._artifacts must be imported before downloads run") from e
-
-
 def _load_httpx_cookies(storage_path: Any) -> Any:
-    return _artifact_seams().load_httpx_cookies(path=storage_path)
+    return load_httpx_cookies(path=storage_path)
 
 
 def _is_trusted_download_host(netloc: str) -> bool:
@@ -174,7 +164,7 @@ class ArtifactDownloadService:
             type_code=ArtifactTypeCode.AUDIO,
         )
 
-        url = _artifact_seams()._extract_artifact_url(audio_art, ArtifactTypeCode.AUDIO.value)
+        url = _extract_artifact_url(audio_art, ArtifactTypeCode.AUDIO.value)
         if not url:
             raise ArtifactParseError(
                 "audio",
@@ -202,7 +192,7 @@ class ArtifactDownloadService:
             type_code=ArtifactTypeCode.VIDEO,
         )
 
-        url = _artifact_seams()._extract_artifact_url(video_art, ArtifactTypeCode.VIDEO.value)
+        url = _extract_artifact_url(video_art, ArtifactTypeCode.VIDEO.value)
         if not url:
             raise ArtifactParseError(
                 "video_artifact",
@@ -228,9 +218,7 @@ class ArtifactDownloadService:
         )
 
         try:
-            url = _artifact_seams()._extract_artifact_url(
-                info_art, ArtifactTypeCode.INFOGRAPHIC.value
-            )
+            url = _extract_artifact_url(info_art, ArtifactTypeCode.INFOGRAPHIC.value)
             if not url:
                 raise ArtifactParseError("infographic", details="Could not find metadata")
             return await methods._download_url(url, output_path)
@@ -337,10 +325,9 @@ class ArtifactDownloadService:
         if not html_content:
             raise ArtifactDownloadError(artifact_type, details="Failed to fetch content")
 
-        json_module = _artifact_seams().json
         try:
-            app_data = _artifact_seams()._extract_app_data(html_content)
-        except (ValueError, json_module.JSONDecodeError) as e:
+            app_data = _extract_app_data(html_content)
+        except (ValueError, json.JSONDecodeError) as e:
             raise ArtifactParseError(
                 artifact_type, details=f"Failed to parse content: {e}", cause=e
             ) from e
@@ -422,25 +409,24 @@ class ArtifactDownloadService:
         else:
             mind_map = mind_maps[0]
 
-        json_module = _artifact_seams().json
         try:
             json_string = mind_maps_service.extract_content(mind_map)
             if json_string is None:
                 raise ArtifactParseError("mind_map_content", details="Invalid structure")
 
-            json_data = json_module.loads(json_string)
+            json_data = json.loads(json_string)
 
             output = Path(output_path)
             output.parent.mkdir(parents=True, exist_ok=True)
 
             def _write_json() -> None:
                 with output.open("w", encoding="utf-8") as f:
-                    _artifact_seams().json.dump(json_data, f, indent=2, ensure_ascii=False)
+                    json.dump(json_data, f, indent=2, ensure_ascii=False)
 
             await asyncio.to_thread(_write_json)
             return str(output)
 
-        except (IndexError, TypeError, json_module.JSONDecodeError) as e:
+        except (IndexError, TypeError, json.JSONDecodeError) as e:
             raise ArtifactParseError(
                 "mind_map", details=f"Failed to parse structure: {e}", cause=e
             ) from e
@@ -467,7 +453,7 @@ class ArtifactDownloadService:
 
         try:
             raw_data = table_art[18]
-            headers, rows = _artifact_seams()._parse_data_table(raw_data)
+            headers, rows = _parse_data_table(raw_data)
 
             output = Path(output_path)
             output.parent.mkdir(parents=True, exist_ok=True)

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -327,7 +327,7 @@ class ArtifactDownloadService:
 
         try:
             app_data = _extract_app_data(html_content)
-        except (ValueError, json.JSONDecodeError) as e:
+        except json.JSONDecodeError as e:
             raise ArtifactParseError(
                 artifact_type, details=f"Failed to parse content: {e}", cause=e
             ) from e

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -31,7 +31,7 @@ from .rpc import (
 from .types import GenerationStatus, ReportSuggestion
 
 if TYPE_CHECKING:
-    from ._artifacts import ArtifactsRuntime, _ArtifactsServiceMethods
+    from ._artifacts import ArtifactsRuntime
     from ._note_service import NoteService
     from ._notebook_metadata import NotebookSourceIdProvider
 
@@ -45,12 +45,10 @@ class ArtifactGenerationService:
         self,
         *,
         runtime: ArtifactsRuntime,
-        methods: _ArtifactsServiceMethods,
         notebooks: NotebookSourceIdProvider,
         note_service: NoteService,
     ) -> None:
         self._runtime = runtime
-        self._methods = methods
         self._notebooks = notebooks
         self._note_service = note_service
 
@@ -99,7 +97,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_video(
         self,
@@ -161,7 +159,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_cinematic_video(
         self,
@@ -204,7 +202,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_report(
         self,
@@ -289,7 +287,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_study_guide(
         self,
@@ -301,9 +299,7 @@ class ArtifactGenerationService:
         """Generate a study guide report."""
         if language is None:
             language = get_default_language()
-        # Preserve the historical facade seam for callers/tests that patch
-        # ArtifactsAPI.generate_report.
-        return await self._methods.generate_report(
+        return await self.generate_report(
             notebook_id,
             report_format=ReportFormat.STUDY_GUIDE,
             source_ids=source_ids,
@@ -355,7 +351,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_flashcards(
         self,
@@ -400,7 +396,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_infographic(
         self,
@@ -444,7 +440,7 @@ class ArtifactGenerationService:
                 [[instructions, language, None, orientation_code, detail_code, style_code]],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_slide_deck(
         self,
@@ -488,7 +484,7 @@ class ArtifactGenerationService:
                 [[instructions, language, format_code, length_code]],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def revise_slide(
         self,
@@ -524,11 +520,7 @@ class ArtifactGenerationService:
             raise
         if result is None:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
-        # Call through the facade so patches on ArtifactsAPI._parse_generation_result
-        # remain effective after extraction.
-        return self._methods._parse_generation_result(
-            result, method_id=RPCMethod.REVISE_SLIDE.value
-        )
+        return self.parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
 
     async def generate_data_table(
         self,
@@ -570,7 +562,7 @@ class ArtifactGenerationService:
                 [None, [instructions, language]],
             ],
         ]
-        return await self._methods._call_generate(notebook_id, params)
+        return await self.call_generate(notebook_id, params)
 
     async def generate_mind_map(
         self,
@@ -708,11 +700,7 @@ class ArtifactGenerationService:
                     error_code=str(e.rpc_code) if e.rpc_code is not None else None,
                 )
             raise
-        # Call through the facade so patches on ArtifactsAPI._parse_generation_result
-        # remain effective after extraction.
-        return self._methods._parse_generation_result(
-            result, method_id=RPCMethod.CREATE_ARTIFACT.value
-        )
+        return self.parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
     def parse_generation_result(
         self,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -6,18 +6,16 @@ Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 """
 
 import builtins
-import json
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Protocol
 
-# ``_mind_map`` is re-exported as ``_artifacts._mind_map`` so legacy
-# patch seams (``test_init_order.test_phase7_artifact_mind_map_patch_seams_are_current``)
-# can still resolve the module via the artifacts facade. The runtime
-# code path in this module talks to the injected
-# ``NoteBackedMindMapService`` / ``NoteService`` instances; the bare
-# module re-export is for monkeypatch convenience only.
+# ``_mind_map`` is re-exported as ``_artifacts._mind_map`` so legacy patch
+# seams can still resolve the module via the artifacts facade. The runtime code
+# path in this module talks to the injected ``NoteBackedMindMapService`` /
+# ``NoteService`` instances; the bare module re-export is for monkeypatch
+# convenience only.
 from . import (
     _artifact_formatters,
     _artifact_polling,
@@ -31,7 +29,6 @@ from ._note_service import NoteService
 from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
 from ._session_contracts import AsyncWorkRuntime, RpcCaller
-from .auth import load_httpx_cookies
 from .rpc import (
     ArtifactTypeCode,
     AudioFormat,
@@ -64,18 +61,16 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-# Private compatibility exports. Tests and downstream code patch these names
-# through ``notebooklm._artifacts`` even though download implementation now
-# lives in ``_artifact_downloads``.
-_DOWNLOAD_COMPAT_EXPORTS = (
+# Private compatibility exports that remain intentionally available through
+# ``notebooklm._artifacts``. Downloads no longer patch through this module, but
+# a few whitebox tests and downstream users still import these private names.
+_ARTIFACT_COMPAT_EXPORTS = (
     DownloadResult,
     ArtifactDownloadError,
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
     _extract_artifact_url,
-    json,
-    load_httpx_cookies,
 )
 
 
@@ -162,61 +157,16 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
 
 
 class _ArtifactsServiceMethods(Protocol):
-    """Narrow ``ArtifactsAPI`` **method-call** surface that helper services depend on.
+    """Narrow ``ArtifactsAPI`` method-call surface used by artifact downloads.
 
-    Artifact service helpers (:class:`ArtifactDownloadService` and
-    :class:`ArtifactGenerationService`) accept an ``ArtifactsAPI`` instance
-    via constructor injection (the ``methods=`` kw-arg) for back-references
-    into selection / RPC / formatting flows. The helpers type that argument
-    as ``_ArtifactsServiceMethods`` rather than the full concrete
-    ``ArtifactsAPI`` — pinning the dependency surface to a documented
-    subset and supporting the AST guard pinned by
-    ``test_artifact_services_have_no_facade_reach_in`` in
-    ``tests/unit/test_init_order.py``.
+    ``ArtifactDownloadService`` accepts an ``ArtifactsAPI`` instance via
+    constructor injection (the ``methods=`` kw-arg) for listing, selection,
+    download, and interactive-formatting flows. The helper types that
+    argument as ``_ArtifactsServiceMethods`` rather than the full concrete
+    ``ArtifactsAPI`` so the private collaboration surface stays explicit.
 
-    The migration that introduced this Protocol shipped in three PRs:
-
-      * `#891 <https://github.com/teng-lin/notebooklm-py/pull/891>`_ (T1)
-        introduced the Protocol declaration.
-      * `#896 <https://github.com/teng-lin/notebooklm-py/pull/896>`_ (T2)
-        migrated ``ArtifactDownloadService`` to constructor injection.
-      * `#910 <https://github.com/teng-lin/notebooklm-py/pull/910>`_ (T3)
-        migrated ``ArtifactGenerationService`` and closed the reverse
-        facade-into-service reach by promoting the service-side
-        ``_call_generate`` / ``_parse_generation_result`` methods.
-
-    Both helpers are now fully migrated; no further migration PRs in this
-    series are pending.
-
-    **Scope (intentionally narrow).** This Protocol covers method calls
-    only. The four *collaborator objects* the helpers depend on —
-    ``_notebooks`` (``NotebookSourceIdProvider``), ``_runtime``
-    (``ArtifactsRuntime``), ``_note_service`` (``NoteService``), and
-    ``_mind_maps`` (``NoteBackedMindMapService``) — are deliberately
-    **not** declared here. They were eliminated as reach-throughs by
-    injecting each collaborator as a separate constructor argument on the
-    helper service (mirroring how :class:`ArtifactsAPI.__init__` already
-    takes them), rather than by widening this Protocol. The reach-in
-    guard catches any residual ``api._notebooks`` / ``api._runtime`` /
-    ``api._note_service`` / ``api._mind_maps`` access as a violation, so
-    any future re-introduction of a coupling here would have to do
-    constructor injection rather than smuggle the dependency through a
-    wider Protocol.
-
-    The underscore-prefixed members are deliberate: this Protocol describes
-    a private collaboration contract between ``ArtifactsAPI`` and its own
-    helper services. ``RpcOwner`` in :mod:`notebooklm._rpc_executor`
-    (see ``docs/architecture.md`` § RpcExecutor) is the established
-    precedent — a Protocol that declares the underscore-prefixed methods
-    a sibling collaborator legitimately calls. See also
-    :class:`DrainHookRegistration` above for the local docstring pattern.
-
-    The three public members (``list_quizzes``, ``list_flashcards``,
-    ``generate_report``) are not new contract — they preserve the documented
-    monkeypatch seam ``ArtifactsAPI.generate_report`` referenced from
-    ``_artifact_generation.py`` (search for "Preserve the historical facade
-    seam") and the two ``list_*`` shapes used by interactive-artifact
-    formatting.
+    Generation no longer depends on this facade-shaped method bag; it owns
+    its RPC call and parser paths directly inside ``ArtifactGenerationService``.
     """
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]: ...
@@ -244,31 +194,9 @@ class _ArtifactsServiceMethods(Protocol):
         is_quiz: bool,
     ) -> str: ...
 
-    async def _call_generate(
-        self, notebook_id: str, params: builtins.list[Any]
-    ) -> GenerationStatus: ...
-
-    def _parse_generation_result(
-        self,
-        result: Any,
-        *,
-        method_id: str,
-        source: str = "_parse_generation_result",
-    ) -> GenerationStatus: ...
-
     async def list_quizzes(self, notebook_id: str) -> builtins.list[Artifact]: ...
 
     async def list_flashcards(self, notebook_id: str) -> builtins.list[Artifact]: ...
-
-    async def generate_report(
-        self,
-        notebook_id: str,
-        report_format: ReportFormat = ReportFormat.BRIEFING_DOC,
-        source_ids: builtins.list[str] | None = None,
-        language: str | None = "en",
-        custom_prompt: str | None = None,
-        extra_instructions: str | None = None,
-    ) -> GenerationStatus: ...
 
 
 class ArtifactsAPI:
@@ -329,7 +257,6 @@ class ArtifactsAPI:
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(
             runtime=self._runtime,
-            methods=self,
             notebooks=self._notebooks,
             note_service=self._note_service,
         )

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import mimetypes
 import os
 import re
@@ -29,6 +30,8 @@ from ._session_contracts import (
     OperationScopeProvider,
     RpcCaller,
 )
+from ._source_listing import SourceLister
+from ._source_polling import SourcePoller
 from .auth import authuser_query, format_authuser_value
 from .exceptions import (
     AuthError,
@@ -93,6 +96,9 @@ class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
 _INVALID_ARGUMENT_RPC_CODE = 3
 _SOURCE_LIMIT_HINT_FLOOR = 50
 _TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
+# Preserve the historical ``notebooklm._sources`` log channel after moving
+# upload choreography into this module.
+module_logger = logging.getLogger("notebooklm").getChild("_sources")
 
 
 async def _build_invalid_argument_source_limit_hint(
@@ -145,58 +151,6 @@ async def _build_invalid_argument_source_limit_hint(
         )
 
     return ""
-
-
-class RegisterFileSource(Protocol):
-    """Late-bound facade hook for file-source registration."""
-
-    async def __call__(self, notebook_id: str, filename: str) -> str: ...
-
-
-class StartResumableUpload(Protocol):
-    """Late-bound facade hook for upload-session start."""
-
-    async def __call__(
-        self,
-        notebook_id: str,
-        filename: str,
-        file_size: int,
-        source_id: str,
-        content_type: str,
-    ) -> str: ...
-
-
-class UploadFileStreaming(Protocol):
-    """Late-bound facade hook for streaming upload finalize."""
-
-    async def __call__(
-        self,
-        upload_url: str,
-        file_obj: IO[bytes] | Path,
-        *,
-        filename: str | None = None,
-        on_progress: Callable[[int, int], object] | None = None,
-        total_bytes: int | None = None,
-    ) -> None: ...
-
-
-class WaitForSource(Protocol):
-    """Wait helper used after upload registration."""
-
-    async def __call__(
-        self,
-        notebook_id: str,
-        source_id: str,
-        timeout: float = 120.0,
-        *,
-        transient_error_types: tuple[int | None, ...] | None = None,
-    ) -> Source: ...
-
-
-class RenameSource(Protocol):
-    """Source rename callback shape."""
-
-    async def __call__(self, notebook_id: str, source_id: str, new_title: str) -> Source: ...
 
 
 class AsyncClientFactory(Protocol):
@@ -319,6 +273,7 @@ class SourceUploadPipeline:
         *,
         record_upload_queue_wait: QueueWaitRecorder | None = None,
         async_client_factory: AsyncClientFactory | None = None,
+        get_source_limit: GetSourceLimit | None = None,
     ):
         self._runtime = runtime
         self._kernel = kernel
@@ -328,6 +283,13 @@ class SourceUploadPipeline:
         self._async_client_factory = async_client_factory
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
+        self._lister = SourceLister(self._runtime.rpc_call)
+        self._poller = SourcePoller()
+        self._get_source_limit = get_source_limit
+
+    def configure_source_limit_lookup(self, get_source_limit: GetSourceLimit | None) -> None:
+        """Set the optional source-limit lookup used in registration hints."""
+        self._get_source_limit = get_source_limit
 
     def _resolve_upload_timeout(self, default: httpx.Timeout) -> httpx.Timeout:
         """Return the configured upload timeout, or ``default`` if unset."""
@@ -377,13 +339,6 @@ class SourceUploadPipeline:
         title: str | None = None,
         on_progress: Callable[[int, int], object] | None = None,
         upload_index: int = 0,
-        register_file_source: RegisterFileSource,
-        start_resumable_upload: StartResumableUpload,
-        upload_file_streaming: UploadFileStreaming,
-        wait_until_ready: WaitForSource,
-        wait_until_registered: WaitForSource,
-        rename: RenameSource,
-        logger: Any,
     ) -> Source:
         """Add a file source to a notebook using resumable upload."""
         # Audit C1: catch cross-loop add_file *before* touching
@@ -392,7 +347,7 @@ class SourceUploadPipeline:
         # otherwise attach a primitive to the wrong loop before the
         # documented ``RuntimeError`` guard fires (ADR-004).
         self._runtime.assert_bound_loop()
-        logger.debug("Adding file source to notebook %s: %s", notebook_id, file_path)
+        module_logger.debug("Adding file source to notebook %s: %s", notebook_id, file_path)
         if title is not None:
             title = title.strip()
             if not title:
@@ -443,8 +398,8 @@ class SourceUploadPipeline:
                 file_obj, file_size = await asyncio.to_thread(_open_and_stat, file_path)
                 handed_off = False
                 try:
-                    source_id = await register_file_source(notebook_id, filename)
-                    upload_url = await start_resumable_upload(
+                    source_id = await self.register_file_source(notebook_id, filename)
+                    upload_url = await self.start_resumable_upload(
                         notebook_id,
                         filename,
                         file_size,
@@ -452,7 +407,7 @@ class SourceUploadPipeline:
                         content_type,
                     )
                     handed_off = True
-                    await upload_file_streaming(
+                    await self.upload_file_streaming(
                         upload_url,
                         file_obj,
                         filename=filename,
@@ -465,14 +420,14 @@ class SourceUploadPipeline:
 
         needs_title_rename = title is not None and title != filename
         if wait:
-            source = await wait_until_ready(
+            source = await self.wait_until_ready(
                 notebook_id,
                 source_id,
                 timeout=wait_timeout,
                 transient_error_types=transient_error_types,
             )
         elif needs_title_rename:
-            source = await wait_until_registered(
+            source = await self.wait_until_registered(
                 notebook_id,
                 source_id,
                 timeout=wait_timeout,
@@ -489,10 +444,10 @@ class SourceUploadPipeline:
         if needs_title_rename:
             try:
                 assert title is not None
-                renamed = await rename(notebook_id, source_id, title)
+                renamed = await self.rename(notebook_id, source_id, title)
                 source = replace(source, title=renamed.title or title)
             except (RPCError, NetworkError):
-                logger.warning(
+                module_logger.warning(
                     "Source %s uploaded but rename to %r failed",
                     source_id,
                     title,
@@ -506,8 +461,8 @@ class SourceUploadPipeline:
         notebook_id: str,
         filename: str,
         *,
-        list_sources: ListSources,
-        logger: Any,
+        list_sources: ListSources | None = None,
+        logger: Any | None = None,
         get_source_limit: GetSourceLimit | None = None,
         rpc_call: RpcCallback | None = None,
     ) -> str:
@@ -536,7 +491,14 @@ class SourceUploadPipeline:
             [2],
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
-        rpc_call = rpc_call or self._runtime.rpc_call
+        if rpc_call is None:
+            rpc_call = self._runtime.rpc_call
+        if list_sources is None:
+            list_sources = self.list_sources
+        if logger is None:
+            logger = module_logger
+        if get_source_limit is None:
+            get_source_limit = self._get_source_limit
 
         # Capture baseline source IDs before the first create attempt so the
         # probe can distinguish "this upload landed" from "a same-named source
@@ -677,6 +639,80 @@ class SourceUploadPipeline:
             label=f"sources.register_file_source[{filename}]",
         )
 
+    async def list_sources(self, notebook_id: str) -> list[Source]:
+        """List notebook sources for upload idempotency and polling."""
+        return await self._lister.list(notebook_id)
+
+    async def get_source(self, notebook_id: str, source_id: str) -> Source | None:
+        """Get a source row by ID using the upload pipeline's lister."""
+        return await self._lister.get(
+            notebook_id,
+            source_id,
+            list_sources=self.list_sources,
+        )
+
+    async def wait_until_ready(
+        self,
+        notebook_id: str,
+        source_id: str,
+        timeout: float = 120.0,
+        initial_interval: float = 1.0,
+        max_interval: float = 10.0,
+        backoff_factor: float = 1.5,
+        transient_error_types: tuple[int | None, ...] | None = None,
+    ) -> Source:
+        """Wait for a source to become ready after upload."""
+        return await self._poller.wait_until_ready(
+            notebook_id,
+            source_id,
+            timeout=timeout,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+            backoff_factor=backoff_factor,
+            transient_error_types=transient_error_types,
+            get_source=self.get_source,
+            sleep=asyncio.sleep,
+            monotonic=monotonic,
+            logger=module_logger,
+        )
+
+    async def wait_until_registered(
+        self,
+        notebook_id: str,
+        source_id: str,
+        timeout: float = 30.0,
+        initial_interval: float = 0.5,
+        max_interval: float = 5.0,
+        backoff_factor: float = 1.5,
+        transient_error_types: tuple[int | None, ...] | None = None,
+    ) -> Source:
+        """Wait until an uploaded source is registered server-side."""
+        return await self._poller.wait_until_registered(
+            notebook_id,
+            source_id,
+            timeout=timeout,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+            backoff_factor=backoff_factor,
+            transient_error_types=transient_error_types,
+            get_source=self.get_source,
+            sleep=asyncio.sleep,
+            monotonic=monotonic,
+            logger=module_logger,
+        )
+
+    async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source:
+        """Rename an uploaded source."""
+        module_logger.debug("Renaming source %s to: %s", source_id, new_title)
+        params = [None, [source_id], [[[new_title]]]]
+        result = await self._runtime.rpc_call(
+            RPCMethod.UPDATE_SOURCE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        return Source.from_api_response(result) if result else Source(id=source_id, title=new_title)
+
     async def start_resumable_upload(
         self,
         notebook_id: str,
@@ -733,9 +769,11 @@ class SourceUploadPipeline:
         filename: str | None = None,
         on_progress: Callable[[int, int], object] | None = None,
         total_bytes: int | None = None,
-        logger: Any,
+        logger: Any | None = None,
     ) -> None:
         """Stream upload file content to the resumable upload URL."""
+        if logger is None:
+            logger = module_logger
         path_fallback: Path | None = file_obj if isinstance(file_obj, Path) else None
         close_wired = False
         try:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -149,6 +149,7 @@ class SourcesAPI:
         self._upload_timeout = upload_timeout
         self._max_concurrent_uploads = max_concurrent_uploads
         self._uploader = uploader
+        self._uploader.configure_source_limit_lookup(self._get_source_limit)
 
     async def _rpc_call(
         self,
@@ -555,13 +556,6 @@ class SourcesAPI:
             wait_timeout=wait_timeout,
             title=title,
             on_progress=on_progress,
-            register_file_source=self._register_file_source,
-            start_resumable_upload=self._start_resumable_upload,
-            upload_file_streaming=self._upload_file_streaming,
-            wait_until_ready=self.wait_until_ready,
-            wait_until_registered=self.wait_until_registered,
-            rename=self.rename,
-            logger=logger,
         )
 
     async def add_drive(
@@ -877,9 +871,6 @@ class SourcesAPI:
         return await self._uploader.register_file_source(
             notebook_id,
             filename,
-            list_sources=self.list,
-            get_source_limit=self._get_source_limit,
-            logger=logger,
         )
 
     async def _get_source_limit(self) -> int | None:

--- a/tests/integration/concurrency/test_add_file_toctou.py
+++ b/tests/integration/concurrency/test_add_file_toctou.py
@@ -147,18 +147,18 @@ async def test_add_file_holds_validated_fd_across_swap(
     async with NotebookLMClient(auth_tokens) as client:
         with (
             patch.object(
-                client.sources,
-                "_register_file_source",
+                client.sources._uploader,
+                "register_file_source",
                 side_effect=stub_register,
             ),
             patch.object(
-                client.sources,
-                "_start_resumable_upload",
+                client.sources._uploader,
+                "start_resumable_upload",
                 side_effect=stub_start_upload,
             ),
             patch.object(
-                client.sources,
-                "_upload_file_streaming",
+                client.sources._uploader,
+                "upload_file_streaming",
                 side_effect=stub_streaming,
             ),
         ):
@@ -284,18 +284,18 @@ async def test_add_file_bounds_concurrent_open_fds(
     async with NotebookLMClient(auth_tokens, max_concurrent_uploads=max_uploads) as client:
         with (
             patch.object(
-                client.sources,
-                "_register_file_source",
+                client.sources._uploader,
+                "register_file_source",
                 side_effect=stub_register,
             ),
             patch.object(
-                client.sources,
-                "_start_resumable_upload",
+                client.sources._uploader,
+                "start_resumable_upload",
                 side_effect=stub_start,
             ),
             patch.object(
-                client.sources,
-                "_upload_file_streaming",
+                client.sources._uploader,
+                "upload_file_streaming",
                 side_effect=stub_streaming,
             ),
             patch.object(builtins, "open", counting_open),
@@ -365,8 +365,8 @@ async def test_add_file_missing_path_raises_clear_error(
 
     async with NotebookLMClient(auth_tokens) as client:
         with patch.object(
-            client.sources,
-            "_register_file_source",
+            client.sources._uploader,
+            "register_file_source",
             side_effect=stub_register,
         ):
             with pytest.raises(FileNotFoundError):
@@ -426,9 +426,15 @@ async def test_add_file_transfers_fd_ownership_to_streaming_helper(
 
     async with NotebookLMClient(auth_tokens) as client:
         with (
-            patch.object(client.sources, "_register_file_source", side_effect=stub_register),
-            patch.object(client.sources, "_start_resumable_upload", side_effect=stub_start),
-            patch.object(client.sources, "_upload_file_streaming", side_effect=stub_streaming),
+            patch.object(
+                client.sources._uploader, "register_file_source", side_effect=stub_register
+            ),
+            patch.object(
+                client.sources._uploader, "start_resumable_upload", side_effect=stub_start
+            ),
+            patch.object(
+                client.sources._uploader, "upload_file_streaming", side_effect=stub_streaming
+            ),
         ):
             await client.sources.add_file("nb_123", file_path)
 
@@ -487,7 +493,9 @@ async def test_add_file_closes_fd_when_registration_fails(
     async with NotebookLMClient(auth_tokens) as client:
         with (
             patch.object(builtins, "open", capturing_open),
-            patch.object(client.sources, "_register_file_source", side_effect=failing_register),
+            patch.object(
+                client.sources._uploader, "register_file_source", side_effect=failing_register
+            ),
         ):
             with pytest.raises(_RegistrationError):
                 await client.sources.add_file("nb_123", file_path)

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -201,7 +201,7 @@ async def test_download_mind_map_runs_write_off_loop_thread(
     ``Path.write_text`` would silently miss the production ``json.dump``
     path.
     """
-    import notebooklm._artifacts as artifacts_module
+    import notebooklm._artifact_downloads as artifact_downloads
 
     api, _ = mock_artifacts_api
     output_path = tmp_path / "mindmap.json"
@@ -239,9 +239,9 @@ async def test_download_mind_map_runs_write_off_loop_thread(
             "list_mind_maps",
             new=AsyncMock(return_value=mind_map_rows),
         ),
-        # Patch the `json` module as imported by `_artifacts` so the
+        # Patch the `json` module as imported by `_artifact_downloads` so the
         # closure inside `download_mind_map` resolves to the stub.
-        patch.object(artifacts_module.json, "dump", recording_json_dump),
+        patch.object(artifact_downloads.json, "dump", recording_json_dump),
         # Cover the legacy ``Path.write_text``-based path too so a
         # rewrite either direction is caught by this test.
         patch.object(Path, "write_text", recording_write_text),
@@ -278,7 +278,7 @@ async def test_concurrent_downloads_both_offload_writes(
     thread. A regression on either path leaves its capture matching the
     loop thread and fails the assertion.
     """
-    import notebooklm._artifacts as artifacts_module
+    import notebooklm._artifact_downloads as artifact_downloads
 
     api, _ = mock_artifacts_api
     report_path = tmp_path / "report.md"
@@ -328,7 +328,7 @@ async def test_concurrent_downloads_both_offload_writes(
             new=AsyncMock(return_value=mind_map_rows),
         ),
         patch.object(Path, "write_text", recording_write_text),
-        patch.object(artifacts_module.json, "dump", recording_json_dump),
+        patch.object(artifact_downloads.json, "dump", recording_json_dump),
     ):
         mock_list.return_value = report_artifact_list
         report_result, mindmap_result = await asyncio.gather(
@@ -377,7 +377,7 @@ async def test_download_urls_batch_cookie_load_runs_off_loop_thread(
         return {}
 
     with patch(
-        "notebooklm._artifacts.load_httpx_cookies",
+        "notebooklm._artifact_downloads.load_httpx_cookies",
         new=recording_load_httpx_cookies,
     ):
         result = await api._download_urls_batch([])
@@ -431,7 +431,7 @@ async def test_download_url_cookie_load_runs_off_loop_thread(
 
     with (
         patch(
-            "notebooklm._artifacts.load_httpx_cookies",
+            "notebooklm._artifact_downloads.load_httpx_cookies",
             new=recording_load_httpx_cookies,
         ),
         pytest.raises(ArtifactDownloadError),
@@ -569,7 +569,7 @@ async def test_download_url_uses_single_writer_thread_for_all_chunks(
 
     with (
         patch.object(real_httpx, "AsyncClient", return_value=mock_client),
-        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+        patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value=MagicMock()),
         patch("notebooklm._artifact_downloads.threading.Thread", new=_RecordingThread),
         patch.object(builtins, "open", new=_patched_open),
     ):
@@ -717,7 +717,7 @@ async def test_download_url_writer_failure_does_not_deadlock_producer(
 
     with (
         patch.object(real_httpx, "AsyncClient", return_value=mock_client),
-        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+        patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value=MagicMock()),
         patch.object(builtins, "open", new=_patched_open),
     ):
         download_coro = api._download_url(

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -1060,7 +1060,7 @@ class TestArtifactErrorPaths:
         httpx_mock.add_response(content=b"pptx-content")
 
         output = str(tmp_path / "slides.pptx")
-        with patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()):
+        with patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value=MagicMock()):
             async with NotebookLMClient(auth_tokens) as client:
                 result = await client.artifacts.download_slide_deck(
                     "nb_123", output, output_format="pptx"

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -402,13 +402,13 @@ async def test_register_file_source_probe_short_circuits_when_first_response_los
         # exercises only the ADD_SOURCE_FILE register step's idempotency.
         with (
             patch.object(
-                client.sources,
-                "_start_resumable_upload",
+                client.sources._uploader,
+                "start_resumable_upload",
                 AsyncMock(return_value="https://upload.example/scotty"),
             ),
             patch.object(
-                client.sources,
-                "_upload_file_streaming",
+                client.sources._uploader,
+                "upload_file_streaming",
                 AsyncMock(return_value=None),
             ),
         ):
@@ -480,13 +480,13 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
     try:
         with (
             patch.object(
-                client.sources,
-                "_start_resumable_upload",
+                client.sources._uploader,
+                "start_resumable_upload",
                 AsyncMock(return_value="https://upload.example/scotty"),
             ),
             patch.object(
-                client.sources,
-                "_upload_file_streaming",
+                client.sources._uploader,
+                "upload_file_streaming",
                 AsyncMock(return_value=None),
             ),
             pytest.raises(ServerError),
@@ -557,13 +557,13 @@ async def test_register_file_source_baseline_unavailable_raises_on_ambiguity(
     try:
         with (
             patch.object(
-                client.sources,
-                "_start_resumable_upload",
+                client.sources._uploader,
+                "start_resumable_upload",
                 AsyncMock(return_value="https://upload.example/scotty"),
             ),
             patch.object(
-                client.sources,
-                "_upload_file_streaming",
+                client.sources._uploader,
+                "upload_file_streaming",
                 AsyncMock(return_value=None),
             ),
             pytest.raises(NotebookLMError, match="baseline snapshot was unavailable"),

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -1665,24 +1665,24 @@ class TestAddFileWait:
 
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.sources,
-                "_register_file_source",
+                client.sources._uploader,
+                "register_file_source",
                 new_callable=AsyncMock,
                 return_value="file_src_001",
             ):
                 with patch.object(
-                    client.sources,
-                    "_start_resumable_upload",
+                    client.sources._uploader,
+                    "start_resumable_upload",
                     new_callable=AsyncMock,
                     return_value="https://upload.example.com/upload_id=abc",
                 ):
                     with patch.object(
-                        client.sources,
-                        "_upload_file_streaming",
+                        client.sources._uploader,
+                        "upload_file_streaming",
                         new_callable=AsyncMock,
                     ):
                         with patch.object(
-                            client.sources,
+                            client.sources._uploader,
                             "wait_until_ready",
                             new_callable=AsyncMock,
                             return_value=ready_source,

--- a/tests/unit/concurrency/test_download_collision.py
+++ b/tests/unit/concurrency/test_download_collision.py
@@ -34,7 +34,7 @@ def _stub_storage_cookies(monkeypatch: pytest.MonkeyPatch) -> None:
     empty dict.
     """
     monkeypatch.setattr(
-        "notebooklm._artifacts.load_httpx_cookies",
+        "notebooklm._artifact_downloads.load_httpx_cookies",
         lambda path=None: {},
     )
 

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -214,7 +214,7 @@ def test_chat_ask_guards_against_cross_loop_call() -> None:
         other_loop.close()
 
 
-def test_add_file_guards_against_cross_loop_call() -> None:
+def test_add_file_guards_against_cross_loop_call(monkeypatch: pytest.MonkeyPatch) -> None:
     """``SourceUploadPipeline.add_file`` must raise on cross-loop misuse.
 
     Regression guard for audit finding C1: previously the upload pipeline
@@ -242,21 +242,17 @@ def test_add_file_guards_against_cross_loop_call() -> None:
     # Construct the pipeline outside any running loop — its ``__init__`` is
     # event-loop-agnostic; the cross-loop guard fires inside ``add_file``.
     pipeline = SourceUploadPipeline(runtime, kernel, auth)
-
-    async def _unused(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - guard fires first
-        raise AssertionError("upload collaborator should not run on cross-loop call")
+    register_file_source = MagicMock(side_effect=AssertionError("register should not run"))
+    start_resumable_upload = MagicMock(side_effect=AssertionError("start should not run"))
+    upload_file_streaming = MagicMock(side_effect=AssertionError("stream should not run"))
+    monkeypatch.setattr(pipeline, "register_file_source", register_file_source)
+    monkeypatch.setattr(pipeline, "start_resumable_upload", start_resumable_upload)
+    monkeypatch.setattr(pipeline, "upload_file_streaming", upload_file_streaming)
 
     async def inner() -> None:
         await pipeline.add_file(
             "nb-id",
             "/nonexistent/path/should-never-be-touched.pdf",
-            register_file_source=_unused,
-            start_resumable_upload=_unused,
-            upload_file_streaming=_unused,
-            wait_until_ready=_unused,
-            wait_until_registered=_unused,
-            rename=_unused,
-            logger=MagicMock(),
         )
 
     with pytest.raises(RuntimeError, match="different event loop"):
@@ -265,8 +261,12 @@ def test_add_file_guards_against_cross_loop_call() -> None:
     # Confirm the cross-loop guard fired *before* any collaborator was
     # touched. Three independent witnesses to the contract: the guard
     # was called once, ``operation_scope`` (the loop-bound async-context
-    # manager the audit specifically calls out) was never entered, and
-    # the lazy upload semaphore was never allocated.
+    # manager the audit specifically calls out) was never entered, upload
+    # collaborators were never touched, and the lazy upload semaphore was
+    # never allocated.
     runtime.assert_bound_loop.assert_called_once()
     runtime.operation_scope.assert_not_called()
+    register_file_source.assert_not_called()
+    start_resumable_upload.assert_not_called()
+    upload_file_streaming.assert_not_called()
     assert pipeline._upload_semaphore is None

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from notebooklm import _artifact_downloads as artifact_downloads
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm.types import (
     ArtifactDownloadError,
@@ -50,6 +51,48 @@ def mock_artifacts_api():
         note_service=note_service,
     )
     return api, mock_core
+
+
+class TestDownloadInteractiveArtifact:
+    """Test shared quiz/flashcard download parsing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_extract_app_data_value_error_propagates(self, monkeypatch, tmp_path):
+        """Bare ValueError from helper internals is not converted to parse drift."""
+        artifact = MagicMock(
+            id="quiz_001",
+            title="My Quiz",
+            is_completed=True,
+            created_at=None,
+        )
+        methods = MagicMock()
+        methods.list_quizzes = AsyncMock(return_value=[artifact])
+        methods.list_flashcards = AsyncMock()
+        methods._get_artifact_content = AsyncMock(
+            return_value='<html><body data-app-data="{&quot;quiz&quot;:[]}"></body></html>'
+        )
+        methods._format_interactive_content = MagicMock(return_value="unused")
+        service = artifact_downloads.ArtifactDownloadService(
+            methods=methods,
+            mind_maps=MagicMock(),
+        )
+
+        monkeypatch.setattr(
+            artifact_downloads,
+            "_extract_app_data",
+            MagicMock(side_effect=ValueError("implementation bug")),
+        )
+
+        with pytest.raises(ValueError, match="implementation bug"):
+            await service.download_interactive_artifact(
+                "nb_123",
+                str(tmp_path / "quiz.json"),
+                None,
+                "json",
+                "quiz",
+            )
+
+        methods._format_interactive_content.assert_not_called()
 
 
 class TestDownloadAudio:

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -465,7 +465,9 @@ class TestDownloadUrl:
             mock_cookies = MagicMock()
             with (
                 patch.object(real_httpx, "AsyncClient", return_value=mock_client),
-                patch("notebooklm._artifacts.load_httpx_cookies", return_value=mock_cookies),
+                patch(
+                    "notebooklm._artifact_downloads.load_httpx_cookies", return_value=mock_cookies
+                ),
             ):
                 result = await api._download_url(
                     "https://storage.googleapis.com/file.mp4", output_path
@@ -506,7 +508,9 @@ class TestDownloadUrl:
             mock_cookies = MagicMock()
             with (
                 patch.object(real_httpx, "AsyncClient", return_value=mock_client),
-                patch("notebooklm._artifacts.load_httpx_cookies", return_value=mock_cookies),
+                patch(
+                    "notebooklm._artifact_downloads.load_httpx_cookies", return_value=mock_cookies
+                ),
                 pytest.raises(ArtifactDownloadError, match="0 bytes"),
             ):
                 await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
@@ -814,7 +818,7 @@ class TestStoragePathEncapsulation:
             raise _StopAfterCapture
 
         with (
-            patch("notebooklm._artifacts.load_httpx_cookies", new=recording),
+            patch("notebooklm._artifact_downloads.load_httpx_cookies", new=recording),
             pytest.raises(_StopAfterCapture),
         ):
             await service.download_url(
@@ -840,7 +844,7 @@ class TestStoragePathEncapsulation:
             captured.append(path)
             return {}
 
-        with patch("notebooklm._artifacts.load_httpx_cookies", new=recording):
+        with patch("notebooklm._artifact_downloads.load_httpx_cookies", new=recording):
             await service.download_urls_batch([])
 
         assert captured == [sentinel]

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -74,7 +74,7 @@ class TestDownloadUrlsBatch:
         mock_response.raise_for_status = MagicMock()
 
         with (
-            patch("notebooklm._artifacts.load_httpx_cookies", return_value={}),
+            patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}),
             patch("httpx.AsyncClient") as mock_client_cls,
         ):
             mock_client = AsyncMock()
@@ -115,7 +115,7 @@ class TestDownloadUrlsBatch:
         mock_response.raise_for_status = MagicMock()
 
         with (
-            patch("notebooklm._artifacts.load_httpx_cookies", return_value={}),
+            patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}),
             patch("httpx.AsyncClient") as mock_client_cls,
         ):
             mock_client = AsyncMock()
@@ -148,7 +148,7 @@ class TestDownloadUrlsBatch:
         success_response.raise_for_status = MagicMock()
 
         with (
-            patch("notebooklm._artifacts.load_httpx_cookies", return_value={}),
+            patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}),
             patch("httpx.AsyncClient") as mock_client_cls,
         ):
             mock_client = AsyncMock()

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -57,14 +57,13 @@ def test_failed_preserves_url_and_exception():
 
 
 def test_artifacts_module_preserves_download_patch_targets():
-    """Private compatibility names remain available through _artifacts."""
+    """Public download result remains available without facade patch targets."""
     import notebooklm._artifacts as artifacts_module
 
     assert artifacts_module.DownloadResult is DownloadResult
     assert artifacts_module.ArtifactDownloadError is not None
-    assert artifacts_module.load_httpx_cookies is not None
     assert artifacts_module._mind_map is not None
-    assert artifacts_module.json.dump is not None
+    assert not hasattr(artifacts_module, "load_httpx_cookies")
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +106,7 @@ def _patched_httpx_client(get_behavior: Any) -> Iterator[AsyncMock]:
     Yields the inner mock_client for further customization if needed.
     """
     with (
-        patch("notebooklm._artifacts.load_httpx_cookies", return_value={}),
+        patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}),
         patch("httpx.AsyncClient") as mock_client_cls,
     ):
         mock_client = AsyncMock()
@@ -205,7 +204,7 @@ async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_p
 
     api, _ = mock_artifacts_api
 
-    with patch("notebooklm._artifacts.load_httpx_cookies", return_value={}):
+    with patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}):
         result = await api._download_urls_batch(
             [("https://evil.example.com/file.mp4", str(tmp_path / "x.mp4"))]
         )

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -95,7 +95,7 @@ def _patch_httpx_client(
 
     return (
         patch.object(httpx, "AsyncClient", return_value=mock_client),
-        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+        patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value=MagicMock()),
     )
 
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -781,24 +781,26 @@ def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> N
     assert isinstance(api._lister, SourceLister)
 
 
-def test_phase7_artifact_mind_map_patch_seams_are_current() -> None:
-    """Final artifact services must still resolve mind-map seams via ``_artifacts``.
+def test_phase7_artifact_download_patch_seams_are_current() -> None:
+    """Artifact downloads must use canonical helpers, not facade module lookup.
 
     Phase 5 (refactor-history.md Migration Plan steps 6-7) moves the mind-map
     create/list/extract paths off the ``_mind_map`` module-level seams
     and onto the injected ``NoteService`` + ``NoteBackedMindMapService``
-    instances. The ``_artifact_generation`` module no longer needs an
-    ``_artifact_seams()`` hop at all (only the JSON/cookie seams remain
-    in ``_artifact_downloads``), so we check the downloads-side seam
-    still resolves and the generation module exposes the ``NoteService``
-    attribute the new wiring depends on.
+    instances. Downloads should now import their canonical helpers directly
+    rather than resolving through ``notebooklm._artifacts`` at runtime.
     """
     import notebooklm._artifact_downloads as artifact_downloads
+    import notebooklm._artifact_formatters as artifact_formatters
     import notebooklm._artifacts as artifacts
     import notebooklm._mind_map as mind_map
+    import notebooklm.auth as auth
 
     assert artifacts._mind_map is mind_map
-    assert artifact_downloads._artifact_seams()._mind_map is mind_map
+    assert not hasattr(artifact_downloads, "_artifact_seams")
+    assert artifact_downloads.load_httpx_cookies is auth.load_httpx_cookies
+    assert artifact_downloads._extract_app_data is artifact_formatters._extract_app_data
+    assert artifact_downloads._parse_data_table is artifact_formatters._parse_data_table
 
 
 def test_notebooks_api_has_no_hidden_sources_api_runtime_dependency() -> None:

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -166,7 +166,8 @@ async def test_upload_semaphore_is_owned_per_pipeline() -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
+async def test_add_file_uses_pipeline_steps_and_finishes_transport(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     file_path = tmp_path / "report.pdf"
@@ -184,16 +185,16 @@ async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
         assert kwargs["total_bytes"] == 5
         file_obj.close()
 
+    monkeypatch.setattr(service, "register_file_source", register_file_source)
+    monkeypatch.setattr(service, "start_resumable_upload", start_resumable_upload)
+    monkeypatch.setattr(service, "upload_file_streaming", upload_file_streaming)
+    monkeypatch.setattr(service, "wait_until_ready", AsyncMock())
+    monkeypatch.setattr(service, "wait_until_registered", AsyncMock())
+    monkeypatch.setattr(service, "rename", AsyncMock())
+
     source = await service.add_file(
         "nb_123",
         file_path,
-        register_file_source=register_file_source,
-        start_resumable_upload=start_resumable_upload,
-        upload_file_streaming=upload_file_streaming,
-        wait_until_ready=AsyncMock(),
-        wait_until_registered=AsyncMock(),
-        rename=AsyncMock(),
-        logger=MagicMock(),
     )
 
     assert source.id == "src_123"
@@ -209,7 +210,9 @@ async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
 
 
 @pytest.mark.asyncio
-async def test_add_file_operation_scope_wraps_sources_semaphore_wait(tmp_path) -> None:
+async def test_add_file_operation_scope_wraps_sources_semaphore_wait(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     first_file = tmp_path / "first.pdf"
     second_file = tmp_path / "second.pdf"
     first_file.write_bytes(b"first")
@@ -225,17 +228,24 @@ async def test_add_file_operation_scope_wraps_sources_semaphore_wait(tmp_path) -
             await release_first_streaming.wait()
         file_obj.close()
 
+    register_file_source = AsyncMock(
+        side_effect=lambda _notebook_id, filename: f"src_{filename.removesuffix('.pdf')}"
+    )
+    monkeypatch.setattr(service, "register_file_source", register_file_source)
+    monkeypatch.setattr(
+        service,
+        "start_resumable_upload",
+        AsyncMock(return_value="https://upload.example.com/session"),
+    )
+    monkeypatch.setattr(service, "upload_file_streaming", upload_file_streaming)
+    monkeypatch.setattr(service, "wait_until_ready", AsyncMock())
+    monkeypatch.setattr(service, "wait_until_registered", AsyncMock())
+    monkeypatch.setattr(service, "rename", AsyncMock())
+
     async def add(path):
         return await service.add_file(
             "nb_123",
             path,
-            register_file_source=AsyncMock(return_value=f"src_{path.stem}"),
-            start_resumable_upload=AsyncMock(return_value="https://upload.example.com/session"),
-            upload_file_streaming=upload_file_streaming,
-            wait_until_ready=AsyncMock(),
-            wait_until_registered=AsyncMock(),
-            rename=AsyncMock(),
-            logger=MagicMock(),
         )
 
     first_task = asyncio.create_task(add(first_file))
@@ -257,6 +267,7 @@ async def test_add_file_operation_scope_wraps_sources_semaphore_wait(tmp_path) -
 
 @pytest.mark.asyncio
 async def test_add_file_custom_title_waits_for_registration_before_rename(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     file_path = tmp_path / "report.pdf"
@@ -271,18 +282,22 @@ async def test_add_file_custom_title_waits_for_registration_before_rename(
     async def upload_file_streaming(_upload_url, file_obj, **_kwargs):
         file_obj.close()
 
+    monkeypatch.setattr(service, "register_file_source", AsyncMock(return_value="src_123"))
+    monkeypatch.setattr(
+        service,
+        "start_resumable_upload",
+        AsyncMock(return_value="https://upload.example.com/session"),
+    )
+    monkeypatch.setattr(service, "upload_file_streaming", upload_file_streaming)
+    monkeypatch.setattr(service, "wait_until_ready", AsyncMock())
+    monkeypatch.setattr(service, "wait_until_registered", wait_until_registered)
+    monkeypatch.setattr(service, "rename", rename)
+
     source = await service.add_file(
         "nb_123",
         file_path,
         title="  Custom  ",
         wait_timeout=45.0,
-        register_file_source=AsyncMock(return_value="src_123"),
-        start_resumable_upload=AsyncMock(return_value="https://upload.example.com/session"),
-        upload_file_streaming=upload_file_streaming,
-        wait_until_ready=AsyncMock(),
-        wait_until_registered=wait_until_registered,
-        rename=rename,
-        logger=MagicMock(),
     )
 
     assert source == Source(id="src_123", title="Custom", _type_code=7, url="https://source")
@@ -360,6 +375,37 @@ async def test_register_file_source_status3_includes_source_limit_context(
     assert "tier-specific" in message
     assert "per-notebook source limit" in message
     assert "fresh notebook" in message
+    get_source_limit.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_uses_configured_source_limit_lookup(
+    service: SourceUploadPipeline,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rpc_error = RPCError(
+        "RPC o4cbdc returned null result with status code 3 (Invalid argument).",
+        method_id="o4cbdc",
+        rpc_code=3,
+    )
+    rpc = RecordingRpc(rpc_error)
+    existing_sources = [
+        Source(id=f"source_{index}", title=f"Source {index}") for index in range(56)
+    ]
+    list_sources = AsyncMock(return_value=existing_sources)
+    get_source_limit = AsyncMock(return_value=50)
+    monkeypatch.setattr(service, "list_sources", list_sources)
+    service.configure_source_limit_lookup(get_source_limit)
+
+    with pytest.raises(SourceAddError) as exc_info:
+        await service.register_file_source(
+            "nb_123",
+            "report.pdf",
+            rpc_call=rpc,
+        )
+
+    assert "56/50 sources" in str(exc_info.value)
+    list_sources.assert_awaited_once_with("nb_123")
     get_source_limit.assert_awaited_once_with()
 
 

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -959,7 +959,7 @@ class TestAddFile:
         test_file.write_bytes(b"fake pdf content")
 
         mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
-        sources_api.wait_until_ready = AsyncMock(
+        sources_api._uploader.wait_until_ready = AsyncMock(
             return_value=MagicMock(id="src_pdf", title="report.pdf")
         )
 
@@ -979,7 +979,7 @@ class TestAddFile:
             )
 
         assert result.id == "src_pdf"
-        sources_api.wait_until_ready.assert_awaited_once_with(
+        sources_api._uploader.wait_until_ready.assert_awaited_once_with(
             "nb_123", "src_pdf", timeout=45.0, transient_error_types=()
         )
 
@@ -1075,10 +1075,10 @@ class TestAddFile:
         # The forced pre-rename registration wait is mocked — we don't want
         # this test to depend on the polling implementation. It returns the
         # registered source so add_file then issues the rename RPC.
-        sources_api.wait_until_registered = AsyncMock(
+        sources_api._uploader.wait_until_registered = AsyncMock(
             return_value=Source(id="src_md", title="boring-filename.md", _type_code=8)
         )
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1104,10 +1104,10 @@ class TestAddFile:
         # Narrow wait uses the caller's wait_timeout (default 120s) — not the
         # full wait_until_ready. wait_until_registered returns on first
         # PROCESSING/READY status so the bound stays cheap in practice.
-        sources_api.wait_until_registered.assert_awaited_once_with(
+        sources_api._uploader.wait_until_registered.assert_awaited_once_with(
             "nb_123", "src_md", timeout=120.0, transient_error_types=()
         )
-        sources_api.wait_until_ready.assert_not_called()
+        sources_api._uploader.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_with_custom_title_renames_after_wait(
@@ -1140,7 +1140,7 @@ class TestAddFile:
             assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
-        sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
+        sources_api._uploader.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1161,7 +1161,7 @@ class TestAddFile:
             )
 
         assert result.title == "Real Intended Title"
-        sources_api.wait_until_ready.assert_awaited_once_with(
+        sources_api._uploader.wait_until_ready.assert_awaited_once_with(
             "nb_123", "src_md", timeout=120.0, transient_error_types=()
         )
         # 3 RPCs in total: baseline + register + rename.
@@ -1196,8 +1196,8 @@ class TestAddFile:
             assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
-        sources_api.wait_until_registered = AsyncMock(side_effect=wait_side_effect)
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_registered = AsyncMock(side_effect=wait_side_effect)
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1217,10 +1217,10 @@ class TestAddFile:
             )
 
         assert result.title == "Real Intended Title"
-        sources_api.wait_until_registered.assert_awaited_once_with(
+        sources_api._uploader.wait_until_registered.assert_awaited_once_with(
             "nb_123", "src_md", timeout=120.0, transient_error_types=()
         )
-        sources_api.wait_until_ready.assert_not_called()
+        sources_api._uploader.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_with_title_forwards_wait_timeout(
@@ -1242,10 +1242,10 @@ class TestAddFile:
             [[[["src_audio"], "Episode 1", [None, None, None, None, 10]]]],
         ]
 
-        sources_api.wait_until_registered = AsyncMock(
+        sources_api._uploader.wait_until_registered = AsyncMock(
             return_value=Source(id="src_audio", title="podcast.mp3", _type_code=10)
         )
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1266,10 +1266,10 @@ class TestAddFile:
             )
 
         # wait_timeout is forwarded directly — no min() cap.
-        sources_api.wait_until_registered.assert_awaited_once_with(
+        sources_api._uploader.wait_until_registered.assert_awaited_once_with(
             "nb_123", "src_audio", timeout=600.0, transient_error_types=(10, 0, None)
         )
-        sources_api.wait_until_ready.assert_not_called()
+        sources_api._uploader.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_no_title_no_wait_does_not_wait(self, sources_api, mock_core, tmp_path):
@@ -1280,7 +1280,7 @@ class TestAddFile:
         test_file.write_bytes(b"fake pdf content")
 
         mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1297,7 +1297,7 @@ class TestAddFile:
 
         assert result.id == "src_pdf"
         assert result.title == "test.pdf"
-        sources_api.wait_until_ready.assert_not_called()
+        sources_api._uploader.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_no_title_no_wait_returns_processing_status(
@@ -1313,7 +1313,7 @@ class TestAddFile:
         test_file.write_bytes(b"fake pdf content")
 
         mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1406,7 +1406,7 @@ class TestAddFile:
             [[[["src_doc"]]]],
             rename_error,
         ]
-        sources_api.wait_until_registered = AsyncMock(
+        sources_api._uploader.wait_until_registered = AsyncMock(
             return_value=Source(id="src_doc", title="doc.txt", _type_code=4)
         )
 
@@ -1462,7 +1462,7 @@ class TestAddFile:
             [[[["src_audio"]]]],
             None,  # Triggers rename()'s Source(id=source_id, title=new_title) fallback
         ]
-        sources_api.wait_until_registered = AsyncMock(
+        sources_api._uploader.wait_until_registered = AsyncMock(
             return_value=Source(
                 id="src_audio",
                 title="podcast.mp3",
@@ -1512,10 +1512,10 @@ class TestAddFile:
             [[[["src_audio"], "My Title", [None, None, None, None, 10]]]],
         ]
 
-        sources_api.wait_until_registered = AsyncMock(
+        sources_api._uploader.wait_until_registered = AsyncMock(
             return_value=Source(id="src_audio", title="long-audio.mp3", _type_code=10)
         )
-        sources_api.wait_until_ready = AsyncMock()
+        sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1536,9 +1536,9 @@ class TestAddFile:
             )
 
         # Narrow wait was used...
-        sources_api.wait_until_registered.assert_awaited_once()
+        sources_api._uploader.wait_until_registered.assert_awaited_once()
         # ...and the full wait was NOT.
-        sources_api.wait_until_ready.assert_not_called()
+        sources_api._uploader.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_rename_failure_still_waits(self, sources_api, mock_core, tmp_path):
@@ -1566,7 +1566,7 @@ class TestAddFile:
             assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="doc.txt", _type_code=4)
 
-        sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
+        sources_api._uploader.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -1587,7 +1587,7 @@ class TestAddFile:
             )
 
         assert result.title == "doc.txt"
-        sources_api.wait_until_ready.assert_awaited_once_with(
+        sources_api._uploader.wait_until_ready.assert_awaited_once_with(
             "nb_123", "src_doc", timeout=120.0, transient_error_types=()
         )
 


### PR DESCRIPTION
## Summary
- remove artifact download `_artifact_seams()` dynamic facade lookups and retarget tests to canonical download seams
- let artifact generation call/parse through `ArtifactGenerationService` instead of the `ArtifactsAPI` method bag while preserving public compatibility wrappers
- deepen source upload choreography so `SourceUploadPipeline.add_file` owns registration, upload start/streaming, waits, rename, and source-limit hint lookup through configured collaborators

## Polish
- ran local simplification pass; removed new method-assignment ignores from pipeline tests
- ran Claude + agy review passes and native Codex review
- addressed blocker findings: removed forbidden `_settings` import from `_source_upload.py`, fixed non-upload wait mock retargeting, strengthened loop-affinity guard coverage

## Tests
- `uv run pytest`
- `uv run ruff check src/notebooklm tests`
- `uv run mypy src/notebooklm`
- `uv run --frozen pre-commit run --all-files`
- focused artifact/source upload and integration batches during polish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of artifact download, generation, and upload flows to simplify service boundaries; no changes to public APIs or visible behavior.
* **Tests**
  * Updated integration and unit tests to target the new internal implementation locations and pipeline-owned upload helpers; test semantics unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->