### PR TITLE
refactor(session): inline pure delegates, route callers to canonical collaborators

### DIFF
--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -107,7 +107,7 @@ def get_default_language() -> str:
     This value is threaded into two places:
 
     * The ``hl`` URL query parameter on every batchexecute RPC call
-      (``_core._build_url`` and ``_chat.ask``).
+      (``RpcExecutor.build_url`` and ``_chat.ask``).
     * Language-aware ``ArtifactsAPI.generate_*`` calls when callers pass
       ``language=None`` to opt in to environment/default resolution. Omitting
       ``language`` in the public Python API keeps the historical ``"en"``

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -112,9 +112,12 @@ class AuthRefreshMiddleware:
       attr on the live client still takes effect (matches the live-binding
       contract preserved for retry budgets in PR 12.7).
     - ``snapshot_provider``: optional async callable returning a fresh
-      :class:`AuthSnapshot` after refresh. Production wires
-      :meth:`Session._snapshot`; tests that omit it preserve the older
-      "retry the same request" unit shape.
+      :class:`AuthSnapshot` after refresh. Production wires a lambda
+      that invokes :meth:`AuthRefreshCoordinator.snapshot` with the
+      live ``Session`` host (the previously-load-bearing
+      ``Session._snapshot`` thin wrapper was inlined in PR #4b of the
+      session-refactor arc); tests that omit ``snapshot_provider``
+      preserve the older "retry the same request" unit shape.
     - ``sleep``: optional sleep injection (defaults to :func:`asyncio.sleep`
       resolved at call time via :func:`_session_helpers.resolve_sleep` —
       the same shared helper :class:`RetryMiddleware` uses).

--- a/src/notebooklm/_reqid_counter.py
+++ b/src/notebooklm/_reqid_counter.py
@@ -29,8 +29,9 @@ Design constraints (load-bearing — see ``tests/unit/test_reqid_counter.py`` an
 * Optional ``on_lock_wait`` callback receives the seconds spent blocked on
   :attr:`_lock`. Decouples the counter from
   :class:`notebooklm._client_metrics.ClientMetrics` so this class is unit-
-  testable in isolation; ``Session`` wires it up to
-  ``self._record_lock_wait`` at construction.
+  testable in isolation; the Session-init helper wires it up to
+  ``ClientMetrics.record_lock_wait`` at construction (see
+  ``_session_init.build_collaborators``).
 """
 
 from __future__ import annotations
@@ -188,8 +189,8 @@ class ReqidCounter:
             self._lock.release()
         # Lock is released; safe to invoke arbitrary user-supplied
         # telemetry. Exceptions from the callback propagate to the caller
-        # (the existing contract — ``Session._record_lock_wait`` can't
-        # raise, but the API surface keeps this defensive).
+        # (the existing contract — ``ClientMetrics.record_lock_wait``
+        # can't raise, but the API surface keeps this defensive).
         self._on_lock_wait(time.perf_counter() - wait_start)
         return new_value
 

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -36,7 +36,6 @@ from ._session_init import (
     wire_middleware_chain,
 )
 from ._session_lifecycle import CookieRotator, CookieSaver
-from ._transport_drain import _TransportOperationToken
 from ._transport_errors import raise_mapped_post_error
 from .auth import (
     AuthTokens,
@@ -74,16 +73,22 @@ logger = logging.getLogger(__name__)
 
 # Auth-snapshot canonical implementation lives on
 # :class:`AuthRefreshCoordinator` (``_session_auth.py`` —
-# ``AuthRefreshCoordinator.snapshot`` / ``.update_auth_tokens``). The
-# :class:`Session` methods of the same name (``Session._snapshot`` /
-# ``Session.update_auth_tokens``) are thin delegates that forward through
-# ``self._auth_coord``; PR 8 collapsed their pre-PR-8 real bodies. The AST
-# guards in ``tests/unit/test_concurrency_refresh_race.py``
+# ``AuthRefreshCoordinator.snapshot`` / ``.update_auth_tokens``). PR 8
+# first collapsed the previously real-bodied ``Session._snapshot`` /
+# ``Session.update_auth_tokens`` into thin delegates that forwarded
+# through ``self._auth_coord``. PR #4b of the session-refactor arc
+# then inlined ``Session._snapshot`` entirely — every site that needs
+# an :class:`AuthSnapshot` now reads ``self._auth_coord.snapshot(self)``
+# directly. ``Session.update_auth_tokens`` is retained as a delegate
+# because :class:`RefreshAuthCore` in ``_auth/session.py`` is the
+# structural Protocol used by ``refresh_auth_session`` and still
+# requires that method on the core. The AST guards in
+# ``tests/unit/test_concurrency_refresh_race.py``
 # (``test_snapshot_acquires_auth_snapshot_lock`` /
-# ``test_update_auth_tokens_has_no_await_inside_mutation_block``) inspect
-# the coordinator's source via ``inspect.getsource(...)`` + AST parsing —
-# changes to auth-snapshot invariants must be applied to the coordinator
-# (not the delegates here).
+# ``test_update_auth_tokens_has_no_await_inside_mutation_block``)
+# inspect the coordinator's source via ``inspect.getsource(...)`` +
+# AST parsing — changes to auth-snapshot invariants must be applied to
+# the coordinator (not the surviving ``update_auth_tokens`` delegate).
 
 
 # Three previously module-level test seams (one each for RPC response
@@ -411,9 +416,6 @@ class Session:
     def _increment_metrics(self, **increments: int | float) -> None:
         self._metrics_obj.increment(**increments)
 
-    def _record_rpc_queue_wait(self, wait_seconds: float) -> None:
-        self._metrics_obj.record_rpc_queue_wait(wait_seconds)
-
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         """Record time spent waiting for the upload semaphore."""
         self._metrics_obj.record_upload_queue_wait(wait_seconds)
@@ -461,44 +463,20 @@ class Session:
         """Raise if this core is used from a loop other than its open-time loop."""
         assert_bound_loop(self.bound_loop)
 
-    def _record_lock_wait(self, wait_seconds: float) -> None:
-        self._metrics_obj.record_lock_wait(wait_seconds)
-
     async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
         await self._metrics_obj.emit_rpc_event(event)
-
-    def _get_drain_condition(self) -> asyncio.Condition:
-        return self._drain_tracker.get_drain_condition()
-
-    def _current_operation_depth(self, task: asyncio.Task[Any] | None) -> int:
-        return self._drain_tracker.current_operation_depth(task)
-
-    async def _begin_transport_post(self, log_label: str) -> _TransportOperationToken:
-        """Reject new top-level transport work once graceful drain has started."""
-        return await self._drain_tracker.begin_transport_post(log_label)
-
-    async def _begin_transport_task(
-        self,
-        task: asyncio.Task[Any],
-        log_label: str,
-    ) -> _TransportOperationToken:
-        """Admit an internally-spawned task as part of the current operation."""
-        return await self._drain_tracker.begin_transport_task(task, log_label)
-
-    async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
-        await self._drain_tracker.finish_transport_post(token)
 
     def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
         """Return a drain-tracked operation scope for feature-owned work."""
 
         @asynccontextmanager
         async def scope() -> AsyncIterator[None]:
-            token = await self._begin_transport_post(label)
+            token = await self._drain_tracker.begin_transport_post(label)
             try:
                 yield None
             finally:
-                await self._finish_transport_post(token)
+                await self._drain_tracker.finish_transport_post(token)
 
         return scope()
 
@@ -637,80 +615,22 @@ class Session:
         """
         self._auth_coord.update_auth_headers(self)
 
-    def _get_auth_snapshot_lock(self) -> asyncio.Lock:
-        """Return the lazily-initialised auth-snapshot lock.
-
-        Delegates to :meth:`AuthRefreshCoordinator.get_auth_snapshot_lock`.
-        The check-then-assign there is safe without an outer lock because
-        asyncio is single-threaded — no other coroutine can execute between
-        the ``is None`` check and the assignment unless we ``await`` (and
-        the accessor does not).
-        """
-        return self._auth_coord.get_auth_snapshot_lock()
-
-    def _get_refresh_lock(self) -> asyncio.Lock:
-        """Return the lazily-initialised refresh lock.
-
-        Delegates to :meth:`AuthRefreshCoordinator.get_refresh_lock`. Every
-        concurrent caller resolves to the *same* lock instance because the
-        check-then-assign is race-free in a single-threaded asyncio loop,
-        so the single-flight refresh dedupe in :meth:`_await_refresh` is
-        preserved.
-        """
-        return self._auth_coord.get_refresh_lock()
-
-    async def _snapshot(self) -> AuthSnapshot:
-        """Delegate to :meth:`AuthRefreshCoordinator.snapshot`.
-
-        Body lived here pre-PR-8 so the AST guard at
-        ``tests/unit/test_concurrency_refresh_race.py::test_snapshot_acquires_auth_snapshot_lock``
-        could inspect ``Session._snapshot`` via ``inspect.getsource(...)``
-        + ``ast.parse(...)`` for the lock acquire. PR 8 moved the guard
-        to inspect :meth:`AuthRefreshCoordinator.snapshot` (the canonical
-        implementation), so the body collapses to a delegate here.
-
-        The coordinator's body has the same semantic shape (lock acquire
-        → four scalar reads → return) but routes the lock-wait metric
-        through ``host._metrics_obj`` directly rather than via the
-        ``_record_lock_wait`` facade. Whole-request atomicity for
-        ``(csrf, sid, cookies)`` on the wire depends on the terminal's
-        freshness check and no-await invariant; the related AST guards live in
-        ``tests/unit/test_concurrency_refresh_race.py``.
-        """
-        return await self._auth_coord.snapshot(self)
-
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
         """Delegate to :meth:`AuthRefreshCoordinator.update_auth_tokens`.
 
-        Body lived here pre-PR-8 so the AST guard at
-        ``tests/unit/test_concurrency_refresh_race.py::test_update_auth_tokens_has_no_await_inside_mutation_block``
-        could inspect ``Session.update_auth_tokens`` via
-        ``inspect.getsource(...)`` + ``ast.parse(...)`` for the no-await
-        invariant inside the csrf/session_id mutation block. PR 8 moved
-        the guard to inspect
-        :meth:`AuthRefreshCoordinator.update_auth_tokens` (the canonical
-        implementation), so the body collapses to a delegate here. The
-        coordinator's body has the same semantic shape (lock acquire →
-        two scalar writes inside ``try``/``finally``) but routes the
-        lock-wait metric through ``host._metrics_obj`` directly rather
-        than via the ``_record_lock_wait`` facade.
+        Retained on Session because the :class:`RefreshAuthCore`
+        Protocol in ``_auth/session.py`` (consumed by
+        :func:`refresh_auth_session`) structurally requires this method
+        on the core. PR 8 collapsed the previously real body into a
+        delegate that forwards through ``self._auth_coord``; PR #4b of
+        the session-refactor arc inlined sibling delegates but kept
+        this one for the Protocol caller. The coordinator routes the
+        lock-wait metric through ``host._metrics_obj`` directly. The
+        AST guard for the no-await mutation-block invariant now lives
+        on :meth:`AuthRefreshCoordinator.update_auth_tokens`
+        (``test_concurrency_refresh_race.test_update_auth_tokens_has_no_await_inside_mutation_block``).
         """
         await self._auth_coord.update_auth_tokens(self, csrf, session_id)
-
-    def _build_url(
-        self,
-        rpc_method: RPCMethod,
-        snapshot: AuthSnapshot,
-        source_path: str = "/",
-        rpc_id_override: str | None = None,
-    ) -> str:
-        """Compatibility wrapper around :class:`RpcExecutor` URL building."""
-        return self._get_rpc_executor().build_url(
-            rpc_method,
-            snapshot,
-            source_path,
-            rpc_id_override=rpc_id_override,
-        )
 
     async def _refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
         """Rebuild the envelope if auth changed before the terminal POST.
@@ -727,7 +647,7 @@ class Session:
         if not isinstance(request_snapshot, AuthSnapshot) or build_request is None:
             return request
 
-        current_snapshot = await self._snapshot()
+        current_snapshot = await self._auth_coord.snapshot(self)
         if current_snapshot == request_snapshot:
             return request
 
@@ -812,7 +732,7 @@ class Session:
             "disable_internal_retries": disable_internal_retries,
             "rpc_method": rpc_method,
         }
-        snapshot = await self._snapshot()
+        snapshot = await self._auth_coord.snapshot(self)
 
         request = materialize_rpc_request(
             build_request=build_request,
@@ -844,7 +764,7 @@ class Session:
             # PR 12.9 finding).
             queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY)
             if queue_wait is not None:
-                self._record_rpc_queue_wait(queue_wait)
+                self._metrics_obj.record_rpc_queue_wait(queue_wait)
 
     async def transport_post(
         self,
@@ -929,44 +849,6 @@ class Session:
             source_path,
             allow_null,
             _is_retry,
-            disable_internal_retries=disable_internal_retries,
-            operation_variant=operation_variant,
-        )
-
-    def _raise_rpc_error_from_http_status(
-        self,
-        exc: httpx.HTTPStatusError,
-        method: RPCMethod,
-    ) -> NoReturn:
-        """Compatibility wrapper around :class:`RpcExecutor`."""
-        self._get_rpc_executor().raise_rpc_error_from_http_status(exc, method)
-
-    def _raise_rpc_error_from_request_error(
-        self,
-        exc: httpx.RequestError,
-        method: RPCMethod,
-    ) -> NoReturn:
-        """Compatibility wrapper around :class:`RpcExecutor`."""
-        self._get_rpc_executor().raise_rpc_error_from_request_error(exc, method)
-
-    async def _try_refresh_and_retry(
-        self,
-        method: RPCMethod,
-        params: list[Any],
-        source_path: str,
-        allow_null: bool,
-        original_error: Exception,
-        *,
-        disable_internal_retries: bool = False,
-        operation_variant: str | None = None,
-    ) -> Any | None:
-        """Compatibility wrapper around :class:`RpcExecutor`."""
-        return await self._get_rpc_executor().try_refresh_and_retry(
-            method,
-            params,
-            source_path,
-            allow_null,
-            original_error,
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
         )

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -467,18 +467,14 @@ class Session:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
         await self._metrics_obj.emit_rpc_event(event)
 
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+    @asynccontextmanager
+    async def operation_scope(self, label: str) -> AsyncIterator[None]:
         """Return a drain-tracked operation scope for feature-owned work."""
-
-        @asynccontextmanager
-        async def scope() -> AsyncIterator[None]:
-            token = await self._drain_tracker.begin_transport_post(label)
-            try:
-                yield None
-            finally:
-                await self._drain_tracker.finish_transport_post(token)
-
-        return scope()
+        token = await self._drain_tracker.begin_transport_post(label)
+        try:
+            yield None
+        finally:
+            await self._drain_tracker.finish_transport_post(token)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new client operations and wait for in-flight ones to finish.

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -260,7 +260,7 @@ def build_collaborators(
     # ``lock_wait_seconds_*`` metrics ticking inside ``metrics`` — we
     # pass the bound method of the metrics object we just built so the
     # counter cannot capture an unbound seam (which is what would happen
-    # if we forwarded ``Session._record_lock_wait`` before
+    # if we forwarded a Session-level thin wrapper before
     # ``self._metrics_obj`` was assigned in the outer ``__init__``).
     reqid = ReqidCounter(on_lock_wait=metrics.record_lock_wait)
     # Auth refresh coordination — single-flight refresh task, snapshot
@@ -268,7 +268,11 @@ def build_collaborators(
     # ``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``, and
     # ``_auth_snapshot_lock``. Tests and internal callers that need
     # implementation state read the coordinator directly. The live auth
-    # snapshot lock is reachable via :meth:`_get_auth_snapshot_lock`.
+    # snapshot lock is reachable via
+    # :meth:`AuthRefreshCoordinator.get_auth_snapshot_lock` (the
+    # Session-level ``_get_auth_snapshot_lock`` thin wrapper was
+    # inlined in PR #4b — callers now address the coordinator directly
+    # through ``self._auth_coord``).
     # The auth snapshot lock is intentionally distinct from
     # ``_refresh_lock`` — mixing them would re-introduce the
     # reentrancy ambiguity that snapshot-side serialization was added
@@ -370,7 +374,7 @@ def wire_middleware_chain(
         server_error_max_retries_provider=lambda: host._server_error_max_retries,
         refresh_retry_delay_provider=lambda: host._refresh_retry_delay,
         refresh_callable=host._await_refresh,
-        auth_snapshot_provider=host._snapshot,
+        auth_snapshot_provider=lambda: collaborators.auth_coord.snapshot(host),
         is_auth_error=config.is_auth_error,
         refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
     )

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -198,14 +198,15 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
         """One-shot synthetic refresh: bump the generation and atomically
         rewrite csrf/sid/cookies under ``_auth_snapshot_lock``.
 
-        Acquires via the production accessor (``_get_auth_snapshot_lock``)
-        rather than the raw private attribute so the lazy-init path is
-        exercised on this side too — keeps the test in lockstep with how
+        Acquires via the production accessor
+        (``AuthRefreshCoordinator.get_auth_snapshot_lock``) rather than
+        the raw private attribute so the lazy-init path is exercised on
+        this side too — keeps the test in lockstep with how
         ``NotebookLMClient.refresh_auth`` acquires the lock.
         """
         nonlocal current_gen
         new_gen = next(gen_iter)
-        async with core._get_auth_snapshot_lock():
+        async with core._auth_coord.get_auth_snapshot_lock():
             core.auth.csrf_token = f"CSRF_{new_gen}"
             core.auth.session_id = f"SID_{new_gen}"
             # Update the live httpx cookie jar synchronously — this is
@@ -237,7 +238,7 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
         # instance. Without this priming, the lazy-init's "first caller
         # wins" check-then-assign would race the parallel coroutines and
         # potentially create two distinct Lock instances.
-        core._get_auth_snapshot_lock()
+        core._auth_coord.get_auth_snapshot_lock()
 
         # Fan out 50 RPCs and one refresh concurrently. ``asyncio.gather``
         # schedules them together; the handler's ``asyncio.sleep(0)``

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -2,24 +2,28 @@
 
 The race fixed here is a torn read of the auth-headers triple
 ``(csrf_token, session_id, cookies)`` while a refresh runs concurrently
-with in-flight RPCs. Today's ``Session._snapshot()`` reads the four
-scalar fields off ``self.auth`` without holding any lock, and
-``_build_url()`` reads ``session_id``/``authuser``/``account_email``
-directly off ``self.auth`` (not the snapshot). A concurrent ``refresh_auth``
-mutates ``csrf_token`` and ``session_id`` in two separate Python statements
-— there's no asyncio yield between them in production today, but the
-moment any maintainer introduces an ``await`` in that prologue, an RPC
-can observe one field from the OLD generation and another from the NEW
-generation. The fix introduces a dedicated ``_auth_snapshot_lock`` that:
+with in-flight RPCs. ``AuthRefreshCoordinator.snapshot()`` (the
+canonical implementation since PR #4b inlined the Session-level
+``_snapshot`` delegate) reads the four scalar fields off ``self.auth``
+without holding any lock, and ``RpcExecutor.build_url()`` (the
+canonical method since PR #4b also inlined the Session-level
+``_build_url`` delegate) reads ``session_id`` / ``authuser`` /
+``account_email`` directly off ``self.auth`` (not the snapshot). A
+concurrent ``refresh_auth`` mutates ``csrf_token`` and ``session_id``
+in two separate Python statements — there's no asyncio yield between
+them in production today, but the moment any maintainer introduces
+an ``await`` in that prologue, an RPC can observe one field from the
+OLD generation and another from the NEW generation. The fix
+introduces a dedicated ``_auth_snapshot_lock`` that:
 
-1. ``_snapshot()`` acquires under ``async with`` to read all scalars
-   atomically.
+1. ``AuthRefreshCoordinator.snapshot()`` acquires under ``async with``
+   to read all scalars atomically.
 2. The refresh-side mutation block in ``client.refresh_auth`` writes
    ``csrf_token`` + ``session_id`` under the same lock — tiny critical
    section, no awaits inside.
-3. ``_build_url()`` consumes the resulting ``AuthSnapshot`` rather than
-   re-reading ``self.auth`` live, so the URL is built from the same
-   generation the body was.
+3. ``RpcExecutor.build_url()`` consumes the resulting ``AuthSnapshot``
+   rather than re-reading ``self.auth`` live, so the URL is built from
+   the same generation the body was.
 
 This test stresses that contract by spawning 50 RPC tasks AND one
 refresh task into a single ``asyncio.gather`` — they all schedule
@@ -32,12 +36,13 @@ the three observed generation tags must match".
 Test scope (honest framing): this is the *runtime smoke proof* that
 the new design composes correctly under concurrent load. It does not,
 on its own, surface a pre-fix torn read against an unfixed code base —
-the actual hazard ``_build_url`` reading ``self.auth`` live only
-materializes if a yield point slips into ``_perform_authed_post``'s
-prologue between snapshot capture and request build, which is what the
-AST guards in ``tests/unit/test_concurrency_refresh_race.py`` lock
-down statically. Together the AST guards and this runtime check form
-the regression net for the auth-snapshot atomicity contract.
+the actual hazard ``RpcExecutor.build_url`` reading ``self.auth`` live
+only materializes if a yield point slips into
+``_perform_authed_post``'s prologue between snapshot capture and
+request build, which is what the AST guards in
+``tests/unit/test_concurrency_refresh_race.py`` lock down statically.
+Together the AST guards and this runtime check form the regression
+net for the auth-snapshot atomicity contract.
 """
 
 from __future__ import annotations
@@ -143,9 +148,10 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
     ``(body's CSRF, URL's f.sid, Cookie header's SID)`` must agree.
 
     Scope honestly: this test verifies the *new design works end-to-end
-    under concurrent load* — the lock serializes ``_snapshot()`` reads
-    with the refresh writes, the snapshot consumer in ``_build_url``
-    makes URL + body share the same generation, and 50 concurrent RPCs
+    under concurrent load* — the lock serializes
+    ``AuthRefreshCoordinator.snapshot()`` reads with the refresh writes,
+    the snapshot consumer in ``RpcExecutor.build_url`` makes URL + body
+    share the same generation, and 50 concurrent RPCs
     + 1 refresh produce 50 coherent captured triples. It does NOT, on
     its own, surface the pre-fix torn read against an unfixed code
     base — that requires a yield point between snapshot capture and
@@ -243,8 +249,8 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
         # Fan out 50 RPCs and one refresh concurrently. ``asyncio.gather``
         # schedules them together; the handler's ``asyncio.sleep(0)``
         # yields control so the refresh task can interleave its lock-
-        # acquired write between RPC ``_snapshot()`` and
-        # ``client.post(...)`` boundaries.
+        # acquired write between RPC ``AuthRefreshCoordinator.snapshot()``
+        # and ``client.post(...)`` boundaries.
         async def one_rpc() -> None:
             await core.rpc_call(RPC_METHOD, [])
 
@@ -282,8 +288,9 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
     assert not torn, (
         f"{len(torn)}/{len(captured)} requests carried mixed-generation auth state. "
         f"Sample: {torn[:5]}. This indicates the (csrf, sid, cookies) triple is no "
-        f"longer atomic under refresh — check _snapshot() lock acquisition and that "
-        f"_build_url() consumes AuthSnapshot rather than reading self.auth live."
+        f"longer atomic under refresh — check AuthRefreshCoordinator.snapshot() "
+        f"lock acquisition and that RpcExecutor.build_url() consumes AuthSnapshot "
+        f"rather than reading self.auth live."
     )
 
     # The refresh task MUST have completed (otherwise the concurrency

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -108,8 +108,9 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
     core.auth.cookie_jar = MagicMock(name="auth_cookie_jar")
     core.get_http_client.return_value.cookies = MagicMock(name="live_cookie_jar")
     core.kernel = core
-    core._begin_transport_post = AsyncMock(return_value=object())
-    core._finish_transport_post = AsyncMock()
+    core._drain_tracker = MagicMock()
+    core._drain_tracker.begin_transport_post = AsyncMock(return_value=object())
+    core._drain_tracker.finish_transport_post = AsyncMock()
     core.operation_scope = MagicMock()
 
     def operation_scope(_label):

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -517,12 +517,15 @@ class TestCrossDomainCookiePreservation:
 
 
 class TestBuildUrlHL:
-    """_build_url() must thread NOTEBOOKLM_HL into the batchexecute URL.
+    """``RpcExecutor.build_url()`` must thread NOTEBOOKLM_HL into the
+    batchexecute URL.
 
     This is the load-bearing site for setting the interface language on
-    every RPC call.
+    every RPC call. The Session-level ``_build_url`` thin wrapper was
+    inlined in PR #4b — callers reach the canonical method through
+    ``core._get_rpc_executor().build_url(...)``.
 
-    ``_build_url`` now requires an ``AuthSnapshot`` (consumes
+    ``RpcExecutor.build_url`` requires an ``AuthSnapshot`` (consumes
     ``session_id`` / ``authuser`` / ``account_email`` from it rather
     than reading ``self.auth`` live). Tests construct a snapshot inline
     from the fixture's ``AuthTokens`` so the URL-construction logic is
@@ -543,17 +546,17 @@ class TestBuildUrlHL:
     def test_build_url_defaults_hl_to_en(self, auth_tokens, monkeypatch):
         monkeypatch.delenv("NOTEBOOKLM_HL", raising=False)
         core = Session(auth_tokens)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "hl=en" in url
 
     def test_build_url_includes_hl_from_env(self, auth_tokens, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
         core = Session(auth_tokens)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "hl=ja" in url
 
     def test_build_url_empty_env_falls_back_to_en(self, auth_tokens, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_HL", "")
         core = Session(auth_tokens)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "hl=en" in url

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -452,13 +452,17 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
             ]
         )
 
-        async def fake_snapshot() -> AuthSnapshot:
+        async def fake_snapshot(_host: object) -> AuthSnapshot:
             try:
                 return next(snapshots)
             except StopIteration:
                 pytest.fail("unexpected extra auth snapshot")
 
-        core._snapshot = fake_snapshot  # type: ignore[method-assign]
+        # PR #4b inlined ``Session._snapshot``; the production call
+        # sites now read ``self._auth_coord.snapshot(self)`` directly,
+        # so this test swaps the canonical coordinator method instead
+        # of the (now-deleted) Session delegate.
+        core._auth_coord.snapshot = fake_snapshot  # type: ignore[method-assign]
         calls: list[AuthSnapshot] = []
 
         def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -7,8 +7,8 @@ These assertions pin down the new contract:
   session-shrink arc; this test now guards against any new
   ``DeprecationWarning`` escaping ``_chat.py``).
 - ``authuser=`` is present on the chat URL when ``account_email`` is set on
-  the auth tokens, mirroring the batchexecute path in ``_core._build_url``.
-  Previously omitted entirely on the chat endpoint.
+  the auth tokens, mirroring the batchexecute path in
+  ``RpcExecutor.build_url``. Previously omitted entirely on the chat endpoint.
 - Concurrent ``asyncio.gather(ask*3)`` produces three distinct reqid values.
 - 401 mid-chat triggers a refresh, and the post-refresh attempt's body
   carries the refreshed CSRF token (snapshot-per-attempt invariant).

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1072,7 +1072,7 @@ class TestBuildUrlAuthuser:
             session_id="sess",
         )
         core = Session(auth=auth)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "authuser" not in url
 
     def test_non_default_authuser_added(self):
@@ -1083,7 +1083,7 @@ class TestBuildUrlAuthuser:
             authuser=2,
         )
         core = Session(auth=auth)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "authuser=2" in url
 
     def test_account_email_preferred_over_authuser_index(self):
@@ -1095,6 +1095,6 @@ class TestBuildUrlAuthuser:
             account_email="bob@example.com",
         )
         core = Session(auth=auth)
-        url = core._build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
+        url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, self._snapshot_for(core))
         assert "authuser=bob%40example.com" in url
         assert "authuser=2" not in url

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -72,7 +72,7 @@ def test_core_build_url_uses_enterprise_base_url(monkeypatch):
     monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
     core = Session(AuthTokens(cookies={}, csrf_token="csrf", session_id="sid"))
 
-    # ``_build_url`` consumes an ``AuthSnapshot`` so callers
+    # ``RpcExecutor.build_url`` consumes an ``AuthSnapshot`` so callers
     # outside ``_perform_authed_post`` must build one inline.
     from notebooklm._request_types import AuthSnapshot
 
@@ -82,7 +82,7 @@ def test_core_build_url_uses_enterprise_base_url(monkeypatch):
         authuser=core.auth.authuser,
         account_email=core.auth.account_email,
     )
-    url = core._build_url(RPCMethod.LIST_NOTEBOOKS, snapshot)
+    url = core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, snapshot)
 
     assert url.startswith("https://notebooklm.cloud.google.com/_/LabsTailwindUi/data/")
 

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -529,8 +529,9 @@ def _build_rpc_executor() -> Any:
     owner._refresh_retry_delay = 0.0
     owner._perform_authed_post = AsyncMock(side_effect=_fake_perform_authed_post)
     owner._await_refresh = AsyncMock()
-    owner._begin_transport_post = AsyncMock(return_value=object())
-    owner._finish_transport_post = AsyncMock()
+    owner._drain_tracker = MagicMock()
+    owner._drain_tracker.begin_transport_post = AsyncMock(return_value=object())
+    owner._drain_tracker.finish_transport_post = AsyncMock()
     owner._increment_metrics = MagicMock()
     owner._emit_rpc_event = AsyncMock()
     owner.rpc_call = AsyncMock()

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -110,12 +110,12 @@ async def test_drain_rejects_new_work_and_waits_for_in_flight(auth_tokens: AuthT
     release = asyncio.Event()
 
     async def in_flight() -> None:
-        operation_token = await core._begin_transport_post("test")
+        operation_token = await core._drain_tracker.begin_transport_post("test")
         started.set()
         try:
             await release.wait()
         finally:
-            await core._finish_transport_post(operation_token)
+            await core._drain_tracker.finish_transport_post(operation_token)
 
     task = asyncio.create_task(in_flight())
     await started.wait()
@@ -125,7 +125,7 @@ async def test_drain_rejects_new_work_and_waits_for_in_flight(auth_tokens: AuthT
 
     assert not drain_task.done()
     with pytest.raises(RuntimeError, match="draining"):
-        await core._begin_transport_post("new")
+        await core._drain_tracker.begin_transport_post("new")
 
     release.set()
     await drain_task
@@ -137,17 +137,17 @@ async def test_drain_allows_nested_work_inside_accepted_operation(
     auth_tokens: AuthTokens,
 ) -> None:
     core = Session(auth_tokens)
-    outer_token = await core._begin_transport_post("source upload")
+    outer_token = await core._drain_tracker.begin_transport_post("source upload")
     try:
         drain_task = asyncio.create_task(core.drain(timeout=1.0))
         await asyncio.sleep(0)
 
-        nested_token = await core._begin_transport_post("RPC ADD_SOURCE")
-        await core._finish_transport_post(nested_token)
+        nested_token = await core._drain_tracker.begin_transport_post("RPC ADD_SOURCE")
+        await core._drain_tracker.finish_transport_post(nested_token)
 
         assert not drain_task.done()
     finally:
-        await core._finish_transport_post(outer_token)
+        await core._drain_tracker.finish_transport_post(outer_token)
 
     await drain_task
 
@@ -171,19 +171,19 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
     auth_tokens: AuthTokens,
 ) -> None:
     core = Session(auth_tokens)
-    outer_token = await core._begin_transport_post("source upload")
+    outer_token = await core._drain_tracker.begin_transport_post("source upload")
     try:
         drain_task = asyncio.create_task(core.drain(timeout=1.0))
         await asyncio.sleep(0)
 
         async def child_work() -> None:
-            child_token = await core._begin_transport_post("child task")
-            await core._finish_transport_post(child_token)
+            child_token = await core._drain_tracker.begin_transport_post("child task")
+            await core._drain_tracker.finish_transport_post(child_token)
 
         with pytest.raises(RuntimeError, match="draining"):
             await asyncio.create_task(child_work())
     finally:
-        await core._finish_transport_post(outer_token)
+        await core._drain_tracker.finish_transport_post(outer_token)
 
     await drain_task
 
@@ -203,7 +203,7 @@ async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> No
 
     async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
         nonlocal poll_count
-        operation_token = await core._begin_transport_post("poll_status")
+        operation_token = await core._drain_tracker.begin_transport_post("poll_status")
         try:
             poll_count += 1
             if poll_count == 1:
@@ -212,7 +212,7 @@ async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> No
                 return GenerationStatus(task_id=task_id, status="in_progress")
             return GenerationStatus(task_id=task_id, status="completed")
         finally:
-            await core._finish_transport_post(operation_token)
+            await core._drain_tracker.finish_transport_post(operation_token)
 
     api.poll_status = fake_poll_status  # type: ignore[method-assign]
 

--- a/tests/unit/test_refresh_lock_lazy_init.py
+++ b/tests/unit/test_refresh_lock_lazy_init.py
@@ -89,10 +89,13 @@ def test_construct_outside_event_loop_with_callback() -> None:
 
 
 async def _trigger_refresh(core: Session) -> object:
-    """Drive ``_try_refresh_and_retry`` with throwaway args (matches the
-    helper in ``test_refresh_state_machine.py`` so this test pins the same
-    code path)."""
-    return await core._try_refresh_and_retry(
+    """Drive ``RpcExecutor.try_refresh_and_retry`` with throwaway args
+    (matches the helper in ``test_refresh_state_machine.py`` so this
+    test pins the same code path). The Session-level
+    ``_try_refresh_and_retry`` delegate was inlined in PR #4b — callers
+    now reach the executor through ``core._get_rpc_executor()``.
+    """
+    return await core._get_rpc_executor().try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,
         [],
         "/",

--- a/tests/unit/test_refresh_state_machine.py
+++ b/tests/unit/test_refresh_state_machine.py
@@ -1,6 +1,9 @@
 """Refresh state-machine regression tests.
 
-Pins three behaviors of ``Session._try_refresh_and_retry``:
+Pins three behaviors of ``RpcExecutor.try_refresh_and_retry`` (the
+canonical implementation; ``Session._try_refresh_and_retry`` was
+inlined in PR #4b and callers now reach the executor through
+``core._get_rpc_executor()``):
 
 1. Concurrent callers share the same in-flight refresh task (single-flight).
 2. Refresh failures propagate to all waiters with chained ``__cause__``.
@@ -35,8 +38,8 @@ EVENT_TIMEOUT_S = 5.0
 
 
 async def _trigger_refresh(core):
-    """Drive ``_try_refresh_and_retry`` with throwaway args."""
-    return await core._try_refresh_and_retry(
+    """Drive ``RpcExecutor.try_refresh_and_retry`` with throwaway args."""
+    return await core._get_rpc_executor().try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,
         [],
         "/",

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -201,8 +201,7 @@ async def test_session_rpc_call_impl_delegates_to_rpc_executor(monkeypatch) -> N
         == "executed"
     )
     assert (
-        core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, snapshot, "/source")
-        == "url"
+        core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, snapshot, "/source") == "url"
     )
     with pytest.raises(RuntimeError, match="http status"):
         core._get_rpc_executor().raise_rpc_error_from_http_status(

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -146,7 +146,16 @@ def _executor(
 
 
 @pytest.mark.asyncio
-async def test_client_rpc_executor_wrappers_delegate_to_rpc_executor(monkeypatch) -> None:
+async def test_session_rpc_call_impl_delegates_to_rpc_executor(monkeypatch) -> None:
+    """``Session._rpc_call_impl`` remains a delegate (per the ``RpcOwner``
+    Protocol) and routes into :meth:`RpcExecutor.execute`. The other
+    executor-adjacent Session wrappers (``_build_url``,
+    ``_raise_rpc_error_from_http_status`` /
+    ``_raise_rpc_error_from_request_error``, ``_try_refresh_and_retry``)
+    were inlined in PR #4b — callers that need those reach the canonical
+    method on :class:`RpcExecutor` directly via
+    ``core._get_rpc_executor().<name>``.
+    """
     core = Session(_auth_tokens())
     snapshot = AuthSnapshot(
         csrf_token="csrf",
@@ -191,22 +200,28 @@ async def test_client_rpc_executor_wrappers_delegate_to_rpc_executor(monkeypatch
         )
         == "executed"
     )
-    assert core._build_url(RPCMethod.LIST_NOTEBOOKS, snapshot, "/source") == "url"
+    assert (
+        core._get_rpc_executor().build_url(RPCMethod.LIST_NOTEBOOKS, snapshot, "/source")
+        == "url"
+    )
     with pytest.raises(RuntimeError, match="http status"):
-        core._raise_rpc_error_from_http_status(_status_error(500), RPCMethod.LIST_NOTEBOOKS)
+        core._get_rpc_executor().raise_rpc_error_from_http_status(
+            _status_error(500), RPCMethod.LIST_NOTEBOOKS
+        )
     with pytest.raises(RuntimeError, match="request error"):
-        core._raise_rpc_error_from_request_error(
+        core._get_rpc_executor().raise_rpc_error_from_request_error(
             httpx.ConnectError("boom"),
             RPCMethod.LIST_NOTEBOOKS,
         )
     assert (
-        await core._try_refresh_and_retry(
+        await core._get_rpc_executor().try_refresh_and_retry(
             RPCMethod.LIST_NOTEBOOKS,
             [],
             "/",
             False,
             RPCError("auth"),
             disable_internal_retries=True,
+            operation_variant=None,
         )
         == "retried"
     )
@@ -222,7 +237,7 @@ async def test_client_rpc_executor_wrappers_delegate_to_rpc_executor(monkeypatch
         "disable_internal_retries": True,
         "operation_variant": None,
     }
-    assert calls[1][2] == {"rpc_id_override": None}
+    assert calls[1][2] == {}
     assert calls[-1][2] == {
         "disable_internal_retries": True,
         "operation_variant": None,
@@ -450,7 +465,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
     monkeypatch.setattr(core, "_await_refresh", fake_await_refresh)
     monkeypatch.setattr(core, "rpc_call", fake_rpc_call)
 
-    result = await core._try_refresh_and_retry(
+    result = await executor.try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,
         ["param"],
         "/notebook/abc",

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -1,20 +1,26 @@
 """Pin: Session compat methods that the RpcOwner Protocol or test suite
 reach are present on Session AND remain delegates (not real-body code).
 
-Phase 4 / PR 10 will delete the property-bridge layer; without this pin
-that surgery could accidentally re-inline executor / coordinator logic
-into Session.  The eight methods locked here are:
+Phase 4 / PR 10 deleted the property-bridge layer; without this pin
+that surgery could have accidentally re-inlined executor / coordinator
+logic into Session. The pin still guards against the reverse direction
+(real logic creeping back into Session) for the delegates that remain.
 
-    six RpcExecutor-adjacent delegates
-        _build_url
+PR #4b of the session-refactor arc (inline-pure-delegates) deleted
+most of the previously-pinned delegates entirely — every caller now
+talks to the canonical collaborator directly
+(``core._auth_coord.snapshot(self)``, ``core._get_rpc_executor().build_url(...)``,
+``core._drain_tracker.begin_transport_post(...)``, etc.). The
+surviving delegates retained on Session are kept because each has a
+structural protocol caller, a Protocol-imposed call site, or an
+established test-seam swap point that would require its own follow-up
+to migrate:
+
+    Protocol-locked (``RpcOwner`` in ``_rpc_executor.py``)
         _await_refresh
         _rpc_call_impl
-        _raise_rpc_error_from_http_status
-        _raise_rpc_error_from_request_error
-        _try_refresh_and_retry
 
-    two AuthRefreshCoordinator-adjacent delegates collapsed in PR 8
-        _snapshot
+    External Protocol surface (``RefreshAuthCore`` in ``_auth/session.py``)
         update_auth_tokens
 
 A delegate body must be at most three top-level statements with at
@@ -37,17 +43,16 @@ import pytest
 
 from notebooklm._session import Session
 
-# Six RpcExecutor-adjacent delegates + two AST-guard-relocated delegates
-# (after PR 8 collapses them).
+# Delegates that MUST stay on Session because an external protocol or
+# load-bearing test seam still resolves them. See module docstring for
+# the per-method rationale; the deleted ones (``_build_url``,
+# ``_raise_rpc_error_from_http_status``, ``_raise_rpc_error_from_request_error``,
+# ``_try_refresh_and_retry``, ``_snapshot``) were inlined when their
+# external callers migrated to the canonical collaborator method.
 _DELEGATE_METHODS = [
-    "_build_url",
     "_await_refresh",
     "_rpc_call_impl",
-    "_raise_rpc_error_from_http_status",
-    "_raise_rpc_error_from_request_error",
-    "_try_refresh_and_retry",
-    "_snapshot",  # post-PR-8 delegate to AuthRefreshCoordinator.snapshot
-    "update_auth_tokens",  # post-PR-8 delegate to AuthRefreshCoordinator.update_auth_tokens
+    "update_auth_tokens",
 ]
 
 # AST node classes that indicate real logic, not delegation.
@@ -164,14 +169,34 @@ def test_session_satisfies_rpc_owner_protocol_members() -> None:
         assert callable(getattr(Session, name)), f"Session.{name} not callable"
 
 
-def test_session_keeps_transport_wrappers() -> None:
-    """The three ``_ensure_observability_state()`` + ``_drain_tracker``
-    wrappers must stay — the ``__new__``-fixture path relies on them
-    for lazy observability init.
+def test_session_keeps_drain_tracker_seam() -> None:
+    """The ``_drain_tracker`` collaborator must remain reachable as an
+    attribute on Session so feature code and tests can address it
+    directly. The ``_begin_transport_post`` / ``_begin_transport_task``
+    / ``_finish_transport_post`` thin wrappers that previously lived
+    here were inlined in PR #4b (inline-pure-delegates); every caller
+    now talks to ``core._drain_tracker.begin_transport_post(...)`` and
+    friends. This pin protects the underlying attribute seam — both
+    that Session exposes ``_drain_tracker`` and that the tracker has
+    the methods the inlined call sites now reach for.
     """
-    for name in (
-        "_begin_transport_post",
-        "_begin_transport_task",
-        "_finish_transport_post",
+    from notebooklm._transport_drain import TransportDrainTracker
+    from notebooklm.auth import AuthTokens
+
+    core = Session(
+        AuthTokens(cookies={"SID": "sid"}, csrf_token="csrf", session_id="sid"),
+    )
+    assert isinstance(core._drain_tracker, TransportDrainTracker), (
+        "Session must expose ``_drain_tracker`` as a ``TransportDrainTracker`` "
+        "instance — feature code and tests address the tracker through this "
+        "attribute now that the Session-level wrappers are gone."
+    )
+    for method in (
+        "begin_transport_post",
+        "begin_transport_task",
+        "finish_transport_post",
     ):
-        assert callable(getattr(Session, name)), f"Session.{name} missing"
+        assert hasattr(core._drain_tracker, method), (
+            f"TransportDrainTracker.{method} missing — Session call sites "
+            f"that were inlined in PR #4b now resolve to this method."
+        )

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -53,8 +53,9 @@ def mock_core():
     core.authuser_header = MagicMock(
         side_effect=lambda: _authuser_header(core.auth.authuser, core.auth.account_email)
     )
-    core._begin_transport_post = AsyncMock(return_value=object())
-    core._finish_transport_post = AsyncMock()
+    core._drain_tracker = MagicMock()
+    core._drain_tracker.begin_transport_post = AsyncMock(return_value=object())
+    core._drain_tracker.finish_transport_post = AsyncMock()
     core.operation_scope = MagicMock()
 
     def operation_scope(_label):


### PR DESCRIPTION
## Summary

Step #4b of the multi-step Session-module refactor arc:
- #1027 (constructor DI seams)
- #1030 (init extract)
- **#4b (this PR)** — inline pure delegates
- #4c (next) — transport extract; out of scope here

Inlines 14 pure-delegate methods from the `Session` class — each was a one-line forwarder to a collaborator (`self._auth_coord`, `self._drain_tracker`, `self._metrics_obj`, `self._get_rpc_executor()`). Every caller now addresses the canonical collaborator method directly.

- LOC: `_session.py` 985 → 867 (−118)
- Method count: 48 → 32 (−16)
- No public API break, no behavior change

Refs: `docs/improvement.md` §3.1.

## Methods inlined + their canonical collaborator

| method                                    | now resolved via                                                |
|-------------------------------------------|-----------------------------------------------------------------|
| `_record_lock_wait`                       | (dead — coordinator/reqid already use `metrics.record_lock_wait`) |
| `_record_rpc_queue_wait`                  | `self._metrics_obj.record_rpc_queue_wait`                       |
| `_get_drain_condition`                    | (dead — no caller)                                              |
| `_current_operation_depth`                | (dead — no caller)                                              |
| `_get_refresh_lock`                       | (dead — `_auth_refresh._get_refresh_lock` is a separate fn)     |
| `_get_auth_snapshot_lock`                 | `core._auth_coord.get_auth_snapshot_lock`                       |
| `_begin_transport_post`                   | `core._drain_tracker.begin_transport_post`                      |
| `_begin_transport_task`                   | (dead — coordinator method still reachable)                     |
| `_finish_transport_post`                  | `core._drain_tracker.finish_transport_post`                     |
| `_snapshot`                               | `core._auth_coord.snapshot(core)`                               |
| `_build_url`                              | `core._get_rpc_executor().build_url`                            |
| `_raise_rpc_error_from_http_status`       | `core._get_rpc_executor().raise_rpc_error_from_http_status`     |
| `_raise_rpc_error_from_request_error`     | `core._get_rpc_executor().raise_rpc_error_from_request_error`   |
| `_try_refresh_and_retry`                  | `core._get_rpc_executor().try_refresh_and_retry`                |

## Retained on Session (intentionally not inlined)

Each survivor has a structural Protocol caller, an `RpcOwner`-Protocol membership constraint, or a load-bearing test-seam swap point that would require its own follow-up:

- `_await_refresh`, `_rpc_call_impl`, `_increment_metrics`, `_emit_rpc_event` — required by `RpcOwner` Protocol in `_rpc_executor.py`; production call sites in `RpcExecutor` reach them via `self._owner.*`.
- `update_auth_tokens` — required by `RefreshAuthCore` Protocol in `_auth/session.py` (consumed by `refresh_auth_session`).
- `_keepalive_loop` — kept per its docstring contract (tests introspect `core._keepalive_loop`).
- Transport methods (`_perform_authed_post`, `_authed_post_chain_terminal`, `_refresh_request_for_current_auth`, `transport_post`) — real orchestration; the transport extract is the scope of #4c, not this PR.

## Test migration

- `test_session_compat_delegates._DELEGATE_METHODS` reduced to the three remaining Protocol-locked delegates; transport-wrapper pin replaced with a stronger `_drain_tracker` attribute + isinstance assertion that actually instantiates a Session.
- `test_authed_post_pipeline` — swap point migrated from `core._snapshot` to `core._auth_coord.snapshot`.
- `test_rpc_executor` — wrapper-delegation test renamed and rewritten to verify `RpcExecutor` methods via `core._get_rpc_executor()`; `_rpc_call_impl` (still a delegate) keeps its prior shape.
- All `core._build_url` / `core._{begin,finish}_transport_post` / `core._get_auth_snapshot_lock` / `core._try_refresh_and_retry` test sites updated to talk to the canonical collaborator.

## Late-binding invariant preserved

The late-binding comment block in `_session.py` (around lines 73-94) is preserved and updated to reflect that `_snapshot` is now inlined while `update_auth_tokens` survives. The AST guards in `tests/unit/test_concurrency_refresh_race.py` (`test_snapshot_acquires_auth_snapshot_lock` / `test_update_auth_tokens_has_no_await_inside_mutation_block`) already inspect `AuthRefreshCoordinator.snapshot` / `.update_auth_tokens` (the canonical implementation) — they pass without change.

## Test plan

- [x] `uv run pytest` — 6329 passed / 54 skipped (no regressions)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check` — clean
- [x] `tests/unit/test_concurrency_refresh_race.py` AST guards — pass
- [x] `tests/unit/test_init_order.py` — pass
- [x] `tests/_lint/` ADR-007 monkeypatch guards (56 tests) — pass

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored session/auth/telemetry internals and streamlined middleware wiring. No user-facing behavior or public APIs changed.
* **Tests**
  * Updated and realigned unit and integration tests to match the internal refactor; test semantics and assertions remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->