### PR TITLE
refactor(architecture): add request envelope materialization contract

### DIFF
--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -12,6 +12,8 @@ defines:
   style: each middleware receives the request and a ``next_call`` callable;
   it decides whether (and how) to invoke ``next_call(request)``, optionally
   observing or transforming the response.
+- :func:`materialize_rpc_request` — converts the legacy ``BuildRequest``
+  callback shape into the future populated ``RpcRequest`` envelope.
 - :func:`build_chain` — composes a ``Sequence[Middleware]`` around a terminal
   ``NextCall`` so the leftmost middleware in the sequence becomes the
   *outermost* wrapper (matches the ordering documented in ADR-009).
@@ -31,6 +33,8 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import httpx
+
+from ._request_types import AuthSnapshot, BuildRequest, materialize_build_request
 
 # ---------------------------------------------------------------------------
 # Chain envelope types.
@@ -119,6 +123,32 @@ class RpcResponse:
     ``request.context['trace_id']`` can read it back here) plus any
     response-side additions a middleware made.
     """
+
+
+def materialize_rpc_request(
+    *,
+    build_request: BuildRequest,
+    snapshot: AuthSnapshot,
+    context: dict[str, Any],
+) -> RpcRequest:
+    """Build a populated chain envelope from the legacy request callback.
+
+    This is a behavior-neutral bridge for the Tier-13 request-materialization
+    migration. ``Session`` still enters the chain with empty request fields
+    today, but the future chain leaf can use this helper to produce the
+    populated ``RpcRequest(url, headers, body)`` shape that middlewares and
+    ``Kernel.post`` should see.
+
+    ``context`` is intentionally retained by reference, matching ADR-009's
+    mutable per-request metadata contract.
+    """
+    request = materialize_build_request(build_request, snapshot)
+    return RpcRequest(
+        url=request.url,
+        headers=request.headers or {},
+        body=request.body,
+        context=context,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -257,4 +257,5 @@ __all__ = [
     "RpcRequest",
     "RpcResponse",
     "build_chain",
+    "materialize_rpc_request",
 ]

--- a/src/notebooklm/_request_types.py
+++ b/src/notebooklm/_request_types.py
@@ -21,6 +21,9 @@ Three names live here:
   shape is preferred for new code (named fields, immutable, type-checked
   at construction) over the legacy tuple return. Existing callers continue
   to use the tuple shape until they migrate.
+- :func:`materialize_build_request` — bridge from the legacy tuple callback
+  to ``BuildRequestResult``. This is the contract the later middleware-chain
+  leaf rewrite will use before handing a request envelope to ``Kernel.post``.
 
 See ``docs/adr/0009-middleware-chain.md`` for the full chain contract and
 ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
@@ -65,8 +68,27 @@ class BuildRequestResult:
     headers: Mapping[str, str] | None
 
 
+def materialize_build_request(
+    build_request: BuildRequest,
+    snapshot: AuthSnapshot,
+) -> BuildRequestResult:
+    """Build one HTTP-attempt request and normalize it to named fields.
+
+    ``BuildRequest`` is the legacy callback shape used by RPC and chat
+    callers. It returns a positional tuple and allows the body to be either a
+    ``str`` or ``bytes``. The middleware chain's target envelope pins
+    ``RpcRequest.body`` to bytes, so this bridge converts strings to UTF-8
+    bytes and copies headers into a detached ``dict``.
+    """
+    url, body, headers = build_request(snapshot)
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else body
+    detached_headers = dict(headers) if headers is not None else None
+    return BuildRequestResult(url=url, body=body_bytes, headers=detached_headers)
+
+
 __all__ = [
     "AuthSnapshot",
     "BuildRequest",
     "BuildRequestResult",
+    "materialize_build_request",
 ]

--- a/tests/unit/test_middleware_types.py
+++ b/tests/unit/test_middleware_types.py
@@ -9,11 +9,11 @@ public-ish aliases in ``src/notebooklm/_request_types.py``:
   satisfies the Protocol without inheriting from it.
 - ``build_chain`` composition order — leftmost middleware in the sequence
   becomes the outermost wrapper (matches ADR-009 chain ordering).
-- ``BuildRequestResult`` value semantics.
+- ``BuildRequestResult`` value semantics and request materialization bridges.
 
-These tests target the type-only scaffolding from PR 12.1. No production
-chain is wired (PR 12.2 does that), so the tests build chains over fake
-terminals and observe behavior directly.
+These tests target the type scaffolding and materialization contracts from
+Tier-12/13. No production chain is wired (PR 12.2 does that), so the tests
+build chains over fake terminals and observe behavior directly.
 """
 
 from __future__ import annotations
@@ -430,3 +430,16 @@ def test_request_types_all_contains_only_public_names() -> None:
     assert "BuildRequestResult" in _request_types.__all__
     assert "materialize_build_request" in _request_types.__all__
     assert all(not name.startswith("_") for name in _request_types.__all__)
+
+
+def test_middleware_all_contains_only_public_names() -> None:
+    """``_middleware.__all__`` exports the chain contract helpers."""
+    from notebooklm import _middleware
+
+    assert "Middleware" in _middleware.__all__
+    assert "NextCall" in _middleware.__all__
+    assert "RpcRequest" in _middleware.__all__
+    assert "RpcResponse" in _middleware.__all__
+    assert "build_chain" in _middleware.__all__
+    assert "materialize_rpc_request" in _middleware.__all__
+    assert all(not name.startswith("_") for name in _middleware.__all__)

--- a/tests/unit/test_middleware_types.py
+++ b/tests/unit/test_middleware_types.py
@@ -30,11 +30,13 @@ from notebooklm._middleware import (
     RpcRequest,
     RpcResponse,
     build_chain,
+    materialize_rpc_request,
 )
 from notebooklm._request_types import (
     AuthSnapshot,
     BuildRequest,
     BuildRequestResult,
+    materialize_build_request,
 )
 
 # ---------------------------------------------------------------------------
@@ -360,6 +362,65 @@ def test_build_request_result_accepts_none_headers() -> None:
     assert r.headers is None
 
 
+def test_materialize_build_request_normalizes_str_body_and_copies_headers() -> None:
+    """Legacy tuple builders become the named bytes-body request shape."""
+    snap = AuthSnapshot(csrf_token="csrf", session_id="sid", authuser=1, account_email=None)
+    original_headers = {"X-Goog-AuthUser": "1"}
+
+    def factory(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        return (
+            f"https://example.test/batchexecute?authuser={snapshot.authuser}",
+            "f.req=%5B%5D&",
+            original_headers,
+        )
+
+    result = materialize_build_request(factory, snap)
+
+    assert result == BuildRequestResult(
+        url="https://example.test/batchexecute?authuser=1",
+        body=b"f.req=%5B%5D&",
+        headers={"X-Goog-AuthUser": "1"},
+    )
+    assert result.headers is not original_headers
+    original_headers["X-Goog-AuthUser"] = "2"
+    assert result.headers == {"X-Goog-AuthUser": "1"}
+
+
+def test_materialize_build_request_preserves_bytes_body_and_none_headers() -> None:
+    snap = AuthSnapshot(csrf_token="csrf", session_id="sid", authuser=0, account_email=None)
+
+    def factory(snapshot: AuthSnapshot) -> tuple[str, bytes, None]:
+        return ("https://example.test/batchexecute", b"raw-bytes", None)
+
+    result = materialize_build_request(factory, snap)
+
+    assert result.body == b"raw-bytes"
+    assert result.headers is None
+
+
+def test_materialize_rpc_request_populates_envelope_and_preserves_context_identity() -> None:
+    """The future middleware envelope keeps ADR-009's shared context object."""
+    snap = AuthSnapshot(csrf_token="csrf", session_id="sid", authuser=0, account_email=None)
+
+    def factory(snapshot: AuthSnapshot) -> tuple[str, str, None]:
+        return (
+            f"https://example.test/batchexecute?authuser={snapshot.authuser}",
+            "f.req=body&",
+            None,
+        )
+
+    context = {"build_request": factory, "log_label": "RPC TEST_METHOD"}
+    request = materialize_rpc_request(build_request=factory, snapshot=snap, context=context)
+
+    assert request.url == "https://example.test/batchexecute?authuser=0"
+    assert request.headers == {}
+    assert request.body == b"f.req=body&"
+    assert request.context is context
+
+    request.context["trace_id"] = "trace-1"
+    assert context["trace_id"] == "trace-1"
+
+
 def test_request_types_all_contains_only_public_names() -> None:
     """``__all__`` is the canonical public-within-package export list."""
     from notebooklm import _request_types
@@ -367,4 +428,5 @@ def test_request_types_all_contains_only_public_names() -> None:
     assert "AuthSnapshot" in _request_types.__all__
     assert "BuildRequest" in _request_types.__all__
     assert "BuildRequestResult" in _request_types.__all__
+    assert "materialize_build_request" in _request_types.__all__
     assert all(not name.startswith("_") for name in _request_types.__all__)


### PR DESCRIPTION
## Summary

- add `materialize_build_request()` to normalize legacy `BuildRequest` callbacks into named `BuildRequestResult` values
- add `materialize_rpc_request()` as the future populated `RpcRequest(url, headers, body)` bridge for the middleware-chain leaf rewrite
- pin body/header/context behavior in middleware type tests before changing `Session._perform_authed_post` or the auth-refresh retry path

## Stack

Stacked on #1014 (`refactor/artifact-download-collaborators`). This is the first low-risk middleware request-materialization slice after the artifact facade cleanup stack.

## Notes

This intentionally does not move the production chain terminal yet. It establishes the request-envelope Interface first so the next PR can rewrite the leaf toward `Kernel.post` with auth-refresh rebuild semantics pinned.

## Tests

- `uv run pytest tests/unit/test_middleware_types.py -q`
- `uv run pytest tests/unit/test_middleware_types.py tests/unit/test_auth_refresh_middleware.py tests/unit/test_authed_transport.py tests/unit/test_middleware_chain_builder.py -q`
- `uv run --frozen ruff check src/notebooklm tests`
- `uv run --frozen mypy src/notebooklm`
- `uv run --frozen pre-commit run --all-files`
- `uv run --frozen pytest -q`

Full pytest: `6196 passed, 12 skipped`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpers to materialize legacy request callbacks into standardized request envelopes with normalized URL, headers, and byte-encoded bodies, while preserving caller-provided context by reference.

* **Tests**
  * Added unit tests covering string-to-bytes conversion, header isolation (copied headers), context preservation, and presence of the new helpers in public exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->