### PR TITLE
refactor(architecture): populate middleware request envelope

### DIFF
--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -18,12 +18,13 @@ defines:
   ``NextCall`` so the leftmost middleware in the sequence becomes the
   *outermost* wrapper (matches the ordering documented in ADR-009).
 
-No middleware is implemented in this PR. No production code wires the
-chain in this PR. PR 12.2 wires an empty chain into ``Session``; PRs
-12.3–12.8 extract one middleware at a time. See
-``docs/adr/0009-middleware-chain.md`` for the load-bearing decisions and
-``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
-PR sequence.
+Production ``Session`` wiring composes these envelopes through the current
+middleware stack. During the request-materialization migration, the chain
+enters with populated ``RpcRequest(url, headers, body)`` fields while the
+terminal still adapts through ``AuthedTransport.perform_authed_post``. A
+later terminal rewrite can consume the same envelope directly through
+``Kernel.post``. See ``docs/adr/0009-middleware-chain.md`` for the
+load-bearing decisions.
 """
 
 from __future__ import annotations
@@ -134,10 +135,10 @@ def materialize_rpc_request(
     """Build a populated chain envelope from the legacy request callback.
 
     This is a behavior-neutral bridge for the Tier-13 request-materialization
-    migration. ``Session`` still enters the chain with empty request fields
-    today, but the future chain leaf can use this helper to produce the
-    populated ``RpcRequest(url, headers, body)`` shape that middlewares and
-    ``Kernel.post`` should see.
+    migration. ``Session`` uses this helper to enter the chain with populated
+    ``RpcRequest(url, headers, body)`` fields while the transitional terminal
+    still delegates through the legacy ``BuildRequest`` callback. A later
+    ``Kernel.post`` terminal can consume the same envelope directly.
 
     ``context`` is intentionally retained by reference, matching ADR-009's
     mutable per-request metadata contract.

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -37,18 +37,16 @@ that duration AFTER the successful refresh and BEFORE the retry. Matches
 the legacy ``AuthedTransport`` behavior so a cassette that recorded the
 post-refresh delay replays the same timing.
 
-Why this PR does NOT use ADR-009's pinned ``rebuild_headers`` /
-``build_request_factory`` closure callbacks (yet): the chain envelope
-(``RpcRequest.url`` / ``.headers`` / ``.body``) is still empty in
-production — the chain leaf builds the HTTP request from
-``context["build_request"]`` on each invocation. So a simple
-``await next_call(request)`` on the unchanged ``RpcRequest`` envelope is
-sufficient: the leaf re-snapshots auth state via
-``AuthRefreshCoordinator.snapshot`` (which sees the refreshed tokens)
-and re-builds headers + body. The full closure-callback contract from
-ADR-009 §"AuthRefreshMiddleware constructor signature" activates in PR
-13.x when the chain envelope carries url/headers/body and the leaf
-shrinks to a pure ``Kernel.post``-shaped seam.
+Request-materialization transition: ``Session`` now enters the chain with
+the initial ``RpcRequest.url`` / ``.headers`` / ``.body`` populated, but the
+leaf still sends through ``context["build_request"]``. A simple
+``await next_call(request)`` on the unchanged envelope remains sufficient:
+the legacy leaf re-snapshots auth state via
+``AuthRefreshCoordinator.snapshot`` (which sees the refreshed tokens) and
+re-builds headers + body from the callback on retry. The full
+closure-callback contract from ADR-009 §"AuthRefreshMiddleware constructor
+signature" activates when the leaf shrinks to a pure ``Kernel.post`` seam
+and refreshed retries must replace the envelope itself.
 
 This regression-fix from PR 12.7 also closes here: pre-PR-12.7 the leaf's
 ``refreshed_this_call`` lived in the same loop as 429/5xx retries (one

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -919,15 +919,15 @@ class Session:
         def _materialized_build_request(_snapshot: AuthSnapshot) -> _BuildRequestTuple:
             return cached_result
 
-        request = materialize_rpc_request(
-            build_request=_materialized_build_request,
-            snapshot=snapshot,
-            context=context,
-        )
         context["build_request"] = _cached_first_build_request(
             original=build_request,
             cached_result=cached_result,
             cached_snapshot=snapshot,
+        )
+        request = materialize_rpc_request(
+            build_request=_materialized_build_request,
+            snapshot=snapshot,
+            context=context,
         )
 
         # The ``max_concurrent_rpcs`` slot is acquired by

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -784,11 +784,14 @@ class Session:
         → four scalar reads → return) but routes the lock-wait metric
         through ``host._metrics_obj`` directly rather than via the
         ``_record_lock_wait`` facade. Whole-request atomicity for
-        ``(csrf, sid, cookies)`` on the wire still depends on the
-        no-await invariant between this method returning and
-        ``client.post(...)`` inside :meth:`_perform_authed_post` (see
+        ``(csrf, sid, cookies)`` on the wire still depends on the terminal's
+        no-await invariant in :meth:`AuthedTransport.perform_authed_post` (see
         the related AST guard in
-        ``tests/unit/test_concurrency_refresh_race.py``).
+        ``tests/unit/test_concurrency_refresh_race.py``). During the
+        request-envelope migration, :meth:`_perform_authed_post` also takes a
+        pre-chain snapshot for middleware-visible materialization; the legacy
+        terminal re-snapshots before the actual POST and discards the cached
+        tuple if auth changed while the call was queued.
         """
         return await self._auth_coord.snapshot(self)
 
@@ -891,7 +894,10 @@ class Session:
         the request. Until the terminal switches to ``Kernel.post`` directly,
         ``context["build_request"]`` is a first-call cache adapter over the
         original callback so the legacy terminal does not call the request
-        builder twice on the happy path.
+        builder twice on the happy path. The terminal still re-snapshots before
+        the actual POST and only reuses this materialized tuple when that
+        snapshot matches, preserving the wire-path no-await invariant while the
+        envelope becomes visible to middlewares.
         """
         # Event-loop affinity guard. Session-shrink PR 3 lifted this OUT of
         # ``AuthedTransport.perform_authed_post`` (where it ran once per

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -14,6 +14,7 @@ from ._authed_transport import (
     AuthedTransport,
     AuthSnapshot,
     BuildRequest,
+    PostBody,
 )
 from ._client_metrics import ClientMetrics
 from ._cookie_persistence import CookiePersistence
@@ -26,6 +27,7 @@ from ._middleware import (
     RpcRequest,
     RpcResponse,
     build_chain,
+    materialize_rpc_request,
 )
 from ._middleware_chain import MiddlewareChainBuilder
 from ._middleware_semaphore import RPC_QUEUE_WAIT_CONTEXT_KEY
@@ -82,6 +84,8 @@ if TYPE_CHECKING:
 from .rpc import RPCMethod
 
 logger = logging.getLogger(__name__)
+
+_BuildRequestTuple = tuple[str, PostBody, dict[str, str] | None]
 
 # Auth-snapshot canonical implementation lives on
 # :class:`AuthRefreshCoordinator` (``_session_auth.py`` —
@@ -141,6 +145,38 @@ def _live_is_auth_error(exc: Exception) -> bool:
     from ._session_helpers import is_auth_error
 
     return is_auth_error(exc)
+
+
+def _cached_first_build_request(
+    *,
+    original: BuildRequest,
+    cached_result: _BuildRequestTuple,
+    cached_snapshot: AuthSnapshot,
+) -> BuildRequest:
+    """Return the materialized first request once, then delegate.
+
+    ``Session._perform_authed_post`` materializes ``RpcRequest`` before
+    entering the middleware chain so middlewares can observe URL, headers, and
+    body. The legacy terminal still calls ``AuthedTransport.perform_authed_post``,
+    which expects a ``BuildRequest`` callback. This adapter lets that first
+    terminal call reuse the already-built tuple when it observes the same auth
+    snapshot, preserving the historical "one build per HTTP attempt" contract.
+
+    If the terminal sees a different snapshot on its first call (for example,
+    auth refreshed while the request was queued), discard the cached tuple and
+    rebuild from the fresh snapshot.
+    """
+    first_call = True
+
+    def _build(snapshot: AuthSnapshot) -> _BuildRequestTuple:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            if snapshot == cached_snapshot:
+                return cached_result
+        return original(snapshot)
+
+    return _build
 
 
 class Session:
@@ -804,15 +840,12 @@ class Session:
         ``self._get_authed_transport()`` is resolved on every invocation so
         late-bound monkeypatches of ``_get_authed_transport`` (e.g. fixtures
         that swap the transport mid-test) still affect live behavior. The
-        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
-        dataclass fields stay unpopulated through Tier-12 — middlewares
-        in PRs 12.3–12.9 carried behavior out of :class:`AuthedTransport`
-        but the leaf still rebuilds the request from ``build_request`` +
-        ``AuthSnapshot`` rather than reading the dataclass fields.
-        Population is deferred to Tier-13 row 13.2 (``Kernel.post``
-        rewrite) — see ADR-009 close-out notes §"AuthRefreshMiddleware
-        shipped without rebuild closures". See ADR-009
-        §"RpcRequest.context keys" for the metadata vocabulary.
+        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body`` fields
+        are populated before chain entry for middleware visibility, but this
+        transitional leaf still delegates through ``build_request`` until the
+        Tier-13 ``Kernel.post`` terminal rewrite lands. See ADR-009
+        §"RpcRequest.context keys" and close-out notes §"AuthRefreshMiddleware
+        shipped without rebuild closures" for the metadata vocabulary.
         """
         context = request.context
         build_request = context["build_request"]
@@ -853,9 +886,12 @@ class Session:
         matching the pre-chain behavior (where ``_chat_transport`` never
         called ``_emit_rpc_event``).
 
-        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
-        intentionally stay empty until PRs 12.5/12.7/12.8 begin populating
-        them as middlewares strip behavior out of :class:`AuthedTransport`.
+        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body`` are
+        populated through :func:`materialize_rpc_request` before the chain sees
+        the request. Until the terminal switches to ``Kernel.post`` directly,
+        ``context["build_request"]`` is a first-call cache adapter over the
+        original callback so the legacy terminal does not call the request
+        builder twice on the happy path.
         """
         # Event-loop affinity guard. Session-shrink PR 3 lifted this OUT of
         # ``AuthedTransport.perform_authed_post`` (where it ran once per
@@ -865,16 +901,27 @@ class Session:
         # currently-running loop differs from the one captured at
         # ``open()``-time.
         self.assert_bound_loop()
-        request = RpcRequest(
-            url="",
-            headers={},
-            body=b"",
-            context={
-                "build_request": build_request,
-                "log_label": log_label,
-                "disable_internal_retries": disable_internal_retries,
-                "rpc_method": rpc_method,
-            },
+        context = {
+            "build_request": build_request,
+            "log_label": log_label,
+            "disable_internal_retries": disable_internal_retries,
+            "rpc_method": rpc_method,
+        }
+        snapshot = await self._snapshot()
+        cached_result = build_request(snapshot)
+
+        def _materialized_build_request(_snapshot: AuthSnapshot) -> _BuildRequestTuple:
+            return cached_result
+
+        request = materialize_rpc_request(
+            build_request=_materialized_build_request,
+            snapshot=snapshot,
+            context=context,
+        )
+        context["build_request"] = _cached_first_build_request(
+            original=build_request,
+            cached_result=cached_result,
+            cached_snapshot=snapshot,
         )
 
         # The ``max_concurrent_rpcs`` slot is acquired by

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -461,13 +461,18 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
     core = _make_core()
     await core.open()
     try:
-        snapshots = [
-            AuthSnapshot("CSRF_OLD", "SID_OLD", 0, None),
-            AuthSnapshot("CSRF_NEW", "SID_NEW", 0, None),
-        ]
+        snapshots = iter(
+            [
+                AuthSnapshot("CSRF_OLD", "SID_OLD", 0, None),
+                AuthSnapshot("CSRF_NEW", "SID_NEW", 0, None),
+            ]
+        )
 
         async def fake_snapshot() -> AuthSnapshot:
-            return snapshots.pop(0)
+            try:
+                return next(snapshots)
+            except StopIteration:
+                pytest.fail("unexpected extra auth snapshot")
 
         core._snapshot = fake_snapshot  # type: ignore[method-assign]
         calls: list[AuthSnapshot] = []

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -123,31 +123,35 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
             {"X-Test": "yes"},
         )
 
-    response = await core._perform_authed_post(
-        build_request=build,
-        log_label="RPC LIST_NOTEBOOKS",
-        disable_internal_retries=True,
-        rpc_method="LIST_NOTEBOOKS",
-    )
+    await core.open()
+    try:
+        response = await core._perform_authed_post(
+            build_request=build,
+            log_label="RPC LIST_NOTEBOOKS",
+            disable_internal_retries=True,
+            rpc_method="LIST_NOTEBOOKS",
+        )
 
-    assert response.status_code == 200
-    assert len(captured) == 1
-    request = captured[0]
-    assert request.url == "https://example.test/x?authuser=0"
-    assert request.headers == {"X-Test": "yes"}
-    assert request.body == b"payload"
-    assert request.context["log_label"] == "RPC LIST_NOTEBOOKS"
-    assert request.context["disable_internal_retries"] is True
-    assert request.context["rpc_method"] == "LIST_NOTEBOOKS"
-    assert len(calls) == 1
-    assert calls[0].csrf_token == "CSRF_OLD"
-    cached_build_request = request.context["build_request"]
-    assert cached_build_request is not build
-    assert cached_build_request(calls[0]) == (
-        "https://example.test/x?authuser=0",
-        "payload",
-        {"X-Test": "yes"},
-    )
+        assert response.status_code == 200
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.url == "https://example.test/x?authuser=0"
+        assert request.headers == {"X-Test": "yes"}
+        assert request.body == b"payload"
+        assert request.context["log_label"] == "RPC LIST_NOTEBOOKS"
+        assert request.context["disable_internal_retries"] is True
+        assert request.context["rpc_method"] == "LIST_NOTEBOOKS"
+        assert len(calls) == 1
+        assert calls[0].csrf_token == "CSRF_OLD"
+        cached_build_request = request.context["build_request"]
+        assert cached_build_request is not build
+        assert cached_build_request(calls[0]) == (
+            "https://example.test/x?authuser=0",
+            "payload",
+            {"X-Test": "yes"},
+        )
+    finally:
+        await core.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -102,6 +102,55 @@ def _status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPSta
 
 
 @pytest.mark.asyncio
+async def test_perform_authed_post_populates_request_envelope_for_chain() -> None:
+    """Middlewares see the materialized URL, headers, and byte body."""
+    core = _make_core()
+    captured: list[RpcRequest] = []
+
+    async def fake_chain(request: RpcRequest) -> RpcResponse:
+        captured.append(request)
+        return RpcResponse(response=_ok_response(), context=request.context)
+
+    core._authed_post_chain = fake_chain  # type: ignore[method-assign]
+
+    calls: list[AuthSnapshot] = []
+
+    def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        calls.append(snapshot)
+        return (
+            f"https://example.test/x?authuser={snapshot.authuser}",
+            "payload",
+            {"X-Test": "yes"},
+        )
+
+    response = await core._perform_authed_post(
+        build_request=build,
+        log_label="RPC LIST_NOTEBOOKS",
+        disable_internal_retries=True,
+        rpc_method="LIST_NOTEBOOKS",
+    )
+
+    assert response.status_code == 200
+    assert len(captured) == 1
+    request = captured[0]
+    assert request.url == "https://example.test/x?authuser=0"
+    assert request.headers == {"X-Test": "yes"}
+    assert request.body == b"payload"
+    assert request.context["log_label"] == "RPC LIST_NOTEBOOKS"
+    assert request.context["disable_internal_retries"] is True
+    assert request.context["rpc_method"] == "LIST_NOTEBOOKS"
+    assert len(calls) == 1
+    assert calls[0].csrf_token == "CSRF_OLD"
+    cached_build_request = request.context["build_request"]
+    assert cached_build_request is not build
+    assert cached_build_request(calls[0]) == (
+        "https://example.test/x?authuser=0",
+        "payload",
+        {"X-Test": "yes"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_chain_reads_live_retry_budget(monkeypatch):
     """Tier-12 PR 12.7 lifted the 429 / 5xx retry loop into ``RetryMiddleware``.
 
@@ -392,6 +441,49 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
         assert response.status_code == 200
         assert len(calls) == 1
         assert calls[0].csrf_token == "CSRF_OLD"
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch):
+    """A changed terminal snapshot discards the materialization cache.
+
+    This pins the transition behavior before the terminal moves to
+    ``Kernel.post`` directly: the pre-chain envelope is observable, but the
+    legacy terminal must not send a stale cached tuple if auth changed before
+    its first POST attempt.
+    """
+    core = _make_core()
+    await core.open()
+    try:
+        snapshots = [
+            AuthSnapshot("CSRF_OLD", "SID_OLD", 0, None),
+            AuthSnapshot("CSRF_NEW", "SID_NEW", 0, None),
+        ]
+
+        async def fake_snapshot() -> AuthSnapshot:
+            return snapshots.pop(0)
+
+        core._snapshot = fake_snapshot  # type: ignore[method-assign]
+        calls: list[AuthSnapshot] = []
+
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            calls.append(snapshot)
+            return "https://example.test/x", f"payload-{snapshot.csrf_token}", {}
+
+        async def fake_post(url, *, content, **kwargs):
+            assert content == "payload-CSRF_NEW"
+            return _ok_response()
+
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert len(calls) == 2
+        assert calls[0].csrf_token == "CSRF_OLD"
+        assert calls[1].csrf_token == "CSRF_NEW"
     finally:
         await core.close()
 

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -1,9 +1,8 @@
-"""Integration tests for the empty middleware chain wired into ``Session``.
+"""Integration tests for the authed-post middleware chain wired into ``Session``.
 
-PR 12.2 of the Tier-12/13 greenfield migration wires
-:func:`notebooklm._middleware.build_chain` into
-:meth:`Session.__init__` with an empty middleware list. The chain leaf
-(:meth:`Session._authed_post_chain_terminal`) reads
+The Tier-12/13 greenfield migration wires
+:func:`notebooklm._middleware.build_chain` into :meth:`Session.__init__`.
+The chain leaf (:meth:`Session._authed_post_chain_terminal`) reads
 ``build_request`` / ``log_label`` / ``disable_internal_retries`` from
 ``RpcRequest.context`` and delegates to
 :meth:`AuthedTransport.perform_authed_post` — the shared seam covering both
@@ -11,14 +10,14 @@ PR 12.2 of the Tier-12/13 greenfield migration wires
 calls ``self._owner._perform_authed_post`` at ``_rpc_executor.py:275``).
 
 These tests verify the wiring contract from
-``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160 and ADR-009
-§"RpcRequest.context keys":
+ADR-009 §"RpcRequest.context keys":
 
-1. Both call paths (``Session._perform_authed_post`` directly and
-   ``RpcExecutor.execute`` indirectly) flow through the empty chain to the
-   transport.
-2. ``RpcRequest.context`` carries ``build_request`` / ``log_label`` /
-   ``disable_internal_retries`` exactly as the leaf expects them.
+1. Both call paths (``Session._perform_authed_post`` directly and the
+   ``RpcExecutor.execute`` keyword shape) flow through the chain terminal to
+   the transport.
+2. ``RpcRequest.context`` carries a legacy ``build_request`` adapter plus
+   ``log_label`` / ``disable_internal_retries`` exactly as the leaf expects
+   them.
 3. The leaf returns an :class:`RpcResponse` wrapping the
    :class:`httpx.Response` from the transport.
 
@@ -79,13 +78,12 @@ def _swap_transport(core: Session, fake: FakeAuthedPost) -> None:
 
 
 @pytest.mark.asyncio
-async def test_empty_chain_routes_perform_authed_post_to_transport() -> None:
-    """``Session._perform_authed_post`` flows through the empty chain to transport.
+async def test_chain_routes_perform_authed_post_to_transport() -> None:
+    """``Session._perform_authed_post`` flows through the chain to transport.
 
-    Covers the first of the two call paths from master plan line 160:
-    direct callers of ``Session._perform_authed_post`` (the chat path
-    in ``_chat_transport.py:64`` and any first-party caller via
-    ``client._session._perform_authed_post``).
+    Covers direct callers of ``Session._perform_authed_post``: the chat
+    path in ``_chat_transport.py:64`` and any first-party caller via
+    ``client._session._perform_authed_post``.
     """
     expected_response = httpx.Response(status_code=200, content=b"chain-routed")
     fake = FakeAuthedPost(response=expected_response)
@@ -104,21 +102,25 @@ async def test_empty_chain_routes_perform_authed_post_to_transport() -> None:
     assert response is expected_response
     assert fake.call_count == 1
     call = fake.calls[0]
-    assert call["build_request"] is build_request
+    assert call["build_request"] is not build_request
+    assert call["build_request"](await core._snapshot()) == (
+        "https://fake/url",
+        b"body",
+        None,
+    )
     assert call["log_label"] == "test-log-label"
     assert call["disable_internal_retries"] is False
 
 
 @pytest.mark.asyncio
-async def test_empty_chain_routes_rpc_executor_path_to_transport() -> None:
+async def test_chain_routes_rpc_executor_path_to_transport() -> None:
     """``RpcExecutor.execute`` → ``_perform_authed_post`` flows through the chain too.
 
-    Covers the second of the two call paths from master plan line 160:
     ``RpcExecutor.execute`` (``_rpc_executor.py:275``) calls
     ``self._owner._perform_authed_post(...)`` which is precisely
-    :meth:`Session._perform_authed_post`. Routing both paths through
-    one seam is the whole point of wiring at ``_perform_authed_post``
-    rather than at each call site.
+    :meth:`Session._perform_authed_post`. Routing both paths through one
+    seam is the whole point of wiring at ``_perform_authed_post`` rather
+    than at each call site.
 
     We exercise the route by calling ``_perform_authed_post`` with the
     keyword shape ``RpcExecutor.execute`` uses (the
@@ -146,7 +148,12 @@ async def test_empty_chain_routes_rpc_executor_path_to_transport() -> None:
     assert response is expected_response
     assert fake.call_count == 1
     call = fake.calls[0]
-    assert call["build_request"] is build_request
+    assert call["build_request"] is not build_request
+    assert call["build_request"](await core._snapshot()) == (
+        "https://fake/rpc",
+        b"rpc-body",
+        {"X-Goog-AuthUser": "0"},
+    )
     assert call["log_label"] == "RPC LIST_NOTEBOOKS"
     # The ``disable_internal_retries`` bool resolved by
     # ``_idempotency.resolve_effective_disable_internal_retries`` upstream
@@ -190,7 +197,7 @@ async def test_chain_terminal_reads_context_keys() -> None:
     assert result.response is expected_response
     # The ``RpcResponse.context`` propagates the same dict the request
     # carried, so middlewares above the leaf can read additions a deeper
-    # link made. The empty chain leaves the dict unchanged.
+    # link made. The terminal adapter leaves the dict unchanged.
     assert result.context is request.context
     assert fake.call_count == 1
     assert fake.calls[0]["build_request"] is build_request
@@ -305,9 +312,9 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
     _swap_transport(core, fake)
 
     # Build a chain with one observer middleware around the production
-    # terminal. The production chain stays empty; this is a per-test
-    # composition that validates the leaf's contract against
-    # ``build_chain`` rather than ``Session.__init__``.
+    # terminal. This per-test composition validates the leaf's contract
+    # against ``build_chain`` without mutating ``Session.__init__``'s
+    # production chain.
     chain: NextCall = build_chain([observer], core._authed_post_chain_terminal)
 
     def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:


### PR DESCRIPTION
Stacked on #1015.

## Summary
- materialize RpcRequest.url, headers, and byte body before the authed-post middleware chain sees the request
- keep the current AuthedTransport.perform_authed_post terminal behind a first-call build_request cache adapter, preserving one builder call on the happy path
- pin snapshot-change behavior so the terminal rebuilds from a fresh auth snapshot if auth moves before the first POST
- update transitional middleware docs/tests to describe the populated-envelope plus legacy-terminal state

## Verification
- uv run --frozen pytest tests/unit/test_authed_transport.py tests/unit/test_chain_wiring.py tests/unit/test_middleware_types.py tests/unit/test_auth_refresh_middleware.py tests/unit/test_concurrency_refresh_race.py -q -> 92 passed, 2 skipped
- uv run --frozen ruff check src/notebooklm tests
- uv run --frozen mypy src/notebooklm
- uv run --frozen pytest -q -> 6199 passed, 12 skipped
- uv run --frozen pre-commit run --all-files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authenticated transport retry pipeline and middleware chain wiring, verifying request envelope population and snapshot-change handling.

* **Documentation**
  * Updated module and function documentation to clarify request materialization and middleware chain behavior during authentication operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->