### PR TITLE
refactor(architecture): remove artifact download method bag

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -20,7 +20,7 @@ import httpx
 from ._artifact_formatters import _extract_app_data, _format_interactive_content, _parse_data_table
 from .auth import load_httpx_cookies
 from .exceptions import ValidationError
-from .rpc import ArtifactTypeCode, RPCMethod
+from .rpc import ArtifactTypeCode, RPCMethod, safe_index
 from .types import (
     Artifact,
     ArtifactDownloadError,
@@ -155,9 +155,11 @@ class ArtifactDownloadService:
         self._storage_path = storage_path
 
     async def _list_raw(self, notebook_id: str) -> list[Any]:
+        """List raw artifacts through the injected listing service."""
         return await self._listing.list_raw(notebook_id, rpc_call=self._runtime.rpc_call)
 
     async def _list_mind_maps(self, notebook_id: str) -> list[Any]:
+        """List mind-map artifacts through the injected mind-map service."""
         return await self._mind_maps.list_mind_maps(notebook_id)
 
     async def _list_artifacts(
@@ -165,6 +167,7 @@ class ArtifactDownloadService:
         notebook_id: str,
         artifact_type: ArtifactType,
     ) -> list[Artifact]:
+        """List typed artifacts using the download service's patchable seams."""
         return await self._listing.list_artifacts(
             notebook_id,
             artifact_type,
@@ -181,6 +184,7 @@ class ArtifactDownloadService:
         *,
         type_code: ArtifactTypeCode,
     ) -> Any:
+        """Select one artifact candidate using the injected listing policy."""
         return self._listing.select_artifact(
             candidates,
             artifact_id,
@@ -190,17 +194,21 @@ class ArtifactDownloadService:
         )
 
     async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
+        """Fetch interactive artifact HTML through the runtime RPC seam."""
         result = await self._runtime.rpc_call(
             RPCMethod.GET_INTERACTIVE_HTML,
             [artifact_id],
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if result and isinstance(result, list) and len(result) > 0:
-            data = result[0]
-            if isinstance(data, list) and len(data) > 9 and data[9]:
-                return data[9][0]
-        return None
+        return safe_index(
+            result,
+            0,
+            9,
+            0,
+            method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
+            source="_artifact_downloads._get_artifact_content",
+        )
 
     async def download_audio(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -17,21 +17,24 @@ from urllib.parse import urlparse
 
 import httpx
 
-from ._artifact_formatters import _extract_app_data, _parse_data_table
+from ._artifact_formatters import _extract_app_data, _format_interactive_content, _parse_data_table
 from .auth import load_httpx_cookies
 from .exceptions import ValidationError
-from .rpc import ArtifactTypeCode
+from .rpc import ArtifactTypeCode, RPCMethod
 from .types import (
+    Artifact,
     ArtifactDownloadError,
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
+    ArtifactType,
     _extract_artifact_url,
 )
 
 if TYPE_CHECKING:
-    from ._artifacts import _ArtifactsServiceMethods
+    from ._artifact_listing import ArtifactListingService
     from ._mind_map import NoteBackedMindMapService
+    from ._session_contracts import RpcCaller
 
 logger = logging.getLogger(__name__)
 
@@ -141,22 +144,71 @@ class ArtifactDownloadService:
     def __init__(
         self,
         *,
-        methods: _ArtifactsServiceMethods,
+        runtime: RpcCaller,
+        listing: ArtifactListingService,
         mind_maps: NoteBackedMindMapService,
         storage_path: Path | None = None,
     ) -> None:
-        self._methods = methods
+        self._runtime = runtime
+        self._listing = listing
         self._mind_maps = mind_maps
         self._storage_path = storage_path
+
+    async def _list_raw(self, notebook_id: str) -> list[Any]:
+        return await self._listing.list_raw(notebook_id, rpc_call=self._runtime.rpc_call)
+
+    async def _list_mind_maps(self, notebook_id: str) -> list[Any]:
+        return await self._mind_maps.list_mind_maps(notebook_id)
+
+    async def _list_artifacts(
+        self,
+        notebook_id: str,
+        artifact_type: ArtifactType,
+    ) -> list[Artifact]:
+        return await self._listing.list_artifacts(
+            notebook_id,
+            artifact_type,
+            list_raw=self._list_raw,
+            list_mind_maps=self._list_mind_maps,
+        )
+
+    def _select_artifact(
+        self,
+        candidates: list[Any],
+        artifact_id: str | None,
+        type_name: str,
+        no_result_error_key: str,
+        *,
+        type_code: ArtifactTypeCode,
+    ) -> Any:
+        return self._listing.select_artifact(
+            candidates,
+            artifact_id,
+            type_name,
+            no_result_error_key,
+            type_code=type_code,
+        )
+
+    async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
+        result = await self._runtime.rpc_call(
+            RPCMethod.GET_INTERACTIVE_HTML,
+            [artifact_id],
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if result and isinstance(result, list) and len(result) > 0:
+            data = result[0]
+            if isinstance(data, list) and len(data) > 9 and data[9]:
+                return data[9][0]
+        return None
 
     async def download_audio(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download an Audio Overview to a file."""
-        methods = self._methods
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
-        audio_art = methods._select_artifact(
+        audio_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Audio",
@@ -172,19 +224,18 @@ class ArtifactDownloadService:
                 details="Could not extract download URL from artifact metadata",
             )
 
-        return await methods._download_url(url, output_path)
+        return await self.download_url(url, output_path)
 
     async def download_video(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download a Video Overview to a file."""
-        methods = self._methods
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
         # Note: distinct error keys preserved — specific-ID miss raises
         # "video" (from type_name="Video"); empty-list raises
         # "video_overview" (from type_name_lower).
-        video_art = methods._select_artifact(
+        video_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Video",
@@ -200,16 +251,15 @@ class ArtifactDownloadService:
                 details="Could not extract download URL from artifact metadata",
             )
 
-        return await methods._download_url(url, output_path)
+        return await self.download_url(url, output_path)
 
     async def download_infographic(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download an Infographic to a file."""
-        methods = self._methods
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
-        info_art = methods._select_artifact(
+        info_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Infographic",
@@ -221,7 +271,7 @@ class ArtifactDownloadService:
             url = _extract_artifact_url(info_art, ArtifactTypeCode.INFOGRAPHIC.value)
             if not url:
                 raise ArtifactParseError("infographic", details="Could not find metadata")
-            return await methods._download_url(url, output_path)
+            return await self.download_url(url, output_path)
 
         except (IndexError, TypeError) as e:
             raise ArtifactParseError(
@@ -236,13 +286,12 @@ class ArtifactDownloadService:
         output_format: str = "pdf",
     ) -> str:
         """Download a slide deck as PDF or PPTX."""
-        methods = self._methods
         if output_format not in ("pdf", "pptx"):
             raise ValidationError(f"Invalid format '{output_format}'. Must be 'pdf' or 'pptx'.")
 
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
-        slide_art = methods._select_artifact(
+        slide_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Slide deck",
@@ -282,7 +331,7 @@ class ArtifactDownloadService:
                 "slide_deck", details=f"Failed to parse structure: {e}", cause=e
             ) from e
 
-        return await methods._download_url(url, output_path)
+        return await self.download_url(url, output_path)
 
     async def download_interactive_artifact(
         self,
@@ -293,7 +342,6 @@ class ArtifactDownloadService:
         artifact_type: str,
     ) -> str:
         """Download quiz or flashcard artifact."""
-        methods = self._methods
         valid_formats = ("json", "markdown", "html")
         if output_format not in valid_formats:
             raise ValidationError(
@@ -302,12 +350,9 @@ class ArtifactDownloadService:
 
         is_quiz = artifact_type == "quiz"
         default_title = "Untitled Quiz" if is_quiz else "Untitled Flashcards"
+        list_type = ArtifactType.QUIZ if is_quiz else ArtifactType.FLASHCARDS
 
-        artifacts = (
-            await methods.list_quizzes(notebook_id)
-            if is_quiz
-            else await methods.list_flashcards(notebook_id)
-        )
+        artifacts = await self._list_artifacts(notebook_id, list_type)
         completed = [a for a in artifacts if a.is_completed]
         if not completed:
             raise ArtifactNotReadyError(artifact_type)
@@ -321,7 +366,7 @@ class ArtifactDownloadService:
         else:
             artifact = completed[0]
 
-        html_content = await methods._get_artifact_content(notebook_id, artifact.id)
+        html_content = await self._get_artifact_content(notebook_id, artifact.id)
         if not html_content:
             raise ArtifactDownloadError(artifact_type, details="Failed to fetch content")
 
@@ -333,9 +378,7 @@ class ArtifactDownloadService:
             ) from e
 
         title = artifact.title or default_title
-        content = methods._format_interactive_content(
-            app_data, title, output_format, html_content, is_quiz
-        )
+        content = _format_interactive_content(app_data, title, output_format, html_content, is_quiz)
 
         output_file = Path(output_path)
         output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -354,10 +397,9 @@ class ArtifactDownloadService:
         artifact_id: str | None = None,
     ) -> str:
         """Download a report artifact as markdown."""
-        methods = self._methods
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
-        report_art = methods._select_artifact(
+        report_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Report",
@@ -438,10 +480,9 @@ class ArtifactDownloadService:
         artifact_id: str | None = None,
     ) -> str:
         """Download a data table as CSV."""
-        methods = self._methods
-        artifacts_data = await methods._list_raw(notebook_id)
+        artifacts_data = await self._list_raw(notebook_id)
 
-        table_art = methods._select_artifact(
+        table_art = self._select_artifact(
             artifacts_data,
             artifact_id,
             "Data table",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -156,49 +156,6 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
     """
 
 
-class _ArtifactsServiceMethods(Protocol):
-    """Narrow ``ArtifactsAPI`` method-call surface used by artifact downloads.
-
-    ``ArtifactDownloadService`` accepts an ``ArtifactsAPI`` instance via
-    constructor injection (the ``methods=`` kw-arg) for listing, selection,
-    download, and interactive-formatting flows. The helper types that
-    argument as ``_ArtifactsServiceMethods`` rather than the full concrete
-    ``ArtifactsAPI`` so the private collaboration surface stays explicit.
-
-    Generation no longer depends on this facade-shaped method bag; it owns
-    its RPC call and parser paths directly inside ``ArtifactGenerationService``.
-    """
-
-    async def _list_raw(self, notebook_id: str) -> builtins.list[Any]: ...
-
-    def _select_artifact(
-        self,
-        candidates: builtins.list[Any],
-        artifact_id: str | None,
-        type_name: str,
-        no_result_error_key: str,
-        *,
-        type_code: ArtifactTypeCode,
-    ) -> Any: ...
-
-    async def _download_url(self, url: str, output_path: str) -> str: ...
-
-    async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None: ...
-
-    def _format_interactive_content(
-        self,
-        app_data: dict,
-        title: str,
-        output_format: str,
-        html_content: str,
-        is_quiz: bool,
-    ) -> str: ...
-
-    async def list_quizzes(self, notebook_id: str) -> builtins.list[Artifact]: ...
-
-    async def list_flashcards(self, notebook_id: str) -> builtins.list[Artifact]: ...
-
-
 class ArtifactsAPI:
     """Operations on NotebookLM artifacts (studio content).
 
@@ -261,7 +218,8 @@ class ArtifactsAPI:
             note_service=self._note_service,
         )
         self._downloads = ArtifactDownloadService(
-            methods=self,
+            runtime=self._runtime,
+            listing=self._listing,
             mind_maps=self._mind_maps,
             storage_path=storage_path,
         )

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -552,21 +552,6 @@ class ArtifactsAPI:
             notebook_id, output_path, artifact_id, output_format
         )
 
-    async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
-        """Fetch artifact HTML content for quiz/flashcard types."""
-        result = await self._runtime.rpc_call(
-            RPCMethod.GET_INTERACTIVE_HTML,
-            [artifact_id],
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        # Response is wrapped: result[0] contains the artifact data
-        if result and isinstance(result, list) and len(result) > 0:
-            data = result[0]
-            if isinstance(data, list) and len(data) > 9 and data[9]:
-                return data[9][0]  # HTML content
-        return None
-
     async def _download_interactive_artifact(
         self,
         notebook_id: str,

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -165,7 +165,7 @@ async def test_download_report_runs_write_off_loop_thread(
         return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
     with (
-        patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
+        patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list,
         patch.object(Path, "write_text", recording_write_text),
     ):
         mock_list.return_value = report_artifact_list
@@ -321,7 +321,7 @@ async def test_concurrent_downloads_both_offload_writes(
         return original_json_dump(*args, **kwargs)  # type: ignore[arg-type]
 
     with (
-        patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
+        patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list,
         patch.object(
             api._mind_maps,
             "list_mind_maps",

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -1389,7 +1389,7 @@ class TestExtractAppData:
         output_path = str(tmp_path / "quiz.json")
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.artifacts,
+                client.artifacts._downloads,
                 "_get_artifact_content",
                 AsyncMock(return_value=html_without_data),
             ):
@@ -2540,7 +2540,7 @@ class TestDownloadQuizFlashcardParsing:
 
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.artifacts,
+                client.artifacts._downloads,
                 "_get_artifact_content",
                 AsyncMock(return_value=html_without_data),
             ):
@@ -2624,7 +2624,7 @@ class TestDownloadQuizFlashcardParsing:
         output_path = str(tmp_path / "quiz.html")
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.artifacts,
+                client.artifacts._downloads,
                 "_get_artifact_content",
                 AsyncMock(return_value=raw_html),
             ):

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -65,17 +65,21 @@ class TestDownloadInteractiveArtifact:
             is_completed=True,
             created_at=None,
         )
-        methods = MagicMock()
-        methods.list_quizzes = AsyncMock(return_value=[artifact])
-        methods.list_flashcards = AsyncMock()
-        methods._get_artifact_content = AsyncMock(
-            return_value='<html><body data-app-data="{&quot;quiz&quot;:[]}"></body></html>'
-        )
-        methods._format_interactive_content = MagicMock(return_value="unused")
         service = artifact_downloads.ArtifactDownloadService(
-            methods=methods,
+            runtime=MagicMock(),
+            listing=MagicMock(),
             mind_maps=MagicMock(),
         )
+        monkeypatch.setattr(service, "_list_artifacts", AsyncMock(return_value=[artifact]))
+        monkeypatch.setattr(
+            service,
+            "_get_artifact_content",
+            AsyncMock(
+                return_value='<html><body data-app-data="{&quot;quiz&quot;:[]}"></body></html>'
+            ),
+        )
+        format_content = MagicMock(return_value="unused")
+        monkeypatch.setattr(artifact_downloads, "_format_interactive_content", format_content)
 
         monkeypatch.setattr(
             artifact_downloads,
@@ -92,7 +96,7 @@ class TestDownloadInteractiveArtifact:
                 "quiz",
             )
 
-        methods._format_interactive_content.assert_not_called()
+        format_content.assert_not_called()
 
 
 class TestDownloadAudio:
@@ -130,7 +134,7 @@ class TestDownloadAudio:
             output_path = os.path.join(tmpdir, "audio.mp4")
 
             with patch.object(
-                api, "_download_url", new_callable=AsyncMock, return_value=output_path
+                api._downloads, "download_url", new_callable=AsyncMock, return_value=output_path
             ):
                 result = await api.download_audio("nb_123", output_path)
 
@@ -180,7 +184,7 @@ class TestDownloadVideo:
             output_path = os.path.join(tmpdir, "video.mp4")
 
             # Patch _list_raw to return video artifact data
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Type 3 (video), status 3 (completed), metadata at index 8
                 mock_list.return_value = [
                     [
@@ -197,7 +201,7 @@ class TestDownloadVideo:
                 ]
 
                 with patch.object(
-                    api, "_download_url", new_callable=AsyncMock, return_value=output_path
+                    api._downloads, "download_url", new_callable=AsyncMock, return_value=output_path
                 ):
                     result = await api.download_video("nb_123", output_path)
 
@@ -208,7 +212,7 @@ class TestDownloadVideo:
         """Test error when no video artifact exists."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             with pytest.raises(ArtifactNotReadyError):
@@ -219,7 +223,7 @@ class TestDownloadVideo:
         """Test error when specific video ID not found."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = [["other_id", "Video", 3, None, 3, None, None, None, []]]
 
             with pytest.raises(ArtifactNotReadyError):
@@ -238,7 +242,7 @@ class TestDownloadInfographic:
             output_path = os.path.join(tmpdir, "infographic.png")
 
             # Patch _list_raw to return infographic data
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Type 7 (infographic), status 3, metadata with nested URL structure
                 mock_list.return_value = [
                     [
@@ -256,7 +260,7 @@ class TestDownloadInfographic:
                 ]
 
                 with patch.object(
-                    api, "_download_url", new_callable=AsyncMock, return_value=output_path
+                    api._downloads, "download_url", new_callable=AsyncMock, return_value=output_path
                 ):
                     result = await api.download_infographic("nb_123", output_path)
 
@@ -267,7 +271,7 @@ class TestDownloadInfographic:
         """Test error when no infographic artifact exists."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             with pytest.raises(ArtifactNotReadyError):
@@ -283,7 +287,7 @@ class TestDownloadInfographic:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "infographic.png")
 
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Artifact with two URL-bearing metadata entries at different indices
                 mock_list.return_value = [
                     [
@@ -302,7 +306,7 @@ class TestDownloadInfographic:
                 ]
 
                 with patch.object(
-                    api, "_download_url", new_callable=AsyncMock, return_value=output_path
+                    api._downloads, "download_url", new_callable=AsyncMock, return_value=output_path
                 ) as mock_dl:
                     result = await api.download_infographic("nb_123", output_path)
 
@@ -323,7 +327,7 @@ class TestDownloadSlideDeck:
 
             # Patch _list_raw to return slide deck artifact data
             # Structure: artifact[16] = [config, title, slides_list, pdf_url]
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Create artifact with 17+ elements, type 8 (slide deck), status 3
                 artifact = ["slide_001", "Slide Deck Title", 8, None, 3]
                 # Pad to index 16
@@ -340,7 +344,7 @@ class TestDownloadSlideDeck:
                 mock_list.return_value = [artifact]
 
                 with patch.object(
-                    api, "_download_url", new_callable=AsyncMock, return_value=output_path
+                    api._downloads, "download_url", new_callable=AsyncMock, return_value=output_path
                 ):
                     result = await api.download_slide_deck("nb_123", output_path)
 
@@ -351,7 +355,7 @@ class TestDownloadSlideDeck:
         """Test error when no slide deck artifact exists."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             with pytest.raises(ArtifactNotReadyError):
@@ -362,7 +366,7 @@ class TestDownloadSlideDeck:
         """Test error when specific slide deck ID not found."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             # Need at least 17 elements for valid structure
             artifact = ["other_id", "Slides", 8, None, 3]
             artifact.extend([None] * 11)
@@ -377,7 +381,7 @@ class TestDownloadSlideDeck:
         """Test error on invalid metadata structure."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             # Create artifact with invalid metadata (less than 4 elements)
             artifact = ["slide_001", "Slides", 8, None, 3]
             artifact.extend([None] * 11)
@@ -574,7 +578,7 @@ class TestDownloadReport:
             output_path = os.path.join(tmpdir, "report.md")
 
             # Patch _list_raw to return report artifact data
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Type 2 (report), status 3 (completed), markdown at index 7 (wrapped in list)
                 mock_list.return_value = [
                     [
@@ -602,7 +606,7 @@ class TestDownloadReport:
         """Test error when no report artifact exists."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             with pytest.raises(ArtifactNotReadyError):
@@ -613,7 +617,7 @@ class TestDownloadReport:
         """Test error when specific report ID not found."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = [["other_id", "Report", 2, None, 3, None, None, ["content"]]]
 
             with pytest.raises(ArtifactNotReadyError):
@@ -627,7 +631,7 @@ class TestDownloadReport:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "report.md")
 
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Type 2 (report), status 3 (completed), markdown as direct string
                 mock_list.return_value = [
                     [
@@ -736,7 +740,7 @@ class TestDownloadDataTable:
             output_path = os.path.join(tmpdir, "data.csv")
 
             # Patch _list_raw to return data table artifact
-            with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+            with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
                 # Create the complex nested structure for data table
                 # artifact[18] contains the rich-text structure
                 artifact = ["table_001", "Data Table Title", 9, None, 3]
@@ -788,7 +792,7 @@ class TestDownloadDataTable:
         """Test error when no data table artifact exists."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             with pytest.raises(ArtifactNotReadyError):
@@ -799,7 +803,7 @@ class TestDownloadDataTable:
         """Test error when specific data table ID not found."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             # Need at least 19 elements for valid structure
             artifact = ["other_id", "Table", 9, None, 3]
             artifact.extend([None] * 14)  # Pad to 19 elements
@@ -813,7 +817,7 @@ class TestDownloadDataTable:
         """Test error when data table has invalid structure resulting in empty headers."""
         api, mock_core = mock_artifacts_api
 
-        with patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list:
+        with patch.object(api._downloads, "_list_raw", new_callable=AsyncMock) as mock_list:
             artifact = ["table_001", "Data Table", 9, None, 3]
             artifact.extend([None] * 13)  # Pad to index 18
 
@@ -845,10 +849,14 @@ class TestStoragePathEncapsulation:
         # MagicMock collaborators are inert — the service must read the
         # ``storage_path`` it was constructed with, not via any
         # collaborator reach-through.
-        methods = MagicMock()
+        runtime = MagicMock()
+        listing = MagicMock()
         mind_maps = MagicMock()
         service = ArtifactDownloadService(
-            methods=methods, mind_maps=mind_maps, storage_path=sentinel
+            runtime=runtime,
+            listing=listing,
+            mind_maps=mind_maps,
+            storage_path=sentinel,
         )
 
         captured: list[object] = []
@@ -875,10 +883,14 @@ class TestStoragePathEncapsulation:
         from notebooklm._artifact_downloads import ArtifactDownloadService
 
         sentinel = tmp_path / "sentinel_storage.json"
-        methods = MagicMock()
+        runtime = MagicMock()
+        listing = MagicMock()
         mind_maps = MagicMock()
         service = ArtifactDownloadService(
-            methods=methods, mind_maps=mind_maps, storage_path=sentinel
+            runtime=runtime,
+            listing=listing,
+            mind_maps=mind_maps,
+            storage_path=sentinel,
         )
 
         captured: list[object] = []

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -798,16 +798,20 @@ def test_phase7_artifact_download_patch_seams_are_current() -> None:
 
     tree = ast.parse((SRC_ROOT / "_artifact_downloads.py").read_text(encoding="utf-8"))
     artifact_facade_imports: list[str] = []
+    artifact_facade_modules = {"_artifacts", "notebooklm._artifacts"}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             artifact_facade_imports.extend(
-                alias.name for alias in node.names if alias.name == "notebooklm._artifacts"
+                alias.name for alias in node.names if alias.name in artifact_facade_modules
             )
-        elif isinstance(node, ast.ImportFrom) and node.module in {
-            "_artifacts",
-            "notebooklm._artifacts",
-        }:
-            artifact_facade_imports.extend(f"{node.module}.{alias.name}" for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in artifact_facade_modules:
+                artifact_facade_imports.extend(f"{module}.{alias.name}" for alias in node.names)
+            elif module in {"", "notebooklm"}:
+                artifact_facade_imports.extend(
+                    alias.name for alias in node.names if alias.name == "_artifacts"
+                )
 
     assert artifact_facade_imports == []
     assert artifacts._mind_map is mind_map

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -322,15 +322,14 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 #
 # Modeled on the core-private-access guard above. Pins the invariant that
 # artifact-service helper modules (``_artifact_downloads.py`` and
-# ``_artifact_generation.py``) depend only on the narrow
-# ``_ArtifactsServiceMethods`` Protocol declared in ``_artifacts.py``, not
-# on the full concrete ``ArtifactsAPI``. Each helper migration PR appends
-# the helper's module name to ``_REACH_IN_MIGRATED_MODULES`` below.
+# ``_artifact_generation.py``) do not retain or call back into the
+# ``ArtifactsAPI`` facade. Each helper migration PR appends the helper's
+# module name to ``_REACH_IN_MIGRATED_MODULES`` below.
 # ----------------------------------------------------------------------------
 
 
-# Modules already migrated to ``_ArtifactsServiceMethods`` constructor
-# injection — the guard below enforces no residual ``self._api`` reach-in.
+# Modules already migrated to constructor-injected collaborators — the guard
+# below enforces no residual ``self._api`` reach-in.
 # Bookkeeping (mirrors the ``_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS`` pattern):
 #   * ``_artifact_downloads.py`` migrated (PR #896, T2 of the
 #     encapsulation-reach-in-remediation phase).
@@ -459,7 +458,7 @@ def test_artifact_services_have_no_facade_reach_in() -> None:
             violations[module_name] = visitor.violations
     assert not violations, (
         f"Encapsulation violations found: {violations}. "
-        "Helpers must depend on _ArtifactsServiceMethods Protocol, not on ArtifactsAPI."
+        "Helpers must depend on explicit collaborators, not on ArtifactsAPI."
     )
 
 
@@ -782,13 +781,14 @@ def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> N
 
 
 def test_phase7_artifact_download_patch_seams_are_current() -> None:
-    """Artifact downloads must use canonical helpers, not facade module lookup.
+    """Artifact downloads must use canonical helpers and collaborators.
 
     Phase 5 (refactor-history.md Migration Plan steps 6-7) moves the mind-map
     create/list/extract paths off the ``_mind_map`` module-level seams
     and onto the injected ``NoteService`` + ``NoteBackedMindMapService``
     instances. Downloads should now import their canonical helpers directly
-    rather than resolving through ``notebooklm._artifacts`` at runtime.
+    rather than resolving through ``notebooklm._artifacts`` at runtime or in
+    type-checking-only imports.
     """
     import notebooklm._artifact_downloads as artifact_downloads
     import notebooklm._artifact_formatters as artifact_formatters
@@ -796,10 +796,28 @@ def test_phase7_artifact_download_patch_seams_are_current() -> None:
     import notebooklm._mind_map as mind_map
     import notebooklm.auth as auth
 
+    tree = ast.parse((SRC_ROOT / "_artifact_downloads.py").read_text(encoding="utf-8"))
+    artifact_facade_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            artifact_facade_imports.extend(
+                alias.name for alias in node.names if alias.name == "notebooklm._artifacts"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module in {
+            "_artifacts",
+            "notebooklm._artifacts",
+        }:
+            artifact_facade_imports.extend(f"{node.module}.{alias.name}" for alias in node.names)
+
+    assert artifact_facade_imports == []
     assert artifacts._mind_map is mind_map
     assert not hasattr(artifact_downloads, "_artifact_seams")
     assert artifact_downloads.load_httpx_cookies is auth.load_httpx_cookies
     assert artifact_downloads._extract_app_data is artifact_formatters._extract_app_data
+    assert (
+        artifact_downloads._format_interactive_content
+        is artifact_formatters._format_interactive_content
+    )
     assert artifact_downloads._parse_data_table is artifact_formatters._parse_data_table
 
 


### PR DESCRIPTION
## Summary

- remove the remaining `_ArtifactsServiceMethods` facade-shaped method bag from artifact downloads
- inject the real artifact collaborators into `ArtifactDownloadService`: runtime RPC caller, listing service, mind-map service, and storage path
- move download tests to canonical download-service seams and strengthen the architecture guard against `_artifact_downloads -> _artifacts` imports

## Stack

Stacked on #1013 (`refactor/artifact-facade-backreferences`). This should be reviewed after #1013 because it builds on the artifact/source facade cleanup there.

## Tests

- `uv run pytest tests/unit/test_artifact_downloads.py -q`
- `uv run pytest tests/unit/test_init_order.py -q`
- `uv run pytest tests/integration/concurrency/test_download_blocks_loop.py -q`
- `uv run pytest tests/integration/test_artifacts_integration.py -q -k "download_audio or download_video or download_infographic or download_slide_deck or download_report or download_data_table or download_quiz or download_flashcards"`
- `uv run pytest tests/unit/test_artifact_downloads.py tests/unit/test_artifacts_coverage.py tests/unit/test_download_url.py tests/unit/test_download_result.py tests/unit/concurrency/test_download_collision.py -q`
- `uv run --frozen ruff check src/notebooklm tests`
- `uv run --frozen mypy src/notebooklm`
- `uv run --frozen pytest -q`
- `uv run --frozen pre-commit run --all-files`

Final full pytest after rebasing onto #1013 follow-up: `6193 passed, 12 skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked artifact download flows to centralize listing, selection, and content fetching for media, slides, reports, tables, and interactive content—improves reliability and consistency of downloads.
* **Tests**
  * Updated integration and unit tests to match the new download implementation and maintain concurrency/regression coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->