### PR TITLE
docs(adr): close ADR-003 — auth.py is now pure re-exports (Wave 5 / Task 2.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ RPC Layer (rpc/)
 | `_middleware_chain.py` | Constructs the middleware chain in the canonical ADR-009 order |
 | `_middleware*.py` | Modular middleware implementations (drain, metrics, semaphore, retry, auth, error injection, tracing) |
 | `rpc/types.py` | RPC method IDs (source of truth) |
-| `auth.py` | Authentication facade and host for retained surface. Still owns `AuthTokens`, `load_auth_from_storage()`, and the `_validate_required_cookies()` write-through that propagates `auth.py`-level policy rebindings into `_auth.cookie_policy` (and mirrors `_SECONDARY_BINDING_WARNED` back). Tests still pin `notebooklm.auth.<name>` monkeypatch behavior (see `tests/unit/test_public_shims.py`); `_AuthFacadeModule` itself was retired in [arch-d1-auth-side](https://github.com/teng-lin/notebooklm-py/pull/834) (#834), but the flat re-export goal in ADR-003 is **deferred** — full retirement of `AuthTokens` / `load_auth_from_storage` to `_auth/` has not happened. |
+| `auth.py` | Authentication facade — **now pure re-exports** (zero function/class bodies; verified via `grep -nE "^def \|^class " src/notebooklm/auth.py` returning empty). Every top-level name forwards from the relevant `_auth/*` module. The previous write-through (`_validate_required_cookies` copy-forwarding `MINIMUM_REQUIRED_COOKIES` / `_EXTRACTION_HINT` / `_has_valid_secondary_binding` into `_cookie_policy` and mirroring `_SECONDARY_BINDING_WARNED` back) was inverted in Wave 4 T2.2 (#1070); `auth._validate_required_cookies` is now identity-equal to `_auth.cookie_policy._validate_required_cookies`. `load_auth_from_storage` body was moved to `_auth/tokens.py` in Wave 3a (#1066). `AuthTokens` was moved to `_auth/tokens.py` in #1055. **ADR-003 flat-re-export goal closed by ADR-014** (session-decoupling Waves 3a + 4 T2.2 + 5). Tests that need to rebind policy names patch `_auth.cookie_policy.X` directly. |
 | `_auth/paths.py` | Storage paths and filesystem helpers |
 | `_auth/extraction.py` | Cookie/token extraction from browser sessions |
 | `_auth/headers.py` | HTTP header construction |
@@ -145,7 +145,7 @@ RPC Layer (rpc/)
 src/notebooklm/
 ├── __init__.py                  # Public exports
 ├── client.py                    # NotebookLMClient
-├── auth.py                      # Authentication facade hosting `AuthTokens`, `load_auth_from_storage()`, and `_validate_required_cookies()` write-through into `_auth.cookie_policy` (ADR-003 flat re-export goal deferred; `_AuthFacadeModule` retired in #834)
+├── auth.py                      # Authentication facade — now pure re-exports (ADR-003 flat-re-export goal closed by ADR-014; see file table above)
 ├── types.py                     # Dataclasses
 ├── _session.py                  # Concrete Session orchestration (NotebookLMClient internals)
 ├── _kernel.py                   # Concrete Kernel transport core

--- a/docs/adr/0003-auth-facade-write-through.md
+++ b/docs/adr/0003-auth-facade-write-through.md
@@ -2,43 +2,39 @@
 
 ## Status
 
-Partially completed — flat re-export goal deferred.
+**Superseded — closed by [ADR-014](./0014-feature-local-runtime-adapters.md) (session-decoupling plan Waves 3a + 4 T2.2 + 5).**
 
-The write-through facade mechanism (`_AuthFacadeModule` + the 5
-`_AUTH_*_FACADE_NAMES` / `_REFRESH_DEP_MIRROR_NAMES` /
-`_KEEPALIVE_DEP_MIRROR_NAMES` mirror tables) was deleted from
-`src/notebooklm/auth.py` in D1 PR-2 ([arch-d1-auth-side / #834](https://github.com/teng-lin/notebooklm-py/pull/834)).
-The remediation moved test-side mirroring into a small
-`tests/_fixtures/auth_seam.py` helper (`patch_auth_seam(monkeypatch, name, value)`),
-which walked the known `_auth/*` seam modules and patched every one that
-already bound the name. **That helper was itself retired in the post-v0.5.0
-audit cleanup** (`docs/test-suite-audit.md` §3): the ~50 call sites migrated
-to targeted `monkeypatch.setattr(<canonical module>, name, value)` against the
-consumer-side import, and the fixture was deleted. New tests should prefer
-constructor injection via `tests._fixtures.make_fake_core` (ADR-007); where
-module-level seam state (file locks, refresh-retry registries) makes
-injection awkward, patch the canonical home directly.
+The deferred goal — reducing `auth.py` to a flat re-export module — was
+completed across three PRs in the session-decoupling plan:
 
-**Deferred.** The original D1 plan also called for `auth.py` to be reduced
-to a flat re-export module — i.e. moving `AuthTokens`,
-`load_auth_from_storage()`, and the `_validate_required_cookies()` write-through
-into `_auth/*` and leaving `auth.py` as a thin facade. That second half was
-not shipped. At HEAD, `auth.py` still owns `AuthTokens` (`src/notebooklm/auth.py`,
-symbol `AuthTokens`), still owns the active load/recovery logic
-(`load_auth_from_storage()`), and still installs
-`_validate_required_cookies()` into `_auth.cookies` to propagate
-`auth.py`-level policy rebindings into `_auth.cookie_policy` (and mirror
-`_SECONDARY_BINDING_WARNED` back). Tests still pin
-`notebooklm.auth.<name>` monkeypatch behavior
-(`tests/unit/test_public_shims.py`).
+- **#1066** (Wave 3a / Task 2.1) moved `load_auth_from_storage()` body into
+  `_auth/tokens.py`. `notebooklm.auth.load_auth_from_storage` became a
+  one-line re-export.
+- **#1070** (Wave 4 T2.2) **inverted** the `_validate_required_cookies()`
+  write-through. Instead of copy-forwarding facade-level rebindings of
+  `MINIMUM_REQUIRED_COOKIES` / `_EXTRACTION_HINT` / `_has_valid_secondary_binding`
+  into `_cookie_policy` (and mirroring `_SECONDARY_BINDING_WARNED` back),
+  `notebooklm.auth._validate_required_cookies` is now identity-equal to
+  `notebooklm._auth.cookie_policy._validate_required_cookies`. Tests that
+  need to rebind policy names now patch `_auth.cookie_policy.X` directly.
+- **#1055** (pre-plan groundwork) had already moved `AuthTokens` into
+  `_auth/tokens.py`; the `auth.py`-level binding became a re-export.
 
-CLAUDE.md and this ADR are pinned to that current reality. Completing the
-retirement (moving `AuthTokens` / `load_auth_from_storage` to `_auth/` and
-demoting `auth.py` to flat re-exports) remains the long-term direction but
-is not scheduled.
+**Post-condition (verified by `grep -nE "^def |^class " src/notebooklm/auth.py`
+returning empty as of this PR's audit):** `auth.py` contains zero function
+bodies and zero class definitions. Every top-level name is a one-line
+re-export from the relevant `_auth/*` module. The historical write-through
+machinery is fully retired.
+
+**Why "Superseded by ADR-014" rather than "Accepted (completed)":** the
+original ADR-003 framing was a *write-through* approach (mirror writes
+through the facade). ADR-014's Rule 3 closes the same goal by *inversion*
+(facades become identity-preserving delegates; rebinding happens on the
+canonical home). The two approaches are not the same shape, so ADR-003
+is correctly marked superseded rather than promoted.
 
 The rest of this ADR is preserved as the historical record of why the
-facade existed at all.
+write-through facade existed at all.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,7 +35,7 @@ The ADR Index table utilizes four eras of Status notation to reflect the lifecyc
 |-----|-------|--------|
 | [0001](0001-layered-core-seams-and-property-bridge-policy.md) | Layered `_core` seams and the property-bridge policy | Superseded — bridge policy retired in session-shrink arc |
 | [0002](0002-capability-protocol-pattern.md) | Capability Protocol pattern (`SessionCapabilities` fat union) | Superseded by [arch-d2-cutover](https://github.com/teng-lin/notebooklm-py/pull/835) (#835) |
-| [0003](0003-auth-facade-write-through.md) | `auth.py` write-through facade (`_AuthFacadeModule`) | Superseded by [arch-d1-auth-side](https://github.com/teng-lin/notebooklm-py/pull/834) (#834) |
+| [0003](0003-auth-facade-write-through.md) | `auth.py` write-through facade (`_AuthFacadeModule`) | Superseded — closed by [ADR-014](0014-feature-local-runtime-adapters.md) (session-decoupling Waves 3a + 4 T2.2 + 5) |
 | [0004](0004-loop-affinity-contract.md) | Loop-affinity contract for `NotebookLMClient` | Accepted (retroactive) |
 | [0005](0005-idempotency-taxonomy.md) | Mutating-RPC idempotency taxonomy | Accepted (retroactive) |
 | [0006](0006-vcr-scrubber-strategy.md) | VCR cassette scrubber strategy | Accepted (retroactive) |


### PR DESCRIPTION
## Summary

**Wave 5 / Task 2.3** of the session-decoupling plan. ADR-003's deferred "flat re-export" goal is **closed** by ADR-014 (Waves 3a + 4 T2.2 + 5).

### Audit result (verified in this PR)

```bash
$ grep -nE "^def |^class " src/notebooklm/auth.py
# (empty)
```

**Zero function/class bodies remain in `auth.py`.** Every top-level name is a one-line re-export from the relevant `_auth/*` module. The historical write-through machinery (`_AuthFacadeModule`, the `_AUTH_*_FACADE_NAMES` mirror tables, `_validate_required_cookies` copy-forward) is fully retired.

### What this PR does (docs-only)

| File | Change |
|---|---|
| `docs/adr/0003-auth-facade-write-through.md` | Status: "Partially completed — deferred" → "Superseded — closed by ADR-014". Body rewritten to cite the three PRs that completed the move (#1055 + #1066 + #1070). New "why Superseded vs Accepted (completed)" note. |
| `docs/adr/README.md` | Index row updated |
| `CLAUDE.md` | `auth.py` row + package-structure tree comment rewritten to reflect the post-close state |

### Why "Superseded by ADR-014" not "Accepted (completed)"

ADR-003 was a **write-through** approach (mirror writes through the facade). ADR-014 closes the same goal by **inversion** (facades become identity-preserving delegates; rebinding happens on the canonical home). The two approaches are not the same shape, so ADR-003 is correctly marked superseded.

### Verification

- No source code changes; no test changes
- `uv run pytest tests/unit tests/_lint` — **5841 passed, 10 skipped, 0 failed**

### Parallel-safety

In flight alongside **#1071** (Wave 7 simple-feature wiring). Zero file overlap (this PR = docs only; #1071 = client.py + test_api_coverage.py).

## Test plan

- [x] Full unit + lint pass
- [x] ADR-003 status visible on README index

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to reflect changes in the authentication module architecture.
  * Marked ADR-003 (auth-facade-write-through) as superseded by ADR-014.
  * Updated architecture decision records index to reflect current supersession status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->