### PR TITLE
fix(review): address missed post-1012 comments

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -340,7 +340,7 @@ class ArtifactDownloadService:
         json_module = _artifact_seams().json
         try:
             app_data = _artifact_seams()._extract_app_data(html_content)
-        except (ValueError, json_module.JSONDecodeError) as e:
+        except json_module.JSONDecodeError as e:
             raise ArtifactParseError(
                 artifact_type, details=f"Failed to parse content: {e}", cause=e
             ) from e

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -48,6 +48,7 @@ from .rpc import (
     SlideDeckLength,
     VideoFormat,
     VideoStyle,
+    safe_index,
 )
 from .types import (
     Artifact,
@@ -675,12 +676,14 @@ class ArtifactsAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        # Response is wrapped: result[0] contains the artifact data
-        if result and isinstance(result, list) and len(result) > 0:
-            data = result[0]
-            if isinstance(data, list) and len(data) > 9 and data[9]:
-                return data[9][0]  # HTML content
-        return None
+        return safe_index(
+            result,
+            0,
+            9,
+            0,
+            method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
+            source="_artifacts._get_artifact_content",
+        )
 
     async def _download_interactive_artifact(
         self,

--- a/src/notebooklm/_authed_transport.py
+++ b/src/notebooklm/_authed_transport.py
@@ -85,9 +85,9 @@ def parse_retry_after(value: str | None) -> int | None:
 class AuthSnapshot:
     """Point-in-time view of auth headers used to build a single request.
 
-    Captured once per HTTP attempt by ``_perform_authed_post`` and passed
-    into the caller-supplied ``build_request`` factory so the URL/body are
-    consistent for that attempt. On retry, a *new* snapshot is taken so
+    Captured once per HTTP attempt by the authenticated POST pipeline and
+    passed into the caller-supplied ``build_request`` factory so the URL/body
+    are consistent for that attempt. On retry, a *new* snapshot is taken so
     refreshed credentials are picked up before the rebuild.
     """
 

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -122,7 +122,7 @@ class NoteService:
         * deleted: ``["id", None, 2]`` — content is ``None`` and slot[2]
           is the soft-delete sentinel.
         * mind-map: content payload (string at ``row[1]`` or
-          ``row[1][1]``) parses as JSON with ``"children":`` or
+          ``row[1][1]``) is a JSON object with ``"children":`` or
           ``"nodes":`` keys.
         * saved-chat: a plain note row whose metadata flags chat mode.
           That metadata is not reliably present on the wire, so when we
@@ -170,7 +170,12 @@ class NoteService:
 
     @staticmethod
     def _is_mind_map_content(content: str | None) -> bool:
-        return bool(content and ('"children":' in content or '"nodes":' in content))
+        if not content:
+            return False
+        stripped = content.strip()
+        if not (stripped.startswith("{") and stripped.endswith("}")):
+            return False
+        return '"children":' in stripped or '"nodes":' in stripped
 
     # ------------------------------------------------------------------
     # CRUD

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -542,18 +542,14 @@ class Session:
     async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
         await self._drain_tracker.finish_transport_post(token)
 
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+    @asynccontextmanager
+    async def operation_scope(self, label: str) -> AsyncIterator[None]:
         """Return a drain-tracked operation scope for feature-owned work."""
-
-        @asynccontextmanager
-        async def scope() -> AsyncIterator[None]:
-            token = await self._begin_transport_post(label)
-            try:
-                yield None
-            finally:
-                await self._finish_transport_post(token)
-
-        return scope()
+        token = await self._begin_transport_post(label)
+        try:
+            yield None
+        finally:
+            await self._finish_transport_post(token)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new client operations and wait for in-flight ones to finish.

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -544,7 +544,7 @@ class Session:
 
     @asynccontextmanager
     async def operation_scope(self, label: str) -> AsyncIterator[None]:
-        """Return a drain-tracked operation scope for feature-owned work."""
+        """Drain-tracked context manager for feature-owned work."""
         token = await self._begin_transport_post(label)
         try:
             yield None

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -1,25 +1,30 @@
 """atomic ``(csrf, sid, cookies)`` snapshot during refresh.
 
-The race fixed here is a torn read of the auth-headers triple
-``(csrf_token, session_id, cookies)`` while a refresh runs concurrently
-with in-flight RPCs. Today's ``Session._snapshot()`` reads the four
-scalar fields off ``self.auth`` without holding any lock, and
-``_build_url()`` reads ``session_id``/``authuser``/``account_email``
-directly off ``self.auth`` (not the snapshot). A concurrent ``refresh_auth``
-mutates ``csrf_token`` and ``session_id`` in two separate Python statements
-— there's no asyncio yield between them in production today, but the
-moment any maintainer introduces an ``await`` in that prologue, an RPC
-can observe one field from the OLD generation and another from the NEW
-generation. The fix introduces a dedicated ``_auth_snapshot_lock`` that:
+The race this test guards against is a torn read of the auth-headers
+triple ``(csrf_token, session_id, cookies)`` while a refresh runs
+concurrently with in-flight RPCs. The pre-fix hazard was: a snapshot
+that read the four scalar fields off ``self.auth`` without holding any
+lock could observe one field from the OLD refresh generation and
+another from the NEW generation if any ``await`` slipped into the
+mutation prologue, and a URL builder that read
+``session_id`` / ``authuser`` / ``account_email`` directly off
+``self.auth`` rather than off a frozen snapshot could put the body's
+CSRF and the URL's ``f.sid`` from different generations on the wire.
 
-1. ``_snapshot()`` acquires under ``async with`` to read all scalars
-   atomically.
+The fix, which is what the current code implements, introduces a
+dedicated ``_auth_snapshot_lock`` and routes the two critical read/build
+steps through the canonical implementations:
+
+1. ``AuthRefreshCoordinator.snapshot()`` acquires the lock to read all
+   scalars atomically into an :class:`AuthSnapshot`
+   (``src/notebooklm/_session_auth.py:182-207``).
 2. The refresh-side mutation block in ``client.refresh_auth`` writes
    ``csrf_token`` + ``session_id`` under the same lock — tiny critical
    section, no awaits inside.
-3. ``_build_url()`` consumes the resulting ``AuthSnapshot`` rather than
-   re-reading ``self.auth`` live, so the URL is built from the same
-   generation the body was.
+3. ``RpcExecutor.build_url()`` consumes the resulting
+   :class:`AuthSnapshot` rather than re-reading ``self.auth`` live, so
+   the URL is built from the same generation the body was
+   (``src/notebooklm/_rpc_executor.py:366-387``).
 
 This test stresses that contract by spawning 50 RPC tasks AND one
 refresh task into a single ``asyncio.gather`` — they all schedule
@@ -30,14 +35,13 @@ under the lock, so the assertion is purely "for every captured request,
 the three observed generation tags must match".
 
 Test scope (honest framing): this is the *runtime smoke proof* that
-the new design composes correctly under concurrent load. It does not,
-on its own, surface a pre-fix torn read against an unfixed code base —
-the actual hazard ``_build_url`` reading ``self.auth`` live only
-materializes if a yield point slips into ``_perform_authed_post``'s
-prologue between snapshot capture and request build, which is what the
-AST guards in ``tests/unit/test_concurrency_refresh_race.py`` lock
-down statically. Together the AST guards and this runtime check form
-the regression net for the auth-snapshot atomicity contract.
+the design composes correctly under concurrent load. It does not, on
+its own, surface a pre-fix torn read against an unfixed code base —
+the original hazard only materializes if a yield point slips into the
+request prologue between snapshot capture and request build. The AST
+guards in ``tests/unit/test_concurrency_refresh_race.py`` lock that
+down statically, and this runtime check verifies the concurrent
+composition.
 """
 
 from __future__ import annotations
@@ -142,14 +146,15 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
     ``(body's CSRF, URL's f.sid, Cookie header's SID)`` must agree.
 
     Scope honestly: this test verifies the *new design works end-to-end
-    under concurrent load* — the lock serializes ``_snapshot()`` reads
-    with the refresh writes, the snapshot consumer in ``_build_url``
-    makes URL + body share the same generation, and 50 concurrent RPCs
-    + 1 refresh produce 50 coherent captured triples. It does NOT, on
-    its own, surface the pre-fix torn read against an unfixed code
-    base — that requires a yield point between snapshot capture and
-    request build (introduced via a future ``await`` slipping into the
-    prologue), which the AST guards
+    under concurrent load* — the lock serializes
+    ``AuthRefreshCoordinator.snapshot()`` reads with the refresh writes,
+    the snapshot consumer in ``RpcExecutor.build_url()`` makes URL +
+    body share the same generation, and 50 concurrent RPCs + 1 refresh
+    produce 50 coherent captured triples. It does NOT, on its own,
+    surface the pre-fix torn read against an unfixed code base — that
+    requires a yield point between snapshot capture and request build
+    (introduced via a future ``await`` slipping into the prologue),
+    which the AST guards
     (``test_perform_authed_post_has_no_await_before_post_per_iteration``,
     ``test_build_url_does_not_read_self_auth``,
     ``test_snapshot_acquires_auth_snapshot_lock``) catch statically.

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from notebooklm import _artifacts as artifacts_module
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm.types import (
     ArtifactDownloadError,
@@ -50,6 +51,41 @@ def mock_artifacts_api():
         note_service=note_service,
     )
     return api, mock_core
+
+
+class TestDownloadInteractiveArtifact:
+    """Test shared quiz/flashcard download parsing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_extract_app_data_value_error_propagates(
+        self, mock_artifacts_api, monkeypatch, tmp_path
+    ):
+        """Bare ValueError from helper internals is not converted to parse drift."""
+        api, _mock_core = mock_artifacts_api
+        artifact = MagicMock(
+            id="quiz_001",
+            title="My Quiz",
+            is_completed=True,
+            created_at=None,
+        )
+        monkeypatch.setattr(api, "list_quizzes", AsyncMock(return_value=[artifact]))
+        monkeypatch.setattr(
+            api,
+            "_get_artifact_content",
+            AsyncMock(return_value='<html data-app-data="{&quot;quiz&quot;:[]}"></html>'),
+        )
+        format_content = MagicMock(return_value="unused")
+        monkeypatch.setattr(api, "_format_interactive_content", format_content)
+        monkeypatch.setattr(
+            artifacts_module,
+            "_extract_app_data",
+            MagicMock(side_effect=ValueError("implementation bug")),
+        )
+
+        with pytest.raises(ValueError, match="implementation bug"):
+            await api.download_quiz("nb_123", str(tmp_path / "quiz.json"))
+
+        format_content.assert_not_called()
 
 
 class TestDownloadAudio:

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -93,6 +93,18 @@ class TestClassifyRow:
         row = ["note_1", "This is a regular note body."]
         assert service.classify_row(row) == NoteRowKind.NOTE
 
+    def test_plain_note_with_mind_map_key_text_classifies_as_note(
+        self, service: NoteService
+    ) -> None:
+        row = ["note_1", 'My "children": Alice and Bob']
+        assert service.classify_row(row) == NoteRowKind.NOTE
+
+    def test_non_object_json_with_mind_map_key_text_classifies_as_note(
+        self, service: NoteService
+    ) -> None:
+        row = ["note_1", '["children": []]']
+        assert service.classify_row(row) == NoteRowKind.NOTE
+
     def test_nested_note_shape_classifies_as_note(self, service: NoteService) -> None:
         row = ["note_2", ["note_2", "Nested body", None, None, "Nested Title"]]
         assert service.classify_row(row) == NoteRowKind.NOTE


### PR DESCRIPTION
## Summary
- narrow interactive artifact JSON parse handling so bare ValueError propagates
- switch interactive HTML extraction to safe_index and add mind-map false-positive guards
- simplify Session.operation_scope and refresh stale auth snapshot docs/test narrative

## Tests
- uv run pytest tests/unit/test_artifact_downloads.py::TestDownloadInteractiveArtifact::test_extract_app_data_value_error_propagates tests/unit/test_note_service.py::TestClassifyRow -q
- uv run pytest tests/integration/concurrency/test_auth_snapshot_torn_read.py -q
- uv run pytest tests/unit/test_artifact_downloads.py tests/unit/test_note_service.py -q
- uv run ruff check src/notebooklm/_artifact_downloads.py src/notebooklm/_artifacts.py src/notebooklm/_session.py src/notebooklm/_note_service.py src/notebooklm/_authed_transport.py tests/unit/test_artifact_downloads.py tests/unit/test_note_service.py tests/integration/concurrency/test_auth_snapshot_torn_read.py
- uv run mypy src/notebooklm/_artifact_downloads.py src/notebooklm/_artifacts.py src/notebooklm/_session.py src/notebooklm/_note_service.py src/notebooklm/_authed_transport.py