### PR TITLE
docs(test): fix torn-read docstring conflating pre-fix hazard with current behavior

### DIFF
--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -1,27 +1,30 @@
 """atomic ``(csrf, sid, cookies)`` snapshot during refresh.
 
-The race fixed here is a torn read of the auth-headers triple
-``(csrf_token, session_id, cookies)`` while a refresh runs concurrently
-with in-flight RPCs. ``AuthRefreshCoordinator.snapshot()`` (the
-canonical implementation since PR #4b inlined the Session-level
-``_snapshot`` delegate) reads the four scalar fields off ``self.auth``
-without holding any lock, and ``RpcExecutor.build_url()`` (the
-canonical method since PR #4b also inlined the Session-level
-``_build_url`` delegate) reads ``session_id`` / ``authuser`` /
-``account_email`` directly off ``self.auth`` (not the snapshot). A
-concurrent ``refresh_auth`` mutates ``csrf_token`` and ``session_id``
-in two separate Python statements — there's no asyncio yield between
-them in production today, but the moment any maintainer introduces
-an ``await`` in that prologue, an RPC can observe one field from the
-OLD generation and another from the NEW generation. The fix
-introduces a dedicated ``_auth_snapshot_lock`` that:
+The race this test guards against is a torn read of the auth-headers
+triple ``(csrf_token, session_id, cookies)`` while a refresh runs
+concurrently with in-flight RPCs. The pre-fix hazard was: a snapshot
+that read the four scalar fields off ``self.auth`` without holding any
+lock could observe one field from the OLD refresh generation and
+another from the NEW generation if any ``await`` slipped into the
+mutation prologue, and a URL builder that read
+``session_id`` / ``authuser`` / ``account_email`` directly off
+``self.auth`` (rather than off a frozen snapshot) could put the body's
+CSRF and the URL's ``f.sid`` from different generations on the wire.
+
+The fix — which is what the current code implements (see
+``AuthRefreshCoordinator.snapshot`` in
+``src/notebooklm/_session_auth.py:177-207`` and
+``RpcExecutor.build_url`` in ``src/notebooklm/_rpc_executor.py:368-389``,
+the canonical homes since PR #4b inlined the Session-level
+``_snapshot`` / ``_build_url`` thin wrappers) — introduces a dedicated
+``_auth_snapshot_lock`` that:
 
 1. ``AuthRefreshCoordinator.snapshot()`` acquires under ``async with``
-   to read all scalars atomically.
+   to read all scalars atomically into an :class:`AuthSnapshot`.
 2. The refresh-side mutation block in ``client.refresh_auth`` writes
    ``csrf_token`` + ``session_id`` under the same lock — tiny critical
    section, no awaits inside.
-3. ``RpcExecutor.build_url()`` consumes the resulting ``AuthSnapshot``
+3. ``RpcExecutor.build_url()`` consumes the resulting :class:`AuthSnapshot`
    rather than re-reading ``self.auth`` live, so the URL is built from
    the same generation the body was.
 
@@ -34,15 +37,18 @@ under the lock, so the assertion is purely "for every captured request,
 the three observed generation tags must match".
 
 Test scope (honest framing): this is the *runtime smoke proof* that
-the new design composes correctly under concurrent load. It does not,
-on its own, surface a pre-fix torn read against an unfixed code base —
-the actual hazard ``RpcExecutor.build_url`` reading ``self.auth`` live
-only materializes if a yield point slips into
-``_perform_authed_post``'s prologue between snapshot capture and
-request build, which is what the AST guards in
-``tests/unit/test_concurrency_refresh_race.py`` lock down statically.
-Together the AST guards and this runtime check form the regression
-net for the auth-snapshot atomicity contract.
+the design composes correctly under concurrent load. It does not, on
+its own, surface a pre-fix torn read against an unfixed code base —
+the original hazard (a URL builder reading ``self.auth`` live instead
+of consuming a frozen ``AuthSnapshot``) only materializes if a yield
+point slips into ``_perform_authed_post``'s prologue between snapshot
+capture and request build, which is what the AST guards in
+``tests/unit/test_concurrency_refresh_race.py`` lock down statically
+(``RpcExecutor.build_url`` is now AST-checked to consume the snapshot
+rather than read ``self.auth``, and the no-await-before-post invariant
+prevents a yield from re-introducing the gap). Together the AST guards
+and this runtime check form the regression net for the auth-snapshot
+atomicity contract.
 """
 
 from __future__ import annotations

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -13,7 +13,7 @@ CSRF and the URL's ``f.sid`` from different generations on the wire.
 
 The fix — which is what the current code implements (see
 ``AuthRefreshCoordinator.snapshot`` in
-``src/notebooklm/_session_auth.py:177-207`` and
+``src/notebooklm/_session_auth.py:182-207`` and
 ``RpcExecutor.build_url`` in ``src/notebooklm/_rpc_executor.py:368-389``,
 the canonical homes since PR #4b inlined the Session-level
 ``_snapshot`` / ``_build_url`` thin wrappers) — introduces a dedicated


### PR DESCRIPTION
## Summary

Follow-up to #1031 (inline-pure-delegates). The docstring fix in commit a218092 was pushed to the #1031 branch AFTER the squash-merge landed, so it didn't make it into main. This PR carries that fix forward as its own atomic change.

## Background

During PR #1031 review, [coderabbit](https://github.com/teng-lin/notebooklm-py/pull/1031#discussion_r3300449864) caught that my earlier docstring rewrite of `tests/integration/concurrency/test_auth_snapshot_torn_read.py` substituted the new class names (`AuthRefreshCoordinator.snapshot`, `RpcExecutor.build_url`) into sentences that originally described the PRE-FIX broken behavior. The result misleadingly claimed the current canonical methods do the broken thing ("AuthRefreshCoordinator.snapshot() reads the four scalar fields off self.auth without holding any lock") when in fact those methods implement the fix.

## What changed

The rewrite separates two concerns that the previous text conflated:

1. **The pre-fix hazard** is now stated generically (no class name attached to "reads `self.auth` without holding any lock"). It describes what the code USED to do — what the bug was — independent of where today's implementation lives.
2. **The current fix** points at the canonical homes (`AuthRefreshCoordinator.snapshot` in `_session_auth.py:177-207` and `RpcExecutor.build_url` in `_rpc_executor.py:368-389`) with file:line citations and explicitly describes what they do TODAY (acquire lock; consume snapshot).
3. **The "honest framing" paragraph** at lines 39-45 likewise no longer attaches the old hazard to the canonical method name, and names the AST guards (`test_concurrency_refresh_race.py`) that statically enforce the snapshot/build invariant on the current methods.

## Test plan

- [x] `uv run pytest tests/integration/concurrency/test_auth_snapshot_torn_read.py` — passes
- [x] `uv run ruff check` — clean
- [x] Zero behavior change — docstring/comment only

Refs: PR #1031 review thread (https://github.com/teng-lin/notebooklm-py/pull/1031#discussion_r3300449864).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test documentation to more clearly explain the authentication header "torn read" concurrency scenario, the runtime fix applied, and how the runtime test complements static validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->