### PR TITLE
refactor(collaborators): push operation_scope / register_drain_hook / assert_bound_loop down (ADR-014 Rule 1 prereq)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -3,8 +3,8 @@
 import asyncio
 import logging
 import random  # noqa: F401 - tests patch this for _backoff jitter
-from collections.abc import AsyncIterator, Awaitable, Callable
-from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -12,7 +12,6 @@ import httpx
 
 from ._error_injection import _refuse_synthetic_error_outside_test_context
 from ._kernel import Kernel
-from ._loop_affinity import assert_bound_loop
 from ._middleware import (
     RpcRequest,
     RpcResponse,
@@ -378,7 +377,9 @@ class Session:
         self._lifecycle = collaborators.lifecycle
         self.cookie_persistence = collaborators.cookie_persistence
         self.poll_registry = collaborators.poll_registry
-        self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
+        # ``_drain_hooks`` storage moved to ``TransportDrainTracker`` in
+        # Wave 2 of the session-decoupling plan (ADR-014 Rule 1).
+        # ``Session.register_drain_hook`` is now a one-line forward.
         self._rpc_executor: RpcExecutor | None = None
 
         # The authed POST hot path (chain terminal, freshness rebuild,
@@ -419,8 +420,13 @@ class Session:
         self._authed_post_chain = wired.authed_post_chain
 
     def register_drain_hook(self, name: str, hook: Callable[[], Awaitable[None]]) -> None:
-        """Register or replace a feature-owned close-time drain hook."""
-        self._drain_hooks[name] = hook
+        """Register or replace a feature-owned close-time drain hook.
+
+        Forward to :meth:`TransportDrainTracker.register_drain_hook` per
+        ADR-014 Rule 1; the storage and firing live on the tracker since
+        Wave 2 of the session-decoupling plan.
+        """
+        self._drain_tracker.register_drain_hook(name, hook)
 
     async def next_reqid(self, step: int = _REQID_DEFAULT_STEP) -> int:
         """Atomically increment the request-id counter and return the new value.
@@ -484,21 +490,30 @@ class Session:
         return loop if isinstance(loop, asyncio.AbstractEventLoop) else None
 
     def assert_bound_loop(self) -> None:
-        """Raise if this core is used from a loop other than its open-time loop."""
-        assert_bound_loop(self.bound_loop)
+        """Raise if this core is used from a loop other than its open-time loop.
+
+        Forward to :meth:`ClientLifecycle.assert_bound_loop` per ADR-014
+        Rule 1; ``ClientLifecycle`` satisfies the ``LoopGuard`` capability
+        Protocol directly since Wave 2 of the session-decoupling plan.
+        """
+        self._lifecycle.assert_bound_loop()
 
     async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
         await self._metrics_obj.emit_rpc_event(event)
 
-    @asynccontextmanager
-    async def operation_scope(self, label: str) -> AsyncIterator[None]:
-        """Return a drain-tracked operation scope for feature-owned work."""
-        token = await self._drain_tracker.begin_transport_post(label)
-        try:
-            yield None
-        finally:
-            await self._drain_tracker.finish_transport_post(token)
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        """Return a drain-tracked operation scope for feature-owned work.
+
+        Forward to :meth:`TransportDrainTracker.operation_scope` per
+        ADR-014 Rule 1; ``TransportDrainTracker`` satisfies the
+        ``OperationScopeProvider`` capability Protocol directly since
+        Wave 2 of the session-decoupling plan. Plain sync function (no
+        ``@asynccontextmanager``) so the inner context manager flows
+        through unchanged; callers still write
+        ``async with session.operation_scope(label):``.
+        """
+        return self._drain_tracker.operation_scope(label)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new client operations and wait for in-flight ones to finish.

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -176,11 +176,15 @@ class _LifecycleHost(Protocol):
     on the host, so future refactors that move state around ``Session``
     surface as Protocol violations rather than silent ``AttributeError``s
     at close-time. ``cookie_persistence`` mirrors today's public attribute
-    name on ``Session``; ``_drain_hooks``, ``_metrics_obj``,
-    ``_drain_tracker``, and ``_auth_coord`` are helper handles.
-    ``_rpc_executor`` is nulled out by :meth:`ClientLifecycle.close` so a
-    follow-up ``open()`` rebuilds it against the new ``httpx.AsyncClient``
-    state.
+    name on ``Session``; ``_metrics_obj``, ``_drain_tracker``, and
+    ``_auth_coord`` are helper handles. ``_rpc_executor`` is nulled out by
+    :meth:`ClientLifecycle.close` so a follow-up ``open()`` rebuilds it
+    against the new ``httpx.AsyncClient`` state.
+
+    Note: ``_drain_hooks`` was removed from this Protocol in Wave 2 of the
+    session-decoupling plan (ADR-014 Rule 1) — the storage and the
+    ``run_drain_hooks`` firing now live on ``TransportDrainTracker``, so
+    ``close()`` reaches them through ``host._drain_tracker`` instead.
     """
 
     auth: AuthTokens
@@ -189,7 +193,6 @@ class _LifecycleHost(Protocol):
     _auth_coord: AuthRefreshCoordinator
     _reqid: ReqidCounter
     cookie_persistence: CookiePersistence
-    _drain_hooks: dict[str, Callable[[], Awaitable[None]]]
     _rpc_executor: RpcExecutor | None
 
 
@@ -276,6 +279,18 @@ class ClientLifecycle:
         attribute stays an implementation detail of this helper.
         """
         return self._bound_loop
+
+    def assert_bound_loop(self) -> None:
+        """Satisfies the ``LoopGuard`` capability Protocol (ADR-014 Rule 1).
+
+        Delegates to the free function in :mod:`notebooklm._loop_affinity`
+        with this lifecycle's captured loop. ``Session.assert_bound_loop``
+        is a thin forward; feature APIs that depend on ``LoopGuard`` take
+        :class:`ClientLifecycle` directly.
+        """
+        from ._loop_affinity import assert_bound_loop as _assert
+
+        _assert(self._bound_loop)
 
     def get_http_client(self) -> httpx.AsyncClient:
         """Return the live HTTP client via the concrete Kernel."""
@@ -413,12 +428,7 @@ class ClientLifecycle:
                 refresh_task.cancel()
                 await asyncio.gather(refresh_task, return_exceptions=True)
 
-            drain_hooks = list(host._drain_hooks.values())
-            if drain_hooks:
-                await asyncio.gather(
-                    *(hook() for hook in drain_hooks),
-                    return_exceptions=True,
-                )
+            await host._drain_tracker.run_drain_hooks()
 
             if self._http_client:
                 try:

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -45,11 +45,16 @@ D1-audit-full once its callers migrated; the field itself remains on
 from __future__ import annotations
 
 import asyncio
+import logging
 import weakref
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 
 from ._loop_affinity import assert_bound_loop
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -106,6 +111,11 @@ class TransportDrainTracker:
         # to the loop that constructed it). ``None`` is a silent no-op
         # for standalone fixtures.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
+        # ADR-014 Rule 1: close-time drain hooks are owned here, not on
+        # ``Session``. Insertion order is preserved (Python 3.7+ dict
+        # invariant) and :meth:`run_drain_hooks` fires them in that order
+        # under ``ClientLifecycle.close``.
+        self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
 
     def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
         """Capture or clear the event-loop binding for the affinity guard.
@@ -212,6 +222,45 @@ class TransportDrainTracker:
             self._in_flight_posts -= 1
             if self._in_flight_posts == 0:
                 condition.notify_all()
+
+    @asynccontextmanager
+    async def operation_scope(self, label: str) -> AsyncIterator[None]:
+        """Drain-tracked operation scope for feature-owned work (ADR-014 Rule 1).
+
+        Wraps :meth:`begin_transport_post` / :meth:`finish_transport_post`
+        so feature code can write ``async with tracker.operation_scope("upload"):``
+        without managing the token by hand. Satisfies ``OperationScopeProvider``
+        directly — ``Session.operation_scope`` becomes a thin forward.
+        """
+        token = await self.begin_transport_post(label)
+        try:
+            yield None
+        finally:
+            await self.finish_transport_post(token)
+
+    def register_drain_hook(self, name: str, hook: Callable[[], Awaitable[None]]) -> None:
+        """Register or replace a feature-owned close-time drain hook.
+
+        ADR-014 Rule 1 + close-out for plan Wave 0.5: the storage moved from
+        ``Session._drain_hooks`` to this tracker so ``DrainHookRegistration``
+        is satisfied directly. ``ClientLifecycle.close`` fires registered
+        hooks via :meth:`run_drain_hooks`.
+        """
+        self._drain_hooks[name] = hook
+
+    async def run_drain_hooks(self) -> None:
+        """Fire every registered drain hook in registration order.
+
+        Called once from ``ClientLifecycle.close`` after the auth-refresh
+        task has been cancelled and before the HTTP client is shut down.
+        Exceptions in individual hooks are suppressed (logged via
+        ``asyncio.gather(return_exceptions=True)``) so a misbehaving feature
+        cannot block the shutdown path.
+        """
+        hooks = list(self._drain_hooks.values())
+        if not hooks:
+            return
+        await asyncio.gather(*(hook() for hook in hooks), return_exceptions=True)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new top-level work and wait for in-flight ops to finish.

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -253,14 +253,25 @@ class TransportDrainTracker:
 
         Called once from ``ClientLifecycle.close`` after the auth-refresh
         task has been cancelled and before the HTTP client is shut down.
-        Exceptions in individual hooks are suppressed (logged via
-        ``asyncio.gather(return_exceptions=True)``) so a misbehaving feature
-        cannot block the shutdown path.
+        Exceptions in individual hooks are caught and logged via
+        ``logger.warning`` (with the registration ``name`` so operators can
+        identify the misbehaving feature), then suppressed so a single
+        misbehaving hook cannot block the shutdown path. The hooks fire
+        concurrently via ``asyncio.gather(..., return_exceptions=True)`` —
+        the per-hook log happens after the gather completes.
         """
-        hooks = list(self._drain_hooks.values())
-        if not hooks:
+        named_hooks = list(self._drain_hooks.items())
+        if not named_hooks:
             return
-        await asyncio.gather(*(hook() for hook in hooks), return_exceptions=True)
+        results = await asyncio.gather(
+            *(hook() for _name, hook in named_hooks),
+            return_exceptions=True,
+        )
+        for (name, _hook), result in zip(named_hooks, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Drain hook %r raised during close: %s", name, result, exc_info=result
+                )
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new top-level work and wait for in-flight ops to finish.

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -127,7 +127,11 @@ def make_fake_core(**overrides: Any) -> FakeSession:
         "operation_scope": MagicMock(side_effect=_operation_scope),
         # DrainHookRegistration (local in ``_artifacts.py``) — close-time
         # hook the artifacts runtime registers against in
-        # ``ArtifactsAPI.__init__``.
+        # ``ArtifactsAPI.__init__``. Wave 2 of session-decoupling moved
+        # the storage onto ``TransportDrainTracker`` (ADR-014 Rule 1); we
+        # keep ``_drain_hooks`` as a public attribute on the fake so test
+        # sites that previously read ``fake._drain_hooks["name"]`` still
+        # work (the fake doesn't have a real ``_drain_tracker``).
         "_drain_hooks": {},
         "register_drain_hook": MagicMock(return_value=None),
         # Upload-pipeline glue: queue-wait recorder consumed by the

--- a/tests/unit/concurrency/test_session_close_refresh_race.py
+++ b/tests/unit/concurrency/test_session_close_refresh_race.py
@@ -68,7 +68,9 @@ class _StubHost:
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
-        self._drain_hooks = {}
+        # Wave 2 of session-decoupling: drain hooks live on
+        # ``TransportDrainTracker``; the host no longer carries ``_drain_hooks``.
+        # The real tracker constructed above already has its own ``_drain_hooks``.
         self._rpc_executor = None
 
 

--- a/tests/unit/test_drain_tracker_hooks.py
+++ b/tests/unit/test_drain_tracker_hooks.py
@@ -51,12 +51,14 @@ async def test_run_drain_hooks_fires_in_registration_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_drain_hooks_continues_when_one_hook_raises() -> None:
-    """A hook that raises must not block the other hooks from running.
+async def test_run_drain_hooks_continues_when_one_hook_raises(caplog) -> None:
+    """A hook that raises must not block the other hooks AND the exception
+    must be logged with the hook's registration name.
 
-    Pinned because the close path swallows hook exceptions via
-    ``asyncio.gather(return_exceptions=True)`` — a misbehaving feature
-    cannot prevent shutdown.
+    Round-2 reviewer fix (PR #1065 gemini + cubic): the prior implementation
+    silently swallowed exceptions despite the docstring promising logging.
+    Now: misbehaving feature cannot prevent shutdown AND its error is observable
+    via ``logger.warning`` at ``notebooklm._transport_drain``.
     """
     tracker = TransportDrainTracker()
     fired: list[str] = []
@@ -75,10 +77,18 @@ async def test_run_drain_hooks_continues_when_one_hook_raises() -> None:
     tracker.register_drain_hook("b", hook_b_raises)
     tracker.register_drain_hook("c", hook_c)
 
-    # ``run_drain_hooks`` itself must not raise even though hook_b does.
-    await tracker.run_drain_hooks()
+    with caplog.at_level("WARNING", logger="notebooklm._transport_drain"):
+        # ``run_drain_hooks`` itself must not raise even though hook_b does.
+        await tracker.run_drain_hooks()
 
     assert fired == ["a", "b_raised", "c"]
+    matching = [r for r in caplog.records if "intentional test failure" in r.getMessage()]
+    assert len(matching) == 1, (
+        f"expected exactly one warning log for hook 'b'; got {len(matching)}"
+    )
+    assert "'b'" in matching[0].getMessage(), (
+        f"log message must include hook name 'b'; got: {matching[0].getMessage()!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_drain_tracker_hooks.py
+++ b/tests/unit/test_drain_tracker_hooks.py
@@ -1,0 +1,114 @@
+"""Close-ordering contract for ``TransportDrainTracker`` drain hooks (ADR-014 Rule 1).
+
+Wave 2 of the session-decoupling plan moved the drain-hook storage and firing
+from ``Session._drain_hooks`` to ``TransportDrainTracker.register_drain_hook``
+/ ``run_drain_hooks``. These tests pin the close-ordering contract that the
+post-Wave-0.5 code MUST preserve:
+
+* Hooks fire in registration order (insertion-order dict invariant).
+* A hook that raises does not block the rest from firing (other hooks still
+  run; ``run_drain_hooks`` does not propagate the exception).
+* No hooks ever registered → ``run_drain_hooks`` is a clean no-op.
+
+The lifecycle-level "drain hooks run before transport teardown" assertion
+lives in ``test_session_lifecycle.py::test_close_runs_drain_hooks_before_transport_teardown``
+— this file is the unit-level contract on the tracker itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._transport_drain import TransportDrainTracker
+
+
+@pytest.mark.asyncio
+async def test_run_drain_hooks_fires_in_registration_order() -> None:
+    """Hooks fire in the order they were registered (dict insertion order).
+
+    Pinned because feature code may register multiple hooks (artifacts.polls,
+    research.polls, etc.) and rely on a deterministic shutdown sequence.
+    """
+    tracker = TransportDrainTracker()
+    fired: list[str] = []
+
+    async def hook_a() -> None:
+        fired.append("a")
+
+    async def hook_b() -> None:
+        fired.append("b")
+
+    async def hook_c() -> None:
+        fired.append("c")
+
+    tracker.register_drain_hook("a", hook_a)
+    tracker.register_drain_hook("b", hook_b)
+    tracker.register_drain_hook("c", hook_c)
+
+    await tracker.run_drain_hooks()
+
+    assert fired == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_run_drain_hooks_continues_when_one_hook_raises() -> None:
+    """A hook that raises must not block the other hooks from running.
+
+    Pinned because the close path swallows hook exceptions via
+    ``asyncio.gather(return_exceptions=True)`` — a misbehaving feature
+    cannot prevent shutdown.
+    """
+    tracker = TransportDrainTracker()
+    fired: list[str] = []
+
+    async def hook_a() -> None:
+        fired.append("a")
+
+    async def hook_b_raises() -> None:
+        fired.append("b_raised")
+        raise RuntimeError("intentional test failure")
+
+    async def hook_c() -> None:
+        fired.append("c")
+
+    tracker.register_drain_hook("a", hook_a)
+    tracker.register_drain_hook("b", hook_b_raises)
+    tracker.register_drain_hook("c", hook_c)
+
+    # ``run_drain_hooks`` itself must not raise even though hook_b does.
+    await tracker.run_drain_hooks()
+
+    assert fired == ["a", "b_raised", "c"]
+
+
+@pytest.mark.asyncio
+async def test_run_drain_hooks_is_noop_when_none_registered() -> None:
+    """No hooks registered → ``run_drain_hooks`` returns cleanly without I/O."""
+    tracker = TransportDrainTracker()
+    # No registrations.
+    await tracker.run_drain_hooks()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_register_drain_hook_overwrites_same_name() -> None:
+    """Registering the same name twice replaces the prior hook.
+
+    Pinned because ``register_drain_hook`` is documented as "register or
+    replace" — re-instantiating a feature inside one session (rare but
+    legal) must not double-fire its drain hook.
+    """
+    tracker = TransportDrainTracker()
+    fired: list[str] = []
+
+    async def first() -> None:
+        fired.append("first")
+
+    async def second() -> None:
+        fired.append("second")
+
+    tracker.register_drain_hook("artifacts.polls", first)
+    tracker.register_drain_hook("artifacts.polls", second)  # replaces first
+
+    await tracker.run_drain_hooks()
+
+    assert fired == ["second"]

--- a/tests/unit/test_drain_tracker_hooks.py
+++ b/tests/unit/test_drain_tracker_hooks.py
@@ -83,9 +83,7 @@ async def test_run_drain_hooks_continues_when_one_hook_raises(caplog) -> None:
 
     assert fired == ["a", "b_raised", "c"]
     matching = [r for r in caplog.records if "intentional test failure" in r.getMessage()]
-    assert len(matching) == 1, (
-        f"expected exactly one warning log for hook 'b'; got {len(matching)}"
-    )
+    assert len(matching) == 1, f"expected exactly one warning log for hook 'b'; got {len(matching)}"
     assert "'b'" in matching[0].getMessage(), (
         f"log message must include hook name 'b'; got: {matching[0].getMessage()!r}"
     )

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -102,7 +102,7 @@ async def test_session_close_drains_artifact_poll_hook() -> None:
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),
     )
-    assert core._drain_hooks["artifacts.polls"] == artifacts._polling.drain
+    assert core._drain_tracker._drain_hooks["artifacts.polls"] == artifacts._polling.drain
     await core.open()
 
     loop = asyncio.get_running_loop()

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -71,7 +71,8 @@ class _StubHost:
       open() path so cross-loop misuse can be caught.
     * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
       coroutine; assertions check it was called with the right args.
-    * ``_drain_hooks`` — close-time hooks registered by feature APIs.
+    * ``_drain_tracker.run_drain_hooks`` — called by close(); set to an
+      ``AsyncMock`` so tests can assert it ran and inspect call order.
     * ``_rpc_executor`` — set to a sentinel marker value so tests can
       assert :meth:`ClientLifecycle.close` nulls it.
     """
@@ -86,6 +87,10 @@ class _StubHost:
         self._metrics_obj = MagicMock()
         self._drain_tracker = MagicMock()
         self._drain_tracker._draining = True  # so we can assert open() resets it
+        # Wave 2 of session-decoupling: drain hooks live on the tracker.
+        # ``close()`` calls ``host._drain_tracker.run_drain_hooks()`` so the
+        # mock needs an async implementation.
+        self._drain_tracker.run_drain_hooks = AsyncMock()
         self._auth_coord = MagicMock()
         # ``_auth_coord._refresh_task`` is checked by ``close()`` (P0-1).
         # Default to ``None`` so the cancel branch is skipped; tests that
@@ -96,7 +101,6 @@ class _StubHost:
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
-        self._drain_hooks = {}
         # Sentinel — close() nulls this out.
         self._rpc_executor: Any = "RPC_EXECUTOR_SENTINEL"
 
@@ -335,31 +339,41 @@ async def test_close_when_never_opened_is_noop() -> None:
 
 @pytest.mark.asyncio
 async def test_close_runs_drain_hooks_before_transport_teardown() -> None:
-    """``close()`` runs feature drain hooks before tearing down the HTTP client."""
+    """``close()`` invokes ``run_drain_hooks`` on the tracker before tearing down the HTTP client.
+
+    Wave 2 of session-decoupling: drain hooks live on ``TransportDrainTracker``;
+    the lifecycle just calls ``host._drain_tracker.run_drain_hooks()`` and the
+    tracker handles the firing + exception suppression.
+    """
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    # Build a real asyncio.Task that's parked indefinitely.
-    async def _park() -> None:
-        try:
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
-            raise
+    # Record ordering: drain hooks must run *before* the HTTP client teardown
+    # (so a hook that needs the live client — e.g. an in-flight cookie save —
+    # can still see it).
+    events: list[str] = []
 
-    parked = asyncio.create_task(_park())
+    async def fake_run_drain_hooks() -> None:
+        assert lifecycle._http_client is not None, (
+            "drain hooks must run while the HTTP client is still open"
+        )
+        events.append("run_drain_hooks")
 
-    async def drain_polls() -> None:
-        assert lifecycle._http_client is not None
-        parked.cancel()
-        await asyncio.gather(parked, return_exceptions=True)
+    host._drain_tracker.run_drain_hooks = fake_run_drain_hooks
 
-    host._drain_hooks["artifacts.polls"] = drain_polls
+    original_aclose = lifecycle._kernel.aclose
+
+    async def recording_aclose() -> None:
+        events.append("kernel_aclose")
+        await original_aclose()
+
+    lifecycle._kernel.aclose = recording_aclose  # type: ignore[method-assign]
 
     await lifecycle.open(host)
     await lifecycle.close(host)
 
-    assert parked.cancelled() or parked.done(), (
-        "close() must run drain hooks before tearing down the client."
+    assert events == ["run_drain_hooks", "kernel_aclose"], (
+        f"close() must run drain hooks before kernel.aclose(); got {events}"
     )
     assert lifecycle._http_client is None
 


### PR DESCRIPTION
## Summary

Wave 2 of the session-decoupling plan (`docs/session-decoupling-plan-2026-05-26.md`). Pushes three Protocol-satisfying methods down from `Session` onto the collaborators that should own them per ADR-014 Rule 1.

This is a **prerequisite** for Wave 1+ (`refactor-auth-refresh-coordinator`, `rewire-rpc-executor-and-delete-rpc-owner`, the simple-feature wiring) — until these methods physically live on the collaborators, the upcoming PRs cannot have `ClientLifecycle` satisfy `LoopGuard` or `TransportDrainTracker` satisfy `OperationScopeProvider` / `DrainHookRegistration` directly. After this PR, those satisfactions are structurally true.

### Per-collaborator changes

| Collaborator | Added | Now satisfies |
|---|---|---|
| `TransportDrainTracker` | `operation_scope(label)`, `register_drain_hook(name, hook)`, `run_drain_hooks()`, `_drain_hooks` storage | `OperationScopeProvider` + `DrainHookRegistration` directly |
| `ClientLifecycle` | `assert_bound_loop()` | `LoopGuard` directly |
| `Session` | `register_drain_hook`, `operation_scope`, `assert_bound_loop` are now **forwards** (deletable in Wave 11 of the plan); `_drain_hooks` storage removed | (no longer needed to satisfy `LoopGuard`/`OperationScopeProvider`/`DrainHookRegistration` once features migrate in Waves 3–4) |

### Non-obvious things this PR also does

- `Session.operation_scope` **drops the `@asynccontextmanager` decorator** and becomes a plain sync function returning the inner contextmanager from the tracker. Callers still write `async with session.operation_scope(label):` — the shape is preserved. (Round-3 momus finding: returning an async-cm from inside an `@asynccontextmanager` body silently breaks.)
- `_LifecycleHost` Protocol shrinks by one field — `_drain_hooks` is removed since the storage moved to the tracker. The lifecycle close path now calls `await host._drain_tracker.run_drain_hooks()`.
- New `tests/unit/test_drain_tracker_hooks.py` with 4 close-ordering tests pinning: registration-order firing, exception non-blocking, no-op when empty, same-name replacement. Required by plan Task 0.5b Step 6.
- Three test sites + the FakeSession fixture migrated to the new shape. The pre-Wave-1 test surface stays green without behaviour change.

### Verification

- `uv run pytest tests/unit tests/_lint` — **5832 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

## Test plan

- [x] All unit + lint pass
- [x] New `test_drain_tracker_hooks.py` (4 tests) verify ADR-014 Rule 1 contract
- [x] `test_close_runs_drain_hooks_before_transport_teardown` rewritten to assert the ordering contract that close() runs drain hooks before kernel.aclose()
- [x] `test_session_close_drains_artifact_poll_hook` migrated to read from the new storage location

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized close-time drain hook registration and execution into a dedicated transport tracker, and updated session/lifecycle methods to delegate loop-affinity and operation scoping to that tracker, improving shutdown ordering and separation of concerns.

* **Tests**
  * Added unit tests verifying drain-hook ordering, error isolation (failing hooks don't stop others), no-op when none registered, and hook-replacement behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->