### PR TITLE
refactor(rpc): consolidate feature rpc caller shapes

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -11,7 +11,7 @@ to need a written tiebreaker:
 1. [Waiting / polling verbs](#1-waiting--polling-verbs-cc2) — `poll_X` vs
    `wait_for_X` vs `wait_until_X` vs `await_X` vs `_wait_for_X`.
 2. [RPC-callable Protocol names](#2-rpc-callable-protocol-names-cc3) —
-   `NextCall` / `RpcCall` / `RpcCallback` / `ShareRpc` / `RpcCaller`.
+   `NextCall` / `RpcCallback` / `RpcCaller`.
 3. [Metrics method verbs](#3-metrics-method-verbs-cc5) — `record_X` vs `emit_X`.
 
 Examples below cite **symbol names only** (no file:line refs). Use
@@ -130,46 +130,45 @@ four verbs above.
 
 ## 2. RPC-callable Protocol names (CC3)
 
-Several feature modules type their RPC dependency against a **local** Protocol
-instead of importing `RpcCaller` from `_session_contracts`. The local Protocols
-are NOT interchangeable with each other or with the shared one — the divergence
-is structural, not stylistic. This section explains what each name signals so
-new code picks the right shape.
+Most feature modules type their RPC dependency as the shared
+`RpcCaller` object Protocol from `_session_contracts`. Only middleware-chain
+callables and upload's keyword-injected registration callback keep local
+callable shapes. These names are NOT interchangeable — the divergence is
+structural, not stylistic. This section explains what each name signals so new
+code picks the right shape.
 
-### The five names in use
+### The three names in use
 
 | Name | Defined in | Protocol shape | Used by |
 |---|---|---|---|
 | `NextCall` | `_middleware.py` | **type alias**, not a class: `Callable[[RpcRequest], Awaitable[RpcResponse]]` | Every `Middleware.__call__` — the "call the next link" function passed into around-style middlewares |
-| `RpcCall` | `_source_listing.py` (and `_source_content.py`) | **Callable** Protocol: `async def __call__(method, params, ...)` | `SourceLister`, `SourceContentRenderer` — feature services that take the RPC entrypoint positionally at construction time |
 | `RpcCallback` | `_source_upload.py` | **Callable** Protocol: `async def __call__(method, params, ...)` | `SourceUploadPipeline.register_file_source` — RPC entrypoint passed as a **keyword argument** at call time |
-| `ShareRpc` | `_sharing_manager.py` | **Callable** Protocol: `async def __call__(method, params, ...)` | Legacy share-link manager — name signals the narrow ad-hoc use site |
-| `RpcCaller` | `_session_contracts.py` | **Object** Protocol: `async def rpc_call(method, params, ...)` (i.e. `obj.rpc_call(...)`) | The canonical shared capability Protocol for pure-RPC feature APIs (`NotesAPI`, `SettingsAPI`, etc.) |
+| `RpcCaller` | `_session_contracts.py` | **Object** Protocol: `async def rpc_call(method, params, ...)` (i.e. `obj.rpc_call(...)`) | The canonical shared capability Protocol for pure-RPC feature APIs and helper services (`NotesAPI`, `SourceLister`, `ShareManager`, etc.) |
 
 ### Why they diverge
 
 Two axes do the actual work:
 
-1. **Callable Protocol vs Object Protocol.** `NextCall`, `RpcCall`,
-   `RpcCallback`, `ShareRpc` are all *callable* shapes — the conformer is
-   itself directly invokable (`rpc(method, params)`). `RpcCaller` is an
+1. **Callable Protocol vs Object Protocol.** `NextCall` and `RpcCallback` are
+   *callable* shapes — the conformer is itself directly invokable
+   (`rpc(method, params)`). `RpcCaller` is an
    *object* shape — the conformer exposes an `.rpc_call(...)` method
    (`session.rpc_call(method, params)`).
    These are NOT interchangeable to mypy: a callable Protocol matches a bare
    function or `__call__`, while `RpcCaller` requires the named method. A
    `Session` instance satisfies `RpcCaller` because it defines `rpc_call`; the
-   bound method `session.rpc_call` satisfies `RpcCall` / `RpcCallback` /
-   `ShareRpc` because they are callable Protocols.
+   bound method `session.rpc_call` satisfies `RpcCallback` because it is a
+   callable Protocol.
 2. **Type alias vs Protocol class.** `NextCall` is a `Callable[...]` alias, not
    a class. It exists because the middleware chain is built from a list of
    wrapped callables (`functools.reduce`-style composition); a Protocol class
    would not buy anything over the alias and would make the middleware
    constructor signatures noisier.
 
-The third reason `RpcCallback` exists separately from `RpcCall` is documented
-on its own docstring: it is a **keyword-only callback** passed into
-`register_file_source`, and keeping it as a structural Protocol (instead of a
-bare `Callable[...]` alias) lets mypy flag keyword-name typos at the call site.
+`RpcCallback` exists separately from `RpcCaller` for one remaining reason:
+it is a **keyword-only callback** passed into `register_file_source`, and
+keeping it as a structural Protocol (instead of a bare `Callable[...]` alias)
+lets mypy flag keyword-name typos at the call site.
 
 ### Choosing a name in new code
 
@@ -179,26 +178,15 @@ bare `Callable[...]` alias) lets mypy flag keyword-name typos at the call site.
   catalogue. Concrete `Session` satisfies it structurally.
 - New middleware? Use **`NextCall`** from `_middleware.py` for the chain
   callable — do not invent a new alias.
-- New feature that takes the RPC entrypoint **positionally** (constructor
-  param) and the upstream `RpcCaller` object is unwieldy? Define a local
-  callable Protocol named **`RpcCall`** in your module. Conformers will pass
-  in `session.rpc_call` (the bound method).
 - New feature that takes the RPC entrypoint as a **keyword argument** at call
   time? Define a local Protocol named **`RpcCallback`** so the keyword-typo
   detection kicks in at every call site.
-- One-off, narrow, legacy use site? An ad-hoc local Protocol named after the
-  feature (`ShareRpc`-style) is acceptable, but prefer reusing one of the four
-  above unless the shape genuinely diverges.
 
-> **Why not collapse them all?** The audit (CC3) considered it. The blockers
-> are: `RpcCaller` is an object Protocol used as a constructor-arg type for
-> *many* feature APIs and structurally tied to `Session.rpc_call`'s method
-> name; `RpcCall` / `RpcCallback` / `ShareRpc` are callable Protocols, often
-> with subtly different keyword arguments (`_is_retry`, `allow_null`,
-> `disable_internal_retries`) that the call-site happens to use. A future
-> consolidation pass is tracked in the architecture-audit follow-ups; until
-> then this section is the authoritative tiebreaker for choosing among the
-> existing names.
+> **Why not collapse the last callback too?** `SourceUploadPipeline` accepts
+> `rpc_call=` as a keyword override inside `register_file_source(...)`; keeping
+> a callable Protocol there preserves mypy's keyword-name checking at the
+> override seam. Ordinary constructor-injected feature services should use
+> `RpcCaller`.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -179,7 +179,7 @@ The architecture tests encode the current layer contract:
 **Naming conventions.** See [`docs/conventions.md`](./conventions.md) for the
 canonical tiebreakers on waiting/polling verbs (`poll_X` / `wait_for_X` /
 `wait_until_X` / `await_X` / `_wait_for_X`), RPC-callable Protocol names
-(`NextCall` / `RpcCall` / `RpcCallback` / `ShareRpc` / `RpcCaller`), and
+(`NextCall` / `RpcCallback` / `RpcCaller`), and
 metrics method verbs (`record_X` vs `emit_X`). New code should pick names
 from those catalogues rather than introducing parallel patterns.
 

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -156,7 +156,7 @@ class ArtifactDownloadService:
 
     async def _list_raw(self, notebook_id: str) -> list[Any]:
         """List raw artifacts through the injected listing service."""
-        return await self._listing.list_raw(notebook_id, rpc_call=self._runtime.rpc_call)
+        return await self._listing.list_raw(notebook_id, rpc=self._runtime)
 
     async def _list_mind_maps(self, notebook_id: str) -> list[Any]:
         """List mind-map artifacts through the injected mind-map service."""

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -9,12 +9,12 @@ from typing import Any
 import httpx
 
 from ._row_adapters import ArtifactRow
+from ._session_contracts import RpcCaller
 from .rpc import ArtifactTypeCode, RPCError, RPCMethod
 from .types import Artifact, ArtifactNotReadyError, ArtifactType
 
 logger = logging.getLogger(__name__)
 
-RpcCall = Callable[..., Awaitable[Any]]
 ListRawCallback = Callable[[str], Awaitable[list[Any]]]
 ListMindMapsCallback = Callable[[str], Awaitable[list[Any]]]
 ListArtifactsCallback = Callable[[str], Awaitable[list[Artifact]]]
@@ -68,10 +68,10 @@ def _matches_artifact_type(artifact: Artifact, artifact_type: ArtifactType | Non
 class ArtifactListingService:
     """List, filter, and select artifacts without depending on the facade."""
 
-    async def list_raw(self, notebook_id: str, *, rpc_call: RpcCall) -> list[Any]:
+    async def list_raw(self, notebook_id: str, *, rpc: RpcCaller) -> list[Any]:
         """Get raw studio artifact rows from NotebookLM."""
         params = [[2], notebook_id, 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"']
-        result = await rpc_call(
+        result = await rpc.rpc_call(
             RPCMethod.LIST_ARTIFACTS,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -899,7 +899,7 @@ class ArtifactsAPI:
         """Get raw artifact list data."""
         # Keep this facade hop so callers/tests that patch ``api._list_raw``
         # still affect public listing paths that delegate into the service.
-        return await self._listing.list_raw(notebook_id, rpc_call=self._runtime.rpc_call)
+        return await self._listing.list_raw(notebook_id, rpc=self._runtime)
 
     def _select_artifact(
         self,

--- a/src/notebooklm/_notebook_metadata.py
+++ b/src/notebooklm/_notebook_metadata.py
@@ -8,7 +8,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Protocol
 
-from ._source_listing import RpcCall as SourceListingRpcCall
+from ._session_contracts import RpcCaller
 from ._source_listing import SourceLister as SourceListingService
 from .types import Notebook, NotebookMetadata, Source, SourceSummary
 
@@ -22,8 +22,8 @@ class NotebookSourceLister(Protocol):
     Consumed by :class:`NotebookMetadataService` for metadata composition
     and by :meth:`ResearchAPI.import_sources_with_verification` for
     snapshot/probe around ``IMPORT_RESEARCH`` (issue #315). Implementations
-    are constructed via :func:`create_default_source_lister` from a bare
-    ``RpcCall`` callable, so feature APIs don't need to depend on
+    are constructed via :func:`create_default_source_lister` from a
+    ``RpcCaller`` object, so feature APIs don't need to depend on
     ``SourcesAPI`` itself.
     """
 
@@ -41,9 +41,9 @@ class NotebookSourceIdProvider(Protocol):
 NotebookGetter = Callable[[str], Awaitable[Notebook]]
 
 
-def create_default_source_lister(rpc_call: SourceListingRpcCall) -> NotebookSourceLister:
+def create_default_source_lister(rpc: RpcCaller) -> NotebookSourceLister:
     """Build the direct-construction source lister without constructing SourcesAPI."""
-    return SourceListingService(rpc_call)
+    return SourceListingService(rpc)
 
 
 class NotebookMetadataService:

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -159,14 +159,14 @@ class NotebooksAPI:
             share_manager: Optional explicit legacy share manager for tests or advanced wiring.
         """
         self._rpc = rpc
-        self._sources = sources_api or create_default_source_lister(self._rpc_call)
+        self._sources = sources_api or create_default_source_lister(self._rpc)
         self._metadata_service = metadata_service or NotebookMetadataService(
             # Keep notebook lookup late-bound so tests and advanced callers that
             # replace ``api.get`` after construction still affect get_metadata().
             get_notebook=lambda notebook_id: self.get(notebook_id),
             source_lister=self._sources,
         )
-        self._share_manager = share_manager or ShareManager(self._rpc_call)
+        self._share_manager = share_manager or ShareManager(self._rpc)
 
     async def _rpc_call(
         self,

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -171,7 +171,7 @@ class ResearchAPI:
                 dependency.
         """
         self._rpc = rpc
-        self._source_lister = source_lister or create_default_source_lister(self._rpc_call)
+        self._source_lister = source_lister or create_default_source_lister(self._rpc)
 
     async def _rpc_call(
         self,
@@ -186,9 +186,9 @@ class ResearchAPI:
     ) -> Any:
         """Delegate through the current RPC caller for late-bound overrides.
 
-        Mirrors :meth:`NotebooksAPI._rpc_call` so the default source-lister
-        built in ``__init__`` picks up post-construction ``rpc`` swaps
-        (advanced tests / instrumentation).
+        Mirrors :meth:`NotebooksAPI._rpc_call` so direct ResearchAPI RPC paths
+        pick up post-construction changes to the underlying caller's
+        ``rpc_call`` method (advanced tests / instrumentation).
         """
         return await self._rpc.rpc_call(
             method,

--- a/src/notebooklm/_sharing_manager.py
+++ b/src/notebooklm/_sharing_manager.py
@@ -1,26 +1,12 @@
 """Legacy notebook share-link composition."""
 
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import Any
 from urllib.parse import quote
 
 from ._env import get_base_url
+from ._session_contracts import RpcCaller
 from .rpc import RPCMethod
-
-
-class ShareRpc(Protocol):
-    """RPC surface needed by the legacy notebook share manager."""
-
-    async def __call__(
-        self,
-        method: RPCMethod,
-        params: list[Any],
-        source_path: str = "/",
-        allow_null: bool = False,
-        _is_retry: bool = False,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> Any: ...
 
 
 def build_share_url(base_url: str, notebook_id: str, artifact_id: str | None = None) -> str:
@@ -41,7 +27,7 @@ class ShareManager:
 
     def __init__(
         self,
-        rpc: ShareRpc,
+        rpc: RpcCaller,
         base_url_provider: Callable[[], str] = get_base_url,
     ) -> None:
         self._rpc = rpc
@@ -56,7 +42,7 @@ class ShareManager:
         if artifact_id:
             params.append(artifact_id)
 
-        await self._rpc(
+        await self._rpc.rpc_call(
             RPCMethod.SHARE_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -74,4 +60,4 @@ class ShareManager:
         return build_share_url(self._base_url_provider(), notebook_id, artifact_id)
 
 
-__all__ = ["ShareManager", "ShareRpc", "build_share_url"]
+__all__ = ["ShareManager", "build_share_url"]

--- a/src/notebooklm/_source_add.py
+++ b/src/notebooklm/_source_add.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import parse_qs
 
 from ._idempotency import idempotent_create
+from ._session_contracts import RpcCaller
 from .exceptions import (
     AuthError,
     NetworkError,
@@ -20,7 +21,6 @@ from .exceptions import (
 from .rpc import RPCError, RPCMethod
 from .types import Source
 
-RpcCall = Callable[..., Awaitable[Any]]
 ListSources = Callable[[str], Awaitable[list[Source]]]
 WaitUntilReady = Callable[..., Awaitable[Source]]
 RawSourceAdder = Callable[[str, str], Awaitable[Any]]
@@ -122,7 +122,7 @@ class SourceAddService:
         wait: bool = False,
         wait_timeout: float = 120.0,
         idempotent: bool = False,
-        rpc_call: RpcCall,
+        rpc: RpcCaller,
         wait_until_ready: WaitUntilReady,
         logger: logging.Logger,
     ) -> Source:
@@ -144,7 +144,7 @@ class SourceAddService:
             None,
         ]
         try:
-            result = await rpc_call(
+            result = await rpc.rpc_call(
                 RPCMethod.ADD_SOURCE,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -176,7 +176,7 @@ class SourceAddService:
         mime_type: str = "application/vnd.google-apps.document",
         wait: bool = False,
         wait_timeout: float = 120.0,
-        rpc_call: RpcCall,
+        rpc: RpcCaller,
         list_sources: ListSources,
         wait_until_ready: WaitUntilReady,
         logger: logging.Logger,
@@ -218,7 +218,7 @@ class SourceAddService:
             # exceptions must propagate so idempotent_create can catch them
             # and run the probe.
             try:
-                result = await rpc_call(
+                result = await rpc.rpc_call(
                     RPCMethod.ADD_SOURCE,
                     params,
                     source_path=f"/notebook/{notebook_id}",
@@ -346,7 +346,7 @@ class SourceAddService:
         notebook_id: str,
         url: str,
         *,
-        rpc_call: RpcCall,
+        rpc: RpcCaller,
     ) -> Any:
         """Add a YouTube video as a source."""
         params = [
@@ -355,7 +355,7 @@ class SourceAddService:
             [2],
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
-        return await rpc_call(
+        return await rpc.rpc_call(
             RPCMethod.ADD_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -369,7 +369,7 @@ class SourceAddService:
         notebook_id: str,
         url: str,
         *,
-        rpc_call: RpcCall,
+        rpc: RpcCaller,
     ) -> Any:
         """Add a regular URL as a source."""
         params = [
@@ -379,7 +379,7 @@ class SourceAddService:
             None,
             None,
         ]
-        return await rpc_call(
+        return await rpc.rpc_call(
             RPCMethod.ADD_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_source_content.py
+++ b/src/notebooklm/_source_content.py
@@ -4,37 +4,24 @@ from __future__ import annotations
 
 import builtins
 import logging
-from typing import Any, Literal, Protocol
+from typing import Any, Literal
 
+from ._session_contracts import RpcCaller
 from .rpc import RPCMethod
 from .types import SourceFulltext, SourceNotFoundError, _extract_source_url
-
-
-class RpcCall(Protocol):
-    async def __call__(
-        self,
-        method: RPCMethod,
-        params: builtins.list[Any],
-        source_path: str = "/",
-        allow_null: bool = False,
-        _is_retry: bool = False,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> Any:
-        """Call a NotebookLM RPC method."""
 
 
 class SourceContentRenderer:
     """Render source guide and fulltext content from source RPC responses."""
 
-    def __init__(self, rpc_call: RpcCall, logger: logging.Logger | None = None) -> None:
-        self._rpc_call = rpc_call
+    def __init__(self, rpc: RpcCaller, logger: logging.Logger | None = None) -> None:
+        self._rpc = rpc
         self._logger = logger or logging.getLogger(__name__)
 
     async def get_guide(self, notebook_id: str, source_id: str) -> dict[str, Any]:
         """Get AI-generated summary and keywords for a specific source."""
         params = [[[[source_id]]]]
-        result = await self._rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_SOURCE_GUIDE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -78,7 +65,7 @@ class SourceContentRenderer:
 
         params = [[source_id], [3], [3]] if output_format == "markdown" else [[source_id], [2], [2]]
 
-        result = await self._rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import builtins
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol
+from typing import Any
 
 from ._row_adapters import SourceRow
+from ._session_contracts import RpcCaller
 from .rpc import RPCError, RPCMethod
 from .types import Source
 
@@ -16,33 +17,19 @@ from .types import Source
 logger = logging.getLogger("notebooklm").getChild("_sources")
 
 
-class RpcCall(Protocol):
-    async def __call__(
-        self,
-        method: RPCMethod,
-        params: builtins.list[Any],
-        source_path: str = "/",
-        allow_null: bool = False,
-        _is_retry: bool = False,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> Any:
-        """Call a NotebookLM RPC method."""
-
-
 SourceListHook = Callable[[str], Awaitable[builtins.list[Source]]]
 
 
 class SourceLister:
     """List and parse notebook sources from GET_NOTEBOOK responses."""
 
-    def __init__(self, rpc_call: RpcCall) -> None:
-        self._rpc_call = rpc_call
+    def __init__(self, rpc: RpcCaller) -> None:
+        self._rpc = rpc
 
     async def list(self, notebook_id: str, *, strict: bool = False) -> builtins.list[Source]:
         """List all sources in a notebook."""
         params = [notebook_id, None, [2], None, 0]
-        notebook = await self._rpc_call(
+        notebook = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -283,7 +283,7 @@ class SourceUploadPipeline:
         self._async_client_factory = async_client_factory
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
-        self._lister = SourceLister(self._runtime.rpc_call)
+        self._lister = SourceLister(self._runtime)
         self._poller = SourcePoller()
         self._get_source_limit = get_source_limit
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -143,8 +143,8 @@ class SourcesAPI:
         # attributes for callers that introspect the instance.
         self._rpc = rpc
         self._adder = SourceAddService()
-        self._content = SourceContentRenderer(self._rpc_call, logger=logger)
-        self._lister = SourceLister(self._rpc_call)
+        self._content = SourceContentRenderer(self._rpc, logger=logger)
+        self._lister = SourceLister(self._rpc)
         self._poller = SourcePoller()
         self._upload_timeout = upload_timeout
         self._max_concurrent_uploads = max_concurrent_uploads
@@ -454,7 +454,7 @@ class SourcesAPI:
             wait=wait,
             wait_timeout=wait_timeout,
             idempotent=idempotent,
-            rpc_call=self._rpc_call,
+            rpc=self._rpc,
             wait_until_ready=self.wait_until_ready,
             logger=logger,
         )
@@ -609,7 +609,7 @@ class SourcesAPI:
             mime_type=mime_type,
             wait=wait,
             wait_timeout=wait_timeout,
-            rpc_call=self._rpc_call,
+            rpc=self._rpc,
             list_sources=self.list,
             wait_until_ready=self.wait_until_ready,
             logger=logger,
@@ -851,7 +851,7 @@ class SourcesAPI:
         return await self._adder.add_youtube_source(
             notebook_id,
             url,
-            rpc_call=self._rpc_call,
+            rpc=self._rpc,
         )
 
     async def _add_url_source(self, notebook_id: str, url: str) -> Any:
@@ -863,7 +863,7 @@ class SourcesAPI:
         return await self._adder.add_url_source(
             notebook_id,
             url,
-            rpc_call=self._rpc_call,
+            rpc=self._rpc,
         )
 
     async def _register_file_source(self, notebook_id: str, filename: str) -> str:

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -260,9 +260,6 @@ async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
         [[1], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
         allow_null=True,
-        _is_retry=False,
-        disable_internal_retries=False,
-        operation_variant=None,
     )
 
 
@@ -282,9 +279,6 @@ async def test_share_private_sends_disable_payload_and_returns_no_url(
         [[0], "nb_123"],
         source_path="/notebook/nb_123",
         allow_null=True,
-        _is_retry=False,
-        disable_internal_retries=False,
-        operation_variant=None,
     )
 
 

--- a/tests/unit/test_notebook_metadata.py
+++ b/tests/unit/test_notebook_metadata.py
@@ -23,7 +23,7 @@ class RecordingRpc:
         self.response = response
         self.calls: list[tuple[RPCMethod, list[Any], str | None]] = []
 
-    async def __call__(
+    async def rpc_call(
         self,
         method: RPCMethod,
         params: list[Any],
@@ -32,6 +32,7 @@ class RecordingRpc:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         self.calls.append((method, params, source_path))
         return self.response

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -17,7 +17,9 @@ def _make_rpc() -> AsyncMock:
 
 def _make_manager() -> tuple[ShareManager, AsyncMock]:
     rpc = _make_rpc()
-    return ShareManager(rpc, base_url_provider=lambda: BASE_URL), rpc
+    core = MagicMock()
+    core.rpc_call = rpc
+    return ShareManager(core, base_url_provider=lambda: BASE_URL), rpc
 
 
 def test_build_share_url_without_artifact() -> None:
@@ -142,9 +144,6 @@ async def test_notebooks_api_default_share_manager_uses_late_bound_rpc_executor_
         [[1], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
         allow_null=True,
-        _is_retry=False,
-        disable_internal_retries=False,
-        operation_variant=None,
     )
 
 

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -21,7 +21,7 @@ class RecordingRpc:
         self.response = response
         self.calls: list[dict[str, Any]] = []
 
-    async def __call__(
+    async def rpc_call(
         self,
         method: RPCMethod,
         params: list[Any],
@@ -147,7 +147,7 @@ async def test_add_text_uses_exact_rpc_shape_and_wait_hook(
         "content",
         wait=True,
         wait_timeout=9.0,
-        rpc_call=rpc,
+        rpc=rpc,
         wait_until_ready=wait_until_ready,
         logger=logger,
     )
@@ -183,7 +183,7 @@ async def test_add_text_refuses_idempotent_flag(
             "Title",
             "content",
             idempotent=True,
-            rpc_call=AsyncMock(),
+            rpc=SimpleNamespace(rpc_call=AsyncMock()),
             wait_until_ready=AsyncMock(),
             logger=logger,
         )
@@ -205,7 +205,7 @@ async def test_add_drive_uses_exact_rpc_shape_and_wait_hook(
         mime_type="application/pdf",
         wait=True,
         wait_timeout=7.0,
-        rpc_call=rpc,
+        rpc=rpc,
         list_sources=AsyncMock(return_value=[]),
         wait_until_ready=wait_until_ready,
         logger=logger,
@@ -258,7 +258,7 @@ async def test_add_drive_raises_source_add_error_on_null_result(
             "nb_1",
             "drive_file",
             "Drive Doc",
-            rpc_call=RecordingRpc(None),
+            rpc=RecordingRpc(None),
             list_sources=AsyncMock(return_value=[]),
             wait_until_ready=AsyncMock(),
             logger=logger,
@@ -283,7 +283,7 @@ async def test_add_drive_preserves_rpc_error_propagation(
             "nb_1",
             "drive_file",
             "Drive Doc",
-            rpc_call=AsyncMock(side_effect=rpc_error),
+            rpc=SimpleNamespace(rpc_call=AsyncMock(side_effect=rpc_error)),
             list_sources=AsyncMock(return_value=[]),
             wait_until_ready=AsyncMock(),
             logger=logger,
@@ -334,8 +334,8 @@ def test_extract_youtube_video_id_parse_error_returns_none(
 async def test_raw_url_helpers_disable_internal_retries(service: SourceAddService) -> None:
     rpc = RecordingRpc(source_response("url", "URL"))
 
-    await service.add_url_source("nb_1", "https://example.com", rpc_call=rpc)
-    await service.add_youtube_source("nb_1", "https://youtu.be/video", rpc_call=rpc)
+    await service.add_url_source("nb_1", "https://example.com", rpc=rpc)
+    await service.add_youtube_source("nb_1", "https://youtu.be/video", rpc=rpc)
 
     assert rpc.calls[0]["disable_internal_retries"] is True
     assert rpc.calls[0]["params"][0][0][2] == ["https://example.com"]

--- a/tests/unit/test_source_content_renderer.py
+++ b/tests/unit/test_source_content_renderer.py
@@ -20,7 +20,7 @@ class RecordingRpc:
         self.response = response
         self.calls: list[dict[str, Any]] = []
 
-    async def __call__(
+    async def rpc_call(
         self,
         method: RPCMethod,
         params: list[Any],
@@ -29,6 +29,7 @@ class RecordingRpc:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         self.calls.append(
             {

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -18,7 +18,7 @@ class RecordingRpc:
         self.response = response
         self.calls: list[tuple[RPCMethod, list[Any], str | None]] = []
 
-    async def __call__(
+    async def rpc_call(
         self,
         method: RPCMethod,
         params: list[Any],
@@ -27,6 +27,7 @@ class RecordingRpc:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         self.calls.append((method, params, source_path))
         return self.response


### PR DESCRIPTION
## Summary
- Convert `SourceLister`, `SourceContentRenderer`, `ShareManager`, `ArtifactListingService`, and `SourceAddService` to consume the shared `RpcCaller` object shape.
- Keep `SourceUploadPipeline.register_file_source`'s `RpcCallback` keyword seam as the remaining callable RPC protocol.
- Update conventions/development docs and tests to reflect the smaller RPC dependency vocabulary.

## Stack
- Follow-up to merged #1058.
- Rebased onto `origin/main` after #1058 merged; this PR now targets `main`.
- #1060 is stacked on this branch.

## Testing
- `uv run --frozen pytest tests/unit/test_source_listing_service.py tests/unit/test_source_content_renderer.py tests/unit/test_sharing_manager.py tests/unit/test_notebook_api.py tests/unit/test_artifact_downloads.py tests/integration/test_artifacts_integration.py` -> 233 passed
- `uv run --frozen pytest tests/unit/test_notebook_metadata.py tests/unit/test_research_import_with_verification.py tests/unit/test_research.py tests/unit/test_source_listing_service.py tests/unit/test_source_content_renderer.py tests/unit/test_sharing_manager.py tests/unit/test_notebook_api.py tests/unit/test_artifact_downloads.py tests/integration/test_artifacts_integration.py` -> 319 passed
- `uv run --frozen pytest tests/_lint` -> 57 passed
- `uv run --frozen ruff check .` -> All checks passed
- `uv run --frozen ruff format --check .` -> 541 files already formatted
- `uv run --frozen mypy src/notebooklm` -> Success: no issues found in 173 source files
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified RPC protocol naming guidance, consolidating recommended names from five to three and clarifying naming/usage guidance.

* **Refactor**
  * Standardized RPC caller usage across listing, source management, addition, rendering, notebook, and sharing flows to a single caller interface.

* **Tests**
  * Updated test helpers and expectations to match the unified RPC caller pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->