### PR TITLE
refactor(session): extract SessionTransport for the chain leaf and authed-POST retry loop

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -660,12 +660,20 @@ class Session:
         return await self._transport.refresh_request_for_current_auth(request)
 
     async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
-        """Forward to :meth:`SessionTransport.terminal` (body moved in
-        move #4c). The production chain is wired around
-        ``transport.terminal`` directly; this forward is reached only by
-        the direct-call tests in :mod:`tests.unit.test_chain_wiring` and
-        :mod:`tests.unit.test_observability`. AST guard inspects
-        :meth:`SessionTransport.terminal` directly.
+        """Middleware chain leaf — forwards to :meth:`SessionTransport.terminal`.
+
+        The body moved to the collaborator in move #4c
+        (``docs/improvement.md`` §3.1). :meth:`Session.__init__` wires
+        this method as the chain leaf (``wire_middleware_chain`` receives
+        ``self._authed_post_chain_terminal``), so this forward IS the
+        live chain leaf — not a test-only entry point. Routing through
+        the Session forward (rather than directly to
+        :meth:`SessionTransport.terminal`) preserves the canonical seam:
+        a subclass override or fixture-time class-level monkeypatch of
+        this method keeps steering the live chain leaf. AST guard
+        (:func:`tests.unit.test_concurrency_refresh_race.test_kernel_post_terminal_has_no_await_before_post_per_attempt`)
+        inspects :meth:`SessionTransport.terminal` directly because the
+        forward carries no try/await structure.
         """
         return await self._transport.terminal(request)
 

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import random  # noqa: F401 - tests patch this for _backoff jitter
-import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
@@ -17,11 +16,9 @@ from ._loop_affinity import assert_bound_loop
 from ._middleware import (
     RpcRequest,
     RpcResponse,
-    materialize_rpc_request,
 )
-from ._middleware_semaphore import RPC_QUEUE_WAIT_CONTEXT_KEY
 from ._reqid_counter import DEFAULT_STEP as _REQID_DEFAULT_STEP
-from ._request_types import AuthSnapshot, BuildRequest
+from ._request_types import BuildRequest
 from ._rpc_executor import RpcExecutor
 from ._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
@@ -32,11 +29,12 @@ from ._session_config import (
 )
 from ._session_init import (
     build_collaborators,
+    build_session_transport,
     validate_constructor_args,
     wire_middleware_chain,
 )
 from ._session_lifecycle import CookieRotator, CookieSaver
-from ._transport_errors import raise_mapped_post_error
+from ._session_transport import SessionTransport
 from .auth import (
     AuthTokens,
 )
@@ -383,6 +381,32 @@ class Session:
         self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
         self._rpc_executor: RpcExecutor | None = None
 
+        # The authed POST hot path (chain terminal, freshness rebuild,
+        # and ``_perform_authed_post`` entry) lives on
+        # :class:`SessionTransport` (move #4c — ``docs/improvement.md``
+        # §3.1). Build the transport BEFORE :func:`wire_middleware_chain`
+        # so the chain leaf can route through :class:`Session`; the
+        # transport reaches the chain itself through a live-binding
+        # ``chain_provider`` closure that reads
+        # ``self._authed_post_chain`` (set just below), which preserves
+        # the long-standing test pattern of reassigning
+        # ``core._authed_post_chain = fake_chain`` post-construction.
+        # The transport receives :data:`logger` (this module's logger,
+        # ``notebooklm._session``) so transport-error log lines stay in
+        # the historical namespace rather than acquiring a new
+        # ``notebooklm._session_transport`` namespace.
+        self._transport: SessionTransport = build_session_transport(
+            collaborators, host=self, logger=logger
+        )
+
+        # The chain leaf wires to the :class:`Session`-side forward
+        # (:meth:`_authed_post_chain_terminal`), not directly to
+        # :meth:`SessionTransport.terminal`. The forward is the canonical
+        # seam: a subclass override or fixture-time class-level
+        # monkeypatch of ``Session._authed_post_chain_terminal`` keeps
+        # steering the live chain leaf, matching pre-extraction
+        # behavior. The forward adds one bound-method dispatch hop per
+        # chain leaf invocation — negligible overhead.
         wired = wire_middleware_chain(
             config,
             collaborators,
@@ -629,58 +653,21 @@ class Session:
         await self._auth_coord.update_auth_tokens(self, csrf, session_id)
 
     async def _refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
-        """Rebuild the envelope if auth changed before the terminal POST.
-
-        ``Session._perform_authed_post`` materializes the request before the
-        outer chain runs, so the request may wait behind Drain/Semaphore before
-        the leaf sends it. Compare the materialization snapshot to a fresh
-        snapshot immediately before ``Kernel.post``; if auth moved, rebuild the
-        envelope synchronously from ``context["build_request"]``.
+        """Forward to :meth:`SessionTransport.refresh_request_for_current_auth`
+        (body moved in move #4c — ``docs/improvement.md`` §3.1; AST guard
+        now inspects the collaborator method directly).
         """
-        context = request.context
-        request_snapshot = context.get("auth_snapshot")
-        build_request = context.get("build_request")
-        if not isinstance(request_snapshot, AuthSnapshot) or build_request is None:
-            return request
-
-        current_snapshot = await self._auth_coord.snapshot(self)
-        if current_snapshot == request_snapshot:
-            return request
-
-        context["auth_snapshot"] = current_snapshot
-        return materialize_rpc_request(
-            build_request=build_request,
-            snapshot=current_snapshot,
-            context=context,
-        )
+        return await self._transport.refresh_request_for_current_auth(request)
 
     async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
-        """Chain leaf — sends the populated ``RpcRequest`` via ``Kernel.post``.
-
-        The chain interface now carries the actual HTTP request. The terminal
-        reads ``RpcRequest.url`` / ``headers`` / ``body``
-        directly, maps raw ``Kernel.post`` errors into the transport
-        exception shapes consumed by Retry/AuthRefresh middleware, and wraps
-        the returned :class:`httpx.Response` in :class:`RpcResponse`.
+        """Forward to :meth:`SessionTransport.terminal` (body moved in
+        move #4c). The production chain is wired around
+        ``transport.terminal`` directly; this forward is reached only by
+        the direct-call tests in :mod:`tests.unit.test_chain_wiring` and
+        :mod:`tests.unit.test_observability`. AST guard inspects
+        :meth:`SessionTransport.terminal` directly.
         """
-        request = await self._refresh_request_for_current_auth(request)
-        context = request.context
-        log_label = context.get("log_label", "<unknown-chain-call>")
-        start = time.perf_counter()
-        try:
-            response = await self._kernel.post(
-                request.url,
-                headers=request.headers,
-                body=request.body,
-            )
-        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
-            raise_mapped_post_error(
-                log_label=log_label,
-                exc=exc,
-                start=start,
-                logger=logger,
-            )
-        return RpcResponse(response=response, context=context)
+        return await self._transport.terminal(request)
 
     async def _perform_authed_post(
         self,
@@ -690,77 +677,20 @@ class Session:
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
     ) -> httpx.Response:
-        """Authed POST entry point — routes through the middleware chain.
-
-        Compatibility surface preserved so ``RpcExecutor.execute``
-        (``_rpc_executor.py:275``), ``_chat_transport`` (``_chat_transport.py:64``),
-        and direct callers (``client._session._perform_authed_post(...)``) keep
-        the same keyword-only signature. The body now builds an
-        :class:`RpcRequest` with the three keyword-only args stashed into
-        ``context`` and dispatches into :attr:`_authed_post_chain`.
-        Middlewares land one per PR in 12.3–12.8; the wiring shape stays
-        unchanged.
-
-        ``rpc_method`` (new in PR 12.4) is the resolved method name string
-        (``RPCMethod.name``) for RPC callers and ``None`` for the chat
-        streaming path. ``MetricsMiddleware`` reads it from
-        ``request.context["rpc_method"]`` to populate
-        :attr:`RpcTelemetryEvent.method` and to decide whether to fire the
-        emission at all — chat-side callers that pass ``None`` skip emission,
-        matching the pre-chain behavior (where ``_chat_transport`` never
-        called ``_emit_rpc_event``).
-
-        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body`` are
-        populated through :func:`materialize_rpc_request` before the chain sees
-        the request. ``context["build_request"]`` remains as the bounded
-        rebuild recipe for auth-refresh and pre-terminal freshness checks.
+        """Forward to :meth:`SessionTransport.perform_authed_post` (body
+        moved in move #4c — ``docs/improvement.md`` §3.1). Kept on
+        :class:`Session` because the :class:`RpcOwner` Protocol in
+        :mod:`notebooklm._rpc_executor` structurally requires the method
+        here (``RpcExecutor.execute`` reaches it via ``self._owner``).
+        ``_chat_transport`` and ``client._session._perform_authed_post(...)``
+        direct callers keep the same keyword-only signature.
         """
-        # Event-loop affinity guard. The check lives here so it fires once
-        # per chain invocation rather than once per leaf attempt.
-        # ``assert_bound_loop`` is a no-op when ``bound_loop``
-        # is ``None`` (pre-open / fresh fixture); it raises only when the
-        # currently-running loop differs from the one captured at
-        # ``open()``-time.
-        self.assert_bound_loop()
-        context = {
-            "build_request": build_request,
-            "log_label": log_label,
-            "disable_internal_retries": disable_internal_retries,
-            "rpc_method": rpc_method,
-        }
-        snapshot = await self._auth_coord.snapshot(self)
-
-        request = materialize_rpc_request(
+        return await self._transport.perform_authed_post(
             build_request=build_request,
-            snapshot=snapshot,
-            context=context,
+            log_label=log_label,
+            disable_internal_retries=disable_internal_retries,
+            rpc_method=rpc_method,
         )
-        context["auth_snapshot"] = snapshot
-
-        # The ``max_concurrent_rpcs`` slot is acquired by
-        # :class:`SemaphoreMiddleware` (chain position 2, between Metrics
-        # and Retry) — that placement keeps Drain admitting queued tasks
-        # AND keeps Metrics timing the queue wait, while still bounding
-        # the retry-and-refresh cohort to one slot per logical RPC.
-        # The middleware writes the queue-wait duration to
-        # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` so the recorder
-        # below can forward it to ``ClientMetrics`` without giving the
-        # middleware an opinionated ``ClientMetrics`` dependency.
-        try:
-            result = await self._authed_post_chain(request)
-            return result.response
-        finally:
-            # Record queue wait even if the chain raised. A failed chain
-            # (RetryMiddleware budget exhaustion, AuthRefreshMiddleware
-            # refresh failure, etc.) MUST still surface the queue-wait
-            # latency. ``SemaphoreMiddleware`` writes the duration to
-            # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` after the
-            # semaphore is acquired; absence of the key means the slot
-            # was never acquired and there's nothing to record (gemini
-            # PR 12.9 finding).
-            queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY)
-            if queue_wait is not None:
-                self._metrics_obj.record_rpc_queue_wait(queue_wait)
 
     async def transport_post(
         self,

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -28,6 +28,7 @@ callables; the caller (``Session.__init__``) owns the
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
@@ -47,6 +48,7 @@ from ._session_auth import AuthRefreshCoordinator
 from ._session_config import normalize_max_concurrent_uploads
 from ._session_helpers import _resolve_keepalive_interval
 from ._session_lifecycle import ClientLifecycle, CookieRotator, CookieSaver
+from ._session_transport import SessionTransport
 from ._transport_drain import TransportDrainTracker
 from .auth import AuthTokens
 
@@ -343,6 +345,54 @@ if TYPE_CHECKING:
     from ._session import Session
 
 
+def build_session_transport(
+    collaborators: SessionCollaborators,
+    *,
+    host: Session,
+    logger: logging.Logger,
+) -> SessionTransport:
+    """Construct the :class:`SessionTransport` collaborator.
+
+    Built **after** :func:`build_collaborators` and **before**
+    :func:`wire_middleware_chain`, because the wired chain is built
+    around ``transport.terminal``. The transport reaches the chain
+    through a live-binding ``chain_provider`` closure that reads
+    ``host._authed_post_chain`` on every authed POST; that attribute is
+    assigned by :class:`Session.__init__` immediately after
+    :func:`wire_middleware_chain` returns. Using a provider closure
+    (rather than a frozen reference) preserves the pre-extraction
+    behavior where tests reassign ``core._authed_post_chain = fake_chain``
+    to install a fake chain and expect the next call to honor it.
+
+    The ``snapshot_provider`` closure captures ``host`` so the transport
+    never needs a direct back-reference to :class:`Session`. The
+    ``bound_loop_check`` lambda re-reads ``host.assert_bound_loop`` on
+    every call rather than freezing the bound method at construction
+    time, so a test that reassigns ``core.assert_bound_loop = mock``
+    after construction still steers the live check — preserving the
+    pre-extraction behavior where the call site read
+    ``self.assert_bound_loop`` live. The lookup goes through
+    ``host.assert_bound_loop`` rather than the lifecycle's
+    ``_bound_loop`` directly so a Mock-based Session fixture (which
+    sets ``_lifecycle`` to a MagicMock) still short-circuits the guard.
+
+    The ``logger`` is forwarded as-is — typically the module logger of
+    ``notebooklm._session`` — so transport-error log lines keep
+    appearing under the historical ``notebooklm._session`` namespace
+    rather than acquiring a new ``notebooklm._session_transport``
+    namespace that callers' log filters / ``caplog`` selectors would
+    not yet recognise.
+    """
+    return SessionTransport(
+        kernel=collaborators.kernel,
+        snapshot_provider=lambda: collaborators.auth_coord.snapshot(host),
+        chain_provider=lambda: getattr(host, "_authed_post_chain", None),
+        metrics=collaborators.metrics,
+        bound_loop_check=lambda: host.assert_bound_loop(),
+        logger=logger,
+    )
+
+
 def wire_middleware_chain(
     config: ValidatedSessionConfig,
     collaborators: SessionCollaborators,
@@ -395,6 +445,7 @@ __all__ = [
     "ValidatedSessionConfig",
     "WiredMiddleware",
     "build_collaborators",
+    "build_session_transport",
     "validate_constructor_args",
     "wire_middleware_chain",
 ]

--- a/src/notebooklm/_session_transport.py
+++ b/src/notebooklm/_session_transport.py
@@ -1,0 +1,293 @@
+"""Authed POST transport collaborator — the chain leaf for :class:`Session`.
+
+Extracted from ``Session`` as move #4c of the session-refactor arc
+(``docs/improvement.md`` §3.1). ``SessionTransport`` owns the three
+pieces of the authed POST hot path that used to live on :class:`Session`:
+
+* :meth:`SessionTransport.terminal` — the middleware-chain leaf. Sends
+  the populated :class:`RpcRequest` via :meth:`Kernel.post` and maps the
+  raw transport errors into the ``Transport*`` exception shapes consumed
+  by ``RetryMiddleware`` / ``AuthRefreshMiddleware``.
+* :meth:`SessionTransport.refresh_request_for_current_auth` — re-builds
+  the envelope from ``context["build_request"]`` if a concurrent refresh
+  moved the auth snapshot between materialization and the terminal POST.
+* :meth:`SessionTransport.perform_authed_post` — the entry point the
+  RPC executor / chat path / ``Session.transport_post`` call. Runs the
+  loop-affinity guard, captures the current auth snapshot, materializes
+  the request envelope, dispatches it through the wired middleware
+  chain, and records the semaphore queue-wait latency.
+
+``Session`` keeps :meth:`Session._authed_post_chain_terminal`,
+:meth:`Session._refresh_request_for_current_auth`, and
+:meth:`Session._perform_authed_post` as one-line forwards to the
+collaborator so the long-standing call surfaces (``RpcOwner`` Protocol,
+``core._perform_authed_post(...)`` direct callers, and the test-side
+``core._authed_post_chain_terminal = fake`` monkeypatch point) keep
+working unchanged. The two AST guards in
+``tests/unit/test_concurrency_refresh_race.py`` follow the source by
+inspecting the collaborator methods directly — the Session forwards
+carry only the dispatch hop, so there is no try/await structure on the
+Session side for those guards to inspect after the move.
+
+``_refresh_retry_delay`` deliberately stays on :class:`Session`.
+``perform_authed_post`` does not read it — the retry/backoff budget for
+the refresh path is owned by ``AuthRefreshMiddleware`` and by
+``RpcExecutor.try_refresh_and_retry``, both of which read
+``host._refresh_retry_delay`` live through provider lambdas wired in
+``_session_init.wire_middleware_chain``. Integration tests that assign
+``client._session._refresh_retry_delay = 0`` keep steering the live
+delay without migration.
+
+Construction order in :class:`Session.__init__`:
+:func:`notebooklm._session_init.build_session_transport` constructs the
+transport **before** :func:`wire_middleware_chain`. The wired chain
+leaf is :meth:`Session._authed_post_chain_terminal` (a one-line forward
+to :meth:`SessionTransport.terminal`) — wiring through the Session
+forward preserves the canonical seam for a subclass override or
+fixture-time class-level monkeypatch of that method. The chain itself
+is reached by the transport through an injected ``chain_provider``
+closure that reads ``host._authed_post_chain`` live, late on every
+:meth:`perform_authed_post` call; this both breaks the construction
+cycle and preserves the long-standing test pattern of reassigning
+``core._authed_post_chain`` to install a fake chain. The
+:class:`AuthRefreshCoordinator` snapshot is reached via an injected
+``snapshot_provider`` callable so :class:`SessionTransport` never has
+to hold a direct back-reference to :class:`Session`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ._middleware import (
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    materialize_rpc_request,
+)
+from ._middleware_semaphore import RPC_QUEUE_WAIT_CONTEXT_KEY
+from ._request_types import AuthSnapshot, BuildRequest
+from ._transport_errors import raise_mapped_post_error
+
+if TYPE_CHECKING:
+    from ._client_metrics import ClientMetrics
+    from ._kernel import Kernel
+
+
+class SessionTransport:
+    """Authed POST chain leaf and entry-point collaborator.
+
+    Owns the three methods extracted from :class:`Session` in move #4c.
+    Does NOT own lifecycle (that stays on :class:`ClientLifecycle`) nor
+    retry/refresh budget state (that stays on :class:`Session` and is
+    threaded into middleware via provider lambdas).
+
+    The chain reference is fetched late on every
+    :meth:`perform_authed_post` — just before chain dispatch, after
+    snapshot + materialization — through the injected ``chain_provider``
+    closure (typically ``lambda: host._authed_post_chain``). The lookup
+    is intentionally deferred so a chain reassignment that happens
+    while the snapshot capture awaits still steers the dispatch,
+    matching the pre-extraction behavior where ``self._authed_post_chain``
+    was read at the dispatch site.
+
+    The injected ``logger`` is held so error messages mapped through
+    :func:`notebooklm._transport_errors.raise_mapped_post_error` keep
+    appearing under the original ``notebooklm._session`` namespace
+    rather than ``notebooklm._session_transport`` — preserving the
+    log-filter / caplog vocabulary callers may already rely on.
+    """
+
+    def __init__(
+        self,
+        *,
+        kernel: Kernel,
+        snapshot_provider: Callable[[], Awaitable[AuthSnapshot]],
+        chain_provider: Callable[[], NextCall | None],
+        metrics: ClientMetrics,
+        bound_loop_check: Callable[[], None],
+        logger: logging.Logger,
+    ) -> None:
+        self._kernel = kernel
+        self._snapshot_provider = snapshot_provider
+        # Live-binding chain accessor. The wired chain is installed onto
+        # :class:`Session` AFTER :class:`SessionTransport` is constructed
+        # (the chain's leaf is :meth:`terminal`, so the transport must
+        # exist first). Tests also reassign ``core._authed_post_chain``
+        # post-construction to install a fake chain — going through a
+        # provider closure (called late in :meth:`perform_authed_post`)
+        # ensures those reassignments take effect on the next call
+        # without any further mutation here.
+        self._chain_provider = chain_provider
+        self._metrics = metrics
+        self._bound_loop_check = bound_loop_check
+        self._logger = logger
+
+    async def refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
+        """Rebuild the envelope if auth changed before the terminal POST.
+
+        :meth:`perform_authed_post` materializes the request before the
+        outer chain runs, so the request may wait behind Drain / Semaphore
+        before the leaf sends it. Compare the materialization snapshot to
+        a fresh snapshot immediately before :meth:`Kernel.post`; if auth
+        moved, rebuild the envelope synchronously from
+        ``context["build_request"]``.
+
+        AST guarded — see
+        :func:`tests.unit.test_concurrency_refresh_race.test_terminal_freshness_check_has_no_await_after_materialization`
+        which reads the source of this method to assert no ``await``
+        follows :func:`materialize_rpc_request`. Any restructuring here
+        must keep that invariant: the snapshot and the rebuilt envelope
+        must be produced together with no suspension point between them.
+        """
+        context = request.context
+        request_snapshot = context.get("auth_snapshot")
+        build_request = context.get("build_request")
+        if not isinstance(request_snapshot, AuthSnapshot) or build_request is None:
+            return request
+
+        current_snapshot = await self._snapshot_provider()
+        if current_snapshot == request_snapshot:
+            return request
+
+        context["auth_snapshot"] = current_snapshot
+        return materialize_rpc_request(
+            build_request=build_request,
+            snapshot=current_snapshot,
+            context=context,
+        )
+
+    async def terminal(self, request: RpcRequest) -> RpcResponse:
+        """Chain leaf — sends the populated ``RpcRequest`` via ``Kernel.post``.
+
+        The chain interface carries the actual HTTP request. The terminal
+        reads ``RpcRequest.url`` / ``headers`` / ``body`` directly, maps raw
+        ``Kernel.post`` errors into the transport exception shapes consumed
+        by ``RetryMiddleware`` / ``AuthRefreshMiddleware``, and wraps the
+        returned :class:`httpx.Response` in :class:`RpcResponse`.
+
+        AST guarded — see
+        :func:`tests.unit.test_concurrency_refresh_race.test_kernel_post_terminal_has_no_await_before_post_per_attempt`
+        which reads the source of this method to assert no ``await``
+        precedes the ``self._kernel.post(...)`` call inside the protective
+        ``try`` block. A concurrent refresh between freshness rebuild and
+        the POST would otherwise mismatch the cookie jar against the
+        materialized headers.
+        """
+        request = await self.refresh_request_for_current_auth(request)
+        context = request.context
+        log_label = context.get("log_label", "<unknown-chain-call>")
+        start = time.perf_counter()
+        try:
+            response = await self._kernel.post(
+                request.url,
+                headers=request.headers,
+                body=request.body,
+            )
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            raise_mapped_post_error(
+                log_label=log_label,
+                exc=exc,
+                start=start,
+                logger=self._logger,
+            )
+        return RpcResponse(response=response, context=context)
+
+    async def perform_authed_post(
+        self,
+        *,
+        build_request: BuildRequest,
+        log_label: str,
+        disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
+    ) -> httpx.Response:
+        """Authed POST entry point — routes through the middleware chain.
+
+        Compatibility surface preserved on :class:`Session` so
+        ``RpcExecutor.execute`` (``_rpc_executor.py``),
+        ``_chat_transport`` (``_chat_transport.py``), and direct
+        callers (``client._session._perform_authed_post(...)``) keep the
+        same keyword-only signature.
+
+        ``RpcRequest.url`` / ``headers`` / ``body`` are populated through
+        :func:`materialize_rpc_request` before the chain sees the
+        request. ``context["build_request"]`` remains as the bounded
+        rebuild recipe for auth-refresh and pre-terminal freshness
+        checks.
+
+        Raises:
+            RuntimeError: if the chain provider returns ``None``. The
+                wired chain is installed by :class:`Session.__init__`
+                immediately after :class:`SessionTransport` is built; a
+                ``None`` value indicates a construction-time wiring bug,
+                not a runtime condition.
+        """
+        # Event-loop affinity guard. The check lives here so it fires once
+        # per chain invocation rather than once per leaf attempt.
+        # ``assert_bound_loop`` (forwarded through ``bound_loop_check``) is
+        # a no-op when ``bound_loop`` is ``None`` (pre-open / fresh
+        # fixture); it raises only when the currently-running loop differs
+        # from the one captured at ``open()``-time.
+        self._bound_loop_check()
+        context = {
+            "build_request": build_request,
+            "log_label": log_label,
+            "disable_internal_retries": disable_internal_retries,
+            "rpc_method": rpc_method,
+        }
+        snapshot = await self._snapshot_provider()
+
+        request = materialize_rpc_request(
+            build_request=build_request,
+            snapshot=snapshot,
+            context=context,
+        )
+        context["auth_snapshot"] = snapshot
+
+        # The ``max_concurrent_rpcs`` slot is acquired by
+        # :class:`SemaphoreMiddleware` (chain position 2, between Metrics
+        # and Retry) — that placement keeps Drain admitting queued tasks
+        # AND keeps Metrics timing the queue wait, while still bounding
+        # the retry-and-refresh cohort to one slot per logical RPC.
+        # The middleware writes the queue-wait duration to
+        # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` so the recorder
+        # below can forward it to ``ClientMetrics`` without giving the
+        # middleware an opinionated ``ClientMetrics`` dependency.
+        #
+        # Chain resolution is deferred to here — AFTER snapshot capture +
+        # materialization, immediately before dispatch — so a reassignment
+        # of ``host._authed_post_chain`` that lands while the snapshot
+        # call awaits still steers this dispatch. Pre-extraction, the
+        # equivalent ``self._authed_post_chain(request)`` read happened
+        # at the dispatch site for the same live-binding reason; the
+        # provider closure preserves that timing.
+        chain = self._chain_provider()
+        if chain is None:  # pragma: no cover - wiring bug guard
+            raise RuntimeError(
+                "SessionTransport.perform_authed_post called before the "
+                "wired chain was installed on Session; Session construction "
+                "must assign self._authed_post_chain before any authed POST."
+            )
+        try:
+            result = await chain(request)
+            return result.response
+        finally:
+            # Record queue wait even if the chain raised. A failed chain
+            # (RetryMiddleware budget exhaustion, AuthRefreshMiddleware
+            # refresh failure, etc.) MUST still surface the queue-wait
+            # latency. ``SemaphoreMiddleware`` writes the duration to
+            # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` after the
+            # semaphore is acquired; absence of the key means the slot
+            # was never acquired and there's nothing to record (gemini
+            # PR 12.9 finding).
+            queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY)
+            if queue_wait is not None:
+                self._metrics.record_rpc_queue_wait(queue_wait)
+
+
+__all__ = ["SessionTransport"]

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -71,8 +71,8 @@ import pytest
 
 from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 from notebooklm._rpc_executor import RpcExecutor
-from notebooklm._session import Session
 from notebooklm._session_auth import AuthRefreshCoordinator
+from notebooklm._session_transport import SessionTransport
 from notebooklm.rpc import RPCMethod
 
 _UNIT_CONFTEST_SPEC = importlib.util.spec_from_file_location(
@@ -98,8 +98,15 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
     await is the actual ``Kernel.post`` send. An await in that try prologue
     would let a concurrent refresh change the cookie jar between request
     rebuild and wire send.
+
+    The terminal body lives on :meth:`SessionTransport.terminal` after
+    move #4c — ``Session._authed_post_chain_terminal`` is now a one-line
+    forward to it, so the AST guard must inspect the collaborator method
+    that carries the actual body. The error messages still mention
+    ``Session._authed_post_chain_terminal`` as the conceptual entry point
+    because that is still where chain-leaf callers reach the behavior.
     """
-    src = textwrap.dedent(inspect.getsource(Session._authed_post_chain_terminal))
+    src = textwrap.dedent(inspect.getsource(SessionTransport.terminal))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
@@ -204,8 +211,15 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
 
 
 def test_terminal_freshness_check_has_no_await_after_materialization():
-    """Freshness rebuild must not yield after materializing a new envelope."""
-    src = textwrap.dedent(inspect.getsource(Session._refresh_request_for_current_auth))
+    """Freshness rebuild must not yield after materializing a new envelope.
+
+    The freshness-rebuild body lives on
+    :meth:`SessionTransport.refresh_request_for_current_auth` after move
+    #4c — ``Session._refresh_request_for_current_auth`` is now a one-line
+    forward to it, so the AST guard must inspect the collaborator method
+    that carries the actual body.
+    """
+    src = textwrap.dedent(inspect.getsource(SessionTransport.refresh_request_for_current_auth))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 


### PR DESCRIPTION
## Summary

Move #4c of the Session refactor arc (`docs/improvement.md` §3.1). Extracts three methods from `Session` into a new `SessionTransport` collaborator (`src/notebooklm/_session_transport.py`) — pure mechanical, no behavior change.

- `SessionTransport.terminal` — middleware-chain leaf (`Kernel.post` + raw transport error mapping).
- `SessionTransport.refresh_request_for_current_auth` — re-builds the envelope if auth moved between materialization and the terminal POST.
- `SessionTransport.perform_authed_post` — entry point that runs the loop-affinity guard, captures the auth snapshot, materializes the request, and dispatches through the wired middleware chain.

`Session` keeps the three method names as one-line forwards so:
- the `RpcOwner` Protocol surface (`Session._perform_authed_post`),
- direct callers (`client._session._perform_authed_post(...)`, `_chat_transport`),
- and the test-side `core._authed_post_chain_terminal = fake` monkeypatch point

all keep working unchanged.

## Prior steps (Session refactor arc)

- #1027 — constructor DI for late-bound test seams; drop `Kernel.http_client` setter
- #1030 — extract `Session.__init__` into `_session_init.py` helpers
- #1031 — inline pure delegates, route callers to canonical collaborators
- **#4c (this PR)** — extract `SessionTransport` for the chain leaf + authed-POST entry

Move #5 (`RpcDispatcher` extract for `rpc_call` orchestration) is stacked on top of this PR and will land as a follow-up.

## Decisions documented

### `_refresh_retry_delay` placement

**Stays on `Session`** as an instance attribute. `SessionTransport.perform_authed_post` does NOT read it — the retry/backoff budget for the refresh path is owned by `AuthRefreshMiddleware` and `RpcExecutor.try_refresh_and_retry`, both of which read `host._refresh_retry_delay` live through provider lambdas wired in `_session_init.wire_middleware_chain`. Integration tests that assign `client._session._refresh_retry_delay = 0` (in `test_auth_refresh_vcr.py`, `test_auto_refresh.py`, `test_error_paths_vcr.py`) keep steering the live delay without any test migration.

### Chain leaf wiring — through `Session._authed_post_chain_terminal`, not directly to `transport.terminal`

The middleware chain leaf is wired through `Session._authed_post_chain_terminal` (the one-line forward) rather than directly to `SessionTransport.terminal`. The forward is the canonical seam: a subclass override or fixture-time class-level monkeypatch of `Session._authed_post_chain_terminal` keeps steering the live chain leaf, preserving pre-extraction behavior. The forward adds one bound-method dispatch hop per chain invocation — negligible overhead.

### Live-binding seams preserved through provider closures

- **`chain_provider`** reads `host._authed_post_chain` on every `perform_authed_post` call, late (just before dispatch). A reassignment that lands while the snapshot await is suspended still steers the in-flight dispatch — matching pre-extraction behavior where `self._authed_post_chain` was read at the dispatch site.
- **`bound_loop_check`** is `lambda: host.assert_bound_loop()` (not a captured bound method), so a test that reassigns `core.assert_bound_loop = mock` after construction still steers the live check.
- **`logger`** is injected so transport-error log lines stay under `notebooklm._session` rather than acquiring a new `notebooklm._session_transport` namespace that callers' log filters / `caplog` selectors would not yet recognise.

### AST guards retargeted

The two guards in `tests/unit/test_concurrency_refresh_race.py` now inspect `SessionTransport.terminal` and `SessionTransport.refresh_request_for_current_auth` directly via `inspect.getsource(...)`. The Session forwards carry only a dispatch hop — there's no try/await structure on the Session side for those guards to inspect after the move.

## Test plan

- [x] `uv run pytest` — 6329 passed, 54 skipped (no new skips)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check src tests` — clean
- [x] AST guards (`test_kernel_post_terminal_has_no_await_before_post_per_attempt`, `test_terminal_freshness_check_has_no_await_after_materialization`) pass against the new targets
- [x] `test_chain_wiring.py` (chain routes from `_perform_authed_post`, RpcExecutor path, terminal context reads, ADR-009 ordering) all pass — verifies wiring through the Session forward still flows to `Kernel.post`
- [x] `test_observability.py` — `core._authed_post_chain_terminal = fake_terminal` plus chain rebuild still works
- [x] `test_session_compat_delegates.py` — `RpcOwner` Protocol surface preserved
- [x] `test_concurrency_refresh_race.py` (8 tests) — concurrency invariants preserved on the new method bodies

## Files

| File | Change | LOC |
|---|---|---|
| `src/notebooklm/_session_transport.py` | **NEW** | 289 |
| `src/notebooklm/_session.py` | three method bodies → 1-line forwards; transport built in `__init__` | 793 (down from 863) |
| `src/notebooklm/_session_init.py` | added `build_session_transport` helper | 451 (up from 400) |
| `tests/unit/test_concurrency_refresh_race.py` | AST guards retargeted to `SessionTransport.{terminal,refresh_request_for_current_auth}` | +18/-4 |

## Deferred polish findings

- **`_session.py` is 793 LOC** (move-#4c target was <650). The remaining bulk is `Session.__init__`'s kwargs docstring (~140 lines, lines 175-314) which is user-facing public API documentation for each constructor seam. Trimming it would lose load-bearing user-visible content — that's a separate "Session __init__ docstring shrink" task, not part of #4c's mechanical extraction.
- **`_session_transport.py` is 289 LOC** (target 150-250). The slip is concentrated in load-bearing AST-guard reminder comments on the two guarded methods and the live-binding rationale in the module/class docstring. These exist to keep future maintainers from accidentally breaking the concurrency invariants pinned by `tests/unit/test_concurrency_refresh_race.py`.

## Polish trail (Step 4 of /execute-task)

- **Stage 1 — code-simplifier**: 0 changes (mechanical extraction is already byte-equivalent to the original; no opportunistic simplification appropriate during a pure move).
- **Stage 2 — triple review (claude + codex; agy skipped per user preference)**: codex flagged 2 Important + 2 Suggestion findings — all four applied in the same commit:
  1. Chain leaf rewired through the Session forward (preserves subclass-override seam).
  2. Chain provider resolved late (after snapshot + materialization) to preserve pre-extraction dispatch-time read timing.
  3. `bound_loop_check` switched to lambda for live `host.assert_bound_loop` lookup.
  4. Logger injected into `SessionTransport` to preserve `notebooklm._session` namespace.
- **Stage 3 — ultrathink**: no new critical findings; updated module docstring to accurately reflect post-fix wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized session internals to separate authentication snapshot handling from request transport and middleware wiring, improving maintainability and hot‑path clarity.
  * Preserved existing public APIs and call signatures to avoid breaking changes.

* **Tests**
  * Updated unit tests to target the new transport entry points while keeping behavioral invariants intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->