### PR TITLE
refactor(rpc)!: RpcExecutor takes direct collaborators; delete RpcOwner Protocol (Wave 4 / Tasks 1.1+1.2)

### DIFF
--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["DecodeResponse", "RpcExecutor", "RpcOwner"]
+__all__ = ["DecodeResponse", "RpcExecutor"]
 
 import json
 import logging
@@ -20,10 +20,7 @@ from ._idempotency import (
     resolve_effective_disable_internal_retries,
 )
 from ._logging import get_request_id, reset_request_id, set_request_id
-from ._request_types import (
-    AuthSnapshot,
-    BuildRequest,
-)
+from ._request_types import AuthSnapshot
 from ._transport_errors import (
     TransportAuthExpired,
     TransportRateLimited,
@@ -46,8 +43,11 @@ from .rpc import (
 )
 
 if TYPE_CHECKING:
+    from ._client_metrics import ClientMetrics
     from ._kernel import Kernel
+    from ._session_auth import AuthRefreshCoordinator
     from ._session_contracts import RpcCaller
+    from ._session_transport import SessionTransport
 
 logger = logging.getLogger(__name__)
 
@@ -56,35 +56,23 @@ class DecodeResponse(Protocol):
     def __call__(self, raw: str, rpc_id: str, *, allow_null: bool = False) -> Any: ...
 
 
-class RpcOwner(Protocol):
-    # Concrete-class reference (NOT a bridge attribute). Used by
-    # :meth:`RpcExecutor.rpc_call` for the pre-open guard
-    # via :meth:`Kernel.get_http_client`, which raises the historical
-    # ``RuntimeError("Client not initialized. Use 'async with' context.")``
-    # when the client hasn't been opened yet.
-    _kernel: Kernel
-
-    async def _perform_authed_post(
-        self,
-        *,
-        build_request: BuildRequest,
-        log_label: str,
-        disable_internal_retries: bool = False,
-        rpc_method: str | None = None,
-    ) -> httpx.Response: ...
-
-    async def _await_refresh(self) -> None: ...
-
-    def _increment_metrics(self, **increments: int | float) -> None: ...
-
-
 class RpcExecutor:
-    """Owns raw batchexecute RPC encode, transport dispatch, decode, and retry."""
+    """Owns raw batchexecute RPC encode, transport dispatch, decode, and retry.
+
+    ADR-014 Rule 5 (Wave 4 of the session-decoupling plan): constructor takes
+    its four runtime collaborators (Kernel, SessionTransport,
+    AuthRefreshCoordinator, ClientMetrics) directly via keyword-only arguments
+    instead of reaching them through a Session-shaped owner. The old
+    ``RpcOwner`` Protocol was deleted in the same PR.
+    """
 
     def __init__(
         self,
-        owner: RpcOwner,
         *,
+        kernel: Kernel,
+        transport: SessionTransport,
+        auth_refresh: AuthRefreshCoordinator,
+        metrics: ClientMetrics,
         decode_response: DecodeResponse,
         is_auth_error: Callable[[Exception], bool],
         sleep: Callable[[float], Awaitable[Any]],
@@ -92,7 +80,10 @@ class RpcExecutor:
         refresh_callback_enabled_provider: Callable[[], bool],
         refresh_retry_delay_provider: Callable[[], float],
     ):
-        self._owner = owner
+        self._kernel = kernel
+        self._transport = transport
+        self._auth_refresh = auth_refresh
+        self._metrics = metrics
         self._decode_response = decode_response
         self._is_auth_error = is_auth_error
         self._sleep = sleep
@@ -133,7 +124,7 @@ class RpcExecutor:
         # kernel accessor instead of the now-narrowed :class:`RpcOwner`
         # Protocol attribute keeps the early-fail behavior intact while
         # removing ``_http_client`` from the Protocol surface.
-        self._owner._kernel.get_http_client()
+        self._kernel.get_http_client()
 
         # Only the outer call mints a request id; the decode-time retry path
         # (``_is_retry=True``) inherits the parent's id so a single
@@ -152,7 +143,7 @@ class RpcExecutor:
                 operation_variant=operation_variant,
             )
 
-        self._owner._increment_metrics(rpc_calls_started=1)
+        self._metrics.increment(rpc_calls_started=1)
         # ``rpc_calls_started`` and reqid stay HERE (outside the chain)
         # because they bracket the entire logical RPC including decode —
         # the chain wraps only the transport leg. Per-attempt latency,
@@ -228,7 +219,7 @@ class RpcExecutor:
             return url, body, {}
 
         try:
-            response = await self._owner._perform_authed_post(
+            response = await self._transport.perform_authed_post(
                 build_request=_build,
                 log_label=f"RPC {method.name}",
                 disable_internal_retries=effective_disable_internal_retries,
@@ -439,7 +430,7 @@ class RpcExecutor:
         logger.info("RPC %s auth error detected, attempting token refresh", method.name)
 
         try:
-            await self._owner._await_refresh()
+            await self._auth_refresh.await_refresh()
         except Exception as refresh_error:
             logger.warning("Token refresh failed: %s", refresh_error)
             raise original_error from refresh_error

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -46,22 +46,13 @@ from .auth import (
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
 if TYPE_CHECKING:
-    from ._rpc_executor import RpcOwner
     from .types import ConnectionLimits
 
-    def _assert_session_satisfies_protocols(s: "Session") -> None:
-        """Compile-time guard: :class:`Session` MUST satisfy ``RpcOwner``.
-
-        Session-shrink PR 3 narrowed the Protocol by removing
-        ``_timeout``, ``_refresh_callback``, ``_refresh_retry_delay``,
-        ``_http_client``, and ``_bound_loop`` declarations. Some of those
-        compatibility bridges have since been retired; what this assertion
-        guarantees is that the narrowed :class:`RpcOwner` shape is satisfied
-        by :class:`Session`. mypy verifies this during
-        ``mypy src/notebooklm``; the function is a no-op at runtime (gated by
-        ``TYPE_CHECKING``).
-        """
-        _owner: RpcOwner = s
+    # ADR-014 Rule 5 (Wave 4 of session-decoupling): the compile-time
+    # ``Session: RpcOwner`` assertion was removed when the ``RpcOwner``
+    # Protocol itself was deleted — ``RpcExecutor`` now takes its
+    # collaborators directly via keyword arguments instead of reaching
+    # them through a Session-shaped owner.
 
 
 from .rpc import RPCMethod
@@ -558,8 +549,14 @@ class Session:
         """
         executor = getattr(self, "_rpc_executor", None)
         if executor is None:
+            # ADR-014 Rule 5 (Wave 4 of session-decoupling): RpcExecutor
+            # takes its collaborators directly via keyword-only arguments
+            # instead of reaching them through a Session-shaped owner.
             executor = RpcExecutor(
-                self,
+                kernel=self._kernel,
+                transport=self._transport,
+                auth_refresh=self._auth_coord,
+                metrics=self._metrics_obj,
                 decode_response=self._decode_response,
                 is_auth_error=self._is_auth_error,
                 sleep=self._sleep,
@@ -701,10 +698,13 @@ class Session:
         rpc_method: str | None = None,
     ) -> httpx.Response:
         """Forward to :meth:`SessionTransport.perform_authed_post` (body
-        moved in move #4c — ``docs/improvement.md`` §3.1). Kept on
-        :class:`Session` because the :class:`RpcOwner` Protocol in
-        :mod:`notebooklm._rpc_executor` structurally requires the method
-        here (``RpcExecutor._execute_once`` reaches it via ``self._owner``).
+        moved in move #4c — ``docs/improvement.md`` §3.1). Retained on
+        :class:`Session` per ADR-014 Rule 4 as a load-bearing middleware-chain
+        seam: ``_chat_transport`` and ``client._session._perform_authed_post(...)``
+        direct callers still reach it here. ``RpcExecutor`` no longer calls
+        this method (Wave 4 of session-decoupling: the executor takes
+        :class:`SessionTransport` directly and calls
+        ``self._transport.perform_authed_post`` without going through Session).
         ``_chat_transport`` and ``client._session._perform_authed_post(...)``
         direct callers keep the same keyword-only signature.
         """

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -184,7 +184,10 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # seam-substitution pattern is extended to cover the CLI resolver
         # surface.
         "tests/unit/test_generate_service.py",
-        "tests/unit/test_idempotency_registry.py",
+        # tests/unit/test_idempotency_registry.py — removed in Wave 4 of
+        # session-decoupling: the test's RpcExecutor construction was
+        # migrated from a MagicMock-owner monkeypatch pattern to the
+        # ADR-014 Rule 5 keyword-collaborator constructor shape.
         "tests/unit/test_init_order.py",
         "tests/unit/test_migration_lock.py",
         "tests/unit/test_notebook_api.py",

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -523,13 +523,21 @@ def _build_rpc_executor() -> Any:
         captured["rpc_method"] = rpc_method
         return httpx.Response(200, text=")]}'\n[]")
 
-    owner = MagicMock()
-    owner._timeout = 30.0
-    owner._refresh_callback = None
-    owner._refresh_retry_delay = 0.0
-    owner._perform_authed_post = AsyncMock(side_effect=_fake_perform_authed_post)
-    owner._await_refresh = AsyncMock()
-    owner._increment_metrics = MagicMock()
+    # ADR-014 Rule 5 (Wave 4 of session-decoupling): RpcExecutor takes
+    # its four collaborators (kernel/transport/auth_refresh/metrics) as
+    # keyword-only args. Use four MagicMock collaborators so each role
+    # can be inspected independently.
+    kernel = MagicMock()
+    transport = MagicMock()
+    transport.perform_authed_post = AsyncMock(side_effect=_fake_perform_authed_post)
+    auth_refresh = MagicMock()
+    auth_refresh.await_refresh = AsyncMock()
+    auth_refresh.has_refresh_callback = False
+    metrics = MagicMock()
+
+    # Surviving legacy ivars used by the providers below.
+    timeout = 30.0
+    refresh_retry_delay = 0.0
 
     def _decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
         return []
@@ -541,19 +549,22 @@ def _build_rpc_executor() -> Any:
         return False
 
     executor = RpcExecutor(
-        owner,
+        kernel=kernel,
+        transport=transport,
+        auth_refresh=auth_refresh,
+        metrics=metrics,
         decode_response=_decode,
         is_auth_error=_is_auth_error,
         sleep=_sleep,
-        # Session-shrink PR 3: providers replace direct owner-attr reads
-        # for the values that used to live on the :class:`RpcOwner`
-        # Protocol. The ``MagicMock`` owner still holds the legacy ivars,
-        # so each provider just reads through.
-        timeout_provider=lambda: owner._timeout,
-        refresh_callback_enabled_provider=lambda: owner._refresh_callback is not None,
-        refresh_retry_delay_provider=lambda: owner._refresh_retry_delay,
+        timeout_provider=lambda: timeout,
+        refresh_callback_enabled_provider=lambda: auth_refresh.has_refresh_callback,
+        refresh_retry_delay_provider=lambda: refresh_retry_delay,
     )
-    return executor, owner, captured
+    # ``_unused`` slot preserved for backward-compatible 3-tuple unpacking
+    # at call sites that have not been migrated to the keyword-collaborators
+    # shape. After Wave 4 of session-decoupling (ADR-014 Rule 5), the executor
+    # holds its collaborators directly so the middle slot is just None.
+    return executor, None, captured
 
 
 @pytest.mark.asyncio
@@ -564,7 +575,7 @@ async def test_default_registry_preserves_today_behavior(
     UNCLASSIFIED policy for every method, an unspecified
     ``disable_internal_retries`` MUST resolve to False — exactly today's
     behavior. No drift."""
-    executor, owner, captured = _build_rpc_executor
+    executor, _unused, captured = _build_rpc_executor
 
     await executor._execute_once(
         RPCMethod.LIST_NOTEBOOKS,
@@ -586,7 +597,7 @@ async def test_caller_disable_true_propagates_through_executor(
 ) -> None:
     """Explicit caller ``disable_internal_retries=True`` MUST reach the
     transport regardless of policy (caller wins)."""
-    executor, owner, captured = _build_rpc_executor
+    executor, _unused, captured = _build_rpc_executor
 
     await executor._execute_once(
         RPCMethod.LIST_NOTEBOOKS,
@@ -610,7 +621,7 @@ async def test_operation_variant_kwarg_threads_through_executor(
     """``operation_variant`` MUST be accepted as a kwarg on
     ``RpcExecutor._execute_once()`` without breaking the call. Wave 2 will wire
     behavioral effects; this PR only adds the seam."""
-    executor, owner, captured = _build_rpc_executor
+    executor, _unused, captured = _build_rpc_executor
 
     # Should not raise — kwarg is accepted everywhere.
     await executor._execute_once(

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -47,6 +47,14 @@ def _status_error(status_code: int, *, retry_after: str | None = None) -> httpx.
 
 
 class _Owner:
+    """Test stub satisfying RpcExecutor's four collaborator dependencies.
+
+    Wave 4 of session-decoupling (ADR-014 Rule 5): RpcExecutor takes
+    Kernel + SessionTransport + AuthRefreshCoordinator + ClientMetrics
+    directly via keyword arguments. This stub plays all four roles in
+    one object — see :func:`_executor` for the wiring.
+    """
+
     def __init__(
         self,
         *,
@@ -67,15 +75,20 @@ class _Owner:
             authuser=1,
             account_email="user@example.test",
         )
+        # Self-reference so the same stub can play both ``kernel`` and the
+        # other three roles when passed to ``RpcExecutor(...)`` below.
         self._kernel = self
 
+    # --- Kernel role ----------------------------------------------------
     def get_http_client(self) -> object:
         return object()
 
-    def _increment_metrics(self, **increments: int | float) -> None:
+    # --- ClientMetrics role ---------------------------------------------
+    def increment(self, **increments: int | float) -> None:
         self.metric_increments.append(increments)
 
-    async def _perform_authed_post(
+    # --- SessionTransport role ------------------------------------------
+    async def perform_authed_post(
         self,
         *,
         build_request,
@@ -95,7 +108,8 @@ class _Owner:
         )
         return self.response
 
-    async def _await_refresh(self) -> None:
+    # --- AuthRefreshCoordinator role ------------------------------------
+    async def await_refresh(self) -> None:
         self.refresh_calls += 1
 
 
@@ -112,16 +126,19 @@ def _executor(
     def _decode(_: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
         return {"rpc_id": rpc_id, "allow_null": allow_null}
 
+    # ADR-014 Rule 5 (Wave 4 of session-decoupling): the executor takes
+    # its four collaborators as keyword-only args. The ``_Owner`` stub
+    # plays all four roles; pass it under each keyword so the executor's
+    # ``self._kernel`` / ``self._metrics`` / ``self._transport`` /
+    # ``self._auth_refresh`` references all land on the same stub.
     return RpcExecutor(
-        owner,
+        kernel=owner,  # type: ignore[arg-type]
+        transport=owner,  # type: ignore[arg-type]
+        auth_refresh=owner,  # type: ignore[arg-type]
+        metrics=owner,  # type: ignore[arg-type]
         decode_response=decode_response or _decode,
         is_auth_error=is_auth_error or (lambda exc: False),
         sleep=sleep or _no_sleep,
-        # Session-shrink PR 3 narrowed :class:`RpcOwner` and added
-        # constructor-time providers for the values that used to be
-        # read off the owner directly. The ``_Owner`` stub still holds
-        # the legacy ivars so individual tests can mutate them — the
-        # providers simply read through to those ivars.
         timeout_provider=lambda: owner._timeout,
         refresh_callback_enabled_provider=lambda: owner._refresh_callback is not None,
         refresh_retry_delay_provider=lambda: owner._refresh_retry_delay,
@@ -223,7 +240,11 @@ async def test_constructor_injected_decode_response_drives_executor(monkeypatch)
     ) -> httpx.Response:
         return _ok_response("wire")
 
-    monkeypatch.setattr(core, "_perform_authed_post", fake_perform_authed_post)
+    # ADR-014 Rule 5 (Wave 4 of session-decoupling): the executor calls
+    # ``self._transport.perform_authed_post(...)`` directly instead of
+    # routing through ``Session._perform_authed_post``. Patch the
+    # collaborator the executor actually reaches.
+    monkeypatch.setattr(core._transport, "perform_authed_post", fake_perform_authed_post)
 
     result = await executor._execute_once(
         RPCMethod.LIST_NOTEBOOKS,
@@ -409,7 +430,9 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         assert operation_variant is None
         return {"ok": True}
 
-    monkeypatch.setattr(core, "_await_refresh", fake_await_refresh)
+    # ADR-014 Rule 5 (Wave 4): executor calls ``self._auth_refresh.await_refresh()``
+    # directly. Patch the collaborator the executor actually reaches.
+    monkeypatch.setattr(core._auth_coord, "await_refresh", fake_await_refresh)
     monkeypatch.setattr(executor, "rpc_call", fake_rpc_call)
 
     result = await executor.try_refresh_and_retry(

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -16,8 +16,11 @@ structural protocol caller, a Protocol-imposed call site, or an
 established test-seam swap point that would require its own follow-up
 to migrate:
 
-    Protocol-locked (``RpcOwner`` in ``_rpc_executor.py``)
-        _await_refresh
+    Middleware-chain seam (ADR-014 Rule 4, retained on Session by design)
+        _await_refresh — captured via ``refresh_callable=host._await_refresh``
+        in ``wire_middleware_chain``; deleting it would break the chain
+        wiring. (``RpcOwner`` Protocol was deleted in Wave 4 of session-decoupling
+        when ``RpcExecutor`` migrated to direct collaborator dependencies.)
 
     External Protocol surface (``RefreshAuthCore`` in ``_auth/session.py``)
         update_auth_tokens
@@ -151,14 +154,27 @@ def test_session_delegate_calls_collaborator(name: str) -> None:
     )
 
 
-def test_session_satisfies_rpc_owner_protocol_members() -> None:
-    """RpcOwner stays narrow: only members the executor directly calls."""
+def test_session_retains_adr_014_rule_4_middleware_chain_seams() -> None:
+    """ADR-014 Rule 4 retention list: Session keeps the surfaces the
+    middleware-chain wiring + downstream Protocol consumers depend on.
+
+    These names were previously the ``RpcOwner`` Protocol surface (deleted
+    in Wave 4 of the session-decoupling plan when ``RpcExecutor`` migrated
+    to direct collaborator dependencies). They remain on Session because:
+
+    - ``_await_refresh`` — captured by ``wire_middleware_chain`` as
+      ``refresh_callable=host._await_refresh``.
+    - ``_perform_authed_post`` — direct callers in ``_chat_transport`` and
+      external client code reach it here; live middleware-chain seam.
+    - ``_increment_metrics`` — provider-closure capture target.
+    - ``_kernel`` — Session owns the transport core.
+    """
     for name in (
         "_await_refresh",
         "_perform_authed_post",
         "_increment_metrics",
     ):
-        assert hasattr(Session, name), f"Session missing RpcOwner member: {name}"
+        assert hasattr(Session, name), f"Session missing Rule-4 retained member: {name}"
         assert callable(getattr(Session, name)), f"Session.{name} not callable"
 
     from notebooklm.auth import AuthTokens
@@ -166,7 +182,7 @@ def test_session_satisfies_rpc_owner_protocol_members() -> None:
     core = Session(
         AuthTokens(cookies={"SID": "sid"}, csrf_token="csrf", session_id="sid"),
     )
-    assert hasattr(core, "_kernel"), "Session missing RpcOwner member: _kernel"
+    assert hasattr(core, "_kernel"), "Session missing Rule-4 retained member: _kernel"
 
 
 def test_session_keeps_drain_tracker_seam() -> None:

--- a/tests/unit/test_tier_13_all_exports.py
+++ b/tests/unit/test_tier_13_all_exports.py
@@ -43,7 +43,7 @@ EXPECTED_TRANSPORT_ERRORS_ALL: list[str] = [
     "raise_mapped_post_error",
 ]
 
-EXPECTED_RPC_EXECUTOR_ALL: list[str] = ["DecodeResponse", "RpcExecutor", "RpcOwner"]
+EXPECTED_RPC_EXECUTOR_ALL: list[str] = ["DecodeResponse", "RpcExecutor"]
 
 EXPECTED_CONVERSATION_CACHE_ALL: list[str] = [
     "MAX_CONVERSATION_CACHE_SIZE",


### PR DESCRIPTION
## Summary

**Wave 4 / Tasks 1.1+1.2 combined** of the session-decoupling plan. ADR-014 Rule 5: `RpcExecutor` stops holding a Session-shaped owner; the four runtime dependencies it actually uses (Kernel, SessionTransport, AuthRefreshCoordinator, ClientMetrics) are passed via keyword-only constructor arguments. **The `RpcOwner` Protocol is deleted in the same change** — no transitional `owner=` path because the proposed transitional code couldn't work (Session has underscore-prefixed methods, not the public names a direct collaborator would expose).

⚠️ **MANUAL APPROVAL GATE.** Per the session-decoupling plan's `manual_approval_gates` list: this PR deletes a structural Protocol. Held for explicit user approval before merge.

### What this PR does

| File | Change |
|---|---|
| `_rpc_executor.py` | `RpcExecutor.__init__` takes 4 keyword-only collaborator args. Dispatch methods rewritten: `self._owner._X` → `self._<collaborator>.X`. **`RpcOwner` Protocol deleted.** `_rpc_executor.__all__` no longer exports `RpcOwner`. |
| `_session.py` | `_get_rpc_executor` constructs with 4 keyword args. `_assert_session_satisfies_protocols` block deleted entirely. `_perform_authed_post` docstring rewritten — retained per ADR-014 Rule 4 (middleware-chain seam), not RpcOwner. |
| `test_rpc_executor.py` | `_Owner` stub methods renamed to public form (`increment` / `perform_authed_post` / `await_refresh`); same stub plays all four roles. Two Session-forward monkeypatches updated to patch the underlying collaborators directly. |
| `test_idempotency_registry.py` | MagicMock owner replaced with four MagicMock collaborators. |
| `test_session_compat_delegates.py` | Renamed `test_session_satisfies_rpc_owner_protocol_members` → `test_session_retains_adr_014_rule_4_middleware_chain_seams`. The names are still on Session per ADR-014 Rule 4. |
| `test_tier_13_all_exports.py` | Dropped `"RpcOwner"` from `EXPECTED_RPC_EXECUTOR_ALL`. |
| `tests/_lint/test_no_forbidden_monkeypatches.py` | **Removed `tests/unit/test_idempotency_registry.py` from the allowlist** — Wave 4's refactor migrated its MagicMock-owner monkeypatch pattern to the ADR-014 Rule 5 keyword-collaborator constructor. ADR-007 allowlist drains by 1 entry. |

### Why this is safe to land

- Session retains every method/attribute on the ADR-014 Rule 4 retention list (`_await_refresh`, `_perform_authed_post`, `_increment_metrics`, `_kernel`). They're load-bearing middleware-chain seams / provider-closure capture targets. The `test_session_retains_adr_014_rule_4_middleware_chain_seams` lint pins this contract.
- `Session.rpc_call` (the public-API forward for `NotebookLMClient.rpc_call`) is unchanged.
- Cassette-replaying tests pass — no wire-shape change.
- ADR-007 allowlist shrinks (regression-positive).

### Verification

- `uv run pytest tests/unit tests/_lint` — **5832 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

### Parallel-safety

This PR is in flight alongside **#1066** (Wave 3a auth move — different files). Wave 6 (`session-collaborators-accessors`) will dispatch in parallel from main; both touch `_session.py` in different sections (Wave 4 changes `_get_rpc_executor` + type-check block; Wave 6 adds `collaborators` accessor properties). Trivial rebase if either lands first.

## Test plan

- [x] All unit + lint pass
- [x] ADR-007 allowlist verified to shrink (stale-entry-removal lint catches the bookkeeping)
- [x] Session retention contract (Rule 4) explicitly pinned by renamed test

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal RPC executor architecture to use direct dependency injection instead of intermediate owner pattern, improving code organization and testability. Updated module exports and adjusted constructor signatures to reflect the new design.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->