### PR TITLE
refactor(session): delete metrics/kernel/authuser forward cluster (Wave 11b / Task 5.2 cluster 2)

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -53,19 +53,8 @@ forbid any `delete in Wave 11` rows once the cluster deletions land.
 | `collaborators` (property) | Stage A accessor | retain — Stage A accessor (ADR-014 Rule 3); deleted under Stage B when `build_collaborators` ownership moves to `NotebookLMClient` |
 | `session_transport` (property) | Stage A accessor | retain — Stage A accessor; exposes late-bound `SessionTransport` not present on `SessionCollaborators` |
 | `rpc_executor` (property) | Stage A accessor | retain — Stage A accessor; exposes lazy `RpcExecutor` not present on `SessionCollaborators` |
-| `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_tokens(...)` at [`_auth/session.py:67`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
-| `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_headers()` at [`_auth/session.py:68`](../src/notebooklm/_auth/session.py) |
-| `metrics_snapshot` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.snapshot` |
-| `_increment_metrics` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.increment` |
-| `record_upload_queue_wait` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.record_upload_queue_wait` |
-| `_emit_rpc_event` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `ClientMetrics.emit_rpc_event` |
-| `kernel` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self._kernel`; readers migrate to `session.collaborators.kernel` |
-| `live_cookies` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.get_http_client().cookies` |
-| `authuser` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.auth.authuser` |
-| `account_email` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `self.auth.account_email` |
-| `authuser_query` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `auth.authuser_query(self.authuser, self.account_email)` |
-| `authuser_header` | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `auth.format_authuser_value(...)` |
-| `get_http_client` | RefreshAuthCore Protocol surface / compatibility forward | delete in Wave 11 (`metrics-and-kernel`) — forward to `Kernel.get_http_client`; the `RefreshAuthCore` Protocol still references `get_http_client`, so Wave 11b MUST first migrate the Protocol (or `refresh_auth_session(core)`) to call `core.collaborators.kernel.get_http_client()` before the Session forward can be removed |
+| `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_tokens(...)` from [`_auth/session.py`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
+| `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_headers()` from [`_auth/session.py`](../src/notebooklm/_auth/session.py) |
 | `next_reqid` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ReqidCounter.next_reqid` |
 | `bound_loop` (property) | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ClientLifecycle.get_bound_loop` with defensive `isinstance` |
 | `_refresh_request_for_current_auth` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `SessionTransport.refresh_request_for_current_auth`; the AST guard at `tests/unit/test_concurrency_refresh_race.py:222` already inspects `SessionTransport.refresh_request_for_current_auth` directly, so no guard migration needed |
@@ -116,3 +105,19 @@ the section sub-header) as the `delete in Wave 11` rows above are dropped.
 | `register_drain_hook` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a one-line forward to `TransportDrainTracker.register_drain_hook`. Callers now reach the tracker directly (`session._drain_tracker.register_drain_hook(...)` in tests; production callers use `ArtifactsRuntimeAdapter.register_drain_hook`). |
 | `operation_scope` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a forward to `TransportDrainTracker.operation_scope`. Callers now reach the tracker directly (`session._drain_tracker.operation_scope(...)` in tests; production callers use `ArtifactsRuntimeAdapter.operation_scope` / `UploadRuntimeAdapter.operation_scope`). |
 | `drain` | compatibility forward | deleted in Wave 11a (commit `80a54fda`) — was a forward to `TransportDrainTracker.drain`. `NotebookLMClient.drain` now calls `self._session._drain_tracker.drain(...)` directly. |
+
+### Wave 11b — metrics-and-kernel cluster (commit `37b16a79`)
+
+| Method | Category | Disposition |
+|---|---|---|
+| `metrics_snapshot` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `ClientMetrics.snapshot`. `NotebookLMClient.metrics_snapshot` now calls `self._session.collaborators.metrics.snapshot()`; in-tree tests reach `core._metrics_obj.snapshot()` directly. |
+| `_increment_metrics` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `ClientMetrics.increment`. No production caller remained; the historical `_middleware_auth_refresh` reference was prose only. |
+| `record_upload_queue_wait` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `ClientMetrics.record_upload_queue_wait`. `NotebookLMClient.__init__` now passes `collaborators.metrics.record_upload_queue_wait` to the upload pipeline; in-tree tests pass `core._metrics_obj.record_upload_queue_wait`. |
+| `_emit_rpc_event` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `ClientMetrics.emit_rpc_event`. The live middleware chain already reads `metrics` directly; no production caller surfaced via Session. |
+| `kernel` (property) | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `self._kernel`. `NotebookLMClient.__init__` now passes `collaborators.kernel` to the upload pipeline; in-tree tests use `core._kernel`. |
+| `live_cookies` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `self.get_http_client().cookies`. The canonical home is `Kernel.cookies` (also reachable via `Kernel.get_http_client().cookies`). |
+| `authuser` (property) | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `self.auth.authuser`. Callers read `auth.authuser` directly. |
+| `account_email` (property) | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `self.auth.account_email`. Callers read `auth.account_email` directly. |
+| `authuser_query` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `notebooklm._auth.account.authuser_query`. Callers import the helper directly. |
+| `authuser_header` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `notebooklm._auth.account.format_authuser_value`. Callers import the helper directly. |
+| `get_http_client` | RefreshAuthCore Protocol surface / compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `Kernel.get_http_client`. The `RefreshAuthCore` and `_AuthRefreshHost` Protocols were migrated in the same commit to require a `_kernel: Kernel` slot instead of `get_http_client`; the two call sites in `_auth/session.py` and `_session_auth.py` now read `core._kernel.get_http_client()` / `host._kernel.get_http_client()`. `Session._kernel` is already an instance attribute (assigned from `collaborators.kernel` in `__init__`), so live `Session` instances satisfy the new Protocol shape without further changes. |

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import httpx
 
@@ -15,15 +15,23 @@ from .account import authuser_query
 from .extraction import extract_wiz_field
 from .tokens import AuthTokens
 
+if TYPE_CHECKING:
+    from .._kernel import Kernel
+
 
 class RefreshAuthCore(Protocol):
-    """Structural core boundary required by auth session refresh."""
+    """Structural core boundary required by auth session refresh.
+
+    Wave 11b of session-decoupling (ADR-014): the live HTTP client is
+    sourced via ``core._kernel.get_http_client()`` instead of a
+    ``core.get_http_client()`` forward on ``Session``. The underscore-
+    prefixed ``_kernel`` slot mirrors the live ``Session._kernel``
+    attribute so structural conformance does not require renaming the
+    Session slot.
+    """
 
     auth: AuthTokens
-
-    def get_http_client(self) -> httpx.AsyncClient:
-        """Return the live HTTP client."""
-        ...
+    _kernel: Kernel
 
     def update_auth_tokens(self, csrf: str, session_id: str) -> Awaitable[None]:
         """Atomically update auth token scalars."""
@@ -40,7 +48,7 @@ class RefreshAuthCore(Protocol):
 
 async def refresh_auth_session(core: RefreshAuthCore) -> AuthTokens:
     """Refresh NotebookLM auth tokens through the raw homepage session path."""
-    http_client = core.get_http_client()
+    http_client = core._kernel.get_http_client()
     url = f"{get_base_url()}/"
     if core.auth.account_email or core.auth.authuser:
         url = f"{url}?{authuser_query(core.auth.authuser, core.auth.account_email)}"

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -132,8 +132,12 @@ class AuthRefreshMiddleware:
       Defaults to the project-canonical ``notebooklm._core`` logger so
       ``caplog.at_level(..., logger="notebooklm._core")`` keeps matching.
     - ``metrics``: a :class:`ClientMetrics` whose ``increment(...)`` is
-      called once per successful refresh (matches the legacy
-      ``host._increment_metrics(rpc_auth_retries=1)`` site).
+      called once per successful refresh (replaces the historical
+      ``host._increment_metrics(rpc_auth_retries=1)`` site —
+      ``Session._increment_metrics`` was a thin forward to this
+      ``ClientMetrics.increment`` call and was deleted in Wave 11b of
+      the session-decoupling arc, so middleware now reaches the
+      collaborator directly).
     """
 
     def __init__(

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ._error_injection import _refuse_synthetic_error_outside_test_context
-from ._kernel import Kernel
 from ._middleware import (
     RpcRequest,
     RpcResponse,
@@ -37,13 +36,7 @@ from ._session_transport import SessionTransport
 from .auth import (
     AuthTokens,
 )
-from .auth import (
-    authuser_query as _authuser_query_value,
-)
-from .auth import (
-    format_authuser_value as _format_authuser_header_value,
-)
-from .types import ClientMetricsSnapshot, RpcTelemetryEvent
+from .types import RpcTelemetryEvent
 
 if TYPE_CHECKING:
     from ._session_init import SessionCollaborators
@@ -430,22 +423,6 @@ class Session:
         """
         return await self._reqid.next_reqid(step)
 
-    def metrics_snapshot(self) -> ClientMetricsSnapshot:
-        """Return cumulative observability counters for this client instance."""
-        return self._metrics_obj.snapshot()
-
-    def _increment_metrics(self, **increments: int | float) -> None:
-        self._metrics_obj.increment(**increments)
-
-    def record_upload_queue_wait(self, wait_seconds: float) -> None:
-        """Record time spent waiting for the upload semaphore."""
-        self._metrics_obj.record_upload_queue_wait(wait_seconds)
-
-    # Session/support surface consumed by feature APIs and private helpers.
-    @property
-    def kernel(self) -> Kernel:
-        return self._kernel
-
     # ------------------------------------------------------------------
     # ADR-014 Rule 3 Stage A accessors (Wave 6 of session-decoupling)
     # ------------------------------------------------------------------
@@ -489,23 +466,6 @@ class Session:
         return self._get_rpc_executor()
 
     @property
-    def authuser(self) -> int:
-        return self.auth.authuser
-
-    @property
-    def account_email(self) -> str | None:
-        return self.auth.account_email
-
-    def authuser_query(self) -> str:
-        return _authuser_query_value(self.authuser, self.account_email)
-
-    def authuser_header(self) -> str:
-        return _format_authuser_header_value(self.authuser, self.account_email)
-
-    def live_cookies(self) -> httpx.Cookies:
-        return self.get_http_client().cookies
-
-    @property
     def bound_loop(self) -> asyncio.AbstractEventLoop | None:
         """Return the open-time captured event loop for affinity checks.
 
@@ -530,10 +490,6 @@ class Session:
         Protocol directly since Wave 2 of the session-decoupling plan.
         """
         self._lifecycle.assert_bound_loop()
-
-    async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
-        """Invoke the optional telemetry callback without affecting RPC behavior."""
-        await self._metrics_obj.emit_rpc_event(event)
 
     def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
         """Return the per-instance RPC semaphore (or a null-context).
@@ -663,9 +619,9 @@ class Session:
         Call this after modifying auth tokens (e.g., after refresh_auth())
         to ensure the HTTP client uses the updated credentials. Delegates
         to :meth:`AuthRefreshCoordinator.update_auth_headers`; the cookie
-        jar source is fetched via ``self.get_http_client()`` so the open()
-        precondition (and its ``RuntimeError`` if not initialised) is
-        enforced at one site.
+        jar source is fetched via ``self._kernel.get_http_client()`` so the
+        ``open()`` precondition (and its ``RuntimeError`` if not initialised)
+        is enforced at one site.
 
         Raises:
             RuntimeError: If client is not initialized.
@@ -808,16 +764,3 @@ class Session:
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
         )
-
-    def get_http_client(self) -> httpx.AsyncClient:
-        """Get the underlying HTTP client for direct requests.
-
-        Used by download operations that need direct HTTP access.
-
-        Returns:
-            The httpx.AsyncClient instance.
-
-        Raises:
-            RuntimeError: If client is not initialized.
-        """
-        return self._kernel.get_http_client()

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -33,7 +33,7 @@ tests/integration/concurrency/test_refresh_cancellation_propagation.py):
   ``host.auth.session_id`` under the snapshot lock. It does NOT touch the
   http client. The cookie-jar sync is a separate concern handled by
   :meth:`update_auth_headers` (sync, no await — it runs the
-  ``host.get_http_client().cookies`` read outside any auth lock).
+  ``host._kernel.get_http_client().cookies`` read outside any auth lock).
 * The ``_refresh_task`` slot is intentionally NOT cleared when a waiter is
   cancelled mid-shield — concurrency tests assert task identity across
   cancellation so siblings joined to the same single-flight refresh see the
@@ -48,8 +48,6 @@ import time
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
-import httpx
-
 from ._loop_affinity import assert_bound_loop
 from ._request_types import AuthSnapshot
 from ._session_config import CORE_LOGGER_NAME
@@ -57,6 +55,7 @@ from .auth import AuthTokens
 
 if TYPE_CHECKING:
     from ._client_metrics import ClientMetrics
+    from ._kernel import Kernel
 
 # Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
 # tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
@@ -67,18 +66,16 @@ logger = logging.getLogger(CORE_LOGGER_NAME)
 class _AuthRefreshHost(Protocol):
     """Structural host boundary required by :class:`AuthRefreshCoordinator`.
 
-    Mirrors the ``RefreshAuthCore`` shape in ``_auth/session.py`` so the
-    coordinator composes cleanly with B2's ``ClientLifecycle`` — both reach
-    the live ``httpx.AsyncClient`` via :meth:`get_http_client`, never via a
-    direct ``_http_client`` attribute access.
+    Mirrors the ``RefreshAuthCore`` shape in ``_auth/session.py``. Wave 11b
+    of session-decoupling (ADR-014) deleted the ``Session.get_http_client``
+    forward; the coordinator now reaches the live ``httpx.AsyncClient`` via
+    ``host._kernel.get_http_client()``, mirroring the ``RefreshAuthCore``
+    migration in ``_auth/session.py``.
     """
 
     auth: AuthTokens
     _metrics_obj: ClientMetrics
-
-    def get_http_client(self) -> httpx.AsyncClient:
-        """Return the live HTTP client (raises if not open)."""
-        ...
+    _kernel: Kernel
 
 
 class AuthRefreshCoordinator:
@@ -249,9 +246,9 @@ class AuthRefreshCoordinator:
 
         Raises:
             RuntimeError: If the host's HTTP client is not initialised (the
-                error originates from :meth:`host.get_http_client`).
+                error originates from :meth:`Kernel.get_http_client`).
         """
-        host.auth.cookie_jar = host.get_http_client().cookies
+        host.auth.cookie_jar = host._kernel.get_http_client().cookies
 
     # ------------------------------------------------------------------
     # Single-flight refresh task.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -313,11 +313,11 @@ class NotebookLMClient:
         )
         source_uploader = SourceUploadPipeline(
             upload_runtime,
-            self._session.kernel,
+            collaborators.kernel,
             self._session.auth,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
-            record_upload_queue_wait=self._session.record_upload_queue_wait,
+            record_upload_queue_wait=collaborators.metrics.record_upload_queue_wait,
         )
         # ADR-014 Rule 3 Stage A (Wave 7 of session-decoupling): simple
         # features take their RpcCaller dependency directly via
@@ -559,7 +559,7 @@ class NotebookLMClient:
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client."""
-        return self._session.metrics_snapshot()
+        return self._session.collaborators.metrics.snapshot()
 
     async def rpc_call(
         self,

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -329,17 +329,22 @@ class TestRPCCallAuthRetry:
 
 
 class TestGetHttpClient:
-    """Tests for get_http_client() RuntimeError when not initialized."""
+    """Tests for get_http_client() RuntimeError when not initialized.
+
+    Wave 11b of session-decoupling: the ``Session.get_http_client`` forward
+    was deleted; the canonical home is ``Kernel.get_http_client`` (reached
+    via ``core._kernel`` / ``client._session._kernel``).
+    """
 
     def test_get_http_client_raises_when_not_initialized(self, auth_tokens):
         core = Session(auth_tokens)
         with pytest.raises(RuntimeError, match="not initialized"):
-            core.get_http_client()
+            core._kernel.get_http_client()
 
     @pytest.mark.asyncio
     async def test_get_http_client_returns_client_when_initialized(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            http_client = client._session.get_http_client()
+            http_client = client._session._kernel.get_http_client()
             assert isinstance(http_client, httpx.AsyncClient)
 
 

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -34,6 +34,23 @@ def _auth(**overrides: object) -> AuthTokens:
     return AuthTokens(**values)
 
 
+class _RecordingKernel:
+    """Stub kernel exposing :meth:`get_http_client`.
+
+    Wave 11b of session-decoupling routes ``refresh_auth_session`` through
+    ``core._kernel.get_http_client()`` rather than the deleted
+    ``Session.get_http_client`` forward. Test cores satisfy the new
+    ``RefreshAuthCore`` Protocol by exposing a ``_kernel`` slot with the
+    same one-method shape.
+    """
+
+    def __init__(self, http_client: httpx.AsyncClient) -> None:
+        self._http_client = http_client
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        return self._http_client
+
+
 @dataclass
 class RecordingRefreshCore:
     auth: AuthTokens
@@ -41,8 +58,10 @@ class RecordingRefreshCore:
     operations: list[str] = field(default_factory=list)
     saved_jars: list[httpx.Cookies] = field(default_factory=list)
 
-    def get_http_client(self) -> httpx.AsyncClient:
-        return self.http_client
+    def __post_init__(self) -> None:
+        # Mirror the live ``Session._kernel`` slot — the Wave 11b Protocol
+        # change reaches the live HTTP client via ``core._kernel.get_http_client()``.
+        self._kernel = _RecordingKernel(self.http_client)
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
         self.operations.append("update_auth_tokens")

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -105,9 +105,9 @@ async def test_upload_start_uses_enterprise_url_and_headers(monkeypatch, httpx_m
             core,
             uploader=SourceUploadPipeline(
                 core,
-                core.kernel,
+                core._kernel,
                 core.auth,
-                record_upload_queue_wait=core.record_upload_queue_wait,
+                record_upload_queue_wait=core._metrics_obj.record_upload_queue_wait,
             ),
         )
         result = await api._start_resumable_upload(

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -88,7 +88,7 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
     assert seen_request_ids == ["batch-42"]
     assert get_request_id() is None
 
-    snapshot = core.metrics_snapshot()
+    snapshot = core._metrics_obj.snapshot()
     assert isinstance(snapshot, ClientMetricsSnapshot)
     assert snapshot.rpc_calls_started == 1
     assert snapshot.rpc_calls_succeeded == 1
@@ -300,9 +300,9 @@ async def test_upload_progress_callback_receives_byte_counts(
             core,
             uploader=SourceUploadPipeline(
                 core,
-                core.kernel,
+                core._kernel,
                 core.auth,
-                record_upload_queue_wait=core.record_upload_queue_wait,
+                record_upload_queue_wait=core._metrics_obj.record_upload_queue_wait,
             ),
         )
         test_file = tmp_path / "upload.txt"

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -15,7 +15,9 @@ Specifically pinned here:
 * ``update_auth_tokens`` writes ONLY ``host.auth.csrf_token`` and
   ``host.auth.session_id`` (does NOT touch the http client);
 * ``update_auth_headers`` syncs ``host.auth.cookie_jar`` from
-  ``host.get_http_client().cookies`` (the SEPARATE cookie-jar sync surface);
+  ``host._kernel.get_http_client().cookies`` (the SEPARATE cookie-jar sync
+  surface; Wave 11b of session-decoupling routes the live HTTP client through
+  the Kernel collaborator rather than a ``Session.get_http_client`` forward);
 * ``await_refresh`` cancellation propagation — a cancelled waiter unwinds
   locally without killing the shared refresh task, and the task slot is
   preserved across cancellation.
@@ -29,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -51,9 +54,13 @@ class _StubHost:
       writes ``csrf_token`` / ``session_id`` directly on it.
     * ``_metrics_obj`` is a real :class:`ClientMetrics` — the coordinator's
       :meth:`record_lock_wait` calls land on it.
-    * :meth:`get_http_client` returns an ``httpx.AsyncClient`` whose cookie
-      jar :meth:`update_auth_headers` reads. The client's lifecycle is
-      owned by the test fixture (`http_host`), not by the stub.
+    * ``_kernel`` exposes a ``get_http_client()`` method that returns an
+      ``httpx.AsyncClient`` whose cookie jar :meth:`update_auth_headers`
+      reads. The client's lifecycle is owned by the test fixture
+      (`http_host`), not by the stub. Wave 11b of session-decoupling moved
+      the live-HTTP-client read off ``Session.get_http_client`` and onto
+      ``host._kernel.get_http_client()`` to match the canonical
+      :class:`Kernel` ownership.
     """
 
     def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
@@ -64,6 +71,7 @@ class _StubHost:
         )
         self._metrics_obj = ClientMetrics(on_rpc_event=None)
         self.http_client = http_client
+        self._kernel = SimpleNamespace(get_http_client=self.get_http_client)
 
     def get_http_client(self) -> httpx.AsyncClient:
         assert self.http_client is not None, "Test forgot to wire an http client."

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -54,13 +53,13 @@ class _StubHost:
       writes ``csrf_token`` / ``session_id`` directly on it.
     * ``_metrics_obj`` is a real :class:`ClientMetrics` — the coordinator's
       :meth:`record_lock_wait` calls land on it.
-    * ``_kernel`` exposes a ``get_http_client()`` method that returns an
-      ``httpx.AsyncClient`` whose cookie jar :meth:`update_auth_headers`
-      reads. The client's lifecycle is owned by the test fixture
-      (`http_host`), not by the stub. Wave 11b of session-decoupling moved
-      the live-HTTP-client read off ``Session.get_http_client`` and onto
-      ``host._kernel.get_http_client()`` to match the canonical
-      :class:`Kernel` ownership.
+    * ``_kernel`` aliases ``self`` so ``host._kernel.get_http_client()``
+      resolves to the stub's own :meth:`get_http_client`. Wave 11b of
+      session-decoupling moved the live-HTTP-client read off
+      ``Session.get_http_client`` and onto ``host._kernel.get_http_client()``
+      to match the canonical :class:`Kernel` ownership; the stub is its
+      own kernel-shaped collaborator because it already exposes the
+      one-method surface the Protocol requires.
     """
 
     def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
@@ -71,7 +70,7 @@ class _StubHost:
         )
         self._metrics_obj = ClientMetrics(on_rpc_event=None)
         self.http_client = http_client
-        self._kernel = SimpleNamespace(get_http_client=self.get_http_client)
+        self._kernel = self
 
     def get_http_client(self) -> httpx.AsyncClient:
         assert self.http_client is not None, "Test forgot to wire an http client."

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -166,13 +166,16 @@ def test_session_retains_adr_014_rule_4_middleware_chain_seams() -> None:
       ``refresh_callable=host._await_refresh``.
     - ``_perform_authed_post`` — direct callers in ``_chat_transport`` and
       external client code reach it here; live middleware-chain seam.
-    - ``_increment_metrics`` — provider-closure capture target.
-    - ``_kernel`` — Session owns the transport core.
+    - ``_kernel`` — Session owns the transport core (instance attribute).
+
+    Wave 11b of session-decoupling deleted the ``_increment_metrics`` /
+    ``metrics_snapshot`` / ``_emit_rpc_event`` / ``record_upload_queue_wait``
+    forwards; live capture sites read ``ClientMetrics`` directly via
+    ``session.collaborators.metrics`` per ADR-014 Rule 3.
     """
     for name in (
         "_await_refresh",
         "_perform_authed_post",
-        "_increment_metrics",
     ):
         assert hasattr(Session, name), f"Session missing Rule-4 retained member: {name}"
         assert callable(getattr(Session, name)), f"Session.{name} not callable"


### PR DESCRIPTION
## Summary

Wave 11b of the [session-decoupling plan](../blob/main/docs/session-decoupling-plan-2026-05-26.md) (Phase 3, Task 5.2 cluster 2 of 3). Deletes the second cluster of `Session` compatibility forwards — the metrics, kernel, and auth-metadata cluster — and migrates every in-tree caller to the canonical collaborator surface. Builds on Wave 11a (#1076).

## Methods removed from `Session`

- **`ClientMetrics` forwards**: `metrics_snapshot`, `_increment_metrics`, `_emit_rpc_event`, `record_upload_queue_wait`
- **`Kernel` forwards**: `kernel` property, `live_cookies`, `get_http_client`
- **AuthMetadata forwards**: `authuser` / `account_email` properties, `authuser_query`, `authuser_header`

`update_auth_tokens` is intentionally retained — the only `Session` mutator left, pinned by the AST guard at `tests/unit/test_concurrency_refresh_race.py:386` and required by the `RefreshAuthCore` Protocol.

## Protocol migration for `get_http_client`

`RefreshAuthCore` (in `_auth/session.py`) and `_AuthRefreshHost` (in `_session_auth.py`) previously required a `get_http_client()` method on the host. Removing the `Session.get_http_client` forward without breaking those structural Protocols required migrating both Protocols to require a `_kernel: Kernel` slot instead, with the two callsites reading `core._kernel.get_http_client()` / `host._kernel.get_http_client()`. `Session._kernel` is already an instance attribute, so live sessions satisfy the new shape without further changes.

## Commits (three, for revertability)

1. `37b16a79` — `refactor(session): delete metrics/kernel/authuser forward cluster (Wave 11b / step 1)` — source-side deletions + Protocol migration + production-caller migrations in `client.py` / `_auth/session.py` / `_session_auth.py`.
2. `7d0ca314` — `test: migrate metrics/kernel/auth test sites off Session forwards (Wave 11b / step 2)` — in-tree test migrations: `test_observability.py`, `test_env_base_url.py`, `test_session_integration.py`, `test_auth_session.py`, `test_session_auth.py`, `test_session_compat_delegates.py`.
3. `bd7fde47` — `docs(session): mark metrics/kernel/auth forwards Deleted in retention.md (Wave 11b / step 3)` — append the 11 deleted rows to a new `Wave 11b — metrics-and-kernel cluster` section under the existing Wave 11a section.

## Dependency on Wave 11a

Wave 11a (#1076, merged in commit `0f3efda0`) deleted the drain/operation cluster from the same `Session` class and added the `Wave 11a — drain-and-operation cluster` section to the retention doc. Wave 11b was cut from `origin/main` HEAD and rebased onto the post-11a tip; my Wave 11b retention rows are appended in a new section directly after Wave 11a's.

## Test plan

- [x] `uv run pytest tests/_lint -v` — 71 passed (retention lint + session-compat-bridges lint + monkeypatch lint all green)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm` — clean (173 files)
- [x] `uv run pytest tests/unit tests/_lint -x -q` — 5827 passed, 49 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session internals refactored to decouple authentication and HTTP client access, streamline collaborator/transport wiring, remove legacy compatibility helpers, and make RPC forwarding explicit.
* **Documentation**
  * Session method inventory updated; deprecated entries moved into a “Deleted” section for Wave 11b with clarifying notes.
* **Tests**
  * Tests updated to follow the new auth/HTTP client and metrics wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->