### PR TITLE
refactor(architecture): use kernel post terminal

### DIFF
--- a/src/notebooklm/_authed_transport.py
+++ b/src/notebooklm/_authed_transport.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 import httpx
 
@@ -162,6 +162,53 @@ class TransportServerError(Exception):
 # this once per attempt so refreshed snapshots are picked up on retry.
 PostBody = str | bytes
 BuildRequest = Callable[[AuthSnapshot], tuple[str, PostBody, dict[str, str] | None]]
+
+
+def _raise_mapped_post_error(
+    *,
+    log_label: str,
+    exc: httpx.HTTPStatusError | httpx.RequestError,
+    start: float,
+    logger: logging.Logger,
+) -> NoReturn:
+    """Map raw ``Kernel.post`` errors to transport exceptions, then raise.
+
+    Both the legacy :class:`AuthedTransport` leaf and the production
+    middleware terminal need identical HTTP error semantics while the
+    AuthedTransport Adapter is retired. Keeping the mapping here prevents
+    drift between the two paths during the transition.
+    """
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+        retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
+        raise TransportRateLimited(
+            f"{log_label} rate-limited (HTTP 429)",
+            retry_after=retry_after,
+            response=exc.response,
+            original=exc,
+        ) from exc
+
+    if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
+        raise TransportServerError(
+            f"{log_label} server error (HTTP {exc.response.status_code})",
+            original=exc,
+            response=exc.response,
+            status_code=exc.response.status_code,
+        ) from exc
+
+    if isinstance(exc, httpx.RequestError):
+        raise TransportServerError(
+            f"{log_label} network error: {exc}",
+            original=exc,
+        ) from exc
+
+    elapsed = time.perf_counter() - start
+    logger.debug(
+        "%s transport error after %.3fs: %s",
+        log_label,
+        elapsed,
+        exc,
+    )
+    raise exc
 
 
 async def stream_post_with_size_cap(
@@ -342,42 +389,12 @@ class AuthedTransport:
                 body=body,
             )
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
-            # --- 429: raise for ``RetryMiddleware`` to catch ----------
-            if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
-                retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
-                raise TransportRateLimited(
-                    f"{log_label} rate-limited (HTTP 429)",
-                    retry_after=retry_after,
-                    response=exc.response,
-                    original=exc,
-                ) from exc
-
-            # --- 5xx / network: raise for ``RetryMiddleware`` ---------
-            if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
-                raise TransportServerError(
-                    f"{log_label} server error (HTTP {exc.response.status_code})",
-                    original=exc,
-                    response=exc.response,
-                    status_code=exc.response.status_code,
-                ) from exc
-            if isinstance(exc, httpx.RequestError):
-                raise TransportServerError(
-                    f"{log_label} network error: {exc}",
-                    original=exc,
-                ) from exc
-
-            # --- 4xx auth shapes (400/401/403) and everything else:
-            # propagate the raw ``httpx.HTTPStatusError`` so
-            # ``AuthRefreshMiddleware`` outside this leaf decides whether
-            # to refresh-and-retry via ``is_auth_error``.
-            elapsed = time.perf_counter() - start
-            self._logger.debug(
-                "%s transport error after %.3fs: %s",
-                log_label,
-                elapsed,
-                exc,
+            _raise_mapped_post_error(
+                log_label=log_label,
+                exc=exc,
+                start=start,
+                logger=self._logger,
             )
-            raise
 
         # Success
         return response

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -20,11 +20,9 @@ defines:
 
 Production ``Session`` wiring composes these envelopes through the current
 middleware stack. During the request-materialization migration, the chain
-enters with populated ``RpcRequest(url, headers, body)`` fields while the
-terminal still adapts through ``AuthedTransport.perform_authed_post``. A
-later terminal rewrite can consume the same envelope directly through
-``Kernel.post``. See ``docs/adr/0009-middleware-chain.md`` for the
-load-bearing decisions.
+enters with populated ``RpcRequest(url, headers, body)`` fields and the
+terminal consumes that envelope directly through ``Kernel.post``. See
+``docs/adr/0009-middleware-chain.md`` for the load-bearing decisions.
 """
 
 from __future__ import annotations
@@ -46,10 +44,9 @@ from ._request_types import AuthSnapshot, BuildRequest, materialize_build_reques
 class RpcRequest:
     """HTTP-shape request envelope passed through the middleware chain.
 
-    The chain wraps ``Kernel.post`` (or, until PR 13.2 renames the seam,
-    ``AuthedTransport.perform_authed_post``). Every middleware sees an
-    already-encoded HTTP request — encoding lives *above* the chain in
-    ``Session.rpc_call``. RPC-level metadata that middlewares need (rpc
+    The chain wraps ``Kernel.post``. Every middleware sees an already-encoded
+    HTTP request — encoding lives *above* the chain in ``Session.rpc_call``.
+    RPC-level metadata that middlewares need (rpc
     method id, idempotency, operation variant, log labels, build-request
     callback, etc.) travels through :attr:`context`.
 
@@ -112,10 +109,10 @@ class RpcResponse:
     response: httpx.Response
     """The buffered :class:`httpx.Response` from the transport leaf.
 
-    Identical in shape to what ``AuthedTransport.perform_authed_post``
-    returns today (see ``_authed_transport.stream_post_with_size_cap``):
-    fully-buffered body, headers stripped of ``content-encoding`` /
-    ``content-length`` so ``.text`` / ``.content`` work synchronously.
+    Identical in shape to what ``Kernel.post`` returns via
+    ``_authed_transport.stream_post_with_size_cap``: fully-buffered body,
+    headers stripped of ``content-encoding`` / ``content-length`` so
+    ``.text`` / ``.content`` work synchronously.
     """
 
     context: dict[str, Any] = field(default_factory=dict)

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -8,14 +8,13 @@ Tier-12 chain (post-PR 12.9, after ``SemaphoreMiddleware`` was inserted between
 PR 12.8 inserts ``AuthRefresh`` between ``Retry`` and ``ErrorInjection`` so
 this ordering is now realized end-to-end.
 
-This PR lifts the **auth-refresh-once retry** loop out of
-``AuthedTransport.perform_authed_post`` (the chain leaf). After PR 12.8 the
-leaf is a *pure* POST that lets ``httpx.HTTPStatusError`` /
-``httpx.RequestError`` propagate raw for auth errors (the 429 / 5xx
-exception-raisers stay since they feed ``RetryMiddleware``). The middleware
+This middleware owns the **auth-refresh-once retry** loop. The leaf is a
+*pure* ``Kernel.post`` terminal that lets ``httpx.HTTPStatusError`` /
+``httpx.RequestError`` propagate raw for auth errors (the 429 / 5xx mapping
+stays at the terminal since it feeds ``RetryMiddleware``). The middleware
 catches the raw auth-error ``httpx.HTTPStatusError``, triggers a coalesced
-refresh via :class:`AuthRefreshCoordinator`, then re-invokes ``next_call``
-exactly once.
+refresh via :class:`AuthRefreshCoordinator`, rebuilds the request envelope,
+then re-invokes ``next_call`` exactly once.
 
 Why "exactly once": ADR-009 §"Retry semantics" pins
 "**exactly one** retry per ``next_call`` invocation. If the retry also
@@ -38,15 +37,11 @@ the legacy ``AuthedTransport`` behavior so a cassette that recorded the
 post-refresh delay replays the same timing.
 
 Request-materialization transition: ``Session`` now enters the chain with
-the initial ``RpcRequest.url`` / ``.headers`` / ``.body`` populated, but the
-leaf still sends through ``context["build_request"]``. A simple
-``await next_call(request)`` on the unchanged envelope remains sufficient:
-the legacy leaf re-snapshots auth state via
-``AuthRefreshCoordinator.snapshot`` (which sees the refreshed tokens) and
-re-builds headers + body from the callback on retry. The full
-closure-callback contract from ADR-009 §"AuthRefreshMiddleware constructor
-signature" activates when the leaf shrinks to a pure ``Kernel.post`` seam
-and refreshed retries must replace the envelope itself.
+the initial ``RpcRequest.url`` / ``.headers`` / ``.body`` populated and the
+terminal consumes that envelope through ``Kernel.post``. After a successful
+refresh this middleware re-snapshots auth state and replaces the request
+envelope before retrying so the terminal never sends stale URL/body/header
+values.
 
 This regression-fix from PR 12.7 also closes here: pre-PR-12.7 the leaf's
 ``refreshed_this_call`` lived in the same loop as 429/5xx retries (one
@@ -69,12 +64,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import httpx
 
-from ._authed_transport import TransportAuthExpired
-from ._middleware import NextCall, RpcRequest, RpcResponse
+from ._authed_transport import AuthSnapshot, BuildRequest, TransportAuthExpired
+from ._middleware import NextCall, RpcRequest, RpcResponse, materialize_rpc_request
 from ._session_config import CORE_LOGGER_NAME
 from ._session_helpers import resolve_sleep
 
@@ -115,6 +110,10 @@ class AuthRefreshMiddleware:
       ``lambda: self._refresh_retry_delay`` so a test that mutates the
       attr on the live client still takes effect (matches the live-binding
       contract preserved for retry budgets in PR 12.7).
+    - ``snapshot_provider``: optional async callable returning a fresh
+      :class:`AuthSnapshot` after refresh. Production wires
+      :meth:`Session._snapshot`; tests that omit it preserve the older
+      "retry the same request" unit shape.
     - ``sleep``: optional sleep injection (defaults to :func:`asyncio.sleep`
       resolved at call time via :func:`_session_helpers.resolve_sleep` —
       the same shared helper :class:`RetryMiddleware` uses).
@@ -134,6 +133,7 @@ class AuthRefreshMiddleware:
         is_auth_error: Callable[[Exception], bool],
         refresh_callback_enabled: Callable[[], bool],
         refresh_retry_delay: Callable[[], float],
+        snapshot_provider: Callable[[], Awaitable[AuthSnapshot]] | None = None,
         sleep: Callable[[float], Awaitable[object]] | None = None,
         logger: logging.Logger | None = None,
         metrics: ClientMetrics | None = None,
@@ -142,6 +142,7 @@ class AuthRefreshMiddleware:
         self._is_auth_error = is_auth_error
         self._refresh_callback_enabled = refresh_callback_enabled
         self._refresh_retry_delay = refresh_retry_delay
+        self._snapshot_provider = snapshot_provider
         # Late-binding rationale lives on ``_session_helpers.resolve_sleep``.
         self._sleep = sleep
         self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
@@ -183,8 +184,10 @@ class AuthRefreshMiddleware:
            ``TransportAuthExpired(original=exc)`` and propagate.
         5. Optional post-refresh sleep (``refresh_retry_delay``).
         6. Increment ``rpc_auth_retries`` metric.
-        7. Re-invoke ``next_call(request)`` — exactly once. If the retry
-           also raises, propagate unchanged (no second refresh,
+        7. Rebuild the request envelope when a ``snapshot_provider`` and
+           ``context["build_request"]`` are available.
+        8. Re-invoke ``next_call(retry_request)`` — exactly once. If the
+           retry also raises, propagate unchanged (no second refresh,
            no recursion).
         """
         log_label = request.context.get("log_label", "<unknown-chain-call>")
@@ -223,11 +226,31 @@ class AuthRefreshMiddleware:
             if self._metrics is not None:
                 self._metrics.increment(rpc_auth_retries=1)
 
+            retry_request = await self._rebuild_request_after_refresh(request)
+
             # Exactly one retry. If this raises (auth or otherwise), the
             # exception propagates — the outer caller decides what to do
             # (chat error mapping, RetryMiddleware does NOT catch auth
             # errors so a persistent 401 won't burn its budget).
-            return await next_call(request)
+            return await next_call(retry_request)
+
+    async def _rebuild_request_after_refresh(self, request: RpcRequest) -> RpcRequest:
+        """Return a refreshed request envelope when production collaborators exist."""
+        if self._snapshot_provider is None:
+            return request
+
+        raw_build_request = request.context.get("build_request")
+        if raw_build_request is None:
+            return request
+
+        build_request = cast(BuildRequest, raw_build_request)
+        snapshot = await self._snapshot_provider()
+        request.context["auth_snapshot"] = snapshot
+        return materialize_rpc_request(
+            build_request=build_request,
+            snapshot=snapshot,
+            context=request.context,
+        )
 
 
 __all__ = ["AuthRefreshMiddleware"]

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -235,7 +235,13 @@ class AuthRefreshMiddleware:
             return await next_call(retry_request)
 
     async def _rebuild_request_after_refresh(self, request: RpcRequest) -> RpcRequest:
-        """Return a refreshed request envelope when production collaborators exist."""
+        """Return a refreshed request envelope when production collaborators exist.
+
+        After the fresh snapshot await returns, keep the context update and
+        envelope materialization synchronous. The terminal still performs a
+        final freshness check immediately before ``Kernel.post`` because inner
+        middlewares may await between this retry rebuild and the wire.
+        """
         if self._snapshot_provider is None:
             return request
 
@@ -245,6 +251,8 @@ class AuthRefreshMiddleware:
 
         build_request = cast(BuildRequest, raw_build_request)
         snapshot = await self._snapshot_provider()
+        # Keep ``auth_snapshot`` and the rebuilt envelope paired in one
+        # synchronous block; see ``test_concurrency_refresh_race``.
         request.context["auth_snapshot"] = snapshot
         return materialize_rpc_request(
             build_request=build_request,

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -1,9 +1,9 @@
 """Composes the ADR-009 middleware chain.
 
 Tier-12 PR 12.2 wired an empty middleware chain around
-``AuthedTransport.perform_authed_post`` (the shared seam covering
-``Session._perform_authed_post`` and ``RpcExecutor.execute``'s call to
-``self._owner._perform_authed_post`` at ``_rpc_executor.py:245``).
+``Kernel.post`` through ``Session._authed_post_chain_terminal`` (the shared
+seam covering ``Session._perform_authed_post`` and ``RpcExecutor.execute``'s
+call to ``self._owner._perform_authed_post`` at ``_rpc_executor.py:245``).
 
 PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
 ``MetricsMiddleware``, PR 12.5 prepended ``DrainMiddleware`` outermost,
@@ -21,20 +21,19 @@ the innermost wrapper.
 
 PR 12.7 lifted the 429 / 5xx retry loops out of the leaf into
 ``RetryMiddleware``; PR 12.8 lifts the auth-refresh-once retry too.
-After PR 12.8 the leaf is a *pure* POST — every retry decision happens
-in the chain. The leaf still raises ``TransportRateLimited`` /
-``TransportServerError`` for 429 / 5xx so ``RetryMiddleware`` can
-catch; raw ``httpx.HTTPStatusError`` (400/401/403) propagates so
+The leaf is a *pure* POST — every retry decision happens in the chain. The
+terminal maps raw ``Kernel.post`` errors to ``TransportRateLimited`` /
+``TransportServerError`` for 429 / 5xx so ``RetryMiddleware`` can catch; raw
+``httpx.HTTPStatusError`` (400/401/403) propagates so
 ``AuthRefreshMiddleware`` can catch via ``is_auth_error`` and drive
 refresh-then-retry.
 
-The terminal adapter reads ``build_request`` / ``log_label`` /
-``disable_internal_retries`` from ``RpcRequest.context`` and delegates
-to ``self._get_authed_transport().perform_authed_post``.
-``RetryMiddleware`` reads ``log_label`` / ``disable_internal_retries``
-from the same ``context`` dict. ``AuthRefreshMiddleware`` reads
-``log_label``. See ADR-009 §"Per-request behavior" and
-``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
+The terminal Adapter reads ``RpcRequest.url`` / ``headers`` / ``body`` and
+delegates to ``Kernel.post``. ``RetryMiddleware`` reads ``log_label`` /
+``disable_internal_retries`` from the same ``context`` dict.
+``AuthRefreshMiddleware`` reads ``log_label`` and uses
+``context["build_request"]`` to rebuild the envelope after refresh. See
+ADR-009 §"Per-request behavior".
 
 The order is pinned at two levels:
 * facade-level by ``tests/unit/test_chain_wiring.py::test_chain_seeded_with_final_adr_009_ordering``
@@ -77,6 +76,7 @@ class MiddlewareChainBuilder:
         server_error_max_retries_provider: Callable[[], int],
         refresh_retry_delay_provider: Callable[[], float],
         refresh_callable: Callable[..., Awaitable[Any]],
+        auth_snapshot_provider: Callable[[], Awaitable[Any]],
         is_auth_error: Callable[[Exception], bool],
         refresh_callback_enabled_provider: Callable[[], bool],
     ) -> None:
@@ -92,6 +92,7 @@ class MiddlewareChainBuilder:
         self._server_error_max_retries_provider = server_error_max_retries_provider
         self._refresh_retry_delay_provider = refresh_retry_delay_provider
         self._refresh_callable = refresh_callable
+        self._auth_snapshot_provider = auth_snapshot_provider
         self._is_auth_error = is_auth_error
         self._refresh_callback_enabled_provider = refresh_callback_enabled_provider
 
@@ -135,11 +136,16 @@ class MiddlewareChainBuilder:
             # ``is_auth_error`` is bound late (see ``_live_is_auth_error``
             # in ``_session.py``) so test monkeypatches of
             # ``notebooklm._core.is_auth_error`` reach the chain.
+            # ``auth_snapshot_provider`` gives AuthRefreshMiddleware a
+            # fresh post-refresh snapshot so it can replace the
+            # populated request envelope before retrying the Kernel.post
+            # terminal.
             AuthRefreshMiddleware(
                 refresh_callable=self._refresh_callable,
                 is_auth_error=self._is_auth_error,
                 refresh_callback_enabled=self._refresh_callback_enabled_provider,
                 refresh_retry_delay=self._refresh_retry_delay_provider,
+                snapshot_provider=self._auth_snapshot_provider,
                 metrics=self._metrics,
             ),
             ErrorInjectionMiddleware(),

--- a/src/notebooklm/_middleware_tracing.py
+++ b/src/notebooklm/_middleware_tracing.py
@@ -1,8 +1,7 @@
 """TracingMiddleware — innermost middleware in the Tier-12 chain.
 
 Per ADR-009 §"Chain ordering" and master plan §2, ``TracingMiddleware`` is
-the **innermost** wrapper around the transport leaf (``Kernel.post`` after
-PR 13.2, ``AuthedTransport.perform_authed_post`` until then). It logs one
+the **innermost** wrapper around the ``Kernel.post`` transport leaf. It logs one
 "starting" record before invoking ``next_call`` and one "completed"
 (success) or "failed" (exception) record after, capturing per-attempt
 HTTP-level visibility — including retry attempts, which is why it sits

--- a/src/notebooklm/_request_types.py
+++ b/src/notebooklm/_request_types.py
@@ -13,8 +13,9 @@ Three names live here:
   ``AuthRefreshMiddleware`` callbacks.
 - :data:`BuildRequest` — sync callable that maps an ``AuthSnapshot`` to a
   ``(url, body, headers)`` tuple ready for the transport. The chain leaf reads
-  the callable from ``RpcRequest.context["build_request"]`` and invokes it
-  inside ``AuthedTransport.perform_authed_post``.
+  the materialized ``RpcRequest`` fields directly; the callable remains in
+  ``RpcRequest.context["build_request"]`` so auth refresh and terminal
+  freshness checks can rebuild the envelope from a new snapshot.
 - :class:`BuildRequestResult` — the *named* dataclass form of the same
   ``(url, body, headers)`` triple, introduced for PR 12.8's
   ``AuthRefreshMiddleware.build_request_factory`` callback. The dataclass

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -833,7 +833,7 @@ class Session:
         """
         request = await self._refresh_request_for_current_auth(request)
         context = request.context
-        log_label = context["log_label"]
+        log_label = context.get("log_label", "<unknown-chain-call>")
         start = time.perf_counter()
         try:
             response = await self._kernel.post(

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import random  # noqa: F401 - tests patch this for _backoff jitter
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
@@ -14,7 +15,7 @@ from ._authed_transport import (
     AuthedTransport,
     AuthSnapshot,
     BuildRequest,
-    PostBody,
+    _raise_mapped_post_error,
 )
 from ._client_metrics import ClientMetrics
 from ._cookie_persistence import CookiePersistence
@@ -85,8 +86,6 @@ from .rpc import RPCMethod
 
 logger = logging.getLogger(__name__)
 
-_BuildRequestTuple = tuple[str, PostBody, dict[str, str] | None]
-
 # Auth-snapshot canonical implementation lives on
 # :class:`AuthRefreshCoordinator` (``_session_auth.py`` —
 # ``AuthRefreshCoordinator.snapshot`` / ``.update_auth_tokens``). The
@@ -145,38 +144,6 @@ def _live_is_auth_error(exc: Exception) -> bool:
     from ._session_helpers import is_auth_error
 
     return is_auth_error(exc)
-
-
-def _cached_first_build_request(
-    *,
-    original: BuildRequest,
-    cached_result: _BuildRequestTuple,
-    cached_snapshot: AuthSnapshot,
-) -> BuildRequest:
-    """Return the materialized first request once, then delegate.
-
-    ``Session._perform_authed_post`` materializes ``RpcRequest`` before
-    entering the middleware chain so middlewares can observe URL, headers, and
-    body. The legacy terminal still calls ``AuthedTransport.perform_authed_post``,
-    which expects a ``BuildRequest`` callback. This adapter lets that first
-    terminal call reuse the already-built tuple when it observes the same auth
-    snapshot, preserving the historical "one build per HTTP attempt" contract.
-
-    If the terminal sees a different snapshot on its first call (for example,
-    auth refreshed while the request was queued), discard the cached tuple and
-    rebuild from the fresh snapshot.
-    """
-    first_call = True
-
-    def _build(snapshot: AuthSnapshot) -> _BuildRequestTuple:
-        nonlocal first_call
-        if first_call:
-            first_call = False
-            if snapshot == cached_snapshot:
-                return cached_result
-        return original(snapshot)
-
-    return _build
 
 
 class Session:
@@ -469,6 +436,7 @@ class Session:
             server_error_max_retries_provider=lambda: self._server_error_max_retries,
             refresh_retry_delay_provider=lambda: self._refresh_retry_delay,
             refresh_callable=self._await_refresh,
+            auth_snapshot_provider=self._snapshot,
             is_auth_error=_live_is_auth_error,
             refresh_callback_enabled_provider=lambda: self._auth_coord.has_refresh_callback,
         )
@@ -828,37 +796,58 @@ class Session:
             rpc_id_override=rpc_id_override,
         )
 
-    async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
-        """Chain leaf — adapts ``RpcRequest`` into ``AuthedTransport`` call shape.
+    async def _refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
+        """Rebuild the envelope if auth changed before the terminal POST.
 
-        Reads ``build_request`` / ``log_label`` / ``disable_internal_retries``
-        from ``request.context`` and delegates to
-        :meth:`AuthedTransport.perform_authed_post` — the shared seam that
-        covers both :meth:`Session._perform_authed_post` and
-        ``RpcExecutor.execute`` (which calls ``_perform_authed_post`` at
-        ``_rpc_executor.py:275``). Wraps the returned :class:`httpx.Response` in
-        an :class:`RpcResponse` so middlewares above the leaf see the chain
-        contract from ``_middleware.py``.
-
-        ``self._get_authed_transport()`` is resolved on every invocation so
-        late-bound monkeypatches of ``_get_authed_transport`` (e.g. fixtures
-        that swap the transport mid-test) still affect live behavior. The
-        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body`` fields
-        are populated before chain entry for middleware visibility, but this
-        transitional leaf still delegates through ``build_request`` until the
-        Tier-13 ``Kernel.post`` terminal rewrite lands. See ADR-009
-        §"RpcRequest.context keys" and close-out notes §"AuthRefreshMiddleware
-        shipped without rebuild closures" for the metadata vocabulary.
+        ``Session._perform_authed_post`` materializes the request before the
+        outer chain runs, so the request may wait behind Drain/Semaphore before
+        the leaf sends it. Compare the materialization snapshot to a fresh
+        snapshot immediately before ``Kernel.post``; if auth moved, rebuild the
+        envelope synchronously from ``context["build_request"]``.
         """
         context = request.context
-        build_request = context["build_request"]
-        log_label = context["log_label"]
-        disable_internal_retries = context.get("disable_internal_retries", False)
-        response = await self._get_authed_transport().perform_authed_post(
+        request_snapshot = context.get("auth_snapshot")
+        build_request = context.get("build_request")
+        if not isinstance(request_snapshot, AuthSnapshot) or build_request is None:
+            return request
+
+        current_snapshot = await self._snapshot()
+        if current_snapshot == request_snapshot:
+            return request
+
+        context["auth_snapshot"] = current_snapshot
+        return materialize_rpc_request(
             build_request=build_request,
-            log_label=log_label,
-            disable_internal_retries=disable_internal_retries,
+            snapshot=current_snapshot,
+            context=context,
         )
+
+    async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
+        """Chain leaf — sends the populated ``RpcRequest`` via ``Kernel.post``.
+
+        The chain Interface now carries the actual HTTP request. The terminal
+        Adapter reads ``RpcRequest.url`` / ``headers`` / ``body`` directly,
+        maps raw ``Kernel.post`` errors into the transport exception shapes
+        consumed by Retry/AuthRefresh middleware, and wraps the returned
+        :class:`httpx.Response` in :class:`RpcResponse`.
+        """
+        request = await self._refresh_request_for_current_auth(request)
+        context = request.context
+        log_label = context["log_label"]
+        start = time.perf_counter()
+        try:
+            response = await self._kernel.post(
+                request.url,
+                headers=request.headers,
+                body=request.body,
+            )
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            _raise_mapped_post_error(
+                log_label=log_label,
+                exc=exc,
+                start=start,
+                logger=logger,
+            )
         return RpcResponse(response=response, context=context)
 
     async def _perform_authed_post(
@@ -891,13 +880,8 @@ class Session:
 
         ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body`` are
         populated through :func:`materialize_rpc_request` before the chain sees
-        the request. Until the terminal switches to ``Kernel.post`` directly,
-        ``context["build_request"]`` is a first-call cache adapter over the
-        original callback so the legacy terminal does not call the request
-        builder twice on the happy path. The terminal still re-snapshots before
-        the actual POST and only reuses this materialized tuple when that
-        snapshot matches, preserving the wire-path no-await invariant while the
-        envelope becomes visible to middlewares.
+        the request. ``context["build_request"]`` remains as the bounded
+        rebuild recipe for auth-refresh and pre-terminal freshness checks.
         """
         # Event-loop affinity guard. Session-shrink PR 3 lifted this OUT of
         # ``AuthedTransport.perform_authed_post`` (where it ran once per
@@ -914,21 +898,13 @@ class Session:
             "rpc_method": rpc_method,
         }
         snapshot = await self._snapshot()
-        cached_result = build_request(snapshot)
 
-        def _materialized_build_request(_snapshot: AuthSnapshot) -> _BuildRequestTuple:
-            return cached_result
-
-        context["build_request"] = _cached_first_build_request(
-            original=build_request,
-            cached_result=cached_result,
-            cached_snapshot=snapshot,
-        )
         request = materialize_rpc_request(
-            build_request=_materialized_build_request,
+            build_request=build_request,
             snapshot=snapshot,
             context=context,
         )
+        context["auth_snapshot"] = snapshot
 
         # The ``max_concurrent_rpcs`` slot is acquired by
         # :class:`SemaphoreMiddleware` (chain position 2, between Metrics
@@ -965,8 +941,8 @@ class Session:
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
         """Session transport facade required by the Tier-13 contract."""
-        # ``Session`` exposes ``parse_label`` for the later feature retype.
-        # The existing transport leaf still calls the same value ``log_label``.
+        # ``Session`` exposes ``parse_label`` for the later feature retype; the
+        # chain context still names that value ``log_label``.
         return await self._perform_authed_post(
             build_request=build_request,
             log_label=parse_label,

--- a/tests/unit/test_auth_refresh_middleware.py
+++ b/tests/unit/test_auth_refresh_middleware.py
@@ -12,7 +12,8 @@ and ADR-009 §"Chain ordering":
 - **Refresh-and-retry on auth error.** First ``next_call`` raises
   ``httpx.HTTPStatusError`` recognized by ``is_auth_error`` → refresh
   callable runs (coalesced single-flight) → optional post-refresh sleep
-  → metric increment → exactly one retry via ``next_call(request)``.
+  → metric increment → rebuilt request envelope when a snapshot provider is
+  wired → exactly one retry via ``next_call(retry_request)``.
 - **Refresh failure** → wrap original ``HTTPStatusError`` in
   ``TransportAuthExpired`` and propagate.
 - **Exactly one retry.** Per ADR-009 §"Retry semantics", a second auth
@@ -43,6 +44,7 @@ import pytest
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
 from notebooklm._authed_transport import (
+    AuthSnapshot,
     TransportAuthExpired,
     TransportRateLimited,
     TransportServerError,
@@ -91,6 +93,7 @@ def _make_middleware(
     refresh_retry_delay: float = 0.0,
     sleep: Callable[[float], Awaitable[object]] | None = None,
     metrics: ClientMetrics | None = None,
+    snapshot_provider: Callable[[], Awaitable[AuthSnapshot]] | None = None,
     auth_error_predicate: Callable[[Exception], bool] = is_auth_error,
 ) -> AuthRefreshMiddleware:
     """Build an ``AuthRefreshMiddleware`` with sensible defaults for tests."""
@@ -103,6 +106,7 @@ def _make_middleware(
         is_auth_error=auth_error_predicate,
         refresh_callback_enabled=lambda: refresh_enabled,
         refresh_retry_delay=lambda: refresh_retry_delay,
+        snapshot_provider=snapshot_provider,
         sleep=sleep,
         metrics=metrics,
     )
@@ -236,6 +240,54 @@ async def test_refreshes_and_retries_on_auth_error() -> None:
     assert len(calls) == 2  # initial + retry
     assert response.response.status_code == 200
     assert response.response.content == b"retry-ok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_rebuilds_request_envelope_from_fresh_snapshot() -> None:
+    """Post-refresh retry replaces URL, headers, and body before terminal send."""
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom, httpx.Response(200, content=b"retry-ok")])
+    fresh_snapshot = AuthSnapshot(
+        csrf_token="CSRF_NEW",
+        session_id="SID_NEW",
+        authuser=1,
+        account_email=None,
+    )
+    build_snapshots: list[AuthSnapshot] = []
+
+    async def snapshot_provider() -> AuthSnapshot:
+        return fresh_snapshot
+
+    def build_request(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+        build_snapshots.append(snapshot)
+        return (
+            f"https://example.test/x?sid={snapshot.session_id}",
+            f"body-{snapshot.csrf_token}",
+            {"X-Goog-AuthUser": str(snapshot.authuser)},
+        )
+
+    middleware = _make_middleware(snapshot_provider=snapshot_provider)
+    chain = build_chain([middleware], terminal)
+    request = make_request(
+        url="https://example.test/x?sid=SID_OLD",
+        headers={"X-Goog-AuthUser": "0"},
+        body=b"body-CSRF_OLD",
+        context={"log_label": "RPC LIST_NOTEBOOKS", "build_request": build_request},
+    )
+
+    response = await chain(request)
+
+    assert response.response.status_code == 200
+    assert len(calls) == 2
+    assert calls[0] is request
+    retry_request = calls[1]
+    assert retry_request is not request
+    assert retry_request.url == "https://example.test/x?sid=SID_NEW"
+    assert retry_request.headers == {"X-Goog-AuthUser": "1"}
+    assert retry_request.body == b"body-CSRF_NEW"
+    assert retry_request.context is request.context
+    assert request.context["auth_snapshot"] == fresh_snapshot
+    assert build_snapshots == [fresh_snapshot]
 
 
 @pytest.mark.parametrize("status", [400, 401, 403])

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -143,13 +143,8 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
         assert request.context["rpc_method"] == "LIST_NOTEBOOKS"
         assert len(calls) == 1
         assert calls[0].csrf_token == "CSRF_OLD"
-        cached_build_request = request.context["build_request"]
-        assert cached_build_request is not build
-        assert cached_build_request(calls[0]) == (
-            "https://example.test/x?authuser=0",
-            "payload",
-            {"X-Test": "yes"},
-        )
+        assert request.context["build_request"] is build
+        assert request.context["auth_snapshot"] == calls[0]
     finally:
         await core.close()
 
@@ -169,7 +164,8 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
     core = _make_core(rate_limit_max_retries=0)
     await core.open()
     try:
-        # Confirm the leaf is still AuthedTransport (sanity).
+        # AuthedTransport still exists as a compatibility Adapter, while the
+        # production chain now sends through Kernel.post directly.
         assert isinstance(core._get_authed_transport(), AuthedTransport)
         # Mutate AFTER open() — middleware reads via lambda closure so this
         # bump from 0 → 1 grants a single retry on the next chain call.
@@ -435,7 +431,7 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
 
         async def fake_post(url, *, content, **kwargs):
             assert url == "https://example.test/x"
-            assert content == "payload"
+            assert content == b"payload"
             return _ok_response()
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
@@ -451,12 +447,10 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch):
-    """A changed terminal snapshot discards the materialization cache.
+    """A changed terminal snapshot rebuilds the envelope before send.
 
-    This pins the transition behavior before the terminal moves to
-    ``Kernel.post`` directly: the pre-chain envelope is observable, but the
-    legacy terminal must not send a stale cached tuple if auth changed before
-    its first POST attempt.
+    The pre-chain envelope is observable, but the ``Kernel.post`` terminal must
+    not send a stale body if auth changed before its first POST attempt.
     """
     core = _make_core()
     await core.open()
@@ -482,7 +476,7 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
             return "https://example.test/x", f"payload-{snapshot.csrf_token}", {}
 
         async def fake_post(url, *, content, **kwargs):
-            assert content == "payload-CSRF_NEW"
+            assert content == b"payload-CSRF_NEW"
             return _ok_response()
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
@@ -526,7 +520,7 @@ async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch
             if call_count["n"] == 1:
                 raise _status_error(401)
             # Second attempt succeeds — confirm it carries the refreshed body.
-            assert content == "body-CSRF_NEW"
+            assert content == b"body-CSRF_NEW"
             return _ok_response()
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
@@ -723,8 +717,8 @@ async def test_rpc_call_happy_path_url_and_body_unchanged(monkeypatch):
         assert "rpcids=" + RPCMethod.LIST_NOTEBOOKS.value in captured["url"]
         assert "f.sid=SID_OLD" in captured["url"]
         # The body must include the CSRF token under the historical ``at=`` param.
-        assert "at=CSRF_OLD" in captured["content"]
-        assert "f.req=" in captured["content"]
+        assert b"at=CSRF_OLD" in captured["content"]
+        assert b"f.req=" in captured["content"]
     finally:
         await core.close()
 

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -2,12 +2,10 @@
 
 The Tier-12/13 greenfield migration wires
 :func:`notebooklm._middleware.build_chain` into :meth:`Session.__init__`.
-The chain leaf (:meth:`Session._authed_post_chain_terminal`) reads
-``build_request`` / ``log_label`` / ``disable_internal_retries`` from
-``RpcRequest.context`` and delegates to
-:meth:`AuthedTransport.perform_authed_post` — the shared seam covering both
-:meth:`Session._perform_authed_post` AND ``RpcExecutor.execute`` (which
-calls ``self._owner._perform_authed_post`` at ``_rpc_executor.py:275``).
+The chain leaf (:meth:`Session._authed_post_chain_terminal`) consumes the
+populated ``RpcRequest.url`` / ``headers`` / ``body`` envelope and delegates
+directly to ``Kernel.post`` — the transport seam under both
+:meth:`Session._perform_authed_post` AND ``RpcExecutor.execute``.
 
 These tests verify the wiring contract from
 ADR-009 §"RpcRequest.context keys":
@@ -15,17 +13,11 @@ ADR-009 §"RpcRequest.context keys":
 1. Both call paths (``Session._perform_authed_post`` directly and the
    ``RpcExecutor.execute`` keyword shape) flow through the chain terminal to
    the transport.
-2. ``RpcRequest.context`` carries a legacy ``build_request`` adapter plus
-   ``log_label`` / ``disable_internal_retries`` exactly as the leaf expects
-   them.
+2. ``RpcRequest.context`` carries ``build_request`` / ``log_label`` /
+   ``disable_internal_retries`` for retry/rebuild metadata while the terminal
+   reads the envelope itself.
 3. The leaf returns an :class:`RpcResponse` wrapping the
    :class:`httpx.Response` from the transport.
-
-The terminal adapter resolves ``self._get_authed_transport()`` per
-invocation so swapping the transport mid-test (the idiom used here) still
-affects live behavior — a property the existing
-``test_authed_transport.py`` test suite already relies on for its
-monkeypatch surface.
 """
 
 from __future__ import annotations
@@ -36,9 +28,6 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the
-# canonical import path documented in ``tests/_fixtures/__init__.py``.
-from _fixtures.chain import FakeAuthedPost
 from notebooklm._middleware import (
     Middleware,
     NextCall,
@@ -53,8 +42,8 @@ def _make_core() -> Session:
     """Build a ``Session`` instance without opening an HTTP client.
 
     ``Session.__init__`` is event-loop-agnostic, so we can construct an
-    instance in synchronous test setup. The transport is then swapped in
-    each test for a :class:`FakeAuthedPost` so no real HTTP call fires.
+    instance in synchronous test setup. Tests replace ``Kernel.post`` directly
+    so no real HTTP call fires.
     """
     auth = MagicMock()
     auth.storage_path = None
@@ -65,16 +54,30 @@ def _make_core() -> Session:
     return Session(auth=auth)
 
 
-def _swap_transport(core: Session, fake: FakeAuthedPost) -> None:
-    """Replace ``core._get_authed_transport`` with a callable returning ``fake``.
+class FakeKernelPost:
+    """Programmable stub for ``Kernel.post``."""
 
-    The chain terminal calls ``self._get_authed_transport()`` per
-    invocation; overriding the bound method on the instance is sufficient
-    because Python's attribute lookup finds the instance attribute before
-    the class method. This keeps the swap local to the test (no shared
-    module-level monkeypatch).
-    """
-    core._get_authed_transport = lambda: fake  # type: ignore[method-assign]
+    def __init__(self, response: httpx.Response | None = None) -> None:
+        self.response = response or httpx.Response(status_code=200, content=b"")
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Any,
+        body: bytes,
+    ) -> httpx.Response:
+        self.calls.append({"url": url, "headers": headers, "body": body})
+        return self.response
+
+
+def _swap_kernel_post(core: Session, fake: FakeKernelPost) -> None:
+    core._kernel.post = fake.post  # type: ignore[method-assign]
 
 
 @pytest.mark.asyncio
@@ -86,9 +89,9 @@ async def test_chain_routes_perform_authed_post_to_transport() -> None:
     ``client._session._perform_authed_post``.
     """
     expected_response = httpx.Response(status_code=200, content=b"chain-routed")
-    fake = FakeAuthedPost(response=expected_response)
+    fake = FakeKernelPost(response=expected_response)
     core = _make_core()
-    _swap_transport(core, fake)
+    _swap_kernel_post(core, fake)
 
     def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
         return ("https://fake/url", b"body", None)
@@ -102,14 +105,9 @@ async def test_chain_routes_perform_authed_post_to_transport() -> None:
     assert response is expected_response
     assert fake.call_count == 1
     call = fake.calls[0]
-    assert call["build_request"] is not build_request
-    assert call["build_request"](await core._snapshot()) == (
-        "https://fake/url",
-        b"body",
-        None,
-    )
-    assert call["log_label"] == "test-log-label"
-    assert call["disable_internal_retries"] is False
+    assert call["url"] == "https://fake/url"
+    assert call["headers"] == {}
+    assert call["body"] == b"body"
 
 
 @pytest.mark.asyncio
@@ -132,9 +130,9 @@ async def test_chain_routes_rpc_executor_path_to_transport() -> None:
     receives," which a direct call validates without the extra surface.
     """
     expected_response = httpx.Response(status_code=200, content=b"rpc-path")
-    fake = FakeAuthedPost(response=expected_response)
+    fake = FakeKernelPost(response=expected_response)
     core = _make_core()
-    _swap_transport(core, fake)
+    _swap_kernel_post(core, fake)
 
     def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
         return ("https://fake/rpc", b"rpc-body", {"X-Goog-AuthUser": "0"})
@@ -148,17 +146,9 @@ async def test_chain_routes_rpc_executor_path_to_transport() -> None:
     assert response is expected_response
     assert fake.call_count == 1
     call = fake.calls[0]
-    assert call["build_request"] is not build_request
-    assert call["build_request"](await core._snapshot()) == (
-        "https://fake/rpc",
-        b"rpc-body",
-        {"X-Goog-AuthUser": "0"},
-    )
-    assert call["log_label"] == "RPC LIST_NOTEBOOKS"
-    # The ``disable_internal_retries`` bool resolved by
-    # ``_idempotency.resolve_effective_disable_internal_retries`` upstream
-    # propagates through the chain unchanged.
-    assert call["disable_internal_retries"] is True
+    assert call["url"] == "https://fake/rpc"
+    assert call["headers"] == {"X-Goog-AuthUser": "0"}
+    assert call["body"] == b"rpc-body"
 
 
 @pytest.mark.asyncio
@@ -173,19 +163,15 @@ async def test_chain_terminal_reads_context_keys() -> None:
     the request into a transport call.
     """
     expected_response = httpx.Response(status_code=204, content=b"")
-    fake = FakeAuthedPost(response=expected_response)
+    fake = FakeKernelPost(response=expected_response)
     core = _make_core()
-    _swap_transport(core, fake)
-
-    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
-        return ("https://fake/ctx", b"ctx-body", None)
+    _swap_kernel_post(core, fake)
 
     request = RpcRequest(
-        url="",
-        headers={},
-        body=b"",
+        url="https://fake/ctx",
+        headers={"X-Test": "yes"},
+        body=b"ctx-body",
         context={
-            "build_request": build_request,
             "log_label": "context-test",
             "disable_internal_retries": False,
         },
@@ -200,9 +186,11 @@ async def test_chain_terminal_reads_context_keys() -> None:
     # link made. The terminal adapter leaves the dict unchanged.
     assert result.context is request.context
     assert fake.call_count == 1
-    assert fake.calls[0]["build_request"] is build_request
-    assert fake.calls[0]["log_label"] == "context-test"
-    assert fake.calls[0]["disable_internal_retries"] is False
+    assert fake.calls[0] == {
+        "url": "https://fake/ctx",
+        "headers": {"X-Test": "yes"},
+        "body": b"ctx-body",
+    }
 
 
 @pytest.mark.asyncio
@@ -215,19 +203,15 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
     seam, master plan section 3) cannot trip the leaf with a
     ``KeyError``.
     """
-    fake = FakeAuthedPost()
+    fake = FakeKernelPost()
     core = _make_core()
-    _swap_transport(core, fake)
-
-    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
-        return ("https://fake/no-retry-flag", b"", None)
+    _swap_kernel_post(core, fake)
 
     request = RpcRequest(
-        url="",
+        url="https://fake/no-retry-flag",
         headers={},
         body=b"",
         context={
-            "build_request": build_request,
             "log_label": "default-flag",
         },
     )
@@ -235,7 +219,7 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
     await core._authed_post_chain_terminal(request)
 
     assert fake.call_count == 1
-    assert fake.calls[0]["disable_internal_retries"] is False
+    assert fake.calls[0]["url"] == "https://fake/no-retry-flag"
 
 
 @pytest.mark.asyncio
@@ -307,9 +291,9 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
         return response
 
     expected_response = httpx.Response(status_code=200, content=b"observed")
-    fake = FakeAuthedPost(response=expected_response)
+    fake = FakeKernelPost(response=expected_response)
     core = _make_core()
-    _swap_transport(core, fake)
+    _swap_kernel_post(core, fake)
 
     # Build a chain with one observer middleware around the production
     # terminal. This per-test composition validates the leaf's contract
@@ -317,15 +301,11 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
     # production chain.
     chain: NextCall = build_chain([observer], core._authed_post_chain_terminal)
 
-    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
-        return ("https://fake/observe", b"", None)
-
     request = RpcRequest(
-        url="",
+        url="https://fake/observe",
         headers={},
         body=b"",
         context={
-            "build_request": build_request,
             "log_label": "observer-test",
             "disable_internal_retries": False,
         },
@@ -338,6 +318,7 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
     assert observed["response"].response is expected_response
     assert result.response is expected_response
     assert fake.call_count == 1
+    assert fake.calls[0]["url"] == "https://fake/observe"
 
 
 def test_build_chain_empty_returns_terminal_unchanged() -> None:

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+from notebooklm._authed_transport import TransportServerError
 from notebooklm._middleware import (
     Middleware,
     NextCall,
@@ -220,6 +221,32 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
     assert fake.call_count == 1
     assert fake.calls[0]["url"] == "https://fake/no-retry-flag"
+
+
+@pytest.mark.asyncio
+async def test_chain_terminal_log_label_defaults_for_direct_calls() -> None:
+    """Direct terminal calls without context metadata still map errors safely."""
+    core = _make_core()
+
+    async def raise_network_error(
+        url: str,
+        *,
+        headers: Any,
+        body: bytes,
+    ) -> httpx.Response:
+        request = httpx.Request("POST", url, headers=dict(headers), content=body)
+        raise httpx.RequestError("boom", request=request)
+
+    core._kernel.post = raise_network_error  # type: ignore[method-assign]
+    request = RpcRequest(
+        url="https://fake/no-log-label",
+        headers={},
+        body=b"",
+        context={},
+    )
+
+    with pytest.raises(TransportServerError, match="<unknown-chain-call> network error"):
+        await core._authed_post_chain_terminal(request)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -27,7 +27,7 @@ The auth-snapshot lock hardened the invariant by:
   refresh's write to ``self.auth.session_id`` slip into the URL between
   snapshot capture and request build.
 
-This file *locks* the invariant in three ways:
+This file *locks* the invariant in four ways:
 
 1. ``test_kernel_post_terminal_has_no_await_before_post_per_attempt`` —
    static AST guard against an ``await`` inside the terminal's ``try`` body
@@ -46,6 +46,13 @@ This file *locks* the invariant in three ways:
    an in-flight ``rpc_call`` (both orderings) and asserts the captured
    ``httpx.Request`` is never observed with mixed-generation (csrf,
    session_id, cookies) state.
+
+4. ``test_auth_refresh_rebuild_has_no_await_after_snapshot_capture`` —
+   static guard on the auth-refresh retry rebuild: once the post-refresh
+   snapshot has been captured, pairing ``context["auth_snapshot"]`` with
+   the rebuilt envelope must remain synchronous. The terminal still owns
+   the final before-wire freshness check because inner middlewares may
+   await after this rebuild.
 """
 
 from __future__ import annotations
@@ -62,6 +69,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 from notebooklm._rpc_executor import RpcExecutor
 from notebooklm._session import Session
 from notebooklm._session_auth import AuthRefreshCoordinator
@@ -219,6 +227,48 @@ def test_terminal_freshness_check_has_no_await_after_materialization():
         "Session._refresh_request_for_current_auth must not await after "
         "materialize_rpc_request; that would let auth/cookies move between "
         "request rebuild and Kernel.post."
+    )
+
+
+def test_auth_refresh_rebuild_has_no_await_after_snapshot_capture():
+    """Auth-refresh retry rebuild pairs fresh snapshot and envelope atomically."""
+    src = textwrap.dedent(inspect.getsource(AuthRefreshMiddleware._rebuild_request_after_refresh))
+    tree = ast.parse(src)
+    func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+
+    snapshot_awaits = [
+        (n.lineno, n.col_offset)
+        for n in ast.walk(func)
+        if isinstance(n, ast.Await)
+        and isinstance(n.value, ast.Call)
+        and isinstance(n.value.func, ast.Attribute)
+        and n.value.func.attr == "_snapshot_provider"
+    ]
+    assert snapshot_awaits, "Could not locate await self._snapshot_provider()"
+    snapshot_position = min(snapshot_awaits)
+
+    materialize_positions = [
+        (n.lineno, n.col_offset)
+        for n in ast.walk(func)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "materialize_rpc_request"
+    ]
+    assert materialize_positions, "Could not locate materialize_rpc_request in refresh rebuild"
+    assert snapshot_position < min(materialize_positions), (
+        "AuthRefreshMiddleware._rebuild_request_after_refresh must capture "
+        "the fresh snapshot before rebuilding the retry envelope."
+    )
+
+    later_awaits = [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Await) and (n.lineno, n.col_offset) > snapshot_position
+    ]
+    assert later_awaits == [], (
+        "AuthRefreshMiddleware._rebuild_request_after_refresh must not await "
+        "after capturing the fresh snapshot; context['auth_snapshot'] and the "
+        "rebuilt RpcRequest must stay paired until the terminal freshness check."
     )
 
 

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -1,13 +1,13 @@
 """Snapshot-invariant for the shared POST helper.
 
 httpx merges the cookie jar into the outgoing ``httpx.Request`` synchronously
-in ``build_request()``, before any ``await``. ``_perform_authed_post`` reads
-the auth snapshot (via ``self._snapshot()``) and assembles ``(url, body,
-headers)`` via ``build_request(snapshot)`` synchronously before
-``await client.post(...)``. Therefore, within a single retry iteration the
+when ``Kernel.post`` opens the stream. ``_perform_authed_post`` materializes a
+``RpcRequest`` from an auth snapshot before the middleware chain, and the
+``Kernel.post`` terminal refreshes that envelope if auth changed while the
+request waited in the chain. Therefore, within a single terminal attempt the
 entire ``(csrf, session_id, cookies)`` snapshot is atomic from a concurrent
-coroutine standpoint: no other task can mutate state between read and the
-wire.
+coroutine standpoint: no other task can mutate state between the terminal
+freshness check and the wire.
 
 The POST was extracted out of ``_rpc_call_impl`` into
 ``_perform_authed_post`` so chat can share the same transport pipeline.
@@ -29,12 +29,11 @@ The auth-snapshot lock hardened the invariant by:
 
 This file *locks* the invariant in three ways:
 
-1. ``test_perform_authed_post_has_no_await_before_post_per_iteration`` —
-   static AST guard against an ``await`` inside the retry loop's try
-   body of ``_perform_authed_post`` that precedes the iteration's
-   ``client.post(...)`` call. The ``await self._snapshot()`` lives
-   *before* the try block (so the lock acquisition itself isn't a
-   regression).
+1. ``test_kernel_post_terminal_has_no_await_before_post_per_attempt`` —
+   static AST guard against an ``await`` inside the terminal's ``try`` body
+   before ``Kernel.post``. The freshness check lives before the try block
+   and is guarded separately so the lock acquisition itself is not a
+   regression.
 
 2. ``test_build_url_does_not_read_self_auth`` — static AST guard
    against any ``self.auth.<field>`` attribute access in
@@ -63,8 +62,8 @@ from pathlib import Path
 import httpx
 import pytest
 
-from notebooklm._authed_transport import AuthedTransport
 from notebooklm._rpc_executor import RpcExecutor
+from notebooklm._session import Session
 from notebooklm._session_auth import AuthRefreshCoordinator
 from notebooklm.rpc import RPCMethod
 
@@ -83,32 +82,16 @@ make_core = _unit_conftest.make_core
 EVENT_TIMEOUT_S = 5.0
 
 
-def test_perform_authed_post_has_no_await_before_post_per_iteration():
-    """No ``await`` may sit lexically inside the ``try:`` block before the
-    ``client.post(...)`` call in ``_perform_authed_post``.
+def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
+    """No ``await`` may sit inside the terminal ``try`` before ``Kernel.post``.
 
-    The leaf begins with ``snapshot = await self._snapshot()`` + a
-    synchronous ``build_request(snapshot)`` — both immediately *before*
-    the try block. The try body's first statement is the actual POST. If
-    anyone introduces an ``await`` between ``build_request`` and the POST
-    (or any new await inside the try body's prologue), a concurrent
-    ``refresh_auth`` could update the httpx cookie jar between the
-    snapshot read and the wire, producing a mismatched-generation
-    request on the cookie axis (the ``_auth_snapshot_lock`` covers
-    csrf/sid coherence; cookies still rely on this no-await rule).
-
-    Tier-12 PRs 12.7 / 12.8 lifted retry / auth-refresh out of the leaf
-    into ``RetryMiddleware`` and ``AuthRefreshMiddleware``. After PR
-    12.8 the leaf no longer has a ``while`` retry loop — it makes
-    exactly one attempt per chain invocation. Each chain-level retry
-    (driven by ``RetryMiddleware`` / ``AuthRefreshMiddleware``) re-enters
-    the leaf and re-runs ``_snapshot`` → ``build_request`` → POST. PR
-    12.9 moved the semaphore acquire OUT of the leaf entirely (it now
-    lives in ``SemaphoreMiddleware`` at chain position 2), so the leaf
-    is a pure POST-with-try block — the guard walks the ``try`` block
-    at the top of the function body.
+    The terminal first refreshes the envelope if auth changed while the
+    request waited behind middlewares, then enters a small ``try`` whose first
+    await is the actual ``Kernel.post`` send. An await in that try prologue
+    would let a concurrent refresh change the cookie jar between request
+    rebuild and wire send.
     """
-    src = textwrap.dedent(inspect.getsource(AuthedTransport.perform_authed_post))
+    src = textwrap.dedent(inspect.getsource(Session._authed_post_chain_terminal))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
@@ -135,7 +118,7 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
     found_try = _find_first_try(func)
     assert found_try is not None, (
         "Could not locate the ``try:`` block guarding the POST in "
-        "AuthedTransport.perform_authed_post. Update this guard to match."
+        "Session._authed_post_chain_terminal. Update this guard to match."
     )
 
     def is_post_await(node):
@@ -145,7 +128,8 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
         - ``await client.post(...)`` (pre-streaming),
         - ``await stream_post_with_size_cap(...)`` (the helper performs the
           streaming POST internally, so it's the same conceptual POST site for
-          the purposes of this concurrency invariant).
+          the purposes of this concurrency invariant),
+        - ``await self._kernel.post(...)`` (current terminal shape).
         """
         if not isinstance(node, ast.Await):
             return False
@@ -191,7 +175,7 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
     post_await_position = min(post_await_positions, default=None)
     assert post_await_position is not None, (
         "Could not locate `await ...post(...)` in the try body of "
-        "AuthedTransport.perform_authed_post. If the call site was refactored (e.g. to "
+        "Session._authed_post_chain_terminal. If the call site was refactored (e.g. to "
         "``client.request(...)``), update this guard to match — the "
         "invariant is 'no await between snapshot read and the POST per "
         "iteration', not specifically the `.post` attribute."
@@ -203,11 +187,38 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
         if isinstance(n, ast.Await) and (n.lineno, n.col_offset) < post_await_position
     ]
     assert not earlier_awaits, (
-        f"AuthedTransport.perform_authed_post gained an await before the per-iteration POST "
+        f"Session._authed_post_chain_terminal gained an await before the per-attempt POST "
         f"at {post_await_position}: "
         f"{[(n.lineno, ast.dump(n)) for n in earlier_awaits]}. "
         "This breaks the snapshot-invariant — auth state could be mutated "
         "between the snapshot read and the actual send."
+    )
+
+
+def test_terminal_freshness_check_has_no_await_after_materialization():
+    """Freshness rebuild must not yield after materializing a new envelope."""
+    src = textwrap.dedent(inspect.getsource(Session._refresh_request_for_current_auth))
+    tree = ast.parse(src)
+    func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+
+    materialize_positions = [
+        (n.lineno, n.col_offset)
+        for n in ast.walk(func)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "materialize_rpc_request"
+    ]
+    assert materialize_positions, "Could not locate materialize_rpc_request in freshness check"
+    materialize_position = min(materialize_positions)
+    later_awaits = [
+        n
+        for n in ast.walk(func)
+        if isinstance(n, ast.Await) and (n.lineno, n.col_offset) > materialize_position
+    ]
+    assert later_awaits == [], (
+        "Session._refresh_request_for_current_auth must not await after "
+        "materialize_rpc_request; that would let auth/cookies move between "
+        "request rebuild and Kernel.post."
     )
 
 

--- a/tests/unit/test_middleware_chain_builder.py
+++ b/tests/unit/test_middleware_chain_builder.py
@@ -16,6 +16,10 @@ from notebooklm._middleware_tracing import TracingMiddleware
 
 def _builder_kwargs():
     """Return kwargs sufficient to instantiate MiddlewareChainBuilder."""
+
+    async def _snapshot():
+        return MagicMock()
+
     return {
         "drain_tracker": MagicMock(),
         "metrics": MagicMock(),
@@ -24,6 +28,7 @@ def _builder_kwargs():
         "server_error_max_retries_provider": lambda: 3,
         "refresh_retry_delay_provider": lambda: 0.0,
         "refresh_callable": lambda: None,
+        "auth_snapshot_provider": _snapshot,
         "is_auth_error": lambda exc: False,
         "refresh_callback_enabled_provider": lambda: True,
     }

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -431,7 +431,7 @@ async def test_rpc_call_host_off_allowlist_ignores_override(monkeypatch):
 
         assert f"rpcids={RPCMethod.LIST_NOTEBOOKS.value}" in captured["url"]
         assert "shouldNOTApply" not in captured["url"]
-        assert "shouldNOTApply" not in captured["content"]
+        assert b"shouldNOTApply" not in captured["content"]
     finally:
         await core.close()
 


### PR DESCRIPTION
Stacked on #1016.

## Summary
- replace the transitional `AuthedTransport.perform_authed_post` chain terminal with a `Kernel.post` terminal that consumes `RpcRequest.url`, headers, and body directly
- keep transport error mapping identical via a shared private mapper used by both the new terminal and legacy `AuthedTransport`
- rebuild the `RpcRequest` envelope after auth refresh using a fresh `AuthSnapshot` before retrying
- keep a pre-terminal freshness check so queued requests rebuild if auth changed before the first POST

## Verification
- `uv run --frozen pytest tests/unit/test_authed_transport.py tests/unit/test_chain_wiring.py tests/unit/test_auth_refresh_middleware.py tests/unit/test_middleware_chain_builder.py tests/unit/test_middleware_types.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_rpc_overrides.py::test_rpc_call_host_off_allowlist_ignores_override -q`
- `uv run --frozen ruff check src/notebooklm tests`
- `uv run --frozen mypy src/notebooklm`
- `uv run --frozen pytest -q`
- `uv run --frozen pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication refresh to rebuild request envelopes with fresh credentials, improving reliability during concurrent auth scenarios.
  * Improved error handling to distinguish rate-limiting errors from server errors with more precise exception mapping.

* **Improvements**
  * Strengthened request freshness checks to prevent mixed-generation authentication states during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->