### PR TITLE
refactor(artifacts): introduce ArtifactRowAdapter for positional wire decoding

### DIFF
--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -144,10 +144,13 @@ class ArtifactListingService:
         # Wrap candidates once; the adapter is a thin frozen view so this
         # is cheap. ``rows`` keeps the (raw, row) pairing so we can
         # return the original raw list back to downstream extractors.
+        # No explicit length-guard against short rows: ``ArtifactRow``
+        # already returns sensible defaults (``status=0``) for missing
+        # positions, and ``matches_type(completed_only=True)`` rejects
+        # those defaults naturally — keeping the adapter's encapsulation
+        # contract intact.
         rows: list[tuple[Any, ArtifactRow]] = [
-            (a, ArtifactRow(a))
-            for a in candidates
-            if isinstance(a, list) and len(a) > ArtifactRow._STATUS_POS
+            (a, ArtifactRow(a)) for a in candidates if isinstance(a, list)
         ]
         filtered: list[tuple[Any, ArtifactRow]] = [
             (raw, row) for raw, row in rows if row.matches_type(type_code, completed_only=True)

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -8,7 +8,8 @@ from typing import Any
 
 import httpx
 
-from .rpc import ArtifactStatus, ArtifactTypeCode, RPCError, RPCMethod
+from ._row_adapters import ArtifactRow
+from .rpc import ArtifactTypeCode, RPCError, RPCMethod
 from .types import Artifact, ArtifactNotReadyError, ArtifactType
 
 logger = logging.getLogger(__name__)
@@ -126,37 +127,50 @@ class ArtifactListingService:
     ) -> Any:
         """Select an artifact from candidates by ID or return latest completed.
 
-        The error-key asymmetry is intentional: explicit-ID misses derive the
-        key from ``type_name`` while empty-filter results use
+        Position knowledge (``a[2]`` type, ``a[4]`` status, ``a[15][0]``
+        timestamp) is delegated to
+        :class:`notebooklm._row_adapters.ArtifactRow` — when Google
+        reshapes the wire, the position constants change there and this
+        method adapts automatically.
+
+        The error-key asymmetry is intentional: explicit-ID misses
+        derive the key from ``type_name`` while empty-filter results use
         ``no_result_error_key`` verbatim.
+
+        Returns the **raw row** (not an :class:`ArtifactRow`) so downstream
+        extractors (audio, video, infographic, slide-deck URL helpers)
+        keep their existing list-positional input shape.
         """
-        filtered = [
-            a
+        # Wrap candidates once; the adapter is a thin frozen view so this
+        # is cheap. ``rows`` keeps the (raw, row) pairing so we can
+        # return the original raw list back to downstream extractors.
+        rows: list[tuple[Any, ArtifactRow]] = [
+            (a, ArtifactRow(a))
             for a in candidates
-            if isinstance(a, list)
-            and len(a) > 4
-            and a[2] == type_code
-            and a[4] == ArtifactStatus.COMPLETED
+            if isinstance(a, list) and len(a) > ArtifactRow._STATUS_POS
+        ]
+        filtered: list[tuple[Any, ArtifactRow]] = [
+            (raw, row) for raw, row in rows if row.matches_type(type_code, completed_only=True)
         ]
 
         if artifact_id:
-            artifact = next((a for a in filtered if a[0] == artifact_id), None)
-            if not artifact:
+            match = next(((raw, row) for raw, row in filtered if row.id == artifact_id), None)
+            if not match:
                 raise ArtifactNotReadyError(
                     type_name.lower().replace(" ", "_"), artifact_id=artifact_id
                 )
-            return artifact
+            return match[0]
 
         if not filtered:
             raise ArtifactNotReadyError(no_result_error_key)
 
-        filtered.sort(
-            key=lambda a: (
-                (a[15][0] or 0) if len(a) > 15 and isinstance(a[15], list) and a[15] else 0
-            ),
-            reverse=True,
-        )
-        return filtered[0]
+        # Sort by raw timestamp so missing / ``None`` / non-list shapes
+        # coerce to ``0`` without crashing the comparison (mirrors the
+        # historical ``(a[15][0] or 0)`` falsy-coerce trick that pinned
+        # the ``test_handles_none_at_timestamp_position_without_typeerror``
+        # contract).
+        filtered.sort(key=lambda pair: pair[1].created_at_raw or 0, reverse=True)
+        return filtered[0][0]
 
     def _filter_studio_artifacts(
         self,

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -1,0 +1,247 @@
+"""Typed views over raw batchexecute response rows.
+
+Google's NotebookLM batchexecute responses are positional ``list`` payloads
+whose indices are pinned only by what we have captured in cassettes and
+observed in production. When Google rotates a shape — a single index
+shifts, a leaf becomes a wrapper, a list becomes a dict — every consumer
+that hand-rolls position knowledge breaks independently.
+
+This module is the **single point of position knowledge for the artifact
+row shape**: if Google reshapes the wire, the position constants change
+**here** and every consumer (currently :class:`notebooklm._types.artifacts.Artifact`
+and :class:`notebooklm._artifact_listing.ArtifactListingService`) adapts
+automatically. The constants therefore function as the canary contract for
+artifact wire-shape changes — see ``tests/unit/test_row_adapters.py`` for
+the pin test that fails loudly when anyone edits a position.
+
+The adapter sits **on top of** :func:`notebooklm.rpc.safe_index`:
+
+* Top-level position presence (``len(self._raw) > _POS``) is treated as
+  optional — missing trailing positions return sensible defaults in both
+  soft and strict modes. This preserves the historical
+  ``Artifact.from_api_response`` contract that accepts short rows.
+* Deep descent into a present position (``data[9][1][0]``,
+  ``data[15][0]``) flows through :func:`safe_index`. Soft mode returns
+  ``None`` on drift, strict mode raises
+  :class:`notebooklm.exceptions.UnknownRPCMethodError` — the desired
+  ADR-011 signal for genuine Google-side reshape.
+
+Out of scope for this module (deferred to follow-up PRs per
+``docs/improvement.md`` §6.2): ``SourceRowAdapter`` and ``NoteRowAdapter``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, ClassVar
+
+from ._types.common import _datetime_from_timestamp
+from .rpc import ArtifactStatus, RPCMethod, safe_index
+
+__all__ = ["ArtifactRow"]
+
+
+@dataclass(frozen=True)
+class ArtifactRow:
+    """Typed view of a raw artifact row from a ``LIST_ARTIFACTS`` response.
+
+    The wrapped row is the per-artifact list returned by the ``gArtLc``
+    (``LIST_ARTIFACTS``) RPC. Position layout:
+
+    =====  ============================================================
+    Index  Meaning
+    =====  ============================================================
+    0      artifact id (str)
+    1      artifact title (str)
+    2      type code (int — see :class:`notebooklm.rpc.ArtifactTypeCode`)
+    4      processing status (int — see :class:`notebooklm.rpc.ArtifactStatus`)
+    9      options block; ``[9][1][0]`` is the variant code (used to
+           distinguish QUIZ from FLASHCARDS when type == 4)
+    15     timestamp block; ``[15][0]`` is the creation timestamp
+           (seconds since epoch)
+    =====  ============================================================
+
+    Position knowledge is centralised here. Consumer sites should NEVER
+    open-code ``data[2]`` / ``data[4]`` / ``data[15]`` — wrap the row in
+    an :class:`ArtifactRow` and read through the typed properties
+    instead.
+
+    The dataclass is frozen so accidentally mutating the wrapped row is
+    impossible through the adapter; the adapter itself never copies the
+    raw row, so it is cheap to construct.
+    """
+
+    # Wrapped row; ``repr=False`` so logs don't explode with the entire
+    # batchexecute payload when an ArtifactRow appears in a stack trace.
+    _raw: list[Any] = field(repr=False)
+    _method_id: str = RPCMethod.LIST_ARTIFACTS.value
+
+    # ---- Position constants (the canary contract) ------------------------
+    # These are ClassVar so the frozen dataclass treats them as class-level
+    # constants rather than instance fields. If any of these change,
+    # ``tests/unit/test_row_adapters.py::test_position_contract`` MUST be
+    # updated in the same commit — that failure is the wire-shape change
+    # signal.
+    _ID_POS: ClassVar[int] = 0
+    _TITLE_POS: ClassVar[int] = 1
+    _TYPE_POS: ClassVar[int] = 2
+    _STATUS_POS: ClassVar[int] = 4
+    _OPTIONS_POS: ClassVar[int] = 9
+    _TIMESTAMP_POS: ClassVar[int] = 15
+
+    # ---- Top-level required positions ------------------------------------
+    # These use length guards (not ``safe_index``) so short rows continue
+    # to receive sensible defaults in BOTH soft and strict modes — that
+    # matches the historical ``Artifact.from_api_response`` contract and
+    # keeps minimal rows like ``["id", "title", 1, None, 3]`` working.
+
+    @property
+    def id(self) -> str:
+        """Artifact identifier — empty string when absent."""
+        if len(self._raw) <= self._ID_POS:
+            return ""
+        return str(self._raw[self._ID_POS])
+
+    @property
+    def title(self) -> str:
+        """Artifact title — empty string when absent."""
+        if len(self._raw) <= self._TITLE_POS:
+            return ""
+        return str(self._raw[self._TITLE_POS])
+
+    @property
+    def type_code(self) -> int:
+        """Type code (see :class:`ArtifactTypeCode`); ``0`` when absent.
+
+        Returned as the raw ``int``, not the enum, because consumers
+        compare against either enum members or raw ints depending on
+        context.
+        """
+        if len(self._raw) <= self._TYPE_POS:
+            return 0
+        value = self._raw[self._TYPE_POS]
+        return value if isinstance(value, int) else 0
+
+    @property
+    def status(self) -> int:
+        """Processing status code (see :class:`ArtifactStatus`); ``0`` when absent."""
+        if len(self._raw) <= self._STATUS_POS:
+            return 0
+        value = self._raw[self._STATUS_POS]
+        return value if isinstance(value, int) else 0
+
+    # ---- Nested descents (delegated to safe_index) -----------------------
+    # The outer ``len`` guard preserves the "optional trailing positions"
+    # contract; the deeper descent goes through ``safe_index`` so strict
+    # mode raises on genuine shape drift.
+
+    @property
+    def variant(self) -> int | None:
+        """Variant code at ``data[9][1][0]`` — distinguishes QUIZ vs FLASHCARDS.
+
+        Returns ``None`` when:
+
+        * position 9 is absent (short row), or
+        * descent through ``[1][0]`` returns ``None`` (soft-mode drift), or
+        * the resulting value is not an ``int``.
+
+        Raises :class:`UnknownRPCMethodError` in strict mode when position
+        9 is present but its inner shape does not match — that is the
+        signal that Google reshaped the options block.
+        """
+        if len(self._raw) <= self._OPTIONS_POS:
+            return None
+        options_block = self._raw[self._OPTIONS_POS]
+        if not isinstance(options_block, list):
+            # Preserves legacy soft-degrade for ``data[9] = None`` rows
+            # (observed in older cassettes) without invoking ``safe_index``
+            # against a non-list root.
+            return None
+        value = safe_index(
+            options_block,
+            1,
+            0,
+            method_id=self._method_id,
+            source="ArtifactRow.variant",
+        )
+        return value if isinstance(value, int) else None
+
+    @property
+    def created_at_raw(self) -> int | float | None:
+        """Raw creation timestamp (seconds since epoch) at ``data[15][0]``.
+
+        Exposed separately from :attr:`created_at` because callers that
+        sort artifact rows by recency need a value that compares cleanly
+        even when the timestamp is missing or ``None``. The
+        :meth:`~notebooklm._artifact_listing.ArtifactListingService.select_artifact`
+        sort key uses ``row.created_at_raw or 0`` to coerce missing
+        values to ``0`` without crashing the comparison.
+
+        Returns ``None`` when:
+
+        * position 15 is absent (short row), or
+        * descent through ``[0]`` returns ``None`` (soft-mode drift), or
+        * the resulting value is not numeric.
+        """
+        if len(self._raw) <= self._TIMESTAMP_POS:
+            return None
+        timestamp_block = self._raw[self._TIMESTAMP_POS]
+        if not isinstance(timestamp_block, list) or not timestamp_block:
+            # Mirrors the legacy
+            # ``len(a) > 15 and isinstance(a[15], list) and a[15]``
+            # guard. ``not timestamp_block`` short-circuits an empty
+            # ``[]`` envelope so we never invoke ``safe_index`` against
+            # it — an empty list at this position is an accepted
+            # edge-case rather than drift (some cassettes legitimately
+            # have ``data[15] = []``).
+            return None
+        value = safe_index(
+            timestamp_block,
+            0,
+            method_id=self._method_id,
+            source="ArtifactRow.created_at_raw",
+        )
+        return value if isinstance(value, (int, float)) else None
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Creation timestamp as a :class:`~datetime.datetime`, or ``None``.
+
+        Wraps :attr:`created_at_raw` and converts via
+        :func:`_datetime_from_timestamp`, which returns ``None`` for
+        out-of-range / non-numeric values.
+        """
+        raw = self.created_at_raw
+        if raw is None:
+            return None
+        return _datetime_from_timestamp(raw)
+
+    # ---- Type-matching helper --------------------------------------------
+
+    def matches_type(self, type_code: int, *, completed_only: bool = False) -> bool:
+        """Return whether this row matches ``type_code``.
+
+        Args:
+            type_code: Raw :class:`ArtifactTypeCode` integer (or any int)
+                to compare against the row's :attr:`type_code`.
+            completed_only: When ``True``, also require :attr:`status`
+                to equal :data:`ArtifactStatus.COMPLETED` (``3``). This
+                is the predicate used by
+                :meth:`~notebooklm._artifact_listing.ArtifactListingService.select_artifact`
+                to pick downloadable artifacts.
+
+        Note:
+            This is a *raw* type-code match. The QUIZ vs FLASHCARDS
+            variant distinction lives one layer up in
+            ``_artifact_listing._matches_artifact_type`` because it
+            operates on :class:`Artifact` objects (which know variant
+            mapping), not raw rows. Keep that separation intentional —
+            the adapter exposes the variant via :attr:`variant` if
+            callers need it.
+        """
+        if self.type_code != type_code:
+            return False
+        if completed_only:
+            return self.status == ArtifactStatus.COMPLETED
+        return True

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -75,7 +75,12 @@ class ArtifactRow:
     # Wrapped row; ``repr=False`` so logs don't explode with the entire
     # batchexecute payload when an ArtifactRow appears in a stack trace.
     _raw: list[Any] = field(repr=False)
-    _method_id: str = RPCMethod.LIST_ARTIFACTS.value
+    # ``method_id`` is intentionally a public extension point: callers
+    # wrapping a row that came from a non-LIST_ARTIFACTS method override
+    # it so ``safe_index`` drift diagnostics point at the correct RPC.
+    # No leading underscore — see the related test
+    # ``TestMethodIdPropagation::test_custom_method_id_propagates``.
+    method_id: str = RPCMethod.LIST_ARTIFACTS.value
 
     # ---- Position constants (the canary contract) ------------------------
     # These are ClassVar so the frozen dataclass treats them as class-level
@@ -162,7 +167,7 @@ class ArtifactRow:
             options_block,
             1,
             0,
-            method_id=self._method_id,
+            method_id=self.method_id,
             source="ArtifactRow.variant",
         )
         return value if isinstance(value, int) else None
@@ -199,7 +204,7 @@ class ArtifactRow:
         value = safe_index(
             timestamp_block,
             0,
-            method_id=self._method_id,
+            method_id=self.method_id,
             source="ArtifactRow.created_at_raw",
         )
         return value if isinstance(value, (int, float)) else None

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+from .._row_adapters import ArtifactRow
 from ..rpc.types import ArtifactStatus, ArtifactTypeCode, artifact_status_to_str
 from .common import UnknownTypeWarning, _datetime_from_timestamp
 
@@ -229,37 +230,33 @@ class Artifact:
     def from_api_response(cls, data: list[Any]) -> Artifact:
         """Parse artifact from API response.
 
-        Structure: [id, title, type, ..., status, ..., metadata, ...]
-        Position 9 contains options with variant code at [9][1][0]:
-          - For type 4: 1=flashcards, 2=quiz
+        Position knowledge for ``id`` / ``title`` / ``type`` / ``status``
+        / ``variant`` / ``timestamp`` lives in
+        :class:`notebooklm._row_adapters.ArtifactRow`. This factory wraps
+        the raw row in an adapter and reads through its typed properties,
+        so any wire-shape change touches the adapter constants only.
+
+        URL extraction stays inline because it dispatches on
+        ``type_code`` to a family of type-specific extractors and
+        operates on the full row — those extractors will be folded into
+        the adapter family in a follow-up PR.
         """
-        artifact_id = data[0] if len(data) > 0 else ""
-        title = data[1] if len(data) > 1 else ""
-        artifact_type = data[2] if len(data) > 2 else 0
-        status = data[4] if len(data) > 4 else 0
-
-        # Extract timestamp from data[15][0]
-        created_at = None
-        if len(data) > 15 and isinstance(data[15], list) and len(data[15]) > 0:
-            created_at = _datetime_from_timestamp(data[15][0])
-
-        # Extract variant code from data[9][1][0] for quiz/flashcard distinction
-        variant = None
-        if len(data) > 9 and isinstance(data[9], list) and len(data[9]) > 1:
-            options = data[9][1]
-            if isinstance(options, list) and len(options) > 0:
-                variant = options[0]
-
+        row = ArtifactRow(data)
+        artifact_type = row.type_code
+        # ``row.type_code`` already normalises non-ints to ``0``; the
+        # ``isinstance`` check is defensive in case an ``IntEnum`` flavour
+        # ever leaks through and to keep ``_extract_artifact_url`` reading
+        # an unambiguous ``int | None``.
         url = _extract_artifact_url(data, artifact_type if isinstance(artifact_type, int) else None)
 
         return cls(
-            id=str(artifact_id),
-            title=str(title),
+            id=row.id,
+            title=row.title,
             _artifact_type=artifact_type,
-            status=status,
-            created_at=created_at,
+            status=row.status,
+            created_at=row.created_at,
             url=url,
-            _variant=variant,
+            _variant=row.variant,
         )
 
     @classmethod

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -243,11 +243,11 @@ class Artifact:
         """
         row = ArtifactRow(data)
         artifact_type = row.type_code
-        # ``row.type_code`` already normalises non-ints to ``0``; the
-        # ``isinstance`` check is defensive in case an ``IntEnum`` flavour
-        # ever leaks through and to keep ``_extract_artifact_url`` reading
-        # an unambiguous ``int | None``.
-        url = _extract_artifact_url(data, artifact_type if isinstance(artifact_type, int) else None)
+        # ``row.type_code`` is statically typed ``int`` and normalises
+        # non-ints to ``0``; ``_extract_artifact_url`` then falls through
+        # to ``None`` for unrecognised codes — no separate ``isinstance``
+        # guard is needed here.
+        url = _extract_artifact_url(data, artifact_type)
 
         return cls(
             id=row.id,

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1,0 +1,414 @@
+"""Tests for ``notebooklm._row_adapters.ArtifactRow``.
+
+The adapter centralises position knowledge for the ``LIST_ARTIFACTS`` row
+shape so consumers (``Artifact.from_api_response`` and
+``ArtifactListingService.select_artifact``) read named properties instead
+of open-coding ``data[2]`` / ``data[4]`` / ``data[15]``. See
+``docs/improvement.md`` §6.2 for the motivation and
+``src/notebooklm/_row_adapters.py`` for the position contract.
+
+These tests cover three layers:
+
+1. **Position-contract pin** — the canary that fails loudly if anyone
+   edits a position constant. When this fails, the diff is the
+   wire-shape change signal Google has rotated something.
+2. **Shape handling** — missing trailing positions return sensible
+   defaults; deep descent goes through ``safe_index`` so strict-mode
+   drift raises ``UnknownRPCMethodError``.
+3. **matches_type** — the predicate used by ``select_artifact``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._row_adapters import ArtifactRow
+from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode
+
+# ---------------------------------------------------------------------------
+# 1. Position-contract pin (the canary)
+# ---------------------------------------------------------------------------
+
+
+class TestPositionContract:
+    """If any of these assertions fail, Google has likely reshaped the wire.
+
+    Changing a position constant is the *only* legitimate reason for one
+    of these tests to need updating. When that happens, the failing diff
+    serves as the audit trail for the wire-shape change.
+    """
+
+    def test_id_position_is_0(self) -> None:
+        assert ArtifactRow._ID_POS == 0
+
+    def test_title_position_is_1(self) -> None:
+        assert ArtifactRow._TITLE_POS == 1
+
+    def test_type_position_is_2(self) -> None:
+        assert ArtifactRow._TYPE_POS == 2
+
+    def test_status_position_is_4(self) -> None:
+        assert ArtifactRow._STATUS_POS == 4
+
+    def test_options_position_is_9(self) -> None:
+        assert ArtifactRow._OPTIONS_POS == 9
+
+    def test_timestamp_position_is_15(self) -> None:
+        assert ArtifactRow._TIMESTAMP_POS == 15
+
+    def test_all_positions_at_once(self) -> None:
+        """A single dict pin so a sweeping reshape (e.g. all positions
+        shift by one because Google inserted a new leading element)
+        fails with one informative assertion rather than six."""
+        assert (
+            ArtifactRow._ID_POS,
+            ArtifactRow._TITLE_POS,
+            ArtifactRow._TYPE_POS,
+            ArtifactRow._STATUS_POS,
+            ArtifactRow._OPTIONS_POS,
+            ArtifactRow._TIMESTAMP_POS,
+        ) == (0, 1, 2, 4, 9, 15)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _full_row(
+    artifact_id: str = "art_id",
+    title: str = "Title",
+    type_code: int = ArtifactTypeCode.AUDIO,
+    status: int = ArtifactStatus.COMPLETED,
+    variant: int | None = None,
+    timestamp: int | None = 1_700_000_000,
+) -> list:
+    """Build a full 16-element row matching the ``LIST_ARTIFACTS`` shape.
+
+    Mirrors the helper used in ``tests/unit/test_select_artifact.py`` so
+    fixtures stay consistent across the artifact-adapter test surface.
+    """
+    row: list = [artifact_id, title, type_code, None, status]
+    # Pad positions 5..8.
+    row.extend([None] * 4)
+    # Position 9: options block — ``[unused, [variant]]``.
+    if variant is None:
+        row.append(None)
+    else:
+        row.append([None, [variant]])
+    # Pad positions 10..14.
+    row.extend([None] * 5)
+    # Position 15: ``[timestamp, ...]``.
+    if timestamp is None:
+        row.append(None)
+    else:
+        row.append([timestamp])
+    return row
+
+
+# ---------------------------------------------------------------------------
+# 2. Shape handling (sensible defaults for short/malformed rows)
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredPositionsAcceptShortRows:
+    """Top-level positions tolerate short rows in BOTH soft and strict modes.
+
+    This is the historical ``Artifact.from_api_response`` contract: a
+    minimal row like ``["id", "title", 1, None, 3]`` must read fine
+    even though positions 9 and 15 are absent.
+    """
+
+    def test_empty_row_yields_default_id_and_title(self) -> None:
+        row = ArtifactRow([])
+        assert row.id == ""
+        assert row.title == ""
+
+    def test_empty_row_yields_default_type_and_status(self) -> None:
+        row = ArtifactRow([])
+        assert row.type_code == 0
+        assert row.status == 0
+
+    def test_id_coerced_to_string(self) -> None:
+        """Defensive: a non-string id is stringified."""
+        row = ArtifactRow([12345, "Title"])
+        assert row.id == "12345"
+
+    def test_title_coerced_to_string(self) -> None:
+        row = ArtifactRow(["id", 999])
+        assert row.title == "999"
+
+    def test_non_int_type_code_falls_back_to_zero(self) -> None:
+        """A non-int at position 2 normalises to ``0`` rather than
+        leaking ``None`` past the ``type_code: int`` contract."""
+        row = ArtifactRow(["id", "title", None, None, 3])
+        assert row.type_code == 0
+
+    def test_non_int_status_falls_back_to_zero(self) -> None:
+        row = ArtifactRow(["id", "title", 1, None, None])
+        assert row.status == 0
+
+    def test_minimal_row_no_variant_no_timestamp(self) -> None:
+        """The smallest meaningful row: positions 0..4 present, 9 and 15 absent."""
+        row = ArtifactRow(["art_minimal", "Audio", 1, None, 3])
+        assert row.id == "art_minimal"
+        assert row.title == "Audio"
+        assert row.type_code == 1
+        assert row.status == 3
+        assert row.variant is None
+        assert row.created_at_raw is None
+        assert row.created_at is None
+
+
+class TestVariantDescent:
+    """``data[9][1][0]`` descent — used to distinguish QUIZ vs FLASHCARDS."""
+
+    def test_variant_extracted_from_options_block(self) -> None:
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.QUIZ, variant=2))
+        assert row.variant == 2
+
+    def test_flashcards_variant(self) -> None:
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.QUIZ, variant=1))
+        assert row.variant == 1
+
+    def test_missing_options_position_returns_none(self) -> None:
+        """Short row without position 9 yields ``None`` (no strict-mode raise)."""
+        row = ArtifactRow(["id", "title", 4, None, 3])
+        assert row.variant is None
+
+    def test_options_block_is_none_returns_none_softly(self) -> None:
+        """``data[9] = None`` (older cassette shape) degrades silently —
+        preserves the legacy ``isinstance(data[9], list)`` guard so the
+        adapter never invokes ``safe_index`` against a non-list root."""
+        raw = _full_row(variant=None)  # already puts None at position 9
+        assert raw[ArtifactRow._OPTIONS_POS] is None
+        row = ArtifactRow(raw)
+        assert row.variant is None
+
+    def test_non_int_variant_falls_back_to_none(self) -> None:
+        """A string at ``[9][1][0]`` is not a valid variant code."""
+        raw = _full_row()
+        raw[ArtifactRow._OPTIONS_POS] = [None, ["not_an_int"]]
+        row = ArtifactRow(raw)
+        assert row.variant is None
+
+
+class TestTimestampDescent:
+    """``data[15][0]`` descent — used for ``created_at`` and sort key."""
+
+    def test_created_at_raw_returns_int_seconds(self) -> None:
+        row = ArtifactRow(_full_row(timestamp=1_700_000_000))
+        assert row.created_at_raw == 1_700_000_000
+
+    def test_created_at_converts_to_datetime(self) -> None:
+        row = ArtifactRow(_full_row(timestamp=1_700_000_000))
+        assert row.created_at is not None
+        assert row.created_at.timestamp() == 1_700_000_000
+
+    def test_missing_timestamp_position_returns_none(self) -> None:
+        row = ArtifactRow(["id", "title", 1, None, 3])
+        assert row.created_at_raw is None
+        assert row.created_at is None
+
+    def test_timestamp_block_is_none_degrades_softly(self) -> None:
+        """``data[15] = None`` returns ``None`` without raising even in
+        strict mode (legacy ``isinstance(data[15], list)`` guard)."""
+        raw = _full_row(timestamp=None)  # explicit None at position 15
+        assert raw[ArtifactRow._TIMESTAMP_POS] is None
+        row = ArtifactRow(raw)
+        assert row.created_at_raw is None
+
+    def test_timestamp_block_is_non_list_degrades_softly(self) -> None:
+        raw = _full_row(timestamp=0)
+        raw[ArtifactRow._TIMESTAMP_POS] = "not_a_list"
+        row = ArtifactRow(raw)
+        assert row.created_at_raw is None
+        assert row.created_at is None
+
+    def test_timestamp_block_empty_returns_none_in_both_modes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``data[15] = []`` is an accepted edge case (some cassettes
+        legitimately produce this), not strict-mode drift. The adapter
+        short-circuits an empty envelope so ``safe_index`` is never
+        invoked against it — preserves the legacy
+        ``len(a) > 15 and isinstance(a[15], list) and a[15]`` contract
+        that ``tests/unit/test_select_artifact.py
+        ::test_handles_missing_or_malformed_timestamps_gracefully``
+        depends on."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        raw = _full_row(timestamp=0)
+        raw[ArtifactRow._TIMESTAMP_POS] = []
+        row = ArtifactRow(raw)
+        assert row.created_at_raw is None  # no exception in strict mode
+
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+        # No DeprecationWarning either — short-circuit avoids safe_index entirely.
+        assert ArtifactRow(raw).created_at_raw is None
+
+    def test_none_at_timestamp_position_zero(self) -> None:
+        """``data[15] = [None, ...]`` is NOT a drift signal — it is the
+        legacy ``[None, "extra"]`` shape that the sort key falsy-coerces
+        to ``0``. The adapter exposes that as ``created_at_raw is None``
+        and lets the caller's ``or 0`` do the coercion."""
+        raw = _full_row(timestamp=0)
+        raw[ArtifactRow._TIMESTAMP_POS] = [None, "extra"]
+        row = ArtifactRow(raw)
+        assert row.created_at_raw is None
+
+
+class TestStrictModeOnDeepDrift:
+    """When a present position has a *malformed inner shape*, strict mode raises."""
+
+    def test_options_block_with_too_short_inner_raises_strict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``data[9] = [single_element]`` lacks ``[9][1]`` — strict mode
+        surfaces this as ``UnknownRPCMethodError`` because the descent
+        through index 1 fails on a real list (not a None envelope)."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        raw = _full_row()
+        raw[ArtifactRow._OPTIONS_POS] = [None]  # length 1, no [1]
+        row = ArtifactRow(raw)
+        with pytest.raises(UnknownRPCMethodError):
+            _ = row.variant
+
+    def test_options_block_with_too_short_inner_soft_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+        raw = _full_row()
+        raw[ArtifactRow._OPTIONS_POS] = [None]
+        row = ArtifactRow(raw)
+        with pytest.warns(DeprecationWarning):
+            assert row.variant is None
+
+
+# ---------------------------------------------------------------------------
+# 3. matches_type predicate
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesType:
+    def test_matches_when_type_codes_align(self) -> None:
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.AUDIO))
+        assert row.matches_type(ArtifactTypeCode.AUDIO) is True
+
+    def test_rejects_mismatched_type_code(self) -> None:
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.VIDEO))
+        assert row.matches_type(ArtifactTypeCode.AUDIO) is False
+
+    def test_completed_only_accepts_completed_artifact(self) -> None:
+        row = ArtifactRow(
+            _full_row(type_code=ArtifactTypeCode.AUDIO, status=ArtifactStatus.COMPLETED)
+        )
+        assert row.matches_type(ArtifactTypeCode.AUDIO, completed_only=True) is True
+
+    def test_completed_only_rejects_pending_artifact(self) -> None:
+        row = ArtifactRow(
+            _full_row(type_code=ArtifactTypeCode.AUDIO, status=ArtifactStatus.PENDING)
+        )
+        assert row.matches_type(ArtifactTypeCode.AUDIO, completed_only=True) is False
+
+    def test_completed_only_rejects_processing_artifact(self) -> None:
+        row = ArtifactRow(
+            _full_row(type_code=ArtifactTypeCode.AUDIO, status=ArtifactStatus.PROCESSING)
+        )
+        assert row.matches_type(ArtifactTypeCode.AUDIO, completed_only=True) is False
+
+    def test_completed_only_rejects_failed_artifact(self) -> None:
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.AUDIO, status=ArtifactStatus.FAILED))
+        assert row.matches_type(ArtifactTypeCode.AUDIO, completed_only=True) is False
+
+    def test_completed_only_false_accepts_any_status(self) -> None:
+        """Without ``completed_only``, status is ignored — used by listing
+        paths that want every artifact of a given type regardless of
+        readiness."""
+        row = ArtifactRow(
+            _full_row(type_code=ArtifactTypeCode.AUDIO, status=ArtifactStatus.PROCESSING)
+        )
+        assert row.matches_type(ArtifactTypeCode.AUDIO) is True
+
+    def test_int_type_code_argument_works(self) -> None:
+        """Callers passing a raw ``int`` (not the enum) still match."""
+        row = ArtifactRow(_full_row(type_code=ArtifactTypeCode.AUDIO))
+        assert row.matches_type(1) is True  # ArtifactTypeCode.AUDIO == 1
+
+    def test_completed_only_on_short_row_returns_false(self) -> None:
+        """A row too short to carry status (``len <= 4``) reads status as
+        ``0``; ``completed_only`` then rejects it. Documents that the
+        ``select_artifact`` filter is safe against short rows even when
+        the candidate-list length-guard in the caller is relaxed."""
+        row = ArtifactRow(["id", "title", 1])  # no position 4
+        assert row.status == 0
+        assert row.matches_type(1, completed_only=True) is False
+        # Without completed_only, the type alone matches.
+        assert row.matches_type(1) is True
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    """The adapter is frozen so the wrapped row can't be swapped out."""
+
+    def test_cannot_assign_to_raw(self) -> None:
+        row = ArtifactRow([])
+        with pytest.raises((AttributeError, Exception)):
+            row._raw = [1, 2, 3]  # type: ignore[misc]
+
+    def test_does_not_mutate_wrapped_row(self) -> None:
+        """Reading properties is side-effect-free — the wrapped row is
+        not modified by sort key computation or type matching."""
+        raw = _full_row(timestamp=1_700_000_000, variant=2)
+        snapshot = list(raw)
+        row = ArtifactRow(raw)
+
+        # Touch every property.
+        _ = row.id
+        _ = row.title
+        _ = row.type_code
+        _ = row.status
+        _ = row.variant
+        _ = row.created_at_raw
+        _ = row.created_at
+        row.matches_type(ArtifactTypeCode.AUDIO, completed_only=True)
+
+        assert raw == snapshot
+
+
+# ---------------------------------------------------------------------------
+# Method-ID plumbing (verifies safe_index gets enough context for drift logs)
+# ---------------------------------------------------------------------------
+
+
+class TestMethodIdPropagation:
+    """``safe_index`` includes ``method_id`` and ``source`` in its drift
+    logs / strict-mode exceptions — verify the adapter wires those
+    through correctly."""
+
+    def test_strict_mode_exception_carries_method_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        raw = _full_row()
+        raw[ArtifactRow._OPTIONS_POS] = [None]  # forces inner drift
+        row = ArtifactRow(raw)
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            _ = row.variant
+        # method_id default is RPCMethod.LIST_ARTIFACTS.value == "gArtLc".
+        assert exc_info.value.method_id == "gArtLc"
+        assert "ArtifactRow.variant" in str(exc_info.value)
+
+    def test_custom_method_id_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Callers wrapping a row that came from a non-LIST_ARTIFACTS
+        method can override ``_method_id`` so drift diagnostics point at
+        the correct RPC."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        raw = _full_row()
+        raw[ArtifactRow._OPTIONS_POS] = [None]
+        row = ArtifactRow(raw, _method_id="custom_method")
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            _ = row.variant
+        assert exc_info.value.method_id == "custom_method"

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -356,8 +356,12 @@ class TestImmutability:
     """The adapter is frozen so the wrapped row can't be swapped out."""
 
     def test_cannot_assign_to_raw(self) -> None:
+        """``dataclasses.FrozenInstanceError`` is an ``AttributeError``
+        subclass, so the narrower expectation here both pins the contract
+        and serves as a real signal — if the assignment raised something
+        else entirely (e.g. ``ValueError``) the test would now fail."""
         row = ArtifactRow([])
-        with pytest.raises((AttributeError, Exception)):
+        with pytest.raises(AttributeError):
             row._raw = [1, 2, 3]  # type: ignore[misc]
 
     def test_does_not_mutate_wrapped_row(self) -> None:
@@ -403,12 +407,12 @@ class TestMethodIdPropagation:
 
     def test_custom_method_id_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Callers wrapping a row that came from a non-LIST_ARTIFACTS
-        method can override ``_method_id`` so drift diagnostics point at
+        method can override ``method_id`` so drift diagnostics point at
         the correct RPC."""
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
         raw = _full_row()
         raw[ArtifactRow._OPTIONS_POS] = [None]
-        row = ArtifactRow(raw, _method_id="custom_method")
+        row = ArtifactRow(raw, method_id="custom_method")
         with pytest.raises(UnknownRPCMethodError) as exc_info:
             _ = row.variant
         assert exc_info.value.method_id == "custom_method"


### PR DESCRIPTION
## Summary
- Introduces `notebooklm._row_adapters.ArtifactRow` as the single point of position knowledge for the `LIST_ARTIFACTS` row shape (positions 0, 1, 2, 4, 9, 15).
- Migrates the two existing consumers to read named properties instead of open-coding `data[2]` / `data[4]` / `data[15]`: `Artifact.from_api_response` (`src/notebooklm/_types/artifacts.py`) and `ArtifactListingService.select_artifact` (`src/notebooklm/_artifact_listing.py`).
- Adds a 41-test position-contract pin + shape-handling + matches-type suite at `tests/unit/test_row_adapters.py`. The position-contract tests are the canary: when Google rotates the wire shape, exactly one diff (the adapter's position constants) needs to change and the pin tests fail loudly to surface it.

## Why
Per `docs/improvement.md` §6.2, six positional-decode sites across the codebase independently invent position knowledge for the same Google `batchexecute` wire shapes. The Critical Constraint in `CLAUDE.md` is that Google can rotate these undocumented shapes at any time — when they do, the change has to propagate across every site by hand. `safe_index` + ADR-011 handle *descent safety* but not *position semantics*; the adapter pattern fills that gap.

This PR ships the first adapter (artifacts) and intentionally keeps the blast radius small. Follow-up PRs will land:
- `SourceRowAdapter` — `_types/sources.py`, `_source_listing.py`, `_notebooks.py` (multi-shape branching).
- `NoteRowAdapter` — `_note_service.py` (legacy vs current shape).
- Adapters for `_artifact_downloads`, `_artifact_polling`, `_chat_protocol` (per ADR-011 "remain unmigrated" list).

## Design notes
- `ArtifactRow` is a `@dataclass(frozen=True)` view; position constants are `ClassVar[int]` so they stay class-level.
- Top-level position presence (`len(self._raw) > _POS`) uses length guards so short rows continue to receive sensible defaults in **both** soft and strict modes — preserves the historical `Artifact.from_api_response` contract that accepts minimal rows like `["id", "title", 1, None, 3]`.
- Deep descent into present positions (`data[9][1][0]`, `data[15][0]`) flows through `safe_index` with `source="ArtifactRow.<field>"` and `method_id=RPCMethod.LIST_ARTIFACTS.value` so strict mode raises `UnknownRPCMethodError` on genuine drift — the desired ADR-011 signal.
- `created_at_raw` is exposed separately from `created_at` so `select_artifact`'s sort key can use `row.created_at_raw or 0` to coerce missing values to `0` without crashing the comparison (preserves the `test_handles_none_at_timestamp_position_without_typeerror` contract).
- `select_artifact` keeps `(raw, row)` pairing so it can return the original raw list back to downstream URL extractors that operate on the full positional shape.

## Test plan
- [x] `uv run pytest` — 6206 passed, 54 skipped (one more than baseline due to the added `test_completed_only_on_short_row_returns_false` case).
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 167 files.
- [x] `uv run ruff check src/notebooklm tests` + `uv run ruff format --check src/notebooklm tests` — clean.
- [x] Existing pin tests in `tests/unit/test_select_artifact.py` (which assert non-mutation, malformed-timestamp handling, and the explicit-id-miss / no-result error-key asymmetry) continue to pass without modification.
- [x] VCR-backed integration tests (`tests/integration/test_artifacts_integration.py`, `tests/integration/test_artifacts_drift.py`, `tests/integration/test_download_multi_artifact.py`) pass unchanged.

## Acceptance criteria
- [x] `src/notebooklm/_row_adapters.py` exists with `ArtifactRow` class + position constants.
- [x] `grep -nE 'data\[2\]|data\[4\]|data\[15\]'` against the two migrated files returns no production-code matches in artifact-row paths (the one remaining match in `_types/artifacts.py:289` is inside `from_mind_map`, which is a different shape and explicitly out of scope for this PR).
- [x] `tests/unit/test_row_adapters.py` exists and pins the position contract via `TestPositionContract` (6 individual pins + 1 aggregate pin so a sweeping reshape fails with one informative assertion).
- [x] `uv run pytest` passes.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved artifact listing and selection logic for more reliable type and completion filtering
  * More robust timestamp handling and ordering, plus safer handling of short or malformed artifact records

* **Tests**
  * Added thorough tests covering artifact row parsing, timestamp conversion, type/completion predicates, strict vs. soft decode behaviors, and immutability guarantees

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->