### PR TITLE
feat(exceptions): add NotFoundError umbrella for cross-type not-found catches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`NotFoundError` cross-domain umbrella exception.** Catch `NotFoundError` to handle any "resource not found" case across notebooks, sources, and artifacts in one `except` clause — replacing `except (NotebookNotFoundError, SourceNotFoundError, ArtifactNotFoundError):`. `NotebookNotFoundError`, `SourceNotFoundError`, and `ArtifactNotFoundError` now also inherit from `NotFoundError`. This is **additive** and does **not** change any existing catch semantics: each `*NotFoundError` keeps its existing type-specific bases (`NotebookNotFoundError` is still an `RPCError` and `NotebookError`; `SourceNotFoundError` is still a `SourceError`; `ArtifactNotFoundError` is still an `ArtifactError`). The known asymmetry where `SourceNotFoundError`/`ArtifactNotFoundError` do not also inherit from `RPCError` is intentionally preserved for this release.
+
 ## [0.5.0] - 2026-05-23
 
 The first release after the v0.4.x auth cookie lifecycle series. Headline user-facing work: a top-to-bottom CLI UX overhaul (uniform `--json`, exit-code policy, shell completion, stdin pipes, SIGINT-resume), auth and cookie reliability hardening (inline PSIDTS cold-start recovery, fail-closed `notebooklm use`, concurrent-upload safety), and the v0.3-era deprecation removal cycle. **Read Breaking changes below before upgrading.**

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -217,6 +217,40 @@ except RPCError as e:
     # - Invalid parameters
 ```
 
+#### Catching any "not found" across domains
+
+`NotFoundError` is a cross-domain umbrella that catches every
+`*NotFoundError` (notebook, source, artifact) in one `except` clause:
+
+```python
+from notebooklm import NotFoundError
+
+try:
+    notebook = await client.notebooks.get(nb_id)
+    source = await client.sources.wait_until_ready(nb_id, src_id)
+    await client.artifacts.download_audio(nb_id, audio_id, dest)
+except NotFoundError as e:
+    # Catches NotebookNotFoundError, SourceNotFoundError,
+    # and ArtifactNotFoundError uniformly.
+    print(f"Missing resource: {e}")
+```
+
+Each `*NotFoundError` keeps its existing type-specific bases — for example,
+`SourceNotFoundError` is still a `SourceError`, and `NotebookNotFoundError`
+is still an `RPCError` *and* a `NotebookError`. The umbrella is purely
+additive and does not change existing catch semantics.
+
+Note: only `NotebookNotFoundError` also inherits from `RPCError` today.
+`SourceNotFoundError` and `ArtifactNotFoundError` do not — a known
+asymmetry preserved for now and revisited in a future release with
+explicit migration notes.
+
+Methods that *raise* (rather than return `None`) on not-found include
+`client.notebooks.get`, `client.sources.wait_until_ready`, and the artifact
+download / content paths. `client.sources.get` and `client.artifacts.get`
+return `None` on missing IDs; use those when you want a lookup that does
+*not* trigger the umbrella.
+
 ### Authentication & Token Refresh
 
 **Automatic Refresh:** The client automatically refreshes CSRF tokens when authentication errors are detected. This happens transparently during any API call - you don't need to handle it manually.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -228,7 +228,7 @@ from notebooklm import NotFoundError
 try:
     notebook = await client.notebooks.get(nb_id)
     source = await client.sources.wait_until_ready(nb_id, src_id)
-    await client.artifacts.download_audio(nb_id, audio_id, dest)
+    await client.artifacts.download_audio(nb_id, dest, audio_id)
 except NotFoundError as e:
     # Catches NotebookNotFoundError, SourceNotFoundError,
     # and ArtifactNotFoundError uniformly.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -79,6 +79,7 @@ ChatReference, ReportSuggestion, SuggestedTopic
 
 # Exceptions (all inherit from NotebookLMError)
 NotebookLMError                    # Base exception
+NotFoundError                      # Cross-domain umbrella for *NotFoundError
 RPCError, AuthError, RateLimitError, RPCTimeoutError, ServerError
 NetworkError, DecodingError, UnknownRPCMethodError
 ClientError, ConfigurationError, ValidationError

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -80,6 +80,8 @@ from .exceptions import (
     # Base
     NotebookLMError,
     NotebookNotFoundError,
+    # Cross-domain umbrellas
+    NotFoundError,
     RateLimitError,
     # Domain: Research
     ResearchTaskMismatchError,
@@ -193,6 +195,8 @@ __all__ = [
     "NotebookLMError",
     "ValidationError",
     "ConfigurationError",
+    # Cross-domain umbrellas
+    "NotFoundError",
     # RPC/Network Exceptions
     "RPCError",
     "DecodingError",

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -41,6 +41,8 @@ def _truncate_response_preview(raw: str | None) -> str | None:
 __all__ = [
     # Base
     "NotebookLMError",
+    # Cross-domain umbrellas
+    "NotFoundError",
     # Validation/Config
     "ValidationError",
     "ConfigurationError",
@@ -97,6 +99,42 @@ class NotebookLMError(Exception):
             await client.notebooks.list()
         except NotebookLMError as e:
             handle_error(e)
+    """
+
+
+# =============================================================================
+# Cross-domain umbrellas
+# =============================================================================
+
+
+class NotFoundError(NotebookLMError):
+    """Common base for resource-not-found exceptions.
+
+    Catch this to handle any not-found case across notebooks, sources,
+    and artifacts in one ``except`` clause::
+
+        try:
+            await client.notebooks.get(nb_id)
+            await client.sources.get(nb_id, src_id)
+            await client.artifacts.get(nb_id, art_id)
+        except NotFoundError as e:
+            # Catches NotebookNotFoundError, SourceNotFoundError,
+            # and ArtifactNotFoundError uniformly.
+            handle_missing_resource(e)
+
+    Subclasses retain their existing type-specific bases — for example,
+    :class:`SourceNotFoundError` is still a :class:`SourceError`, and
+    :class:`NotebookNotFoundError` is still an :class:`RPCError` and a
+    :class:`NotebookError`. This umbrella is additive and does not
+    change existing catch semantics.
+
+    .. note::
+
+        Today, only :class:`NotebookNotFoundError` also inherits from
+        :class:`RPCError`. :class:`SourceNotFoundError` and
+        :class:`ArtifactNotFoundError` do not — a known asymmetry that
+        is *not* addressed by this umbrella and is deferred to a future
+        release with explicit migration notes.
     """
 
 
@@ -553,15 +591,18 @@ class NotebookError(NotebookLMError):
     """Base for notebook operations."""
 
 
-class NotebookNotFoundError(RPCError, NotebookError):
+class NotebookNotFoundError(NotFoundError, RPCError, NotebookError):
     """Notebook not found.
 
-    Inherits from both :class:`RPCError` and :class:`NotebookError` so callers
-    can catch either base. The RPC base is what ``client.notebooks.get`` raises
-    when the server returns an empty / degenerate payload for a missing ID, so
-    ``except RPCError`` keeps working at call sites that handle transport-level
-    failures. ``except NotebookError`` continues to work at domain-level call
-    sites that don't care about the RPC layer.
+    Inherits from :class:`NotFoundError`, :class:`RPCError`, and
+    :class:`NotebookError` so callers can catch any of them. The
+    :class:`NotFoundError` umbrella catches this alongside
+    :class:`SourceNotFoundError` and :class:`ArtifactNotFoundError`. The RPC
+    base is what ``client.notebooks.get`` raises when the server returns an
+    empty / degenerate payload for a missing ID, so ``except RPCError`` keeps
+    working at call sites that handle transport-level failures.
+    ``except NotebookError`` continues to work at domain-level call sites that
+    don't care about the RPC layer.
 
     Attributes:
         notebook_id: The ID that was not found.
@@ -707,8 +748,18 @@ class SourceAddError(SourceError):
         super().__init__(msg)
 
 
-class SourceNotFoundError(SourceError):
+class SourceNotFoundError(NotFoundError, SourceError):
     """Source not found in notebook.
+
+    Inherits from :class:`NotFoundError` (cross-domain umbrella) and
+    :class:`SourceError` (domain base). Existing ``except SourceError`` and
+    ``except SourceNotFoundError`` clauses continue to work unchanged.
+
+    .. note::
+
+        Unlike :class:`NotebookNotFoundError`, this class does not inherit
+        from :class:`RPCError`. That asymmetry is intentional for this
+        release (no behavior change); see the note on :class:`NotFoundError`.
 
     Attributes:
         source_id: The ID that was not found.
@@ -765,8 +816,18 @@ class ArtifactError(NotebookLMError):
     """Base for artifact operations."""
 
 
-class ArtifactNotFoundError(ArtifactError):
+class ArtifactNotFoundError(NotFoundError, ArtifactError):
     """Artifact not found.
+
+    Inherits from :class:`NotFoundError` (cross-domain umbrella) and
+    :class:`ArtifactError` (domain base). Existing ``except ArtifactError``
+    and ``except ArtifactNotFoundError`` clauses continue to work unchanged.
+
+    .. note::
+
+        Unlike :class:`NotebookNotFoundError`, this class does not inherit
+        from :class:`RPCError`. That asymmetry is intentional for this
+        release (no behavior change); see the note on :class:`NotFoundError`.
 
     Attributes:
         artifact_id: The ID that was not found.

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -114,13 +114,19 @@ class NotFoundError(NotebookLMError):
     and artifacts in one ``except`` clause::
 
         try:
-            await client.notebooks.get(nb_id)
-            await client.sources.get(nb_id, src_id)
-            await client.artifacts.get(nb_id, art_id)
+            notebook = await client.notebooks.get(nb_id)
+            source = await client.sources.wait_until_ready(nb_id, src_id)
+            await client.artifacts.download_audio(nb_id, dest, audio_id)
         except NotFoundError as e:
             # Catches NotebookNotFoundError, SourceNotFoundError,
             # and ArtifactNotFoundError uniformly.
             handle_missing_resource(e)
+
+    The example uses methods that *raise* a ``*NotFoundError`` on missing
+    IDs (:meth:`NotebooksAPI.get`, :meth:`SourcesAPI.wait_until_ready`,
+    the artifact download / content paths). :meth:`SourcesAPI.get` and
+    :meth:`ArtifactsAPI.get` instead return ``None`` for missing IDs — use
+    them when you want a lookup that does not trigger the umbrella.
 
     Subclasses retain their existing type-specific bases — for example,
     :class:`SourceNotFoundError` is still a :class:`SourceError`, and

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -21,6 +21,7 @@ from notebooklm.exceptions import (
     NotebookLimitError,
     NotebookLMError,
     NotebookNotFoundError,
+    NotFoundError,
     RateLimitError,
     RPCError,
     RPCTimeoutError,
@@ -45,6 +46,7 @@ class TestExceptionHierarchy:
             ValidationError,
             ConfigurationError,
             NetworkError,
+            NotFoundError,
             RPCError,
             DecodingError,
             UnknownRPCMethodError,
@@ -112,6 +114,104 @@ class TestExceptionHierarchy:
         assert notebooklm.AccountTier is AccountTier
         assert "AccountLimits" in notebooklm.__all__
         assert "AccountTier" in notebooklm.__all__
+
+
+class TestNotFoundErrorUmbrella:
+    """The NotFoundError umbrella catches every *NotFoundError across domains.
+
+    Catch semantics for the existing per-type bases (NotebookError /
+    SourceError / ArtifactError / RPCError) MUST remain unchanged — this is
+    an additive change. The asymmetry where SourceNotFoundError and
+    ArtifactNotFoundError do not inherit from RPCError is intentionally
+    preserved here; widening that is a separate (breaking) change deferred
+    to a future release.
+    """
+
+    def test_not_found_error_is_subclass_of_notebooklm_error(self):
+        """NotFoundError lives under the top-level NotebookLMError umbrella."""
+        assert issubclass(NotFoundError, NotebookLMError)
+
+    def test_not_found_error_catches_notebook_not_found(self):
+        """`except NotFoundError` catches NotebookNotFoundError."""
+        assert issubclass(NotebookNotFoundError, NotFoundError)
+        with pytest.raises(NotFoundError):
+            raise NotebookNotFoundError("nb-123")
+
+    def test_not_found_error_catches_source_not_found(self):
+        """`except NotFoundError` catches SourceNotFoundError."""
+        assert issubclass(SourceNotFoundError, NotFoundError)
+        with pytest.raises(NotFoundError):
+            raise SourceNotFoundError("src-123")
+
+    def test_not_found_error_catches_artifact_not_found(self):
+        """`except NotFoundError` catches ArtifactNotFoundError."""
+        assert issubclass(ArtifactNotFoundError, NotFoundError)
+        with pytest.raises(NotFoundError):
+            raise ArtifactNotFoundError("art-123", "audio")
+
+    def test_existing_catches_still_work(self):
+        """Adding NotFoundError must not break existing domain catches.
+
+        Regression guard: each *NotFoundError must still be caught by its
+        legacy domain base(s).
+        """
+        # Notebook side: still RPCError + NotebookError.
+        with pytest.raises(NotebookError):
+            raise NotebookNotFoundError("nb-1")
+        with pytest.raises(RPCError):
+            raise NotebookNotFoundError("nb-2")
+
+        # Source side: still SourceError.
+        with pytest.raises(SourceError):
+            raise SourceNotFoundError("src-1")
+
+        # Artifact side: still ArtifactError.
+        with pytest.raises(ArtifactError):
+            raise ArtifactNotFoundError("art-1", "audio")
+
+    def test_source_not_found_does_not_gain_rpc_error(self):
+        """Asymmetry is preserved: SourceNotFoundError MUST NOT be an RPCError.
+
+        Adding RPCError to SourceNotFoundError is a behavior change (would
+        suddenly broaden `except RPCError:` clauses at every domain call
+        site) and is explicitly deferred to a future release.
+        """
+        assert not issubclass(SourceNotFoundError, RPCError)
+        assert RPCError not in SourceNotFoundError.__mro__
+
+    def test_artifact_not_found_does_not_gain_rpc_error(self):
+        """Asymmetry is preserved: ArtifactNotFoundError MUST NOT be an RPCError.
+
+        See ``test_source_not_found_does_not_gain_rpc_error`` for the
+        reasoning — same constraint applies here.
+        """
+        assert not issubclass(ArtifactNotFoundError, RPCError)
+        assert RPCError not in ArtifactNotFoundError.__mro__
+
+    def test_not_found_error_is_exported_from_package(self):
+        """NotFoundError is reachable via ``from notebooklm import NotFoundError``."""
+        assert notebooklm.NotFoundError is NotFoundError
+        assert "NotFoundError" in notebooklm.__all__
+
+    def test_not_found_error_catches_all_three_in_one_clause(self):
+        """The motivating use case: one `except NotFoundError` clause
+        replaces a 3-tuple ``except (NotebookNotFoundError, SourceNotFoundError,
+        ArtifactNotFoundError):``."""
+        caught: list[type] = []
+        for exc in (
+            NotebookNotFoundError("nb"),
+            SourceNotFoundError("src"),
+            ArtifactNotFoundError("art", "audio"),
+        ):
+            try:
+                raise exc
+            except NotFoundError as e:
+                caught.append(type(e))
+        assert caught == [
+            NotebookNotFoundError,
+            SourceNotFoundError,
+            ArtifactNotFoundError,
+        ]
 
 
 class TestRPCErrorAttributes:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -131,6 +131,18 @@ class TestNotFoundErrorUmbrella:
         """NotFoundError lives under the top-level NotebookLMError umbrella."""
         assert issubclass(NotFoundError, NotebookLMError)
 
+    def test_not_found_error_itself_is_not_an_rpc_error(self):
+        """The umbrella must NOT inherit from RPCError.
+
+        Pairs with ``test_source_not_found_does_not_gain_rpc_error`` and
+        ``test_artifact_not_found_does_not_gain_rpc_error`` — together
+        these guard that the RPCError asymmetry (only
+        :class:`NotebookNotFoundError` inherits from :class:`RPCError`)
+        is preserved end-to-end, including at the umbrella level.
+        """
+        assert not issubclass(NotFoundError, RPCError)
+        assert RPCError not in NotFoundError.__mro__
+
     def test_not_found_error_catches_notebook_not_found(self):
         """`except NotFoundError` catches NotebookNotFoundError."""
         assert issubclass(NotebookNotFoundError, NotFoundError)

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -358,6 +358,7 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "DecodingError",
     "NetworkError",
     "NonIdempotentRetryError",
+    "NotFoundError",
     "NotebookError",
     "NotebookLimitError",
     "NotebookLMError",


### PR DESCRIPTION
## Summary

Introduces a `NotFoundError` umbrella exception so callers can catch *any* "resource not found" error across notebooks, sources, and artifacts in **one** `except` clause:

```python
from notebooklm import NotFoundError

try:
    notebook = await client.notebooks.get(nb_id)
    source = await client.sources.wait_until_ready(nb_id, src_id)
    await client.artifacts.download_audio(nb_id, audio_id, dest)
except NotFoundError as e:
    # Catches NotebookNotFoundError, SourceNotFoundError,
    # and ArtifactNotFoundError uniformly.
    print(f"Missing resource: {e}")
```

Replaces the previously-required tuple catch:

```python
except (NotebookNotFoundError, SourceNotFoundError, ArtifactNotFoundError):
    ...
```

Follows §7.2a of `docs/improvement.md`.

## Additive change. No existing catch semantics change.

- `NotebookNotFoundError` → now `(NotFoundError, RPCError, NotebookError)`
- `SourceNotFoundError` → now `(NotFoundError, SourceError)`
- `ArtifactNotFoundError` → now `(NotFoundError, ArtifactError)`

Every `*NotFoundError` keeps its prior type-specific bases. `except RPCError:` still catches `NotebookNotFoundError`. `except SourceError:` still catches `SourceNotFoundError`. `except ArtifactError:` still catches `ArtifactNotFoundError`. Regression-guarded in `tests/unit/test_exceptions.py::TestNotFoundErrorUmbrella::test_existing_catches_still_work`.

`NotFoundError` is exported from `notebooklm` and `notebooklm.exceptions` (added to both `__all__` lists).

## Scope: §7.2b (RPCError asymmetry) is intentionally NOT included

The known asymmetry where only `NotebookNotFoundError` also inherits from `RPCError` (while `SourceNotFoundError` and `ArtifactNotFoundError` do not) is **preserved** in this PR. Two regression-guard tests pin that explicitly:

- `test_source_not_found_does_not_gain_rpc_error` — `assert RPCError not in SourceNotFoundError.__mro__`
- `test_artifact_not_found_does_not_gain_rpc_error` — `assert RPCError not in ArtifactNotFoundError.__mro__`

Adding `RPCError` to those two classes would be a behavior change (any `except RPCError:` clause at a source/artifact call site would suddenly start catching not-found errors that previously flowed through to a `SourceError`/`ArtifactError` handler) and is **deferred to a future release** (target: v1.0 or a documented v0.6 breaking-change cycle) with explicit migration notes.

## Files changed

- `src/notebooklm/exceptions.py` — new `NotFoundError(NotebookLMError)` class; updated MROs of the three `*NotFoundError` classes; updated `__all__`.
- `src/notebooklm/__init__.py` — re-export `NotFoundError`; add to `__all__`.
- `tests/unit/test_exceptions.py` — new `TestNotFoundErrorUmbrella` class (9 tests).
- `tests/unit/test_public_shims.py` — added `"NotFoundError"` to `_TOP_LEVEL_EXCEPTION_EXPORTS` manifest (alphabetically placed).
- `docs/python-api.md` — new "Catching any not found across domains" subsection with a working example and a caveat about which methods raise vs return `None`.
- `docs/stability.md` — added to the public Exceptions list.
- `CHANGELOG.md` — new `## [Unreleased]` section with an Added entry.

## Test plan

- [x] `uv run pytest` — 6338 passed, 54 skipped. One pre-existing flake in `tests/unit/cli/test_login_multi_account.py` confirmed reproducible on plain `origin/main` (terminal-width assertion issue under xdist) — unrelated to this change.
- [x] `uv run pytest tests/unit/test_exceptions.py` — 49 passed (9 new in `TestNotFoundErrorUmbrella`).
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (no issues in 170 source files).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] Verified MRO: `NotebookNotFoundError.__mro__` includes `[NotFoundError, RPCError, NotebookError, NotebookLMError, Exception, ...]` in that order; no metaclass conflict; `super().__init__` still flows to `RPCError.__init__` correctly.
- [x] Verified `SourceNotFoundError.__mro__` does NOT contain `RPCError` (asymmetry preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a NotFoundError umbrella exception to catch notebook/source/artifact "not found" cases in a single except clause.

* **Documentation**
  * Updated docs and stability notes to describe the umbrella exception, its scope, and the existing inheritance asymmetry and when it will be raised vs returning None.

* **Tests**
  * Added/updated tests to validate the umbrella behavior and public export.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->