### PR TITLE
refactor(sources): introduce SourceRowAdapter for positional wire decoding

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -10,6 +10,7 @@ from ._notebook_metadata import (
     NotebookSourceLister,
     create_default_source_lister,
 )
+from ._row_adapters import SourceRow
 from ._session_contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
@@ -206,9 +207,11 @@ class NotebooksAPI:
         Note:
             RPC, auth, and network errors raised by ``get_raw()`` propagate to
             the caller; only local source-shape validation failures are caught
-            below and converted to an empty list.
-            Source IDs are triple-nested in RPC responses: ``source[0][0]``
-            contains the ID.
+            below and converted to an empty list. Per-row id-envelope
+            decoding (including the drive-backed ``[None, True, [id]]``
+            shape) is delegated to
+            :class:`notebooklm._row_adapters.SourceRow`; this method only
+            performs the envelope walk down to ``notebook[0][1]``.
         """
         notebook_data = await self.get_raw(notebook_id)
 
@@ -244,11 +247,21 @@ class NotebooksAPI:
             for source in sources:
                 if not (isinstance(source, list) and source):
                     continue
-                first = source[0]
-                if not (isinstance(first, list) and first):
-                    continue
-                sid = first[0]
-                if isinstance(sid, str):
+                # Per-row id-envelope decoding is delegated to SourceRow:
+                # ``SourceRow.id`` returns ``""`` for malformed envelopes
+                # (matching legacy ``isinstance(first, list) and first``)
+                # and stringifies non-string ids. The legacy code here
+                # additionally required ``isinstance(sid, str)``; that
+                # check was inconsistent with the sibling
+                # ``_source_listing._extract_source_id`` path (which
+                # accepts any non-None id via ``str(src_id)`` at the
+                # ``Source(id=...)`` boundary). Unifying both call sites
+                # through ``SourceRow.id`` aligns behavior — integer-ids
+                # (none observed in Google's wire today) would now be
+                # stringified rather than silently dropped.
+                row = SourceRow.from_entry(source, method_id=RPCMethod.GET_NOTEBOOK.value)
+                sid = row.id
+                if sid:
                     source_ids.append(sid)
         except (IndexError, TypeError) as e:
             # Defense-in-depth: guards above should make this unreachable.

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -642,6 +642,13 @@ class SourceRow:
     _ID_ENVELOPE_DRIVE_PAYLOAD_POS: ClassVar[int] = 2
     _ID_ENVELOPE_DRIVE_INNER_POS: ClassVar[int] = 0
 
+    # Neutral "first element of a single-item list" index, used by url
+    # helpers that pull the leading element from ``metadata[7]``,
+    # ``metadata[5]``, etc. Kept separate from ``_ID_ENVELOPE_PLAIN_POS``
+    # (also ``0``) so a future id-envelope reshape doesn't accidentally
+    # break URL extraction — claude review feedback on #1029.
+    _LIST_FIRST_POS: ClassVar[int] = 0
+
     # ---- Dispatchers -----------------------------------------------------
 
     @classmethod
@@ -812,10 +819,19 @@ class SourceRow:
         ``Source.from_api_response`` carried ``title: str | None`` and
         downstream consumers (CLI table renderers, etc.) branch on the
         ``None`` case.
+
+        Non-``None`` non-string values are coerced via ``str()`` so the
+        ``str | None`` annotation is honored at runtime — aligns with
+        :attr:`ArtifactRow.title`'s coercion (claude review feedback on
+        #1029). ``None`` is preserved as-is so the legacy "missing
+        title" sentinel still distinguishes from "title is empty string".
         """
         if len(self._raw) <= self._TITLE_POS:
             return None
-        return self._raw[self._TITLE_POS]
+        value = self._raw[self._TITLE_POS]
+        if value is None:
+            return None
+        return value if isinstance(value, str) else str(value)
 
     @property
     def metadata(self) -> list[Any] | None:
@@ -887,7 +903,7 @@ class SourceRow:
         url_list = metadata[self._META_URL_POS]
         if not isinstance(url_list, list) or not url_list:
             return None
-        first = url_list[self._ID_ENVELOPE_PLAIN_POS]
+        first = url_list[self._LIST_FIRST_POS]
         if not first:
             return None
         return first if isinstance(first, str) else str(first)
@@ -907,9 +923,9 @@ class SourceRow:
         if (
             isinstance(yt_block, list)
             and yt_block
-            and isinstance(yt_block[self._ID_ENVELOPE_PLAIN_POS], str)
+            and isinstance(yt_block[self._LIST_FIRST_POS], str)
         ):
-            return yt_block[self._ID_ENVELOPE_PLAIN_POS]
+            return yt_block[self._LIST_FIRST_POS]
         return None
 
     def _url_from_bare_metadata_zero(self, metadata: list[Any]) -> str | None:
@@ -980,7 +996,12 @@ class SourceRow:
         * the status code is not one of the known enum values.
 
         This mirrors the legacy ``SourceLister._extract_status``
-        contract.
+        contract — same fallback to :data:`SourceStatus.READY` on any
+        unrecognised code. The membership check uses ``SourceStatus(...)``
+        directly (catching :class:`ValueError`) rather than an explicit
+        member tuple so the adapter automatically accepts any new values
+        added to :class:`SourceStatus` without a parallel update here
+        (claude review feedback on #1029).
         """
         if (
             len(self._raw) <= self._STATUS_BLOCK_POS
@@ -990,11 +1011,7 @@ class SourceRow:
             return SourceStatus.READY
 
         status_code = self._raw[self._STATUS_BLOCK_POS][self._STATUS_INNER_POS]
-        if status_code in (
-            SourceStatus.PROCESSING,
-            SourceStatus.READY,
-            SourceStatus.ERROR,
-            SourceStatus.PREPARING,
-        ):
+        try:
             return SourceStatus(status_code)
-        return SourceStatus.READY
+        except ValueError:
+            return SourceStatus.READY

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -503,8 +503,6 @@ class NoteRow:
         return '"children":' in content or '"nodes":' in content
 
 
-
-
 # ---------------------------------------------------------------------------
 # SourceRow
 # ---------------------------------------------------------------------------
@@ -852,42 +850,86 @@ class SourceRow:
 
         Precedence (matches the legacy ``_extract_source_url`` logic):
 
-        1. ``metadata[7][0]`` (typical canonical URL slot).
-        2. ``metadata[5][0]`` (YouTube-style block, only when its first
-           element is a string).
-        3. ``metadata[0]`` — only honored when
-           :attr:`url_allow_bare_http` is ``True`` AND the value starts
-           with ``http``. This restricted fallback exists for the
-           deeply-nested ``ADD_SOURCE`` shape.
+        1. :meth:`_url_from_canonical_block` — ``metadata[7][0]`` (typical
+           canonical URL slot, present on every modern source).
+        2. :meth:`_url_from_youtube_block` — ``metadata[5][0]`` (YouTube-
+           style block, only when its first element is a string).
+        3. :meth:`_url_from_bare_metadata_zero` — ``metadata[0]`` —
+           only honored when :attr:`url_allow_bare_http` is ``True`` AND
+           the value starts with ``http``. This restricted fallback
+           exists for the deeply-nested ``ADD_SOURCE`` shape.
+
+        Each precedence level is a tiny named helper so the dispatch
+        reads at the same level of abstraction (gemini review feedback
+        on #1029): the property body is the precedence order, and each
+        helper owns one slot's positional knowledge.
         """
         metadata = self.metadata
         if metadata is None:
             return None
+        return (
+            self._url_from_canonical_block(metadata)
+            or self._url_from_youtube_block(metadata)
+            or self._url_from_bare_metadata_zero(metadata)
+        )
 
-        # 1. metadata[7][0]
-        if len(metadata) > self._META_URL_POS:
-            url_list = metadata[self._META_URL_POS]
-            if isinstance(url_list, list) and url_list:
-                first = url_list[self._ID_ENVELOPE_PLAIN_POS]
-                if first:
-                    return first if isinstance(first, str) else str(first)
+    def _url_from_canonical_block(self, metadata: list[Any]) -> str | None:
+        """Extract the URL from ``metadata[7][0]`` (canonical slot).
 
-        # 2. metadata[5][0] (YouTube-style)
-        if len(metadata) > self._META_YOUTUBE_POS:
-            yt_block = metadata[self._META_YOUTUBE_POS]
-            if (
-                isinstance(yt_block, list)
-                and yt_block
-                and isinstance(yt_block[self._ID_ENVELOPE_PLAIN_POS], str)
-            ):
-                return yt_block[self._ID_ENVELOPE_PLAIN_POS]
+        Returns ``None`` when position 7 is absent, non-list, empty, or
+        when its first element is falsy. Non-string truthy values are
+        stringified to honor the legacy
+        ``_extract_source_url`` contract where ``url`` is whatever the
+        wire stored at this position.
+        """
+        if len(metadata) <= self._META_URL_POS:
+            return None
+        url_list = metadata[self._META_URL_POS]
+        if not isinstance(url_list, list) or not url_list:
+            return None
+        first = url_list[self._ID_ENVELOPE_PLAIN_POS]
+        if not first:
+            return None
+        return first if isinstance(first, str) else str(first)
 
-        # 3. metadata[0] — only when explicitly enabled by shape.
-        if self.url_allow_bare_http and len(metadata) > self._META_BARE_URL_POS:
-            candidate = metadata[self._META_BARE_URL_POS]
-            if isinstance(candidate, str) and candidate.startswith("http"):
-                return candidate
+    def _url_from_youtube_block(self, metadata: list[Any]) -> str | None:
+        """Extract the URL from ``metadata[5][0]`` (YouTube-style block).
 
+        Returns ``None`` unless position 5 is a non-empty list whose
+        first element is a string. The string requirement preserves
+        legacy behavior where non-string YouTube-block elements (e.g.
+        the video id at ``[5][1]`` or channel name at ``[5][2]``) are
+        not interpreted as URLs.
+        """
+        if len(metadata) <= self._META_YOUTUBE_POS:
+            return None
+        yt_block = metadata[self._META_YOUTUBE_POS]
+        if (
+            isinstance(yt_block, list)
+            and yt_block
+            and isinstance(yt_block[self._ID_ENVELOPE_PLAIN_POS], str)
+        ):
+            return yt_block[self._ID_ENVELOPE_PLAIN_POS]
+        return None
+
+    def _url_from_bare_metadata_zero(self, metadata: list[Any]) -> str | None:
+        """Extract the URL from ``metadata[0]`` — restricted fallback.
+
+        Returns ``None`` unless ALL of:
+
+        * :attr:`url_allow_bare_http` is ``True`` (only the deeply-
+          nested ``ADD_SOURCE`` shape sets this), AND
+        * position 0 exists, is a string, and starts with ``http``.
+
+        The ``http`` prefix guard avoids treating arbitrary
+        ``metadata[0]`` strings (e.g. drive ids, mime types) as URLs
+        on shapes where this slot packs unrelated content.
+        """
+        if not self.url_allow_bare_http or len(metadata) <= self._META_BARE_URL_POS:
+            return None
+        candidate = metadata[self._META_BARE_URL_POS]
+        if isinstance(candidate, str) and candidate.startswith("http"):
+            return candidate
         return None
 
     @property

--- a/src/notebooklm/_row_adapters.py
+++ b/src/notebooklm/_row_adapters.py
@@ -7,10 +7,10 @@ shifts, a leaf becomes a wrapper, a list becomes a dict — every consumer
 that hand-rolls position knowledge breaks independently.
 
 This module is the **single point of position knowledge for the
-``LIST_ARTIFACTS`` and ``GET_NOTES_AND_MIND_MAPS`` row shapes**: if
-Google reshapes the wire, the position constants change **here** and
-every consumer adapts automatically. The constants therefore function
-as the canary contract for wire-shape changes — see
+``LIST_ARTIFACTS``, ``GET_NOTES_AND_MIND_MAPS``, and source-row
+shapes**: if Google reshapes the wire, the position constants change
+**here** and every consumer adapts automatically. The constants
+therefore function as the canary contract for wire-shape changes — see
 ``tests/unit/test_row_adapters.py`` for the pin tests that fail loudly
 when anyone edits a position.
 
@@ -19,12 +19,14 @@ The adapters sit **on top of** :func:`notebooklm.rpc.safe_index`:
 * Top-level position presence (``len(self._raw) > _POS``) is treated as
   optional — missing trailing positions return sensible defaults in both
   soft and strict modes. This preserves the historical
-  ``Artifact.from_api_response`` contract that accepts short rows.
+  ``Artifact.from_api_response`` / ``Source.from_api_response`` contract
+  that accepts short rows.
 * Deep descent into a present position (``data[9][1][0]``,
-  ``data[15][0]``, ``data[1][1]``, ``data[1][4]``) flows through
-  :func:`safe_index`. Soft mode returns ``None`` on drift, strict mode
-  raises :class:`notebooklm.exceptions.UnknownRPCMethodError` — the
-  desired ADR-011 signal for genuine Google-side reshape.
+  ``data[15][0]``, ``data[1][1]``, ``data[1][4]``, ``metadata[7][0]``,
+  ``metadata[2][0]``) flows through :func:`safe_index`. Soft mode
+  returns ``None`` on drift, strict mode raises
+  :class:`notebooklm.exceptions.UnknownRPCMethodError` — the desired
+  ADR-011 signal for genuine Google-side reshape.
 
 Wire-shape variants:
 
@@ -34,21 +36,29 @@ Wire-shape variants:
   shape divergence (legacy: ``[id, content]``; current:
   ``[id, [id, content, metadata, None, title]]``) so consumers never
   open-code ``row[1][1]`` / ``row[1][4]``.
+* :class:`SourceRow` wraps a single source row across three wire shapes
+  (deeply nested, medium nested, flat) plus an "already extracted" entry
+  layout. The :meth:`SourceRow.from_unknown_shape` classmethod is the
+  multi-shape dispatcher; consumers (``Source.from_api_response``,
+  ``SourceLister._parse_source``, ``NotebooksAPI.get_source_ids``) read
+  named properties regardless of which shape arrived.
 
-Out of scope for this module (deferred to a follow-up PR per
-``docs/improvement.md`` §6.2): ``SourceRowAdapter``.
+The §6.2 row-adapter rollout from ``docs/improvement.md`` is complete
+with this module.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from typing import Any, ClassVar
 
 from ._types.common import _datetime_from_timestamp
 from .rpc import ArtifactStatus, RPCMethod, safe_index
+from .rpc.types import SourceStatus
 
-__all__ = ["ArtifactRow", "NoteRow"]
+__all__ = ["ArtifactRow", "NoteRow", "SourceRow", "SourceRowShape"]
 
 
 @dataclass(frozen=True)
@@ -491,3 +501,458 @@ class NoteRow:
         if not content or not content.startswith("{"):
             return False
         return '"children":' in content or '"nodes":' in content
+
+
+
+
+# ---------------------------------------------------------------------------
+# SourceRow
+# ---------------------------------------------------------------------------
+
+
+class SourceRowShape(str, Enum):
+    """The wire shape that a :class:`SourceRow` was extracted from.
+
+    Source rows arrive over three distinct shapes; the shape is tracked
+    on the row only for diagnostics (so drift logs can name the path
+    that was taken). All three normalize to the same :class:`SourceRow`
+    interface — consumer sites read named properties regardless of
+    shape.
+
+    See :meth:`SourceRow.from_unknown_shape` for the dispatcher and
+    :class:`SourceRow` for the position contract on the **normalized
+    entry** form that the adapter wraps internally.
+    """
+
+    #: ``[[[[id], title, metadata, ...]]]`` — deeply-nested response,
+    #: e.g. some ``ADD_SOURCE`` shapes where the entry is wrapped in an
+    #: extra outer list.
+    DEEPLY_NESTED = "deeply_nested"
+
+    #: ``[[[id], title, metadata, ...]]`` — medium-nested, the most
+    #: common shape used by ``GET_NOTEBOOK`` and ``ADD_SOURCE``.
+    MEDIUM_NESTED = "medium_nested"
+
+    #: ``[id, title, ...]`` — flat shape. Used by some callers that pre-
+    #: extracted the entry envelope.
+    FLAT = "flat"
+
+    #: A pre-extracted ``[[id], title, metadata, ...]`` entry — what
+    #: :meth:`SourceRow.from_entry` wraps directly without dispatching.
+    #: Identical layout to ``MEDIUM_NESTED`` after one unwrap; tracked
+    #: separately so drift logs can distinguish "dispatcher produced
+    #: this" from "caller handed us an already-unwrapped entry".
+    ENTRY = "entry"
+
+
+@dataclass(frozen=True)
+class SourceRow:
+    """Typed view of a single source row.
+
+    Source rows arrive over three wire shapes (see
+    :class:`SourceRowShape`); the :meth:`from_unknown_shape` classmethod
+    dispatches the three into a single **normalized entry** layout that
+    this adapter wraps:
+
+    =====  ============================================================
+    Index  Meaning
+    =====  ============================================================
+    0      source-id envelope. Variants:
+
+           * ``"id"`` — bare string (legacy / flat shape).
+           * ``["id"]`` — typical wrapping.
+           * ``[None, True, ["id"]]`` — drive-backed entries nest the
+             id one level deeper at ``raw_id[2][0]``. Surfaced by
+             :attr:`id` transparently.
+    1      title (str) — may be ``None`` / missing on short rows.
+    2      metadata sub-list (see below).
+    3      status block; ``[3][1]`` is the
+           :class:`~notebooklm.rpc.SourceStatus` code (used by
+           ``GET_NOTEBOOK`` source-list rows).
+    =====  ============================================================
+
+    **Metadata sub-list layout** (``self._raw[2]``):
+
+    =====  ============================================================
+    Index  Meaning
+    =====  ============================================================
+    0      Mixed — sometimes a bare ``http(s)://...`` URL (legacy
+           shape, only honored when ``url_allow_bare_http=True``).
+    2      timestamp block; ``[2][0]`` is the creation timestamp
+           (seconds since epoch).
+    4      type code (int — see
+           :class:`notebooklm._types.sources.SourceType` mapping in
+           ``_types/sources.py``).
+    5      youtube/source-specific block; ``[5][0]`` is a YouTube URL.
+    7      url block; ``[7][0]`` is the canonical source URL when
+           present (takes precedence over ``metadata[5][0]`` and
+           ``metadata[0]``).
+    =====  ============================================================
+
+    Position knowledge is centralised here. Consumer sites should NEVER
+    open-code ``data[0][0]`` / ``data[0][0][0]`` / ``metadata[4]`` —
+    wrap the row in a :class:`SourceRow` and read through the typed
+    properties instead.
+
+    The dataclass is frozen so accidentally mutating the wrapped row is
+    impossible through the adapter; the adapter itself never copies the
+    raw row, so it is cheap to construct.
+    """
+
+    # Wrapped normalized entry; ``repr=False`` so logs don't explode
+    # with the entire batchexecute payload.
+    _raw: list[Any] = field(repr=False)
+    # ``method_id`` is a public extension point: callers wrapping a row
+    # that came from a non-default RPC override it so ``safe_index``
+    # drift diagnostics point at the correct method.
+    method_id: str = RPCMethod.GET_NOTEBOOK.value
+    # Records which dispatcher branch produced this row. Default is
+    # ``ENTRY`` because direct construction (``SourceRow(entry)``)
+    # bypasses dispatch.
+    shape: SourceRowShape = SourceRowShape.ENTRY
+    # The deeply-nested ``ADD_SOURCE``-style path historically allowed
+    # a bare ``http(s)://...`` value at ``metadata[0]`` to act as the
+    # URL when no ``metadata[7]``/``metadata[5]`` entry was present.
+    # Medium-nested and entry-shaped rows (``GET_NOTEBOOK`` source list
+    # + most ``ADD_SOURCE`` shapes) pack unrelated content into
+    # ``metadata[0]`` and must NOT honor it as a URL.
+    url_allow_bare_http: bool = False
+
+    # ---- Position constants (the canary contract) ------------------------
+    # ClassVar so the frozen dataclass treats them as class-level
+    # constants. If any of these change,
+    # ``tests/unit/test_row_adapters.py::TestSourceRowPositionContract``
+    # MUST be updated in the same commit — that failure is the wire-shape
+    # change signal.
+
+    # Top-level (entry) positions.
+    _ID_POS: ClassVar[int] = 0
+    _TITLE_POS: ClassVar[int] = 1
+    _METADATA_POS: ClassVar[int] = 2
+    _STATUS_BLOCK_POS: ClassVar[int] = 3
+    _STATUS_INNER_POS: ClassVar[int] = 1
+
+    # Metadata sub-list positions.
+    _META_BARE_URL_POS: ClassVar[int] = 0
+    _META_TIMESTAMP_POS: ClassVar[int] = 2
+    _META_TYPE_POS: ClassVar[int] = 4
+    _META_YOUTUBE_POS: ClassVar[int] = 5
+    _META_URL_POS: ClassVar[int] = 7
+
+    # Id-envelope inner positions (the three layouts at ``self._raw[0]``).
+    _ID_ENVELOPE_PLAIN_POS: ClassVar[int] = 0
+    _ID_ENVELOPE_DRIVE_PAYLOAD_POS: ClassVar[int] = 2
+    _ID_ENVELOPE_DRIVE_INNER_POS: ClassVar[int] = 0
+
+    # ---- Dispatchers -----------------------------------------------------
+
+    @classmethod
+    def from_unknown_shape(
+        cls,
+        data: list[Any],
+        *,
+        method_id: str | None = None,
+    ) -> SourceRow:
+        """Normalize any of the three source wire shapes into a
+        :class:`SourceRow`.
+
+        Shapes handled (matching the legacy ``Source.from_api_response``
+        branches):
+
+        1. **Deeply nested** — ``[[[[id], title, metadata, ...]]]``.
+           Unwraps ``data[0][0]`` to reach the entry. Honors the legacy
+           ``url_allow_bare_http=True`` policy (only this shape lets a
+           bare ``http(s)://...`` at ``metadata[0]`` act as the URL).
+        2. **Medium nested** — ``[[[id], title, metadata, ...]]``.
+           Unwraps ``data[0]`` to reach the entry.
+        3. **Flat** — ``[id, title, ...]``. Wraps directly; metadata is
+           absent so :attr:`url`, :attr:`type_code`, :attr:`created_at`
+           all return ``None`` / ``0``.
+
+        Args:
+            data: Raw decoded payload. Must be a non-empty list.
+            method_id: Override for diagnostics; defaults to the class
+                default (``GET_NOTEBOOK``) when ``None``.
+
+        Returns:
+            A :class:`SourceRow` wrapping the normalized entry.
+
+        Raises:
+            ValueError: When ``data`` is empty or not a list.
+        """
+        if not data or not isinstance(data, list):
+            raise ValueError(f"Invalid source data: {data!r}")
+
+        mid = method_id if method_id is not None else RPCMethod.GET_NOTEBOOK.value
+
+        outer = data[cls._ID_POS]
+        # The medium/deep dispatch mirrors the legacy
+        # ``Source.from_api_response`` two-level guard:
+        #   data[0] is a non-empty list, AND data[0][0] is a non-empty list.
+        # If data[0][0][0] is *itself* a list, we have an extra wrapper
+        # (deeply-nested): the entry lives at data[0][0] and its id
+        # envelope at data[0][0][0]. Otherwise the entry lives at
+        # data[0] and its id envelope at data[0][0].
+        if (
+            isinstance(outer, list)
+            and outer
+            and isinstance(outer[cls._ID_POS], list)
+            and outer[cls._ID_POS]
+        ):
+            inner = outer[cls._ID_POS]
+            if isinstance(inner[cls._ID_ENVELOPE_PLAIN_POS], list):
+                # Deeply nested: data[0][0] IS the entry; its [0] is
+                # itself a list (the id envelope), so we have an extra
+                # outer wrapper around the entry.
+                return cls(
+                    _raw=inner,
+                    method_id=mid,
+                    shape=SourceRowShape.DEEPLY_NESTED,
+                    url_allow_bare_http=True,
+                )
+            # Medium nested: data[0] IS the entry; data[0][0] is its
+            # id envelope.
+            return cls(
+                _raw=outer,
+                method_id=mid,
+                shape=SourceRowShape.MEDIUM_NESTED,
+                url_allow_bare_http=False,
+            )
+
+        # Flat: [id, title, ...]
+        return cls(
+            _raw=data,
+            method_id=mid,
+            shape=SourceRowShape.FLAT,
+            url_allow_bare_http=False,
+        )
+
+    @classmethod
+    def from_entry(
+        cls,
+        entry: list[Any],
+        *,
+        method_id: str | None = None,
+    ) -> SourceRow:
+        """Wrap an already-extracted entry (``[[id], title, metadata, ...]``).
+
+        Used by callers that walked the response envelope themselves —
+        e.g. :class:`notebooklm._source_listing.SourceLister` iterating
+        over ``notebook[0][1]`` and
+        :meth:`notebooklm._notebooks.NotebooksAPI.get_source_ids`
+        iterating over the same envelope. Shape is recorded as
+        :attr:`SourceRowShape.ENTRY`.
+        """
+        mid = method_id if method_id is not None else RPCMethod.GET_NOTEBOOK.value
+        return cls(
+            _raw=entry,
+            method_id=mid,
+            shape=SourceRowShape.ENTRY,
+            url_allow_bare_http=False,
+        )
+
+    # ---- Top-level required positions ------------------------------------
+    # Length guards (not ``safe_index``) so short rows continue to
+    # receive sensible defaults in BOTH soft and strict modes.
+
+    @property
+    def id(self) -> str:
+        """Source identifier — empty string when the envelope is malformed.
+
+        Handles three id-envelope variants transparently:
+
+        * Bare string at ``self._raw[0]`` (flat shape).
+        * ``["id"]`` at ``self._raw[0]`` (typical).
+        * ``[None, True, ["id"]]`` at ``self._raw[0]`` (drive-backed).
+        """
+        raw_id = self._id_envelope()
+        if raw_id is None:
+            return ""
+        if not isinstance(raw_id, list):
+            # Flat shape: id is the entry element directly.
+            return str(raw_id)
+        # ``[id, ...]`` — typical wrapping.
+        if raw_id and raw_id[self._ID_ENVELOPE_PLAIN_POS] is not None:
+            return str(raw_id[self._ID_ENVELOPE_PLAIN_POS])
+        # ``[None, True, [id]]`` — drive-backed nesting.
+        if (
+            len(raw_id) > self._ID_ENVELOPE_DRIVE_PAYLOAD_POS
+            and isinstance(raw_id[self._ID_ENVELOPE_DRIVE_PAYLOAD_POS], list)
+            and raw_id[self._ID_ENVELOPE_DRIVE_PAYLOAD_POS]
+        ):
+            inner = raw_id[self._ID_ENVELOPE_DRIVE_PAYLOAD_POS][self._ID_ENVELOPE_DRIVE_INNER_POS]
+            return str(inner) if inner is not None else ""
+        return ""
+
+    def _id_envelope(self) -> Any:
+        """Return the raw id envelope (``self._raw[0]``) or ``None``."""
+        if len(self._raw) <= self._ID_POS:
+            return None
+        return self._raw[self._ID_POS]
+
+    @property
+    def has_id(self) -> bool:
+        """Whether the row resolves to a non-empty :attr:`id`.
+
+        Used by :class:`notebooklm._source_listing.SourceLister` to skip
+        rows whose id envelopes legacy ``_extract_source_id`` would
+        have rejected (returning ``None``) — including the rare
+        ``[None, True, [None]]`` drive-payload-with-``None``-inner case
+        that :attr:`id` decodes to ``""``.
+
+        Equivalent to ``bool(self.id)``; exposed as a named predicate
+        so consumer call sites read intent-first.
+        """
+        return bool(self.id)
+
+    @property
+    def title(self) -> str | None:
+        """Source title — ``None`` when absent (preserves legacy contract).
+
+        Unlike :attr:`ArtifactRow.title`, this returns ``None`` rather
+        than an empty string because the legacy
+        ``Source.from_api_response`` carried ``title: str | None`` and
+        downstream consumers (CLI table renderers, etc.) branch on the
+        ``None`` case.
+        """
+        if len(self._raw) <= self._TITLE_POS:
+            return None
+        return self._raw[self._TITLE_POS]
+
+    @property
+    def metadata(self) -> list[Any] | None:
+        """The metadata sub-list at ``self._raw[2]``, or ``None``.
+
+        Returned as ``None`` (not ``[]``) when absent or non-list, so
+        callers can distinguish "no metadata block" from "metadata
+        block exists but is empty".
+        """
+        if len(self._raw) <= self._METADATA_POS:
+            return None
+        value = self._raw[self._METADATA_POS]
+        return value if isinstance(value, list) else None
+
+    @property
+    def type_code(self) -> int | None:
+        """Type code at ``metadata[4]`` (int) or ``None`` when absent.
+
+        Returned as raw ``int``; callers map via
+        :func:`notebooklm._types.sources._safe_source_type` to get the
+        :class:`~notebooklm._types.sources.SourceType` enum.
+        """
+        metadata = self.metadata
+        if metadata is None or len(metadata) <= self._META_TYPE_POS:
+            return None
+        value = metadata[self._META_TYPE_POS]
+        return value if isinstance(value, int) else None
+
+    @property
+    def url(self) -> str | None:
+        """Canonical source URL — ``None`` when absent.
+
+        Precedence (matches the legacy ``_extract_source_url`` logic):
+
+        1. ``metadata[7][0]`` (typical canonical URL slot).
+        2. ``metadata[5][0]`` (YouTube-style block, only when its first
+           element is a string).
+        3. ``metadata[0]`` — only honored when
+           :attr:`url_allow_bare_http` is ``True`` AND the value starts
+           with ``http``. This restricted fallback exists for the
+           deeply-nested ``ADD_SOURCE`` shape.
+        """
+        metadata = self.metadata
+        if metadata is None:
+            return None
+
+        # 1. metadata[7][0]
+        if len(metadata) > self._META_URL_POS:
+            url_list = metadata[self._META_URL_POS]
+            if isinstance(url_list, list) and url_list:
+                first = url_list[self._ID_ENVELOPE_PLAIN_POS]
+                if first:
+                    return first if isinstance(first, str) else str(first)
+
+        # 2. metadata[5][0] (YouTube-style)
+        if len(metadata) > self._META_YOUTUBE_POS:
+            yt_block = metadata[self._META_YOUTUBE_POS]
+            if (
+                isinstance(yt_block, list)
+                and yt_block
+                and isinstance(yt_block[self._ID_ENVELOPE_PLAIN_POS], str)
+            ):
+                return yt_block[self._ID_ENVELOPE_PLAIN_POS]
+
+        # 3. metadata[0] — only when explicitly enabled by shape.
+        if self.url_allow_bare_http and len(metadata) > self._META_BARE_URL_POS:
+            candidate = metadata[self._META_BARE_URL_POS]
+            if isinstance(candidate, str) and candidate.startswith("http"):
+                return candidate
+
+        return None
+
+    @property
+    def created_at_raw(self) -> int | float | None:
+        """Raw creation timestamp (seconds since epoch) at ``metadata[2][0]``.
+
+        Returns ``None`` when:
+
+        * metadata is absent / non-list, or
+        * ``metadata[2]`` is absent / non-list / empty, or
+        * the resulting value is not numeric.
+
+        An empty ``metadata[2] = []`` envelope is treated as a soft
+        edge-case (not strict-mode drift), mirroring
+        :attr:`ArtifactRow.created_at_raw`.
+        """
+        metadata = self.metadata
+        if metadata is None or len(metadata) <= self._META_TIMESTAMP_POS:
+            return None
+        timestamp_block = metadata[self._META_TIMESTAMP_POS]
+        if not isinstance(timestamp_block, list) or not timestamp_block:
+            return None
+        value = safe_index(
+            timestamp_block,
+            0,
+            method_id=self.method_id,
+            source="SourceRow.created_at_raw",
+        )
+        return value if isinstance(value, (int, float)) else None
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Creation timestamp as a :class:`~datetime.datetime`, or ``None``."""
+        raw = self.created_at_raw
+        if raw is None:
+            return None
+        return _datetime_from_timestamp(raw)
+
+    @property
+    def status(self) -> SourceStatus:
+        """Processing status from ``self._raw[3][1]``.
+
+        Used by ``GET_NOTEBOOK`` source-list rows where every entry
+        carries a status block. Defaults to
+        :data:`SourceStatus.READY` when:
+
+        * position 3 is absent / non-list / too short, or
+        * the status code is not one of the known enum values.
+
+        This mirrors the legacy ``SourceLister._extract_status``
+        contract.
+        """
+        if (
+            len(self._raw) <= self._STATUS_BLOCK_POS
+            or not isinstance(self._raw[self._STATUS_BLOCK_POS], list)
+            or len(self._raw[self._STATUS_BLOCK_POS]) <= self._STATUS_INNER_POS
+        ):
+            return SourceStatus.READY
+
+        status_code = self._raw[self._STATUS_BLOCK_POS][self._STATUS_INNER_POS]
+        if status_code in (
+            SourceStatus.PROCESSING,
+            SourceStatus.READY,
+            SourceStatus.ERROR,
+            SourceStatus.PREPARING,
+        ):
+            return SourceStatus(status_code)
+        return SourceStatus.READY

--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -7,9 +7,9 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
+from ._row_adapters import SourceRow
 from .rpc import RPCError, RPCMethod
-from .rpc.types import SourceStatus
-from .types import Source, _extract_source_created_at, _extract_source_url
+from .types import Source
 
 # Keep source-list warnings on the historical logger so existing log filters
 # continue to see the same channel after the service extraction.
@@ -127,72 +127,28 @@ class SourceLister:
         if not isinstance(src, builtins.list) or len(src) == 0:
             return None
 
-        src_id = SourceLister._extract_source_id(src)
-        if src_id is None:
+        # GET_NOTEBOOK source-list entries arrive in the "entry" layout
+        # (``[[id], title, metadata, status_block, ...]`` after the
+        # envelope walk above) so we hand them directly to
+        # ``SourceRow.from_entry`` and let the adapter handle all
+        # positional knowledge — id-envelope variants (plain, drive-
+        # backed), metadata url precedence, status decoding, etc.
+        row = SourceRow.from_entry(src, method_id=RPCMethod.GET_NOTEBOOK.value)
+        if not row.has_id:
             logger.warning(
                 "SourcesAPI.list: Skipping source with unexpected id shape: %s",
                 repr(src)[:500],
             )
             return None
 
-        title = src[1] if len(src) > 1 else None
-        metadata = src[2] if len(src) > 2 else None
-
-        # GET_NOTEBOOK source entries use the same medium-nested metadata
-        # shape as Source.from_api_response. In this shape metadata[0] can
-        # pack unrelated data, so only the shared [7] > [5] precedence applies.
-        url = _extract_source_url(metadata, allow_bare_http=False)
-        created_at = _extract_source_created_at(metadata)
-        status = SourceLister._extract_status(src)
-        type_code = SourceLister._extract_type_code(metadata)
-
         return Source(
-            id=str(src_id),
-            title=title,
-            url=url,
-            _type_code=type_code,
-            created_at=created_at,
-            status=status,
+            id=row.id,
+            title=row.title,
+            url=row.url,
+            _type_code=row.type_code,
+            created_at=row.created_at,
+            status=row.status,
         )
-
-    @staticmethod
-    def _extract_source_id(src: builtins.list[Any]) -> object | None:
-        raw_id = src[0]
-        if not isinstance(raw_id, builtins.list):
-            return raw_id
-        if raw_id and raw_id[0] is not None:
-            return raw_id[0]
-        # Drive-backed entries can nest the source id inside the id envelope:
-        # [None, true, [source_id]]. Keep this local to source-list parsing so
-        # the public Source model remains a shape-preserving value object.
-        if len(raw_id) > 2 and isinstance(raw_id[2], builtins.list) and raw_id[2]:
-            return raw_id[2][0]
-        return None
-
-    @staticmethod
-    def _extract_status(src: builtins.list[Any]) -> SourceStatus:
-        if len(src) <= 3 or not isinstance(src[3], builtins.list) or len(src[3]) <= 1:
-            return SourceStatus.READY
-
-        status_code = src[3][1]
-        if status_code in (
-            SourceStatus.PROCESSING,
-            SourceStatus.READY,
-            SourceStatus.ERROR,
-            SourceStatus.PREPARING,
-        ):
-            return status_code
-        return SourceStatus.READY
-
-    @staticmethod
-    def _extract_type_code(metadata: Any) -> int | None:
-        if (
-            isinstance(metadata, builtins.list)
-            and len(metadata) > 4
-            and isinstance(metadata[4], int)
-        ):
-            return metadata[4]
-        return None
 
 
 __all__ = ["SourceLister"]

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -163,66 +163,39 @@ class Source:
 
     @classmethod
     def from_api_response(cls, data: list[Any], notebook_id: str | None = None) -> Source:
-        """Parse source data from various API response formats."""
-        if not data or not isinstance(data, list):
-            raise ValueError(f"Invalid source data: {data}")
+        """Parse source data from various API response formats.
 
-        # Try deeply nested format: [[[[id], title, metadata, ...]]]
-        if isinstance(data[0], list) and len(data[0]) > 0:
-            if isinstance(data[0][0], list) and len(data[0][0]) > 0:
-                # Check if deeply nested vs medium nested
-                if isinstance(data[0][0][0], list):
-                    # Deeply nested: [[[[id], title, ...]]]
-                    entry = data[0][0]
-                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
-                    title = entry[1] if len(entry) > 1 else None
-                    # Fall through to the shared metadata parser below.
-                else:
-                    # Medium nested: [[['id'], 'title', ...]]
-                    entry = data[0]
-                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
-                    title = entry[1] if len(entry) > 1 else None
+        Multi-shape dispatch (the three wire shapes — deeply nested,
+        medium nested, flat) is centralised in
+        :meth:`notebooklm._row_adapters.SourceRow.from_unknown_shape`;
+        position knowledge for the entry layout lives on
+        :class:`SourceRow` itself. This method only translates the
+        adapter's typed properties into the :class:`Source` dataclass.
+        See ``docs/improvement.md`` §6.2 for context.
+        """
+        # Local import: ``_row_adapters`` re-imports ``_datetime_from_timestamp``
+        # from ``_types/common`` (a sibling). The dependency graph is
+        # acyclic (``_types/__init__.py`` doesn't pull in ``sources.py``),
+        # but the import is kept local to make the row-adapter dependency
+        # explicit on every call path and to keep the module's top-level
+        # import surface unchanged.
+        from .._row_adapters import SourceRow, SourceRowShape
 
-                    metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
-                    url = _extract_source_url(metadata, allow_bare_http=False)
-                    type_code = (
-                        metadata[4]
-                        if metadata is not None
-                        and len(metadata) > 4
-                        and isinstance(metadata[4], int)
-                        else None
-                    )
-                    created_at = _extract_source_created_at(metadata)
+        row = SourceRow.from_unknown_shape(data)
 
-                    return cls(
-                        id=str(source_id),
-                        title=title,
-                        url=url,
-                        _type_code=type_code,
-                        created_at=created_at,
-                    )
+        # Flat shape preserves the historical contract: ``_type_code``
+        # is always ``None`` and metadata-derived fields are not
+        # consulted (legacy ``return cls(id=..., title=..., _type_code=None)``).
+        if row.shape is SourceRowShape.FLAT:
+            return cls(id=row.id, title=row.title, _type_code=None)
 
-                metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
-                url = _extract_source_url(metadata)
-                type_code = (
-                    metadata[4]
-                    if metadata is not None and len(metadata) > 4 and isinstance(metadata[4], int)
-                    else None
-                )
-                created_at = _extract_source_created_at(metadata)
-
-                return cls(
-                    id=str(source_id),
-                    title=title,
-                    url=url,
-                    _type_code=type_code,
-                    created_at=created_at,
-                )
-
-        # Simple flat format: [id, title] or [id, title, ...]
-        source_id = data[0] if len(data) > 0 else ""
-        title = data[1] if len(data) > 1 else None
-        return cls(id=str(source_id), title=title, _type_code=None)
+        return cls(
+            id=row.id,
+            title=row.title,
+            url=row.url,
+            _type_code=row.type_code,
+            created_at=row.created_at,
+        )
 
 
 @dataclass

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -384,7 +384,6 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
     "_extract_audio_artifact_url",
     "_extract_infographic_artifact_url",
     "_extract_slide_deck_artifact_url",
-    "_extract_source_created_at",
     "_extract_source_url",
     "_extract_video_artifact_url",
     "_is_valid_artifact_url",
@@ -392,7 +391,15 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
     "_warned_source_types",
 ]
 
-_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS: list[str] = []
+# Private helpers that are no longer imported by first-party code but
+# must remain exportable through ``notebooklm.types`` for downstream
+# compatibility. ``_extract_source_created_at`` moved here when the
+# row-adapter migration (see ``_row_adapters.SourceRow.created_at``)
+# replaced its sole first-party consumer
+# (``_source_listing._parse_source``).
+_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS: list[str] = [
+    "_extract_source_created_at",
+]
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1,13 +1,15 @@
-"""Tests for ``notebooklm._row_adapters`` (``ArtifactRow`` + ``NoteRow``).
+"""Tests for ``notebooklm._row_adapters`` (``ArtifactRow`` + ``NoteRow`` + ``SourceRow``).
 
-The adapters centralise position knowledge for the ``LIST_ARTIFACTS``
-and ``GET_NOTES_AND_MIND_MAPS`` row shapes so consumers
+The adapters centralise position knowledge for the ``LIST_ARTIFACTS``,
+``GET_NOTES_AND_MIND_MAPS``, and source row shapes so consumers
 (``Artifact.from_api_response``, ``ArtifactListingService.select_artifact``,
-``NoteService.classify_row``, ``NotesAPI._parse_note``) read named
-properties instead of open-coding ``data[2]`` / ``data[4]`` / ``data[15]``
-or ``row[1][1]`` / ``row[1][4]``. See ``docs/improvement.md`` §6.2 for
-the motivation and ``src/notebooklm/_row_adapters.py`` for the position
-contracts.
+``NoteService.classify_row``, ``NotesAPI._parse_note``,
+``Source.from_api_response``, ``SourceLister._parse_source``,
+``NotebooksAPI.get_source_ids``) read named properties instead of
+open-coding ``data[2]`` / ``data[4]`` / ``data[15]`` / ``row[1][1]`` /
+``row[1][4]`` / ``data[0][0]`` / ``metadata[4]``. See
+``docs/improvement.md`` §6.2 for the motivation and
+``src/notebooklm/_row_adapters.py`` for the position contracts.
 
 These tests cover three layers per adapter:
 
@@ -18,7 +20,8 @@ These tests cover three layers per adapter:
    defaults; deep descent goes through ``safe_index`` so strict-mode
    drift raises ``UnknownRPCMethodError``.
 3. **Predicate / domain helpers** — ``matches_type`` for artifacts,
-   ``is_deleted`` / ``is_mind_map_content`` for notes.
+   ``is_deleted`` / ``is_mind_map_content`` for notes, multi-shape
+   dispatch (``from_unknown_shape``) for sources.
 """
 
 from __future__ import annotations
@@ -27,9 +30,9 @@ import json
 
 import pytest
 
-from notebooklm._row_adapters import ArtifactRow, NoteRow
+from notebooklm._row_adapters import ArtifactRow, NoteRow, SourceRow, SourceRowShape
 from notebooklm.exceptions import UnknownRPCMethodError
-from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode
+from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode, SourceStatus
 
 # ---------------------------------------------------------------------------
 # 1. Position-contract pin (the canary)
@@ -838,3 +841,599 @@ class TestNoteRowMethodIdField:
         the correct method."""
         row = NoteRow(["id", "body"], method_id="custom_note_rpc")
         assert row.method_id == "custom_note_rpc"
+
+
+# ===========================================================================
+# SourceRow
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# 1. Position-contract pin (the canary)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowPositionContract:
+    """If any of these assertions fail, Google has likely reshaped the wire.
+
+    The constants cover both the top-level entry layout (id envelope,
+    title, metadata, status block) AND the metadata sub-list layout
+    (timestamp, type code, url precedence chain). Changing any of these
+    is the *only* legitimate reason for one of these tests to need
+    updating — the failing diff is the audit trail.
+    """
+
+    def test_top_level_positions(self) -> None:
+        """Entry-level positions: id, title, metadata, status block."""
+        assert SourceRow._ID_POS == 0
+        assert SourceRow._TITLE_POS == 1
+        assert SourceRow._METADATA_POS == 2
+        assert SourceRow._STATUS_BLOCK_POS == 3
+        assert SourceRow._STATUS_INNER_POS == 1
+
+    def test_metadata_positions(self) -> None:
+        """Metadata-sub-list positions: bare-url, timestamp, type, yt, url."""
+        assert SourceRow._META_BARE_URL_POS == 0
+        assert SourceRow._META_TIMESTAMP_POS == 2
+        assert SourceRow._META_TYPE_POS == 4
+        assert SourceRow._META_YOUTUBE_POS == 5
+        assert SourceRow._META_URL_POS == 7
+
+    def test_id_envelope_positions(self) -> None:
+        """Id-envelope positions: plain id at [0]; drive-backed at [2][0]."""
+        assert SourceRow._ID_ENVELOPE_PLAIN_POS == 0
+        assert SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS == 2
+        assert SourceRow._ID_ENVELOPE_DRIVE_INNER_POS == 0
+
+    def test_all_positions_at_once(self) -> None:
+        """A single dict pin so a sweeping reshape fails with one
+        informative assertion rather than many."""
+        assert (
+            SourceRow._ID_POS,
+            SourceRow._TITLE_POS,
+            SourceRow._METADATA_POS,
+            SourceRow._STATUS_BLOCK_POS,
+            SourceRow._STATUS_INNER_POS,
+            SourceRow._META_BARE_URL_POS,
+            SourceRow._META_TIMESTAMP_POS,
+            SourceRow._META_TYPE_POS,
+            SourceRow._META_YOUTUBE_POS,
+            SourceRow._META_URL_POS,
+            SourceRow._ID_ENVELOPE_PLAIN_POS,
+            SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
+            SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
+        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 0, 2, 0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _metadata(
+    *,
+    timestamp: int | float | None = 1_700_000_000,
+    type_code: int | None = 5,
+    canonical_url: str | None = "https://example.com/canonical",
+    youtube_url: str | None = None,
+    bare_url: str | None = None,
+) -> list:
+    """Build a metadata sub-list matching the documented layout.
+
+    Mirrors ``Source.from_api_response`` test fixtures so the positions
+    here stay in lockstep with the production code.
+    """
+    md: list = [bare_url, None]
+    md.append([timestamp] if timestamp is not None else None)
+    md.append(None)
+    md.append(type_code)
+    if youtube_url is not None:
+        md.append([youtube_url, "ytid", "channel"])
+    else:
+        md.append(None)
+    md.append(None)
+    if canonical_url is not None:
+        md.append([canonical_url])
+    else:
+        md.append(None)
+    return md
+
+
+def _entry(
+    *,
+    source_id: str = "src_test",
+    title: str | None = "Source Title",
+    drive_backed: bool = False,
+    plain_id_string: bool = False,
+    status_code: int | None = None,
+    metadata: list | None = None,
+) -> list:
+    """Build a medium-nested entry: ``[[id], title, metadata, [None, status]]``."""
+    if plain_id_string:
+        id_envelope: object = source_id
+    elif drive_backed:
+        id_envelope = [None, True, [source_id]]
+    else:
+        id_envelope = [source_id]
+    entry: list = [id_envelope, title]
+    if metadata is None:
+        entry.append(_metadata())
+    else:
+        entry.append(metadata)
+    if status_code is not None:
+        entry.append([None, status_code])
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# 2. Shape-dispatch normalization
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowShapeDispatch:
+    """``SourceRow.from_unknown_shape`` normalizes all three wire shapes."""
+
+    def test_deeply_nested_shape(self) -> None:
+        """``[[[[id], title, metadata, ...]]]`` → DEEPLY_NESTED.
+
+        Honors ``url_allow_bare_http=True`` because the deeply-nested
+        ``ADD_SOURCE`` shape historically allowed a bare URL at
+        ``metadata[0]`` as a fallback. The internal ``_raw`` points at
+        the unwrapped entry so :attr:`id` reads cleanly.
+        """
+        data = [[[["id_deep"], "Deep", _metadata(canonical_url="https://deep.example/")]]]
+        row = SourceRow.from_unknown_shape(data)
+        assert row.shape is SourceRowShape.DEEPLY_NESTED
+        assert row.url_allow_bare_http is True
+        assert row.id == "id_deep"
+        assert row.title == "Deep"
+        assert row.url == "https://deep.example/"
+
+    def test_medium_nested_shape(self) -> None:
+        """``[[[id], title, metadata, ...]]`` → MEDIUM_NESTED."""
+        data = [[["id_med"], "Med", _metadata(canonical_url="https://med.example/")]]
+        row = SourceRow.from_unknown_shape(data)
+        assert row.shape is SourceRowShape.MEDIUM_NESTED
+        assert row.url_allow_bare_http is False
+        assert row.id == "id_med"
+        assert row.title == "Med"
+        assert row.url == "https://med.example/"
+
+    def test_flat_shape(self) -> None:
+        """``[id, title]`` → FLAT; metadata-dependent props degrade."""
+        row = SourceRow.from_unknown_shape(["id_flat", "Flat"])
+        assert row.shape is SourceRowShape.FLAT
+        assert row.url_allow_bare_http is False
+        assert row.id == "id_flat"
+        assert row.title == "Flat"
+        # Flat rows have no metadata block, so url/type/timestamp are absent.
+        assert row.metadata is None
+        assert row.url is None
+        assert row.type_code is None
+        assert row.created_at_raw is None
+
+    def test_empty_data_raises_value_error(self) -> None:
+        """Empty/non-list data fails fast (mirrors legacy ``Source.from_api_response``)."""
+        with pytest.raises(ValueError, match="Invalid source data"):
+            SourceRow.from_unknown_shape([])
+
+    def test_non_list_data_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid source data"):
+            SourceRow.from_unknown_shape("not a list")  # type: ignore[arg-type]
+
+    def test_from_entry_records_entry_shape(self) -> None:
+        """Pre-extracted entries get ``shape=ENTRY``; ``url_allow_bare_http`` stays False.
+
+        This is the path used by ``SourceLister._parse_source`` and
+        ``NotebooksAPI.get_source_ids`` after they walk the response
+        envelope themselves.
+        """
+        entry = _entry(source_id="entry_id", title="Entry")
+        row = SourceRow.from_entry(entry)
+        assert row.shape is SourceRowShape.ENTRY
+        assert row.url_allow_bare_http is False
+        assert row.id == "entry_id"
+        assert row.title == "Entry"
+
+    def test_dispatch_method_id_override(self) -> None:
+        """Explicit ``method_id`` propagates to the wrapped row."""
+        row = SourceRow.from_unknown_shape(
+            [[["id"], "T", _metadata()]],
+            method_id="my_custom_method",
+        )
+        assert row.method_id == "my_custom_method"
+
+    def test_dispatch_default_method_id_is_get_notebook(self) -> None:
+        """Default ``method_id`` is ``GET_NOTEBOOK`` for source-list diagnostics."""
+        row = SourceRow.from_unknown_shape([[["id"], "T", _metadata()]])
+        # GET_NOTEBOOK == "rLM1Ne"
+        assert row.method_id == "rLM1Ne"
+
+
+# ---------------------------------------------------------------------------
+# 3. Id-envelope decoding (drive-backed + edge cases)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowId:
+    """:attr:`SourceRow.id` handles three id-envelope variants."""
+
+    def test_typical_wrapped_id(self) -> None:
+        """``[[id], title, ...]`` is the common case."""
+        row = SourceRow.from_entry(_entry(source_id="typical"))
+        assert row.id == "typical"
+        assert row.has_id is True
+
+    def test_drive_backed_id_at_index_2(self) -> None:
+        """Drive-backed entries nest the id as ``[None, True, [id]]``."""
+        row = SourceRow.from_entry(_entry(source_id="drv42", drive_backed=True))
+        assert row.id == "drv42"
+        assert row.has_id is True
+
+    def test_bare_string_id(self) -> None:
+        """Some flat-shaped rows put the id directly at ``self._raw[0]``."""
+        row = SourceRow(_raw=["bare_id", "T"])
+        assert row.id == "bare_id"
+        assert row.has_id is True
+
+    def test_empty_id_envelope_returns_empty(self) -> None:
+        """``[[], title, ...]`` — id envelope is an empty list."""
+        row = SourceRow(_raw=[[], "T"])
+        assert row.id == ""
+        assert row.has_id is False
+
+    def test_missing_id_position_returns_empty(self) -> None:
+        """``self._raw == []`` — no id envelope at all."""
+        row = SourceRow(_raw=[])
+        assert row.id == ""
+        assert row.has_id is False
+
+    def test_drive_backed_with_empty_inner_returns_empty(self) -> None:
+        """``[None, True, []]`` — drive payload is empty."""
+        row = SourceRow(_raw=[[None, True, []], "T"])
+        assert row.id == ""
+        assert row.has_id is False
+
+    def test_drive_backed_with_inner_none_returns_empty(self) -> None:
+        """``[None, True, [None]]`` — drive inner element is ``None``.
+
+        Both :attr:`id` and :attr:`has_id` must return falsy values so
+        :class:`notebooklm._source_listing.SourceLister` skips the row
+        (matching legacy ``_extract_source_id`` which returned ``None``
+        from ``raw_id[2][0] is None``).
+        """
+        row = SourceRow(_raw=[[None, True, [None]], "T"])
+        assert row.id == ""
+        assert row.has_id is False
+
+    def test_integer_id_is_stringified(self) -> None:
+        """Defensive: non-string ids stringify (mirrors ``Source(id=str(src_id))``)."""
+        row = SourceRow(_raw=[[12345], "T"])
+        assert row.id == "12345"
+
+
+# ---------------------------------------------------------------------------
+# 4. URL precedence (metadata[7] > metadata[5] > metadata[0])
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowUrlPrecedence:
+    """:attr:`SourceRow.url` precedence matches legacy ``_extract_source_url``."""
+
+    def test_canonical_url_at_metadata_7(self) -> None:
+        row = SourceRow.from_entry(
+            _entry(
+                metadata=_metadata(
+                    canonical_url="https://canonical.example/",
+                    youtube_url="https://youtube.example/v",
+                )
+            )
+        )
+        # [7] wins over [5].
+        assert row.url == "https://canonical.example/"
+
+    def test_youtube_url_at_metadata_5_when_7_absent(self) -> None:
+        row = SourceRow.from_entry(
+            _entry(
+                metadata=_metadata(
+                    canonical_url=None,
+                    youtube_url="https://youtube.example/v",
+                )
+            )
+        )
+        assert row.url == "https://youtube.example/v"
+
+    def test_youtube_block_first_element_non_string_skipped(self) -> None:
+        """``metadata[5][0]`` must be a string to be honored."""
+        md = _metadata(canonical_url=None)
+        md[SourceRow._META_YOUTUBE_POS] = [42, "ytid"]
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.url is None
+
+    def test_bare_url_at_metadata_0_ignored_when_allow_bare_http_false(self) -> None:
+        """ENTRY / MEDIUM_NESTED shapes never honor ``metadata[0]`` —
+        unrelated content can live there."""
+        row = SourceRow.from_entry(
+            _entry(
+                metadata=_metadata(
+                    canonical_url=None,
+                    youtube_url=None,
+                    bare_url="https://bare.example/",
+                )
+            )
+        )
+        assert row.url is None
+
+    def test_bare_url_at_metadata_0_honored_for_deeply_nested(self) -> None:
+        """Only the deeply-nested ``ADD_SOURCE`` shape lets a bare
+        ``http(s)://...`` at ``metadata[0]`` act as the URL."""
+        md = _metadata(canonical_url=None, youtube_url=None, bare_url="https://bare.example/")
+        data = [[[["id"], "T", md]]]
+        row = SourceRow.from_unknown_shape(data)
+        assert row.shape is SourceRowShape.DEEPLY_NESTED
+        assert row.url == "https://bare.example/"
+
+    def test_bare_url_non_http_ignored_even_when_allowed(self) -> None:
+        """``metadata[0]`` is only honored when it starts with ``http``."""
+        md = _metadata(canonical_url=None, youtube_url=None, bare_url="ftp://bare.example/")
+        data = [[[["id"], "T", md]]]
+        row = SourceRow.from_unknown_shape(data)
+        assert row.url is None
+
+    def test_url_returns_none_when_metadata_absent(self) -> None:
+        row = SourceRow(_raw=[["id"], "T"])
+        assert row.url is None
+
+    def test_url_returns_none_when_all_slots_empty(self) -> None:
+        md = _metadata(canonical_url=None, youtube_url=None)
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.url is None
+
+
+# ---------------------------------------------------------------------------
+# 5. type_code and metadata access
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowTypeCodeAndMetadata:
+    def test_type_code_from_metadata_4(self) -> None:
+        row = SourceRow.from_entry(_entry(metadata=_metadata(type_code=9)))
+        assert row.type_code == 9
+
+    def test_type_code_none_when_metadata_too_short(self) -> None:
+        """Metadata shorter than 5 elements → ``type_code`` is ``None``."""
+        row = SourceRow.from_entry(_entry(metadata=[None, None, [1700000000], None]))
+        assert row.type_code is None
+
+    def test_type_code_none_when_not_int(self) -> None:
+        md = _metadata()
+        md[SourceRow._META_TYPE_POS] = "not_an_int"
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.type_code is None
+
+    def test_type_code_none_when_metadata_absent(self) -> None:
+        row = SourceRow(_raw=[["id"], "T"])
+        assert row.type_code is None
+
+    def test_metadata_returns_list_when_present(self) -> None:
+        md = _metadata()
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.metadata is md  # adapter doesn't copy
+
+    def test_metadata_returns_none_when_non_list(self) -> None:
+        row = SourceRow(_raw=[["id"], "T", "not_a_list"])
+        assert row.metadata is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Timestamp descent (delegated to safe_index for the deep step)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowTimestamp:
+    def test_created_at_raw_returns_int(self) -> None:
+        row = SourceRow.from_entry(_entry(metadata=_metadata(timestamp=1_700_000_000)))
+        assert row.created_at_raw == 1_700_000_000
+
+    def test_created_at_converts_to_datetime(self) -> None:
+        row = SourceRow.from_entry(_entry(metadata=_metadata(timestamp=1_700_000_000)))
+        assert row.created_at is not None
+        assert row.created_at.timestamp() == 1_700_000_000
+
+    def test_missing_timestamp_block_returns_none(self) -> None:
+        row = SourceRow.from_entry(_entry(metadata=_metadata(timestamp=None)))
+        assert row.created_at_raw is None
+        assert row.created_at is None
+
+    def test_empty_timestamp_block_returns_none_in_both_modes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``metadata[2] = []`` is an accepted soft edge-case (mirrors
+        :class:`ArtifactRow` timestamp handling)."""
+        md = _metadata()
+        md[SourceRow._META_TIMESTAMP_POS] = []
+        row = SourceRow.from_entry(_entry(metadata=md))
+
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        assert row.created_at_raw is None  # no exception in strict mode
+
+    def test_non_list_timestamp_block_returns_none(self) -> None:
+        md = _metadata()
+        md[SourceRow._META_TIMESTAMP_POS] = "not_a_list"
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.created_at_raw is None
+
+    def test_metadata_absent_returns_none(self) -> None:
+        row = SourceRow(_raw=[["id"], "T"])
+        assert row.created_at_raw is None
+
+    def test_metadata_too_short_for_timestamp_returns_none(self) -> None:
+        row = SourceRow.from_entry(_entry(metadata=[None, None]))
+        assert row.created_at_raw is None
+
+    def test_non_numeric_timestamp_returns_none(self) -> None:
+        md = _metadata()
+        md[SourceRow._META_TIMESTAMP_POS] = ["not_numeric"]
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.created_at_raw is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Status decoding (used by SourceLister)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowStatus:
+    """:attr:`SourceRow.status` mirrors legacy ``SourceLister._extract_status``."""
+
+    def test_status_ready_when_status_block_absent(self) -> None:
+        row = SourceRow.from_entry(_entry(status_code=None))
+        assert row.status == SourceStatus.READY
+
+    def test_status_processing(self) -> None:
+        row = SourceRow.from_entry(_entry(status_code=SourceStatus.PROCESSING))
+        assert row.status == SourceStatus.PROCESSING
+
+    def test_status_error(self) -> None:
+        row = SourceRow.from_entry(_entry(status_code=SourceStatus.ERROR))
+        assert row.status == SourceStatus.ERROR
+
+    def test_status_preparing(self) -> None:
+        row = SourceRow.from_entry(_entry(status_code=SourceStatus.PREPARING))
+        assert row.status == SourceStatus.PREPARING
+
+    def test_unknown_status_falls_back_to_ready(self) -> None:
+        """Status codes outside the known enum coerce to READY."""
+        row = SourceRow.from_entry(_entry(status_code=999))
+        assert row.status == SourceStatus.READY
+
+    def test_non_list_status_block_falls_back_to_ready(self) -> None:
+        entry = _entry()
+        entry.append("not_a_list")  # status block at position 3
+        row = SourceRow.from_entry(entry)
+        assert row.status == SourceStatus.READY
+
+    def test_short_status_block_falls_back_to_ready(self) -> None:
+        entry = _entry()
+        entry.append([None])  # status block too short — no [1]
+        row = SourceRow.from_entry(entry)
+        assert row.status == SourceStatus.READY
+
+
+# ---------------------------------------------------------------------------
+# 8. Schema-drift edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowSchemaDrift:
+    """Short / malformed rows degrade to sensible defaults."""
+
+    def test_empty_row_yields_safe_defaults(self) -> None:
+        row = SourceRow(_raw=[])
+        assert row.id == ""
+        assert row.title is None
+        assert row.metadata is None
+        assert row.type_code is None
+        assert row.url is None
+        assert row.created_at_raw is None
+        assert row.status == SourceStatus.READY
+
+    def test_id_only_row(self) -> None:
+        row = SourceRow(_raw=[["only_id"]])
+        assert row.id == "only_id"
+        assert row.title is None  # title is None (not ""), preserving legacy
+        assert row.metadata is None
+
+    def test_title_position_can_be_none(self) -> None:
+        row = SourceRow(_raw=[["id"], None])
+        assert row.title is None
+
+    def test_metadata_with_only_url_block(self) -> None:
+        """Minimal metadata: only enough length to carry ``[7]``."""
+        md: list = [None] * 8
+        md[SourceRow._META_URL_POS] = ["https://only-url.example/"]
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.url == "https://only-url.example/"
+        assert row.type_code is None
+        assert row.created_at_raw is None
+
+
+# ---------------------------------------------------------------------------
+# 9. Strict-mode behaviour on deep drift
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowStrictMode:
+    """``method_id`` plumbing and strict-mode behavior for deep descents.
+
+    Unlike :class:`ArtifactRow.variant` (which walks a two-step
+    ``[9][1][0]`` descent and CAN trigger strict-mode raises when
+    ``[9][1]`` is missing), :attr:`SourceRow.created_at_raw` walks only
+    a single ``metadata[2][0]`` step gated by an outer "non-empty list"
+    guard. That guard short-circuits the two scenarios safe_index would
+    raise on (empty / non-list timestamp block), so in practice the
+    safe_index call here is a forward-compatible placeholder: it
+    propagates ``method_id`` for diagnostics today and is the migration
+    point if Google ever deepens the timestamp block to require
+    ``[0][0]``-style descent.
+    """
+
+    def test_method_id_default_is_get_notebook(self) -> None:
+        """The default ``method_id`` matches the most-common caller (GET_NOTEBOOK)."""
+        row = SourceRow.from_entry(_entry())
+        assert row.method_id == "rLM1Ne"  # RPCMethod.GET_NOTEBOOK
+
+    def test_method_id_propagates_through_constructor(self) -> None:
+        row = SourceRow.from_entry(_entry(), method_id="my_custom")
+        assert row.method_id == "my_custom"
+
+    def test_method_id_propagates_through_unknown_shape(self) -> None:
+        row = SourceRow.from_unknown_shape(
+            [[["id"], "T", _metadata()]],
+            method_id="my_custom",
+        )
+        assert row.method_id == "my_custom"
+
+    def test_non_numeric_timestamp_returns_none_in_strict_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even in strict mode, a non-numeric value at ``metadata[2][0]``
+        degrades to ``None`` rather than raising — the type-guard at the
+        property boundary is the legitimate filter, not drift."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+        md = _metadata()
+        md[SourceRow._META_TIMESTAMP_POS] = [{"unexpected": "shape"}]
+        row = SourceRow.from_entry(_entry(metadata=md))
+        assert row.created_at_raw is None
+
+
+# ---------------------------------------------------------------------------
+# 10. Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRowImmutability:
+    """The adapter is frozen so the wrapped row can't be swapped out."""
+
+    def test_cannot_assign_to_raw(self) -> None:
+        row = SourceRow(_raw=[])
+        with pytest.raises(AttributeError):
+            row._raw = [1, 2, 3]  # type: ignore[misc]
+
+    def test_does_not_mutate_wrapped_row(self) -> None:
+        raw = _entry()
+        snapshot = list(raw)
+        row = SourceRow.from_entry(raw)
+
+        # Touch every property.
+        _ = row.id
+        _ = row.title
+        _ = row.metadata
+        _ = row.type_code
+        _ = row.url
+        _ = row.created_at_raw
+        _ = row.created_at
+        _ = row.status
+        _ = row.has_id
+
+        assert raw == snapshot

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -885,6 +885,13 @@ class TestSourceRowPositionContract:
         assert SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS == 2
         assert SourceRow._ID_ENVELOPE_DRIVE_INNER_POS == 0
 
+    def test_list_first_position_is_neutral(self) -> None:
+        """``_LIST_FIRST_POS`` is a neutral "first element" index used by
+        URL helpers — kept separate from ``_ID_ENVELOPE_PLAIN_POS`` so a
+        future id-envelope reshape doesn't accidentally break URL
+        extraction (claude review feedback on #1029)."""
+        assert SourceRow._LIST_FIRST_POS == 0
+
     def test_all_positions_at_once(self) -> None:
         """A single dict pin so a sweeping reshape fails with one
         informative assertion rather than many."""
@@ -902,7 +909,8 @@ class TestSourceRowPositionContract:
             SourceRow._ID_ENVELOPE_PLAIN_POS,
             SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
             SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
-        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 0, 2, 0)
+            SourceRow._LIST_FIRST_POS,
+        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 0, 2, 0, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -1110,6 +1118,45 @@ class TestSourceRowId:
         """Defensive: non-string ids stringify (mirrors ``Source(id=str(src_id))``)."""
         row = SourceRow(_raw=[[12345], "T"])
         assert row.id == "12345"
+
+    def test_drive_backed_id_through_deeply_nested_dispatch(self) -> None:
+        """Drive-backed id-envelope inside the DEEPLY_NESTED wire shape.
+
+        Combines the two dispatch axes: the extra outer wrapper +
+        ``[None, True, [id]]`` id envelope. The production
+        ``ADD_SOURCE`` path produces this exact combination for
+        drive-backed sources. Covers the test gap noted in claude
+        review feedback on #1029.
+        """
+        deep_drive = [
+            [
+                [
+                    [None, True, ["drive_in_deep"]],
+                    "Drive Title",
+                    _metadata(canonical_url="https://drive.example/"),
+                ]
+            ]
+        ]
+        row = SourceRow.from_unknown_shape(deep_drive)
+        assert row.shape is SourceRowShape.DEEPLY_NESTED
+        assert row.id == "drive_in_deep"
+        assert row.title == "Drive Title"
+        assert row.url == "https://drive.example/"
+
+    def test_drive_backed_id_through_medium_nested_dispatch(self) -> None:
+        """Drive-backed id-envelope inside the MEDIUM_NESTED wire shape."""
+        med_drive = [
+            [
+                [None, True, ["drive_in_med"]],
+                "Drive Title Med",
+                _metadata(canonical_url="https://drive-med.example/"),
+            ]
+        ]
+        row = SourceRow.from_unknown_shape(med_drive)
+        assert row.shape is SourceRowShape.MEDIUM_NESTED
+        assert row.id == "drive_in_med"
+        assert row.title == "Drive Title Med"
+        assert row.url == "https://drive-med.example/"
 
 
 # ---------------------------------------------------------------------------
@@ -1319,6 +1366,17 @@ class TestSourceRowStatus:
         row = SourceRow.from_entry(entry)
         assert row.status == SourceStatus.READY
 
+    def test_non_int_status_code_falls_back_to_ready(self) -> None:
+        """Non-int status codes (None, str, etc.) fall back via the
+        ``SourceStatus(...)`` ValueError path (claude review feedback on
+        #1029 — switching from explicit membership tuple to try/except
+        retains this behavior for any non-enum value)."""
+        for bad_code in (None, "not_a_status", []):
+            entry = _entry()
+            entry.append([None, bad_code])  # whatever-type status code at [3][1]
+            row = SourceRow.from_entry(entry)
+            assert row.status == SourceStatus.READY, f"failed for {bad_code!r}"
+
 
 # ---------------------------------------------------------------------------
 # 8. Schema-drift edge cases
@@ -1347,6 +1405,17 @@ class TestSourceRowSchemaDrift:
     def test_title_position_can_be_none(self) -> None:
         row = SourceRow(_raw=[["id"], None])
         assert row.title is None
+
+    def test_title_non_string_coerced_to_str(self) -> None:
+        """Non-``None`` non-string titles coerce via ``str()`` so the
+        ``str | None`` annotation is honored at runtime — aligns with
+        :attr:`ArtifactRow.title`'s coercion (claude review feedback on
+        #1029). ``None`` stays as ``None`` (preserves "missing title"
+        sentinel)."""
+        row_int = SourceRow(_raw=[["id"], 12345])
+        assert row_int.title == "12345"
+        row_none = SourceRow(_raw=[["id"], None])
+        assert row_none.title is None  # None is preserved
 
     def test_metadata_with_only_url_block(self) -> None:
         """Minimal metadata: only enough length to carry ``[7]``."""


### PR DESCRIPTION
## Summary

Introduces `SourceRow` to `_row_adapters.py`, the **third and final** row adapter in the `docs/improvement.md` §6.2 rollout after `ArtifactRow` (#1026). Source rows arrive over three distinct wire shapes and one already-extracted entry layout; this PR centralises that multi-shape dispatch and all positional knowledge into a single adapter, then migrates the three consumer sites to read through typed properties.

## Why this is the most complex of the three adapters

Source rows have **three wire shapes** (vs `ArtifactRow`'s one) that must be dispatched centrally:

- **Deeply nested**: `[[[[id], title, metadata, ...]]]` — some `ADD_SOURCE` paths
- **Medium nested**: `[[[id], title, metadata, ...]]` — common `GET_NOTEBOOK` / `ADD_SOURCE` shape
- **Flat**: `[id, title, ...]` — legacy compatibility shape

Plus an "already extracted" entry layout used by the `GET_NOTEBOOK` source-list walker. The id envelope at position `[0]` has three variants of its own (plain string, `[id]` wrapping, drive-backed `[None, True, [id]]`), and the `type_code` lives at `metadata[4]` inside the metadata sub-list. The multi-shape dispatcher is the genuinely novel work over the `ArtifactRow` pattern.

## What changed

### New: `SourceRow` adapter (`src/notebooklm/_row_adapters.py`)

- Frozen dataclass wrapping a normalized **entry** layout (`[[id], title, metadata, status_block, ...]`).
- `SourceRowShape` enum tracks which shape was detected (diagnostics only).
- `SourceRow.from_unknown_shape(data, method_id=...)` classmethod dispatches all three wire shapes into the normalized entry form. Gates the legacy `url_allow_bare_http` policy on the detected shape (only `DEEPLY_NESTED` enables it).
- `SourceRow.from_entry(entry, method_id=...)` classmethod for callers that already walked the response envelope (used by `_source_listing` and `get_source_ids`).
- Typed properties: `id`, `title`, `metadata`, `type_code`, `url`, `created_at`, `created_at_raw`, `status`, `has_id`.
- All descent guarded by length / `isinstance` checks; the deep timestamp step flows through `safe_index` per ADR-011 (forward-compatible placeholder — see commit message for details).
- Position constants pinned as `ClassVar` integers; canary-tested in `tests/unit/test_row_adapters.py`.

### Migrated consumer sites

1. **`src/notebooklm/_types/sources.py::Source.from_api_response`** — the ~50-line three-branch decoder collapses to a thin translation from `SourceRow` typed properties into the `Source` dataclass. Public API signature unchanged.
2. **`src/notebooklm/_source_listing.py::SourceLister._parse_source`** — each envelope-walked source-list entry is now wrapped via `SourceRow.from_entry` and read through the adapter for url/type/timestamp/status. The four sibling `_extract_*` static helpers (`_extract_source_id` / `_extract_status` / `_extract_type_code`) are removed; the cross-module `_extract_source_url` / `_extract_source_created_at` helpers are no longer consumed first-party (still exported through `notebooklm.types`).
3. **`src/notebooklm/_notebooks.py::NotebooksAPI.get_source_ids`** — per-row id-envelope decoding (including the drive-backed `[None, True, [id]]` shape) is delegated to `SourceRow.id`. The envelope walk + WARNING logging is preserved.

### Behavioral note

The legacy `get_source_ids` had an `isinstance(sid, str)` filter that was inconsistent with the sibling `_source_listing._extract_source_id` path (which accepts any non-None id via `str(src_id)` at the `Source(id=...)` boundary). The migration unifies both call sites through `SourceRow.id` — integer ids (none observed in Google's wire today) would now be stringified rather than silently dropped. This change is documented inline at the call site.

## Position contract (the canary)

`tests/unit/test_row_adapters.py` adds `TestSourceRowPositionContract` pinning all 13 positional constants (entry layout, metadata-sublist layout, and id-envelope variants). When Google reshapes the wire, those tests fail loudly — the failing diff is the audit trail.

## Acceptance criteria

- [x] `SourceRow` class added to `_row_adapters.py`
- [x] All 3 sites migrated; no inline positional indexing for source rows in production code
- [x] `grep -rnE "data\[0\]\[0\]|data\[0\]\[0\]\[0\]|metadata\[4\]" src/notebooklm/_types/sources.py src/notebooklm/_source_listing.py src/notebooklm/_notebooks.py` returns no matches
- [x] `tests/unit/test_row_adapters.py` has `SourceRow` position-contract + multi-shape coverage (50 new tests)
- [x] `uv run pytest` passes (6313 passed, 12 skipped — including VCR-backed source listing tests)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (168 files)

## Test plan

- [x] Position-contract pin (canary for Google reshape) — `TestSourceRowPositionContract`
- [x] Shape-dispatch normalization across all three wire shapes + entry — `TestSourceRowShapeDispatch`
- [x] Id-envelope decoding (plain / drive-backed / bare-string / malformed) — `TestSourceRowId`
- [x] URL precedence (`metadata[7]` > `metadata[5]` > bare `metadata[0]` only when allowed) — `TestSourceRowUrlPrecedence`
- [x] type_code and metadata access (length-guarded; non-int falls back to None) — `TestSourceRowTypeCodeAndMetadata`
- [x] Timestamp descent (delegated to `safe_index` for the deep step) — `TestSourceRowTimestamp`
- [x] Status decoding mirrors legacy `_extract_status` — `TestSourceRowStatus`
- [x] Schema-drift edge cases (short / malformed rows degrade safely) — `TestSourceRowSchemaDrift`
- [x] Strict-mode `method_id` plumbing — `TestSourceRowStrictMode`
- [x] Frozen-dataclass immutability — `TestSourceRowImmutability`
- [x] Existing source-related tests (unit + VCR-backed integration) still pass

## References

- `docs/improvement.md` §6.2 — row-adapter rollout
- #1026 — `ArtifactRow` prior art; mimics the constant-naming, `safe_index` invocation style, and test layout settled during its review
- This PR **completes** the 3-adapter rollout listed in §6.2 (`ArtifactRow` / `SourceRow` / `NoteRow`). `NoteRow` is the remaining adapter in §6.2 not yet on main; a `NoteRow` PR can build directly on the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a typed SourceRow and shape indicator to normalize multiple source payload shapes and preserve legacy flat-source behavior.
  * ID extraction now accepts decoded/enveloped IDs and skips entries without valid IDs.

* **Refactor**
  * Centralized source parsing into a single normalization layer, removing duplicated per-file parsing logic.

* **Tests**
  * Added broad tests for shapes, id/url/timestamp/status rules, strict-mode behavior, and immutability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->