### PR TITLE
refactor(session): constructor DI for late-bound test seams; drop http_client.setter

### DIFF
--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -30,13 +30,20 @@ class Kernel:
 
     @property
     def http_client(self) -> httpx.AsyncClient | None:
-        """Return the live HTTP client, or ``None`` when closed."""
-        return self._http_client
+        """Return the live HTTP client, or ``None`` when closed.
 
-    @http_client.setter
-    def http_client(self, value: httpx.AsyncClient | None) -> None:
-        # Test-injection seam for fixtures that swap the live transport.
-        self._http_client = value
+        The property is read-only by design. Production code mutates the
+        underlying client only through :meth:`open` (which constructs the
+        live client via the injected ``async_client_factory``) and
+        :meth:`aclose` (which nulls it on teardown). Tests that need to
+        substitute the live transport at construction time should inject
+        an ``async_client_factory`` into :class:`notebooklm._session.Session`
+        (the factory is forwarded into this kernel's ``__init__``); tests
+        that need to swap the live client AFTER ``open()`` should use the
+        dedicated test helper at
+        ``tests/_fixtures/kernel_test_helpers.py``.
+        """
+        return self._http_client
 
     @property
     def cookies(self) -> httpx.Cookies:

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -111,7 +111,7 @@ class RpcExecutor:
         self,
         owner: RpcOwner,
         *,
-        decode_response_late_bound: DecodeResponse,
+        decode_response: DecodeResponse,
         is_auth_error: Callable[[Exception], bool],
         sleep: Callable[[float], Awaitable[Any]],
         timeout_provider: Callable[[], float],
@@ -119,7 +119,7 @@ class RpcExecutor:
         refresh_retry_delay_provider: Callable[[], float],
     ):
         self._owner = owner
-        self._decode_response = decode_response_late_bound
+        self._decode_response = decode_response
         self._is_auth_error = is_auth_error
         self._sleep = sleep
         self._timeout_provider = timeout_provider

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -425,13 +425,16 @@ class Session:
         _resolved_storage_path: Path | None = (
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
-        # ``None`` (default) resolves to a name-lookup of ``httpx.AsyncClient``
-        # on this module at call time so tests that
+        # ``None`` (default) resolves to a fresh name-lookup of
+        # ``httpx.AsyncClient`` on this module at construction time so
+        # tests that
         # ``monkeypatch.setattr("notebooklm._session.httpx.AsyncClient", …)``
-        # before invoking the constructor still steer the live transport
-        # build. Explicit callables (production passes ``httpx.AsyncClient``
-        # via default; tests pass a ``MockTransport``-aware factory) bypass
-        # the lookup hop entirely.
+        # BEFORE constructing :class:`Session` still steer the live
+        # transport build. (The resolved callable is captured into the
+        # kernel below; ``Kernel.open()`` invokes it later but does not
+        # re-resolve.) Explicit callables (production passes
+        # ``httpx.AsyncClient`` via default; tests pass a
+        # ``MockTransport``-aware factory) bypass the lookup hop entirely.
         _resolved_async_client_factory = (
             async_client_factory if async_client_factory is not None else httpx.AsyncClient
         )

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -92,50 +92,14 @@ logger = logging.getLogger(__name__)
 # (not the delegates here).
 
 
-def _decode_response_late_bound(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
-    # Phase 2 PR 5 (``.sisyphus/plans/refactor-completion-plan.md``):
-    # imports ``decode_response`` from the canonical :mod:`notebooklm.rpc`
-    # surface rather than the legacy ``notebooklm._core`` compatibility
-    # shim. Tests that patched ``notebooklm._core.decode_response`` are
-    # re-targeted to ``notebooklm.rpc.decode_response`` in the same
-    # commit so the live RPC decode path stays patchable end-to-end.
-    from .rpc import decode_response
-
-    return decode_response(raw, rpc_id, allow_null=allow_null)
-
-
-def _sleep_late_bound(seconds: float) -> Awaitable[Any]:
-    """Late-bound ``asyncio.sleep`` for tests that patch the module seam.
-
-    Tests patch ``notebooklm._session.asyncio.sleep`` (this module is
-    where the symbol is referenced) — e.g. ``test_authed_post_pipeline.py``
-    and ``test_rpc_executor.py``. Patching the ``asyncio.sleep``
-    attribute on the module singleton affects this function regardless
-    of whether the ``import asyncio`` lives at module top or inside the
-    body, because both forms resolve through the same ``asyncio`` module
-    object; the function-body import is kept for symmetry with the
-    other late-bound seams in this module.
-    """
-    import asyncio
-
-    return asyncio.sleep(seconds)
-
-
-def _live_is_auth_error(exc: Exception) -> bool:
-    """Resolve ``is_auth_error`` against the canonical seam at call time.
-
-    Python function-body name lookup hits the module ``__dict__`` on each
-    call, so a ``monkeypatch.setattr("notebooklm._session_helpers.is_auth_error", ...)``
-    swap is observed immediately. Used by every chain seed site that
-    wires ``AuthRefreshMiddleware`` and by ``RpcExecutor`` so the
-    project-wide test idiom of patching the symbol on the canonical
-    module stays live without each seed site re-implementing the lambda.
-    The historical ``notebooklm._core`` indirection was removed in
-    v0.5.0 when the ``_core`` compatibility shim was deleted.
-    """
-    from ._session_helpers import is_auth_error
-
-    return is_auth_error(exc)
+# Three previously module-level test seams (one each for RPC response
+# decoding, the awaitable used by retry/backoff loops, and the
+# authentication-error classifier) were retired in favour of
+# constructor-injected callables on :class:`Session`. Tests that need to
+# substitute behaviour pass ``decode_response=…``, ``sleep=…``, or
+# ``is_auth_error=…`` keyword arguments to :class:`Session` directly
+# instead of monkeypatching module attributes. See ``docs/improvement.md``
+# §4.1 for the rationale.
 
 
 class Session:
@@ -169,6 +133,11 @@ class Session:
         on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
         cookie_saver: CookieSaver | None = None,
         cookie_rotator: CookieRotator | None = None,
+        *,
+        decode_response: Callable[..., Any] | None = None,
+        sleep: Callable[[float], Awaitable[Any]] | None = None,
+        is_auth_error: Callable[[Exception], bool] | None = None,
+        async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
     ):
         """Initialize the core client.
 
@@ -262,6 +231,45 @@ class Session:
                 resolves to :func:`_default_cookie_rotator`, which late-binds
                 to ``notebooklm._auth.keepalive._rotate_cookies``. Must be
                 async — it is awaited from :meth:`ClientLifecycle._keepalive_loop`.
+            decode_response: Override for the canonical RPC response
+                decoder. ``None`` (default) resolves to
+                :func:`notebooklm.rpc.decode_response` via the
+                module-level imported binding at construction time —
+                tests that ``monkeypatch.setattr("notebooklm.rpc.decode_response",
+                fake)`` BEFORE constructing :class:`Session` still steer
+                the captured callable. Replaces the retired module-level
+                decode wrapper, which performed the lookup on every call;
+                tests that need to swap the decoder AFTER construction
+                should pass an explicit callable here or assign
+                ``session._decode_response = fake`` before the first RPC.
+                See ``docs/improvement.md`` §4.1.
+            sleep: Override for the awaitable used by retry/backoff loops.
+                ``None`` (default) resolves to :func:`asyncio.sleep` via
+                the module-level binding at construction time. Replaces
+                the retired module-level sleep wrapper — tests can pass
+                ``sleep=fake_sleep`` directly or
+                ``monkeypatch.setattr("notebooklm._session.asyncio.sleep",
+                fake_sleep)`` BEFORE constructing :class:`Session`.
+            is_auth_error: Override for the authentication-error classifier
+                used by the chain's ``AuthRefreshMiddleware`` and by
+                :class:`RpcExecutor`'s decode-time refresh path. ``None``
+                (default) resolves to
+                :func:`notebooklm._session_helpers.is_auth_error` via the
+                module-level imported binding at construction time.
+                Replaces the retired module-level classifier wrapper.
+            async_client_factory: Override for the live ``httpx.AsyncClient``
+                factory used by :meth:`Kernel.open` to build the live
+                transport. ``None`` (default) resolves to
+                :class:`httpx.AsyncClient` via a module-level name lookup
+                at call time, so tests that
+                ``monkeypatch.setattr("notebooklm._session.httpx.AsyncClient",
+                fake)`` before constructing the client still steer the
+                live transport build. Pass an explicit callable to install
+                a mock transport (e.g. via ``httpx.MockTransport``) without
+                going through the late-bind hop. The retired
+                ``Kernel.http_client`` setter previously absorbed that
+                post-construction mutation. See ``docs/improvement.md``
+                §4.2.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
@@ -290,6 +298,40 @@ class Session:
         # through ``self._lifecycle`` and the live HTTP client through
         # ``self._kernel``.
         _resolved_limits = limits if limits is not None else ConnectionLimits()
+        # Constructor-injected seams retained on the instance so
+        # :meth:`_get_rpc_executor` can read them when it lazily constructs
+        # the executor on first RPC. The chain builder is wired below with
+        # ``is_auth_error`` directly (the builder is built eagerly inside
+        # this ``__init__``). See ``docs/improvement.md`` §4.1 for the
+        # rationale that replaced the retired module-level decode / sleep /
+        # auth-error classifier wrappers.
+        #
+        # ``None`` (the default) resolves to a fresh module-attribute
+        # lookup at construction time — that preserves the ability for
+        # tests to ``monkeypatch.setattr("notebooklm.rpc.decode_response",
+        # …)`` / ``…("notebooklm._session.asyncio.sleep", …)`` /
+        # ``…("notebooklm._session_helpers.is_auth_error", …)`` BEFORE
+        # constructing :class:`Session` and still steer the captured
+        # callable. (Post-construction patches do NOT propagate because
+        # the seam is captured here, not re-resolved on every RPC. New
+        # tests should pass an explicit callable instead.) Lookups go
+        # through their canonical modules so the monkeypatch surface
+        # documented in ADR-007 is unchanged.
+        if decode_response is None:
+            from .rpc import decode_response as _resolved_decode_response
+
+            self._decode_response: Callable[..., Any] = _resolved_decode_response
+        else:
+            self._decode_response = decode_response
+        self._sleep: Callable[[float], Awaitable[Any]] = (
+            sleep if sleep is not None else asyncio.sleep
+        )
+        if is_auth_error is None:
+            from ._session_helpers import is_auth_error as _resolved_is_auth_error
+
+            self._is_auth_error: Callable[[Exception], bool] = _resolved_is_auth_error
+        else:
+            self._is_auth_error = is_auth_error
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and the middleware chain and SET
         # by integration tests against ``client._session``. The refresh
@@ -383,7 +425,17 @@ class Session:
         _resolved_storage_path: Path | None = (
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
-        self._kernel = Kernel(async_client_factory=httpx.AsyncClient)
+        # ``None`` (default) resolves to a name-lookup of ``httpx.AsyncClient``
+        # on this module at call time so tests that
+        # ``monkeypatch.setattr("notebooklm._session.httpx.AsyncClient", …)``
+        # before invoking the constructor still steer the live transport
+        # build. Explicit callables (production passes ``httpx.AsyncClient``
+        # via default; tests pass a ``MockTransport``-aware factory) bypass
+        # the lookup hop entirely.
+        _resolved_async_client_factory = (
+            async_client_factory if async_client_factory is not None else httpx.AsyncClient
+        )
+        self._kernel = Kernel(async_client_factory=_resolved_async_client_factory)
         self._lifecycle = ClientLifecycle(
             timeout=timeout,
             connect_timeout=connect_timeout,
@@ -426,7 +478,7 @@ class Session:
             refresh_retry_delay_provider=lambda: self._refresh_retry_delay,
             refresh_callable=self._await_refresh,
             auth_snapshot_provider=self._snapshot,
-            is_auth_error=_live_is_auth_error,
+            is_auth_error=self._is_auth_error,
             refresh_callback_enabled_provider=lambda: self._auth_coord.has_refresh_callback,
         )
         self._middlewares: list[Middleware] = self._chain_builder.build()
@@ -583,19 +635,19 @@ class Session:
     def _get_rpc_executor(self) -> RpcExecutor:
         """Return the RPC execution collaborator, lazily initialized.
 
-        The adapters resolve through this module at call time so existing
-        monkeypatches of ``notebooklm.rpc.decode_response``,
-        ``notebooklm._session_helpers.is_auth_error``, and
-        ``notebooklm._session.asyncio.sleep`` keep affecting live RPC
-        behavior after the collaborator has been constructed.
+        The decode/sleep/is-auth-error callables are the constructor-injected
+        seams (``Session(..., decode_response=…, sleep=…, is_auth_error=…)``).
+        Tests substitute behaviour at construction time rather than via
+        ``monkeypatch.setattr`` on module attributes; see
+        ``docs/improvement.md`` §4.1 for the migration rationale.
         """
         executor = getattr(self, "_rpc_executor", None)
         if executor is None:
             executor = RpcExecutor(
                 self,
-                decode_response_late_bound=_decode_response_late_bound,
-                is_auth_error=_live_is_auth_error,
-                sleep=_sleep_late_bound,
+                decode_response=self._decode_response,
+                is_auth_error=self._is_auth_error,
+                sleep=self._sleep,
                 timeout_provider=lambda: self._lifecycle._timeout,
                 refresh_callback_enabled_provider=lambda: self._auth_coord.has_refresh_callback,
                 refresh_retry_delay_provider=lambda: self._refresh_retry_delay,

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -249,11 +249,16 @@ class ClientLifecycle:
 
     @property
     def _http_client(self) -> httpx.AsyncClient | None:
+        # Read-only forwarder over the concrete kernel's live client. The
+        # corresponding setter was retired alongside ``Kernel.http_client``'s
+        # setter: production never mutated this attribute (open() builds the
+        # client through the kernel's injected ``async_client_factory``;
+        # close() nulls it via :meth:`Kernel.aclose`). Tests that need to
+        # install a stand-in client should use the constructor-time
+        # ``async_client_factory`` injection on :class:`Session` (preferred)
+        # or the ``install_http_client_for_test`` helper in
+        # ``tests/_fixtures/kernel_test_helpers.py``.
         return self._kernel.http_client
-
-    @_http_client.setter
-    def _http_client(self, value: httpx.AsyncClient | None) -> None:
-        self._kernel.http_client = value
 
     # ------------------------------------------------------------------
     # State accessors

--- a/tests/_fixtures/__init__.py
+++ b/tests/_fixtures/__init__.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 
 from .cli_session import patch_session_login_dual
 from .fake_core import FakeSession, make_fake_core
+from .kernel_test_helpers import install_http_client_for_test
 
 __all__ = [
     "FakeSession",
+    "install_http_client_for_test",
     "make_fake_core",
     "patch_session_login_dual",
 ]

--- a/tests/_fixtures/kernel_test_helpers.py
+++ b/tests/_fixtures/kernel_test_helpers.py
@@ -1,0 +1,60 @@
+"""Test-only Kernel helpers for installing or replacing the live HTTP client.
+
+The retired ``Kernel.http_client`` setter (``src/notebooklm/_kernel.py``,
+removed in the same PR as this module's introduction — see
+``docs/improvement.md`` §4.2) used to absorb every post-construction
+``core._kernel.http_client = …`` swap. Production code never used it;
+the only callers were tests that needed to substitute a
+``MockTransport``-backed client either before or after ``Session.open()``.
+
+The preferred replacement is **constructor-time injection** via
+``Session(..., async_client_factory=…)`` — that factory is forwarded into
+``Kernel.__init__`` and applied by ``Kernel.open()`` so the live client
+carries the test transport from birth. Most call sites can migrate to
+the factory pattern.
+
+A small minority of tests cannot use the factory cleanly:
+
+- Tests that need to install a stand-in client BEFORE invoking ``open()``
+  (e.g. arbitration tests that stub out ``Session.open`` entirely and
+  only need a non-``None`` client for ``close()`` to operate on).
+- Tests that need to swap the client AFTER ``open()`` returned its real
+  transport but BEFORE driving the next operation.
+
+Both classes use :func:`install_http_client_for_test` to perform the swap
+explicitly. The helper writes to ``Kernel._http_client`` directly so the
+test-only seam is concentrated in this module (instead of being scattered
+across every call site as a property setter would invite). New uses
+outside this module should prefer the constructor-injected factory path
+unless they fall into one of the two cases above.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from notebooklm._kernel import Kernel
+
+
+def install_http_client_for_test(
+    kernel: Kernel,
+    client: httpx.AsyncClient | None,
+) -> None:
+    """Install or clear the live HTTP client on a :class:`Kernel`.
+
+    Mirrors the retired ``Kernel.http_client`` setter for test scenarios
+    that cannot reach the live client through constructor-time
+    ``async_client_factory`` injection. See this module's docstring for
+    the migration guidance.
+
+    Args:
+        kernel: The :class:`Kernel` instance whose live HTTP client is
+            being replaced. Typically reached via
+            ``client._session._kernel`` (or ``core._kernel`` in older
+            test fixtures).
+        client: The replacement ``httpx.AsyncClient`` (or ``None`` to
+            clear the live client and force the next operation to fail
+            with the pre-open ``RuntimeError`` from
+            :meth:`Kernel.get_http_client`).
+    """
+    kernel._http_client = client

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 
 # mock-based __aexit__ arbitration tests; no HTTP, no cassette.
@@ -43,7 +44,7 @@ def _stub_open(monkeypatch: pytest.MonkeyPatch) -> None:
         # Lazy import keeps the test file dep-free at module load.
         import httpx
 
-        self._kernel.http_client = httpx.AsyncClient()
+        install_http_client_for_test(self._kernel, httpx.AsyncClient())
 
     monkeypatch.setattr("notebooklm._session.Session.open", _stub_open)
 

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -51,6 +51,7 @@ from collections.abc import Iterator
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
@@ -222,10 +223,13 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
         # we can observe outgoing requests post-cookie-merge.
         prior_cookies = core._kernel.get_http_client().cookies
         await core._kernel.get_http_client().aclose()
-        core._kernel.http_client = httpx.AsyncClient(
-            cookies=prior_cookies,
-            transport=transport,
-            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        install_http_client_for_test(
+            core._kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
         )
 
         # Force ``_auth_snapshot_lock`` to exist BEFORE the gather so the

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -33,6 +33,7 @@ from urllib.parse import parse_qs, unquote
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 
 # Mock-only tests (no real HTTP, no cassette) — opt out of the
@@ -151,11 +152,14 @@ def _make_client(transport: httpx.AsyncBaseTransport, auth_tokens) -> NotebookLM
     POSTs route through the mock instead of opening a real socket.
     """
     client = NotebookLMClient(auth_tokens)
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -49,6 +49,7 @@ import asyncio
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
@@ -90,10 +91,13 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Sessi
     assert core._kernel.http_client is not None
     prior_cookies = core._kernel.get_http_client().cookies
     await core._kernel.get_http_client().aclose()
-    core._kernel.http_client = httpx.AsyncClient(
-        cookies=prior_cookies,
-        transport=transport,
-        timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+    install_http_client_for_test(
+        core._kernel,
+        httpx.AsyncClient(
+            cookies=prior_cookies,
+            transport=transport,
+            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        ),
     )
     return core
 
@@ -163,7 +167,7 @@ def test_cross_loop_use_raises_actionable_runtime_error(
         # primitives bound to loop A.
         if core._kernel.http_client is not None:
             await core._kernel.get_http_client().aclose()
-            core._kernel.http_client = None
+            install_http_client_for_test(core._kernel, None)
 
     asyncio.run(call_under_loop_b())
 
@@ -222,10 +226,13 @@ async def test_bound_loop_captured_on_open(
         assert core._kernel.http_client is not None
         prior_cookies = core._kernel.get_http_client().cookies
         await core._kernel.get_http_client().aclose()
-        core._kernel.http_client = httpx.AsyncClient(
-            cookies=prior_cookies,
-            transport=mock_transport_concurrent,
-            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        install_http_client_for_test(
+            core._kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=mock_transport_concurrent,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
         )
     finally:
         await core.close()

--- a/tests/integration/concurrency/test_harness_smoke.py
+++ b/tests/integration/concurrency/test_harness_smoke.py
@@ -39,6 +39,7 @@ import time
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
@@ -82,10 +83,13 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Sessi
     assert core._kernel.http_client is not None
     prior_cookies = core._kernel.get_http_client().cookies
     await core._kernel.get_http_client().aclose()
-    core._kernel.http_client = httpx.AsyncClient(
-        cookies=prior_cookies,
-        transport=transport,
-        timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+    install_http_client_for_test(
+        core._kernel,
+        httpx.AsyncClient(
+            cookies=prior_cookies,
+            transport=transport,
+            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        ),
     )
     return core
 

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -36,6 +36,7 @@ import json
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import (
     NonIdempotentRetryError,
     NotebookLMClient,
@@ -138,11 +139,14 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/concurrency/test_max_concurrent_rpcs.py
+++ b/tests/integration/concurrency/test_max_concurrent_rpcs.py
@@ -59,6 +59,7 @@ import asyncio
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
@@ -102,10 +103,13 @@ async def _open_core_with_transport(
     assert core._kernel.http_client is not None
     prior_cookies = core._kernel.get_http_client().cookies
     await core._kernel.get_http_client().aclose()
-    core._kernel.http_client = httpx.AsyncClient(
-        cookies=prior_cookies,
-        transport=transport,
-        timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+    install_http_client_for_test(
+        core._kernel,
+        httpx.AsyncClient(
+            cookies=prior_cookies,
+            transport=transport,
+            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        ),
     )
     return core
 

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -29,6 +29,7 @@ import json
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 from notebooklm.rpc import RPCMethod
 
@@ -57,11 +58,14 @@ def _make_client_with_transport(
 ) -> NotebookLMClient:
     """Wire a ``NotebookLMClient`` to a mock transport, bypassing full open()."""
     client = NotebookLMClient(auth_tokens)
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 
@@ -203,7 +207,7 @@ async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> No
         # client and warn at gc time.
         if client._session._kernel.http_client is not None:
             await client._session._kernel.get_http_client().aclose()
-            client._session._kernel.http_client = None
+            install_http_client_for_test(client._session._kernel, None)
 
 
 @pytest.mark.asyncio
@@ -232,4 +236,4 @@ async def test_no_cancel_no_cleanup(auth_tokens) -> None:
     finally:
         if client._session._kernel.http_client is not None:
             await client._session._kernel.get_http_client().aclose()
-            client._session._kernel.http_client = None
+            install_http_client_for_test(client._session._kernel, None)

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient, RateLimitError
 from notebooklm.rpc import RPCMethod
@@ -91,7 +92,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._kernel.http_client = mock_http
+    install_http_client_for_test(client._session._kernel, mock_http)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         result = await client.notebooks.list()
@@ -121,7 +122,7 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._kernel.http_client = mock_http
+    install_http_client_for_test(client._session._kernel, mock_http)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
         await client.notebooks.list()
@@ -161,7 +162,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._kernel.http_client = mock_http
+    install_http_client_for_test(client._session._kernel, mock_http)
 
     sleep_calls: list[float] = []
 
@@ -210,7 +211,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._kernel.http_client = mock_http
+    install_http_client_for_test(client._session._kernel, mock_http)
 
     def _build_request(_snap):
         return ("https://example.invalid/x", b"body", None)

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -34,6 +34,7 @@ import json
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient, RateLimitError, ServerError
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
 from notebooklm.rpc import RPCMethod
@@ -124,11 +125,14 @@ def _make_client_with_transport(
         auth_tokens,  # type: ignore[arg-type]
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -1,7 +1,7 @@
 """Integration tests for automatic token refresh."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -79,12 +79,16 @@ class TestAutoRefreshIntegration:
             response.raise_for_status = MagicMock()
             return response
 
+        # Override the constructor-injected decode-response seam BEFORE the
+        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
+        # stub. The previous ``patch("notebooklm.rpc.decode_response", …)``
+        # idiom relied on the retired module-level late-binding wrapper;
+        # see ``docs/improvement.md`` §4.1.
+        client._session._decode_response = lambda *a, **kw: [[["nb1"], ["Notebook 1"]]]
+
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
-
-            with patch("notebooklm.rpc.decode_response") as mock_decode:
-                mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
-                await client.notebooks.list()
+            await client.notebooks.list()
 
         assert len(refresh_calls) == 1, "Should have refreshed once"
         assert call_count[0] == 2, "Should have retried once"
@@ -126,11 +130,14 @@ class TestAutoRefreshIntegration:
                 raise RPCError("Authentication expired")
             return [[["nb1"], ["Notebook 1"]]]
 
+        # Override the constructor-injected decode-response seam BEFORE the
+        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
+        # stub. See ``docs/improvement.md`` §4.1.
+        client._session._decode_response = mock_decode
+
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
-
-            with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
-                await client.notebooks.list()
+            await client.notebooks.list()
 
         assert len(refresh_calls) == 1, "Should have refreshed once"
         assert decode_count[0] == 2, "Should have retried once"
@@ -165,14 +172,16 @@ class TestAutoRefreshIntegration:
             response.raise_for_status = MagicMock()
             return response
 
+        # Override the constructor-injected decode-response seam BEFORE the
+        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
+        # stub. See ``docs/improvement.md`` §4.1.
+        client._session._decode_response = lambda *a, **kw: []
+
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
 
             start_time = asyncio.get_event_loop().time()
-
-            with patch("notebooklm.rpc.decode_response", return_value=[]):
-                await client.notebooks.list()
-
+            await client.notebooks.list()
             elapsed = asyncio.get_event_loop().time() - start_time
 
         # Should have taken at least the delay time

--- a/tests/integration/test_notes_idempotency.py
+++ b/tests/integration/test_notes_idempotency.py
@@ -36,6 +36,7 @@ import json
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient, ServerError
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
 from notebooklm.rpc import RPCMethod
@@ -68,11 +69,14 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -37,6 +37,7 @@ import json
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient, ServerError
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
 from notebooklm.rpc import RPCMethod
@@ -69,11 +70,14 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -303,14 +303,26 @@ class TestRPCCallAuthRetry:
 
             mock_post = AsyncMock(return_value=success_response)
             install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
-            with patch(
-                "notebooklm.rpc.decode_response",
-                side_effect=[
+
+            # Override the constructor-injected decode-response seam BEFORE
+            # the first RPC fires so the lazily-built ``RpcExecutor`` picks
+            # up the stub. See ``docs/improvement.md`` §4.1.
+            decode_responses = iter(
+                [
                     RPCError("authentication expired"),
                     ["result_data"],
-                ],
-            ):
-                result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+                ]
+            )
+
+            def fake_decode(*_a, **_kw):
+                value = next(decode_responses)
+                if isinstance(value, BaseException):
+                    raise value
+                return value
+
+            core._decode_response = fake_decode
+
+            result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
             assert result == ["result_data"]
             refresh_callback.assert_called_once()

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -30,6 +30,7 @@ import logging
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NetworkError, NotebookLMClient
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
 from notebooklm.rpc import RPCMethod
@@ -77,11 +78,14 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -49,6 +49,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
 from notebooklm.exceptions import NetworkError, NotebookLMError
@@ -111,11 +112,14 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._kernel.http_client = httpx.AsyncClient(
-        transport=transport,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        },
+    install_http_client_for_test(
+        client._session._kernel,
+        httpx.AsyncClient(
+            transport=transport,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+        ),
     )
     return client
 

--- a/tests/unit/concurrency/test_session_close_refresh_race.py
+++ b/tests/unit/concurrency/test_session_close_refresh_race.py
@@ -35,6 +35,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._client_metrics import ClientMetrics
 from notebooklm._session_auth import AuthRefreshCoordinator
 from notebooklm._session_lifecycle import ClientLifecycle
@@ -110,7 +111,7 @@ async def test_close_cancels_in_flight_refresh_task() -> None:
     # real AsyncClient so close()'s aclose runs. Easiest: build it inline
     # since ClientLifecycle.open expects to read an httpx client mode from
     # _core which we can't easily stub here.
-    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    install_http_client_for_test(lifecycle._kernel, httpx.AsyncClient(transport=transport))
     lifecycle._bound_loop = asyncio.get_running_loop()
 
     # Park a long-sleeping task on the auth coordinator — models a refresh
@@ -156,7 +157,7 @@ async def test_close_with_no_refresh_task_is_a_noop_on_that_path() -> None:
     lifecycle = _make_lifecycle()
     host = _StubHost()
     transport = httpx.MockTransport(lambda req: httpx.Response(200))
-    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    install_http_client_for_test(lifecycle._kernel, httpx.AsyncClient(transport=transport))
     lifecycle._bound_loop = asyncio.get_running_loop()
 
     assert host._auth_coord._refresh_task is None
@@ -177,7 +178,7 @@ async def test_close_with_completed_refresh_task_does_not_recancel() -> None:
     lifecycle = _make_lifecycle()
     host = _StubHost()
     transport = httpx.MockTransport(lambda req: httpx.Response(200))
-    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    install_http_client_for_test(lifecycle._kernel, httpx.AsyncClient(transport=transport))
     lifecycle._bound_loop = asyncio.get_running_loop()
 
     async def _quick_refresh() -> str:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@ from typing import Any
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
 
@@ -155,10 +156,13 @@ async def make_core(refresh_callback=None, transport=None, refresh_retry_delay=0
         # closed AsyncClient is brittle across httpx versions.
         prior_cookies = core._kernel.get_http_client().cookies
         await core._kernel.get_http_client().aclose()
-        core._kernel.http_client = httpx.AsyncClient(
-            cookies=prior_cookies,
-            transport=transport,
-            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        install_http_client_for_test(
+            core._kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
         )
     try:
         yield core

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc.types import (
@@ -53,7 +54,7 @@ class TestConfigureChat:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         client._session.rpc_call = AsyncMock(return_value=None)
         return client
 
@@ -123,7 +124,7 @@ class TestGetSourceGuide:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         return client
 
     @pytest.mark.asyncio
@@ -170,7 +171,7 @@ class TestGetSuggestedReportFormats:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         return client
 
     @pytest.mark.asyncio
@@ -207,7 +208,7 @@ class TestAddSourceDrive:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         client._session.rpc_call = AsyncMock(return_value=[["source_id_123"]])
         return client
 
@@ -247,7 +248,7 @@ class TestGetNotebookDescription:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         return client
 
     @pytest.mark.asyncio
@@ -286,7 +287,7 @@ class TestPayloadFixes:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._kernel.http_client = MagicMock()
+        install_http_client_for_test(client._session._kernel, MagicMock())
         client._session.rpc_call = AsyncMock(return_value=True)
         return client
 

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm._auth.session import refresh_auth_session
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
@@ -213,13 +214,13 @@ async def test_refresh_auth_session_persists_through_client_core_save_cookies(
         cookies=auth.cookie_jar,
         follow_redirects=True,
     )
-    core._kernel.http_client = http_client
+    install_http_client_for_test(core._kernel, http_client)
     core.cookie_persistence.capture_open_snapshot(http_client.cookies)
     try:
         await refresh_auth_session(core)
     finally:
         await http_client.aclose()
-        core._kernel.http_client = None
+        install_http_client_for_test(core._kernel, None)
 
     assert len(calls) == 1
     path, return_result, original_snapshot = calls[0]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from conftest import install_post_as_stream
 from notebooklm._session import Session
 from notebooklm._session_helpers import is_auth_error
@@ -638,7 +639,15 @@ class TestRpcCallAutoRetry:
             refresh_called.append(True)
             return auth
 
-        core = Session(auth, refresh_callback=mock_refresh, refresh_retry_delay=0)
+        def fake_decode(*args, **kwargs):
+            return ["result"]
+
+        core = Session(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            decode_response=fake_decode,
+        )
 
         call_count = [0]
 
@@ -655,13 +664,12 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
         core._kernel.get_http_client().headers = {"Cookie": "old"}
 
-        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
-            result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+        result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once"
         assert call_count[0] == 2, "RPC should be called twice (original + retry)"
@@ -682,20 +690,6 @@ class TestRpcCallAutoRetry:
             refresh_called.append(True)
             return auth
 
-        core = Session(auth, refresh_callback=mock_refresh, refresh_retry_delay=0)
-
-        # Mock HTTP client - always succeeds
-        async def mock_post(*args, **kwargs):
-            response = MagicMock()
-            response.text = "mock response"
-            response.raise_for_status = MagicMock()
-            return response
-
-        core._kernel.http_client = MagicMock()
-        core._kernel.get_http_client().post = mock_post
-        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
-        core._kernel.get_http_client().headers = {"Cookie": "old"}
-
         decode_call_count = [0]
 
         def mock_decode(*args, **kwargs):
@@ -705,8 +699,26 @@ class TestRpcCallAutoRetry:
                 raise RPCError("Authentication expired", method_id="wXbhsf")
             return ["result"]
 
-        with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
-            result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+        core = Session(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            decode_response=mock_decode,
+        )
+
+        # Mock HTTP client - always succeeds
+        async def mock_post(*args, **kwargs):
+            response = MagicMock()
+            response.text = "mock response"
+            response.raise_for_status = MagicMock()
+            return response
+
+        install_http_client_for_test(core._kernel, MagicMock())
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
+
+        result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once"
         assert decode_call_count[0] == 2, "decode should be called twice (original + retry)"
@@ -731,7 +743,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
@@ -766,7 +778,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
         core._kernel.get_http_client().headers = {"Cookie": "old"}
@@ -812,7 +824,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(500, request=request)
             raise httpx.HTTPStatusError("Server Error", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
@@ -841,7 +853,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
@@ -868,7 +880,12 @@ class TestRpcCallAutoRetry:
             await asyncio.sleep(0.05)  # Simulate slow refresh
             return auth
 
-        core = Session(auth, refresh_callback=mock_refresh, refresh_retry_delay=0)
+        core = Session(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            decode_response=lambda *a, **kw: ["result"],
+        )
 
         call_count = [0]
 
@@ -885,18 +902,17 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
         core._kernel.get_http_client().headers = {"Cookie": "old"}
 
-        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
-            # Start two concurrent calls
-            await asyncio.gather(
-                core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []),
-                core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []),
-                return_exceptions=True,
-            )
+        # Start two concurrent calls
+        await asyncio.gather(
+            core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []),
+            core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []),
+            return_exceptions=True,
+        )
 
         # With shared task pattern, refresh should be called exactly once
         # (second caller waits on the same task instead of starting a new refresh)
@@ -924,7 +940,12 @@ class TestRpcCallAutoRetry:
             refresh_called.append(True)
             return auth
 
-        core = Session(auth, refresh_callback=mock_refresh, refresh_retry_delay=0)
+        core = Session(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            decode_response=lambda *a, **kw: ["result"],
+        )
 
         call_count = [0]
 
@@ -941,13 +962,12 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
         core._kernel.get_http_client().headers = {"Cookie": "old"}
 
-        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
-            result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+        result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once on 400"
         assert call_count[0] == 2, "RPC should be called twice (original + retry)"
@@ -977,7 +997,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(400, request=request)
             raise httpx.HTTPStatusError("Bad Request", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
@@ -1013,7 +1033,7 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(400, request=request)
             raise httpx.HTTPStatusError("Bad Request", request=request, response=response)
 
-        core._kernel.http_client = MagicMock()
+        install_http_client_for_test(core._kernel, MagicMock())
         core._kernel.get_http_client().post = mock_post
         install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -547,7 +547,7 @@ def _build_rpc_executor() -> Any:
 
     executor = RpcExecutor(
         owner,
-        decode_response_late_bound=_decode,
+        decode_response=_decode,
         is_auth_error=_is_auth_error,
         sleep=_sleep,
         # Session-shrink PR 3: providers replace direct owner-attr reads

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -561,6 +561,123 @@ def test_lifted_core_modules_are_retired() -> None:
     assert sorted(path.name for path in SRC_ROOT.glob("_core_*.py")) == []
 
 
+# ---------------------------------------------------------------------------
+# Constructor-DI seams (``docs/improvement.md`` §4.1 + §4.2)
+#
+# These pin tests guard the post-refactor wiring shape so a future
+# refactor cannot silently re-introduce the retired module-level
+# late-binding wrappers (``_decode_response_late_bound``,
+# ``_sleep_late_bound``, ``_live_is_auth_error``) or the retired
+# ``Kernel.http_client`` setter.
+# ---------------------------------------------------------------------------
+
+
+def test_session_exposes_constructor_di_seams_for_decode_sleep_auth_factory() -> None:
+    """``Session.__init__`` MUST expose the four constructor-DI seams.
+
+    The seams replace the retired module-level late-binding wrappers
+    (see ``docs/improvement.md`` §4.1) and the retired
+    ``Kernel.http_client`` setter (§4.2). Each must be keyword-only and
+    default to ``None`` so the body can resolve the canonical seam via
+    a fresh module-attribute lookup at construction time (preserving
+    pre-construction monkeypatch propagation).
+    """
+    import inspect
+
+    from notebooklm._session import Session
+
+    sig = inspect.signature(Session.__init__)
+    for name in ("decode_response", "sleep", "is_auth_error", "async_client_factory"):
+        assert name in sig.parameters, f"Session.__init__ must expose constructor-DI kwarg {name!r}"
+        param = sig.parameters[name]
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name!r} must be keyword-only; got {param.kind!r}"
+        )
+        assert param.default is None, (
+            f"{name!r} must default to None (None-sentinel + fresh module "
+            f"lookup); got default {param.default!r}"
+        )
+
+
+def test_session_retired_late_bound_wrappers_are_gone() -> None:
+    """The three module-level late-binding wrappers MUST stay deleted.
+
+    See ``docs/improvement.md`` §4.1. The constructor-DI seams above
+    (``decode_response`` / ``sleep`` / ``is_auth_error``) replaced them;
+    re-adding the wrappers would re-introduce the test-shaped production
+    code the refactor removed.
+    """
+    import notebooklm._session as session_mod
+
+    for symbol in (
+        "_decode_response_late_bound",
+        "_sleep_late_bound",
+        "_live_is_auth_error",
+    ):
+        assert not hasattr(session_mod, symbol), (
+            f"notebooklm._session.{symbol} must stay deleted (see docs/improvement.md §4.1)"
+        )
+
+
+def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
+    """Constructor-injected seams MUST reach the executor and chain builder.
+
+    The chain builder's ``is_auth_error`` and the lazily-built
+    ``RpcExecutor`` (``decode_response``, ``is_auth_error``, ``sleep``)
+    all read from the ``self._decode_response`` / ``self._sleep`` /
+    ``self._is_auth_error`` attributes captured at construction time.
+    Explicit callables passed to ``Session.__init__`` MUST reach the
+    executor end-to-end.
+    """
+    from notebooklm._session import Session
+    from notebooklm.auth import AuthTokens
+
+    auth = AuthTokens(
+        cookies={"SID": "x"},
+        csrf_token="csrf",
+        session_id="sid",
+    )
+
+    def custom_decode(*_a, **_kw):
+        return ["custom"]
+
+    async def custom_sleep(_seconds):
+        return None
+
+    def custom_is_auth_error(_exc):
+        return True
+
+    core = Session(
+        auth,
+        decode_response=custom_decode,
+        sleep=custom_sleep,
+        is_auth_error=custom_is_auth_error,
+    )
+
+    assert core._decode_response is custom_decode
+    assert core._sleep is custom_sleep
+    assert core._is_auth_error is custom_is_auth_error
+
+    # The lazily-constructed RpcExecutor reads from these attributes.
+    executor = core._get_rpc_executor()
+    assert executor._decode_response is custom_decode
+    assert executor._sleep is custom_sleep
+    assert executor._is_auth_error is custom_is_auth_error
+
+
+def test_kernel_http_client_is_read_only_property() -> None:
+    """``Kernel.http_client`` MUST have no setter (``docs/improvement.md`` §4.2)."""
+    from notebooklm._kernel import Kernel
+
+    descriptor = Kernel.__dict__["http_client"]
+    assert isinstance(descriptor, property)
+    assert descriptor.fset is None, (
+        "Kernel.http_client must remain read-only; the retired setter was a "
+        "test-injection seam that constructor-time async_client_factory "
+        "injection now replaces (see docs/improvement.md §4.2)."
+    )
+
+
 def _is_type_checking_guard(node: ast.AST) -> bool:
     return (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING") or (
         isinstance(node, ast.Attribute)

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from notebooklm import (
     ClientMetricsSnapshot,
     NotebookLMClient,
@@ -44,8 +45,18 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
     event with the expected fields.
     """
     events: list[RpcTelemetryEvent] = []
-    core = Session(auth_tokens, on_rpc_event=events.append)
-    core._kernel.http_client = AsyncMock(spec=httpx.AsyncClient)
+
+    # Inject the decoder at construction time (Session DI seam — see
+    # ``docs/improvement.md`` §4.1). The real decoder requires a wire
+    # payload that matches the method's RPC ID; constructing one makes
+    # the test brittle to RPC-ID changes. Stubbing keeps the test focused
+    # on observability semantics (counters + events + correlation) rather
+    # than wire-format details.
+    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
+        return {"ok": True}
+
+    core = Session(auth_tokens, on_rpc_event=events.append, decode_response=fake_decode)
+    install_http_client_for_test(core._kernel, AsyncMock(spec=httpx.AsyncClient))
     seen_request_ids: list[str | None] = []
 
     # Mock the chain LEAF (innermost wrapper around
@@ -72,18 +83,7 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
 
     core._authed_post_chain = build_chain(core._middlewares, fake_terminal)
 
-    # Patch the decoder to a no-network stub. The real decoder requires a
-    # wire payload that matches the method's RPC ID; constructing one
-    # makes the test brittle to RPC-ID changes. Stubbing keeps the test
-    # focused on observability semantics (counters + events + correlation)
-    # rather than wire-format details.
-    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
-        return {"ok": True}
-
-    with (
-        patch("notebooklm.rpc.decode_response", fake_decode),
-        correlation_id("batch-42"),
-    ):
+    with correlation_id("batch-42"):
         result = await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])
 
     assert result == {"ok": True}

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
 from conftest import install_post_as_stream
 from notebooklm._session import Session
 from notebooklm.rpc import RateLimitError, RPCError, RPCMethod
@@ -54,7 +55,7 @@ async def test_rate_limit_retry_success_with_budget(auth_tokens):
     mock_client.post.side_effect = [_build_429("1"), _build_200([["result"]])]
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._kernel.http_client = mock_client
+    install_http_client_for_test(core._kernel, mock_client)
     install_post_as_stream(None, mock_client, mock_client.post)
 
     # Decode may fail on the synthetic 200 — that's fine, what we care about
@@ -77,7 +78,7 @@ async def test_rate_limit_retry_exhausted_with_budget(auth_tokens):
     mock_client.post.return_value = _build_429("1")
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._kernel.http_client = mock_client
+    install_http_client_for_test(core._kernel, mock_client)
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
@@ -104,7 +105,7 @@ async def test_rate_limit_no_retry_if_disabled(auth_tokens):
 
     # Explicitly disable retries
     core = Session(auth_tokens, rate_limit_max_retries=0)
-    core._kernel.http_client = mock_client
+    install_http_client_for_test(core._kernel, mock_client)
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with pytest.raises(RateLimitError):
@@ -127,7 +128,7 @@ async def test_rate_limit_exp_backoff_fallback_without_header(auth_tokens):
     mock_client.post.return_value = _build_429(retry_after=None)
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._kernel.http_client = mock_client
+    install_http_client_for_test(core._kernel, mock_client)
     install_post_as_stream(None, mock_client, mock_client.post)
 
     sleeps: list[float] = []
@@ -153,7 +154,7 @@ async def test_rate_limit_no_retry_without_header_when_disabled(auth_tokens):
     mock_client.post.return_value = _build_429(retry_after=None)
 
     core = Session(auth_tokens, rate_limit_max_retries=0)
-    core._kernel.http_client = mock_client
+    install_http_client_for_test(core._kernel, mock_client)
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with pytest.raises(RateLimitError):

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -119,7 +119,7 @@ class _Owner:
 def _executor(
     owner: _Owner,
     *,
-    decode_response_late_bound: Callable[..., Any] | None = None,
+    decode_response: Callable[..., Any] | None = None,
     is_auth_error: Callable[[Exception], bool] | None = None,
     sleep: Callable[[float], Awaitable[Any]] | None = None,
 ) -> RpcExecutor:
@@ -131,7 +131,7 @@ def _executor(
 
     return RpcExecutor(
         owner,
-        decode_response_late_bound=decode_response_late_bound or _decode,
+        decode_response=decode_response or _decode,
         is_auth_error=is_auth_error or (lambda exc: False),
         sleep=sleep or _no_sleep,
         # Session-shrink PR 3 narrowed :class:`RpcOwner` and added
@@ -230,8 +230,25 @@ async def test_client_rpc_executor_wrappers_delegate_to_rpc_executor(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_core_decode_response_monkeypatch_after_executor_construction(monkeypatch) -> None:
-    core = Session(_auth_tokens())
+async def test_constructor_injected_decode_response_drives_executor(monkeypatch) -> None:
+    """Pin that the constructor-injected ``decode_response`` reaches the executor.
+
+    The legacy module-level ``_decode_response_late_bound`` wrapper used to
+    re-import ``notebooklm.rpc.decode_response`` on every call, so a
+    ``monkeypatch.setattr("notebooklm.rpc.decode_response", …)`` after the
+    executor was already constructed still affected the live decode path.
+    The constructor-DI seam (``Session(..., decode_response=…)``) intentionally
+    captures the callable at construction time — see
+    ``docs/improvement.md`` §4.1. This test asserts the new contract: the
+    injected callable reaches :class:`RpcExecutor` end-to-end.
+    """
+    decode_calls: list[dict[str, Any]] = []
+
+    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+        decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
+        return {"decoded": rpc_id}
+
+    core = Session(_auth_tokens(), decode_response=fake_decode)
     executor = core._get_rpc_executor()
 
     async def fake_perform_authed_post(
@@ -243,14 +260,7 @@ async def test_core_decode_response_monkeypatch_after_executor_construction(monk
     ) -> httpx.Response:
         return _ok_response("wire")
 
-    decode_calls: list[dict[str, Any]] = []
-
-    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
-        decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
-        return {"decoded": rpc_id}
-
     monkeypatch.setattr(core, "_perform_authed_post", fake_perform_authed_post)
-    monkeypatch.setattr("notebooklm.rpc.decode_response", fake_decode)
 
     result = await core._rpc_call_impl(
         RPCMethod.LIST_NOTEBOOKS,
@@ -281,7 +291,7 @@ async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeyp
         decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
         return {"ok": True}
 
-    result = await _executor(owner, decode_response_late_bound=decode).execute(
+    result = await _executor(owner, decode_response=decode).execute(
         RPCMethod.LIST_NOTEBOOKS,
         [["param"]],
         "/notebook/abc",
@@ -325,7 +335,7 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
 
     result = await _executor(
         owner,
-        decode_response_late_bound=decode,
+        decode_response=decode,
         is_auth_error=is_auth_error,
         sleep=sleep,
     ).execute(
@@ -367,7 +377,7 @@ async def test_decode_time_auth_retry_preserves_none_result() -> None:
 
     result = await _executor(
         owner,
-        decode_response_late_bound=decode,
+        decode_response=decode,
         is_auth_error=lambda exc: True,
     ).execute(
         RPCMethod.LIST_NOTEBOOKS,
@@ -384,18 +394,35 @@ async def test_decode_time_auth_retry_preserves_none_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -> None:
+async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
+    """Pin that the constructor-injected ``sleep`` reaches the executor.
+
+    The legacy module-level ``_sleep_late_bound`` wrapper used to re-import
+    ``asyncio.sleep`` on every call, so a
+    ``monkeypatch.setattr("notebooklm._session.asyncio.sleep", …)`` after the
+    executor was already constructed still affected the live sleep path.
+    The constructor-DI seam (``Session(..., sleep=…)``) intentionally captures
+    the callable at construction time — see ``docs/improvement.md`` §4.1.
+    This test asserts the new contract: the injected callable reaches
+    :class:`RpcExecutor`'s refresh-and-retry delay.
+    """
+
     async def refresh_callback() -> AuthTokens:
         return _auth_tokens()
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
 
     core = Session(
         _auth_tokens(),
         refresh_callback=refresh_callback,
         refresh_retry_delay=0.5,
+        sleep=fake_sleep,
     )
     executor = core._get_rpc_executor()
     refresh_calls = 0
-    sleep_calls: list[float] = []
 
     async def fake_await_refresh() -> None:
         nonlocal refresh_calls
@@ -420,12 +447,8 @@ async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -
         assert operation_variant is None
         return {"ok": True}
 
-    async def fake_sleep(seconds: float) -> None:
-        sleep_calls.append(seconds)
-
     monkeypatch.setattr(core, "_await_refresh", fake_await_refresh)
     monkeypatch.setattr(core, "rpc_call", fake_rpc_call)
-    monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
     result = await core._try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,
@@ -527,7 +550,7 @@ async def test_decode_shape_error_wrapped(
         raise decoder_exc
 
     with pytest.raises(RPCError) as raised:
-        await _executor(owner, decode_response_late_bound=decode).execute(
+        await _executor(owner, decode_response=decode).execute(
             RPCMethod.LIST_NOTEBOOKS,
             [],
             "/",
@@ -555,7 +578,7 @@ async def test_decode_shape_error_json_decode_wrapped() -> None:
         raise decoder_exc
 
     with pytest.raises(RPCError) as raised:
-        await _executor(owner, decode_response_late_bound=decode).execute(
+        await _executor(owner, decode_response=decode).execute(
             RPCMethod.LIST_NOTEBOOKS,
             [],
             "/",
@@ -584,7 +607,7 @@ async def test_rpc_error_log_includes_class_code_and_retry_after(caplog) -> None
         caplog.at_level(logging.ERROR, logger="notebooklm._rpc_executor"),
         pytest.raises(RateLimitError),
     ):
-        await _executor(owner, decode_response_late_bound=decode).execute(
+        await _executor(owner, decode_response=decode).execute(
             RPCMethod.START_DEEP_RESEARCH,
             [],
             "/",
@@ -634,7 +657,7 @@ async def test_decode_code_bug_propagates(
         raise decoder_exc
 
     with pytest.raises(type(decoder_exc)) as raised:
-        await _executor(owner, decode_response_late_bound=decode).execute(
+        await _executor(owner, decode_response=decode).execute(
             RPCMethod.LIST_NOTEBOOKS,
             [],
             "/",


### PR DESCRIPTION
## Summary

- Retire three module-level late-binding wrappers in `_session.py` (`_decode_response_late_bound`, `_sleep_late_bound`, `_live_is_auth_error`) that existed solely as monkeypatch reachability shims. `Session.__init__` now exposes four keyword-only constructor-DI seams — `decode_response`, `sleep`, `is_auth_error`, `async_client_factory` — that default to `None` and resolve via fresh module-attribute lookup at construction time.
- Drop `@http_client.setter` from `Kernel` (and the forwarding `@_http_client.setter` from `ClientLifecycle`) — production never wrote through them. Tests that need to install a stand-in HTTP client now use constructor-time `async_client_factory` injection on `Session` or the new `tests/_fixtures/kernel_test_helpers.py::install_http_client_for_test` helper.
- Migrate ~50 test sites away from `core._kernel.http_client = X` setter mutation and migrate the half-dozen tests that monkeypatched `notebooklm.rpc.decode_response` / `notebooklm._session.asyncio.sleep` AFTER constructing `Session` to constructor-time injection.
- Add four pin tests in `tests/unit/test_init_order.py` guarding the new wiring shape against future regressions.

## Task

References `docs/improvement.md` §4.1 (late-bound seam retirement) and §4.2 (`Kernel.http_client` setter retirement). Unblocks the upcoming `_session_init.py` extraction (§3.1) by removing the three module-level wrappers that would otherwise have to be re-threaded through the split.

## Behaviour change

None. This is a refactor with no behaviour change — CI passing is the primary signal. The new constructor seams default to `None` and resolve to the canonical implementations via fresh module-attribute lookup at construction time, so tests that ``monkeypatch.setattr(...)`` BEFORE constructing `Session` continue to steer the live callables exactly as before.

The retired post-construction monkeypatch path (e.g. `with patch("notebooklm.rpc.decode_response", ...)` invoked AFTER `Session` already exists) was migrated to either explicit constructor injection (`Session(..., decode_response=...)`) or to direct attribute assignment (`session._decode_response = fake` before the first RPC fires).

## No public API break

`NotebookLMClient` / `from_storage` signatures unchanged for end users. The new `Session` kwargs are keyword-only and default to `None` so existing positional and named callers are unaffected.

## Test plan

- [x] `uv run ruff check src/notebooklm tests/` — clean
- [x] `uv run ruff format --check src/notebooklm tests/` — clean (508 files)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (166 files)
- [x] `uv run pytest --timeout=240` — 6211 passed, 12 skipped, 0 failed (~97s)
- [x] `grep -rn "_late_bound\|_live_is_auth_error" src/notebooklm/_session.py` — returns nothing
- [x] `grep -n "@http_client.setter\|http_client.setter" src/notebooklm/_kernel.py` — returns nothing
- [x] `uv run pytest tests/unit/test_init_order.py` — 43 passed (39 existing + 4 new pin tests)
- [x] `uv run pytest tests/_lint/test_no_forbidden_monkeypatches.py` — passes (no regression to ADR-007 allowlist)

## Deferred polish findings

- Add a direct unit test for `install_http_client_for_test` (currently covered implicitly by ~50 migrated test sites).
- Add a direct unit test exercising the explicit `async_client_factory=` constructor path (currently covered structurally by the new pin tests + the integration test `test_pool_tuning.py` exercising the late-binding fallback path).
- Future PRs can tighten the ADR-007 monkeypatch allowlist by migrating the remaining `monkeypatch.setattr("notebooklm._session.asyncio.sleep", ...)` sites in `test_authed_post_pipeline.py` (13 sites) and `test_side_effects_idempotency.py` (5 sites) to constructor-DI; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The client session's HTTP client property is now read-only; direct assignment via a setter has been removed.

* **New Features**
  * Session construction supports optional injection of hooks for response decoding, sleep/backoff, auth-error detection, and the HTTP-client factory to customize runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->