### PR TITLE
refactor(auth): move auth tokens into private module

### DIFF
--- a/src/notebooklm/_auth/__init__.py
+++ b/src/notebooklm/_auth/__init__.py
@@ -1,5 +1,5 @@
 """Private authentication implementation package."""
 
-from . import extraction, headers, keepalive, paths, refresh
+from . import extraction, headers, keepalive, paths, refresh, tokens
 
-__all__ = ["extraction", "headers", "keepalive", "paths", "refresh"]
+__all__ = ["extraction", "headers", "keepalive", "paths", "refresh", "tokens"]

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -10,8 +10,10 @@ import httpx
 
 from .._env import get_base_url
 from .._url_utils import is_google_auth_redirect
-from ..auth import AuthTokens, authuser_query, extract_wiz_field
 from ..exceptions import AuthExtractionError
+from .account import authuser_query
+from .extraction import extract_wiz_field
+from .tokens import AuthTokens
 
 
 class RefreshAuthCore(Protocol):

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -152,7 +152,7 @@ class AuthTokens:
             # Load from a specific profile
             auth = await AuthTokens.from_storage(profile="work")
         """
-        if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
+        if path is None and (profile is not None or not os.environ.get("NOTEBOOKLM_AUTH_JSON")):
             path = get_storage_path(profile=profile)
 
         if path is None:

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -1,0 +1,245 @@
+"""Authentication token container and storage loader."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import httpx
+
+from ..paths import get_storage_path
+from . import account as _auth_account
+from . import cookies as _auth_cookies
+from . import refresh as _auth_refresh
+from . import storage as _auth_storage
+
+DomainCookieMap: TypeAlias = _auth_cookies.DomainCookieMap
+FlatCookieMap: TypeAlias = _auth_cookies.FlatCookieMap
+CookieSnapshot: TypeAlias = _auth_storage.CookieSnapshot
+
+
+@dataclass
+class AuthTokens:
+    """Authentication tokens for NotebookLM API.
+
+    Attributes:
+        cookies: Required Google auth cookies keyed by ``(name, domain, path)``
+            per RFC 6265 §5.3 (issue #369). Legacy 2-tuple ``(name, domain)``
+            and flat ``name -> value`` shapes are still accepted on
+            construction and widened to the path-aware shape by
+            :func:`normalize_cookie_map` during ``__post_init__``.
+        csrf_token: CSRF token (SNlM0e) extracted from page
+        session_id: Session ID (FdrFJe) extracted from page
+        storage_path: Path to the storage_state.json file, if file-based auth was used
+        cookie_jar: Domain-preserving httpx.Cookies jar. Preferred over flat cookies dict
+            for HTTP operations as it retains original cookie domains (e.g.,
+            .googleusercontent.com vs .google.com).
+        authuser: Google ``authuser`` index this profile authenticates as.
+            ``0`` (the default account) is used when no account metadata is
+            present in ``context.json`` — matching pre-multi-account behavior.
+        account_email: Stable Google account identity for routing. When set,
+            NotebookLM requests use it as the ``authuser`` value instead of the
+            integer index, because Google account indices can change when other
+            accounts sign out.
+        cookie_snapshot: Internal save baseline used when a pre-client token
+            fetch mutates cookies but persistence fails or CAS-rejects. This
+            lets the eventual Session retry the unpersisted delta instead
+            of snapshotting the already-mutated jar as clean state.
+    """
+
+    # Secret fields are excluded from the dataclass-generated ``__repr__`` via
+    # ``field(repr=False)`` and re-surfaced as redacted placeholders by the
+    # custom ``__repr__`` below (P1-1). This prevents accidental secret
+    # leakage through ``logger.debug("%r", auth)``, ``pytest -vv`` failure
+    # diffs, and any third-party tooling that calls ``repr()`` on the dataclass.
+    cookies: DomainCookieMap = field(repr=False)
+    csrf_token: str = field(repr=False)
+    session_id: str = field(repr=False)
+    storage_path: Path | None = None
+    cookie_jar: httpx.Cookies | None = field(default=None, repr=False)
+    authuser: int = 0
+    cookie_snapshot: CookieSnapshot | None = field(default=None, repr=False)
+    account_email: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize legacy flat cookie mappings into domain-keyed mappings."""
+        self.cookies = _auth_cookies.normalize_cookie_map(self.cookies)
+        if self.cookie_jar is None:
+            self.cookie_jar = _auth_cookies.build_cookie_jar(
+                cookies=self.cookies,
+                storage_path=self.storage_path,
+            )
+
+    def __repr__(self) -> str:
+        """Return a redacted representation safe for logs and pytest diffs.
+
+        Cookie values, CSRF + session tokens, the live ``cookie_jar``, and the
+        ``cookie_snapshot`` are all credential-equivalent and never appear
+        verbatim. The cookie count is preserved so reprs remain useful for
+        debugging (e.g. "expected 4 cookies, got 2"). Non-secret identity
+        fields (``authuser``, ``account_email``, ``storage_path``) are kept
+        for the same reason — they help identify *which* profile is involved
+        without leaking *how to impersonate it*.
+        """
+        jar_summary = "<redacted>" if self.cookie_jar is not None else "None"
+        snapshot_summary = "<redacted>" if self.cookie_snapshot is not None else "None"
+        return (
+            "AuthTokens("
+            f"cookies=<{len(self.cookies)} redacted>, "
+            "csrf_token=<redacted>, "
+            "session_id=<redacted>, "
+            f"storage_path={self.storage_path!r}, "
+            f"cookie_jar={jar_summary}, "
+            f"authuser={self.authuser!r}, "
+            f"cookie_snapshot={snapshot_summary}, "
+            f"account_email={self.account_email!r}"
+            ")"
+        )
+
+    @property
+    def cookie_header(self) -> str:
+        """Generate Cookie header value for HTTP requests.
+
+        Returns:
+            Semicolon-separated cookie string (e.g., "SID=abc; HSID=def")
+        """
+        return "; ".join(f"{k}={v}" for k, v in self.flat_cookies.items())
+
+    @property
+    def account_route(self) -> str:
+        """Return the value to send in NotebookLM ``authuser`` routing fields."""
+        return _auth_account.format_authuser_value(self.authuser, self.account_email)
+
+    @property
+    def flat_cookies(self) -> FlatCookieMap:
+        """Return a legacy name→value cookie mapping.
+
+        Duplicate-name resolution follows :func:`_auth_domain_priority` so the
+        result matches what :func:`load_auth_from_storage` produces for the same
+        storage state (see issue #375). Domain-aware HTTP operations should use
+        ``cookie_jar`` or ``cookies`` directly instead.
+        """
+        return _auth_cookies.flatten_cookie_map(self.cookies)
+
+    @classmethod
+    async def from_storage(cls, path: Path | None = None, profile: str | None = None) -> AuthTokens:
+        """Create AuthTokens from Playwright storage state file.
+
+        This is the recommended way to create AuthTokens for programmatic use.
+        It loads cookies from storage and fetches CSRF/session tokens automatically.
+
+        Args:
+            path: Path to storage_state.json. If provided, takes precedence over profile.
+            profile: Profile name to load auth from (e.g., "work", "personal").
+                If None, uses the active profile (from CLI flag, env var, or config).
+
+        Returns:
+            Fully initialized AuthTokens ready for API calls.
+
+        Raises:
+            FileNotFoundError: If storage file doesn't exist
+            ValueError: If required cookies are missing or tokens can't be extracted
+            httpx.HTTPError: If token fetch request fails
+
+        Example:
+            auth = await AuthTokens.from_storage()
+            async with NotebookLMClient(auth) as client:
+                notebooks = await client.list_notebooks()
+
+            # Load from a specific profile
+            auth = await AuthTokens.from_storage(profile="work")
+        """
+        if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
+            path = get_storage_path(profile=profile)
+
+        if path is None:
+            authuser = 0
+            account_email = None
+            account_metadata = _auth_account.read_account_metadata_from_storage_state(
+                _auth_cookies._load_storage_state(path)
+            )
+            raw_authuser = account_metadata.get("authuser")
+            raw_email = account_metadata.get("email")
+            if isinstance(raw_authuser, int) and raw_authuser >= 0:
+                authuser = raw_authuser
+            if isinstance(raw_email, str) and raw_email.strip():
+                account_email = raw_email.strip()
+        else:
+            authuser = _auth_account.get_authuser_for_storage(path)
+            account_email = _auth_account.get_account_email_for_storage(path)
+        # Build the cookie jar via the lossless loader so path/secure/httpOnly
+        # survive into the live jar. The earlier
+        # extract_cookies_with_domains -> build_cookie_jar pipeline only carried
+        # (name, domain) -> value and dropped the same attributes the load
+        # paths in #365 fixed.
+        jar = _auth_cookies.build_httpx_cookies_from_storage(path)
+        # Snapshot before token fetch can rotate cookies; the snapshot/delta
+        # merge in save_cookies_to_storage will then write only what this
+        # process actually rotated, preserving sibling-process state.
+        snapshot = _auth_storage.snapshot_cookie_jar(jar)
+        route_kwargs: dict[str, Any] = {"authuser": authuser}
+        if account_email is not None:
+            route_kwargs["account_email"] = account_email
+        (
+            csrf_token,
+            session_id,
+            refreshed,
+            post_refresh_snapshot,
+        ) = await _auth_refresh._fetch_tokens_with_refresh(jar, path, profile, **route_kwargs)
+
+        # If NOTEBOOKLM_REFRESH_CMD ran, ``_fetch_tokens_with_refresh`` captured
+        # a snapshot immediately after the jar was wholesale-replaced from
+        # disk — before the retry fetch could mutate it with redirect
+        # Set-Cookies. Use that snapshot so the retry's rotations land on
+        # disk as deltas instead of being silently absorbed into the baseline.
+        if refreshed and post_refresh_snapshot is not None:
+            snapshot = post_refresh_snapshot
+
+        # Persist any refreshed cookies from the token fetch. If the save
+        # fails, carry the old baseline into the returned AuthTokens so a
+        # later Session can retry the delta instead of treating the mutated
+        # jar as clean state.
+        # ``save_cookies_to_storage`` performs atomic-replace + fsync + flock
+        # under a synchronous file lock; offload to a worker thread so a
+        # slow filesystem (network FS, encrypted home, fcntl contention)
+        # can't freeze the event loop.
+        post_save_snapshot = _auth_storage.snapshot_cookie_jar(jar)
+        save_result = await asyncio.to_thread(
+            _auth_storage.save_cookies_to_storage,
+            jar,
+            path,
+            original_snapshot=snapshot,
+            return_result=True,
+        )
+        if isinstance(save_result, _auth_storage.CookieSaveResult):
+            if save_result.ok:
+                cookie_snapshot = None
+            elif save_result.cas_rejected_keys:
+                cookie_snapshot = _auth_storage.advance_cookie_snapshot_after_save(
+                    snapshot, post_save_snapshot, save_result.cas_rejected_keys
+                )
+            else:
+                cookie_snapshot = snapshot
+        else:
+            cookie_snapshot = None if save_result else snapshot
+        cookies = _auth_cookies._cookie_map_from_jar(jar)
+
+        return cls(
+            cookies=cookies,
+            csrf_token=csrf_token,
+            session_id=session_id,
+            storage_path=path,
+            cookie_jar=jar,
+            authuser=authuser,
+            cookie_snapshot=cookie_snapshot,
+            account_email=account_email,
+        )
+
+
+AuthTokens.__module__ = "notebooklm.auth"
+
+
+__all__ = ["AuthTokens"]

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -27,13 +27,10 @@ Security Notes:
     - Path traversal protection is enforced on all file operations
 """
 
-import asyncio
 import logging
-import os
 import subprocess  # noqa: F401  # re-exported for tests that patch ``auth.subprocess.run``
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 import httpx
 
@@ -47,7 +44,8 @@ from ._auth import paths as _auth_paths
 from ._auth import psidts_recovery as _auth_psidts_recovery
 from ._auth import refresh as _auth_refresh
 from ._auth import storage as _auth_storage
-from .paths import get_storage_path
+from ._auth.tokens import AuthTokens
+from .paths import get_storage_path  # noqa: F401  # kept as a module-level compat alias
 
 logger = logging.getLogger(__name__)
 
@@ -198,220 +196,6 @@ def _validate_required_cookies(
 
 
 _auth_cookies._validate_required_cookies = _validate_required_cookies
-
-
-@dataclass
-class AuthTokens:
-    """Authentication tokens for NotebookLM API.
-
-    Attributes:
-        cookies: Required Google auth cookies keyed by ``(name, domain, path)``
-            per RFC 6265 §5.3 (issue #369). Legacy 2-tuple ``(name, domain)``
-            and flat ``name -> value`` shapes are still accepted on
-            construction and widened to the path-aware shape by
-            :func:`normalize_cookie_map` during ``__post_init__``.
-        csrf_token: CSRF token (SNlM0e) extracted from page
-        session_id: Session ID (FdrFJe) extracted from page
-        storage_path: Path to the storage_state.json file, if file-based auth was used
-        cookie_jar: Domain-preserving httpx.Cookies jar. Preferred over flat cookies dict
-            for HTTP operations as it retains original cookie domains (e.g.,
-            .googleusercontent.com vs .google.com).
-        authuser: Google ``authuser`` index this profile authenticates as.
-            ``0`` (the default account) is used when no account metadata is
-            present in ``context.json`` — matching pre-multi-account behavior.
-        account_email: Stable Google account identity for routing. When set,
-            NotebookLM requests use it as the ``authuser`` value instead of the
-            integer index, because Google account indices can change when other
-            accounts sign out.
-        cookie_snapshot: Internal save baseline used when a pre-client token
-            fetch mutates cookies but persistence fails or CAS-rejects. This
-            lets the eventual Session retry the unpersisted delta instead
-            of snapshotting the already-mutated jar as clean state.
-    """
-
-    # Secret fields are excluded from the dataclass-generated ``__repr__`` via
-    # ``field(repr=False)`` and re-surfaced as redacted placeholders by the
-    # custom ``__repr__`` below (P1-1). This prevents accidental secret
-    # leakage through ``logger.debug("%r", auth)``, ``pytest -vv`` failure
-    # diffs, and any third-party tooling that calls ``repr()`` on the dataclass.
-    cookies: DomainCookieMap = field(repr=False)
-    csrf_token: str = field(repr=False)
-    session_id: str = field(repr=False)
-    storage_path: Path | None = None
-    cookie_jar: httpx.Cookies | None = field(default=None, repr=False)
-    authuser: int = 0
-    cookie_snapshot: CookieSnapshot | None = field(default=None, repr=False)
-    account_email: str | None = None
-
-    def __post_init__(self) -> None:
-        """Normalize legacy flat cookie mappings into domain-keyed mappings."""
-        self.cookies = normalize_cookie_map(self.cookies)
-        if self.cookie_jar is None:
-            self.cookie_jar = build_cookie_jar(cookies=self.cookies, storage_path=self.storage_path)
-
-    def __repr__(self) -> str:
-        """Return a redacted representation safe for logs and pytest diffs.
-
-        Cookie values, CSRF + session tokens, the live ``cookie_jar``, and the
-        ``cookie_snapshot`` are all credential-equivalent and never appear
-        verbatim. The cookie count is preserved so reprs remain useful for
-        debugging (e.g. "expected 4 cookies, got 2"). Non-secret identity
-        fields (``authuser``, ``account_email``, ``storage_path``) are kept
-        for the same reason — they help identify *which* profile is involved
-        without leaking *how to impersonate it*.
-        """
-        jar_summary = "<redacted>" if self.cookie_jar is not None else "None"
-        snapshot_summary = "<redacted>" if self.cookie_snapshot is not None else "None"
-        return (
-            "AuthTokens("
-            f"cookies=<{len(self.cookies)} redacted>, "
-            "csrf_token=<redacted>, "
-            "session_id=<redacted>, "
-            f"storage_path={self.storage_path!r}, "
-            f"cookie_jar={jar_summary}, "
-            f"authuser={self.authuser!r}, "
-            f"cookie_snapshot={snapshot_summary}, "
-            f"account_email={self.account_email!r}"
-            ")"
-        )
-
-    @property
-    def cookie_header(self) -> str:
-        """Generate Cookie header value for HTTP requests.
-
-        Returns:
-            Semicolon-separated cookie string (e.g., "SID=abc; HSID=def")
-        """
-        return "; ".join(f"{k}={v}" for k, v in self.flat_cookies.items())
-
-    @property
-    def account_route(self) -> str:
-        """Return the value to send in NotebookLM ``authuser`` routing fields."""
-        return format_authuser_value(self.authuser, self.account_email)
-
-    @property
-    def flat_cookies(self) -> FlatCookieMap:
-        """Return a legacy name→value cookie mapping.
-
-        Duplicate-name resolution follows :func:`_auth_domain_priority` so the
-        result matches what :func:`load_auth_from_storage` produces for the same
-        storage state (see issue #375). Domain-aware HTTP operations should use
-        ``cookie_jar`` or ``cookies`` directly instead.
-        """
-        return flatten_cookie_map(self.cookies)
-
-    @classmethod
-    async def from_storage(
-        cls, path: Path | None = None, profile: str | None = None
-    ) -> "AuthTokens":
-        """Create AuthTokens from Playwright storage state file.
-
-        This is the recommended way to create AuthTokens for programmatic use.
-        It loads cookies from storage and fetches CSRF/session tokens automatically.
-
-        Args:
-            path: Path to storage_state.json. If provided, takes precedence over profile.
-            profile: Profile name to load auth from (e.g., "work", "personal").
-                If None, uses the active profile (from CLI flag, env var, or config).
-
-        Returns:
-            Fully initialized AuthTokens ready for API calls.
-
-        Raises:
-            FileNotFoundError: If storage file doesn't exist
-            ValueError: If required cookies are missing or tokens can't be extracted
-            httpx.HTTPError: If token fetch request fails
-
-        Example:
-            auth = await AuthTokens.from_storage()
-            async with NotebookLMClient(auth) as client:
-                notebooks = await client.list_notebooks()
-
-            # Load from a specific profile
-            auth = await AuthTokens.from_storage(profile="work")
-        """
-        if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
-            path = get_storage_path(profile=profile)
-
-        if path is None:
-            authuser = 0
-            account_email = None
-            account_metadata = _auth_account.read_account_metadata_from_storage_state(
-                _load_storage_state(path)
-            )
-            raw_authuser = account_metadata.get("authuser")
-            raw_email = account_metadata.get("email")
-            if isinstance(raw_authuser, int) and raw_authuser >= 0:
-                authuser = raw_authuser
-            if isinstance(raw_email, str) and raw_email.strip():
-                account_email = raw_email.strip()
-        else:
-            authuser = get_authuser_for_storage(path)
-            account_email = get_account_email_for_storage(path)
-        # Build the cookie jar via the lossless loader so path/secure/httpOnly
-        # survive into the live jar. The earlier
-        # extract_cookies_with_domains -> build_cookie_jar pipeline only carried
-        # (name, domain) -> value and dropped the same attributes the load
-        # paths in #365 fixed.
-        jar = build_httpx_cookies_from_storage(path)
-        # Snapshot before token fetch can rotate cookies; the snapshot/delta
-        # merge in save_cookies_to_storage will then write only what this
-        # process actually rotated, preserving sibling-process state.
-        snapshot = snapshot_cookie_jar(jar)
-        route_kwargs: dict[str, Any] = {"authuser": authuser}
-        if account_email is not None:
-            route_kwargs["account_email"] = account_email
-        csrf_token, session_id, refreshed, post_refresh_snapshot = await _fetch_tokens_with_refresh(
-            jar, path, profile, **route_kwargs
-        )
-
-        # If NOTEBOOKLM_REFRESH_CMD ran, ``_fetch_tokens_with_refresh`` captured
-        # a snapshot immediately after the jar was wholesale-replaced from
-        # disk — before the retry fetch could mutate it with redirect
-        # Set-Cookies. Use that snapshot so the retry's rotations land on
-        # disk as deltas instead of being silently absorbed into the baseline.
-        if refreshed and post_refresh_snapshot is not None:
-            snapshot = post_refresh_snapshot
-
-        # Persist any refreshed cookies from the token fetch. If the save
-        # fails, carry the old baseline into the returned AuthTokens so a
-        # later Session can retry the delta instead of treating the mutated
-        # jar as clean state.
-        # ``save_cookies_to_storage`` performs atomic-replace + fsync + flock
-        # under a synchronous file lock; offload to a worker thread so a
-        # slow filesystem (network FS, encrypted home, fcntl contention)
-        # can't freeze the event loop.
-        post_save_snapshot = snapshot_cookie_jar(jar)
-        save_result = await asyncio.to_thread(
-            save_cookies_to_storage,
-            jar,
-            path,
-            original_snapshot=snapshot,
-            return_result=True,
-        )
-        if isinstance(save_result, CookieSaveResult):
-            if save_result.ok:
-                cookie_snapshot = None
-            elif save_result.cas_rejected_keys:
-                cookie_snapshot = advance_cookie_snapshot_after_save(
-                    snapshot, post_save_snapshot, save_result.cas_rejected_keys
-                )
-            else:
-                cookie_snapshot = snapshot
-        else:
-            cookie_snapshot = None if save_result else snapshot
-        cookies = _cookie_map_from_jar(jar)
-
-        return cls(
-            cookies=cookies,
-            csrf_token=csrf_token,
-            session_id=session_id,
-            storage_path=path,
-            cookie_jar=jar,
-            authuser=authuser,
-            cookie_snapshot=cookie_snapshot,
-            account_email=account_email,
-        )
 
 
 # WIZ field token extraction (CSRF, session ID, generic WIZ data) lives in

--- a/tests/unit/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/unit/concurrency/test_auth_load_blocks_loop.py
@@ -12,7 +12,7 @@ Post-fix: each call site wraps the synchronous save with
 blocking work runs on the default thread executor and the event loop
 keeps spinning sibling tasks.
 
-This test monkeypatches ``notebooklm.auth.save_cookies_to_storage`` to
+This test monkeypatches ``notebooklm._auth.storage.save_cookies_to_storage`` to
 ``time.sleep(0.5)``. While ``AuthTokens.from_storage`` is mid-save, a
 concurrently scheduled async task increments a counter every 50 ms.
 Pre-fix the counter is ~0–1 (loop frozen by the sync sleep); post-fix
@@ -34,6 +34,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 import notebooklm._auth.refresh as _auth_refresh
+import notebooklm._auth.storage as _auth_storage
 from notebooklm import auth as auth_module
 from notebooklm.auth import AuthTokens
 
@@ -98,11 +99,9 @@ async def test_from_storage_save_does_not_block_event_loop(
         time.sleep(_SLEEP_SECONDS)
         return True
 
-    # ``AuthTokens.from_storage`` calls ``save_cookies_to_storage`` via the
-    # module-local alias in ``notebooklm.auth`` (auth.py:86), so patch the
-    # consumer-side name on that module rather than the canonical home in
-    # ``_auth.storage``.
-    monkeypatch.setattr(auth_module, "save_cookies_to_storage", _blocking_save)
+    # ``AuthTokens.from_storage`` owns token loading in ``_auth.tokens`` and
+    # resolves the storage save through the private owner module.
+    monkeypatch.setattr(_auth_storage, "save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0
     stop = asyncio.Event()

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -950,10 +950,9 @@ class TestRefreshCmdResnapshot:
             cookie_jar.set("__Secure-1PSIDTS", "post_refresh", domain=".google.com", path="/")
             return ("csrf", "sid", True, snapshot_cookie_jar(cookie_jar))
 
-        # ``AuthTokens.from_storage`` lives in ``notebooklm.auth`` and uses the
-        # local-aliased symbols bound at import time (auth.py:578-579), so the
-        # patch must target the facade module — not just ``_auth.refresh``.
-        monkeypatch.setattr(auth_mod, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
+        # ``AuthTokens.from_storage`` lives in ``_auth.tokens`` and resolves the
+        # token fetch through the private owner module.
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
 
         captured_snapshots: list = []
         real_save = auth_mod.save_cookies_to_storage
@@ -962,7 +961,7 @@ class TestRefreshCmdResnapshot:
             captured_snapshots.append(original_snapshot)
             return real_save(jar, path, original_snapshot=original_snapshot, **kwargs)
 
-        monkeypatch.setattr(auth_mod, "save_cookies_to_storage", capture_save)
+        monkeypatch.setattr(_auth_storage, "save_cookies_to_storage", capture_save)
 
         await auth_mod.AuthTokens.from_storage(path=storage)
 
@@ -1178,10 +1177,9 @@ class TestBaselineNotAdvancedOnSaveFailure:
             result = CookieSaveResult(False)
             return result if return_result else result.ok
 
-        # ``AuthTokens.from_storage`` uses the local aliases in ``notebooklm.auth``
-        # (auth.py:86 + auth.py:579), so the facade module is the call site.
-        monkeypatch.setattr(auth_mod, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
-        monkeypatch.setattr(auth_mod, "save_cookies_to_storage", failed_save)
+        # ``AuthTokens.from_storage`` resolves through the private owner modules.
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
+        monkeypatch.setattr(_auth_storage, "save_cookies_to_storage", failed_save)
 
         auth = await auth_mod.AuthTokens.from_storage(path=storage)
         core = Session(auth)
@@ -1507,8 +1505,8 @@ class TestCASVariantAware:
             _write_storage(storage_path, cookies)
             return ("csrf", "session", False, None)
 
-        # ``AuthTokens.from_storage`` uses ``notebooklm.auth``'s local alias.
-        monkeypatch.setattr(auth_mod, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
+        # ``AuthTokens.from_storage`` resolves through the private refresh owner.
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_refresh", fake_fetch_with_refresh)
 
         # Pre-client save runs through the real save_cookies_to_storage; the
         # CAS rejection must keep SIBLING on disk and the variant-aware

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -114,6 +114,7 @@ def test_public_import_manifest_has_no_duplicates() -> None:
 def test_public_facade_imports_are_identity_reexports() -> None:
     """Compatibility facades must keep returning the canonical public objects."""
     import notebooklm
+    import notebooklm._auth.tokens as private_tokens
     import notebooklm.auth as public_auth
     import notebooklm.rpc as public_rpc
     import notebooklm.rpc.overrides as rpc_overrides
@@ -121,6 +122,7 @@ def test_public_facade_imports_are_identity_reexports() -> None:
     import notebooklm.types as public_types
 
     assert notebooklm.AuthTokens is public_auth.AuthTokens
+    assert public_auth.AuthTokens is private_tokens.AuthTokens
     assert notebooklm.ConnectionLimits is public_types.ConnectionLimits
     assert public_rpc.RPCMethod is rpc_types.RPCMethod
     assert public_rpc.resolve_rpc_id is rpc_overrides.resolve_rpc_id

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+import notebooklm._auth.refresh as refresh_mod
 from notebooklm import auth as auth_mod
 from notebooklm.auth import (
     NOTEBOOKLM_REFRESH_CMD_ENV,
@@ -34,10 +35,10 @@ def _clear_refresh_env(monkeypatch):
 
 
 def _stub_storage_path(monkeypatch, tmp_path: Path) -> Path:
-    """Point ``get_storage_path`` at a writable temp file."""
+    """Point the refresh owner module at a writable temp storage file."""
     storage = tmp_path / "storage_state.json"
     storage.write_text("{}")
-    monkeypatch.setattr(auth_mod, "get_storage_path", lambda profile=None: storage)
+    monkeypatch.setattr(refresh_mod, "get_storage_path", lambda profile=None: storage)
     return storage
 
 


### PR DESCRIPTION
## Summary
- Move `AuthTokens` and `AuthTokens.from_storage` into `_auth.tokens`
- Re-export `AuthTokens` from `notebooklm.auth` without changing the public identity surface
- Retarget white-box tests to patch private owner modules used by the moved body

## Notes
- `AuthTokens.__module__` stays `notebooklm.auth` for public compatibility.
- This intentionally leaves `load_auth_from_storage`, account enumeration, and PSIDTS recovery in the public auth facade for later slices.

Closes #1046

## Tests
- `uv run pytest tests/unit/test_public_shims.py tests/unit/test_public_surface.py tests/unit/test_auth_repr_redaction.py tests/unit/test_auth_storage.py::TestAuthTokensFromStorage tests/unit/test_auth_storage.py::TestLoaderFlatCookieParity tests/unit/test_auth_account.py::TestAuthuserPlumbing::test_auth_tokens_from_auth_json_preserves_in_band_account tests/unit/test_auth_cookie_save_race.py::TestRefreshCmdResnapshot tests/unit/test_auth_cookie_save_race.py::TestBaselineNotAdvancedOnSaveFailure tests/unit/test_auth_cookie_save_race.py::TestCASVariantAware tests/unit/test_auth_session.py tests/unit/test_session_auth.py -q`
- `uv run ruff format --check src/notebooklm/auth.py src/notebooklm/_auth/tokens.py src/notebooklm/_auth/session.py tests/unit/test_auth_cookie_save_race.py tests/unit/test_public_shims.py`
- `uv run ruff check src/notebooklm/auth.py src/notebooklm/_auth/tokens.py src/notebooklm/_auth/session.py tests/unit/test_auth_cookie_save_race.py tests/unit/test_public_shims.py`
- `uv run mypy src/notebooklm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated authentication token handling into a dedicated implementation and updated the public facade to re-export that canonical class.

* **Tests**
  * Adjusted unit and concurrency tests to target the updated authentication structure and preserve coverage of refresh/save and race scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->