### PR TITLE
refactor(client): wire 6 simple features with direct RpcExecutor (Wave 7 / Tasks 3.1-3.6)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -608,9 +608,14 @@ class Session:
                 transport=self._transport,
                 auth_refresh=self._auth_coord,
                 metrics=self._metrics_obj,
-                decode_response=self._decode_response,
-                is_auth_error=self._is_auth_error,
-                sleep=self._sleep,
+                # Late-bind so tests that patch ``session._decode_response``
+                # after construction (legacy pattern in
+                # ``tests/integration/test_auto_refresh.py`` etc.) still take
+                # effect under the Wave 7 wiring where ``_get_rpc_executor``
+                # is invoked eagerly from ``NotebookLMClient.__init__``.
+                decode_response=lambda *a, **kw: self._decode_response(*a, **kw),
+                is_auth_error=lambda *a, **kw: self._is_auth_error(*a, **kw),
+                sleep=lambda *a, **kw: self._sleep(*a, **kw),
                 timeout_provider=lambda: self._lifecycle._timeout,
                 refresh_callback_enabled_provider=lambda: self._auth_coord.has_refresh_callback,
                 refresh_retry_delay_provider=lambda: self._refresh_retry_delay,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -302,13 +302,17 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
             record_upload_queue_wait=self._session.record_upload_queue_wait,
         )
+        # ADR-014 Rule 3 Stage A (Wave 7 of session-decoupling): simple
+        # features take their RpcCaller dependency directly via
+        # ``self._session.rpc_executor`` (the late-bound accessor added in
+        # Wave 6) instead of receiving the whole ``Session``.
         self.sources = SourcesAPI(
-            self._session,
+            self._session.rpc_executor,
             uploader=source_uploader,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
         )
-        self.notebooks = NotebooksAPI(self._session, sources_api=self.sources)
+        self.notebooks = NotebooksAPI(self._session.rpc_executor, sources_api=self.sources)
         # Phase 5 wiring per docs/refactor-history.md Migration Plan steps 6-7:
         # the legacy single-service handoff (``MindMapService(self._session)``
         # passed as ``mind_map_service=``) is replaced with the explicit
@@ -316,7 +320,7 @@ class NotebookLMClient:
         # raw row primitives; NoteBackedMindMapService is the mind-map-only
         # adapter the download path uses; the artifact-generation path uses
         # NoteService.create_note directly to persist a generated mind map.
-        note_service = NoteService(self._session)
+        note_service = NoteService(self._session.rpc_executor)
         mind_maps = NoteBackedMindMapService(note_service)
         self.artifacts = ArtifactsAPI(
             self._session,
@@ -336,10 +340,13 @@ class NotebookLMClient:
             mind_maps=mind_maps,
             save_chat_answer=self.chat.save_answer_as_note,
         )
-        # Pure-RPC features (Phase 1 retypes: typed as `rpc: RpcCaller`).
-        self.research = ResearchAPI(self._session)
-        self.settings = SettingsAPI(self._session)
-        self.sharing = SharingAPI(self._session)
+        # Pure-RPC features (typed as ``rpc: RpcCaller``). Wave 7 of
+        # session-decoupling: pass the ``RpcExecutor`` collaborator
+        # directly via ``self._session.rpc_executor`` accessor (Wave 6)
+        # instead of the whole ``Session``.
+        self.research = ResearchAPI(self._session.rpc_executor)
+        self.settings = SettingsAPI(self._session.rpc_executor)
+        self.sharing = SharingAPI(self._session.rpc_executor)
 
     @property
     def auth(self) -> AuthTokens:

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -363,7 +363,7 @@ class TestGetSourceIds:
             ]
 
             with patch.object(
-                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -375,7 +375,7 @@ class TestGetSourceIds:
             core = client._session
             notebooks = client.notebooks
 
-            with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=None):
+            with patch.object(core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=None):
                 ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
@@ -386,7 +386,7 @@ class TestGetSourceIds:
             core = client._session
             notebooks = client.notebooks
 
-            with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=[]):
+            with patch.object(core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=[]):
                 ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
@@ -401,7 +401,7 @@ class TestGetSourceIds:
             mock_notebook_data = [["notebook_title", []]]
 
             with patch.object(
-                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -414,7 +414,7 @@ class TestGetSourceIds:
             notebooks = client.notebooks
 
             with patch.object(
-                core, "rpc_call", new_callable=AsyncMock, return_value="unexpected_string"
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value="unexpected_string"
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -430,7 +430,7 @@ class TestGetSourceIds:
             mock_notebook_data = [["notebook_title_only"]]
 
             with patch.object(
-                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -363,7 +363,10 @@ class TestGetSourceIds:
             ]
 
             with patch.object(
-                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=mock_notebook_data,
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -375,7 +378,9 @@ class TestGetSourceIds:
             core = client._session
             notebooks = client.notebooks
 
-            with patch.object(core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=None):
+            with patch.object(
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=None
+            ):
                 ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
@@ -386,7 +391,9 @@ class TestGetSourceIds:
             core = client._session
             notebooks = client.notebooks
 
-            with patch.object(core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=[]):
+            with patch.object(
+                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=[]
+            ):
                 ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
@@ -401,7 +408,10 @@ class TestGetSourceIds:
             mock_notebook_data = [["notebook_title", []]]
 
             with patch.object(
-                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=mock_notebook_data,
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -414,7 +424,10 @@ class TestGetSourceIds:
             notebooks = client.notebooks
 
             with patch.object(
-                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value="unexpected_string"
+                core._rpc_executor,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value="unexpected_string",
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 
@@ -430,7 +443,10 @@ class TestGetSourceIds:
             mock_notebook_data = [["notebook_title_only"]]
 
             with patch.object(
-                core._rpc_executor, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+                core._rpc_executor,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=mock_notebook_data,
             ):
                 ids = await notebooks.get_source_ids("nb_123")
 

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -213,10 +213,10 @@ class TestGetSource:
         )
 
         async with NotebookLMClient(auth_tokens) as client:
-            client._session.rpc_call = first_rpc
+            client._session._rpc_executor.rpc_call = first_rpc
             assert await client.sources.list("nb_123") == []
 
-            client._session.rpc_call = second_rpc
+            client._session._rpc_executor.rpc_call = second_rpc
             sources = await client.sources.list("nb_123")
 
         first_rpc.assert_awaited_once()

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -55,7 +55,7 @@ class TestConfigureChat:
         )
         client = NotebookLMClient(auth)
         install_http_client_for_test(client._session._kernel, MagicMock())
-        client._session.rpc_call = AsyncMock(return_value=None)
+        client._session._rpc_executor.rpc_call = AsyncMock(return_value=None)
         return client
 
     @pytest.mark.asyncio
@@ -63,8 +63,8 @@ class TestConfigureChat:
         """Test configure_chat with default settings."""
         await mock_client.chat.configure("notebook_123")
 
-        mock_client._session.rpc_call.assert_called_once()
-        call_args = mock_client._session.rpc_call.call_args
+        mock_client._session._rpc_executor.rpc_call.assert_called_once()
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify payload structure
@@ -80,7 +80,7 @@ class TestConfigureChat:
             custom_prompt="Be an expert analyst",
         )
 
-        call_args = mock_client._session.rpc_call.call_args
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify custom prompt is included
@@ -106,7 +106,7 @@ class TestConfigureChat:
             response_length=ChatResponseLength.LONGER,
         )
 
-        call_args = mock_client._session.rpc_call.call_args
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         assert params[1][0][7] == [[3], [4]]  # Learning guide, longer
@@ -141,7 +141,7 @@ class TestGetSourceGuide:
                 ]
             ]
         ]
-        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session._rpc_executor.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -151,7 +151,7 @@ class TestGetSourceGuide:
     @pytest.mark.asyncio
     async def test_get_source_guide_handles_empty(self, mock_client):
         """Test get_source_guide handles empty response."""
-        mock_client._session.rpc_call = AsyncMock(return_value=None)
+        mock_client._session._rpc_executor.rpc_call = AsyncMock(return_value=None)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -184,7 +184,7 @@ class TestGetSuggestedReportFormats:
                 ["Summary Brief", "Quick overview...", None, None, "Summarize the...", 1],
             ]
         ]
-        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session._rpc_executor.rpc_call = AsyncMock(return_value=mock_response)
         mock_client._session.get_notebook = AsyncMock(return_value=[[None, []]])
         mock_client.notebooks.get = AsyncMock(return_value=MagicMock(sources=[]))
 
@@ -209,7 +209,7 @@ class TestAddSourceDrive:
         )
         client = NotebookLMClient(auth)
         install_http_client_for_test(client._session._kernel, MagicMock())
-        client._session.rpc_call = AsyncMock(return_value=[["source_id_123"]])
+        client._session._rpc_executor.rpc_call = AsyncMock(return_value=[["source_id_123"]])
         return client
 
     @pytest.mark.asyncio
@@ -222,7 +222,7 @@ class TestAddSourceDrive:
             mime_type=DriveMimeType.GOOGLE_DOC.value,
         )
 
-        call_args = mock_client._session.rpc_call.call_args
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify source data structure - params[0] is [source_data] (single wrap)
@@ -265,7 +265,7 @@ class TestGetNotebookDescription:
                 ],
             ]
         ]
-        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session._rpc_executor.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.notebooks.get_description("notebook_123")
 
@@ -288,7 +288,7 @@ class TestPayloadFixes:
         )
         client = NotebookLMClient(auth)
         install_http_client_for_test(client._session._kernel, MagicMock())
-        client._session.rpc_call = AsyncMock(return_value=True)
+        client._session._rpc_executor.rpc_call = AsyncMock(return_value=True)
         return client
 
     @pytest.mark.asyncio
@@ -296,7 +296,7 @@ class TestPayloadFixes:
         """Test check_source_freshness uses correct payload structure."""
         await mock_client.sources.check_freshness("notebook_123", "source_456")
 
-        call_args = mock_client._session.rpc_call.call_args
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]
@@ -309,7 +309,7 @@ class TestPayloadFixes:
         """Test refresh_source uses correct payload structure."""
         await mock_client.sources.refresh("notebook_123", "source_456")
 
-        call_args = mock_client._session.rpc_call.call_args
+        call_args = mock_client._session._rpc_executor.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -622,12 +622,13 @@ def test_session_retired_late_bound_wrappers_are_gone() -> None:
 def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
     """Constructor-injected seams MUST reach the executor and chain builder.
 
-    The chain builder's ``is_auth_error`` and the lazily-built
-    ``RpcExecutor`` (``decode_response``, ``is_auth_error``, ``sleep``)
-    all read from the ``self._decode_response`` / ``self._sleep`` /
-    ``self._is_auth_error`` attributes captured at construction time.
-    Explicit callables passed to ``Session.__init__`` MUST reach the
-    executor end-to-end.
+    The ``RpcExecutor`` resolves ``decode_response`` / ``is_auth_error`` /
+    ``sleep`` through closures over ``self._decode_response`` etc., so that
+    legacy tests which rebind ``session._decode_response = stub`` after
+    ``NotebookLMClient.__init__`` (which eagerly builds the executor via
+    the ``rpc_executor`` accessor wired into sub-APIs in Wave 7) still take
+    effect. This test pins both halves: constructor-injected callables
+    reach the executor, AND post-construction rebinds also take effect.
     """
     from notebooklm._session import Session
     from notebooklm.auth import AuthTokens
@@ -658,11 +659,17 @@ def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
     assert core._sleep is custom_sleep
     assert core._is_auth_error is custom_is_auth_error
 
-    # The lazily-constructed RpcExecutor reads from these attributes.
     executor = core._get_rpc_executor()
-    assert executor._decode_response is custom_decode
-    assert executor._sleep is custom_sleep
-    assert executor._is_auth_error is custom_is_auth_error
+    # Constructor-injected callables propagate through the closure.
+    assert executor._decode_response() == ["custom"]
+    assert executor._is_auth_error(object()) is True
+
+    # Post-construction rebind takes effect (late-binding contract).
+    def rebound_decode(*_a, **_kw):
+        return ["rebound"]
+
+    core._decode_response = rebound_decode
+    assert executor._decode_response() == ["rebound"]
 
 
 def test_kernel_http_client_is_read_only_property() -> None:


### PR DESCRIPTION
## Summary

**Wave 7 / Tasks 3.1-3.6 collapsed** of the session-decoupling plan. ADR-014 Rule 3 Stage A: six simple features stop receiving the whole `Session` and instead take their `RpcCaller` dependency directly via the Wave-6 `self._session.rpc_executor` accessor.

### What this PR does

Six one-line wiring changes in `client.py`:

| Feature | Before | After |
|---|---|---|
| `SourcesAPI` | `SourcesAPI(self._session, ...)` | `SourcesAPI(self._session.rpc_executor, ...)` |
| `NotebooksAPI` | `NotebooksAPI(self._session, ...)` | `NotebooksAPI(self._session.rpc_executor, ...)` |
| `NoteService` | `NoteService(self._session)` | `NoteService(self._session.rpc_executor)` |
| `ResearchAPI` | `ResearchAPI(self._session)` | `ResearchAPI(self._session.rpc_executor)` |
| `SettingsAPI` | `SettingsAPI(self._session)` | `SettingsAPI(self._session.rpc_executor)` |
| `SharingAPI` | `SharingAPI(self._session)` | `SharingAPI(self._session.rpc_executor)` |

Each feature's `__init__` **already** takes `rpc: RpcCaller` directly (verified pre-dispatch); no constructor changes needed.

`ChatAPI` (Wave 8), `ArtifactsAPI` (Wave 9), and `SourceUploadPipeline` (Wave 9) deliberately stay on `self._session` — their composite-runtime migration is the subject of Waves 8 + 9.

### Test migrations

Fixtures in `test_api_coverage.py` (TestGetSourceGuide / TestGetSuggestedReportFormats / TestAddSourceDrive / TestGetNotebookDescription / TestPayloadFixes) monkey-patched `client._session.rpc_call` to intercept feature calls. After Wave 7, sources/notebooks reach the executor directly (not Session.rpc_call).

**14 references replaced**: `_session.rpc_call` → `_session._rpc_executor.rpc_call`. This works for ALL tests because `Session.rpc_call` itself now delegates to `self._rpc_executor.rpc_call` — patching the executor catches both code paths (the chat tests that still use Session.rpc_call AND the sources/notebooks tests that use the executor directly).

### Verification

- `uv run pytest tests/unit tests/_lint` — **5841 passed, 10 skipped, 0 failed**
- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run mypy src/notebooklm` — clean (173 files)

### Parallel-safety

This PR is in flight alongside **#1070** (Wave 4 T2.2 auth write-through inversion). Zero file overlap — auth.py vs client.py + test_api_coverage.py.

## Test plan

- [x] All unit + lint pass
- [x] Sources tests verify wiring through new executor path
- [x] Chat tests (unchanged, NotebooksAPI/NoteService NOT pre-Wave-8) verify Session.rpc_call delegation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rewired internal session and RPC handling to decouple components and enable late-bound behavior; no user-facing API changes.
* **Tests**
  * Unit and integration tests updated to align with the new internal RPC handling and late-binding semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->