### PR TITLE
docs(adr): add demote/consolidate criterion to ADR-012

### DIFF
--- a/docs/adr/0012-implementation-surface-convention.md
+++ b/docs/adr/0012-implementation-surface-convention.md
@@ -213,18 +213,18 @@ purpose accumulate even after their original consumers are gone.
 To balance the ratchet, two seam-tier consolidation triggers apply:
 
 1. **Sibling fold.** When two `_<domain>_*.py` siblings each have
-   <300 LOC and import only each other plus shared deps (no other
-   `notebooklm._*` seam imports either of them by name), they are
+   <300 LOC, each imports only the other plus shared deps, **and** no
+   other `notebooklm._*` seam imports either of them by name, they are
    **candidates to fold** into a single `_<domain>.py` (or
    `_<domain>_<concern>.py`, picking whichever name remains
    self-describing).
 2. **Capability demotion.** When a capability that was previously
    promoted to a shared Protocol (per
    [ADR-013](0013-composable-session-capabilities.md) §1, the ≥2
-   feature-consumer rule) has dropped back to **zero remaining second
-   consumers** — i.e. exactly one feature still types against it —
-   that capability is a **candidate to demote** back into its sole
-   consumer as a feature-local Protocol, mirroring the
+   feature-consumer rule) has dropped back to **a single consumer** —
+   i.e. exactly one feature still types against it — that capability
+   is a **candidate to demote** back into its sole consumer as a
+   feature-local Protocol, mirroring the
    `ChatRuntime` / `ArtifactsRuntime` / `UploadRuntime` pattern in
    ADR-013 §3.
 

--- a/docs/adr/0012-implementation-surface-convention.md
+++ b/docs/adr/0012-implementation-surface-convention.md
@@ -234,7 +234,7 @@ different audiences, when an imminent third consumer is in flight, or
 when keeping the shared Protocol clarifies a domain boundary). The
 rule exists to make consolidation a normal motion that doesn't need a
 fresh justification each time — not to force collapses against
-reviewer judgement.
+reviewer judgment.
 
 **Demotion does not require an ADR update.** It is the symmetric
 counterpart to ADR-013's promotion rule (also a standing rule that

--- a/docs/adr/0012-implementation-surface-convention.md
+++ b/docs/adr/0012-implementation-surface-convention.md
@@ -198,6 +198,62 @@ deprecation policy in `docs/stability.md`: one release of
 `DeprecationWarning` from the public module, then removal in the next
 minor (0.x) or major (post-1.0) bump.
 
+### Demotion / consolidation rule
+
+The promotion rule above governs only the public-surface boundary
+(seam → public re-export). It says nothing about motion *within* the
+seam tier — and without a symmetric rule the prefix convention becomes
+a one-way ratchet toward more files. The Tier-7 through Tier-13 arc
+biased toward *splitting* seams because every refactor that produced a
+new `_<domain>_*.py` sibling was self-justifying ("this concern now has
+a name"), while collapses had no named policy backing them. The result
+is structural drift: seams that were extracted for a single Tier's
+purpose accumulate even after their original consumers are gone.
+
+To balance the ratchet, two seam-tier consolidation triggers apply:
+
+1. **Sibling fold.** When two `_<domain>_*.py` siblings each have
+   <300 LOC and import only each other plus shared deps (no other
+   `notebooklm._*` seam imports either of them by name), they are
+   **candidates to fold** into a single `_<domain>.py` (or
+   `_<domain>_<concern>.py`, picking whichever name remains
+   self-describing).
+2. **Capability demotion.** When a capability that was previously
+   promoted to a shared Protocol (per
+   [ADR-013](0013-composable-session-capabilities.md) §1, the ≥2
+   feature-consumer rule) has dropped back to **zero remaining second
+   consumers** — i.e. exactly one feature still types against it —
+   that capability is a **candidate to demote** back into its sole
+   consumer as a feature-local Protocol, mirroring the
+   `ChatRuntime` / `ArtifactsRuntime` / `UploadRuntime` pattern in
+   ADR-013 §3.
+
+Both triggers are *candidates*, not mandates: a reviewer may decline
+the fold/demotion (e.g. when the two siblings have meaningfully
+different audiences, when an imminent third consumer is in flight, or
+when keeping the shared Protocol clarifies a domain boundary). The
+rule exists to make consolidation a normal motion that doesn't need a
+fresh justification each time — not to force collapses against
+reviewer judgement.
+
+**Demotion does not require an ADR update.** It is the symmetric
+counterpart to ADR-013's promotion rule (also a standing rule that
+applies per-PR, not per-ADR). A demotion or sibling fold is a normal
+refactor PR; it references this section as its policy basis, the same
+way a new shared Protocol references ADR-013 §1. Only a change to the
+*criteria themselves* (the <300-LOC threshold, the second-consumer
+count, or the mutual-isolation condition on cross-seam imports)
+requires an ADR amendment.
+
+This rule is paired with the underscore-prefix convention rather than
+with ADR-013 because the rule's *evidence* is module-level
+(file sizes, file-to-file imports inside `src/notebooklm/`) and the
+rule's *target* is the seam-tier file layout this ADR pins. The two
+ADRs read as a paired policy: ADR-013 §1 governs when a
+single-consumer capability becomes shared; this section governs when
+a previously-shared capability or an over-decomposed file pair
+collapses back.
+
 ## Consequences
 
 **Wanted:**

--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -103,6 +103,17 @@ runtimes. Concretely:
    `LoopGuard + OperationScopeProvider`). The promotion criterion is
    **shared by ≥2 features**. No capability is promoted on speculation.
 
+   The symmetric demotion / sibling-fold rule lives in
+   [ADR-012](0012-implementation-surface-convention.md) §Demotion /
+   consolidation rule: when a previously-shared capability drops back
+   to a single consumer, or when two underscore-prefixed seam siblings
+   become small enough and mutually-isolated, the ADR-012 rule
+   authorises the inverse motion. The two rules read as a paired
+   policy — ADR-013 §1 governs promotion *up* into a shared Protocol;
+   ADR-012 §Demotion governs collapse *back down* into a feature-local
+   Protocol or a folded seam file. Neither motion needs a fresh ADR;
+   only changes to the criteria themselves do.
+
 2. **Retain `AuthMetadata` and `Kernel`** (both in
    `_session_contracts.py`, symbols `AuthMetadata` and `Kernel`) as
    standalone Protocols — they are **NOT** members of any

--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -104,15 +104,15 @@ runtimes. Concretely:
    **shared by ≥2 features**. No capability is promoted on speculation.
 
    The symmetric demotion / sibling-fold rule lives in
-   [ADR-012](0012-implementation-surface-convention.md) §Demotion /
-   consolidation rule: when a previously-shared capability drops back
-   to a single consumer, or when two underscore-prefixed seam siblings
-   become small enough and mutually-isolated, the ADR-012 rule
-   authorises the inverse motion. The two rules read as a paired
-   policy — ADR-013 §1 governs promotion *up* into a shared Protocol;
-   ADR-012 §Demotion governs collapse *back down* into a feature-local
-   Protocol or a folded seam file. Neither motion needs a fresh ADR;
-   only changes to the criteria themselves do.
+   [ADR-012 §Demotion / consolidation rule](0012-implementation-surface-convention.md#demotion--consolidation-rule):
+   when a previously-shared capability drops back to a single consumer,
+   or when two underscore-prefixed seam siblings become small enough
+   and mutually-isolated, the ADR-012 rule authorizes the inverse
+   motion. The two rules read as a paired policy — ADR-013 §1 governs
+   promotion *up* into a shared Protocol; ADR-012 §Demotion governs
+   collapse *back down* into a feature-local Protocol or a folded
+   seam file. Neither motion needs a fresh ADR; only changes to the
+   criteria themselves do.
 
 2. **Retain `AuthMetadata` and `Kernel`** (both in
    `_session_contracts.py`, symbols `AuthMetadata` and `Kernel`) as


### PR DESCRIPTION
## Summary

- Adds a **Demotion / consolidation rule** section to ADR-012 (the underscore-prefix surface convention), giving the existing promotion rule a symmetric counterpart.
- Adds a paired-policy cross-reference paragraph to ADR-013 Decision §1 so the two ADRs read as one promotion/demotion policy.
- Pure docs PR — no code changes (only `docs/adr/0012-implementation-surface-convention.md` and `docs/adr/0013-composable-session-capabilities.md` modified).

## Motivation (from `docs/improvement.md` §3.3)

ADR-012 had only a promotion rule (seam → public re-export). Without a symmetric demote/consolidate side, the prefix convention behaves as a one-way ratchet toward more files. Every Tier-7 through Tier-13 refactor that produced a new `_<domain>_*.py` sibling was self-justifying ("this concern now has a name"); collapses had no named policy backing them.

**Empirical evidence the ratchet is real**: the codebase had 4 files >700 LOC at the `docs/improvement.md` baseline (2026-05-22); `origin/main` today has **seven**:

| File | LOC |
|---|---|
| `_artifacts.py` | 1041 |
| `_session.py` | 1031 |
| `_source_upload.py` | 911 |
| `_artifact_downloads.py` | 877 |
| `_chat.py` | 845 |
| `_notebooks.py` | 723 |
| `_artifact_generation.py` | 722 |

Note: this rule does not directly attack the 7 big files (that is `improvement.md` §3.2's broader work). What the rule does is prevent the *next* arc of decomposition from over-fragmenting when those files do get split — by making consolidation a normal motion that does not need a fresh justification each time.

## What the new rule says

Two seam-tier consolidation triggers:

1. **Sibling fold** — two `_<domain>_*.py` siblings each <300 LOC that import only each other plus shared deps are candidates to fold.
2. **Capability demotion** — a previously-shared capability Protocol (per ADR-013 §1, the ≥2-feature-consumer rule) that drops back to a single consumer is a candidate to demote into its sole consumer as a feature-local Protocol, mirroring the `ChatRuntime` / `ArtifactsRuntime` / `UploadRuntime` pattern from ADR-013 §3.

Both are *candidates*, not mandates — a reviewer may decline the fold/demotion. **Demotion does not require an ADR update** — it is the symmetric counterpart to ADR-013's promotion rule (also a standing per-PR rule). Only changes to the *criteria themselves* (the <300-LOC threshold, the second-consumer count, or the mutual-isolation condition) require an ADR amendment.

The rule is grounded in existing precedent: ADR-013 §C-AA already demoted `DrainHookRegistration` from `_session_contracts.py` into `_artifacts.py` under exactly this shape.

## Acceptance criteria (from task spec)

- [x] `grep -i "demote\|consolidate\|fold" docs/adr/0012-implementation-surface-convention.md` returns matches inside a named Decision/policy section (the new `### Demotion / consolidation rule` subsection).
- [x] ADR-012 and ADR-013 cross-reference each other (ADR-012 → ADR-013 §1 and §3; ADR-013 §1 → ADR-012 §Demotion).
- [x] No code changes; pure docs PR (only the two ADR files modified; +67 lines).

## Test plan

- [x] `grep` verification of the acceptance criteria (above).
- [x] Both ADRs re-read end-to-end to confirm prose flows and cross-references resolve.
- [ ] No Python CI required (pre-commit + mypy + pytest target Python only).

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a demotion/consolidation rule describing when seam-tier files may be folded or shared protocols returned to feature-local scope.
  * Clarified these are candidate triggers treated as normal refactor PRs, not mandates, unless the criteria change.
  * Linked promotion and demotion guidance to show their paired, inverse relationship.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->