### PR TITLE
refactor(session): delete drain/operation forward cluster (Wave 11a / Task 5.2 cluster 1)

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -55,9 +55,6 @@ forbid any `delete in Wave 11` rows once the cluster deletions land.
 | `rpc_executor` (property) | Stage A accessor | retain — Stage A accessor; exposes lazy `RpcExecutor` not present on `SessionCollaborators` |
 | `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_tokens(...)` at [`_auth/session.py:67`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
 | `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_headers()` at [`_auth/session.py:68`](../src/notebooklm/_auth/session.py) |
-| `register_drain_hook` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — one-line forward to `TransportDrainTracker.register_drain_hook`; migrate callers to `session.collaborators.drain_tracker` |
-| `operation_scope` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — forward to `TransportDrainTracker.operation_scope` |
-| `drain` | compatibility forward | delete in Wave 11 (`drain-and-operation`) — forward to `TransportDrainTracker.drain` |
 | `metrics_snapshot` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.snapshot` |
 | `_increment_metrics` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.increment` |
 | `record_upload_queue_wait` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.record_upload_queue_wait` |
@@ -111,4 +108,11 @@ land.
 
 Wave 11 sub-wave PRs append entries here (preserving the deleting PR's SHA in
 the section sub-header) as the `delete in Wave 11` rows above are dropped.
-Empty at Wave 10.
+
+### Wave 11a — drain-and-operation cluster (commit `80a54fda`)
+
+| Method | Category | Disposition |
+|---|---|---|
+| `register_drain_hook` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a one-line forward to `TransportDrainTracker.register_drain_hook`. Callers now reach the tracker directly (`session._drain_tracker.register_drain_hook(...)` in tests; production callers use `ArtifactsRuntimeAdapter.register_drain_hook`). |
+| `operation_scope` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a forward to `TransportDrainTracker.operation_scope`. Callers now reach the tracker directly (`session._drain_tracker.operation_scope(...)` in tests; production callers use `ArtifactsRuntimeAdapter.operation_scope` / `UploadRuntimeAdapter.operation_scope`). |
+| `drain` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a forward to `TransportDrainTracker.drain`. `NotebookLMClient.drain` now calls `self._session._drain_tracker.drain(...)` directly. |

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -419,15 +419,6 @@ class Session:
         self._middlewares = wired.middlewares
         self._authed_post_chain = wired.authed_post_chain
 
-    def register_drain_hook(self, name: str, hook: Callable[[], Awaitable[None]]) -> None:
-        """Register or replace a feature-owned close-time drain hook.
-
-        Forward to :meth:`TransportDrainTracker.register_drain_hook` per
-        ADR-014 Rule 1; the storage and firing live on the tracker since
-        Wave 2 of the session-decoupling plan.
-        """
-        self._drain_tracker.register_drain_hook(name, hook)
-
     async def next_reqid(self, step: int = _REQID_DEFAULT_STEP) -> int:
         """Atomically increment the request-id counter and return the new value.
 
@@ -543,28 +534,6 @@ class Session:
     async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
         await self._metrics_obj.emit_rpc_event(event)
-
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
-        """Return a drain-tracked operation scope for feature-owned work.
-
-        Forward to :meth:`TransportDrainTracker.operation_scope` per
-        ADR-014 Rule 1; ``TransportDrainTracker`` satisfies the
-        ``OperationScopeProvider`` capability Protocol directly since
-        Wave 2 of the session-decoupling plan. Plain sync function (no
-        ``@asynccontextmanager``) so the inner context manager flows
-        through unchanged; callers still write
-        ``async with session.operation_scope(label):``.
-        """
-        return self._drain_tracker.operation_scope(label)
-
-    async def drain(self, timeout: float | None = None) -> None:
-        """Stop accepting new client operations and wait for in-flight ones to finish.
-
-        If ``timeout`` expires, ``TimeoutError`` is raised and the client
-        remains in draining mode so shutdown callers do not accidentally admit
-        new work after a missed deadline.
-        """
-        await self._drain_tracker.drain(timeout)
 
     def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
         """Return the per-instance RPC semaphore (or a null-context).

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -431,7 +431,10 @@ class NotebookLMClient:
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new operations and wait for in-flight operations to finish."""
-        await self._session.drain(timeout=timeout)
+        # ADR-014 Rule 4 (Wave 11a of session-decoupling): reach the
+        # ``TransportDrainTracker`` collaborator directly instead of going
+        # through a deleted ``Session.drain`` forward.
+        await self._session._drain_tracker.drain(timeout=timeout)
 
     async def close(
         self,

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -262,9 +262,12 @@ async def test_cancel_during_drain_in_close_does_not_leak_transport(
     - Open the client.
     - Capture ``http_client_ref`` BEFORE the cancel (successful close
       nulls the kernel's transport attribute).
-    - Monkeypatch ``client._session.drain`` to park on an unset
-      ``asyncio.Event`` so drain() blocks indefinitely; the only exit is
-      the ``CancelledError`` injected by the outer ``wait_for`` deadline.
+    - Monkeypatch ``client._session._drain_tracker.drain`` to park on an
+      unset ``asyncio.Event`` so drain() blocks indefinitely; the only
+      exit is the ``CancelledError`` injected by the outer ``wait_for``
+      deadline. (Wave 11a of session-decoupling deleted the
+      ``Session.drain`` forward; the public ``NotebookLMClient.drain``
+      reaches the tracker directly.)
     - Drive ``close(drain=True)`` through ``asyncio.wait_for(timeout=0.1)``
       so the cancel reliably lands while ``drain`` is parked.
 
@@ -302,7 +305,7 @@ async def test_cancel_during_drain_in_close_does_not_leak_transport(
             drain_entered.set()
             await hang_event.wait()
 
-        monkeypatch.setattr(client._session, "drain", _hanging_drain)
+        monkeypatch.setattr(client._session._drain_tracker, "drain", _hanging_drain)
 
         # Drive ``close(drain=True)`` through a short ``wait_for`` so a
         # cancel lands while ``drain`` is parked. The cancel propagates

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -14,7 +14,7 @@ from notebooklm import (
     correlation_id,
     get_request_id,
 )
-from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._artifacts import ArtifactsAPI, ArtifactsRuntimeAdapter
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
 from notebooklm._session import Session
@@ -118,7 +118,7 @@ async def test_drain_rejects_new_work_and_waits_for_in_flight(auth_tokens: AuthT
     task = asyncio.create_task(in_flight())
     await started.wait()
 
-    drain_task = asyncio.create_task(core.drain(timeout=1.0))
+    drain_task = asyncio.create_task(core._drain_tracker.drain(timeout=1.0))
     await asyncio.sleep(0)
 
     assert not drain_task.done()
@@ -137,7 +137,7 @@ async def test_drain_allows_nested_work_inside_accepted_operation(
     core = Session(auth_tokens)
     outer_token = await core._drain_tracker.begin_transport_post("source upload")
     try:
-        drain_task = asyncio.create_task(core.drain(timeout=1.0))
+        drain_task = asyncio.create_task(core._drain_tracker.drain(timeout=1.0))
         await asyncio.sleep(0)
 
         nested_token = await core._drain_tracker.begin_transport_post("RPC ADD_SOURCE")
@@ -156,7 +156,7 @@ async def test_operation_scope_tracks_drain_without_upload_semaphore(
 ) -> None:
     core = Session(auth_tokens)
 
-    async with core.operation_scope("plain-operation"):
+    async with core._drain_tracker.operation_scope("plain-operation"):
         assert core._drain_tracker._in_flight_posts == 1
         assert not hasattr(core, "get_upload_semaphore")
 
@@ -171,7 +171,7 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
     core = Session(auth_tokens)
     outer_token = await core._drain_tracker.begin_transport_post("source upload")
     try:
-        drain_task = asyncio.create_task(core.drain(timeout=1.0))
+        drain_task = asyncio.create_task(core._drain_tracker.drain(timeout=1.0))
         await asyncio.sleep(0)
 
         async def child_work() -> None:
@@ -189,8 +189,17 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
 @pytest.mark.asyncio
 async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> None:
     core = Session(auth_tokens)
+    # Wave 11a of session-decoupling deleted ``Session.register_drain_hook``
+    # / ``Session.operation_scope`` forwards; ``ArtifactsAPI`` now consumes
+    # an ``ArtifactsRuntimeAdapter`` composite (mirrors production wiring
+    # in ``NotebookLMClient.__init__``).
+    runtime = ArtifactsRuntimeAdapter(
+        rpc=core.rpc_executor,
+        drain=core._drain_tracker,
+        lifecycle=core._lifecycle,
+    )
     api = ArtifactsAPI(
-        core,
+        runtime,
         notebooks=MagicMock(),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),
@@ -225,7 +234,7 @@ async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> No
     )
     await first_poll_started.wait()
 
-    drain_task = asyncio.create_task(core.drain(timeout=1.0))
+    drain_task = asyncio.create_task(core._drain_tracker.drain(timeout=1.0))
     await asyncio.sleep(0)
     assert not drain_task.done()
 
@@ -249,7 +258,7 @@ async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: Auth
     async def close_transport() -> None:
         calls.append("close")
 
-    client._session.drain = drain_timeout  # type: ignore[method-assign]
+    client._session._drain_tracker.drain = drain_timeout  # type: ignore[method-assign]
     client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(TimeoutError, match="deadline"):
@@ -270,7 +279,7 @@ async def test_close_with_invalid_drain_does_not_close_transport(auth_tokens: Au
     async def close_transport() -> None:
         calls.append("close")
 
-    client._session.drain = invalid_drain  # type: ignore[method-assign]
+    client._session._drain_tracker.drain = invalid_drain  # type: ignore[method-assign]
     client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(ValueError, match="bad deadline"):
@@ -332,8 +341,15 @@ async def test_upload_progress_callback_receives_byte_counts(
 @pytest.mark.asyncio
 async def test_wait_for_completion_status_change_callback(auth_tokens: AuthTokens) -> None:
     core = Session(auth_tokens)
+    # Wave 11a of session-decoupling deleted the ``Session`` drain forwards;
+    # ``ArtifactsAPI`` now consumes an ``ArtifactsRuntimeAdapter`` composite.
+    runtime = ArtifactsRuntimeAdapter(
+        rpc=core.rpc_executor,
+        drain=core._drain_tracker,
+        lifecycle=core._lifecycle,
+    )
     api = ArtifactsAPI(
-        core,
+        runtime,
         notebooks=MagicMock(),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._artifacts import ArtifactsAPI, ArtifactsRuntimeAdapter
 from notebooklm._polling_registry import PollRegistry
 from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
@@ -96,8 +96,17 @@ async def test_session_close_drains_artifact_poll_hook() -> None:
     from notebooklm._note_service import NoteService
 
     core = Session(_auth())
+    # Wave 11a of session-decoupling deleted ``Session.register_drain_hook``
+    # / ``Session.operation_scope`` forwards; ``ArtifactsAPI`` now consumes
+    # an ``ArtifactsRuntimeAdapter`` composite (mirrors production wiring
+    # in ``NotebookLMClient.__init__``).
+    runtime = ArtifactsRuntimeAdapter(
+        rpc=core.rpc_executor,
+        drain=core._drain_tracker,
+        lifecycle=core._lifecycle,
+    )
     artifacts = ArtifactsAPI(
-        core,
+        runtime,
         notebooks=MagicMock(),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),
@@ -140,7 +149,7 @@ async def test_session_close_absorbs_drain_hook_errors() -> None:
     async def angry_hook() -> None:
         raise RuntimeError("poll cleanup failed")
 
-    core.register_drain_hook("angry", angry_hook)
+    core._drain_tracker.register_drain_hook("angry", angry_hook)
 
     # return_exceptions=True in close() means this should NOT propagate.
     await asyncio.wait_for(core.close(), timeout=1.0)
@@ -174,7 +183,7 @@ async def test_client_close_default_drain_is_true() -> None:
     async def fake_close() -> None:
         pass
 
-    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session._drain_tracker.drain = fake_drain  # type: ignore[method-assign]
     client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close()
@@ -196,7 +205,7 @@ async def test_client_close_drain_false_skips_drain() -> None:
     async def fake_close() -> None:
         pass
 
-    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session._drain_tracker.drain = fake_drain  # type: ignore[method-assign]
     client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close(drain=False)
@@ -216,7 +225,7 @@ async def test_client_aexit_uses_drain_true_default() -> None:
     async def fake_close() -> None:
         pass
 
-    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session._drain_tracker.drain = fake_drain  # type: ignore[method-assign]
     client._session.close = fake_close  # type: ignore[method-assign]
 
     # Drive __aexit__ directly rather than `async with` so we can use the


### PR DESCRIPTION
## Summary

First of three sequential `Session` deletion sub-waves under [Phase 3 / Task 5.2](../docs/session-decoupling-plan-2026-05-26.md#task-52-delete-forwards-in-clusters) of the [session-decoupling plan](../docs/session-decoupling-plan-2026-05-26.md). Implements ADR-014 Rule 4 (forward-only methods belong on the collaborator that owns the behavior) for the `drain-and-operation` cluster.

Deletes three pure forwards from `Session` that were added in Wave 2 as compatibility shims over `TransportDrainTracker`:

- `Session.operation_scope` -> `TransportDrainTracker.operation_scope`
- `Session.register_drain_hook` -> `TransportDrainTracker.register_drain_hook`
- `Session.drain` -> `TransportDrainTracker.drain`

`Session._get_rpc_semaphore` stays: it is NOT a pure forward (owns the lazy-init for `self._rpc_semaphore` and the `nullcontext` opt-out branch) and is wired into the middleware chain via `rpc_semaphore_factory=` in `wire_middleware_chain`.

Depends on Wave 10 (#1075, merged) for `docs/session-method-retention.md` + the retention-doc lint guard.

## Commits

1. `refactor(session): delete drain/operation_scope forward cluster (Wave 11a / step 1)` — `_session.py` deletions + `NotebookLMClient.drain` migration.
2. `test: migrate drain-tracker test sites off Session forwards (Wave 11a / step 2)` — test-site migration.
3. `docs(session): mark drain forwards Deleted in retention.md (Wave 11a / step 3)` — retention-doc update post-rebase.

Three separate commits chosen for revertability: if production caller migration regresses, step 1 alone can be reverted without losing the test migrations or the retention-doc update.

## Production caller migration

Only one production call site referenced a deleted forward:

- `NotebookLMClient.drain` now calls `self._session._drain_tracker.drain(timeout=timeout)` directly.

All other production callers were already using the runtime-adapter pattern (`self.drain.operation_scope(label)` in `_source_upload.py` / `_artifacts.py` via `UploadRuntimeAdapter` / `ArtifactsRuntimeAdapter`, both introduced in Wave 9).

## Test migration approach

Two distinct test-site patterns required different treatments:

- **Real-`Session` call sites in `test_observability.py` + `test_session_close.py`**: rewritten to reach the collaborator directly (`core._drain_tracker.drain(...)`, `core._drain_tracker.operation_scope(...)`, `core._drain_tracker.register_drain_hook(...)`). Two `ArtifactsAPI(core, ...)` construction sites were rewrapped with `ArtifactsRuntimeAdapter(rpc=core.rpc_executor, drain=core._drain_tracker, lifecycle=core._lifecycle)` to mirror the production wiring in `NotebookLMClient.__init__`.
- **Monkeypatch sites in `test_observability.py` + `test_session_close.py` + `test_close_cancellation_leak.py`**: retargeted from `client._session.drain = ...` to `client._session._drain_tracker.drain = ...` so the public `NotebookLMClient.close()` drain path still picks up the substitute.
- **MagicMock-fake `core` sites in `tests/integration/...` and `tests/unit/test_artifacts_*.py`**: untouched. `MagicMock` auto-vivifies `register_drain_hook` so these never depended on the real Session forward.

## Test plan

- [x] `uv run pytest tests/_lint/test_session_retention.py tests/_lint/test_no_forbidden_monkeypatches.py tests/unit/concurrency -v` (38 passed)
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pytest tests/unit tests/_lint -x -q` (5866 passed, 10 skipped)
- [x] `uv run pytest tests/integration -x -q` (636 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `register_drain_hook()`, `operation_scope()`, and `drain()` methods from Session public API.

* **Refactor**
  * Restructured internal drain operation handling for improved separation of concerns.

* **Documentation**
  * Updated session method retention inventory to reflect API removals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->