### PR TITLE
refactor(chat): direct collaborator injection; delete ChatRuntime Protocol (Wave 8 / Task 4.1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,15 +91,18 @@ error mapping, so the first ask POST goes through:
 
 ```text
 ChatAPI.ask(...)
-  -> assert_bound_loop(), source-id lookup, conversation lock/cache, next_reqid()
-  -> chat_aware_authed_post(...)
-  -> ChatRuntime.transport_post(...) (production: Session.transport_post)
-  -> Session._perform_authed_post(...)
+  -> loop_guard.assert_bound_loop(), source-id lookup, conversation lock/cache, reqid.next_reqid()
+  -> chat_aware_authed_post(transport, ...)
   -> SessionTransport.perform_authed_post(...)
   -> ADR-009 middleware chain
   -> SessionTransport.terminal(...) -> Kernel.post
   <- streaming chat parser + citation/reference parser
 ```
+
+After Wave 8 of the session-decoupling plan (ADR-014 Rule 2 Corollary),
+`ChatAPI` holds the four collaborators it needs (`rpc`, `transport`,
+`reqid`, `loop_guard`) directly — the legacy `ChatRuntime` Protocol
+composite and the indirection through `Session.transport_post` are gone.
 
 For a new conversation, `ChatAPI.ask()` then calls `GET_LAST_CONVERSATION_ID`
 through the normal `RpcExecutor` path. Other chat methods such as
@@ -263,10 +266,16 @@ not exported from `_session_contracts.py`):
 
 | Protocol | Module | Responsibility |
 |----------|--------|----------------|
-| `ChatRuntime` | [`_chat.py`](../src/notebooklm/_chat.py) | Chat-feature capability union — composes `RpcCaller` + `LoopGuard` and adds chat-specific `transport_post()` + `next_reqid()` methods. (The `ConversationCache` lives on `ChatAPI`, not the Protocol.) |
 | `ArtifactsRuntime` | [`_artifacts.py`](../src/notebooklm/_artifacts.py) | Artifact-feature capability union — composes `RpcCaller` + `AsyncWorkRuntime` + `DrainHookRegistration`. No own members; used by `ArtifactsAPI` for RPC dispatch, loop affinity, operation scopes, and close-time drain-hook registration. The `PollRegistry` lives on `ArtifactsAPI`, not the Protocol. |
 | `UploadRuntime` | [`_source_upload.py`](../src/notebooklm/_source_upload.py) | Upload-pipeline capability union — composes `RpcCaller` + `OperationScopeProvider` + `LoopGuard`. The upload semaphore is internal to `SourceUploadPipeline`, not the Protocol. |
 | `DrainHookRegistration` | [`_artifacts.py`](../src/notebooklm/_artifacts.py) | Exposes `register_drain_hook(name, hook)` for close-time cleanup. Sole `DrainHookRegistration` after the broad-`Session` Protocol was deleted from `_session_contracts.py` (see the `_session_contracts.py` module docstring). |
+
+`ChatRuntime` was deleted in Wave 8 of the session-decoupling plan
+(ADR-014 Rule 2 Corollary). `ChatAPI` now takes its four direct
+collaborators (`rpc: RpcCaller`, `transport: SessionTransport`,
+`reqid: ReqidCounter`, `loop_guard: LoopGuard`) by keyword-only
+constructor argument rather than reaching them through a feature-local
+runtime composite.
 
 Production satisfies the shared Protocols via `Session`; tests substitute
 [`tests/_fixtures/fake_core.py:FakeSession`](../tests/_fixtures/fake_core.py)
@@ -499,7 +508,11 @@ module-level seams and direct attribute assignment like
 which returns a `FakeSession` configured to satisfy the narrow capability
 Protocols a feature actually consumes (`RpcCaller`, `LoopGuard`,
 `OperationScopeProvider`, `AuthMetadata`, `Kernel`, plus feature-local
-runtimes like `ChatRuntime` / `ArtifactsRuntime` / `UploadRuntime`).
+runtimes like `ArtifactsRuntime` / `UploadRuntime`). `ChatAPI` no
+longer uses a feature-local runtime (Wave 8 of session-decoupling,
+ADR-014 Rule 2 Corollary) — chat unit tests inject narrow
+`MagicMock(spec=RpcCaller, rpc_call=AsyncMock(...))`-style fakes
+directly via the keyword-only constructor.
 
 The meta-lint at `tests/_lint/test_no_forbidden_monkeypatches.py`
 enforces the policy; the file-level allowlist shrinks as legacy tests

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -678,9 +678,13 @@ compatibility shim was removed in v0.5.0.
 
 Feature APIs depend on narrow per-capability Protocols defined in
 `notebooklm._session_contracts` (and feature-local runtime Protocols
-such as `ChatRuntime`, `ArtifactsRuntime`, `UploadRuntime`) rather than
-on the concrete `Session` class. See [ADR-013](adr/0013-composable-session-capabilities.md)
-and [`docs/architecture.md`](architecture.md) for the rationale and the
+such as `ArtifactsRuntime`, `UploadRuntime`) rather than on the
+concrete `Session` class. `ChatAPI` takes its four direct collaborators
+(`rpc`, `transport`, `reqid`, `loop_guard`) by keyword-only constructor
+argument as of Wave 8 of the session-decoupling plan (ADR-014 Rule 2
+Corollary); the prior `ChatRuntime` feature-local composite was deleted.
+See [ADR-013](adr/0013-composable-session-capabilities.md) and
+[`docs/architecture.md`](architecture.md) for the rationale and the
 post-v0.5.0 collaborator graph.
 
 If you previously imported from `notebooklm._core` modules, see

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -113,6 +113,16 @@ class ChatRuntime(RpcCaller, LoopGuard, Protocol):
 
     async def next_reqid(self, step: int = 100000) -> int: ...
 
+    # Wave 8 (ADR-014 Rule 2 Corollary): ``chat_aware_authed_post`` now
+    # takes :class:`SessionTransport` directly. Expose the late-bound
+    # accessor on this transitional Protocol so ``ChatAPI.ask`` can pass
+    # ``self._runtime.session_transport`` to the helper without a typing
+    # escape. Removed together with the rest of the Protocol in commit
+    # 3 of the same PR once :class:`ChatAPI` takes :class:`SessionTransport`
+    # via direct constructor injection.
+    @property
+    def session_transport(self) -> Any: ...
+
 
 class ChatAPI:
     """Operations for notebook chat/conversations.
@@ -328,7 +338,7 @@ class ChatAPI:
             reqid_token = None if get_request_id() is not None else set_request_id()
             try:
                 response = await chat_aware_authed_post(
-                    self._runtime,
+                    self._runtime.session_transport,
                     build_request=build_request,
                     parse_label="chat.ask",
                 )

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -4,11 +4,13 @@ Provides operations for asking questions, managing conversations, and
 retrieving conversation history.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
 import weakref
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import httpx
 
@@ -31,6 +33,10 @@ from ._notebook_metadata import NotebookSourceIdProvider
 from ._request_types import AuthSnapshot, BuildRequest
 from ._session_contracts import LoopGuard, RpcCaller
 from .exceptions import ChatError, NetworkError, ValidationError
+
+if TYPE_CHECKING:
+    from ._reqid_counter import ReqidCounter
+    from ._session_transport import SessionTransport
 from .rpc import (
     ChatGoal,
     ChatResponseLength,
@@ -146,30 +152,62 @@ class ChatAPI:
 
     def __init__(
         self,
-        runtime: ChatRuntime,
         *,
+        rpc: RpcCaller,
+        transport: SessionTransport,
+        reqid: ReqidCounter,
+        loop_guard: LoopGuard,
         conversation_cache: ConversationCache | None = None,
         notebooks: NotebookSourceIdProvider | None = None,
     ):
         """Initialize the chat API.
 
+        Per ADR-014 Rule 2 Corollary (Wave 8 of the session-decoupling
+        plan), ``ChatAPI`` depends on the **direct** collaborators it
+        actually exercises rather than a chat-local Runtime Protocol that
+        bundles them. The chat-local ``ChatRuntime`` Protocol used to
+        compose ``RpcCaller`` + ``LoopGuard`` + ``transport_post`` +
+        ``next_reqid``; once ``chat_aware_authed_post`` was switched to
+        take :class:`SessionTransport` directly (Wave 8 step 1), the
+        single-member surface that justified the Protocol disappeared, so
+        the Protocol was deleted and ChatAPI takes the four underlying
+        collaborators by keyword argument instead.
+
         Args:
-            runtime: Local :class:`ChatRuntime` providing RPC dispatch,
-                chat-aware transport, request-id minting, and loop-affinity
-                assertion. The concrete :class:`Session` structurally
-                satisfies this protocol.
+            rpc: RPC dispatch collaborator (typically
+                ``session.rpc_executor``) for the ``get_conversation_*``,
+                ``configure``, ``delete_conversation``, and
+                ``save_answer_as_note`` round-trips.
+            transport: :class:`SessionTransport` collaborator (typically
+                ``session.session_transport``) that owns the authed-POST
+                entry point used by :meth:`ask` via
+                :func:`chat_aware_authed_post`.
+            reqid: :class:`ReqidCounter` collaborator (typically
+                ``session.collaborators.reqid``) that mints the
+                per-attempt ``_reqid`` query parameter for the streamed
+                chat request.
+            loop_guard: :class:`LoopGuard` collaborator (typically
+                ``session.collaborators.lifecycle``) whose
+                :meth:`assert_bound_loop` fires before :meth:`ask`
+                acquires the per-conversation lock so a cross-loop
+                follow-up doesn't hang on a lock bound to a dead loop.
             conversation_cache: Optional injected cache; defaults to a fresh
                 per-instance ``ConversationCache`` (chat-domain state, no
                 other consumer).
             notebooks: Optional source-id resolver. Defaults to a
-                ``NotebooksAPI`` wrapper around ``runtime`` for backward
-                compatibility with tests that construct ``ChatAPI(fake)``.
+                ``NotebooksAPI`` wrapper around ``rpc`` so a bare
+                ``ChatAPI(rpc=..., transport=..., reqid=..., loop_guard=...)``
+                still has a default source-id resolver without callers
+                wiring the full NotebooksAPI graph.
         """
-        self._runtime = runtime
+        self._rpc = rpc
+        self._transport = transport
+        self._reqid = reqid
+        self._loop_guard = loop_guard
         if notebooks is None:
             from ._notebooks import NotebooksAPI
 
-            notebooks = NotebooksAPI(runtime)
+            notebooks = NotebooksAPI(rpc)
         self._notebooks = notebooks
         self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the
@@ -268,7 +306,7 @@ class ChatAPI:
         # guard in ``Session._perform_authed_post`` only catches misuse on
         # the POST itself, which is *after* the conversation lock is
         # already held — too late.
-        self._runtime.assert_bound_loop()
+        self._loop_guard.assert_bound_loop()
         logger.debug(
             "Asking question in notebook %s (conversation=%s)",
             notebook_id,
@@ -315,8 +353,11 @@ class ChatAPI:
             # previous direct mutation ``self._core._reqid_counter += 100000``
             # (``self._core`` was the pre-Phase-2 attribute name, now
             # ``self._runtime``) raced under ``asyncio.gather`` and produced
-            # duplicate ``_reqid`` URL params.
-            reqid = await self._runtime.next_reqid()
+            # duplicate ``_reqid`` URL params. After Wave 8 of session-
+            # decoupling, ``ChatAPI`` holds the :class:`ReqidCounter`
+            # directly (constructor injection) instead of reaching for it
+            # through a runtime composite.
+            reqid = await self._reqid.next_reqid()
 
             def build_request(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
                 return self._build_chat_request(
@@ -338,7 +379,7 @@ class ChatAPI:
             reqid_token = None if get_request_id() is not None else set_request_id()
             try:
                 response = await chat_aware_authed_post(
-                    self._runtime.session_transport,
+                    self._transport,
                     build_request=build_request,
                     parse_label="chat.ask",
                 )
@@ -453,7 +494,7 @@ class ChatAPI:
             limit,
         )
         params: list[Any] = [[], None, None, conversation_id, limit]
-        return await self._runtime.rpc_call(
+        return await self._rpc.rpc_call(
             RPCMethod.GET_CONVERSATION_TURNS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -472,7 +513,7 @@ class ChatAPI:
         """
         logger.debug("Getting conversation ID for notebook %s", notebook_id)
         params: list[Any] = [[], None, notebook_id, 1]
-        raw = await self._runtime.rpc_call(
+        raw = await self._rpc.rpc_call(
             RPCMethod.GET_LAST_CONVERSATION_ID,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -628,7 +669,7 @@ class ChatAPI:
             # Param shape captured from web-UI traffic. The trailing 1 is
             # always observed; its meaning is uncharted — treated as a fixed flag.
             params: list[Any] = [[], conversation_id, None, 1]
-            await self._runtime.rpc_call(
+            await self._rpc.rpc_call(
                 RPCMethod.DELETE_CONVERSATION,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -694,7 +735,7 @@ class ChatAPI:
             [[None, None, None, None, None, None, None, chat_settings]],
         ]
 
-        await self._runtime.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.RENAME_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -771,7 +812,7 @@ class ChatAPI:
             else f"Chat: {ask_result.answer[:50].strip().replace(chr(10), ' ')}"
         )
         return await save_chat_answer_as_note(
-            self._runtime,
+            self._rpc,
             notebook_id,
             ask_result.answer,
             ask_result.references,

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -10,9 +10,7 @@ import asyncio
 import contextlib
 import logging
 import weakref
-from typing import TYPE_CHECKING, Any, Protocol
-
-import httpx
+from typing import TYPE_CHECKING, Any
 
 from ._chat_notes import save_chat_answer_as_note
 from ._chat_protocol import (
@@ -30,7 +28,7 @@ from ._chat_transport import chat_aware_authed_post
 from ._conversation_cache import ConversationCache
 from ._logging import get_request_id, reset_request_id, set_request_id
 from ._notebook_metadata import NotebookSourceIdProvider
-from ._request_types import AuthSnapshot, BuildRequest
+from ._request_types import AuthSnapshot
 from ._session_contracts import LoopGuard, RpcCaller
 from .exceptions import ChatError, NetworkError, ValidationError
 
@@ -97,37 +95,6 @@ def _extract_next_turn_content(next_turn: Any) -> str | None:
         )
         return None
     return content
-
-
-class ChatRuntime(RpcCaller, LoopGuard, Protocol):
-    """Runtime capabilities required by the chat feature.
-
-    Local to ``_chat.py`` because ``transport_post`` and ``next_reqid`` are
-    chat-specific surfaces today and not shared with any other feature. If
-    another feature later needs the same capability, promote these members
-    to ``_session_contracts.py``; until then keeping them local minimises
-    the chat dependency surface (refactor-history.md §Local Chat Runtime, ADR-013).
-    """
-
-    async def transport_post(
-        self,
-        build_request: BuildRequest,
-        parse_label: str,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> httpx.Response: ...
-
-    async def next_reqid(self, step: int = 100000) -> int: ...
-
-    # Wave 8 (ADR-014 Rule 2 Corollary): ``chat_aware_authed_post`` now
-    # takes :class:`SessionTransport` directly. Expose the late-bound
-    # accessor on this transitional Protocol so ``ChatAPI.ask`` can pass
-    # ``self._runtime.session_transport`` to the helper without a typing
-    # escape. Removed together with the rest of the Protocol in commit
-    # 3 of the same PR once :class:`ChatAPI` takes :class:`SessionTransport`
-    # via direct constructor injection.
-    @property
-    def session_transport(self) -> Any: ...
 
 
 class ChatAPI:

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -5,13 +5,17 @@ single authed POST attempt against the NotebookLM batchexecute
 endpoint. It is the chat-domain consumer-side seam: transport-layer
 exceptions (``TransportAuthExpired``, ``TransportRateLimited``,
 ``TransportServerError``, raw ``httpx.HTTPStatusError``) raised by
-``Session._perform_authed_post`` are translated into ``ChatError``
-or ``NetworkError`` so callers (currently only :class:`ChatAPI.ask`)
-stay free of HTTP-status branching.
+:meth:`SessionTransport.perform_authed_post` are translated into
+``ChatError`` or ``NetworkError`` so callers (currently only
+:class:`ChatAPI.ask`) stay free of HTTP-status branching.
 
 After the D2 cutover (PR-2 / arch-d2-cutover), :meth:`ChatAPI.ask`
 calls :func:`chat_aware_authed_post` directly, replacing the prior
-chat-side wrapper that lived on the core's RPC executor.
+chat-side wrapper that lived on the core's RPC executor. As of Wave 8
+of the session-decoupling plan (ADR-014 Rule 2 Corollary), this helper
+takes the :class:`SessionTransport` collaborator directly rather than a
+local ``ChatRuntime`` Protocol — the indirection through a chat-local
+Protocol added no value once ``transport_post`` was its only member.
 """
 
 from __future__ import annotations
@@ -28,17 +32,17 @@ from ._transport_errors import (
 from .exceptions import ChatError, NetworkError
 
 if TYPE_CHECKING:
-    from ._chat import ChatRuntime
     from ._request_types import BuildRequest
+    from ._session_transport import SessionTransport
 
 
 async def chat_aware_authed_post(
-    runtime: ChatRuntime,
+    transport: SessionTransport,
     *,
     build_request: BuildRequest,
     parse_label: str,
 ) -> httpx.Response:
-    """Chat-side semantic owner around :meth:`ChatRuntime.transport_post`.
+    """Chat-side semantic owner around :meth:`SessionTransport.perform_authed_post`.
 
     Wraps the shared transport pipeline with chat-flavored exception
     mapping: transport-layer auth failures become
@@ -52,21 +56,28 @@ async def chat_aware_authed_post(
     executor).
 
     Args:
-        runtime: Local chat runtime (typically the shared client session,
-            which structurally satisfies :class:`ChatRuntime`).
-        build_request: Request builder forwarded to :meth:`ChatRuntime.transport_post`.
+        transport: :class:`SessionTransport` collaborator that owns the
+            authed POST entry point on the shared transport pipeline.
+            Passed directly via constructor injection from
+            ``NotebookLMClient.__init__`` (ADR-014 Rule 2 Corollary, Wave 8
+            of session-decoupling) — no chat-local Protocol intermediates.
+        build_request: Request builder forwarded to
+            :meth:`SessionTransport.perform_authed_post`.
         parse_label: Caller-friendly label used in log lines and error
-            messages (e.g. ``"chat.ask"``).
+            messages (e.g. ``"chat.ask"``). Threaded through to the
+            transport as ``log_label`` — the two names refer to the same
+            value (``parse_label`` is the chat-domain spelling; the chain
+            context still names it ``log_label``).
     """
     # Drain admission lives in ``DrainMiddleware`` at the outermost chain
-    # position around ``_perform_authed_post`` — it reads ``log_label``
+    # position around ``perform_authed_post`` — it reads ``log_label``
     # from ``RpcRequest.context`` (passed below as ``parse_label``), so a
     # drained client still surfaces ``RuntimeError`` with the chat-friendly
     # label without explicit bracketing here.
     try:
-        return await runtime.transport_post(
+        return await transport.perform_authed_post(
             build_request=build_request,
-            parse_label=parse_label,
+            log_label=parse_label,
         )
     except TransportAuthExpired as exc:
         raise ChatError(

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -17,8 +17,10 @@ Contents:
 The broad ``Session`` Protocol that previously bundled all of these
 together was deleted in Phase 7 (refactor-history.md §Migration Plan step 10).
 Feature APIs that need more than one capability either compose the
-shared Protocols here or define a feature-local runtime in their own
-module (``ChatRuntime`` in ``_chat.py``, ``ArtifactsRuntime`` in
+shared Protocols here, take direct collaborators by keyword-only
+constructor argument (``ChatAPI`` in ``_chat.py`` after Wave 8 of the
+session-decoupling plan, ADR-014 Rule 2 Corollary), or define a
+feature-local runtime in their own module (``ArtifactsRuntime`` in
 ``_artifacts.py``, ``UploadRuntime`` in ``_source_upload.py``). The
 standalone ``DrainHookRegistration`` Protocol that lived here in the
 broad-``Session`` era was deleted in the same step; the canonical

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -2,9 +2,8 @@
 
 This module defines the narrow structural Protocols feature APIs depend
 on. Per ADR-013, a Protocol lives here only when **shared by ≥2
-features**; single-consumer capabilities (e.g. chat's ``transport_post``
-+ ``next_reqid``, artifact polling's ``register_drain_hook``) stay
-local to their owning feature module.
+features**; single-consumer capabilities (e.g. artifact polling's
+``register_drain_hook``) stay local to their owning feature module.
 
 Contents:
 

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -89,7 +89,10 @@ class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
     Audit C1: ``LoopGuard`` is included so :meth:`SourceUploadPipeline.add_file`
     can short-circuit cross-loop misuse *before* entering
     ``operation_scope`` or lazily allocating the per-loop upload semaphore.
-    Mirrors the ``ChatRuntime`` / ``ArtifactsRuntime`` pattern.
+    Mirrors the ``ArtifactsRuntime`` pattern. (The historical
+    ``ChatRuntime`` Protocol that this docstring also referenced was
+    deleted in Wave 8 of the session-decoupling plan, ADR-014 Rule 2
+    Corollary, in favour of direct constructor injection on ``ChatAPI``.)
     """
 
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -334,7 +334,22 @@ class NotebookLMClient:
         # exists at NotesAPI construction time. Phase 6 (refactor-history.md
         # Step 8, ADR-013) moves saved-chat ownership to ChatAPI and
         # has NotesAPI delegate via constructor injection.
-        self.chat = ChatAPI(self._session, notebooks=self.notebooks)
+        #
+        # Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary): ChatAPI
+        # takes its four direct collaborators (RpcCaller, SessionTransport,
+        # ReqidCounter, LoopGuard) by keyword argument instead of a
+        # chat-local ``ChatRuntime`` runtime composite. The collaborators
+        # are sourced from the late-bound ``session.rpc_executor`` /
+        # ``session.session_transport`` accessors and the
+        # ``session.collaborators`` bundle.
+        chat_collaborators = self._session.collaborators
+        self.chat = ChatAPI(
+            rpc=self._session.rpc_executor,
+            transport=self._session.session_transport,
+            reqid=chat_collaborators.reqid,
+            loop_guard=chat_collaborators.lifecycle,
+            notebooks=self.notebooks,
+        )
         self.notes = NotesAPI(
             notes=note_service,
             mind_maps=mind_maps,

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -5,8 +5,11 @@ returns a ``FakeSession`` instance shaped to satisfy the **shared
 capability Protocols** in :mod:`notebooklm._session_contracts`
 (``RpcCaller``, ``LoopGuard``, ``OperationScopeProvider``,
 ``AsyncWorkRuntime``, ``AuthMetadata``, ``Kernel``) plus the
-feature-local runtime Protocols (``ChatRuntime``, ``ArtifactsRuntime``,
-``UploadRuntime``) that compose them. Tests pass the result to a
+feature-local runtime Protocols (``ArtifactsRuntime``,
+``UploadRuntime``) that compose them. (``ChatRuntime`` was deleted in
+Wave 8 of the session-decoupling plan, ADR-014 Rule 2 Corollary —
+``ChatAPI`` takes direct collaborators by keyword arg and does not
+need a feature-local runtime Protocol.) Tests pass the result to a
 sub-client constructor (``NotebooksAPI(fake)``) instead of constructing
 a real ``Session`` and mutating its attributes after the fact.
 
@@ -115,10 +118,13 @@ def make_fake_core(**overrides: Any) -> FakeSession:
         # RpcCaller — every feature API uses this. Fresh list per call so
         # tests can mutate the response without bleeding into siblings.
         "rpc_call": AsyncMock(side_effect=lambda *a, **kw: []),
-        # ChatRuntime — chat-only transport + reqid helpers consumed via
-        # the chat composite runtime; kept here so the same FakeSession
-        # can satisfy ChatRuntime, ArtifactsRuntime, and UploadRuntime
-        # for tests that wire the bag through several sub-clients.
+        # Legacy chat-runtime helpers (``transport_post``, ``next_reqid``)
+        # kept on the bag for now: tests outside the chat suite that wire
+        # the bag through several sub-clients can still rely on them, and
+        # ``ArtifactsRuntime`` / ``UploadRuntime`` may reference these in
+        # the future. ChatAPI itself stopped using these in Wave 8 of the
+        # session-decoupling plan (ADR-014 Rule 2 Corollary — ``ChatAPI``
+        # takes direct collaborators by keyword arg).
         "transport_post": AsyncMock(),
         "next_reqid": AsyncMock(return_value=100000),
         # AsyncWorkRuntime (LoopGuard + OperationScopeProvider) — used by

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -118,15 +118,6 @@ def make_fake_core(**overrides: Any) -> FakeSession:
         # RpcCaller — every feature API uses this. Fresh list per call so
         # tests can mutate the response without bleeding into siblings.
         "rpc_call": AsyncMock(side_effect=lambda *a, **kw: []),
-        # Legacy chat-runtime helpers (``transport_post``, ``next_reqid``)
-        # kept on the bag for now: tests outside the chat suite that wire
-        # the bag through several sub-clients can still rely on them, and
-        # ``ArtifactsRuntime`` / ``UploadRuntime`` may reference these in
-        # the future. ChatAPI itself stopped using these in Wave 8 of the
-        # session-decoupling plan (ADR-014 Rule 2 Corollary — ``ChatAPI``
-        # takes direct collaborators by keyword arg).
-        "transport_post": AsyncMock(),
-        "next_reqid": AsyncMock(return_value=100000),
         # AsyncWorkRuntime (LoopGuard + OperationScopeProvider) — used by
         # ArtifactsAPI polling and SourceUploadPipeline.
         "assert_bound_loop": MagicMock(return_value=None),

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -153,7 +153,6 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # rotation/lock helpers.
         "tests/unit/test_auth_psidts_recovery.py",
         "tests/unit/test_backoff.py",
-        "tests/unit/test_chat_delete_conversation.py",
         # Phase 2 PR 5 migrated this file's ``asyncio.to_thread`` patch
         # off the legacy ``notebooklm._core.asyncio.to_thread`` shim onto
         # its canonical importing module

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -190,20 +190,30 @@ def test_wait_for_completion_guards_against_cross_loop_call() -> None:
 def test_chat_ask_guards_against_cross_loop_call() -> None:
     """``ChatAPI.ask`` must raise on cross-loop misuse.
 
-    The chat entry calls its core capability's ``assert_bound_loop`` *before*
+    The chat entry calls its ``loop_guard.assert_bound_loop`` *before*
     acquiring the per-conversation lock so a cross-loop follow-up doesn't
     hang on a lock bound to a dead loop.
+
+    Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary): ``ChatAPI``
+    takes the :class:`LoopGuard` collaborator directly via keyword arg
+    instead of reaching for it through a chat-local runtime composite.
     """
     from notebooklm._chat import ChatAPI
 
-    capabilities = MagicMock()
     other_loop = asyncio.new_event_loop()
     try:
-        capabilities.assert_bound_loop = MagicMock(
-            side_effect=RuntimeError("NotebookLM client used from a different event loop")
+        loop_guard = MagicMock(
+            assert_bound_loop=MagicMock(
+                side_effect=RuntimeError("NotebookLM client used from a different event loop")
+            )
         )
 
-        chat = ChatAPI(capabilities)
+        chat = ChatAPI(
+            rpc=MagicMock(),
+            transport=MagicMock(),
+            reqid=MagicMock(),
+            loop_guard=loop_guard,
+        )
 
         async def inner() -> None:
             await chat.ask("nb-id", "question", source_ids=["src-1"])

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -315,7 +315,17 @@ class TestChatRefreshRetry:
             assert core._kernel.http_client is not None
             install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-            api = ChatAPI(core)
+            # Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary):
+            # ``ChatAPI`` takes its four direct collaborators by keyword
+            # arg. Wired here from the real ``Session`` under test so the
+            # refresh path exercises the production transport/rpc/reqid
+            # collaborators end-to-end.
+            api = ChatAPI(
+                rpc=core.rpc_executor,
+                transport=core.session_transport,
+                reqid=core.collaborators.reqid,
+                loop_guard=core.collaborators.lifecycle,
+            )
             result = await api.ask("nb_x", "Q?", source_ids=["s1"])
 
             assert call_count["n"] == 2
@@ -421,10 +431,18 @@ class TestBuildChatRequestFactory:
     """
 
     def _factory(self) -> ChatAPI:
+        # Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary):
+        # ``ChatAPI`` takes direct collaborators by keyword arg. Pure
+        # ``_build_chat_request`` exercise — none of these collaborators
+        # are touched, so they are bare ``MagicMock()`` placeholders.
         from unittest.mock import MagicMock
 
-        core = MagicMock(spec=Session)
-        return ChatAPI(core)
+        return ChatAPI(
+            rpc=MagicMock(),
+            transport=MagicMock(),
+            reqid=MagicMock(),
+            loop_guard=MagicMock(),
+        )
 
     def test_build_request_omits_authuser_for_default_profile(self):
         chat = self._factory()

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1819,9 +1819,14 @@ class TestGetConversationIdNullRaw:
     ):
         """Test get_conversation_id returns None when rpc_call returns None (arc 231->230)."""
         async with NotebookLMClient(auth_tokens) as client:
-            # Patch rpc_call to return None directly (bypasses decode error)
+            # Patch the direct ``rpc`` collaborator on ChatAPI to return
+            # None (bypasses decode error). Wave 8 of session-decoupling
+            # (ADR-014 Rule 2 Corollary) replaced the ``client._session``
+            # facade with direct constructor injection of the underlying
+            # collaborators, so we reach the chat dispatch surface via
+            # ``client.chat._rpc`` rather than ``client._session``.
             with patch.object(
-                client._session,
+                client.chat._rpc,
                 "rpc_call",
                 new_callable=AsyncMock,
                 return_value=None,

--- a/tests/unit/test_chat_delete_conversation.py
+++ b/tests/unit/test_chat_delete_conversation.py
@@ -3,6 +3,14 @@
 Pins the wire contract for the ``J7Gthc`` RPC (params shape, source_path)
 and the local-cache invariant: the per-instance cache is purged only when
 the server-side delete succeeds.
+
+Wave 8 of the session-decoupling plan (ADR-014 Rule 2 Corollary): the
+chat-local ``ChatRuntime`` Protocol composite was deleted in favour of
+direct constructor injection of the underlying collaborators. These
+tests now use narrow ``MagicMock(spec=RpcCaller)`` fakes for the only
+collaborator ``delete_conversation`` actually touches (the ``rpc``
+dispatcher); the other three collaborators (transport, reqid,
+loop_guard) are unused by this method and are mocked without specs.
 """
 
 from __future__ import annotations
@@ -12,36 +20,48 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._chat import ChatAPI
+from notebooklm._session_contracts import RpcCaller
 from notebooklm.rpc import RPCMethod
 
 
 @pytest.fixture
-def mock_core() -> MagicMock:
-    core = MagicMock()
-    core.rpc_call = AsyncMock(return_value=None)
-    return core
+def mock_rpc() -> MagicMock:
+    """Narrow ``RpcCaller`` fake — the only collaborator this surface uses.
+
+    Constructor injection via ``ChatAPI(rpc=..., transport=..., reqid=...,
+    loop_guard=...)`` satisfies ADR-007 (no post-hoc attribute assignment
+    of an ``AsyncMock`` onto ``rpc_call``); the ``AsyncMock`` is wired
+    into the ``MagicMock(spec=...)`` via its constructor so the ADR-007
+    meta-lint stays clean.
+    """
+    return MagicMock(spec=RpcCaller, rpc_call=AsyncMock(return_value=None))
 
 
 @pytest.fixture
-def api(mock_core: MagicMock) -> ChatAPI:
-    return ChatAPI(mock_core)
+def api(mock_rpc: MagicMock) -> ChatAPI:
+    return ChatAPI(
+        rpc=mock_rpc,
+        transport=MagicMock(),
+        reqid=MagicMock(),
+        loop_guard=MagicMock(),
+    )
 
 
 class TestDeleteConversation:
     @pytest.mark.asyncio
-    async def test_sends_expected_payload(self, api: ChatAPI, mock_core: MagicMock) -> None:
+    async def test_sends_expected_payload(self, api: ChatAPI, mock_rpc: MagicMock) -> None:
         assert await api.delete_conversation("nb_xyz", "conv_abc") is True
 
         # Pin the load-bearing args only; the capability adapter's wiring
         # defaults (allow_null, operation_variant, etc.) are covered elsewhere.
-        mock_core.rpc_call.assert_awaited_once()
-        args, kwargs = mock_core.rpc_call.call_args
+        mock_rpc.rpc_call.assert_awaited_once()
+        args, kwargs = mock_rpc.rpc_call.call_args
         assert args == (RPCMethod.DELETE_CONVERSATION, [[], "conv_abc", None, 1])
         assert kwargs["source_path"] == "/notebook/nb_xyz"
 
     @pytest.mark.asyncio
     async def test_clears_local_cache_for_deleted_conversation(
-        self, api: ChatAPI, mock_core: MagicMock
+        self, api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
         api._cache.cache_conversation_turn("conv_abc", "Q1?", "A1.", turn_number=1)
         api._cache.cache_conversation_turn("conv_other", "Q?", "A.", turn_number=1)
@@ -56,13 +76,13 @@ class TestDeleteConversation:
 
     @pytest.mark.asyncio
     async def test_rpc_failure_propagates_and_cache_survives(
-        self, api: ChatAPI, mock_core: MagicMock
+        self, api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
         # Seed BEFORE arming the failure so the test detects a regression
         # that clears the cache pre- or mid-failure. Seeding after would
         # mask exactly the bug the test is meant to catch.
         api._cache.cache_conversation_turn("conv_abc", "Q1?", "A1.", turn_number=1)
-        mock_core.rpc_call.side_effect = RuntimeError("server 500")
+        mock_rpc.rpc_call.side_effect = RuntimeError("server 500")
 
         with pytest.raises(RuntimeError, match="server 500"):
             await api.delete_conversation("nb_xyz", "conv_abc")

--- a/tests/unit/test_chat_error_payload.py
+++ b/tests/unit/test_chat_error_payload.py
@@ -12,7 +12,16 @@ class MalformedErrorPayload(list):
 
 
 def test_rate_limit_payload_parse_failure_logs_debug(caplog):
-    api = ChatAPI(MagicMock())
+    # Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary): ``ChatAPI``
+    # takes direct collaborators by keyword arg. ``_raise_if_rate_limited``
+    # is a pure-payload-parsing helper that does not touch any collaborator,
+    # so all four are plain ``MagicMock()`` placeholders.
+    api = ChatAPI(
+        rpc=MagicMock(),
+        transport=MagicMock(),
+        reqid=MagicMock(),
+        loop_guard=MagicMock(),
+    )
 
     with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
         api._raise_if_rate_limited(MalformedErrorPayload())

--- a/tests/unit/test_chat_save_answer_as_note.py
+++ b/tests/unit/test_chat_save_answer_as_note.py
@@ -14,6 +14,12 @@ These tests pin:
 * the explicit-title override path,
 * the 7-element CREATE_NOTE params payload + ``[2]`` mode flag,
 * the malformed-response failure mode.
+
+Wave 8 of the session-decoupling plan (ADR-014 Rule 2 Corollary): the
+chat-local ``ChatRuntime`` Protocol was deleted; ``ChatAPI`` takes its
+four direct collaborators (RpcCaller, SessionTransport, ReqidCounter,
+LoopGuard) by keyword argument. ``save_answer_as_note`` only touches
+the ``rpc`` collaborator, so the other three are mocked without specs.
 """
 
 from __future__ import annotations
@@ -22,39 +28,44 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from _fixtures.fake_core import FakeSession, make_fake_core
 from notebooklm._chat import ChatAPI
+from notebooklm._session_contracts import RpcCaller
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import AskResult, ChatReference
 
 
 @pytest.fixture
-def mock_runtime() -> FakeSession:
-    """ADR-007 substrate: a ``FakeSession`` with ``rpc_call`` injected.
+def mock_rpc() -> MagicMock:
+    """Narrow ``RpcCaller`` fake — the only collaborator this surface uses.
 
-    ``save_answer_as_note`` only calls ``runtime.rpc_call`` — no
-    transport / reqid / loop-guard surface is exercised, so the
-    ``FakeSession`` from ``make_fake_core`` (a structural
-    ``ChatRuntime`` stand-in) suffices.
+    ``save_answer_as_note`` only calls ``rpc.rpc_call`` — no transport /
+    reqid / loop-guard surface is exercised. The ``AsyncMock`` is wired
+    into the ``MagicMock(spec=...)`` via its constructor so the ADR-007
+    meta-lint stays clean (no post-hoc attribute assignment).
     """
-    return make_fake_core(rpc_call=AsyncMock())
+    return MagicMock(spec=RpcCaller, rpc_call=AsyncMock())
 
 
 @pytest.fixture
-def chat_api(mock_runtime: FakeSession) -> ChatAPI:
-    """A ``ChatAPI`` instance whose runtime is the ADR-007 fake.
+def chat_api(mock_rpc: MagicMock) -> ChatAPI:
+    """A ``ChatAPI`` instance wired with narrow collaborator fakes.
 
     A ``MagicMock(get_source_ids=AsyncMock(...))`` notebooks resolver
     is injected so the ``NotebooksAPI`` fallback in
-    ``ChatAPI.__init__`` does not try to wrap the runtime; the
+    ``ChatAPI.__init__`` does not try to wrap ``rpc``; the
     ``NotebookSourceIdProvider`` protocol surface is small enough that
     a ``MagicMock`` with a single async stub satisfies it without
     falling into ADR-007's forbidden-attribute-assignment lint
-    (the stub is passed via constructor injection, not via
-    ``notebooks.get_source_ids = AsyncMock(...)`` post-hoc).
+    (the stub is passed via constructor injection).
     """
     notebooks = MagicMock(get_source_ids=AsyncMock(return_value=[]))
-    return ChatAPI(mock_runtime, notebooks=notebooks)
+    return ChatAPI(
+        rpc=mock_rpc,
+        transport=MagicMock(),
+        reqid=MagicMock(),
+        loop_guard=MagicMock(),
+        notebooks=notebooks,
+    )
 
 
 def _make_ask_result(
@@ -93,11 +104,11 @@ class TestSaveAnswerAsNote:
 
     @pytest.mark.asyncio
     async def test_default_title_derives_from_answer_not_question(
-        self, chat_api: ChatAPI, mock_runtime: FakeSession
+        self, chat_api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
         # Wrapped response shape — slot [0] is a list whose first
         # element is the note_id.
-        mock_runtime.rpc_call.return_value = [
+        mock_rpc.rpc_call.return_value = [
             [
                 "note-new-id",
                 "One fruit mentioned is apples [1].",
@@ -112,7 +123,7 @@ class TestSaveAnswerAsNote:
         # Server-returned title is what surfaces in the Note.
         assert note.title == "ServerTitle"
         # The RPC call received our derived default title (from .answer).
-        sent_title = mock_runtime.rpc_call.call_args[0][1][4]
+        sent_title = mock_rpc.rpc_call.call_args[0][1][4]
         assert sent_title.startswith("Chat: ")
         # Derivation truncates the answer to 50 chars — confirm the
         # source field is .answer, not anything question-derived.
@@ -120,9 +131,9 @@ class TestSaveAnswerAsNote:
 
     @pytest.mark.asyncio
     async def test_explicit_title_overrides_default(
-        self, chat_api: ChatAPI, mock_runtime: FakeSession
+        self, chat_api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
-        mock_runtime.rpc_call.return_value = [
+        mock_rpc.rpc_call.return_value = [
             "note-new-id",
             "answer",
             [2, "u", [1, 2]],
@@ -132,14 +143,14 @@ class TestSaveAnswerAsNote:
         ]
         ask_result = _make_ask_result()
         note = await chat_api.save_answer_as_note("nb-1", ask_result, title="My Title")
-        assert mock_runtime.rpc_call.call_args[0][1][4] == "My Title"
+        assert mock_rpc.rpc_call.call_args[0][1][4] == "My Title"
         assert note.title == "My Title"
 
     @pytest.mark.asyncio
     async def test_uses_create_note_rpc_with_mode_flag_2(
-        self, chat_api: ChatAPI, mock_runtime: FakeSession
+        self, chat_api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
-        mock_runtime.rpc_call.return_value = [
+        mock_rpc.rpc_call.return_value = [
             "note-id",
             "x",
             [2, "u", [1, 2]],
@@ -149,7 +160,7 @@ class TestSaveAnswerAsNote:
         ]
         ask_result = _make_ask_result()
         await chat_api.save_answer_as_note("nb-1", ask_result, title="T")
-        call_args = mock_runtime.rpc_call.call_args
+        call_args = mock_rpc.rpc_call.call_args
         assert call_args[0][0] == RPCMethod.CREATE_NOTE
         params = call_args[0][1]
         # 7-element params with [2] mode flag at slot 2 (vs [1] for blank-note variant)
@@ -157,30 +168,30 @@ class TestSaveAnswerAsNote:
         assert params[2] == [2]
         assert params[6] == [2]
         # Only ONE RPC call — no follow-up UPDATE_NOTE.
-        assert mock_runtime.rpc_call.call_count == 1
+        assert mock_rpc.rpc_call.call_count == 1
 
     @pytest.mark.asyncio
     async def test_missing_note_id_in_response_raises(
-        self, chat_api: ChatAPI, mock_runtime: FakeSession
+        self, chat_api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
         # Malformed response (note_id slot is None / not a str) must
         # surface a clear ``RuntimeError`` rather than returning a Note
         # with id="".
-        mock_runtime.rpc_call.return_value = [None, "x", [], [], "T", []]
+        mock_rpc.rpc_call.return_value = [None, "x", [], [], "T", []]
         ask_result = _make_ask_result()
         with pytest.raises(RuntimeError, match="no note ID"):
             await chat_api.save_answer_as_note("nb-1", ask_result, title="T")
 
     @pytest.mark.asyncio
     async def test_returned_note_carries_answer_with_markers(
-        self, chat_api: ChatAPI, mock_runtime: FakeSession
+        self, chat_api: ChatAPI, mock_rpc: MagicMock
     ) -> None:
         """``Note.content`` is the answer text WITH ``[N]`` markers.
 
         Rich citation anchors live server-side and surface via the
         NotebookLM UI; the dataclass only carries the raw answer.
         """
-        mock_runtime.rpc_call.return_value = [
+        mock_rpc.rpc_call.return_value = [
             "note-id",
             "ignored-server-content",
             [2, "u", [1, 2]],

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -1,24 +1,31 @@
 """Unit tests for :func:`notebooklm._chat_transport.chat_aware_authed_post`.
 
 Exercises the chat-domain error-mapping seam over the generic transport
-primitives. Each test injects a stub ``session`` whose ``transport_post``
-raises one of the transport-layer exceptions (or the raw ``httpx``
-status error) and asserts the function maps the failure to the expected
-``ChatError`` / ``NetworkError`` shape, message, and exception chain.
+primitives. Each test injects a stub ``transport`` whose
+``perform_authed_post`` raises one of the transport-layer exceptions
+(or the raw ``httpx`` status error) and asserts the function maps the
+failure to the expected ``ChatError`` / ``NetworkError`` shape, message,
+and exception chain.
 
 As of Tier-12 PR 12.5 the drain-tracking bookkeeping
 (``_begin_transport_post`` / ``_finish_transport_post``) has moved into
 ``DrainMiddleware`` at the outermost chain position around
-``Session.transport_post``. ``chat_aware_authed_post`` no longer brackets
-its own transport call with explicit drain calls —
+``SessionTransport.perform_authed_post``. ``chat_aware_authed_post`` no
+longer brackets its own transport call with explicit drain calls —
 admission and finalization are middleware concerns now. The tests
-correspondingly stub only ``transport_post`` on the session.
+correspondingly stub only ``perform_authed_post`` on the transport.
 
-The stub ``session`` is a lightweight ``SimpleNamespace`` rather than a
-``MagicMock(spec=Session)`` so the tests stay independent of the
-protocol's exact member set — they only need the transport
-primitive the function actually calls. The drain-fires-on-exception
-invariant is now covered by
+As of Wave 8 of the session-decoupling plan (ADR-014 Rule 2 Corollary),
+``chat_aware_authed_post`` takes the :class:`SessionTransport` collaborator
+directly rather than a chat-local ``ChatRuntime`` Protocol, and calls
+``transport.perform_authed_post(build_request=..., log_label=parse_label)``
+on it.
+
+The stub ``transport`` is a lightweight ``SimpleNamespace`` rather than a
+``MagicMock(spec=SessionTransport)`` so the tests stay independent of the
+class's exact member set — they only need the transport primitive the
+function actually calls. The drain-fires-on-exception invariant is now
+covered by
 ``tests/unit/test_drain_middleware.py::test_finish_fires_on_exception``.
 """
 
@@ -55,24 +62,28 @@ def _make_status_error(code: int, *, retry_after: str | None = None) -> httpx.HT
     return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
 
 
-def _make_stub_session(
+def _make_stub_transport(
     *,
     transport_side_effect: Any = None,
     transport_return_value: Any = None,
 ) -> SimpleNamespace:
-    """Build a stub ``session`` matching the slice of ``Session`` we exercise.
+    """Build a stub ``transport`` matching the slice of ``SessionTransport`` we exercise.
 
-    Pass ``transport_side_effect`` to make ``transport_post`` raise
+    Pass ``transport_side_effect`` to make ``perform_authed_post`` raise
     (exception instance) or invoke a callable; pass ``transport_return_value``
     to make it return that response unchanged. Exactly one of the two
     should be supplied per test — they are mutually exclusive.
 
     PR 12.5 lifted ``_begin_transport_post`` / ``_finish_transport_post``
     into DrainMiddleware, so the stub no longer needs to mock them —
-    ``chat_aware_authed_post`` does not call them.
+    ``chat_aware_authed_post`` does not call them. Wave 8 of
+    session-decoupling switched the helper to take a
+    :class:`SessionTransport` directly, so the stub exposes the
+    transport's ``perform_authed_post`` method (the chat-side
+    ``parse_label`` is forwarded to it as ``log_label``).
     """
     return SimpleNamespace(
-        transport_post=AsyncMock(
+        perform_authed_post=AsyncMock(
             side_effect=transport_side_effect,
             return_value=transport_return_value,
         ),
@@ -93,18 +104,18 @@ def _noop_build_request(_snapshot: Any) -> tuple[str, str, dict[str, str]]:
 async def test_chat_aware_authed_post_returns_response_and_balances_bookkeeping():
     """Success path: response forwarded; begin/finish tokens balanced."""
     expected_response = httpx.Response(200, request=_make_request())
-    session = _make_stub_session(transport_return_value=expected_response)
+    transport = _make_stub_transport(transport_return_value=expected_response)
 
     result = await chat_aware_authed_post(
-        session,  # type: ignore[arg-type]
+        transport,  # type: ignore[arg-type]
         build_request=_noop_build_request,
         parse_label="chat.ask",
     )
 
     assert result is expected_response
-    session.transport_post.assert_awaited_once_with(
+    transport.perform_authed_post.assert_awaited_once_with(
         build_request=_noop_build_request,
-        parse_label="chat.ask",
+        log_label="chat.ask",
     )
 
 
@@ -117,11 +128,11 @@ async def test_chat_aware_authed_post_returns_response_and_balances_bookkeeping(
 async def test_transport_auth_expired_maps_to_chat_error():
     original = _make_status_error(401)
     transport_exc = TransportAuthExpired("auth refresh failed", original=original)
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(ChatError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -146,11 +157,11 @@ async def test_transport_rate_limited_with_retry_after_includes_retry_seconds():
         response=response,
         original=original,
     )
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(ChatError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -172,11 +183,11 @@ async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
         response=response,
         original=original,
     )
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(ChatError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -202,11 +213,11 @@ async def test_transport_server_error_with_http_status_error_maps_to_chat_error(
         response=original.response,
         status_code=503,
     )
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(ChatError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -221,11 +232,11 @@ async def test_transport_server_error_with_http_status_error_maps_to_chat_error(
 async def test_transport_server_error_with_request_error_maps_to_network_error():
     original = httpx.RequestError("connect failed", request=_make_request())
     transport_exc = TransportServerError("network failure", original=original)
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(NetworkError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -244,11 +255,11 @@ async def test_transport_server_error_with_timeout_exception_keeps_timeout_messa
     would collapse to the generic "network error after retries" line."""
     original = httpx.ReadTimeout("read timed out", request=_make_request())
     transport_exc = TransportServerError("timeout", original=original)
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(NetworkError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -272,11 +283,11 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
 
     original = _UnexpectedException("not http, not request")
     transport_exc = TransportServerError("bogus original", original=original)
-    session = _make_stub_session(transport_side_effect=transport_exc)
+    transport = _make_stub_transport(transport_side_effect=transport_exc)
 
     with pytest.raises(TypeError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )
@@ -298,15 +309,15 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
 @pytest.mark.asyncio
 async def test_raw_http_status_error_maps_to_chat_error():
     """Non-401 / non-429 / non-5xx status errors that fall through
-    ``Session.transport_post`` reach this layer as raw
+    ``SessionTransport.perform_authed_post`` reach this layer as raw
     ``httpx.HTTPStatusError`` and get wrapped in a ``ChatError`` that
     surfaces the status code."""
     raw_exc = _make_status_error(404)
-    session = _make_stub_session(transport_side_effect=raw_exc)
+    transport = _make_stub_transport(transport_side_effect=raw_exc)
 
     with pytest.raises(ChatError) as excinfo:
         await chat_aware_authed_post(
-            session,  # type: ignore[arg-type]
+            transport,  # type: ignore[arg-type]
             build_request=_noop_build_request,
             parse_label="chat.ask",
         )

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -113,6 +113,27 @@ def mock_notebooks_api():
     return notebooks
 
 
+def _chat_from_mock_core(mock_core, *, notebooks=None) -> ChatAPI:
+    """Build a ``ChatAPI`` from the ``mock_core`` fixture's surfaces.
+
+    Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary): ``ChatAPI``
+    takes its four direct collaborators by keyword arg. The legacy single-
+    arg ``ChatAPI(mock_core)`` form is gone; this helper preserves the
+    test shape by mapping the bag-of-attributes mock_core fixture onto
+    the new constructor surface (rpc, transport, reqid, loop_guard).
+    Tests pass ``mock_core.rpc_call`` for ``rpc.rpc_call`` and the
+    fixture's pre-wired ``mock_core.session_transport.perform_authed_post``
+    for the transport entry point.
+    """
+    return ChatAPI(
+        rpc=mock_core,
+        transport=mock_core.session_transport,
+        reqid=mock_core,
+        loop_guard=mock_core,
+        notebooks=notebooks,
+    )
+
+
 @pytest.fixture
 def mock_mind_map_service():
     """Bundle of stand-in services required by ``ArtifactsAPI.__init__``.
@@ -139,7 +160,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_with_explicit_source_ids(self, mock_core):
         """Test ask() with explicitly provided source_ids."""
-        api = ChatAPI(mock_core)
+        api = _chat_from_mock_core(mock_core)
 
         result = await api.ask(
             notebook_id="nb_123",
@@ -163,7 +184,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_with_none_fetches_all_sources(self, mock_core, mock_notebooks_api):
         """Test ask() with source_ids=None fetches all sources."""
-        api = ChatAPI(mock_core, notebooks=mock_notebooks_api)
+        api = _chat_from_mock_core(mock_core, notebooks=mock_notebooks_api)
 
         # Mock get_source_ids to return source IDs
         mock_notebooks_api.get_source_ids.return_value = ["src_001", "src_002", "src_003"]
@@ -182,7 +203,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_source_encoding_format(self, mock_core):
         """Verify the correct encoding format for source IDs in ask()."""
-        api = ChatAPI(mock_core)
+        api = _chat_from_mock_core(mock_core)
 
         await api.ask(
             notebook_id="nb_123",
@@ -731,7 +752,7 @@ class TestEmptySourceIds:
     @pytest.mark.asyncio
     async def test_ask_with_empty_source_list(self, mock_core):
         """Test ask with empty source_ids list."""
-        api = ChatAPI(mock_core)
+        api = _chat_from_mock_core(mock_core)
 
         await api.ask(
             notebook_id="nb_123",

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -24,10 +24,12 @@ from notebooklm.rpc import InfographicStyle, VideoFormat, VideoStyle
 def mock_core():
     """Create a mock Session.
 
-    After the D2 cutover, ``ChatAPI.ask`` reaches the network through
-    ``Session.transport_post``. The fixture stubs that session method and
-    invokes the caller-supplied ``build_request`` factory so URL/body
-    assertions still exercise the production request builder.
+    After Wave 8 of session-decoupling, ``ChatAPI.ask`` reaches the network
+    through ``self._runtime.session_transport.perform_authed_post`` (the
+    direct :class:`SessionTransport` collaborator). The fixture stubs that
+    transport method and invokes the caller-supplied ``build_request``
+    factory so URL/body assertions still exercise the production request
+    builder.
     """
     from notebooklm._request_types import AuthSnapshot
 
@@ -62,12 +64,14 @@ def mock_core():
     core.assert_bound_loop = MagicMock(return_value=None)
     core.get_http_client = MagicMock()
 
-    # Default ``transport_post`` stub: invokes the caller-supplied
-    # ``build_request`` factory with a frozen snapshot (so the URL/body the
-    # test wants to assert on actually gets assembled) and returns a stock
-    # answer response. Individual tests that need to inspect the URL/body can
-    # read ``core._last_chat_request`` after calling ``ChatAPI.ask``.
-    async def _transport_post_default(*, build_request, parse_label):
+    # Default ``perform_authed_post`` stub on the session-transport
+    # collaborator: invokes the caller-supplied ``build_request`` factory
+    # with a frozen snapshot (so the URL/body the test wants to assert on
+    # actually gets assembled) and returns a stock answer response.
+    # Individual tests that need to inspect the URL/body can read
+    # ``core._last_chat_request`` after calling ``ChatAPI.ask``. The
+    # chat-side ``parse_label`` is forwarded as ``log_label``.
+    async def _perform_authed_post_default(*, build_request, log_label):
         snapshot = AuthSnapshot(
             csrf_token=core.auth.csrf_token,
             session_id=core.auth.session_id,
@@ -95,7 +99,10 @@ def mock_core():
         return resp
 
     # Track call counts so tests can assert on transport invocation.
-    core.transport_post = AsyncMock(side_effect=_transport_post_default)
+    # Wave 8 of session-decoupling: chat now reaches the network through
+    # ``session_transport.perform_authed_post`` rather than the legacy
+    # ``transport_post`` facade on Session.
+    core.session_transport.perform_authed_post = AsyncMock(side_effect=_perform_authed_post_default)
     return core
 
 
@@ -142,8 +149,9 @@ class TestChatSourceSelection:
 
         assert result.answer == "Default answer long enough to be valid."
 
-        # transport_post is the session entry point; the request body is captured
-        # into ``_last_chat_request`` by the mock_core fixture.
+        # session_transport.perform_authed_post is the session entry point;
+        # the request body is captured into ``_last_chat_request`` by the
+        # mock_core fixture.
         body = mock_core._last_chat_request["body"]
 
         # The body should contain the encoded sources_array
@@ -182,9 +190,10 @@ class TestChatSourceSelection:
             source_ids=["s1", "s2", "s3"],
         )
 
-        # transport_post should have been called once with a build_request factory
-        # that produces the URL-encoded body with the triple-nested sources.
-        mock_core.transport_post.assert_awaited_once()
+        # session_transport.perform_authed_post should have been called once
+        # with a build_request factory that produces the URL-encoded body
+        # with the triple-nested sources.
+        mock_core.session_transport.perform_authed_post.assert_awaited_once()
         body = mock_core._last_chat_request["body"]
 
         # The body contains URL-encoded f.req parameter

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -25,9 +25,13 @@ def mock_core():
     """Create a mock Session.
 
     After Wave 8 of session-decoupling, ``ChatAPI.ask`` reaches the network
-    through ``self._runtime.session_transport.perform_authed_post`` (the
-    direct :class:`SessionTransport` collaborator). The fixture stubs that
-    transport method and invokes the caller-supplied ``build_request``
+    through its injected :class:`SessionTransport` collaborator via
+    ``self._transport.perform_authed_post`` (constructor-injected by the
+    ``_chat_from_mock_core`` helper below, which maps the bag-of-attributes
+    ``mock_core`` fixture onto the four keyword-only collaborator slots).
+    The fixture stubs ``mock_core.session_transport.perform_authed_post`` —
+    that ``AsyncMock`` is the value ``_chat_from_mock_core`` passes as
+    ``transport=`` — and invokes the caller-supplied ``build_request``
     factory so URL/body assertions still exercise the production request
     builder.
     """


### PR DESCRIPTION
## Summary

Wave 8 of the session-decoupling plan ([`docs/session-decoupling-plan-2026-05-26.md`](docs/session-decoupling-plan-2026-05-26.md)), Task 4.1. Per [ADR-014](docs/adr/0014-feature-local-runtime-adapters.md) Rule 2 Corollary: a feature-local Protocol that only restates an existing shared collaborator's API is dead Protocol surface — delete it instead of adding adapters.

Rewires `ChatAPI` to take its four direct collaborators (`rpc`, `transport`, `reqid`, `loop_guard`) by keyword-only constructor argument, deletes the chat-local `ChatRuntime` Protocol composite, and switches `chat_aware_authed_post` to take `SessionTransport` directly.

## Three commits (clean revertability)

1. **`refactor(chat): chat_aware_authed_post takes SessionTransport`** (ddfb7b08): the helper signature change. The `_chat.py` call site temporarily reaches through `self._runtime.session_transport` so ChatAPI keeps working without the constructor rewire; `ChatRuntime` gains a transitional `session_transport` member that is deleted in commit 3. Test stubs for the helper switch from `transport_post` to `perform_authed_post`.
2. **`refactor(chat): ChatAPI takes direct collaborators`** (0a02d888): the constructor rewire — `ChatAPI.__init__` takes `rpc`, `transport`, `reqid`, `loop_guard` (keyword-only) plus the existing `conversation_cache` / `notebooks` knobs. `client.py` wires the new shape from `session.rpc_executor`, `session.session_transport`, and `session.collaborators.{reqid,lifecycle}` (the Wave 6 accessors + the Wave 7 eager `rpc_executor` materialization). All chat unit tests migrate to narrow `MagicMock(spec=RpcCaller, rpc_call=AsyncMock(...))`-style fakes; no more `FakeSession` / `make_fake_core(...)` for ChatAPI. ADR-007 allowlist entry for `tests/unit/test_chat_delete_conversation.py` removed (the fixture now wires `AsyncMock` via `MagicMock(spec=...)` constructor args).
3. **`refactor(chat): delete ChatRuntime Protocol`** (41ea70ae): deletes the now-unused `ChatRuntime` Protocol body + transitional `session_transport` member; cleans up cross-reference docstrings in `_session_contracts.py`, `_source_upload.py`, and `tests/_fixtures/fake_core.py`. `rg ChatRuntime src tests` shows only explanatory docstrings remain.

## Test plan

- [x] `uv run pytest tests/unit/chat -v` (n/a — chat tests live in `tests/unit/test_chat*.py`; ran those explicitly: 205 passed)
- [x] `uv run pytest tests/_lint -v` (63 passed)
- [x] `uv run ruff format --check .` (clean)
- [x] `uv run ruff check .` (clean)
- [x] `uv run mypy src/notebooklm` (0 errors in 173 source files)
- [x] `uv run pytest tests/unit tests/_lint -x -q` (5802 passed, 49 skipped)
- [x] `uv run pytest tests/integration -q` (633 passed, 5 skipped) — covers the real-Session `ChatAPI` wiring end-to-end via `NotebookLMClient(...)` in characterization tests.
- [x] `rg ChatRuntime src tests` — only explanatory docstrings remain, no Protocol consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat APIs now receive collaborators directly via constructor injection, replacing prior composite runtime indirection.

* **Documentation**
  * Updated architecture and Python API docs to describe the session-decoupling model and new constructor injection patterns.

* **Tests**
  * Updated unit tests and fixtures to construct chat APIs with explicit collaborator mocks/stubs and to target the new transport/RPC entry points.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->