### PR TITLE
feat(adapters): introduce ArtifactsRuntimeAdapter + UploadRuntimeAdapter (Wave 9 / Tasks 4.2+4.3)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -192,7 +192,7 @@ class ArtifactsRuntimeAdapter:
 
     async def rpc_call(
         self,
-        method: Any,
+        method: RPCMethod,
         params: list[Any],
         source_path: str = "/",
         allow_null: bool = False,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -8,8 +8,10 @@ Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 import builtins
 import logging
 from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 # ``_mind_map`` is re-exported as ``_artifacts._mind_map`` so legacy patch
 # seams can still resolve the module via the artifacts facade. The runtime code
@@ -29,6 +31,10 @@ from ._note_service import NoteService
 from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
 from ._session_contracts import AsyncWorkRuntime, RpcCaller
+
+if TYPE_CHECKING:
+    from ._session_lifecycle import ClientLifecycle
+    from ._transport_drain import TransportDrainTracker
 from .rpc import (
     ArtifactTypeCode,
     AudioFormat,
@@ -154,6 +160,69 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
     ``operation_scope``), and :class:`DrainHookRegistration` (for
     close-time poll-task cleanup).
     """
+
+
+@dataclass(frozen=True)
+class ArtifactsRuntimeAdapter:
+    """Concrete satisfier of :class:`ArtifactsRuntime` per ADR-014.
+
+    Earns its keep under Rule 2 because:
+
+    - the composite has three capabilities (``RpcCaller`` +
+      ``AsyncWorkRuntime`` + ``DrainHookRegistration``);
+    - :class:`ArtifactsAPI` takes the whole composite as a single
+      dependency (``runtime``), and passes it through to
+      ``ArtifactPollingService`` (which consumes ``AsyncWorkRuntime``)
+      and ``ArtifactDownloadService`` (which consumes ``RpcCaller``) —
+      consumer-demand;
+    - ``register_drain_hook`` is a meaningful named affordance worth
+      exposing as one method.
+
+    The adapter is constructed at the composition root
+    (:class:`notebooklm.client.NotebookLMClient`) from the three
+    underlying collaborators: :class:`RpcCaller`,
+    :class:`TransportDrainTracker`, and :class:`ClientLifecycle`. It
+    transitively satisfies :class:`AsyncWorkRuntime` per ADR-014 Rule 2
+    — no dedicated ``_AsyncWorkAdapter`` is introduced.
+    """
+
+    rpc: RpcCaller
+    drain: "TransportDrainTracker"
+    lifecycle: "ClientLifecycle"
+
+    async def rpc_call(
+        self,
+        method: Any,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
+    ) -> Any:
+        return await self.rpc.rpc_call(
+            method,
+            params,
+            source_path,
+            allow_null,
+            _is_retry,
+            disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
+        )
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        return self.drain.operation_scope(label)
+
+    def register_drain_hook(
+        self,
+        name: str,
+        hook: Callable[[], Awaitable[None]],
+    ) -> None:
+        self.drain.register_drain_hook(name, hook)
+
+    def assert_bound_loop(self) -> None:
+        self.lifecycle.assert_bound_loop()
 
 
 class ArtifactsAPI:
@@ -1039,3 +1108,16 @@ class ArtifactsAPI:
             Returns True on unexpected structure (defensive fallback).
         """
         return _artifact_polling._is_media_ready(art, artifact_type)
+
+
+if TYPE_CHECKING:
+    # mypy guard: ``ArtifactsRuntimeAdapter`` must structurally satisfy
+    # the ``ArtifactsRuntime`` Protocol it adapts. Failing this assertion
+    # at type-check time catches shape drift on the delegate methods
+    # before runtime construction at the composition root would. Mirrors
+    # the pattern used by ``_rpc_executor._assert_rpc_executor_satisfies_rpc_caller``.
+
+    def _assert_adapter_satisfies_artifacts_runtime(
+        adapter: ArtifactsRuntimeAdapter,
+    ) -> None:
+        _: ArtifactsRuntime = adapter

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -9,10 +9,11 @@ import mimetypes
 import os
 import re
 from collections.abc import Awaitable, Callable
-from dataclasses import replace
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass, replace
 from pathlib import Path
 from time import monotonic
-from typing import IO, Any, Protocol, cast
+from typing import IO, TYPE_CHECKING, Any, Protocol, cast
 
 import httpx
 
@@ -43,6 +44,10 @@ from .exceptions import (
 from .rpc import RPCError, RPCMethod, get_upload_url
 from .rpc.types import SourceStatus
 from .types import Source, SourceAddError
+
+if TYPE_CHECKING:
+    from ._session_lifecycle import ClientLifecycle
+    from ._transport_drain import TransportDrainTracker
 
 _SOURCE_ID_UUID_PATTERN = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -94,6 +99,66 @@ class UploadRuntime(RpcCaller, OperationScopeProvider, LoopGuard, Protocol):
     deleted in Wave 8 of the session-decoupling plan, ADR-014 Rule 2
     Corollary, in favour of direct constructor injection on ``ChatAPI``.)
     """
+
+
+@dataclass(frozen=True)
+class UploadRuntimeAdapter:
+    """Concrete satisfier of :class:`UploadRuntime` per ADR-014 Rule 2.
+
+    Earns its keep under Rule 2 because:
+
+    - the composite has three capabilities (``RpcCaller`` +
+      ``OperationScopeProvider`` + ``LoopGuard``);
+    - :class:`SourceUploadPipeline` takes the whole composite as a
+      single dependency (``runtime``) and threads it into the
+      lister/poller collaborators — consumer-demand;
+    - ``assert_bound_loop`` is a meaningful named affordance used as a
+      cross-loop short-circuit guard in :meth:`SourceUploadPipeline.add_file`.
+
+    The adapter is constructed at the composition root
+    (:class:`notebooklm.client.NotebookLMClient`) from the three
+    underlying collaborators: :class:`RpcCaller`,
+    :class:`TransportDrainTracker`, and :class:`ClientLifecycle`. It
+    transitively satisfies ``AsyncWorkRuntime`` (``LoopGuard`` +
+    ``OperationScopeProvider``) per ADR-014 Rule 2 — no dedicated
+    ``_AsyncWorkAdapter`` is introduced.
+
+    :class:`SourceUploadPipeline` continues to take :class:`Kernel`
+    and :class:`AuthMetadata` as separate parameters, so this adapter
+    covers only the composite ``UploadRuntime`` Protocol — mirroring
+    the ADR-014 Rule 6 example.
+    """
+
+    rpc: RpcCaller
+    drain: TransportDrainTracker
+    lifecycle: ClientLifecycle
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
+    ) -> Any:
+        return await self.rpc.rpc_call(
+            method,
+            params,
+            source_path,
+            allow_null,
+            _is_retry,
+            disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
+        )
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        return self.drain.operation_scope(label)
+
+    def assert_bound_loop(self) -> None:
+        self.lifecycle.assert_bound_loop()
 
 
 _INVALID_ARGUMENT_RPC_CODE = 3
@@ -908,7 +973,21 @@ __all__ = [
     "RpcCallback",
     "SourceUploadPipeline",
     "UploadRuntime",
+    "UploadRuntimeAdapter",
     "_SOURCE_ID_UUID_PATTERN",
     "_extract_register_file_source_id",
     "_looks_like_id_string",
 ]
+
+
+if TYPE_CHECKING:
+    # mypy guard: ``UploadRuntimeAdapter`` must structurally satisfy
+    # the ``UploadRuntime`` Protocol it adapts. Failing this assertion
+    # at type-check time catches shape drift on the delegate methods
+    # before runtime construction at the composition root would. Mirrors
+    # the pattern used by ``_rpc_executor._assert_rpc_executor_satisfies_rpc_caller``.
+
+    def _assert_adapter_satisfies_upload_runtime(
+        adapter: UploadRuntimeAdapter,
+    ) -> None:
+        _: UploadRuntime = adapter

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
-from ._artifacts import ArtifactsAPI
+from ._artifacts import ArtifactsAPI, ArtifactsRuntimeAdapter
 from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
 from ._env import get_base_url as get_base_url
@@ -55,7 +55,7 @@ from ._session_config import (
 from ._session_lifecycle import CookieRotator, CookieSaver
 from ._settings import SettingsAPI
 from ._sharing import SharingAPI
-from ._source_upload import SourceUploadPipeline
+from ._source_upload import SourceUploadPipeline, UploadRuntimeAdapter
 from ._sources import SourcesAPI
 from ._url_utils import is_google_auth_redirect as is_google_auth_redirect
 from .auth import AuthTokens
@@ -290,12 +290,22 @@ class NotebookLMClient:
             cookie_rotator=cookie_rotator,
         )
 
-        # Wire the upload pipeline explicitly with the concrete capability
-        # surfaces (UploadRuntime via the Session, plus Kernel and AuthMetadata).
-        # NotebookLMClient is the only composition root that knows these
-        # internals — SourcesAPI no longer reads them back off the session.
+        # Wave 9 of session-decoupling (ADR-014 Rule 2 + Rule 3): the
+        # upload pipeline takes a ``UploadRuntimeAdapter`` composite —
+        # built from ``rpc_executor`` + ``drain_tracker`` + ``lifecycle``
+        # — instead of the whole ``Session``. ``Kernel`` and
+        # ``AuthMetadata`` continue to flow as separate parameters per
+        # the ADR-014 Rule 6 example. ``NotebookLMClient.__init__`` is
+        # the composition root that knows these internals;
+        # ``SourcesAPI`` no longer reads them back off the session.
+        upload_collaborators = self._session.collaborators
+        upload_runtime = UploadRuntimeAdapter(
+            rpc=self._session.rpc_executor,
+            drain=upload_collaborators.drain_tracker,
+            lifecycle=upload_collaborators.lifecycle,
+        )
         source_uploader = SourceUploadPipeline(
-            self._session,
+            upload_runtime,
             self._session.kernel,
             self._session.auth,
             upload_timeout=upload_timeout,
@@ -322,8 +332,21 @@ class NotebookLMClient:
         # NoteService.create_note directly to persist a generated mind map.
         note_service = NoteService(self._session.rpc_executor)
         mind_maps = NoteBackedMindMapService(note_service)
+        # Wave 9 of session-decoupling (ADR-014 Rule 2 + Rule 3): the
+        # artifacts API takes an ``ArtifactsRuntimeAdapter`` composite —
+        # built from ``rpc_executor`` + ``drain_tracker`` + ``lifecycle``
+        # — instead of the whole ``Session``. The adapter satisfies
+        # ``ArtifactsRuntime`` (RpcCaller + AsyncWorkRuntime +
+        # DrainHookRegistration) by delegating to those three
+        # collaborators directly.
+        artifacts_collaborators = self._session.collaborators
+        artifacts_runtime = ArtifactsRuntimeAdapter(
+            rpc=self._session.rpc_executor,
+            drain=artifacts_collaborators.drain_tracker,
+            lifecycle=artifacts_collaborators.lifecycle,
+        )
         self.artifacts = ArtifactsAPI(
-            self._session,
+            artifacts_runtime,
             notebooks=self.notebooks,
             mind_maps=mind_maps,
             note_service=note_service,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -290,6 +290,14 @@ class NotebookLMClient:
             cookie_rotator=cookie_rotator,
         )
 
+        # Per ADR-014 Rule 3 Stage A, every feature adapter draws from
+        # the same ``SessionCollaborators`` bundle exposed by Wave 6.
+        # Hoist the accessor once so the upload / artifacts / chat
+        # wirings below read as obvious siblings rather than as
+        # potentially-distinct bundles. (Claude review on PR #1074
+        # Wave 9 / step 3 flagged the per-adapter aliases as misleading.)
+        collaborators = self._session.collaborators
+
         # Wave 9 of session-decoupling (ADR-014 Rule 2 + Rule 3): the
         # upload pipeline takes a ``UploadRuntimeAdapter`` composite —
         # built from ``rpc_executor`` + ``drain_tracker`` + ``lifecycle``
@@ -298,11 +306,10 @@ class NotebookLMClient:
         # the ADR-014 Rule 6 example. ``NotebookLMClient.__init__`` is
         # the composition root that knows these internals;
         # ``SourcesAPI`` no longer reads them back off the session.
-        upload_collaborators = self._session.collaborators
         upload_runtime = UploadRuntimeAdapter(
             rpc=self._session.rpc_executor,
-            drain=upload_collaborators.drain_tracker,
-            lifecycle=upload_collaborators.lifecycle,
+            drain=collaborators.drain_tracker,
+            lifecycle=collaborators.lifecycle,
         )
         source_uploader = SourceUploadPipeline(
             upload_runtime,
@@ -339,11 +346,10 @@ class NotebookLMClient:
         # ``ArtifactsRuntime`` (RpcCaller + AsyncWorkRuntime +
         # DrainHookRegistration) by delegating to those three
         # collaborators directly.
-        artifacts_collaborators = self._session.collaborators
         artifacts_runtime = ArtifactsRuntimeAdapter(
             rpc=self._session.rpc_executor,
-            drain=artifacts_collaborators.drain_tracker,
-            lifecycle=artifacts_collaborators.lifecycle,
+            drain=collaborators.drain_tracker,
+            lifecycle=collaborators.lifecycle,
         )
         self.artifacts = ArtifactsAPI(
             artifacts_runtime,
@@ -365,12 +371,11 @@ class NotebookLMClient:
         # are sourced from the late-bound ``session.rpc_executor`` /
         # ``session.session_transport`` accessors and the
         # ``session.collaborators`` bundle.
-        chat_collaborators = self._session.collaborators
         self.chat = ChatAPI(
             rpc=self._session.rpc_executor,
             transport=self._session.session_transport,
-            reqid=chat_collaborators.reqid,
-            loop_guard=chat_collaborators.lifecycle,
+            reqid=collaborators.reqid,
+            loop_guard=collaborators.lifecycle,
             notebooks=self.notebooks,
         )
         self.notes = NotesAPI(

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -1563,8 +1563,13 @@ class TestReviseSlide:
         async with NotebookLMClient(auth_tokens) as client:
             err = RPCError("Rate limit exceeded")
             err.rpc_code = "USER_DISPLAYABLE_ERROR"
+            # Wave 9 of session-decoupling: ``ArtifactsAPI._runtime`` is now a
+            # frozen ``ArtifactsRuntimeAdapter``, so patches go through the
+            # held ``rpc`` collaborator (the ``RpcExecutor``) rather than
+            # the adapter itself — frozen dataclasses reject ``setattr`` and
+            # ``patch.object`` cleanup also fails on ``delattr``.
             with patch.object(
-                client.artifacts._runtime,
+                client.artifacts._runtime.rpc,
                 "rpc_call",
                 AsyncMock(side_effect=err),
             ):
@@ -1590,9 +1595,10 @@ class TestReviseSlide:
         async with NotebookLMClient(auth_tokens) as client:
             err = RPCError("Internal error")
             err.rpc_code = "INTERNAL_ERROR"
+            # See sibling test above for the Wave 9 patch-target rationale.
             with (
                 patch.object(
-                    client.artifacts._runtime,
+                    client.artifacts._runtime.rpc,
                     "rpc_call",
                     AsyncMock(side_effect=err),
                 ),
@@ -2097,9 +2103,13 @@ class TestCallGenerateErrorHandling:
             err = RPCError("You have exceeded your quota")
             err.rpc_code = "USER_DISPLAYABLE_ERROR"
             # Pass source_ids explicitly so get_source_ids (GET_NOTEBOOK) is NOT called.
-            # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
+            # Then patch the held ``rpc`` collaborator's ``rpc_call`` so the
+            # CREATE_ARTIFACT call raises the error. Wave 9 of session-decoupling:
+            # ``_runtime`` is now a frozen ``ArtifactsRuntimeAdapter``, so the
+            # patch goes through ``_runtime.rpc`` (the ``RpcExecutor``) — see
+            # the ``revise_slide`` siblings above for the same rationale.
             with patch.object(
-                client.artifacts._runtime,
+                client.artifacts._runtime.rpc,
                 "rpc_call",
                 AsyncMock(side_effect=err),
             ):
@@ -2120,10 +2130,12 @@ class TestCallGenerateErrorHandling:
             err = RPCError("Server error")
             err.rpc_code = "INTERNAL_ERROR"
             # Pass source_ids explicitly so get_source_ids (GET_NOTEBOOK) is NOT called.
-            # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
+            # Then patch the held ``rpc`` collaborator's ``rpc_call`` so the
+            # CREATE_ARTIFACT call raises the error. See sibling tests above
+            # for the Wave 9 patch-target rationale.
             with (
                 patch.object(
-                    client.artifacts._runtime,
+                    client.artifacts._runtime.rpc,
                     "rpc_call",
                     AsyncMock(side_effect=err),
                 ),

--- a/tests/unit/test_artifacts_mind_map_injection.py
+++ b/tests/unit/test_artifacts_mind_map_injection.py
@@ -18,16 +18,32 @@ These tests pin three contracts:
    keyword-only — the legacy ``mind_map_service`` kwarg is gone.
 3. Constructing without the new kwargs (or with the old name) raises
    ``TypeError``.
+
+Wave 9 of the session-decoupling plan (ADR-014 Rule 2) replaced the
+``make_fake_core()`` FakeSession runtime fakes used here with narrow
+mocks that only expose the ``ArtifactsRuntime`` surface (RpcCaller +
+AsyncWorkRuntime + DrainHookRegistration). The tests do not exercise
+RPC traffic — they pin the constructor contract — so the runtime mock
+only needs to silently accept ``register_drain_hook``.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from _fixtures.fake_core import make_fake_core
-from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._artifacts import ArtifactsAPI, ArtifactsRuntime
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
+
+
+def _make_runtime() -> MagicMock:
+    """Return a narrow ``ArtifactsRuntime`` mock for constructor-contract tests.
+
+    The mock only needs ``register_drain_hook`` (called by
+    :meth:`ArtifactsAPI.__init__`); no test in this file exercises an
+    RPC or operation-scope path on the runtime.
+    """
+    return MagicMock(spec=ArtifactsRuntime)
 
 
 @pytest.mark.asyncio
@@ -40,13 +56,13 @@ async def test_list_mind_maps_delegates_to_injected_facade():
     injected adapter. Confirming the adapter sees the call still pins
     the contract.
     """
-    core = make_fake_core()
+    runtime = _make_runtime()
     fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
     fake_mind_maps.list_mind_maps = AsyncMock(return_value=["sentinel-row"])
     fake_note_service = MagicMock(spec=NoteService)
 
     api = ArtifactsAPI(
-        core,
+        runtime,
         notebooks=MagicMock(),
         mind_maps=fake_mind_maps,
         note_service=fake_note_service,
@@ -59,18 +75,18 @@ async def test_list_mind_maps_delegates_to_injected_facade():
 
 def test_mind_maps_and_note_service_are_required():
     """Both new kwargs are required — no implicit fallback installs them."""
-    core = make_fake_core()
+    runtime = _make_runtime()
     fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
     fake_note_service = MagicMock(spec=NoteService)
 
     # Missing both.
     with pytest.raises(TypeError):
-        ArtifactsAPI(core, notebooks=MagicMock())  # type: ignore[call-arg]
+        ArtifactsAPI(runtime, notebooks=MagicMock())  # type: ignore[call-arg]
 
     # Missing note_service.
     with pytest.raises(TypeError):
         ArtifactsAPI(  # type: ignore[call-arg]
-            core,
+            runtime,
             notebooks=MagicMock(),
             mind_maps=fake_mind_maps,
         )
@@ -78,7 +94,7 @@ def test_mind_maps_and_note_service_are_required():
     # Missing mind_maps.
     with pytest.raises(TypeError):
         ArtifactsAPI(  # type: ignore[call-arg]
-            core,
+            runtime,
             notebooks=MagicMock(),
             note_service=fake_note_service,
         )
@@ -86,11 +102,11 @@ def test_mind_maps_and_note_service_are_required():
 
 def test_mind_maps_and_note_service_are_keyword_only():
     """All non-``runtime`` parameters remain keyword-only."""
-    core = make_fake_core()
+    runtime = _make_runtime()
     fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
     fake_note_service = MagicMock(spec=NoteService)
     with pytest.raises(TypeError):
-        ArtifactsAPI(core, MagicMock(), fake_mind_maps, fake_note_service)  # type: ignore[misc]
+        ArtifactsAPI(runtime, MagicMock(), fake_mind_maps, fake_note_service)  # type: ignore[misc]
 
 
 def test_legacy_mind_map_service_kwarg_is_rejected():
@@ -99,12 +115,12 @@ def test_legacy_mind_map_service_kwarg_is_rejected():
     Passing it must raise ``TypeError`` so silent breakage on partial
     upgrades surfaces immediately.
     """
-    core = make_fake_core()
+    runtime = _make_runtime()
     fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
     fake_note_service = MagicMock(spec=NoteService)
     with pytest.raises(TypeError):
         ArtifactsAPI(  # type: ignore[call-arg]
-            core,
+            runtime,
             notebooks=MagicMock(),
             mind_map_service=fake_mind_maps,
             note_service=fake_note_service,
@@ -118,13 +134,13 @@ def test_artifacts_no_longer_exposes_core_property_alias():
     helper modules read; the transitional ``_core`` shim added in Phase 3
     is dead code.
     """
-    core = make_fake_core()
+    runtime = _make_runtime()
     api = ArtifactsAPI(
-        core,
+        runtime,
         notebooks=MagicMock(),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),
     )
     # The descriptor must be gone — not just empty, not just delegating.
     assert not hasattr(api, "_core")
-    assert api._runtime is core
+    assert api._runtime is runtime

--- a/tests/unit/test_artifacts_runtime_adapter.py
+++ b/tests/unit/test_artifacts_runtime_adapter.py
@@ -1,0 +1,175 @@
+"""Tests for :class:`ArtifactsRuntimeAdapter` (ADR-014 Rule 2).
+
+Pins the adapter's three contracts:
+
+1. Structural — the frozen dataclass satisfies the
+   :class:`ArtifactsRuntime` Protocol it adapts (also enforced statically
+   by the ``TYPE_CHECKING`` assertion at the bottom of ``_artifacts.py``).
+2. Delegation — each of the four delegate methods forwards to the
+   right held collaborator with the right positional/keyword shape.
+3. Immutability — the adapter is a ``@dataclass(frozen=True)`` so its
+   field set is fixed at construction; no post-construction mutation
+   can re-bind ``rpc`` / ``drain`` / ``lifecycle``.
+
+Wave 9 of the session-decoupling plan introduced this adapter so
+:class:`ArtifactsAPI` stops receiving a whole ``Session`` and instead
+receives a narrow composite built from
+``session.rpc_executor`` + ``coll.drain_tracker`` + ``coll.lifecycle``
+at the composition root.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._artifacts import ArtifactsRuntime, ArtifactsRuntimeAdapter
+from notebooklm.rpc import RPCMethod
+
+
+def _make_adapter(
+    *,
+    rpc: Any = None,
+    drain: Any = None,
+    lifecycle: Any = None,
+) -> ArtifactsRuntimeAdapter:
+    return ArtifactsRuntimeAdapter(
+        rpc=rpc if rpc is not None else MagicMock(),
+        drain=drain if drain is not None else MagicMock(),
+        lifecycle=lifecycle if lifecycle is not None else MagicMock(),
+    )
+
+
+def test_adapter_is_a_frozen_dataclass() -> None:
+    """ADR-014 Rule 2 mandates frozen-dataclass adapter shape."""
+    assert dataclasses.is_dataclass(ArtifactsRuntimeAdapter)
+    # ``frozen=True`` forbids re-binding fields after construction.
+    adapter = _make_adapter()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        adapter.rpc = MagicMock()  # type: ignore[misc]
+
+
+def test_adapter_structurally_satisfies_artifacts_runtime() -> None:
+    """Runtime check: a constructed adapter is assignable to the Protocol.
+
+    Pins the same contract the ``TYPE_CHECKING`` mypy guard pins at
+    static-analysis time, but exercised at runtime so a CI without
+    mypy still catches shape drift.
+    """
+    adapter = _make_adapter()
+    # ``ArtifactsRuntime`` is a structural Protocol; the assignment is the
+    # contract — a runtime ``isinstance`` would require
+    # ``@runtime_checkable``, which the Protocol intentionally is not.
+    runtime: ArtifactsRuntime = adapter
+    assert runtime is adapter
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_forwards_to_rpc_collaborator() -> None:
+    """``adapter.rpc_call(...)`` proxies the full signature to ``rpc``.
+
+    The mock for the held collaborator is constructed with its
+    ``rpc_call`` attribute set at construction time (via the
+    ``MagicMock`` kwarg form), not assigned post-construction; the
+    ADR-007 lint rejects ``<chain>.rpc_call = AsyncMock(...)`` because
+    that pattern signals mutating an instance under test, which is not
+    what this adapter test is doing — but we use the constructor form
+    so the lint doesn't even need to reason about intent.
+    """
+    rpc_call = AsyncMock(return_value="sentinel-result")
+    rpc = MagicMock(rpc_call=rpc_call)
+    adapter = _make_adapter(rpc=rpc)
+
+    result = await adapter.rpc_call(
+        RPCMethod.LIST_NOTEBOOKS,
+        ["params"],
+        source_path="/notebook/abc",
+        allow_null=True,
+        _is_retry=True,
+        disable_internal_retries=True,
+        operation_variant="variant-X",
+    )
+
+    assert result == "sentinel-result"
+    rpc_call.assert_awaited_once_with(
+        RPCMethod.LIST_NOTEBOOKS,
+        ["params"],
+        "/notebook/abc",
+        True,
+        True,
+        disable_internal_retries=True,
+        operation_variant="variant-X",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_defaults_match_protocol_signature() -> None:
+    """Default values match :meth:`RpcCaller.rpc_call` exactly."""
+    rpc_call = AsyncMock(return_value=None)
+    rpc = MagicMock(rpc_call=rpc_call)
+    adapter = _make_adapter(rpc=rpc)
+
+    await adapter.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    rpc_call.assert_awaited_once_with(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+def test_operation_scope_forwards_to_drain_collaborator() -> None:
+    """``operation_scope(label)`` returns the drain's async ctx manager.
+
+    Identity matters: the adapter must not wrap the returned context
+    manager, or callers that ``async with`` it would see a different
+    object than the underlying drain produced.
+    """
+
+    @asynccontextmanager
+    async def _scope():
+        yield None
+
+    sentinel_cm = _scope()
+    drain = MagicMock()
+    drain.operation_scope = MagicMock(return_value=sentinel_cm)
+    adapter = _make_adapter(drain=drain)
+
+    result = adapter.operation_scope("upload artifact xyz")
+
+    assert result is sentinel_cm
+    drain.operation_scope.assert_called_once_with("upload artifact xyz")
+
+
+def test_register_drain_hook_forwards_to_drain_collaborator() -> None:
+    """``register_drain_hook(name, hook)`` proxies (name, hook) to drain."""
+    drain = MagicMock()
+    drain.register_drain_hook = MagicMock(return_value=None)
+    adapter = _make_adapter(drain=drain)
+
+    async def _hook() -> None:
+        return None
+
+    adapter.register_drain_hook("artifacts.polls", _hook)
+
+    drain.register_drain_hook.assert_called_once_with("artifacts.polls", _hook)
+
+
+def test_assert_bound_loop_forwards_to_lifecycle_collaborator() -> None:
+    """``assert_bound_loop()`` proxies to lifecycle (no args, no return)."""
+    lifecycle = MagicMock()
+    lifecycle.assert_bound_loop = MagicMock(return_value=None)
+    adapter = _make_adapter(lifecycle=lifecycle)
+
+    result = adapter.assert_bound_loop()
+
+    assert result is None
+    lifecycle.assert_bound_loop.assert_called_once_with()

--- a/tests/unit/test_artifacts_runtime_adapter.py
+++ b/tests/unit/test_artifacts_runtime_adapter.py
@@ -54,16 +54,24 @@ def test_adapter_is_a_frozen_dataclass() -> None:
 
 
 def test_adapter_structurally_satisfies_artifacts_runtime() -> None:
-    """Runtime check: a constructed adapter is assignable to the Protocol.
+    """Static-analysis pin: the adapter is assignable to the Protocol.
 
-    Pins the same contract the ``TYPE_CHECKING`` mypy guard pins at
-    static-analysis time, but exercised at runtime so a CI without
-    mypy still catches shape drift.
+    Pins the same contract the ``TYPE_CHECKING`` mypy guard at the
+    bottom of ``_artifacts.py`` pins at static-analysis time. Python
+    does not enforce type annotations at runtime, so the assignment
+    itself is a no-op — the contract bites at mypy time on the
+    annotation, not at runtime. This test exists alongside the
+    delegate-behaviour tests below to keep the Protocol-satisfaction
+    intent visible in the suite even on a CI without mypy enabled
+    (the annotation would still surface as a syntax/import error if
+    the Protocol moved or was renamed).
+
+    Runtime structural verification would require
+    ``@runtime_checkable`` plus ``isinstance``, which the Protocol
+    intentionally is not — per the project's "prefer mypy + signature
+    pins" rule of thumb (gemini-code-assist guidance, Wave 9).
     """
     adapter = _make_adapter()
-    # ``ArtifactsRuntime`` is a structural Protocol; the assignment is the
-    # contract — a runtime ``isinstance`` would require
-    # ``@runtime_checkable``, which the Protocol intentionally is not.
     runtime: ArtifactsRuntime = adapter
     assert runtime is adapter
 

--- a/tests/unit/test_source_upload_runtime_adapter.py
+++ b/tests/unit/test_source_upload_runtime_adapter.py
@@ -57,16 +57,24 @@ def test_adapter_is_a_frozen_dataclass() -> None:
 
 
 def test_adapter_structurally_satisfies_upload_runtime() -> None:
-    """Runtime check: a constructed adapter is assignable to the Protocol.
+    """Static-analysis pin: the adapter is assignable to the Protocol.
 
-    Pins the same contract the ``TYPE_CHECKING`` mypy guard pins at
-    static-analysis time, but exercised at runtime so a CI without
-    mypy still catches shape drift.
+    Pins the same contract the ``TYPE_CHECKING`` mypy guard at the
+    bottom of ``_source_upload.py`` pins at static-analysis time.
+    Python does not enforce type annotations at runtime, so the
+    assignment itself is a no-op — the contract bites at mypy time on
+    the annotation, not at runtime. This test exists alongside the
+    delegate-behaviour tests below to keep the Protocol-satisfaction
+    intent visible in the suite even on a CI without mypy enabled
+    (the annotation would still surface as a syntax/import error if
+    the Protocol moved or was renamed).
+
+    Runtime structural verification would require
+    ``@runtime_checkable`` plus ``isinstance``, which the Protocol
+    intentionally is not — per the project's "prefer mypy + signature
+    pins" rule of thumb (gemini-code-assist guidance, Wave 9).
     """
     adapter = _make_adapter()
-    # ``UploadRuntime`` is a structural Protocol; the assignment is the
-    # contract — a runtime ``isinstance`` would require
-    # ``@runtime_checkable``, which the Protocol intentionally is not.
     runtime: UploadRuntime = adapter
     assert runtime is adapter
 

--- a/tests/unit/test_source_upload_runtime_adapter.py
+++ b/tests/unit/test_source_upload_runtime_adapter.py
@@ -1,0 +1,177 @@
+"""Tests for :class:`UploadRuntimeAdapter` (ADR-014 Rule 2).
+
+Pins the adapter's three contracts:
+
+1. Structural — the frozen dataclass satisfies the
+   :class:`UploadRuntime` Protocol it adapts (also enforced statically
+   by the ``TYPE_CHECKING`` assertion at the bottom of
+   ``_source_upload.py``).
+2. Delegation — each of the three delegate methods forwards to the
+   right held collaborator with the right positional/keyword shape.
+3. Immutability — the adapter is a ``@dataclass(frozen=True)`` so its
+   field set is fixed at construction; no post-construction mutation
+   can re-bind ``rpc`` / ``drain`` / ``lifecycle``.
+
+Wave 9 of the session-decoupling plan introduced this adapter so
+:class:`SourceUploadPipeline` stops receiving a whole ``Session`` and
+instead receives a narrow composite built from
+``session.rpc_executor`` + ``coll.drain_tracker`` + ``coll.lifecycle``
+at the composition root. :class:`SourceUploadPipeline` still takes
+:class:`Kernel` and :class:`AuthMetadata` as separate parameters, so
+this adapter covers only the composite ``UploadRuntime`` part.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._source_upload import UploadRuntime, UploadRuntimeAdapter
+from notebooklm.rpc import RPCMethod
+
+
+def _make_adapter(
+    *,
+    rpc: Any = None,
+    drain: Any = None,
+    lifecycle: Any = None,
+) -> UploadRuntimeAdapter:
+    return UploadRuntimeAdapter(
+        rpc=rpc if rpc is not None else MagicMock(),
+        drain=drain if drain is not None else MagicMock(),
+        lifecycle=lifecycle if lifecycle is not None else MagicMock(),
+    )
+
+
+def test_adapter_is_a_frozen_dataclass() -> None:
+    """ADR-014 Rule 2 mandates frozen-dataclass adapter shape."""
+    assert dataclasses.is_dataclass(UploadRuntimeAdapter)
+    # ``frozen=True`` forbids re-binding fields after construction.
+    adapter = _make_adapter()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        adapter.rpc = MagicMock()  # type: ignore[misc]
+
+
+def test_adapter_structurally_satisfies_upload_runtime() -> None:
+    """Runtime check: a constructed adapter is assignable to the Protocol.
+
+    Pins the same contract the ``TYPE_CHECKING`` mypy guard pins at
+    static-analysis time, but exercised at runtime so a CI without
+    mypy still catches shape drift.
+    """
+    adapter = _make_adapter()
+    # ``UploadRuntime`` is a structural Protocol; the assignment is the
+    # contract — a runtime ``isinstance`` would require
+    # ``@runtime_checkable``, which the Protocol intentionally is not.
+    runtime: UploadRuntime = adapter
+    assert runtime is adapter
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_forwards_to_rpc_collaborator() -> None:
+    """``adapter.rpc_call(...)`` proxies the full signature to ``rpc``.
+
+    The mock for the held collaborator is constructed with its
+    ``rpc_call`` attribute set at construction time (via the
+    ``MagicMock`` kwarg form), not assigned post-construction; the
+    ADR-007 lint rejects ``<chain>.rpc_call = AsyncMock(...)`` because
+    that pattern signals mutating an instance under test, which is not
+    what this adapter test is doing — but we use the constructor form
+    so the lint doesn't even need to reason about intent.
+    """
+    rpc_call = AsyncMock(return_value="sentinel-result")
+    rpc = MagicMock(rpc_call=rpc_call)
+    adapter = _make_adapter(rpc=rpc)
+
+    result = await adapter.rpc_call(
+        RPCMethod.ADD_SOURCE_FILE,
+        ["params"],
+        source_path="/notebook/abc",
+        allow_null=True,
+        _is_retry=True,
+        disable_internal_retries=True,
+        operation_variant="variant-X",
+    )
+
+    assert result == "sentinel-result"
+    rpc_call.assert_awaited_once_with(
+        RPCMethod.ADD_SOURCE_FILE,
+        ["params"],
+        "/notebook/abc",
+        True,
+        True,
+        disable_internal_retries=True,
+        operation_variant="variant-X",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_defaults_match_protocol_signature() -> None:
+    """Default values match :meth:`RpcCaller.rpc_call` exactly."""
+    rpc_call = AsyncMock(return_value=None)
+    rpc = MagicMock(rpc_call=rpc_call)
+    adapter = _make_adapter(rpc=rpc)
+
+    await adapter.rpc_call(RPCMethod.ADD_SOURCE_FILE, [])
+
+    rpc_call.assert_awaited_once_with(
+        RPCMethod.ADD_SOURCE_FILE,
+        [],
+        "/",
+        False,
+        False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+def test_operation_scope_forwards_to_drain_collaborator() -> None:
+    """``operation_scope(label)`` returns the drain's async ctx manager.
+
+    Identity matters: the adapter must not wrap the returned context
+    manager, or callers that ``async with`` it would see a different
+    object than the underlying drain produced.
+    """
+
+    @asynccontextmanager
+    async def _scope():
+        yield None
+
+    sentinel_cm = _scope()
+    drain = MagicMock()
+    drain.operation_scope = MagicMock(return_value=sentinel_cm)
+    adapter = _make_adapter(drain=drain)
+
+    result = adapter.operation_scope("upload source xyz")
+
+    assert result is sentinel_cm
+    drain.operation_scope.assert_called_once_with("upload source xyz")
+
+
+def test_assert_bound_loop_forwards_to_lifecycle_collaborator() -> None:
+    """``assert_bound_loop()`` proxies to lifecycle (no args, no return)."""
+    lifecycle = MagicMock()
+    lifecycle.assert_bound_loop = MagicMock(return_value=None)
+    adapter = _make_adapter(lifecycle=lifecycle)
+
+    result = adapter.assert_bound_loop()
+
+    assert result is None
+    lifecycle.assert_bound_loop.assert_called_once_with()
+
+
+def test_adapter_does_not_expose_register_drain_hook() -> None:
+    """``UploadRuntime`` does NOT include ``DrainHookRegistration``.
+
+    The artifacts feature registers a close-time drain hook (artifact
+    polling cancellation); the upload pipeline does not. Pinning the
+    absence here documents the divergence between the two adapter
+    shapes and catches any future drift that silently expands the
+    upload contract.
+    """
+    adapter = _make_adapter()
+    assert not hasattr(adapter, "register_drain_hook")


### PR DESCRIPTION
## Summary

Wave 9 of the session-decoupling plan (Tasks 4.2 + 4.3) — completes
ADR-014 Rule 2 for the two remaining composite-runtime consumers
(`ArtifactsAPI` + `SourceUploadPipeline`).

Introduces feature-local **frozen-dataclass adapters** that satisfy
the `ArtifactsRuntime` and `UploadRuntime` composite Protocols by
holding three direct collaborators (`RpcCaller` +
`TransportDrainTracker` + `ClientLifecycle`) and exposing each
Protocol method as a 1:1 delegate. `NotebookLMClient.__init__` is
the composition root that constructs the adapters from
`session.rpc_executor` + `session.collaborators.drain_tracker` +
`session.collaborators.lifecycle`, then passes the composites to
the feature APIs.

Unlike Wave 8 (which **deleted** `ChatRuntime` per ADR-014 Rule 2
Corollary), this Wave **keeps** the `ArtifactsRuntime` and
`UploadRuntime` Protocols: each composite has three capabilities, its
sole consumer takes it as one dependency that gets forwarded into
sub-services, and `register_drain_hook` (artifacts only) is a
meaningful named affordance worth exposing as one method.

`AsyncWorkRuntime` is satisfied **transitively** by both adapters
(no `_AsyncWorkAdapter`) — `TransportDrainTracker.operation_scope`
and `ClientLifecycle.assert_bound_loop` already exist after the
Wave 2 push-downs.

Composition root (post-Wave 9):

```python
upload_runtime = UploadRuntimeAdapter(
    rpc=self._session.rpc_executor,
    drain=upload_collaborators.drain_tracker,
    lifecycle=upload_collaborators.lifecycle,
)
artifacts_runtime = ArtifactsRuntimeAdapter(
    rpc=self._session.rpc_executor,
    drain=artifacts_collaborators.drain_tracker,
    lifecycle=artifacts_collaborators.lifecycle,
)
```

`SourceUploadPipeline` continues to take `Kernel` and `AuthMetadata`
as separate positional parameters; the adapter only covers the
composite `UploadRuntime` part (ADR-014 Rule 6).

## Commits

This PR is split into three commits for revertability (GitHub squashes
on merge):

1. **`feat(artifacts): introduce ArtifactsRuntimeAdapter (Wave 9 / step 1)`** — adapter dataclass + delegate methods next to `ArtifactsRuntime`; `TYPE_CHECKING` mypy guard pinning structural Protocol satisfaction; new `test_artifacts_runtime_adapter.py` (7 tests) + migration of `test_artifacts_mind_map_injection.py` off `make_fake_core()` (FakeSession) to a narrow `MagicMock(spec=ArtifactsRuntime)`.
2. **`feat(upload): introduce UploadRuntimeAdapter (Wave 9 / step 2)`** — adapter dataclass + delegate methods next to `UploadRuntime`; `TYPE_CHECKING` mypy guard; new `test_source_upload_runtime_adapter.py` (8 tests) including a pin that the upload adapter does NOT expose `register_drain_hook` (which is artifacts-only). `__all__` extended with `UploadRuntimeAdapter`.
3. **`refactor(client): wire artifacts + upload via adapters (Wave 9 / step 3)`** — `NotebookLMClient.__init__` switches both feature APIs to receive their respective adapter instead of the whole `Session`. Four `patch.object(client.artifacts._runtime, "rpc_call", ...)` sites in `tests/integration/test_artifacts_integration.py` were updated to patch `_runtime.rpc.rpc_call` (the held `RpcExecutor`), since `patch.object` is incompatible with frozen-dataclass attributes.

## Test plan

- [x] `uv run pytest tests/unit/test_artifacts*.py tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py tests/unit/test_source_upload_runtime_adapter.py -v` — 253 passed
- [x] `uv run pytest tests/_lint -v` — 60 passed (forbidden-monkeypatches lint clean; no stale allowlist entries)
- [x] `uv run ruff format --check .` — 547 files already formatted
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src/notebooklm` — Success, no issues in 173 source files (mypy guard in each adapter module confirms Protocol satisfaction)
- [x] `uv run pytest tests/unit tests/_lint tests/integration -x -q` — 6491 passed, 12 skipped

## Notes on the allowlist

No `_ALLOWLIST` entries in `tests/_lint/test_no_forbidden_monkeypatches.py` were removed: the lint's built-in stale-entry detector (`stale = sorted(_ALLOWLIST - seen_files_with_findings)`) passed, indicating every listed file still contains at least one forbidden pattern unrelated to the adapter wiring. The `patch.object` sites the adapter migration touched are not on the ADR-007 forbidden list; they were always allowed.

## Related

- [ADR-014: Feature-local runtime adapters as Protocol satisfiers](https://github.com/teng-lin/notebooklm-py/blob/main/docs/adr/0014-feature-local-runtime-adapters.md) — load-bearing decision (Rule 2 + Rule 3 + Rule 6).
- [`docs/session-decoupling-plan-2026-05-26.md`](https://github.com/teng-lin/notebooklm-py/blob/main/docs/session-decoupling-plan-2026-05-26.md) — Wave 9 task spec.
- Builds on #1069 (Wave 6: `SessionCollaborators` bundle), #1071 (Wave 7: direct `RpcExecutor` for simple features), #1073 (Wave 8: direct collaborator injection for `ChatAPI` + delete `ChatRuntime`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Decoupled session internals by introducing runtime adapter objects and updated client wiring for clearer separation of responsibilities.

* **Tests**
  * Added unit tests validating adapter behavior and updated integration tests to align with the refactor, improving reliability and coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->