### PR TITLE
refactor(auth): AuthRefreshCoordinator.await_refresh drops host parameter (Wave 3b / Task 1.0)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -731,7 +731,11 @@ class Session:
         replaced only on the next refresh wave once the current task
         transitions to ``done()``.
         """
-        await self._auth_coord.await_refresh(self)
+        # Wave 3b of session-decoupling (Task 1.0): ``await_refresh`` no
+        # longer takes a host parameter — its only host attribute reach
+        # (``_metrics_obj``) is now supplied via the coordinator's
+        # constructor.
+        await self._auth_coord.await_refresh()
 
     async def rpc_call(
         self,

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -94,12 +94,20 @@ class AuthRefreshCoordinator:
         self,
         *,
         refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
+        metrics: ClientMetrics | None = None,
     ) -> None:
         # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
         # Python versions, and this object can be constructed outside one.
         self._refresh_lock: asyncio.Lock | None = None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = refresh_callback
+        # Wave 3b of session-decoupling: ``await_refresh`` records lock-wait
+        # latency via this metrics dep (was previously read off the
+        # ``_AuthRefreshHost`` parameter — see plan Task 1.0). ``None`` is a
+        # safe fallback for tests that construct the coordinator standalone
+        # without a metrics collaborator; the lock-wait latency is simply not
+        # recorded in that case.
+        self._metrics: ClientMetrics | None = metrics
         # Distinct from ``_refresh_lock`` — see module docstring.
         self._auth_snapshot_lock: asyncio.Lock | None = None
         # P0-2: loop-affinity guard. Set by :meth:`ClientLifecycle.open`
@@ -249,7 +257,7 @@ class AuthRefreshCoordinator:
     # Single-flight refresh task.
     # ------------------------------------------------------------------
 
-    async def await_refresh(self, host: _AuthRefreshHost) -> None:
+    async def await_refresh(self) -> None:
         """Run / join the shared refresh task.
 
         Concurrent callers share one refresh task so a thundering herd of
@@ -265,6 +273,13 @@ class AuthRefreshCoordinator:
         same single-flight refresh. The slot at :attr:`_refresh_task` is left
         intact across the cancellation and is replaced only on the next
         refresh wave once the current task transitions to ``done()``.
+
+        Wave 3b of the session-decoupling plan (Task 1.0): this method no
+        longer takes an ``_AuthRefreshHost`` parameter — the only host
+        attribute it touched (``_metrics_obj``) is now supplied via the
+        ``metrics`` kwarg on :meth:`__init__`. The other coordinator
+        methods (``snapshot``, ``update_auth_tokens``, ``update_auth_headers``)
+        still take ``host`` — out of scope for this PR.
         """
         # P0-2: catch cross-loop refresh before touching ``_refresh_lock``.
         # The lock is lazily bound to the loop that first awaited
@@ -287,7 +302,8 @@ class AuthRefreshCoordinator:
         lock = self.get_refresh_lock()
         wait_start = time.perf_counter()
         await lock.acquire()
-        host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+        if self._metrics is not None:
+            self._metrics.record_lock_wait(time.perf_counter() - wait_start)
         try:
             if self._refresh_task is not None and not self._refresh_task.done():
                 refresh_task = self._refresh_task

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -281,7 +281,13 @@ def build_collaborators(
     # to avoid. The attribute name ``_auth_coord`` is part of the
     # inter-helper contract for the upcoming B2/C1 extractions; do not
     # rename.
-    auth_coord = AuthRefreshCoordinator(refresh_callback=refresh_callback)
+    # Wave 3b of session-decoupling (Task 1.0): supply ``metrics`` so
+    # ``await_refresh`` records lock-wait latency without needing an
+    # ``_AuthRefreshHost`` parameter.
+    auth_coord = AuthRefreshCoordinator(
+        refresh_callback=refresh_callback,
+        metrics=metrics,
+    )
     # HTTP-client lifecycle — owns loop binding, keepalive, and close
     # ordering while delegating the live ``httpx.AsyncClient`` to
     # ``self._kernel``. The ``_resolve_keepalive_interval`` clamp lives

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -142,13 +142,13 @@ def test_await_refresh_guards_against_cross_loop_call() -> None:
     try:
         coord.set_bound_loop(other_loop)
 
-        # Minimal host mock; ``await_refresh`` only touches
-        # ``host._metrics_obj.record_lock_wait`` on the happy path, which
-        # the cross-loop guard short-circuits before reaching.
-        host = MagicMock()
-
+        # Wave 3b of session-decoupling (Task 1.0): ``await_refresh`` no
+        # longer takes a host parameter — the lock-wait metric is recorded
+        # via the coordinator's own ``metrics`` field (None here, which is
+        # a safe fallback). The cross-loop guard short-circuits before any
+        # metric is recorded either way.
         async def inner() -> None:
-            await coord.await_refresh(host)
+            await coord.await_refresh()
 
         with pytest.raises(RuntimeError, match="different event loop"):
             asyncio.run(inner())

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -287,7 +287,7 @@ async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
 
     coord = AuthRefreshCoordinator(refresh_callback=cb)
 
-    tasks = [asyncio.create_task(coord.await_refresh(stub_host)) for _ in range(3)]
+    tasks = [asyncio.create_task(coord.await_refresh()) for _ in range(3)]
     await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
 
     # Yield enough times for waiters 2/3 to reach ``await shield(task)``.
@@ -322,11 +322,11 @@ async def test_await_refresh_creates_new_task_after_first_done(
 
     coord = AuthRefreshCoordinator(refresh_callback=cb)
 
-    await coord.await_refresh(stub_host)
+    await coord.await_refresh()
     first_task = coord._refresh_task
     assert first_task is not None and first_task.done()
 
-    await coord.await_refresh(stub_host)
+    await coord.await_refresh()
     second_task = coord._refresh_task
     assert second_task is not None and second_task.done()
 
@@ -365,8 +365,8 @@ async def test_await_refresh_cancellation_preserves_task_slot(
 
     coord = AuthRefreshCoordinator(refresh_callback=cb)
 
-    waiter_a = asyncio.create_task(coord.await_refresh(stub_host))
-    waiter_b = asyncio.create_task(coord.await_refresh(stub_host))
+    waiter_a = asyncio.create_task(coord.await_refresh())
+    waiter_b = asyncio.create_task(coord.await_refresh())
     await asyncio.wait_for(enter.wait(), EVENT_TIMEOUT_S)
 
     # Yield so both waiters reach ``await shield(task)``.


### PR DESCRIPTION
## Summary

Wave 3b of the session-decoupling plan (Task 1.0). Prerequisite for the upcoming Wave 4 `rewire-rpc-executor-and-delete-rpc-owner` PR: when `RpcExecutor` stops holding a Session-shaped owner, it cannot supply `host` to `await_refresh`. This PR moves the only host attribute `await_refresh` touches (`_metrics_obj`) into the coordinator's own constructor.

**Scope: narrowly limited to `await_refresh`.** Other coordinator methods (`snapshot`, `update_auth_tokens`, `update_auth_headers`) still take `host` for OTHER attributes — explicitly out of scope per plan Task 1.0.

**Parallel with Wave 2 (#1065) and Wave 3a (#1066).** Overlap is only on `_session.py` (different methods) and `_session_init.py` (Wave 2 doesn't touch it). Trivial rebase if any of the three lands before this one.

### What this PR does

| File | Change |
|---|---|
| `_session_auth.py` | `AuthRefreshCoordinator.__init__` accepts new `metrics: ClientMetrics \| None = None` kwarg. `await_refresh()` is now parameterless. The `host._metrics_obj.record_lock_wait` call becomes `self._metrics.record_lock_wait` (guarded by `if not None`). `None` is a safe fallback for tests that construct the coordinator standalone — the lock-wait metric is simply not recorded. |
| `_session_init.py` | `AuthRefreshCoordinator` construction now passes `metrics=metrics`. |
| `_session.py` | `Session._await_refresh` drops the `self` argument: `await self._auth_coord.await_refresh()` instead of `await self._auth_coord.await_refresh(self)`. |
| `tests/unit/test_session_auth.py` | 5 call sites drop the `stub_host` argument. The stub itself stays — other tests in the file still use it for the methods that still take `host`. |
| `tests/unit/concurrency/test_loop_affinity_guard.py` | Drop the now-unused `host = MagicMock()` local; the cross-loop guard short-circuits before any metric would be recorded so semantics are unchanged. |

### Verification

- `uv run pytest tests/unit tests/_lint` — **5828 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

## Test plan

- [x] All unit + lint pass
- [x] `test_session_auth.py::test_await_refresh_is_single_flight` still verifies the thundering-herd contract
- [x] `test_loop_affinity_guard.py` still verifies the cross-loop short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication refresh coordination by streamlining how metrics are handled and simplifying method signatures for better architectural consistency.

* **Tests**
  * Updated unit tests to validate authentication refresh logic under the refined architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->