### PR TITLE
feat(session): expose SessionCollaborators + late-bound accessors (Wave 6 / Task 3.0)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -46,6 +46,8 @@ from .auth import (
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
 if TYPE_CHECKING:
+    from ._session_init import SessionCollaborators
+    from ._session_transport import SessionTransport
     from .types import ConnectionLimits
 
     # ADR-014 Rule 5 (Wave 4 of session-decoupling): the compile-time
@@ -360,6 +362,13 @@ class Session:
             cookie_saver=cookie_saver,
             cookie_rotator=cookie_rotator,
         )
+        # ADR-014 Rule 3 Stage A (Wave 6 of session-decoupling): store the
+        # bundle so the ``Session.collaborators`` accessor below can expose
+        # it as a single typed attribute for ``NotebookLMClient.__init__``
+        # feature wiring. Stage B (Wave 7 follow-up) moves
+        # ``build_collaborators`` ownership to NotebookLMClient and deletes
+        # this storage along with the accessor.
+        self._collaborators = collaborators
         self._metrics_obj = collaborators.metrics
         self._drain_tracker = collaborators.drain_tracker
         self._reqid = collaborators.reqid
@@ -445,6 +454,48 @@ class Session:
     @property
     def kernel(self) -> Kernel:
         return self._kernel
+
+    # ------------------------------------------------------------------
+    # ADR-014 Rule 3 Stage A accessors (Wave 6 of session-decoupling)
+    # ------------------------------------------------------------------
+    #
+    # Three typed accessors that let ``NotebookLMClient.__init__`` wire
+    # feature APIs with the collaborators they actually depend on, instead
+    # of passing the whole ``Session`` and having features reach for
+    # underscore-prefixed attributes. The base bundle (``collaborators``)
+    # exposes the eight fields ``SessionCollaborators`` carries today; two
+    # narrow accessors expose the late-bound collaborators that are NOT on
+    # the dataclass (``session_transport`` is constructed after the bundle
+    # via ``build_session_transport``; ``rpc_executor`` is lazy via
+    # ``_get_rpc_executor``).
+    #
+    # Per Stage B (Wave 7 follow-up): when ``build_collaborators`` ownership
+    # moves to ``NotebookLMClient``, all three accessors are deleted along
+    # with the ``self._collaborators`` storage above.
+    #
+    # The Wave 6 lint guard (``tests/_lint/test_client_composition.py``)
+    # restricts reads of these accessors to ``client.py`` + ``_session.py``
+    # + ``tests/`` to keep them from becoming a discoverability hub.
+
+    @property
+    def collaborators(self) -> "SessionCollaborators":
+        """Typed access to the constructed collaborator bundle (ADR-014 Rule 3 Stage A)."""
+        return self._collaborators
+
+    @property
+    def session_transport(self) -> "SessionTransport":
+        """Late-bound collaborator not present on :class:`SessionCollaborators`
+        today (constructed via :func:`build_session_transport` after the bundle).
+        Deleted in Wave 7 follow-up along with the other Stage-A accessors.
+        """
+        return self._transport
+
+    @property
+    def rpc_executor(self) -> RpcExecutor:
+        """Lazily-constructed collaborator not present on :class:`SessionCollaborators`
+        today. Deleted in Wave 7 follow-up along with the other Stage-A accessors.
+        """
+        return self._get_rpc_executor()
 
     @property
     def authuser(self) -> int:

--- a/tests/unit/test_session_accessors.py
+++ b/tests/unit/test_session_accessors.py
@@ -1,0 +1,117 @@
+"""ADR-014 Rule 3 Stage A: Session.collaborators + late-bound accessors (Wave 6).
+
+Three typed accessors that let ``NotebookLMClient.__init__`` wire feature APIs
+with the collaborators they actually depend on, instead of passing the whole
+``Session``:
+
+* ``collaborators`` — the ``SessionCollaborators`` bundle from
+  ``build_collaborators``.
+* ``session_transport`` — late-bound; constructed after the bundle via
+  ``build_session_transport``.
+* ``rpc_executor`` — late-bound; lazily constructed by ``_get_rpc_executor``.
+
+Per Stage B (Wave 7 follow-up), all three accessors are deleted when
+``build_collaborators`` ownership moves to ``NotebookLMClient``. The lint
+guard in ``tests/_lint/test_client_composition.py`` (added in plan Wave 13)
+restricts reads of these accessors to ``client.py`` + ``_session.py`` +
+``tests/`` to prevent them from becoming a discoverability hub.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._rpc_executor import RpcExecutor
+from notebooklm._session import Session
+from notebooklm._session_init import SessionCollaborators
+from notebooklm._session_transport import SessionTransport
+from notebooklm.auth import AuthTokens
+
+
+def _make_session() -> Session:
+    return Session(
+        AuthTokens(
+            cookies={"SID": "sid"},
+            csrf_token="csrf",
+            session_id="sid",
+        )
+    )
+
+
+def test_collaborators_accessor_returns_bundle() -> None:
+    """``Session.collaborators`` exposes the ``SessionCollaborators`` dataclass."""
+    session = _make_session()
+
+    coll = session.collaborators
+
+    assert isinstance(coll, SessionCollaborators)
+    # The bundle field names per _session_init.py:92-109 — the plan uses these
+    # exact names (note: ``reqid``, NOT ``reqid_counter``).
+    assert coll.metrics is session._metrics_obj
+    assert coll.drain_tracker is session._drain_tracker
+    assert coll.reqid is session._reqid
+    assert coll.auth_coord is session._auth_coord
+    assert coll.kernel is session._kernel
+    assert coll.lifecycle is session._lifecycle
+
+
+def test_session_transport_accessor_returns_concrete_transport() -> None:
+    """``Session.session_transport`` exposes the late-bound transport."""
+    session = _make_session()
+
+    assert isinstance(session.session_transport, SessionTransport)
+    assert session.session_transport is session._transport
+
+
+def test_rpc_executor_accessor_returns_lazy_executor_singleton() -> None:
+    """``Session.rpc_executor`` returns the lazy executor and caches it."""
+    session = _make_session()
+
+    executor1 = session.rpc_executor
+    executor2 = session.rpc_executor
+
+    assert isinstance(executor1, RpcExecutor)
+    assert executor1 is executor2, "rpc_executor must be stable across calls"
+
+
+def test_collaborators_accessor_does_not_construct_new_bundle() -> None:
+    """The accessor is read-only — the same bundle instance every call."""
+    session = _make_session()
+
+    assert session.collaborators is session.collaborators
+
+
+def test_collaborators_field_name_is_reqid_not_reqid_counter() -> None:
+    """Plan naming-note pin: the dataclass field is ``reqid``, not ``reqid_counter``.
+
+    Catches any downstream code that wires features with ``coll.reqid_counter``
+    (which would fail at runtime). Wave 7 / Task 4.1 feature wiring depends on
+    this exact field name.
+    """
+    session = _make_session()
+
+    assert hasattr(session.collaborators, "reqid"), (
+        "SessionCollaborators must carry 'reqid' (not 'reqid_counter')"
+    )
+    assert not hasattr(session.collaborators, "reqid_counter"), (
+        "Wave 7 feature wiring assumes the field is named 'reqid'; "
+        "if 'reqid_counter' is added too, downstream feature constructors will "
+        "silently pick the wrong attribute."
+    )
+
+
+@pytest.mark.parametrize(
+    "accessor_name",
+    ["collaborators", "session_transport", "rpc_executor"],
+)
+def test_accessor_is_read_only_property(accessor_name: str) -> None:
+    """Each accessor is a property (not a settable attribute).
+
+    Per the plan: the lint guard in tests/_lint/test_client_composition.py
+    treats these as the *only* legitimate way Wave 7+ wires features. Making
+    them properties enforces the read-only intent at the class level.
+    """
+    attr = getattr(Session, accessor_name)
+    assert isinstance(attr, property), (
+        f"Session.{accessor_name} must be a @property (got {type(attr).__name__})"
+    )

--- a/tests/unit/test_session_accessors.py
+++ b/tests/unit/test_session_accessors.py
@@ -45,14 +45,19 @@ def test_collaborators_accessor_returns_bundle() -> None:
     coll = session.collaborators
 
     assert isinstance(coll, SessionCollaborators)
-    # The bundle field names per _session_init.py:92-109 — the plan uses these
-    # exact names (note: ``reqid``, NOT ``reqid_counter``).
+    # All 8 SessionCollaborators fields validated per _session_init.py:92-109.
+    # The plan uses these exact names (note: ``reqid``, NOT ``reqid_counter``).
+    # Round-1 reviewer finding on PR #1069 (gemini + coderabbit): the prior
+    # 6-of-8 coverage left ``cookie_persistence`` and ``poll_registry``
+    # un-asserted — any future drift in those fields would slip through.
     assert coll.metrics is session._metrics_obj
     assert coll.drain_tracker is session._drain_tracker
     assert coll.reqid is session._reqid
     assert coll.auth_coord is session._auth_coord
     assert coll.kernel is session._kernel
     assert coll.lifecycle is session._lifecycle
+    assert coll.cookie_persistence is session.cookie_persistence
+    assert coll.poll_registry is session.poll_registry
 
 
 def test_session_transport_accessor_returns_concrete_transport() -> None:


### PR DESCRIPTION
## Summary

Wave 6 / Task 3.0 of the session-decoupling plan. **ADR-014 Rule 3 Stage A**: adds three typed accessors on `Session` so `NotebookLMClient.__init__` can wire feature APIs with the collaborators they actually depend on, instead of passing the whole `Session` and having features reach for underscore-prefixed attributes.

### What this PR adds

| Accessor | Returns | Why a separate accessor (not on the bundle) |
|---|---|---|
| `Session.collaborators` | `SessionCollaborators` | The bundle from `build_collaborators` — fields: `metrics`, `drain_tracker`, `reqid`, `auth_coord`, `kernel`, `lifecycle`, `cookie_persistence`, `poll_registry` |
| `Session.session_transport` | `SessionTransport` | Late-bound — constructed *after* the bundle via `build_session_transport`, so not on `SessionCollaborators` |
| `Session.rpc_executor` | `RpcExecutor` | Late-bound — lazy via `_get_rpc_executor`, so not on `SessionCollaborators` |

The three accessors are why this is **"Stage A"** — the bundle dataclass alone cannot replace all three because `session_transport` and `rpc_executor` are constructed after it. **Stage B (Wave 7 follow-up)**: when `build_collaborators` ownership moves to `NotebookLMClient`, all three accessors are deleted along with `self._collaborators` storage.

### Why this is safe to land

- The `__init__` change is **additive only**: `self._collaborators = collaborators` is added BEFORE the existing per-field unpacking (`self._metrics_obj = collaborators.metrics`, etc.). Both coexist so middleware-chain provider closures still resolve.
- No production caller uses the new accessors yet — they're staged for Wave 7 (feature wiring). This PR is the prerequisite.
- 8 new tests pin the contract: bundle identity, late-bound transport, lazy executor singleton, **field name is `reqid` NOT `reqid_counter`** (plan naming-note), property type for read-only enforcement.

### Verification

- `uv run pytest tests/unit tests/_lint` — **5840 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

### Parallel-safety

In flight alongside:
- **#1066** (Wave 3a auth move) — different files, no conflict.
- **#1068** (Wave 4 RpcExecutor rewire) — touches `_session.py` `_get_rpc_executor` block; this PR adds new accessors in the property section + new line in `__init__`. Minimal conflict, clean rebase. If #1068 lands first, this PR's `Session.rpc_executor` accessor wraps the new constructor; if this lands first, #1068 rebases on top of the new accessor.

## Test plan

- [x] 8 new accessor tests pass (bundle identity, late-bound transport, lazy executor singleton, `reqid` field-name pin, @property read-only enforcement)
- [x] Full unit + lint suite (5840) green
- [x] Mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Session exposes new stable, read-only accessors for collaborators, session transport, and a lazily created RPC executor to improve wiring and stability.

* **Tests**
  * Added unit tests ensuring these accessors exist as read-only properties, return cached/stable instances, and behave consistently across repeated access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->