### PR TITLE
refactor(notes): introduce NoteRowAdapter for positional wire decoding (stacked on #1026)

### DIFF
--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -27,6 +27,7 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from ._row_adapters import NoteRow
 from .rpc.types import RPCMethod
 from .types import Note
 
@@ -119,25 +120,30 @@ class NoteService:
         """Identify what kind of row this is.
 
         Wire shapes encountered:
-        * deleted: ``["id", None, 2]`` — content is ``None`` and slot[2]
-          is the soft-delete sentinel.
-        * mind-map: content payload (string at ``row[1]`` or
-          ``row[1][1]``) parses as JSON with ``"children":`` or
-          ``"nodes":`` keys.
+        * deleted: ``["id", None, 2]`` — content is ``None`` and the
+          slot at position 2 is the soft-delete sentinel.
+        * mind-map: content payload parses as JSON with ``"children":``
+          or ``"nodes":`` keys (regardless of legacy vs current shape).
         * saved-chat: a plain note row whose metadata flags chat mode.
           That metadata is not reliably present on the wire, so when we
           cannot positively confirm chat mode we fall through to
           ``NOTE`` rather than ``UNKNOWN`` (refactor-history.md §Risks).
         * plain note: default for any other content-bearing row.
+
+        Position knowledge (the deletion sentinel and the
+        legacy-vs-current content dispatch) lives in
+        :class:`notebooklm._row_adapters.NoteRow`. This classifier reads
+        named properties on the adapter and does not touch raw indices.
         """
         if not isinstance(row, list) or len(row) == 0:
             return NoteRowKind.UNKNOWN
 
-        if self._is_deleted(row):
+        note_row = NoteRow(row)
+        if note_row.is_deleted:
             return NoteRowKind.DELETED
 
-        content = self.extract_content(row)
-        if self._is_mind_map_content(content):
+        content = note_row.content
+        if NoteRow.is_mind_map_content(content):
             return NoteRowKind.MIND_MAP
 
         if content is None:
@@ -150,27 +156,16 @@ class NoteService:
     def extract_content(self, row: list[Any]) -> str | None:
         """Get the JSON content payload of a row, or ``None``.
 
-        Handles both legacy (``[id, content]``) and current
-        (``[id, [id, content, metadata, None, title]]``) wire shapes.
+        Thin facade over :attr:`NoteRow.content`. Kept on
+        :class:`NoteService` so existing callers
+        (``NotesAPI._extract_content``, ``NoteBackedMindMapService.extract_content``,
+        and the tests pinning ``service.extract_content`` behaviour)
+        continue to work unchanged while position knowledge moves to
+        the adapter.
         """
-        if not isinstance(row, list) or len(row) <= 1:
+        if not isinstance(row, list):
             return None
-
-        if isinstance(row[1], str):
-            return row[1]
-        if isinstance(row[1], list) and len(row[1]) > 1 and isinstance(row[1][1], str):
-            return row[1][1]
-        return None
-
-    @staticmethod
-    def _is_deleted(row: list[Any]) -> bool:
-        if not isinstance(row, list) or len(row) < 3:
-            return False
-        return row[1] is None and row[2] == 2
-
-    @staticmethod
-    def _is_mind_map_content(content: str | None) -> bool:
-        return bool(content and ('"children":' in content or '"nodes":' in content))
+        return NoteRow(row).content
 
     # ------------------------------------------------------------------
     # CRUD

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -256,8 +256,12 @@ class NotesAPI:
     def _is_deleted(self, item: builtins.list[Any]) -> bool:
         """Check if a note/mind map item is deleted (status=2).
 
-        Deleted items have structure: ['id', None, 2]
-        The content at position [1] is None and status at [2] is 2.
+        Delegates to :meth:`NoteService.classify_row`, which reads the
+        deletion sentinel via :attr:`NoteRow.is_deleted`. The wire
+        shape (``[id, None, 2]`` — content slot ``None`` plus the
+        soft-delete sentinel at position 2) is documented on
+        :class:`NoteRow`; this method exists only as the historical
+        ``NotesAPI`` private surface.
 
         Args:
             item: Raw note/mind map data.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -22,6 +22,7 @@ from typing import Any, Protocol
 
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteRowKind, NoteService
+from ._row_adapters import NoteRow
 from .types import AskResult, Note
 
 logger = logging.getLogger(__name__)
@@ -271,27 +272,20 @@ class NotesAPI:
         return self._notes.extract_content(item)
 
     def _parse_note(self, item: builtins.list[Any], notebook_id: str) -> Note:
-        """Parse a raw note item into a Note object."""
-        note_id = item[0] if len(item) > 0 else ""
+        """Parse a raw note item into a Note object.
 
-        content = ""
-        title = ""
-
-        if len(item) > 1:
-            if isinstance(item[1], str):
-                # Old format: [note_id, content]
-                content = item[1]
-            elif isinstance(item[1], list):
-                # New format: [note_id, [note_id, content, metadata, None, title]]
-                inner = item[1]
-                if len(inner) > 1 and isinstance(inner[1], str):
-                    content = inner[1]
-                if len(inner) > 4 and isinstance(inner[4], str):
-                    title = inner[4]
-
+        Position knowledge (legacy ``[id, content]`` vs current
+        ``[id, [id, content, metadata, None, title]]`` dispatch, and
+        the title slot at ``raw[1][4]``) lives in
+        :class:`notebooklm._row_adapters.NoteRow` — this method just
+        reads the named properties. ``content`` defaults to ``""``
+        (not ``None``) here to preserve the v0.4.1 :class:`Note`
+        contract.
+        """
+        row = NoteRow(item)
         return Note(
-            id=str(note_id),
+            id=row.id,
             notebook_id=notebook_id,
-            title=title,
-            content=content,
+            title=row.title,
+            content=row.content or "",
         )

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -6,28 +6,37 @@ observed in production. When Google rotates a shape — a single index
 shifts, a leaf becomes a wrapper, a list becomes a dict — every consumer
 that hand-rolls position knowledge breaks independently.
 
-This module is the **single point of position knowledge for the artifact
-row shape**: if Google reshapes the wire, the position constants change
-**here** and every consumer (currently :class:`notebooklm._types.artifacts.Artifact`
-and :class:`notebooklm._artifact_listing.ArtifactListingService`) adapts
-automatically. The constants therefore function as the canary contract for
-artifact wire-shape changes — see ``tests/unit/test_row_adapters.py`` for
-the pin test that fails loudly when anyone edits a position.
+This module is the **single point of position knowledge for the
+``LIST_ARTIFACTS`` and ``GET_NOTES_AND_MIND_MAPS`` row shapes**: if
+Google reshapes the wire, the position constants change **here** and
+every consumer adapts automatically. The constants therefore function
+as the canary contract for wire-shape changes — see
+``tests/unit/test_row_adapters.py`` for the pin tests that fail loudly
+when anyone edits a position.
 
-The adapter sits **on top of** :func:`notebooklm.rpc.safe_index`:
+The adapters sit **on top of** :func:`notebooklm.rpc.safe_index`:
 
 * Top-level position presence (``len(self._raw) > _POS``) is treated as
   optional — missing trailing positions return sensible defaults in both
   soft and strict modes. This preserves the historical
   ``Artifact.from_api_response`` contract that accepts short rows.
 * Deep descent into a present position (``data[9][1][0]``,
-  ``data[15][0]``) flows through :func:`safe_index`. Soft mode returns
-  ``None`` on drift, strict mode raises
-  :class:`notebooklm.exceptions.UnknownRPCMethodError` — the desired
-  ADR-011 signal for genuine Google-side reshape.
+  ``data[15][0]``, ``data[1][1]``, ``data[1][4]``) flows through
+  :func:`safe_index`. Soft mode returns ``None`` on drift, strict mode
+  raises :class:`notebooklm.exceptions.UnknownRPCMethodError` — the
+  desired ADR-011 signal for genuine Google-side reshape.
 
-Out of scope for this module (deferred to follow-up PRs per
-``docs/improvement.md`` §6.2): ``SourceRowAdapter`` and ``NoteRowAdapter``.
+Wire-shape variants:
+
+* :class:`ArtifactRow` wraps a single artifact row from ``LIST_ARTIFACTS``.
+* :class:`NoteRow` wraps a single note / mind-map row from
+  ``GET_NOTES_AND_MIND_MAPS`` and absorbs the legacy-vs-current
+  shape divergence (legacy: ``[id, content]``; current:
+  ``[id, [id, content, metadata, None, title]]``) so consumers never
+  open-code ``row[1][1]`` / ``row[1][4]``.
+
+Out of scope for this module (deferred to a follow-up PR per
+``docs/improvement.md`` §6.2): ``SourceRowAdapter``.
 """
 
 from __future__ import annotations
@@ -39,7 +48,7 @@ from typing import Any, ClassVar
 from ._types.common import _datetime_from_timestamp
 from .rpc import ArtifactStatus, RPCMethod, safe_index
 
-__all__ = ["ArtifactRow"]
+__all__ = ["ArtifactRow", "NoteRow"]
 
 
 @dataclass(frozen=True)
@@ -250,3 +259,216 @@ class ArtifactRow:
         if completed_only:
             return self.status == ArtifactStatus.COMPLETED
         return True
+
+
+@dataclass(frozen=True)
+class NoteRow:
+    """Typed view of a raw note / mind-map row from ``GET_NOTES_AND_MIND_MAPS``.
+
+    The wrapped row is the per-note list returned by the ``cFji9``
+    (``GET_NOTES_AND_MIND_MAPS``) RPC. Two wire shapes coexist in the
+    wild — the adapter absorbs both so consumers never branch on shape:
+
+    * **Legacy** — ``[id, content_string]``: the JSON payload lives
+      directly at position 1 as a string. Older cassettes and rows
+      created before the metadata envelope rollout still arrive this
+      way. There is no per-row title slot in the legacy shape; the
+      adapter returns ``""`` for :attr:`title`.
+
+    * **Current** — ``[id, [id, content_string, metadata, None, title]]``:
+      the JSON payload lives at ``row[1][1]`` and the title at
+      ``row[1][4]``. This is the production shape for any row created
+      since the metadata envelope rollout.
+
+    * **Deleted** — ``[id, None, 2]``: position 1 is ``None`` and
+      position 2 is the soft-delete sentinel. :attr:`is_deleted` is
+      ``True``; :attr:`content` and :attr:`title` both return ``None``
+      / ``""`` respectively (callers should classify with
+      :attr:`is_deleted` before reading other properties).
+
+    Position knowledge is centralised here. Consumer sites should NEVER
+    open-code ``row[1][1]`` / ``row[1][4]`` / ``row[1] is None`` — wrap
+    the row in a :class:`NoteRow` and read through the typed properties
+    instead. This is exactly the seam that lets a future Google reshape
+    fix every consumer with one set of constant changes here.
+
+    The dataclass is frozen so accidentally mutating the wrapped row is
+    impossible through the adapter; the adapter itself never copies the
+    raw row, so it is cheap to construct.
+    """
+
+    # Wrapped row; ``repr=False`` so logs don't explode with the entire
+    # batchexecute payload when a NoteRow appears in a stack trace.
+    _raw: list[Any] = field(repr=False)
+    _method_id: str = RPCMethod.GET_NOTES_AND_MIND_MAPS.value
+
+    # ---- Position constants (the canary contract) ------------------------
+    # These are ClassVar so the frozen dataclass treats them as class-level
+    # constants rather than instance fields. If any of these change,
+    # ``tests/unit/test_row_adapters.py::TestNoteRowPositionContract``
+    # MUST be updated in the same commit — that failure is the wire-shape
+    # change signal.
+    _ID_POS: ClassVar[int] = 0
+    # Position 1 is overloaded: legacy puts the content string here
+    # directly; current puts the metadata envelope (a list) here; deleted
+    # rows put ``None`` here.
+    _CONTENT_POS: ClassVar[int] = 1
+    # Position 2 is the soft-delete sentinel slot — ``row[2] == 2`` plus
+    # ``row[1] is None`` together signal a deleted row.
+    _STATUS_POS: ClassVar[int] = 2
+    # Inner envelope positions (only meaningful for the *current* shape
+    # where ``row[1]`` is a list of length 5).
+    _INNER_CONTENT_POS: ClassVar[int] = 1
+    _INNER_TITLE_POS: ClassVar[int] = 4
+    # Soft-delete sentinel value at ``_STATUS_POS``.
+    _DELETED_SENTINEL: ClassVar[int] = 2
+
+    # ---- Top-level position (the row id) ---------------------------------
+
+    @property
+    def id(self) -> str:
+        """Row identifier — empty string when absent."""
+        if len(self._raw) <= self._ID_POS:
+            return ""
+        return str(self._raw[self._ID_POS])
+
+    # ---- Deletion detection ----------------------------------------------
+
+    @property
+    def is_deleted(self) -> bool:
+        """Whether this row is the soft-delete sentinel ``[id, None, 2]``.
+
+        Centralises the ``row[1] is None and row[2] == 2`` check so
+        consumers (``NoteService.classify_row``, ``NotesAPI._is_deleted``)
+        never re-derive it. Short rows (``len(raw) < 3``) are *not*
+        deleted — soft deletion requires both the ``None`` content slot
+        and the sentinel at position 2.
+        """
+        if len(self._raw) <= self._STATUS_POS:
+            return False
+        return (
+            self._raw[self._CONTENT_POS] is None
+            and self._raw[self._STATUS_POS] == self._DELETED_SENTINEL
+        )
+
+    # ---- Multi-shape content / title dispatch ----------------------------
+    # Both descents short-circuit on the legacy ``str``-at-position-1
+    # shape *before* invoking ``safe_index`` so the legitimate legacy
+    # path emits no DeprecationWarning. The current shape's inner
+    # descent flows through ``safe_index`` so strict mode raises on
+    # genuine inner-shape drift.
+
+    @property
+    def content(self) -> str | None:
+        """JSON content payload, dispatching across legacy / current shapes.
+
+        Returns:
+            * ``str`` — the JSON payload (from legacy ``row[1]`` or
+              current ``row[1][1]``)
+            * ``None`` — when the row is too short, deleted, the
+              ``row[1]`` slot is an unrecognised type (e.g. an integer),
+              or the current-shape inner envelope is too short to carry
+              a content slot
+
+        Both the outer length guard and the inner length guard preserve
+        the historical "short rows soft-degrade to ``None``" contract —
+        ``safe_index`` is invoked only when the inner envelope is long
+        enough to legitimately carry the content slot, so genuine
+        production short shapes never trip strict-mode drift detection.
+
+        Raises:
+            UnknownRPCMethodError: In strict mode, when ``row[1]`` is a
+                list long enough for ``[1]`` indexing but the descent
+                itself fails (e.g. the inner is a dict instead of a
+                list — genuine wire reshape).
+        """
+        if len(self._raw) <= self._CONTENT_POS:
+            return None
+        slot = self._raw[self._CONTENT_POS]
+        # Legacy shape: ``row[1]`` is the content string itself.
+        if isinstance(slot, str):
+            return slot
+        # Current shape: ``row[1]`` is the metadata envelope list. Some
+        # cassettes legitimately have a length-1 or empty inner envelope
+        # (older nested rows without the content slot populated) — those
+        # are NOT drift, so length-guard before invoking ``safe_index``.
+        if isinstance(slot, list):
+            if len(slot) <= self._INNER_CONTENT_POS:
+                return None
+            value = safe_index(
+                slot,
+                self._INNER_CONTENT_POS,
+                method_id=self._method_id,
+                source="NoteRow.content",
+            )
+            return value if isinstance(value, str) else None
+        # ``None`` (deleted) or any other type — no extractable content.
+        return None
+
+    @property
+    def title(self) -> str:
+        """Note title, available only on the current shape.
+
+        Returns ``""`` when:
+
+        * the row is in legacy shape (``row[1]`` is a string — there is
+          no per-row title slot in that shape), or
+        * the row is too short to carry ``row[1]``, or
+        * ``row[1]`` is ``None`` (deleted) or not a list, or
+        * the inner envelope is too short to carry the title slot
+          (length 5 is the canonical current shape; shorter inners
+          predate the title rollout and are not drift), or
+        * the inner descent through ``[4]`` returns a non-string.
+
+        Raises:
+            UnknownRPCMethodError: In strict mode, when ``row[1]`` is a
+                list long enough for ``[4]`` indexing but the descent
+                itself fails (genuine wire reshape).
+        """
+        if len(self._raw) <= self._CONTENT_POS:
+            return ""
+        slot = self._raw[self._CONTENT_POS]
+        if not isinstance(slot, list):
+            return ""
+        # Length-guard short inners — some legitimate cassette rows have
+        # ``[id, content]`` shapes (no title slot) that are not drift.
+        if len(slot) <= self._INNER_TITLE_POS:
+            return ""
+        value = safe_index(
+            slot,
+            self._INNER_TITLE_POS,
+            method_id=self._method_id,
+            source="NoteRow.title",
+        )
+        return value if isinstance(value, str) else ""
+
+    # ---- Mind-map content classification ---------------------------------
+
+    @property
+    def is_mind_map(self) -> bool:
+        """Whether :attr:`content` looks like a serialised mind-map.
+
+        Convenience wrapper around :meth:`is_mind_map_content` that
+        applies the same predicate to ``self.content``. Returns ``False``
+        when :attr:`content` is ``None``.
+        """
+        return self.is_mind_map_content(self.content)
+
+    @staticmethod
+    def is_mind_map_content(content: str | None) -> bool:
+        """Return whether ``content`` is a serialised mind-map payload.
+
+        Mind maps are JSON blobs that always contain either a
+        ``"children":`` or ``"nodes":`` key at the top level. We match
+        on the substring rather than parsing the JSON because (a) the
+        payloads can be large and we run this check on every row in a
+        notebook list, and (b) the substring discriminator has been
+        stable across every cassette captured to date — it's the same
+        predicate the wire decoder uses.
+
+        Exposed as a ``@staticmethod`` so callers that already have a
+        content string in hand (e.g. ``NoteService.classify_row``
+        threading through the cached ``content`` value) can classify
+        without constructing a fresh :class:`NoteRow`.
+        """
+        return bool(content and ('"children":' in content or '"nodes":' in content))

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -464,7 +464,7 @@ class NoteRow:
     def is_mind_map_content(content: str | None) -> bool:
         """Return whether ``content`` is a serialised mind-map payload.
 
-        Mind maps are JSON blobs that always contain either a
+        Mind maps are JSON object blobs that always contain either a
         ``"children":`` or ``"nodes":`` key at the top level. We match
         on the substring rather than parsing the JSON because (a) the
         payloads can be large and we run this check on every row in a
@@ -472,9 +472,19 @@ class NoteRow:
         stable across every cassette captured to date — it's the same
         predicate the wire decoder uses.
 
+        The ``startswith("{")`` guard avoids false positives on plain
+        text notes that happen to contain the substring ``"children":``
+        verbatim (e.g. a note body like ``My "children": Alice, Bob``).
+        Production mind-map payloads are always JSON objects, never
+        arrays / strings / etc., so requiring the leading ``{`` is a
+        zero-cost reduction in false-positive surface — gemini review
+        feedback on #1028.
+
         Exposed as a ``@staticmethod`` so callers that already have a
         content string in hand (e.g. ``NoteService.classify_row``
         threading through the cached ``content`` value) can classify
         without constructing a fresh :class:`NoteRow`.
         """
-        return bool(content and ('"children":' in content or '"nodes":' in content))
+        if not content or not content.startswith("{"):
+            return False
+        return '"children":' in content or '"nodes":' in content

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -382,11 +382,13 @@ class NoteRow:
         enough to legitimately carry the content slot, so genuine
         production short shapes never trip strict-mode drift detection.
 
-        Raises:
-            UnknownRPCMethodError: In strict mode, when ``row[1]`` is a
-                list long enough for ``[1]`` indexing but the descent
-                itself fails (e.g. the inner is a dict instead of a
-                list — genuine wire reshape).
+        Note: ``safe_index`` is routed through for consistency with
+        :class:`ArtifactRow` and to keep one telemetry seam for any
+        future relaxation of the length guard. Given the current
+        invariants (``isinstance(slot, list)`` + ``len(slot) > 1``),
+        ``safe_index`` cannot actually raise here — strict-mode drift
+        on this descent is unreachable. Documented via
+        ``TestNoteRowShortInnerIsNotDrift`` in the test suite.
         """
         if len(self._raw) <= self._CONTENT_POS:
             return None
@@ -426,10 +428,11 @@ class NoteRow:
           predate the title rollout and are not drift), or
         * the inner descent through ``[4]`` returns a non-string.
 
-        Raises:
-            UnknownRPCMethodError: In strict mode, when ``row[1]`` is a
-                list long enough for ``[4]`` indexing but the descent
-                itself fails (genuine wire reshape).
+        See the note on :attr:`content` re: ``safe_index`` invariants —
+        the same reasoning applies here. The inner length guard makes
+        the descent through ``[4]`` unreachable as a drift signal under
+        current invariants; ``safe_index`` stays for consistency with
+        :class:`ArtifactRow` and as a telemetry seam.
         """
         if len(self._raw) <= self._CONTENT_POS:
             return ""

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -300,7 +300,13 @@ class NoteRow:
     # Wrapped row; ``repr=False`` so logs don't explode with the entire
     # batchexecute payload when a NoteRow appears in a stack trace.
     _raw: list[Any] = field(repr=False)
-    _method_id: str = RPCMethod.GET_NOTES_AND_MIND_MAPS.value
+    # ``method_id`` is intentionally a public extension point (matching
+    # :class:`ArtifactRow`'s post-#1026 convention): callers wrapping a
+    # row that came from a non-default method override it so
+    # ``safe_index`` drift diagnostics point at the correct RPC. No
+    # leading underscore — see the related test
+    # ``TestNoteRowMethodIdField::test_custom_method_id_can_be_supplied``.
+    method_id: str = RPCMethod.GET_NOTES_AND_MIND_MAPS.value
 
     # ---- Position constants (the canary contract) ------------------------
     # These are ClassVar so the frozen dataclass treats them as class-level
@@ -398,7 +404,7 @@ class NoteRow:
             value = safe_index(
                 slot,
                 self._INNER_CONTENT_POS,
-                method_id=self._method_id,
+                method_id=self.method_id,
                 source="NoteRow.content",
             )
             return value if isinstance(value, str) else None
@@ -437,7 +443,7 @@ class NoteRow:
         value = safe_index(
             slot,
             self._INNER_TITLE_POS,
-            method_id=self._method_id,
+            method_id=self.method_id,
             source="NoteRow.title",
         )
         return value if isinstance(value, str) else ""

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -617,6 +617,16 @@ class TestNoteRowContentDegradation:
         """Dicts are not a recognised shape variant — soft-degrade."""
         assert NoteRow(["id", {"oops": True}]).content is None
 
+    def test_inner_non_string_content_returns_none(self) -> None:
+        """The inner envelope is long enough for ``[1]`` indexing but
+        the value at ``inner[1]`` is not a string — ``safe_index``
+        succeeds and the ``isinstance(value, str)`` filter degrades
+        the result to ``None`` rather than leaking a non-string past
+        the ``content: str | None`` contract. Closes claude[bot]'s
+        Issue 2 from #1028's first review."""
+        assert NoteRow(["id", ["inner_id", 99]]).content is None
+        assert NoteRow(["id", ["inner_id", None]]).content is None
+
 
 class TestNoteRowShortInnerIsNotDrift:
     """Short inner envelopes are a legitimate production shape, not drift.
@@ -737,14 +747,10 @@ class TestNoteRowIsMindMapContent:
         Without the guard a user-typed note like ``My "children": Alice``
         would be misclassified as a mind map and silently filtered out
         of :meth:`NotesAPI.list`."""
-        assert (
-            NoteRow.is_mind_map_content('My "children": Alice and Bob') is False
-        )
+        assert NoteRow.is_mind_map_content('My "children": Alice and Bob') is False
 
     def test_plain_text_with_nodes_substring_not_mind_map(self) -> None:
-        assert (
-            NoteRow.is_mind_map_content('Graph "nodes": twelve in total') is False
-        )
+        assert NoteRow.is_mind_map_content('Graph "nodes": twelve in total') is False
 
     def test_json_array_with_children_key_not_mind_map(self) -> None:
         """Mind-map payloads are always JSON *objects*, never arrays.
@@ -785,8 +791,11 @@ class TestNoteRowImmutability:
     """The adapter is frozen so the wrapped row can't be swapped out."""
 
     def test_cannot_assign_to_raw(self) -> None:
+        # ``dataclasses.FrozenInstanceError`` is a subclass of
+        # ``AttributeError`` — narrowing matches the ArtifactRow test
+        # convention (coderabbit nit on #1028).
         row = NoteRow([])
-        with pytest.raises((AttributeError, Exception)):
+        with pytest.raises(AttributeError):
             row._raw = [1, 2, 3]  # type: ignore[misc]
 
     def test_does_not_mutate_wrapped_row(self) -> None:

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -786,8 +786,9 @@ class TestNoteRowImmutability:
 
 
 class TestNoteRowMethodIdField:
-    """The adapter exposes ``_method_id`` for callers that need to tag
-    diagnostics with the RPC the row came from.
+    """The adapter exposes ``method_id`` for callers that need to tag
+    diagnostics with the RPC the row came from. Public (no leading
+    underscore) to mirror :class:`ArtifactRow`'s post-#1026 convention.
 
     Drift-triggering inputs cannot be synthesised through the
     content / title descents (length-guards short-circuit before
@@ -798,11 +799,11 @@ class TestNoteRowMethodIdField:
     def test_default_method_id_is_get_notes_and_mind_maps(self) -> None:
         row = NoteRow(["id", "body"])
         # ``GET_NOTES_AND_MIND_MAPS.value`` per ``rpc/types.py``.
-        assert row._method_id == "cFji9"
+        assert row.method_id == "cFji9"
 
     def test_custom_method_id_can_be_supplied(self) -> None:
         """Callers wrapping a row that came from a non-default RPC can
-        override ``_method_id`` so any future drift diagnostics name
+        override ``method_id`` so any future drift diagnostics name
         the correct method."""
-        row = NoteRow(["id", "body"], _method_id="custom_note_rpc")
-        assert row._method_id == "custom_note_rpc"
+        row = NoteRow(["id", "body"], method_id="custom_note_rpc")
+        assert row.method_id == "custom_note_rpc"

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -730,6 +730,28 @@ class TestNoteRowIsMindMapContent:
     def test_empty_string_not_mind_map(self) -> None:
         assert NoteRow.is_mind_map_content("") is False
 
+    def test_plain_text_with_children_substring_not_mind_map(self) -> None:
+        """The ``startswith("{")`` guard prevents false positives on
+        plain note bodies that happen to contain the substring
+        ``"children":`` verbatim — gemini review feedback on #1028.
+        Without the guard a user-typed note like ``My "children": Alice``
+        would be misclassified as a mind map and silently filtered out
+        of :meth:`NotesAPI.list`."""
+        assert (
+            NoteRow.is_mind_map_content('My "children": Alice and Bob') is False
+        )
+
+    def test_plain_text_with_nodes_substring_not_mind_map(self) -> None:
+        assert (
+            NoteRow.is_mind_map_content('Graph "nodes": twelve in total') is False
+        )
+
+    def test_json_array_with_children_key_not_mind_map(self) -> None:
+        """Mind-map payloads are always JSON *objects*, never arrays.
+        A JSON array starting with ``[`` is rejected even if it
+        contains the discriminator substring."""
+        assert NoteRow.is_mind_map_content('[{"children": []}]') is False
+
 
 class TestNoteRowIsMindMap:
     """The instance-property convenience wrapper around

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1,13 +1,15 @@
-"""Tests for ``notebooklm._row_adapters.ArtifactRow``.
+"""Tests for ``notebooklm._row_adapters`` (``ArtifactRow`` + ``NoteRow``).
 
-The adapter centralises position knowledge for the ``LIST_ARTIFACTS`` row
-shape so consumers (``Artifact.from_api_response`` and
-``ArtifactListingService.select_artifact``) read named properties instead
-of open-coding ``data[2]`` / ``data[4]`` / ``data[15]``. See
-``docs/improvement.md`` §6.2 for the motivation and
-``src/notebooklm/_row_adapters.py`` for the position contract.
+The adapters centralise position knowledge for the ``LIST_ARTIFACTS``
+and ``GET_NOTES_AND_MIND_MAPS`` row shapes so consumers
+(``Artifact.from_api_response``, ``ArtifactListingService.select_artifact``,
+``NoteService.classify_row``, ``NotesAPI._parse_note``) read named
+properties instead of open-coding ``data[2]`` / ``data[4]`` / ``data[15]``
+or ``row[1][1]`` / ``row[1][4]``. See ``docs/improvement.md`` §6.2 for
+the motivation and ``src/notebooklm/_row_adapters.py`` for the position
+contracts.
 
-These tests cover three layers:
+These tests cover three layers per adapter:
 
 1. **Position-contract pin** — the canary that fails loudly if anyone
    edits a position constant. When this fails, the diff is the
@@ -15,14 +17,17 @@ These tests cover three layers:
 2. **Shape handling** — missing trailing positions return sensible
    defaults; deep descent goes through ``safe_index`` so strict-mode
    drift raises ``UnknownRPCMethodError``.
-3. **matches_type** — the predicate used by ``select_artifact``.
+3. **Predicate / domain helpers** — ``matches_type`` for artifacts,
+   ``is_deleted`` / ``is_mind_map_content`` for notes.
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from notebooklm._row_adapters import ArtifactRow
+from notebooklm._row_adapters import ArtifactRow, NoteRow
 from notebooklm.exceptions import UnknownRPCMethodError
 from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode
 
@@ -416,3 +421,388 @@ class TestMethodIdPropagation:
         with pytest.raises(UnknownRPCMethodError) as exc_info:
             _ = row.variant
         assert exc_info.value.method_id == "custom_method"
+
+
+# ===========================================================================
+# NoteRow — note / mind-map row adapter for GET_NOTES_AND_MIND_MAPS
+# ===========================================================================
+
+
+class TestNoteRowPositionContract:
+    """The canary for the ``GET_NOTES_AND_MIND_MAPS`` row shape.
+
+    These pin tests fail loudly if anyone edits a position constant.
+    When that happens, the failing diff IS the audit trail for the
+    Google-side wire reshape. See
+    ``src/notebooklm/_row_adapters.py:NoteRow`` for the shape contract.
+    """
+
+    def test_id_position_is_0(self) -> None:
+        assert NoteRow._ID_POS == 0
+
+    def test_content_position_is_1(self) -> None:
+        assert NoteRow._CONTENT_POS == 1
+
+    def test_status_position_is_2(self) -> None:
+        assert NoteRow._STATUS_POS == 2
+
+    def test_inner_content_position_is_1(self) -> None:
+        assert NoteRow._INNER_CONTENT_POS == 1
+
+    def test_inner_title_position_is_4(self) -> None:
+        assert NoteRow._INNER_TITLE_POS == 4
+
+    def test_deleted_sentinel_is_2(self) -> None:
+        assert NoteRow._DELETED_SENTINEL == 2
+
+    def test_all_positions_at_once(self) -> None:
+        """A single tuple pin so a sweeping reshape (e.g. Google inserts
+        a new leading element shifting every position by one) fails with
+        one informative assertion rather than six."""
+        assert (
+            NoteRow._ID_POS,
+            NoteRow._CONTENT_POS,
+            NoteRow._STATUS_POS,
+            NoteRow._INNER_CONTENT_POS,
+            NoteRow._INNER_TITLE_POS,
+            NoteRow._DELETED_SENTINEL,
+        ) == (0, 1, 2, 1, 4, 2)
+
+
+# ---------------------------------------------------------------------------
+# NoteRow helpers — fixtures matching the in-the-wild shape varieties
+# ---------------------------------------------------------------------------
+
+
+def _legacy_note_row(
+    note_id: str = "note_id",
+    content: str = "Plain note body",
+) -> list:
+    """Legacy shape: ``[id, content_string]``.
+
+    Older rows arrive in this shape; the adapter must keep extracting
+    content from position 1 directly and return ``""`` for title.
+    """
+    return [note_id, content]
+
+
+def _current_note_row(
+    note_id: str = "note_id",
+    content: str = "Plain note body",
+    title: str = "Note Title",
+    metadata: object = None,
+) -> list:
+    """Current shape: ``[id, [id, content, metadata, None, title]]``.
+
+    Standard production shape since the metadata envelope rollout —
+    content at ``raw[1][1]``, title at ``raw[1][4]``.
+    """
+    return [note_id, [note_id, content, metadata, None, title]]
+
+
+def _deleted_note_row(note_id: str = "note_id") -> list:
+    """Soft-deletion sentinel: ``[id, None, 2]``."""
+    return [note_id, None, 2]
+
+
+# ---------------------------------------------------------------------------
+# NoteRow — id and is_deleted
+# ---------------------------------------------------------------------------
+
+
+class TestNoteRowId:
+    def test_id_extracted_from_position_0(self) -> None:
+        assert NoteRow(_legacy_note_row(note_id="abc")).id == "abc"
+
+    def test_id_extracted_from_current_shape(self) -> None:
+        assert NoteRow(_current_note_row(note_id="xyz")).id == "xyz"
+
+    def test_id_extracted_from_deleted_row(self) -> None:
+        """Deleted rows still expose their id so callers can correlate
+        the deletion with prior reads."""
+        assert NoteRow(_deleted_note_row(note_id="gone")).id == "gone"
+
+    def test_id_empty_for_empty_row(self) -> None:
+        assert NoteRow([]).id == ""
+
+    def test_id_coerced_to_string(self) -> None:
+        """A non-string id is stringified — defensive against drift in
+        position 0's type."""
+        assert NoteRow([12345, "body"]).id == "12345"
+
+
+class TestNoteRowIsDeleted:
+    """Centralised ``row[1] is None and row[2] == 2`` check."""
+
+    def test_canonical_deleted_shape(self) -> None:
+        assert NoteRow(_deleted_note_row()).is_deleted is True
+
+    def test_deleted_with_trailing_metadata(self) -> None:
+        """Some cassettes carry trailing metadata after the sentinel —
+        the adapter should still classify it as deleted."""
+        row = [*_deleted_note_row(), {"extra": True}]
+        assert NoteRow(row).is_deleted is True
+
+    def test_legacy_active_row_not_deleted(self) -> None:
+        assert NoteRow(_legacy_note_row()).is_deleted is False
+
+    def test_current_active_row_not_deleted(self) -> None:
+        assert NoteRow(_current_note_row()).is_deleted is False
+
+    def test_status_zero_not_deleted(self) -> None:
+        """Status ``0`` at position 2 is not the soft-delete sentinel."""
+        assert NoteRow(["id", None, 0]).is_deleted is False
+
+    def test_status_other_int_not_deleted(self) -> None:
+        assert NoteRow(["id", None, 5]).is_deleted is False
+
+    def test_content_not_none_not_deleted(self) -> None:
+        """A row with ``row[2] == 2`` but content present is NOT
+        deleted — both conditions are required."""
+        assert NoteRow(["id", "content", 2]).is_deleted is False
+
+    def test_short_row_not_deleted(self) -> None:
+        """Rows too short to carry position 2 are never deleted."""
+        assert NoteRow([]).is_deleted is False
+        assert NoteRow(["id"]).is_deleted is False
+        assert NoteRow(["id", None]).is_deleted is False
+
+
+# ---------------------------------------------------------------------------
+# NoteRow — multi-shape content dispatch (the whole point of the adapter)
+# ---------------------------------------------------------------------------
+
+
+class TestNoteRowContentLegacyShape:
+    """Legacy shape: ``row[1]`` is the content string directly."""
+
+    def test_content_from_legacy_shape(self) -> None:
+        assert NoteRow(_legacy_note_row(content="legacy body")).content == "legacy body"
+
+    def test_empty_string_content_returned(self) -> None:
+        """An empty content string is a *valid* legacy payload — must
+        not collapse to ``None``."""
+        assert NoteRow(["id", ""]).content == ""
+
+
+class TestNoteRowContentCurrentShape:
+    """Current shape: ``row[1][1]`` is the content string via the envelope."""
+
+    def test_content_from_current_shape(self) -> None:
+        row = _current_note_row(content="nested body")
+        assert NoteRow(row).content == "nested body"
+
+    def test_content_with_full_envelope(self) -> None:
+        row = ["nid", ["nid", "body", {"meta": 1}, None, "Title"]]
+        assert NoteRow(row).content == "body"
+
+
+class TestNoteRowContentDegradation:
+    """Unknown / short / mistyped slots return ``None`` in soft mode."""
+
+    def test_empty_row_returns_none(self) -> None:
+        assert NoteRow([]).content is None
+
+    def test_id_only_row_returns_none(self) -> None:
+        assert NoteRow(["id"]).content is None
+
+    def test_deleted_row_content_is_none(self) -> None:
+        assert NoteRow(_deleted_note_row()).content is None
+
+    def test_int_at_position_1_returns_none(self) -> None:
+        """A non-str/non-list slot is not extractable content."""
+        assert NoteRow(["id", 123]).content is None
+
+    def test_dict_at_position_1_returns_none(self) -> None:
+        """Dicts are not a recognised shape variant — soft-degrade."""
+        assert NoteRow(["id", {"oops": True}]).content is None
+
+
+class TestNoteRowShortInnerIsNotDrift:
+    """Short inner envelopes are a legitimate production shape, not drift.
+
+    Some cassettes legitimately carry rows like ``[id, [id, content]]``
+    (length-2 inner with no metadata/title slots — predates the title
+    rollout). The adapter MUST length-guard these before invoking
+    ``safe_index`` so strict mode never raises on a real production
+    shape. This is the key behavioural difference from
+    :class:`ArtifactRow`, whose options-block descent has no
+    length-guard because every production options block is length 2.
+    """
+
+    def test_inner_length_1_returns_none_in_strict_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        # ``[id_only]`` is below the content slot — length-guarded to
+        # ``None`` without invoking ``safe_index``, so strict mode does
+        # NOT raise.
+        assert NoteRow(["id", ["id_only"]]).content is None
+
+    def test_inner_length_2_returns_content_in_strict_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Length-2 inner is just barely long enough to carry the
+        content slot at position 1 — extracts cleanly."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        assert NoteRow(["id", ["id", "the body"]]).content == "the body"
+
+    def test_inner_length_2_title_returns_empty_in_strict_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The length-2 inner lacks a title slot — length-guarded to
+        ``""`` without invoking ``safe_index``."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        assert NoteRow(["id", ["id", "the body"]]).title == ""
+
+    def test_empty_inner_returns_none_in_strict_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        assert NoteRow(["id", []]).content is None
+        assert NoteRow(["id", []]).title == ""
+
+
+# ---------------------------------------------------------------------------
+# NoteRow — title (current-shape only)
+# ---------------------------------------------------------------------------
+
+
+class TestNoteRowTitle:
+    def test_title_extracted_from_current_shape(self) -> None:
+        row = _current_note_row(title="My Title")
+        assert NoteRow(row).title == "My Title"
+
+    def test_title_empty_for_legacy_shape(self) -> None:
+        """Legacy ``[id, content_string]`` has no title slot — return
+        ``""`` rather than guessing at one."""
+        assert NoteRow(_legacy_note_row()).title == ""
+
+    def test_title_empty_for_deleted_row(self) -> None:
+        assert NoteRow(_deleted_note_row()).title == ""
+
+    def test_title_empty_for_short_row(self) -> None:
+        assert NoteRow([]).title == ""
+        assert NoteRow(["id"]).title == ""
+
+    def test_title_empty_when_inner_too_short(self) -> None:
+        """``inner = [id, content]`` (length 2) predates the title
+        slot — degrade to ``""`` without raising, since this is a
+        legitimate variant of the current shape (not drift)."""
+        assert NoteRow(["id", ["id", "content"]]).title == ""
+
+    def test_title_empty_when_inner_has_no_title_slot(self) -> None:
+        """``inner = [id, content, meta, None]`` (length 4) is still
+        below the title slot at position 4."""
+        assert NoteRow(["id", ["id", "content", None, None]]).title == ""
+
+    def test_title_empty_when_inner_title_is_not_str(self) -> None:
+        """A non-string at ``[1][4]`` (rare drift case) falls back to
+        ``""`` rather than leaking ``None`` past the ``title: str``
+        contract."""
+        row = ["id", ["id", "content", None, None, 999]]
+        assert NoteRow(row).title == ""
+
+
+# ---------------------------------------------------------------------------
+# NoteRow — mind-map content detection
+# ---------------------------------------------------------------------------
+
+
+class TestNoteRowIsMindMapContent:
+    """The ``"children":`` / ``"nodes":`` substring discriminator."""
+
+    def test_children_key_classifies_as_mind_map(self) -> None:
+        assert NoteRow.is_mind_map_content(json.dumps({"children": []})) is True
+
+    def test_nodes_key_classifies_as_mind_map(self) -> None:
+        assert NoteRow.is_mind_map_content(json.dumps({"nodes": []})) is True
+
+    def test_plain_text_not_mind_map(self) -> None:
+        assert NoteRow.is_mind_map_content("Just a plain note body") is False
+
+    def test_other_json_not_mind_map(self) -> None:
+        """JSON without the mind-map discriminator keys is not a mind
+        map — the predicate is intentionally narrow."""
+        assert NoteRow.is_mind_map_content(json.dumps({"title": "x"})) is False
+
+    def test_none_content_not_mind_map(self) -> None:
+        assert NoteRow.is_mind_map_content(None) is False
+
+    def test_empty_string_not_mind_map(self) -> None:
+        assert NoteRow.is_mind_map_content("") is False
+
+
+class TestNoteRowIsMindMap:
+    """The instance-property convenience wrapper around
+    :meth:`NoteRow.is_mind_map_content`."""
+
+    def test_legacy_mind_map_row(self) -> None:
+        row = NoteRow(_legacy_note_row(content=json.dumps({"children": []})))
+        assert row.is_mind_map is True
+
+    def test_current_mind_map_row(self) -> None:
+        row = NoteRow(_current_note_row(content=json.dumps({"nodes": []})))
+        assert row.is_mind_map is True
+
+    def test_plain_note_row_not_mind_map(self) -> None:
+        assert NoteRow(_legacy_note_row(content="plain body")).is_mind_map is False
+        assert NoteRow(_current_note_row(content="plain body")).is_mind_map is False
+
+    def test_deleted_row_not_mind_map(self) -> None:
+        assert NoteRow(_deleted_note_row()).is_mind_map is False
+
+    def test_empty_row_not_mind_map(self) -> None:
+        assert NoteRow([]).is_mind_map is False
+
+
+# ---------------------------------------------------------------------------
+# NoteRow — immutability + method_id propagation
+# ---------------------------------------------------------------------------
+
+
+class TestNoteRowImmutability:
+    """The adapter is frozen so the wrapped row can't be swapped out."""
+
+    def test_cannot_assign_to_raw(self) -> None:
+        row = NoteRow([])
+        with pytest.raises((AttributeError, Exception)):
+            row._raw = [1, 2, 3]  # type: ignore[misc]
+
+    def test_does_not_mutate_wrapped_row(self) -> None:
+        """Reading every property is side-effect-free — the wrapped row
+        is not modified by classification or extraction."""
+        raw = _current_note_row(content="body", title="Title")
+        snapshot = [raw[0], list(raw[1])]
+        row = NoteRow(raw)
+
+        # Touch every property.
+        _ = row.id
+        _ = row.is_deleted
+        _ = row.content
+        _ = row.title
+        _ = row.is_mind_map
+
+        assert raw[0] == snapshot[0]
+        assert raw[1] == snapshot[1]
+
+
+class TestNoteRowMethodIdField:
+    """The adapter exposes ``_method_id`` for callers that need to tag
+    diagnostics with the RPC the row came from.
+
+    Drift-triggering inputs cannot be synthesised through the
+    content / title descents (length-guards short-circuit before
+    ``safe_index`` is reached), so this test pins the field default
+    and override behaviour instead of trying to provoke a raise.
+    """
+
+    def test_default_method_id_is_get_notes_and_mind_maps(self) -> None:
+        row = NoteRow(["id", "body"])
+        # ``GET_NOTES_AND_MIND_MAPS.value`` per ``rpc/types.py``.
+        assert row._method_id == "cFji9"
+
+    def test_custom_method_id_can_be_supplied(self) -> None:
+        """Callers wrapping a row that came from a non-default RPC can
+        override ``_method_id`` so any future drift diagnostics name
+        the correct method."""
+        row = NoteRow(["id", "body"], _method_id="custom_note_rpc")
+        assert row._method_id == "custom_note_rpc"


### PR DESCRIPTION
## Summary

Second of the three row adapters tracked in [`docs/improvement.md` §6.2](../blob/main/docs/improvement.md#62-positional-row-decoding). Centralises position knowledge for the `GET_NOTES_AND_MIND_MAPS` row shape so consumers never branch on shape and never open-code `row[1][1]` / `row[1][4]`.

- **What `NoteRow` absorbs.** The legacy ↔ current shape divergence (legacy `[id, content]`, current `[id, [id, content, metadata, None, title]]`), soft-deletion detection (`row[1] is None and row[2] == 2`), and the `"children":` / `"nodes":` mind-map content discriminator. The whole point of the adapter is that the multi-shape dispatch lives **inside** `NoteRow` rather than at the call sites.
- **Sites migrated.** `_note_service.py:classify_row` + `extract_content` (the two `row[1][1]` / `row[1] is None` hotspots flagged in the task), plus `_notes.py:_parse_note` (the third positional site, with the `inner[4]` title slot). The acceptance grep `row\[1\]\[1\]\|row\[1\] is None` over `src/notebooklm/_note_service.py` now returns nothing in production code.
- **Pattern mimics `ArtifactRow`.** Frozen dataclass, ClassVar position constants pinned by a canary test, deep descent through `safe_index`, narrow `__all__` export, public `method_id` extension field (aligned with the post-review rename from #1026).
- **One deliberate asymmetry vs `ArtifactRow`:** `NoteRow` length-guards its inner descents before invoking `safe_index`, because the production note shape has two legitimate inner-length variants (2 and 5) — unlike artifact options blocks which are always length 2. Documented inline on both `content` and `title`.

## Stacking history

- Originally branched off `refactor/row-adapters-artifact` (#1026's branch) per the task spec.
- **#1026 merged onto `main` while this PR was in polish.** Rebased onto `origin/main` (commit `07bf6bf`) cleanly via cherry-pick — my changes are purely additive on `_row_adapters.py` (after `ArtifactRow`'s section) and modify two files (`_note_service.py`, `_notes.py`) that #1026 doesn't touch.
- A follow-up commit (`117416e`) aligns `NoteRow.method_id` with the public-field convention #1026 settled on during review (was `_method_id` in the original branch).

## Follow-up

`SourceRowAdapter` (the third adapter in §6.2) is intentionally **out of scope** here and lands in a third PR off `main` after this one merges. Keeping each review surface narrow lets the source-side work be informed by feedback on these two.

## Test plan

- [x] `uv run pytest tests/unit tests/integration` — 6216 passed, 49 skipped
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Acceptance grep: `grep -n "row\[1\]\[1\]\|row\[1\] is None" src/notebooklm/_note_service.py` returns no matches in production code
- [x] Existing `test_note_service.py` (24 tests) + `test_notes_unit.py` (61 tests) continue to pass — they now exercise `NoteRow` indirectly via the unchanged `NoteService.extract_content` / `NoteService.classify_row` / `NotesAPI._parse_note` wrappers
- [x] New `tests/unit/test_row_adapters.py::TestNoteRow*` (49 tests) cover the position-contract canary, legacy/current shape dispatch, deletion detection, mind-map classification, short-inner-is-not-drift semantics, immutability, and method-id field convention

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized a shape-tolerant note row adapter to unify note/mind‑map parsing, deletion detection, content/title defaults, and mind‑map recognition for more robust and consistent note display.
* **Tests**
  * Expanded unit tests to cover legacy/current/deleted shapes, id/content/title extraction, deletion rules, mind‑map detection, strict vs soft decoding, immutability, and RPC method id exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->