### PR TITLE
refactor(auth): move load_auth_from_storage body to _auth/tokens.py (Wave 3a / Task 2.1)

### DIFF
--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -251,7 +251,8 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
     2. NOTEBOOKLM_AUTH_JSON environment variable (inline JSON, no file needed)
     3. File at $NOTEBOOKLM_HOME/storage_state.json (or ~/.notebooklm/storage_state.json)
 
-    Duplicate-name resolution follows :func:`_auth_domain_priority`, matching
+    Duplicate-name resolution follows
+    :func:`notebooklm._auth.cookie_policy._auth_domain_priority`, matching
     :attr:`AuthTokens.flat_cookies` for the same storage state — previously the
     two paths disagreed on names that live only on non-base hosts (e.g.
     ``OSID`` on ``myaccount.google.com`` vs ``notebooklm.google.com``). See
@@ -299,4 +300,4 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
         return _auth_cookies.extract_cookies_from_storage(storage_state)
 
 
-__all__ = ["AuthTokens"]
+__all__ = ["AuthTokens", "load_auth_from_storage"]

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -13,6 +13,7 @@ import httpx
 from ..paths import get_storage_path
 from . import account as _auth_account
 from . import cookies as _auth_cookies
+from . import psidts_recovery as _auth_psidts_recovery
 from . import refresh as _auth_refresh
 from . import storage as _auth_storage
 
@@ -240,6 +241,62 @@ class AuthTokens:
 
 
 AuthTokens.__module__ = "notebooklm.auth"
+
+
+def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
+    """Load Google cookies from storage as a flat name→value dict.
+
+    Loads authentication cookies with the following precedence:
+    1. Explicit path argument (from --storage CLI flag)
+    2. NOTEBOOKLM_AUTH_JSON environment variable (inline JSON, no file needed)
+    3. File at $NOTEBOOKLM_HOME/storage_state.json (or ~/.notebooklm/storage_state.json)
+
+    Duplicate-name resolution follows :func:`_auth_domain_priority`, matching
+    :attr:`AuthTokens.flat_cookies` for the same storage state — previously the
+    two paths disagreed on names that live only on non-base hosts (e.g.
+    ``OSID`` on ``myaccount.google.com`` vs ``notebooklm.google.com``). See
+    issue #375.
+
+    Args:
+        path: Path to storage_state.json. If provided, takes precedence over env vars.
+
+    Returns:
+        Dict mapping cookie names to values (e.g., {"SID": "...", "HSID": "..."}).
+
+    Raises:
+        FileNotFoundError: If storage file doesn't exist (when using file-based auth).
+        ValueError: If required cookies (SID) are missing or JSON is malformed.
+
+    Example::
+
+        # CLI flag takes precedence
+        cookies = load_auth_from_storage(Path("/custom/path.json"))
+
+        # Or use NOTEBOOKLM_AUTH_JSON for CI/CD (no file writes needed)
+        # export NOTEBOOKLM_AUTH_JSON='{"cookies":[...]}'
+        cookies = load_auth_from_storage()
+    """
+    storage_state = _auth_cookies._load_storage_state(path)
+    try:
+        return _auth_cookies.extract_cookies_from_storage(storage_state)
+    except ValueError:
+        # Inline ``__Secure-1PSIDTS`` recovery (issue #865). Playwright login
+        # can land a ``storage_state.json`` that carries SID + secondary
+        # binding but lacks PSIDTS, because Google only mints PSIDTS
+        # deterministically in response to the dedicated ``RotateCookies``
+        # POST — not on the passive ``goto()`` navigations the login flow
+        # uses. The preflight then rejects before the keepalive's RotateCookies
+        # path can heal the state. When the recovery preconditions hold, fire
+        # one POST + persist before re-raising — see
+        # :mod:`notebooklm._auth.psidts_recovery` for the precondition list.
+        # ``_recover_psidts_inline`` resolves the effective storage path
+        # itself (default file when ``path is None`` and env-var unset), so
+        # we pass ``path`` through verbatim — including ``None`` for the
+        # default-profile case.
+        if not _auth_psidts_recovery._recover_psidts_inline(path):
+            raise
+        storage_state = _auth_cookies._load_storage_state(path)
+        return _auth_cookies.extract_cookies_from_storage(storage_state)
 
 
 __all__ = ["AuthTokens"]

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -29,7 +29,6 @@ Security Notes:
 
 import logging
 import subprocess  # noqa: F401  # re-exported for tests that patch ``auth.subprocess.run``
-from pathlib import Path
 from typing import TypeAlias
 
 import httpx
@@ -44,6 +43,7 @@ from ._auth import paths as _auth_paths
 from ._auth import psidts_recovery as _auth_psidts_recovery
 from ._auth import refresh as _auth_refresh
 from ._auth import storage as _auth_storage
+from ._auth import tokens as _auth_tokens
 from ._auth.tokens import AuthTokens
 from .paths import get_storage_path  # noqa: F401  # kept as a module-level compat alias
 
@@ -242,59 +242,11 @@ async def enumerate_accounts(
     )
 
 
-def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
-    """Load Google cookies from storage as a flat name→value dict.
-
-    Loads authentication cookies with the following precedence:
-    1. Explicit path argument (from --storage CLI flag)
-    2. NOTEBOOKLM_AUTH_JSON environment variable (inline JSON, no file needed)
-    3. File at $NOTEBOOKLM_HOME/storage_state.json (or ~/.notebooklm/storage_state.json)
-
-    Duplicate-name resolution follows :func:`_auth_domain_priority`, matching
-    :attr:`AuthTokens.flat_cookies` for the same storage state — previously the
-    two paths disagreed on names that live only on non-base hosts (e.g.
-    ``OSID`` on ``myaccount.google.com`` vs ``notebooklm.google.com``). See
-    issue #375.
-
-    Args:
-        path: Path to storage_state.json. If provided, takes precedence over env vars.
-
-    Returns:
-        Dict mapping cookie names to values (e.g., {"SID": "...", "HSID": "..."}).
-
-    Raises:
-        FileNotFoundError: If storage file doesn't exist (when using file-based auth).
-        ValueError: If required cookies (SID) are missing or JSON is malformed.
-
-    Example:
-        # CLI flag takes precedence
-        cookies = load_auth_from_storage(Path("/custom/path.json"))
-
-        # Or use NOTEBOOKLM_AUTH_JSON for CI/CD (no file writes needed)
-        # export NOTEBOOKLM_AUTH_JSON='{"cookies":[...]}'
-        cookies = load_auth_from_storage()
-    """
-    storage_state = _load_storage_state(path)
-    try:
-        return extract_cookies_from_storage(storage_state)
-    except ValueError:
-        # Inline ``__Secure-1PSIDTS`` recovery (issue #865). Playwright login
-        # can land a ``storage_state.json`` that carries SID + secondary
-        # binding but lacks PSIDTS, because Google only mints PSIDTS
-        # deterministically in response to the dedicated ``RotateCookies``
-        # POST — not on the passive ``goto()`` navigations the login flow
-        # uses. The preflight then rejects before the keepalive's RotateCookies
-        # path can heal the state. When the recovery preconditions hold, fire
-        # one POST + persist before re-raising — see
-        # :mod:`notebooklm._auth.psidts_recovery` for the precondition list.
-        # ``_recover_psidts_inline`` resolves the effective storage path
-        # itself (default file when ``path is None`` and env-var unset), so
-        # we pass ``path`` through verbatim — including ``None`` for the
-        # default-profile case.
-        if not _auth_psidts_recovery._recover_psidts_inline(path):
-            raise
-        storage_state = _load_storage_state(path)
-        return extract_cookies_from_storage(storage_state)
+# ``load_auth_from_storage`` body lives in ``_auth/tokens.py`` per Wave 3a of
+# the session-decoupling plan (ADR-014 + Stage 6 of architecture-fix-plan).
+# This module re-exports it so ``notebooklm.auth.load_auth_from_storage``
+# stays a stable public import.
+load_auth_from_storage = _auth_tokens.load_auth_from_storage
 
 
 # Env-var name constants live in ``notebooklm._auth.paths``. Re-exported so

--- a/tests/unit/test_auth_storage.py
+++ b/tests/unit/test_auth_storage.py
@@ -18,6 +18,17 @@ from notebooklm.auth import (
 )
 
 
+def test_load_auth_from_storage_lives_in_private_module() -> None:
+    """Wave 3a of session-decoupling: load_auth_from_storage body lives in
+    ``_auth/tokens.py``; ``notebooklm.auth.load_auth_from_storage`` is a
+    re-export. Identity pin so a future drift (someone re-introducing a
+    distinct body on ``auth.py``) fails at PR time."""
+    from notebooklm import auth as auth_module
+    from notebooklm._auth import tokens as tokens_module
+
+    assert auth_module.load_auth_from_storage is tokens_module.load_auth_from_storage
+
+
 class TestLoadAuthFromStorage:
     def test_loads_from_file(self, tmp_path):
         """Test loading auth from storage state file."""


### PR DESCRIPTION
## Summary

Wave 3a of the session-decoupling plan (`docs/session-decoupling-plan-2026-05-26.md`, Task 2.1). Closes Stage 6 of the original architecture-fix-plan: `load_auth_from_storage`'s body moves into the `_auth/` subpackage; `notebooklm.auth` becomes a stable re-export point.

**Parallel with Wave 2 (#1065)** — zero file overlap, targets `main` directly. Both can land independently.

### What this PR does

| File | Change |
|---|---|
| `src/notebooklm/_auth/tokens.py` | Adds `load_auth_from_storage(path)` with the full body cut from `auth.py:245`. Body uses the `_auth_cookies` alias for `_load_storage_state` / `extract_cookies_from_storage` (same pattern `AuthTokens` already uses). Imports `_auth_psidts_recovery` for the recovery branch. |
| `src/notebooklm/auth.py` | Multi-line function replaced with one-line `load_auth_from_storage = _auth_tokens.load_auth_from_storage` re-export. Adds `from ._auth import tokens as _auth_tokens`. Drops `from pathlib import Path` (no longer used). |
| `tests/unit/test_auth_storage.py` | Adds `test_load_auth_from_storage_lives_in_private_module` — identity pin so any future drift (someone re-introducing a distinct body on `auth.py`) fails at PR time. |

### Why this is safe

- `notebooklm.auth.load_auth_from_storage` is a re-export so the public import path doesn't change.
- `test_public_shims.py` pins still hold (the re-export is identity-preserving).
- No behaviour change — same function body, same recovery branch, same cross-module helpers.

### Verification

- `uv run pytest tests/unit tests/_lint` — **5829 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

## Test plan

- [x] All unit + lint pass
- [x] New identity pin verifies `auth.load_auth_from_storage is tokens.load_auth_from_storage`
- [x] Existing `test_auth_storage.py` tests pass unchanged (the public import path is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication cookie loading with a robust recovery/retry path and consistent duplicate resolution for more reliable sign-in behavior.

* **Tests**
  * Added unit test ensuring the authentication loader remains the canonical implementation to prevent drift and preserve expected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->