### PR TITLE
fix(notes): accept wrapped note rows

### DIFF
--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -104,16 +104,64 @@ class NoteService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if not (
-            result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list)
-        ):
+        rows = self._extract_note_row_container(result)
+        if not rows:
             return []
 
-        return [
-            item
-            for item in result[0]
-            if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str)
-        ]
+        normalized: list[Any] = []
+        for item in rows:
+            row = self._normalize_note_row(item)
+            if row is not None:
+                normalized.append(row)
+        return normalized
+
+    def _extract_note_row_container(self, result: Any) -> list[Any]:
+        """Return the list that contains raw note rows.
+
+        Historical responses wrap rows as ``[[row, ...]]``. Newer web
+        responses use the same first response field for rows and a second
+        timestamp field, so this helper also accepts a flat row list.
+        """
+        if not result or not isinstance(result, list):
+            return []
+
+        first = result[0] if result else None
+        if self._is_note_row_like(first):
+            return result
+        if isinstance(first, list):
+            return first
+        return []
+
+    def _normalize_note_row(self, item: Any) -> list[Any] | None:
+        """Normalize supported note wrapper shapes into parser rows.
+
+        Current NotebookLM front-end code wraps live notes as
+        ``[None, [note_id, content, metadata, ..., title]]``. The public
+        parsers expect ``[note_id, nested_note]``, so normalize that wrapper
+        before classification/parsing while preserving legacy rows and
+        soft-deleted rows such as ``[note_id, None, 2]``.
+        """
+        if not self._is_note_row_like(item):
+            return None
+
+        if isinstance(item[0], str):
+            return item
+
+        nested = item[1]
+        return [nested[0], nested, *item[2:]]
+
+    def _is_note_row_like(self, item: Any) -> bool:
+        if not isinstance(item, list) or len(item) == 0:
+            return False
+        if isinstance(item[0], str):
+            return True
+        return (
+            item[0] is None
+            and len(item) > 1
+            and isinstance(item[1], list)
+            and len(item[1]) > 0
+            and isinstance(item[1][0], str)
+        )
 
     def classify_row(self, row: list[Any]) -> NoteRowKind:
         """Identify what kind of row this is.

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -125,7 +125,7 @@ class NoteService:
         if not result or not isinstance(result, list):
             return []
 
-        first = result[0] if result else None
+        first = result[0]
         if self._is_note_row_like(first):
             return result
         if isinstance(first, list):

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -49,16 +49,22 @@ class TestFetchNoteRows:
         mock_session.rpc_call.return_value = [
             [
                 ["note_1", "Content"],
+                [None, ["note_3", "Nested body", None, None, "Nested Title"]],
                 [],
                 "not-a-row",
                 [123, "Non-string ID"],
+                [None, "Non-nested note payload"],
                 ["note_2", "Content"],
             ]
         ]
 
         rows = await service.fetch_note_rows("nb_123")
 
-        assert rows == [["note_1", "Content"], ["note_2", "Content"]]
+        assert rows == [
+            ["note_1", "Content"],
+            ["note_3", ["note_3", "Nested body", None, None, "Nested Title"]],
+            ["note_2", "Content"],
+        ]
         mock_session.rpc_call.assert_awaited_once_with(
             RPCMethod.GET_NOTES_AND_MIND_MAPS,
             ["nb_123"],
@@ -73,6 +79,20 @@ class TestFetchNoteRows:
     ) -> None:
         mock_session.rpc_call.return_value = payload
         assert await service.fetch_note_rows("nb_123") == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_note_rows_accepts_flat_row_container(
+        self, service: NoteService, mock_session: FakeSession
+    ) -> None:
+        mock_session.rpc_call.return_value = [
+            ["note_1", "Content"],
+            ["deleted_note", None, 2],
+        ]
+
+        assert await service.fetch_note_rows("nb_123") == [
+            ["note_1", "Content"],
+            ["deleted_note", None, 2],
+        ]
 
 
 class TestClassifyRow:


### PR DESCRIPTION
## Summary
- Normalize newer NotebookLM note row wrappers like `[null, [note_id, ...]]` before parsing
- Accept both historical nested row containers and newer flat row containers
- Add unit coverage for wrapped rows, invalid wrappers, and flat containers

## Problem
During live NotebookLM smoke testing, `note list` could return no notes when the service response used the newer frontend wrapper shape instead of the older `[[row, ...]]` container. No existing issue was found for this exact shape change.

## Test Plan
- [x] `env -u PYTHONPATH uv run ruff format --check .`
- [x] `env -u PYTHONPATH uv run ruff check .`
- [x] `env -u PYTHONPATH uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `env -u PYTHONPATH uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`
- [x] `env -u PYTHONPATH uv run --frozen pytest tests/unit/test_note_service.py tests/unit/test_notes_unit.py tests/unit/cli/test_note.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note retrieval to handle multiple response formats and normalize differing row shapes, making note loading more reliable and robust.

* **Tests**
  * Expanded test coverage for note handling, including flat-row scenarios and stricter validation of malformed or nested rows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->