### PR TITLE
docs+test(session): add session-method-retention.md + lint guard (Wave 10 / Task 5.1)

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -1,0 +1,114 @@
+# Session method retention (ADR-014 Rule 4)
+
+Source classification for every method (and `@property`) currently defined on
+`Session` in [`src/notebooklm/_session.py`](../src/notebooklm/_session.py).
+
+**Companion lint:** [`tests/_lint/test_session_retention.py`](../tests/_lint/test_session_retention.py)
+AST-parses `_session.py`, enumerates every method/property on the `Session`
+class, and asserts each one appears in the inventory below with a valid
+disposition. Adding a new method without a row here fails the lint at PR time.
+
+**Status:** Wave 10 of the [session-decoupling plan](session-decoupling-plan-2026-05-26.md)
+(Phase 3, Task 5.1). Wave 11 (sub-waves 11a–11c) will delete the
+`delete in Wave 11` rows in three clusters and move them to the **Deleted**
+section at the bottom of this file. Wave 11c also tightens the lint to
+forbid any `delete in Wave 11` rows once the cluster deletions land.
+
+## Categories
+
+| Category | Meaning |
+|---|---|
+| `constructor` | `__init__` — instance setup, not a candidate for deletion. |
+| `lifecycle` | `open` / `close` / `is_open` / `_keepalive_loop` — open-time + drain-on-close orchestration. |
+| `public API forward` | Forward that backs a documented public surface on `NotebookLMClient`; AST-pinned by a test. |
+| `middleware chain leaf` | Wired into the live middleware chain by `_session_init.wire_middleware_chain`; deletion breaks the chain. |
+| `provider-closure capture target` | Read live by a provider lambda passed to `wire_middleware_chain` / `build_session_transport`; deletion breaks the chain wiring. Capture mode is noted per row. |
+| `Stage A accessor` | Typed accessor added in Wave 6 so `NotebookLMClient.__init__` can wire features against collaborators (ADR-014 Rule 3 Stage A). Deleted under Rule 3 Stage B (Wave 7 follow-up). |
+| `lazy collaborator factory` | Real factory body (not a forward) backing a Stage A accessor or a public-API forward. |
+| `RefreshAuthCore Protocol surface` | Method required by the `RefreshAuthCore` Protocol in [`src/notebooklm/_auth/session.py`](../src/notebooklm/_auth/session.py); `refresh_auth_session(core)` calls it on the Session passed as `core`. |
+| `compatibility forward` | One-line forward to a collaborator method; kept only because in-tree callers (mostly tests) reach it via `Session`. Wave 11 deletes these and migrates callers to the owning collaborator. |
+
+## Dispositions
+
+| Disposition | Meaning |
+|---|---|
+| `retain — <reason>` | Stays on `Session` after Wave 11. |
+| `delete in Wave 11 (<cluster>)` | Scheduled for deletion in one of the three Wave 11 sub-wave PRs. Cluster names match [phase-3.md](../.sisyphus/phases/session-decoupling/phase-3.md): `drain-and-operation` (11a), `metrics-and-kernel` (11b), `transport-and-reqid` (11c). |
+
+## Inventory
+
+| Method | Category | Disposition |
+|---|---|---|
+| `__init__` | constructor | retain — instance setup |
+| `open` | lifecycle | retain — open-time setup (loop binding + keepalive task) |
+| `close` | lifecycle | retain — drain + transport teardown |
+| `is_open` (property) | lifecycle | retain — public open-state read |
+| `_keepalive_loop` | lifecycle | retain — background task body; introspected by `test_client_keepalive` |
+| `rpc_call` | public API forward | retain — pinned by `tests/unit/test_public_shims.py:1048-1089` (`NotebookLMClient.rpc_call` forwards through it) |
+| `_authed_post_chain_terminal` | middleware chain leaf | retain — live chain leaf wired by `_session_init.wire_middleware_chain` (`authed_post_chain_terminal=self._authed_post_chain_terminal` at [`_session.py:411-417`](../src/notebooklm/_session.py)) |
+| `_await_refresh` | provider-closure capture target | retain — captured as bound-method (`refresh_callable=host._await_refresh`) by [`_session_init.py:430`](../src/notebooklm/_session_init.py) |
+| `assert_bound_loop` | provider-closure capture target | retain — captured via lambda (`bound_loop_check=lambda: host.assert_bound_loop()`) by `build_session_transport` at [`_session_init.py:395`](../src/notebooklm/_session_init.py); late-bound so a test reassigning `core.assert_bound_loop = mock` still steers the live check |
+| `_get_rpc_semaphore` | provider-closure capture target | retain — passed as `rpc_semaphore_factory=self._get_rpc_semaphore` to `wire_middleware_chain` at [`_session.py:416`](../src/notebooklm/_session.py); has real body (lazy semaphore creation) reading `self._max_concurrent_rpcs` / `self._rpc_semaphore`, not a forward |
+| `_get_rpc_executor` | lazy collaborator factory | retain — builds the `RpcExecutor` collaborator the first time `rpc_call` or the Stage A `rpc_executor` accessor needs it; real construction logic, not a forward |
+| `collaborators` (property) | Stage A accessor | retain — Stage A accessor (ADR-014 Rule 3); deleted under Stage B when `build_collaborators` ownership moves to `NotebookLMClient` |
+| `session_transport` (property) | Stage A accessor | retain — Stage A accessor; exposes late-bound `SessionTransport` not present on `SessionCollaborators` |
+| `rpc_executor` (property) | Stage A accessor | retain — Stage A accessor; exposes lazy `RpcExecutor` not present on `SessionCollaborators` |
+| `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_tokens(...)` at [`_auth/session.py:67`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
+| `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_headers()` at [`_auth/session.py:68`](../src/notebooklm/_auth/session.py) |
+| `register_drain_hook` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — one-line forward to `TransportDrainTracker.register_drain_hook`; migrate callers to `session.collaborators.drain_tracker` |
+| `operation_scope` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — forward to `TransportDrainTracker.operation_scope` |
+| `drain` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — forward to `TransportDrainTracker.drain` |
+| `metrics_snapshot` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.snapshot` |
+| `_increment_metrics` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.increment` |
+| `record_upload_queue_wait` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.record_upload_queue_wait` |
+| `_emit_rpc_event` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.emit_rpc_event` |
+| `kernel` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self._kernel`; readers migrate to `session.collaborators.kernel` |
+| `live_cookies` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.get_http_client().cookies` |
+| `authuser` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.auth.authuser` |
+| `account_email` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.auth.account_email` |
+| `authuser_query` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `auth.authuser_query(self.authuser, self.account_email)` |
+| `authuser_header` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `auth.format_authuser_value(...)` |
+| `get_http_client` | RefreshAuthCore Protocol surface / compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `Kernel.get_http_client`; the `RefreshAuthCore` Protocol still references `get_http_client`, so Wave 11b MUST first migrate the Protocol (or `refresh_auth_session(core)`) to call `core.collaborators.kernel.get_http_client()` before the Session forward can be removed |
+| `next_reqid` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ReqidCounter.next_reqid` |
+| `bound_loop` (property) | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ClientLifecycle.get_bound_loop` with defensive `isinstance` |
+| `_refresh_request_for_current_auth` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `SessionTransport.refresh_request_for_current_auth`; the AST guard at `tests/unit/test_concurrency_refresh_race.py:222` already inspects `SessionTransport.refresh_request_for_current_auth` directly, so no guard migration needed |
+| `_perform_authed_post` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `SessionTransport.perform_authed_post`; production callers (`_chat_transport`) already call `SessionTransport.perform_authed_post` directly. Verify no surviving production caller via `rg "session\._perform_authed_post\(\|core\._perform_authed_post\(\|host\._perform_authed_post\b" src/notebooklm` before deleting. Test callers in `tests/unit/test_authed_post_pipeline.py` migrate to `session.session_transport.perform_authed_post` or `make_fake_core` |
+| `transport_post` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `_perform_authed_post`; no production callers (`rg "\.transport_post\(" src/ tests/` returns 0) |
+| `save_cookies` | RefreshAuthCore Protocol surface / compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ClientLifecycle.save_cookies`; the `RefreshAuthCore` Protocol still references `save_cookies`, so Wave 11c MUST first migrate the Protocol (or `refresh_auth_session(core)`) to call `core.collaborators.lifecycle.save_cookies(core, jar, path)` before the Session forward can be removed |
+
+## Stage-A and Rule-4 attribute capture targets (context, not lint-enumerated)
+
+The `_rate_limit_max_retries`, `_server_error_max_retries`, and
+`_refresh_retry_delay` slots on `Session` are plain instance attributes (not
+methods), assigned in `__init__` from the validated config. They are
+**provider-closure capture targets**: the `MiddlewareChainBuilder` reads them
+through lambdas at [`_session_init.py:427-429`](../src/notebooklm/_session_init.py)
+so post-construction integration-test mutation (e.g.
+`session._rate_limit_max_retries = 0`) still steers the live chain. They are
+**retain**ed for the same reason `_await_refresh` is retained — deletion
+breaks the chain wiring. They are not enumerated by the AST lint (which scans
+method definitions, not assignments to `self.X` inside `__init__`); this
+section documents them for the next architecture refactor reader.
+
+## Follow-up ADR-014 issues
+
+The two follow-up issues filed per ADR-014 close-out (Wave 6 / Task 6.2):
+
+- **Stage B (Rule 3 completion):** move `build_collaborators` ownership from
+  `Session` to `NotebookLMClient`; delete `Session.collaborators` /
+  `Session.session_transport` / `Session.rpc_executor` accessors.
+- **`MiddlewareChainHost` extraction (Rule 4 completion):** extract a
+  `MiddlewareChainHost` collaborator owning `_authed_post_chain_terminal` +
+  the `_rate_limit_max_retries` / `_server_error_max_retries` /
+  `_refresh_retry_delay` tunables; `Session` holds it like any other
+  collaborator.
+
+Both issues remain open after Wave 12; the Stage A accessors and the chain
+seams on Session listed above are explicitly carved out until those issues
+land.
+
+## Deleted
+
+Wave 11 sub-wave PRs append entries here (preserving the deleting PR's SHA in
+the section sub-header) as the `delete in Wave 11` rows above are dropped.
+Empty at Wave 10.

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -1,0 +1,311 @@
+"""Meta-lint: every ``Session`` method must be listed in the retention doc.
+
+Pairs with [`docs/session-method-retention.md`](../../docs/session-method-retention.md).
+AST-parses [`src/notebooklm/_session.py`](../../src/notebooklm/_session.py),
+enumerates every method / property defined inside the ``Session`` class body,
+and asserts each one appears in the retention table with a valid disposition.
+
+Adding a new method to ``Session`` without a corresponding row in the doc
+fails this lint at PR time — the retention doc is the single source of truth
+for the post-Wave-11 ``Session`` shape.
+
+Lint shape (modeled after :mod:`tests._lint.test_no_session_compat_bridges`
+and :mod:`tests._lint.test_no_core_imports`):
+
+* True AST parse — no regex against the source.
+* Enumerates :class:`ast.FunctionDef` + :class:`ast.AsyncFunctionDef` nodes
+  whose immediate parent is the ``Session`` class body. Properties
+  (``@property``-decorated functions) are included; nested functions inside
+  methods are NOT (the parent walk gates them out).
+* The doc parser scans the inventory table for rows shaped
+  ``| `method_name` | category | disposition |``. Method names appear
+  inside the first backtick-pair of column one; the entire backtick token
+  may also carry a ``(property)`` suffix (e.g. ``kernel`` (property)).
+* Valid dispositions are either ``retain — <reason>`` or
+  ``delete in Wave 11 (<cluster>)``. Wave 11c will tighten the lint to
+  reject the latter once the cluster-deletion PRs land.
+
+The lint enumerates methods only — not instance attributes like
+``Session._rate_limit_max_retries`` (those are assigned in ``__init__`` and
+documented in the "Stage-A and Rule-4 attribute capture targets" section of
+the retention doc for context).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SESSION_MODULE: Path = REPO_ROOT / "src" / "notebooklm" / "_session.py"
+RETENTION_DOC: Path = REPO_ROOT / "docs" / "session-method-retention.md"
+
+SESSION_CLASS_NAME: str = "Session"
+
+# Disposition prefixes that the retention doc may use. Wave 11c tightens this
+# to ``{"retain"}`` after the cluster-deletion PRs land.
+_RETAIN_PREFIX: str = "retain"
+_DELETE_PREFIX: str = "delete in Wave 11"
+VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX, _DELETE_PREFIX)
+
+
+def _enumerate_session_methods(source: str) -> list[str]:
+    """Return the ordered list of method/property names defined on ``Session``.
+
+    Includes ``@property``-decorated functions; excludes nested functions
+    defined inside method bodies (the parent walk gates them out).
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == SESSION_CLASS_NAME:
+            return [
+                item.name
+                for item in node.body
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+    raise AssertionError(
+        f"{SESSION_MODULE.relative_to(REPO_ROOT)} no longer defines a "
+        f"{SESSION_CLASS_NAME!r} class — update this lint to point at the new "
+        "lifecycle owner."
+    )
+
+
+# Matches an inventory row's first column:
+#   | `method_name` | ...
+#   | `method_name` (property) | ...
+# Captures ``method_name``. The optional ``(property)`` suffix lives outside
+# the backticks per the doc's column-one convention.
+_ROW_FIRST_CELL = re.compile(r"^\|\s*`(?P<name>[A-Za-z_][A-Za-z0-9_]*)`(?:\s*\(property\))?\s*\|")
+
+
+INVENTORY_SECTION_HEADER: str = "## Inventory"
+
+
+def _parse_retention_doc(text: str) -> dict[str, str]:
+    """Return a ``{method_name: disposition_cell}`` mapping from the doc.
+
+    Only rows under the ``## Inventory`` section are considered. The
+    ``## Categories`` / ``## Dispositions`` glossary tables earlier in the
+    file also use backtick-quoted identifiers in column 1, but those name
+    *categories* / *dispositions* — not Session methods — and would otherwise
+    be misread as stale rows.
+
+    The header row and separator row (``|---|---|---|``) do not start with a
+    backticked identifier so they are naturally skipped by the regex. The
+    next ``##`` heading after the inventory ends the scan window so the
+    "Stage-A and Rule-4 attribute capture targets" section and the
+    "Deleted" section are also out of scope.
+    """
+    lines = text.splitlines()
+    rows: dict[str, str] = {}
+    in_inventory = False
+    for line in lines:
+        if line.startswith("## "):
+            in_inventory = line.strip() == INVENTORY_SECTION_HEADER
+            continue
+        if not in_inventory:
+            continue
+        match = _ROW_FIRST_CELL.match(line)
+        if match is None:
+            continue
+        # Split the row into cells on ``|``; first and last entries are the
+        # empty strings surrounding the leading / trailing pipes.
+        cells = [cell.strip() for cell in line.split("|")]
+        # cells = ["", "`name`...", category, disposition, ""]  → expect 5
+        if len(cells) < 4:
+            continue
+        name = match.group("name")
+        disposition = cells[3]
+        rows[name] = disposition
+    return rows
+
+
+def _disposition_is_valid(disposition: str) -> bool:
+    """Return ``True`` iff ``disposition`` starts with a valid prefix.
+
+    The retain branch must carry a reason (em-dash + text); the delete branch
+    must carry a cluster name in parentheses. Wave 10's contract checks the
+    prefix; Wave 11c will tighten to assert the cluster name matches the
+    known set and that retain reasons reference a load-bearing seam.
+    """
+    return disposition.startswith(VALID_DISPOSITION_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Cached scans — load files once per test run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def session_methods() -> list[str]:
+    source = SESSION_MODULE.read_text(encoding="utf-8")
+    return _enumerate_session_methods(source)
+
+
+@pytest.fixture(scope="module")
+def retention_rows() -> dict[str, str]:
+    text = RETENTION_DOC.read_text(encoding="utf-8")
+    return _parse_retention_doc(text)
+
+
+# ---------------------------------------------------------------------------
+# Self-coverage — prove the helpers behave as advertised.
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_session_methods_finds_known_methods() -> None:
+    """Sanity: ``__init__`` and ``rpc_call`` must always be on Session."""
+    source = SESSION_MODULE.read_text(encoding="utf-8")
+    names = _enumerate_session_methods(source)
+    assert "__init__" in names, "Session must always define __init__."
+    assert "rpc_call" in names, (
+        "Session.rpc_call is the public-API forward and must remain. If this "
+        "lint enumerates an empty list, the AST walk lost the class body — "
+        "check that the Session class still parses."
+    )
+
+
+def test_enumerate_session_methods_skips_nested_functions() -> None:
+    """A nested function inside a method body must NOT appear in the inventory."""
+    source = (
+        "class Session:\n"
+        "    def outer(self):\n"
+        "        def nested():\n"
+        "            return 1\n"
+        "        return nested()\n"
+    )
+    names = _enumerate_session_methods(source)
+    assert names == ["outer"], f"Expected only ['outer'], got {names!r}"
+
+
+def test_enumerate_session_methods_skips_other_classes() -> None:
+    """Methods on sibling classes must NOT be enumerated."""
+    source = "class Other:\n    def stray(self): ...\nclass Session:\n    def real(self): ...\n"
+    assert _enumerate_session_methods(source) == ["real"]
+
+
+def test_parse_retention_doc_extracts_known_rows() -> None:
+    """Sanity: parsing the live doc returns at least ``rpc_call`` with a retain disposition."""
+    text = RETENTION_DOC.read_text(encoding="utf-8")
+    rows = _parse_retention_doc(text)
+    assert "rpc_call" in rows, (
+        "Retention doc must list `rpc_call`. If the row was removed, the "
+        "doc has drifted from the retention contract."
+    )
+    assert rows["rpc_call"].startswith(_RETAIN_PREFIX), (
+        f"`rpc_call` disposition must be `retain — ...`, got: {rows['rpc_call']!r}"
+    )
+
+
+def test_parse_retention_doc_handles_property_suffix() -> None:
+    """The ``(property)`` suffix outside backticks must not block the row match."""
+    text = (
+        "## Inventory\n"
+        "\n"
+        "| Method | Category | Disposition |\n"
+        "|---|---|---|\n"
+        "| `kernel` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) |\n"
+    )
+    rows = _parse_retention_doc(text)
+    assert rows == {"kernel": "delete in Wave 11 (`metrics-and-kernel`)"}
+
+
+def test_parse_retention_doc_skips_glossary_tables() -> None:
+    """Backticked tokens in the Categories / Dispositions glossary tables
+    appear before the inventory section and MUST NOT be parsed as method rows.
+    """
+    text = (
+        "## Categories\n"
+        "\n"
+        "| Category | Meaning |\n"
+        "|---|---|\n"
+        "| `constructor` | something |\n"
+        "| `lifecycle` | something else |\n"
+        "\n"
+        "## Inventory\n"
+        "\n"
+        "| Method | Category | Disposition |\n"
+        "|---|---|---|\n"
+        "| `rpc_call` | public API forward | retain — pinned |\n"
+        "\n"
+        "## Deleted\n"
+        "\n"
+        "| `old_method` | compatibility forward | deleted in #999 |\n"
+    )
+    rows = _parse_retention_doc(text)
+    assert rows == {"rpc_call": "retain — pinned"}, (
+        "Glossary and Deleted sections must not contribute rows."
+    )
+
+
+def test_disposition_validator_accepts_known_shapes() -> None:
+    assert _disposition_is_valid("retain — lifecycle")
+    assert _disposition_is_valid("delete in Wave 11 (`drain-and-operation`)")
+
+
+def test_disposition_validator_rejects_unknown_prefix() -> None:
+    assert not _disposition_is_valid("TODO — figure it out later")
+    assert not _disposition_is_valid("")
+
+
+# ---------------------------------------------------------------------------
+# The actual contract.
+# ---------------------------------------------------------------------------
+
+
+def test_every_session_method_appears_in_retention_doc(
+    session_methods: list[str],
+    retention_rows: dict[str, str],
+) -> None:
+    """Every method on ``Session`` must have a row in the retention doc."""
+    missing = [name for name in session_methods if name not in retention_rows]
+    assert not missing, (
+        "These Session methods are not listed in "
+        f"{RETENTION_DOC.relative_to(REPO_ROOT)}:\n"
+        + "\n".join(f"  - {name}" for name in missing)
+        + "\n\nAdd a row for each per the doc's existing format. Categories: "
+        "lifecycle | public API forward | middleware chain leaf | "
+        "provider-closure capture target | Stage A accessor | "
+        "lazy collaborator factory | RefreshAuthCore Protocol surface | "
+        "compatibility forward."
+    )
+
+
+def test_every_listed_disposition_is_valid(retention_rows: dict[str, str]) -> None:
+    """Every row's disposition must start with a recognised prefix."""
+    invalid = {
+        name: disposition
+        for name, disposition in retention_rows.items()
+        if not _disposition_is_valid(disposition)
+    }
+    assert not invalid, (
+        "These rows in "
+        f"{RETENTION_DOC.relative_to(REPO_ROOT)} carry an unrecognised "
+        f"disposition. Use `retain — <reason>` or `delete in Wave 11 "
+        f"(<cluster>)`. Offenders:\n"
+        + "\n".join(f"  - `{name}`: {disposition!r}" for name, disposition in invalid.items())
+    )
+
+
+def test_retention_doc_does_not_list_unknown_methods(
+    session_methods: list[str],
+    retention_rows: dict[str, str],
+) -> None:
+    """A row that names a non-existent Session method indicates doc drift.
+
+    If a method was deleted in Wave 11 (or earlier), its row should move to
+    the **Deleted** section at the bottom of the doc rather than survive in
+    the live inventory table.
+    """
+    known = set(session_methods)
+    stale = [name for name in retention_rows if name not in known]
+    assert not stale, (
+        f"These rows in {RETENTION_DOC.relative_to(REPO_ROOT)} reference "
+        "Session methods that no longer exist. Move them to the Deleted "
+        "section (with the deleting PR's SHA) or remove them:\n"
+        + "\n".join(f"  - `{name}`" for name in stale)
+    )

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -60,7 +60,13 @@ def _enumerate_session_methods(source: str) -> list[str]:
     defined inside method bodies (the parent walk gates them out).
     """
     tree = ast.parse(source)
-    for node in ast.walk(tree):
+    # Iterate ``tree.body`` directly rather than ``ast.walk(tree)``:
+    # ``Session`` is a top-level class in ``_session.py`` and the lint
+    # contract requires the *outermost* same-named class, so the
+    # shallow walk is more predictable and rejects an accidental nested
+    # ``class Session: ...`` inside a function body. (gemini-code-assist
+    # review on PR #1075.)
+    for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == SESSION_CLASS_NAME:
             return [
                 item.name
@@ -78,8 +84,13 @@ def _enumerate_session_methods(source: str) -> list[str]:
 #   | `method_name` | ...
 #   | `method_name` (property) | ...
 # Captures ``method_name``. The optional ``(property)`` suffix lives outside
-# the backticks per the doc's column-one convention.
-_ROW_FIRST_CELL = re.compile(r"^\|\s*`(?P<name>[A-Za-z_][A-Za-z0-9_]*)`(?:\s*\(property\))?\s*\|")
+# the backticks per the doc's column-one convention. Leading whitespace
+# before the pipe is tolerated so a future markdownlint / Prettier pass
+# that indents tables doesn't silently empty the inventory.
+# (gemini-code-assist review on PR #1075.)
+_ROW_FIRST_CELL = re.compile(
+    r"^\s*\|\s*`(?P<name>[A-Za-z_][A-Za-z0-9_]*)`(?:\s*\(property\))?\s*\|"
+)
 
 
 INVENTORY_SECTION_HEADER: str = "## Inventory"


### PR DESCRIPTION
## Summary

Wave 10 of the [session-decoupling plan](../blob/main/docs/session-decoupling-plan-2026-05-26.md) — the first PR of Phase 3. Two new files, no source changes:

1. **`docs/session-method-retention.md`** — checked-in inventory classifying every method (and `@property`) currently defined on `Session` in [`_session.py`](../blob/main/src/notebooklm/_session.py) against the ADR-014 Rule 4 retention contract. Each row carries a category (`lifecycle` / `public API forward` / `middleware chain leaf` / `provider-closure capture target` / `Stage A accessor` / `lazy collaborator factory` / `RefreshAuthCore Protocol surface` / `compatibility forward`) and a disposition (`retain — <reason>` or `delete in Wave 11 (<cluster>)`).

2. **`tests/_lint/test_session_retention.py`** — AST guard that enumerates Session methods and asserts every one appears in the inventory with a valid disposition. Adding a new method without a row fails the lint at PR time; deleting a method without moving its row to the "Deleted" section also fails (drift in the opposite direction).

## Contract

- The doc parser scopes to the `## Inventory` section so the `## Categories` / `## Dispositions` glossary tables (which also use backticked identifiers in column 1) and the future "Deleted" section don't contribute false rows.
- Valid disposition prefixes today: `retain` or `delete in Wave 11`. Wave 11c will tighten the lint to reject the latter once the three cluster-deletion PRs land.
- 36 Session methods enumerated; 16 marked `retain` (3 Stage-A accessors, `rpc_call`, `_authed_post_chain_terminal`, `_await_refresh`, `assert_bound_loop`, `_get_rpc_semaphore`, `_get_rpc_executor`, 5 lifecycle methods, 2 `RefreshAuthCore` Protocol surfaces), 20 marked `delete in Wave 11` across three clusters.

## Follow-ups (Wave 11)

Wave 11 sub-waves 11a-11c (sequential — all touch `_session.py`) delete each cluster and move rows to the "Deleted" section:

- **11a `drain-and-operation`:** `register_drain_hook`, `operation_scope`, `drain`
- **11b `metrics-and-kernel`:** `metrics_snapshot`, `_increment_metrics`, `record_upload_queue_wait`, `_emit_rpc_event`, `kernel`, `live_cookies`, `authuser`, `account_email`, `authuser_query`, `authuser_header`, `get_http_client` (gated on `RefreshAuthCore` Protocol migration)
- **11c `transport-and-reqid`:** `next_reqid`, `bound_loop`, `_refresh_request_for_current_auth`, `_perform_authed_post`, `transport_post`, `save_cookies` (gated on `RefreshAuthCore` Protocol migration). Tightens the lint to forbid `delete in Wave 11` rows.

## Test plan

- [x] `uv run pytest tests/_lint/test_session_retention.py -v` — 11 passed
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm` — no issues in 173 files
- [x] `uv run pytest tests/unit tests/_lint -x -q` — 5866 passed, 10 skipped

## References

- Plan: [`docs/session-decoupling-plan-2026-05-26.md`](../blob/main/docs/session-decoupling-plan-2026-05-26.md) (Task 5.1)
- Phase: [`.sisyphus/phases/session-decoupling/phase-3.md`](../blob/main/.sisyphus/phases/session-decoupling/phase-3.md) (Wave 10)
- ADR: [`docs/adr/0014-feature-local-runtime-adapters.md`](../blob/main/docs/adr/0014-feature-local-runtime-adapters.md) (Rule 4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for internal session method retention planning and roadmap.

* **Tests**
  * Added validation tests to ensure documentation remains synchronized with actual implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->