### PR TITLE
refactor(session): delete transport/reqid forward cluster + tighten retention lint (Wave 11c / Task 5.2 cluster 3)

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -8,11 +8,15 @@ AST-parses `_session.py`, enumerates every method/property on the `Session`
 class, and asserts each one appears in the inventory below with a valid
 disposition. Adding a new method without a row here fails the lint at PR time.
 
-**Status:** Wave 10 of the [session-decoupling plan](session-decoupling-plan-2026-05-26.md)
-(Phase 3, Task 5.1). Wave 11 (sub-waves 11a–11c) will delete the
-`delete in Wave 11` rows in three clusters and move them to the **Deleted**
-section at the bottom of this file. Wave 11c also tightens the lint to
-forbid any `delete in Wave 11` rows once the cluster deletions land.
+**Status:** Wave 11 of the [session-decoupling plan](session-decoupling-plan-2026-05-26.md)
+(Phase 3, Task 5.2) is complete. The three sub-wave PRs (11a, 11b, 11c)
+deleted every `delete in Wave 11` row and moved the entries to the
+**Deleted** section at the bottom of this file. Wave 11c also tightened
+the [`tests/_lint/test_session_retention.py`](../tests/_lint/test_session_retention.py)
+lint to assert the **retain-only invariant**: every method on `Session`
+must carry a `retain — <reason>` disposition. No method may be tagged
+`delete in Wave 11` (the cluster deletions have all landed; the
+transitional disposition is gone from the recognised set).
 
 ## Categories
 
@@ -26,14 +30,22 @@ forbid any `delete in Wave 11` rows once the cluster deletions land.
 | `Stage A accessor` | Typed accessor added in Wave 6 so `NotebookLMClient.__init__` can wire features against collaborators (ADR-014 Rule 3 Stage A). Deleted under Rule 3 Stage B (Wave 7 follow-up). |
 | `lazy collaborator factory` | Real factory body (not a forward) backing a Stage A accessor or a public-API forward. |
 | `RefreshAuthCore Protocol surface` | Method required by the `RefreshAuthCore` Protocol in [`src/notebooklm/_auth/session.py`](../src/notebooklm/_auth/session.py); `refresh_auth_session(core)` calls it on the Session passed as `core`. |
-| `compatibility forward` | One-line forward to a collaborator method; kept only because in-tree callers (mostly tests) reach it via `Session`. Wave 11 deletes these and migrates callers to the owning collaborator. |
+| `compatibility forward` | One-line forward to a collaborator method; kept only because in-tree callers (mostly tests) reached it via `Session`. Wave 11 (sub-waves 11a, 11b, 11c) deleted every compatibility forward; no row in the live inventory now carries this category. The label is retained in this glossary for the **Deleted** section below and as the disposition lint's vocabulary for any future short-lived forward. |
 
 ## Dispositions
 
 | Disposition | Meaning |
 |---|---|
-| `retain — <reason>` | Stays on `Session` after Wave 11. |
-| `delete in Wave 11 (<cluster>)` | Scheduled for deletion in one of the three Wave 11 sub-wave PRs. Cluster names match [phase-3.md](../.sisyphus/phases/session-decoupling/phase-3.md): `drain-and-operation` (11a), `metrics-and-kernel` (11b), `transport-and-reqid` (11c). |
+| `retain — <reason>` | Stays on `Session` after Wave 11. **The only valid disposition** after Wave 11c tightened the lint. |
+
+The transitional `delete in Wave 11 (<cluster>)` disposition was used in
+Wave 10 to schedule the three sub-wave cluster deletions
+(`drain-and-operation` = 11a, `metrics-and-kernel` = 11b,
+`transport-and-reqid` = 11c). All three cluster PRs landed; the
+disposition is gone from the recognised set, and any new row that
+tries to use it fails the
+[`tests/_lint/test_session_retention.py`](../tests/_lint/test_session_retention.py)
+lint at PR time.
 
 ## Inventory
 
@@ -55,12 +67,6 @@ forbid any `delete in Wave 11` rows once the cluster deletions land.
 | `rpc_executor` (property) | Stage A accessor | retain — Stage A accessor; exposes lazy `RpcExecutor` not present on `SessionCollaborators` |
 | `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_tokens(...)` from [`_auth/session.py`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
 | `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core)` calls `core.update_auth_headers()` from [`_auth/session.py`](../src/notebooklm/_auth/session.py) |
-| `next_reqid` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ReqidCounter.next_reqid` |
-| `bound_loop` (property) | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ClientLifecycle.get_bound_loop` with defensive `isinstance` |
-| `_refresh_request_for_current_auth` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `SessionTransport.refresh_request_for_current_auth`; the AST guard at `tests/unit/test_concurrency_refresh_race.py:222` already inspects `SessionTransport.refresh_request_for_current_auth` directly, so no guard migration needed |
-| `_perform_authed_post` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `SessionTransport.perform_authed_post`; production callers (`_chat_transport`) already call `SessionTransport.perform_authed_post` directly. Verify no surviving production caller via `rg "session\._perform_authed_post\(\|core\._perform_authed_post\(\|host\._perform_authed_post\b" src/notebooklm` before deleting. Test callers in `tests/unit/test_authed_post_pipeline.py` migrate to `session.session_transport.perform_authed_post` or `make_fake_core` |
-| `transport_post` | compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `_perform_authed_post`; no production callers (`rg "\.transport_post\(" src/ tests/` returns 0) |
-| `save_cookies` | RefreshAuthCore Protocol surface / compatibility forward | delete in Wave 11 (`transport-and-reqid`) — forward to `ClientLifecycle.save_cookies`; the `RefreshAuthCore` Protocol still references `save_cookies`, so Wave 11c MUST first migrate the Protocol (or `refresh_auth_session(core)`) to call `core.collaborators.lifecycle.save_cookies(core, jar, path)` before the Session forward can be removed |
 
 ## Stage-A and Rule-4 attribute capture targets (context, not lint-enumerated)
 
@@ -95,8 +101,13 @@ land.
 
 ## Deleted
 
-Wave 11 sub-wave PRs append entries here (preserving the deleting PR's SHA in
-the section sub-header) as the `delete in Wave 11` rows above are dropped.
+The three Wave 11 sub-wave PRs (11a, 11b, 11c) each appended a
+cluster-keyed section here, preserving the deleting commit's SHA in
+the sub-header. This section is the historical record of every
+compatibility forward that once lived on `Session`; the lint above
+enforces that no Session method exists today without either a
+`retain — <reason>` row in the **Inventory** above or a `deleted in
+Wave 11<sub>` row in one of the cluster sub-sections below.
 
 ### Wave 11a — drain-and-operation cluster (commit `80a54fda`)
 
@@ -121,3 +132,14 @@ the section sub-header) as the `delete in Wave 11` rows above are dropped.
 | `authuser_query` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `notebooklm._auth.account.authuser_query`. Callers import the helper directly. |
 | `authuser_header` | compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `notebooklm._auth.account.format_authuser_value`. Callers import the helper directly. |
 | `get_http_client` | RefreshAuthCore Protocol surface / compatibility forward | deleted in Wave 11b (commit `37b16a79`) — was a forward to `Kernel.get_http_client`. The `RefreshAuthCore` and `_AuthRefreshHost` Protocols were migrated in the same commit to require a `_kernel: Kernel` slot instead of `get_http_client`; the two call sites in `_auth/session.py` and `_session_auth.py` now read `core._kernel.get_http_client()` / `host._kernel.get_http_client()`. `Session._kernel` is already an instance attribute (assigned from `collaborators.kernel` in `__init__`), so live `Session` instances satisfy the new Protocol shape without further changes. |
+
+### Wave 11c — transport-and-reqid cluster (commit `579c7a35`)
+
+| Method | Category | Disposition |
+|---|---|---|
+| `next_reqid` | compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a forward to `ReqidCounter.next_reqid`. Callers reach the counter directly (`core._reqid.next_reqid(...)` in tests; production code in `ChatAPI.ask` already uses `self._reqid.next_reqid(...)` since Wave 8). |
+| `bound_loop` (property) | compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a forward to `ClientLifecycle.get_bound_loop` with a defensive `isinstance`. Tests now call `core._lifecycle.get_bound_loop()` directly; the `isinstance` guard is unnecessary because the canonical accessor on `ClientLifecycle` already returns `asyncio.AbstractEventLoop \| None`. |
+| `_refresh_request_for_current_auth` | compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a forward to `SessionTransport.refresh_request_for_current_auth`. The AST guard at `tests/unit/test_concurrency_refresh_race.py:222` already inspects `SessionTransport.refresh_request_for_current_auth` directly, so no guard migration was needed. |
+| `_perform_authed_post` | compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a forward to `SessionTransport.perform_authed_post`. Production callers (`_chat_transport`, `RpcExecutor`) already call `SessionTransport.perform_authed_post` directly; test callers in `tests/unit/test_authed_post_pipeline.py` / `test_chain_wiring.py` / `test_session_lifecycle.py` / `test_rate_limit_default.py` migrated to `core._transport.perform_authed_post(...)`. The keyword-only signature contract is now pinned on the canonical collaborator method via `test_chain_wiring.test_perform_authed_post_signature_unchanged`. |
+| `transport_post` | compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a `parse_label`-renaming forward over `_perform_authed_post` retained for the Tier-13 chat contract. The chat path moved to `SessionTransport.perform_authed_post` directly in Wave 8; no production or test callers remained at deletion time. |
+| `save_cookies` | RefreshAuthCore Protocol surface / compatibility forward | deleted in Wave 11c (commit `579c7a35`) — was a forward to `ClientLifecycle.save_cookies`. The `RefreshAuthCore` Protocol in `_auth/session.py` was narrowed in the same commit: the `save_cookies` method requirement was dropped and replaced with a `collaborators: SessionCollaborators` accessor; `refresh_auth_session(core)` now persists rotated cookies through `core.collaborators.lifecycle.save_cookies(core, jar)` (the canonical chokepoint that already serialises with keepalive and close saves). The Session host argument is widened to `_LifecycleHost` via `typing.cast` — the production `Session` satisfies both `RefreshAuthCore` and `_LifecycleHost` structurally; the cast is the typing-level acknowledgement that `RefreshAuthCore` deliberately stays narrow. Test callers in `tests/unit/test_auth_cookie_save_race.py` / `test_save_lock_contract.py` / `test_client_keepalive.py` / `test_cookie_persistence.py` migrated to `core._lifecycle.save_cookies(core, jar)`. |

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
-
-import httpx
+from typing import TYPE_CHECKING, Protocol, cast
 
 from .._env import get_base_url
 from .._url_utils import is_google_auth_redirect
@@ -17,6 +14,8 @@ from .tokens import AuthTokens
 
 if TYPE_CHECKING:
     from .._kernel import Kernel
+    from .._session_init import SessionCollaborators
+    from .._session_lifecycle import _LifecycleHost
 
 
 class RefreshAuthCore(Protocol):
@@ -28,6 +27,13 @@ class RefreshAuthCore(Protocol):
     prefixed ``_kernel`` slot mirrors the live ``Session._kernel``
     attribute so structural conformance does not require renaming the
     Session slot.
+
+    Wave 11c of session-decoupling: the ``save_cookies`` forward on
+    ``Session`` was also deleted — :func:`refresh_auth_session` now
+    reaches the cookie persistence chokepoint through
+    ``core.collaborators.lifecycle`` directly
+    (``ClientLifecycle.save_cookies``), which is the canonical home
+    identified by ADR-014.
     """
 
     auth: AuthTokens
@@ -41,8 +47,9 @@ class RefreshAuthCore(Protocol):
         """Refresh auth-dependent HTTP state after token mutation."""
         ...
 
-    def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> Awaitable[None]:
-        """Persist refreshed cookies."""
+    @property
+    def collaborators(self) -> SessionCollaborators:
+        """Access the constructed collaborator bundle (Stage A accessor)."""
         ...
 
 
@@ -74,8 +81,18 @@ async def refresh_auth_session(core: RefreshAuthCore) -> AuthTokens:
     # observe a torn token pair while refresh is in flight.
     await core.update_auth_tokens(csrf or "", sid or "")
     core.update_auth_headers()
-    # Persist through Session.save_cookies so refresh serializes with
-    # keepalive and close saves.
-    await core.save_cookies(http_client.cookies)
+    # Persist through ClientLifecycle.save_cookies so refresh serializes
+    # with keepalive and close saves. The ``Session.save_cookies`` forward
+    # was deleted in Wave 11c of session-decoupling; callers now reach the
+    # lifecycle collaborator directly. The ``cast`` widens the
+    # ``RefreshAuthCore`` shape to the lifecycle's ``_LifecycleHost`` shape —
+    # ``Session`` (the only production caller) satisfies both Protocols
+    # structurally; the cast is a typing-level acknowledgement that
+    # ``RefreshAuthCore`` deliberately stays narrow (it doesn't pull in
+    # the lifecycle host's metrics / drain / reqid / auth-coord fields
+    # because none of those are read by ``refresh_auth_session``).
+    await core.collaborators.lifecycle.save_cookies(
+        cast("_LifecycleHost", core), http_client.cookies
+    )
 
     return core.auth

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -15,8 +15,6 @@ from ._middleware import (
     RpcRequest,
     RpcResponse,
 )
-from ._reqid_counter import DEFAULT_STEP as _REQID_DEFAULT_STEP
-from ._request_types import BuildRequest
 from ._rpc_executor import RpcExecutor
 from ._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
@@ -216,7 +214,7 @@ class Session:
                 ``httpx.AsyncClient`` (Scotty endpoint) and don't share
                 the RPC pool.
             max_concurrent_rpcs: Ceiling on simultaneous in-flight
-                ``_perform_authed_post`` RPC POSTs. Defaults to
+                ``SessionTransport.perform_authed_post`` RPC POSTs. Defaults to
                 ``DEFAULT_MAX_CONCURRENT_RPCS`` (16) — well below the
                 default httpx pool size (``max_connections=100``) so
                 short-lived helper requests (refresh GETs, upload
@@ -371,12 +369,12 @@ class Session:
         self.cookie_persistence = collaborators.cookie_persistence
         self.poll_registry = collaborators.poll_registry
         # ``_drain_hooks`` storage moved to ``TransportDrainTracker`` in
-        # Wave 2 of the session-decoupling plan (ADR-014 Rule 1).
-        # ``Session.register_drain_hook`` is now a one-line forward.
+        # Wave 2 of the session-decoupling plan (ADR-014 Rule 1);
+        # ``Session.register_drain_hook`` was deleted in Wave 11a.
         self._rpc_executor: RpcExecutor | None = None
 
         # The authed POST hot path (chain terminal, freshness rebuild,
-        # and ``_perform_authed_post`` entry) lives on
+        # and ``perform_authed_post`` entry) lives on
         # :class:`SessionTransport` (move #4c — ``docs/improvement.md``
         # §3.1). Build the transport BEFORE :func:`wire_middleware_chain`
         # so the chain leaf can route through :class:`Session`; the
@@ -411,17 +409,6 @@ class Session:
         self._chain_builder = wired.chain_builder
         self._middlewares = wired.middlewares
         self._authed_post_chain = wired.authed_post_chain
-
-    async def next_reqid(self, step: int = _REQID_DEFAULT_STEP) -> int:
-        """Atomically increment the request-id counter and return the new value.
-
-        Thin facade over :meth:`ReqidCounter.next_reqid`. The default ``step``
-        is sourced from :data:`notebooklm._reqid_counter.DEFAULT_STEP` so the
-        facade and the underlying helper cannot silently drift apart; see
-        :class:`notebooklm._reqid_counter.ReqidCounter` for the full contract,
-        validation rules, and lazy-lock semantics.
-        """
-        return await self._reqid.next_reqid(step)
 
     # ------------------------------------------------------------------
     # ADR-014 Rule 3 Stage A accessors (Wave 6 of session-decoupling)
@@ -465,23 +452,6 @@ class Session:
         """
         return self._get_rpc_executor()
 
-    @property
-    def bound_loop(self) -> asyncio.AbstractEventLoop | None:
-        """Return the open-time captured event loop for affinity checks.
-
-        Defensive ``isinstance`` so a ``MagicMock``-shaped fixture whose
-        ``_lifecycle`` auto-vivifies into a mock doesn't synthesize a fake
-        loop object that the affinity helper would otherwise treat as a
-        real (mismatched) loop. Returns ``None`` when the underlying core
-        has no lifecycle or has not been opened; the affinity helper
-        treats ``None`` as a silent no-op.
-        """
-        lifecycle = getattr(self, "_lifecycle", None)
-        if lifecycle is None:
-            return None
-        loop = lifecycle.get_bound_loop()
-        return loop if isinstance(loop, asyncio.AbstractEventLoop) else None
-
     def assert_bound_loop(self) -> None:
         """Raise if this core is used from a loop other than its open-time loop.
 
@@ -496,9 +466,9 @@ class Session:
 
         When ``max_concurrent_rpcs`` was set to ``None`` at construction
         time, this returns a :class:`contextlib.nullcontext` so the
-        ``async with`` wrapper in :meth:`_perform_authed_post` collapses
-        to a no-op (callers with their own external rate-limiter opted
-        out of the gate). Otherwise it lazily constructs an
+        ``async with`` wrapper inside the chain's ``SemaphoreMiddleware``
+        collapses to a no-op (callers with their own external rate-limiter
+        opted out of the gate). Otherwise it lazily constructs an
         ``asyncio.Semaphore`` bound to the running loop on first use,
         mirroring the lazy-init pattern of :attr:`_reqid_lock` /
         :attr:`_auth_snapshot_lock`.
@@ -566,21 +536,6 @@ class Session:
         """
         await self._lifecycle.open(self)
 
-    async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
-        """Persist a cookie jar through the shared cookie-persistence collaborator.
-
-        Thin facade over :meth:`ClientLifecycle.save_cookies`. The storage
-        writer resolves through ``self._lifecycle._cookie_saver`` — by
-        default the ``_default_cookie_saver`` wrapper that late-binds to
-        ``notebooklm._auth.storage.save_cookies_to_storage`` so a
-        ``monkeypatch.setattr("notebooklm._auth.storage.save_cookies_to_storage", …)``
-        on the canonical seam keeps affecting the live save path. Phase 2
-        PR 4 added the ``cookie_saver=`` constructor kwarg as the
-        preferred test-side seam; passing a custom callable there bypasses
-        the late-bind hop entirely.
-        """
-        await self._lifecycle.save_cookies(self, jar, path)
-
     async def close(self) -> None:
         """Close the HTTP client connection.
 
@@ -590,7 +545,7 @@ class Session:
         1. Cancels and joins the keepalive task (so the loop can't issue a
            poke against an already-closed transport).
         2. Runs registered feature drain hooks.
-        3. Saves cookies one last time through ``save_cookies``.
+        3. Saves cookies one last time through ``ClientLifecycle.save_cookies``.
         4. Calls ``aclose()`` under :func:`asyncio.shield` so cancellation
            arriving mid-close cannot leak the underlying httpx transport.
         5. Nulls out ``_kernel._http_client`` and ``_rpc_executor`` so a
@@ -645,13 +600,6 @@ class Session:
         """
         await self._auth_coord.update_auth_tokens(self, csrf, session_id)
 
-    async def _refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
-        """Forward to :meth:`SessionTransport.refresh_request_for_current_auth`
-        (body moved in move #4c — ``docs/improvement.md`` §3.1; AST guard
-        now inspects the collaborator method directly).
-        """
-        return await self._transport.refresh_request_for_current_auth(request)
-
     async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
         """Middleware chain leaf — forwards to :meth:`SessionTransport.terminal`.
 
@@ -669,48 +617,6 @@ class Session:
         forward carries no try/await structure.
         """
         return await self._transport.terminal(request)
-
-    async def _perform_authed_post(
-        self,
-        *,
-        build_request: BuildRequest,
-        log_label: str,
-        disable_internal_retries: bool = False,
-        rpc_method: str | None = None,
-    ) -> httpx.Response:
-        """Forward to :meth:`SessionTransport.perform_authed_post` (body
-        moved in move #4c — ``docs/improvement.md`` §3.1). Retained on
-        :class:`Session` per ADR-014 Rule 4 as a load-bearing middleware-chain
-        seam: ``_chat_transport`` and ``client._session._perform_authed_post(...)``
-        direct callers still reach it here. ``RpcExecutor`` no longer calls
-        this method (Wave 4 of session-decoupling: the executor takes
-        :class:`SessionTransport` directly and calls
-        ``self._transport.perform_authed_post`` without going through Session).
-        ``_chat_transport`` and ``client._session._perform_authed_post(...)``
-        direct callers keep the same keyword-only signature.
-        """
-        return await self._transport.perform_authed_post(
-            build_request=build_request,
-            log_label=log_label,
-            disable_internal_retries=disable_internal_retries,
-            rpc_method=rpc_method,
-        )
-
-    async def transport_post(
-        self,
-        build_request: BuildRequest,
-        parse_label: str,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> httpx.Response:
-        """Session transport facade required by the Tier-13 contract."""
-        # ``Session`` exposes ``parse_label`` for the later feature retype; the
-        # chain context still names that value ``log_label``.
-        return await self._perform_authed_post(
-            build_request=build_request,
-            log_label=parse_label,
-            disable_internal_retries=disable_internal_retries,
-        )
 
     async def _await_refresh(self) -> None:
         """Run / join the shared refresh task.

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -30,7 +30,6 @@ Forbidden patterns
    .. code-block:: python
 
        core.rpc_call = AsyncMock(return_value=None)
-       client._core._perform_authed_post = AsyncMock()
 
 Allowlist
 ---------
@@ -106,9 +105,12 @@ _PATTERN_OBJECT_ATTR = re.compile(r"monkeypatch\.setattr\(\s*notebooklm\.")
 # matches; with it, each occurrence is reported once with the natural
 # start position.
 _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
-    r"(?<![\w.])[\w.]+\."
-    r"(rpc_call|_perform_authed_post|_begin_transport_post|_begin_transport_task|_finish_transport_post)"
-    r"\s*=\s*(?:[\w]+\.)*AsyncMock"
+    # Wave 11c of session-decoupling deleted ``Session._perform_authed_post``
+    # along with the ``_begin_transport_*`` / ``_finish_transport_*`` legacy
+    # names — once a method no longer exists on ``Session``, attempting to
+    # patch it with ``AsyncMock`` would surface immediately at runtime as an
+    # ``AttributeError``, so the lint pattern stops enumerating them.
+    r"(?<![\w.])[\w.]+\.(rpc_call)\s*=\s*(?:[\w]+\.)*AsyncMock"
 )
 
 _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -50,9 +50,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # properties are gone so tests cannot quietly reintroduce those reach-ins.
 FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
     {
-        # ClientLifecycle bridges retired in session-shrink PR 6 — readers now
-        # go straight to ``session._kernel`` / ``session._lifecycle`` or use
-        # the public ``session.bound_loop`` property. Lifecycle bridge names
+        # ClientLifecycle bridges retired in session-shrink PR 6 — readers
+        # now go straight to ``session._kernel`` / ``session._lifecycle``
+        # and call ``session._lifecycle.get_bound_loop()`` for the open-time
+        # loop (the ``session.bound_loop`` property forward was deleted in
+        # Wave 11c of session-decoupling). Lifecycle bridge names
         # (``_http_client``, ``_bound_loop``, ``_timeout``, ``_connect_timeout``,
         # ``_limits``, ``_keepalive_interval``, ``_keepalive_task``) are
         # intentionally NOT listed below: ``Session`` no longer defines them,

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -21,9 +21,13 @@ and :mod:`tests._lint.test_no_core_imports`):
   ``| `method_name` | category | disposition |``. Method names appear
   inside the first backtick-pair of column one; the entire backtick token
   may also carry a ``(property)`` suffix (e.g. ``kernel`` (property)).
-* Valid dispositions are either ``retain — <reason>`` or
-  ``delete in Wave 11 (<cluster>)``. Wave 11c will tighten the lint to
-  reject the latter once the cluster-deletion PRs land.
+* The only valid disposition is ``retain — <reason>``. Wave 11c tightened
+  the lint to its **final form** when the three sub-wave cluster
+  deletions (11a + 11b + 11c) had all landed: the transitional
+  ``delete in Wave 11 (<cluster>)`` disposition that Wave 10 introduced
+  to schedule the cluster deletions is no longer accepted; the rows
+  that carried it moved to the **Deleted** section at the bottom of
+  the retention doc (which the parser scopes out).
 
 The lint enumerates methods only — not instance attributes like
 ``Session._rate_limit_max_retries`` (those are assigned in ``__init__`` and
@@ -46,11 +50,19 @@ RETENTION_DOC: Path = REPO_ROOT / "docs" / "session-method-retention.md"
 
 SESSION_CLASS_NAME: str = "Session"
 
-# Disposition prefixes that the retention doc may use. Wave 11c tightens this
-# to ``{"retain"}`` after the cluster-deletion PRs land.
+# Disposition prefixes that the retention doc may use. Wave 11c tightened
+# this to ``{"retain"}`` after the three sub-wave cluster-deletion PRs
+# (11a, 11b, 11c) had all landed; the transitional ``delete in Wave 11``
+# prefix that Wave 10 introduced to schedule the cluster deletions is
+# no longer accepted (any row that still carries it is doc drift and
+# must be moved to the **Deleted** section at the bottom of the
+# retention doc, which the parser scopes out).
 _RETAIN_PREFIX: str = "retain"
-_DELETE_PREFIX: str = "delete in Wave 11"
-VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX, _DELETE_PREFIX)
+VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX,)
+# Recognised but **rejected** prefix — kept as a named constant so the
+# self-coverage tests below can pin "Wave 11c rejects this" without
+# accidentally widening the live ``VALID_DISPOSITION_PREFIXES`` tuple.
+_RETIRED_DELETE_PREFIX: str = "delete in Wave 11"
 
 
 def _enumerate_session_methods(source: str) -> list[str]:
@@ -138,10 +150,12 @@ def _parse_retention_doc(text: str) -> dict[str, str]:
 def _disposition_is_valid(disposition: str) -> bool:
     """Return ``True`` iff ``disposition`` starts with a valid prefix.
 
-    The retain branch must carry a reason (em-dash + text); the delete branch
-    must carry a cluster name in parentheses. Wave 10's contract checks the
-    prefix; Wave 11c will tighten to assert the cluster name matches the
-    known set and that retain reasons reference a load-bearing seam.
+    After Wave 11c the retain branch is the only accepted shape — every
+    row in the live Inventory must read ``retain — <reason>``. The
+    transitional ``delete in Wave 11 (<cluster>)`` form that Wave 10
+    introduced is now rejected; any row that still carries it is doc
+    drift and must be moved to the **Deleted** section at the bottom
+    of the retention doc (which the inventory parser scopes out).
     """
     return disposition.startswith(VALID_DISPOSITION_PREFIXES)
 
@@ -213,16 +227,23 @@ def test_parse_retention_doc_extracts_known_rows() -> None:
 
 
 def test_parse_retention_doc_handles_property_suffix() -> None:
-    """The ``(property)`` suffix outside backticks must not block the row match."""
+    """The ``(property)`` suffix outside backticks must not block the row match.
+
+    Uses a ``retain`` disposition (the only one the live lint accepts after
+    Wave 11c). The parser is opaque to disposition contents — it only
+    captures the first-cell method name — but the sample chosen here
+    matches the post-Wave-11 vocabulary so a future reader doesn't
+    mistake it for live ``delete in Wave 11`` usage.
+    """
     text = (
         "## Inventory\n"
         "\n"
         "| Method | Category | Disposition |\n"
         "|---|---|---|\n"
-        "| `kernel` (property) | compatibility forward | delete in Wave 11 (`metrics-and-kernel`) |\n"
+        "| `kernel` (property) | Stage A accessor | retain — Stage A accessor |\n"
     )
     rows = _parse_retention_doc(text)
-    assert rows == {"kernel": "delete in Wave 11 (`metrics-and-kernel`)"}
+    assert rows == {"kernel": "retain — Stage A accessor"}
 
 
 def test_parse_retention_doc_skips_glossary_tables() -> None:
@@ -254,8 +275,22 @@ def test_parse_retention_doc_skips_glossary_tables() -> None:
 
 
 def test_disposition_validator_accepts_known_shapes() -> None:
+    """``retain — <reason>`` is the only accepted shape after Wave 11c."""
     assert _disposition_is_valid("retain — lifecycle")
-    assert _disposition_is_valid("delete in Wave 11 (`drain-and-operation`)")
+    assert _disposition_is_valid("retain — Stage A accessor")
+
+
+def test_disposition_validator_rejects_retired_delete_prefix() -> None:
+    """Wave 11c retired ``delete in Wave 11 (<cluster>)`` — the lint must reject it.
+
+    Pins the **final-form** invariant: any row that still carries the
+    transitional Wave-10 disposition is doc drift left over from before
+    the three cluster-deletion PRs (11a, 11b, 11c) landed, and must be
+    moved to the **Deleted** section at the bottom of the retention doc.
+    """
+    assert not _disposition_is_valid(f"{_RETIRED_DELETE_PREFIX} (`drain-and-operation`)")
+    assert not _disposition_is_valid(f"{_RETIRED_DELETE_PREFIX} (`metrics-and-kernel`)")
+    assert not _disposition_is_valid(f"{_RETIRED_DELETE_PREFIX} (`transport-and-reqid`)")
 
 
 def test_disposition_validator_rejects_unknown_prefix() -> None:
@@ -287,17 +322,25 @@ def test_every_session_method_appears_in_retention_doc(
 
 
 def test_every_listed_disposition_is_valid(retention_rows: dict[str, str]) -> None:
-    """Every row's disposition must start with a recognised prefix."""
+    """Every row's disposition must start with a recognised prefix.
+
+    After Wave 11c the only accepted prefix is ``retain``. Rows that
+    still carry the transitional Wave-10 ``delete in Wave 11 (<cluster>)``
+    disposition are doc drift and must be moved to the **Deleted**
+    section at the bottom of the retention doc (which the parser scopes
+    out, so a properly-located row does not surface here).
+    """
     invalid = {
         name: disposition
         for name, disposition in retention_rows.items()
         if not _disposition_is_valid(disposition)
     }
     assert not invalid, (
-        "These rows in "
-        f"{RETENTION_DOC.relative_to(REPO_ROOT)} carry an unrecognised "
-        f"disposition. Use `retain — <reason>` or `delete in Wave 11 "
-        f"(<cluster>)`. Offenders:\n"
+        f"These rows in {RETENTION_DOC.relative_to(REPO_ROOT)} carry an "
+        f"unrecognised disposition. Use `retain — <reason>`; the "
+        f"transitional `delete in Wave 11 (<cluster>)` disposition was "
+        f"retired by Wave 11c — move the row to the **Deleted** section "
+        f"at the bottom of the doc instead. Offenders:\n"
         + "\n".join(f"  - `{name}`: {disposition!r}" for name, disposition in invalid.items())
     )
 

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -12,27 +12,30 @@ httpx, or — worse — a hang on a never-acquired lock that belongs to
 a dead loop.
 
 Post-fix: ``Session.open()`` captures
-``asyncio.get_running_loop()`` in ``self.bound_loop`` and
-``_perform_authed_post`` asserts the running loop matches via a cheap
-``is`` comparison. On mismatch we raise an actionable ``RuntimeError``
-at the call site instead of letting the failure escalate into the
-httpx pool or asyncio.Lock internals.
+``asyncio.get_running_loop()`` on the lifecycle (read via
+``core._lifecycle.get_bound_loop()``) and
+``SessionTransport.perform_authed_post`` asserts the running loop matches
+via a cheap ``is`` comparison through ``assert_bound_loop``. On mismatch
+we raise an actionable ``RuntimeError`` at the call site instead of
+letting the failure escalate into the httpx pool or asyncio.Lock internals.
 
 The test exercises the surgical contract:
 
 1. **Cross-loop use raises early** — open the core under one loop, then
-   call ``rpc_call`` (which routes through ``_perform_authed_post``)
-   under a *different* loop and assert the loop-affinity ``RuntimeError``
-   surfaces with the documented message. The error must come from G2's
-   guard, not from a downstream httpx symptom.
+   call ``rpc_call`` (which routes through
+   ``SessionTransport.perform_authed_post``) under a *different* loop
+   and assert the loop-affinity ``RuntimeError`` surfaces with the
+   documented message. The error must come from G2's guard, not from a
+   downstream httpx symptom.
 2. **Same-loop use is unaffected** — open + dispatch under one loop and
    confirm 100 fan-out calls succeed (no false positive on the
    ``is`` comparison).
 3. **No binding before open()** — a freshly-constructed ``Session``
-   that has never been ``open()``ed has ``bound_loop is None``; we
-   only check inside ``_perform_authed_post`` which already asserts
-   ``self._kernel.http_client is not None``, so an "unopened client" caller
-   sees the existing assertion error, not the loop guard.
+   that has never been ``open()``ed has
+   ``core._lifecycle.get_bound_loop() is None``; the check inside
+   ``SessionTransport.perform_authed_post`` already asserts
+   ``self._kernel.http_client is not None``, so an "unopened client"
+   caller sees the existing assertion error, not the loop guard.
 
 Why this lives under ``tests/integration/concurrency/`` and not
 ``tests/unit/``: the regression requires a real ``httpx.AsyncClient``
@@ -83,8 +86,8 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Sessi
     normally — which is the moment the loop affinity is captured —
     then close-and-replace the underlying client with one that routes
     through our recording transport. The replacement keeps
-    ``self.bound_loop`` unchanged because we don't call ``open()``
-    again.
+    ``self._lifecycle.get_bound_loop()`` unchanged because we don't call
+    ``open()`` again.
     """
     core = Session(auth=_make_auth())
     await core.open()
@@ -209,13 +212,13 @@ async def test_bound_loop_captured_on_open(
     construction-time loop may not be the dispatch-time loop.
     """
     core = Session(auth=_make_auth())
-    assert core.bound_loop is None, (
+    assert core._lifecycle.get_bound_loop() is None, (
         "Session must not bind to a loop at construction time — open() is the binding moment."
     )
 
     await core.open()
     try:
-        assert core.bound_loop is asyncio.get_running_loop(), (
+        assert core._lifecycle.get_bound_loop() is asyncio.get_running_loop(), (
             "open() must capture the *running* loop, not a stored or module-level reference."
         )
 

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -9,7 +9,7 @@ Post-fix:
 - ``Session.__init__`` defaults ``rate_limit_max_retries`` to ``3``.
 - ``NotebookLMClient.__init__`` and ``NotebookLMClient.from_storage``
   match the new default.
-- ``_perform_authed_post`` falls back to capped exponential backoff
+- ``SessionTransport.perform_authed_post`` falls back to capped exponential backoff
   (start 1s, cap 30s, ±20% jitter) when a 429 lacks a parseable
   ``Retry-After`` header, so the new default is useful even when the
   server omits the hint.
@@ -196,7 +196,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     creates would silently inherit the new default and the idempotency
     safety net would no longer apply.
 
-    This test exercises ``_perform_authed_post`` directly with
+    This test exercises ``SessionTransport.perform_authed_post`` directly with
     ``disable_internal_retries=True`` and verifies the very first 429
     raises ``TransportRateLimited`` (which the API layer translates
     into ``RateLimitError``) without sleeping.
@@ -217,7 +217,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
         return ("https://example.invalid/x", b"body", None)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(TransportRateLimited):
-        await client._session._perform_authed_post(
+        await client._session._transport.perform_authed_post(
             build_request=_build_request,
             log_label="test",
             disable_internal_retries=True,

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -27,10 +27,9 @@ def mock_artifacts_api():
     # and confuse the ``existing is not None`` branch.
     mock_core.poll_registry = PollRegistry()
     mock_core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
-    # ``bound_loop`` must be ``None`` (silent-no-op for the affinity
-    # guard) so the artifact polling helper does not raise on a
-    # ``MagicMock``-shaped loop value.
-    mock_core.bound_loop = None
+    # The affinity guard is consumed by feature APIs through
+    # ``assert_bound_loop()`` directly; the ``Session.bound_loop`` property
+    # forward was deleted in Wave 11c of session-decoupling.
     mock_core.assert_bound_loop = MagicMock(return_value=None)
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -107,7 +107,6 @@ def api():
 def _make_session_core() -> MagicMock:
     core = MagicMock()
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
-    core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
     core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
     return core

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1144,7 +1144,9 @@ class TestBaselineNotAdvancedOnSaveFailure:
         async with client:
             baseline_before = client._session.cookie_persistence.loaded_cookie_snapshot
             assert client._session._kernel.http_client is not None
-            await client._session.save_cookies(client._session._kernel.get_http_client().cookies)
+            await client._session._lifecycle.save_cookies(
+                client._session, client._session._kernel.get_http_client().cookies
+            )
             baseline_after = client._session.cookie_persistence.loaded_cookie_snapshot
 
         assert baseline_after is baseline_before, (
@@ -1354,11 +1356,11 @@ class TestCASRejectReturnsFalse:
                     cookie["value"] = "sibling"
             _write_storage(storage, cookies)
 
-            await core.save_cookies(jar_with("sid1"))
+            await core._lifecycle.save_cookies(core, jar_with("sid1"))
             assert _cookie_value(storage, "SID", ".google.com") == "sid1"
             assert _cookie_value(storage, "__Secure-1PSIDTS", ".google.com") == "sibling"
 
-            await core.save_cookies(jar_with("sid2"))
+            await core._lifecycle.save_cookies(core, jar_with("sid2"))
             assert _cookie_value(storage, "SID", ".google.com") == "sid2", (
                 "The successful SID delta from the partial save must advance "
                 "baseline; otherwise the next SID rotation CAS-rejects against "
@@ -1549,7 +1551,7 @@ class TestCASVariantAware:
             # holds. Run the second save through the real Session plumbing.
             assert core._kernel.http_client is not None
             _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "SIBLING")
-            await core.save_cookies(core._kernel.get_http_client().cookies)
+            await core._lifecycle.save_cookies(core, core._kernel.get_http_client().cookies)
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "SIBLING", (
                 "Second save must not re-clobber the sibling write — the "
@@ -1566,7 +1568,7 @@ class TestCASVariantAware:
             )
 
             _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "NEXT")
-            await core.save_cookies(core._kernel.get_http_client().cookies)
+            await core._lifecycle.save_cookies(core, core._kernel.get_http_client().cookies)
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "NEXT", (
                 "After convergence advances the baseline, a later OSID "
@@ -1701,8 +1703,8 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
 
         try:
             await asyncio.gather(
-                core.save_cookies(jar_a),
-                core.save_cookies(jar_b),
+                core._lifecycle.save_cookies(core, jar_a),
+                core._lifecycle.save_cookies(core, jar_b),
             )
         finally:
             await core.close()

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -7,6 +7,8 @@ import inspect
 import textwrap
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import httpx
 import pytest
@@ -51,30 +53,81 @@ class _RecordingKernel:
         return self._http_client
 
 
+class _RecordingLifecycle:
+    """Lifecycle stub matching the ``ClientLifecycle.save_cookies`` shape.
+
+    Wave 11c of session-decoupling deleted the ``Session.save_cookies``
+    Protocol surface; :func:`refresh_auth_session` now reaches the
+    canonical cookie-persistence chokepoint through
+    ``core.collaborators.lifecycle.save_cookies(core, jar, path)``. The
+    ``host`` (``core``) argument is forwarded as-is — for these unit
+    tests it's the :class:`RecordingRefreshCore` itself, since the real
+    save path is not exercised here.
+    """
+
+    def __init__(self) -> None:
+        self.operations: list[str] = []
+        self.saved_jars: list[httpx.Cookies] = []
+
+    async def save_cookies(
+        self,
+        host: Any,
+        jar: httpx.Cookies,
+        path: Path | None = None,
+    ) -> None:
+        assert path is None
+        self.operations.append("save_cookies")
+        self.saved_jars.append(jar)
+
+
 @dataclass
 class RecordingRefreshCore:
     auth: AuthTokens
     http_client: httpx.AsyncClient
-    operations: list[str] = field(default_factory=list)
-    saved_jars: list[httpx.Cookies] = field(default_factory=list)
+    _own_operations: list[str] = field(default_factory=list)
+    _lifecycle: _RecordingLifecycle = field(default_factory=_RecordingLifecycle)
 
     def __post_init__(self) -> None:
         # Mirror the live ``Session._kernel`` slot — the Wave 11b Protocol
-        # change reaches the live HTTP client via ``core._kernel.get_http_client()``.
+        # change reaches the live HTTP client via
+        # ``core._kernel.get_http_client()``.
         self._kernel = _RecordingKernel(self.http_client)
+        # Wire the lifecycle's operations list to share storage with ours so
+        # the legacy ``core.operations`` ordering ([..., "save_cookies"])
+        # still matches without forcing tests to read from two separate
+        # logs. Wave 11c routes ``save_cookies`` through
+        # ``core.collaborators.lifecycle`` (the ``Session.save_cookies``
+        # forward was deleted), so the recording lives on the lifecycle
+        # stub and is bridged back into ``operations`` here.
+        self._lifecycle.operations = self._own_operations
+
+    @property
+    def operations(self) -> list[str]:
+        """Combined operation log — recordings from this core plus the lifecycle."""
+        return self._own_operations
+
+    @property
+    def saved_jars(self) -> list[httpx.Cookies]:
+        """Back-compat passthrough so existing assertions still read the recorded jars."""
+        return self._lifecycle.saved_jars
+
+    @property
+    def collaborators(self) -> SimpleNamespace:
+        """Expose the recording lifecycle through the Stage-A accessor shape.
+
+        Mirrors :attr:`Session.collaborators`, which returns the constructed
+        :class:`SessionCollaborators` bundle whose ``lifecycle`` field is the
+        :class:`ClientLifecycle` :func:`refresh_auth_session` invokes.
+        """
+        return SimpleNamespace(lifecycle=self._lifecycle)
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
-        self.operations.append("update_auth_tokens")
+        self._own_operations.append("update_auth_tokens")
         self.auth.csrf_token = csrf
         self.auth.session_id = session_id
 
     def update_auth_headers(self) -> None:
-        self.operations.append("update_auth_headers")
-
-    async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
-        assert path is None
-        self.operations.append("save_cookies")
-        self.saved_jars.append(jar)
+        self._own_operations.append("update_auth_headers")
 
 
 def _client(handler: httpx.MockTransport | httpx.AsyncBaseTransport) -> httpx.AsyncClient:

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -1,7 +1,9 @@
 """Parity tests for the shared transport pipeline.
 
-Pins down the behavior of :meth:`Session._perform_authed_post`
-used by the RPC executor path:
+Pins down the behavior of :meth:`SessionTransport.perform_authed_post`
+used by the RPC executor path (the ``Session._perform_authed_post``
+compatibility forward was deleted in Wave 11c of session-decoupling;
+tests now drive the canonical collaborator method directly):
 
 - ``build_request`` factory is called once per HTTP attempt.
 - On a single auth-error retry, the factory is called TWICE, and the second
@@ -96,7 +98,7 @@ def _status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPSta
 
 
 # ---------------------------------------------------------------------------
-# _perform_authed_post
+# SessionTransport.perform_authed_post
 # ---------------------------------------------------------------------------
 
 
@@ -124,7 +126,7 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
 
     await core.open()
     try:
-        response = await core._perform_authed_post(
+        response = await core._transport.perform_authed_post(
             build_request=build,
             log_label="RPC LIST_NOTEBOOKS",
             disable_internal_retries=True,
@@ -157,7 +159,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
     mutates the budget AFTER ``open()`` still takes effect — preserving
     the pre-PR-12.7 contract where the retry loop read the same attr live.
     Drives the chain via
-    ``core._perform_authed_post`` so the assertion exercises the
+    ``core._transport.perform_authed_post`` so the assertion exercises the
     production seam ``RpcExecutor._execute_once`` uses.
     """
     core = _make_core(rate_limit_max_retries=0)
@@ -189,7 +191,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2
@@ -206,7 +208,7 @@ async def test_perform_authed_post_requires_open_client():
         return "https://example.test/x", "payload", {}
 
     with pytest.raises(RuntimeError, match="Client not initialized"):
-        await core._perform_authed_post(build_request=build, log_label="test")
+        await core._transport.perform_authed_post(build_request=build, log_label="test")
 
 
 @pytest.mark.asyncio
@@ -269,7 +271,7 @@ async def test_auth_refresh_middleware_honors_injected_predicate() -> None:
 async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
     """Production-chain regression: a real ``HTTPStatusError(401)`` raised
     by the transport leaf must drive the refresh-and-retry path through
-    ``Session._perform_authed_post``.
+    ``SessionTransport.perform_authed_post``.
 
     This is the wiring-level counterpart to
     :func:`test_auth_refresh_middleware_honors_injected_predicate` (which
@@ -319,7 +321,7 @@ async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert refresh_calls == [True], (
@@ -363,7 +365,7 @@ async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2
@@ -396,7 +398,7 @@ async def test_perform_authed_post_disable_internal_retries_short_circuits(monke
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError):
-            await core._perform_authed_post(
+            await core._transport.perform_authed_post(
                 build_request=build,
                 log_label="test",
                 disable_internal_retries=True,
@@ -426,7 +428,7 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert len(calls) == 1
@@ -475,7 +477,7 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert len(calls) == 2
@@ -519,7 +521,7 @@ async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert len(refresh_calls) == 1
@@ -556,7 +558,7 @@ async def test_transport_auth_expired_when_refresh_fails(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportAuthExpired) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert exc_info.value.original is original
         assert exc_info.value.__cause__ is refresh_error
@@ -589,7 +591,7 @@ async def test_429_retries_exhaust_to_transport_rate_limited(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportRateLimited) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # Initial attempt + 2 retries = 3 total POSTs.
         assert call_count["n"] == 3
@@ -614,7 +616,7 @@ async def test_429_without_retry_budget_raises_immediately(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportRateLimited) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert exc_info.value.retry_after == 60
     finally:
@@ -650,8 +652,8 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        # Use _perform_authed_post directly inside set_request_id to verify
-        # the helper itself doesn't reset the id. ``_perform_authed_post``
+        # Use perform_authed_post directly inside set_request_id to verify
+        # the helper itself doesn't reset the id. ``perform_authed_post``
         # is the transport-level call below ``rpc_call``; it never invokes
         # ``decode_response``, so no decode_response patch is needed here.
         # (Pre-Phase-2-PR-5 this test carried a stale
@@ -663,7 +665,7 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
 
         token = set_request_id("REQ-stable-1234")
         try:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
         finally:
             reset_request_id(token)
 
@@ -748,7 +750,7 @@ async def test_5xx_retries_then_succeeds(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2
@@ -783,7 +785,7 @@ async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # Initial + 3 retries = 4 total attempts.
         assert call_count["n"] == 4
@@ -821,7 +823,7 @@ async def test_network_error_retries_then_succeeds(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
-        response = await core._perform_authed_post(build_request=build, log_label="test")
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2
@@ -853,7 +855,7 @@ async def test_network_error_exhausts_budget_raises_transport_server_error(monke
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # Initial + 2 retries = 3 attempts; 2 sleeps (1, 2).
         assert sleeps == [1, 2]
@@ -889,7 +891,7 @@ async def test_server_error_budget_zero_raises_immediately(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # Exactly one attempt, no sleep.
         assert call_count["n"] == 1
@@ -921,7 +923,7 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError):
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # min(2 ** attempt, 30) for attempt in 0..7 → 1, 2, 4, 8, 16, 30, 30, 30.
         assert sleeps == [1, 2, 4, 8, 16, 30, 30, 30]
@@ -952,7 +954,7 @@ async def test_5xx_path_does_not_touch_429_path(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportRateLimited) as exc_info:
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         # 429-path sleep uses Retry-After (5), NOT exponential backoff.
         assert sleeps == [5]
@@ -992,7 +994,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
         install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(TransportServerError):
-            await core._perform_authed_post(build_request=build, log_label="test")
+            await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert refresh_calls == []
     finally:

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -5,14 +5,17 @@ The Tier-12/13 greenfield migration wires
 The chain leaf (:meth:`Session._authed_post_chain_terminal`) consumes the
 populated ``RpcRequest.url`` / ``headers`` / ``body`` envelope and delegates
 directly to ``Kernel.post`` — the transport seam under both
-:meth:`Session._perform_authed_post` AND ``RpcExecutor._execute_once``.
+:meth:`SessionTransport.perform_authed_post` AND
+``RpcExecutor._execute_once``. The ``Session._perform_authed_post``
+compatibility forward was deleted in Wave 11c of session-decoupling;
+tests now drive the canonical collaborator method directly.
 
 These tests verify the wiring contract from
 ADR-009 §"RpcRequest.context keys":
 
-1. Both call paths (``Session._perform_authed_post`` directly and the
-   ``RpcExecutor._execute_once`` keyword shape) flow through the chain terminal to
-   the transport.
+1. Both call paths (``SessionTransport.perform_authed_post`` directly
+   and the ``RpcExecutor._execute_once`` keyword shape) flow through
+   the chain terminal to the transport.
 2. ``RpcRequest.context`` carries ``build_request`` / ``log_label`` /
    ``disable_internal_retries`` for retry/rebuild metadata while the terminal
    reads the envelope itself.
@@ -83,11 +86,11 @@ def _swap_kernel_post(core: Session, fake: FakeKernelPost) -> None:
 
 @pytest.mark.asyncio
 async def test_chain_routes_perform_authed_post_to_transport() -> None:
-    """``Session._perform_authed_post`` flows through the chain to transport.
+    """``SessionTransport.perform_authed_post`` flows through the chain.
 
-    Covers direct callers of ``Session._perform_authed_post``: the chat
-    path in ``_chat_transport.py:64`` and any first-party caller via
-    ``client._session._perform_authed_post``.
+    Covers direct callers of ``SessionTransport.perform_authed_post``:
+    the chat path in ``_chat_transport.py:64`` and any first-party
+    caller via ``client._session._transport.perform_authed_post``.
     """
     expected_response = httpx.Response(status_code=200, content=b"chain-routed")
     fake = FakeKernelPost(response=expected_response)
@@ -97,7 +100,7 @@ async def test_chain_routes_perform_authed_post_to_transport() -> None:
     def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
         return ("https://fake/url", b"body", None)
 
-    response = await core._perform_authed_post(
+    response = await core._transport.perform_authed_post(
         build_request=build_request,
         log_label="test-log-label",
         disable_internal_retries=False,
@@ -113,21 +116,22 @@ async def test_chain_routes_perform_authed_post_to_transport() -> None:
 
 @pytest.mark.asyncio
 async def test_chain_routes_rpc_executor_path_to_transport() -> None:
-    """``RpcExecutor._execute_once`` → ``_perform_authed_post`` flows through the chain too.
+    """``RpcExecutor._execute_once`` → ``perform_authed_post`` flows through the chain too.
 
     ``RpcExecutor._execute_once`` calls
-    ``self._owner._perform_authed_post(...)`` which is precisely
-    :meth:`Session._perform_authed_post`. Routing both paths through one
-    seam is the whole point of wiring at ``_perform_authed_post`` rather
-    than at each call site.
+    ``self._transport.perform_authed_post(...)`` (Wave 4 of
+    session-decoupling: the executor takes :class:`SessionTransport`
+    directly instead of reaching through Session). Routing both paths
+    through one seam is the whole point of wiring at
+    ``perform_authed_post`` rather than at each call site.
 
-    We exercise the route by calling ``_perform_authed_post`` with the
+    We exercise the route by calling ``perform_authed_post`` with the
     keyword shape ``RpcExecutor._execute_once`` uses (the
     ``log_label=f"RPC {method.name}"`` template)
     and asserting the chain leaf hands those exact kwargs to the
     transport. We do NOT spin up a full ``RpcExecutor`` here because that
     pulls in the idempotency registry and encoder fixtures; the seam
-    invariant is "the chain receives whatever ``_perform_authed_post``
+    invariant is "the chain receives whatever ``perform_authed_post``
     receives," which a direct call validates without the extra surface.
     """
     expected_response = httpx.Response(status_code=200, content=b"rpc-path")
@@ -138,7 +142,7 @@ async def test_chain_routes_rpc_executor_path_to_transport() -> None:
     def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
         return ("https://fake/rpc", b"rpc-body", {"X-Goog-AuthUser": "0"})
 
-    response = await core._perform_authed_post(
+    response = await core._transport.perform_authed_post(
         build_request=build_request,
         log_label="RPC LIST_NOTEBOOKS",
         disable_internal_retries=True,
@@ -158,7 +162,7 @@ async def test_chain_terminal_reads_context_keys() -> None:
 
     Drives the terminal adapter directly with a hand-built ``RpcRequest``
     so we can assert the contract independently of
-    :meth:`Session._perform_authed_post`'s context-construction code.
+    :meth:`SessionTransport.perform_authed_post`'s context-construction code.
     This is what every middleware PR 12.3–12.8 will rely on when it
     builds a chain over ``[*middlewares, ...]`` and lets the leaf adapt
     the request into a transport call.
@@ -198,11 +202,9 @@ async def test_chain_terminal_reads_context_keys() -> None:
 async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
     """When ``context`` omits ``disable_internal_retries`` the leaf reads ``False``.
 
-    ``_perform_authed_post`` always populates the key, but the leaf
+    ``perform_authed_post`` always populates the key, but the leaf
     defends against a missing entry so middlewares that build a request
-    without the key (e.g. a future ``Session.transport_post`` raw-POST
-    seam, master plan section 3) cannot trip the leaf with a
-    ``KeyError``.
+    without the key cannot trip the leaf with a ``KeyError``.
     """
     fake = FakeKernelPost()
     core = _make_core()
@@ -371,16 +373,21 @@ def test_build_chain_empty_returns_terminal_unchanged() -> None:
 
 
 def test_perform_authed_post_signature_unchanged() -> None:
-    """The keyword-only signature of ``_perform_authed_post`` is unchanged.
+    """The keyword-only signature of ``perform_authed_post`` is unchanged.
 
     Many call sites pass the three kwargs by name, including the RPC executor,
-    chat transport, and integration tests.
-    The chain wiring inside the body must NOT change the public-ish
-    signature; this guard catches an accidental rename.
+    chat transport, and integration tests. The chain wiring inside the body
+    must NOT change the public-ish signature; this guard catches an
+    accidental rename. The Session-level ``_perform_authed_post`` forward
+    was deleted in Wave 11c of session-decoupling; the signature contract
+    now lives on the canonical collaborator method
+    (``SessionTransport.perform_authed_post``).
     """
     import inspect
 
-    sig = inspect.signature(Session._perform_authed_post)
+    from notebooklm._session_transport import SessionTransport
+
+    sig = inspect.signature(SessionTransport.perform_authed_post)
     params = sig.parameters
     assert "build_request" in params
     assert "log_label" in params

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -2,7 +2,7 @@
 
 These assertions pin down the new contract:
 
-- ``ask`` uses ``core.next_reqid()`` for the URL ``_reqid`` param (the
+- ``ask`` uses ``self._reqid.next_reqid()`` for the URL ``_reqid`` param (the
   ``_reqid_counter`` property + deprecation gesture were retired in the
   session-shrink arc; this test now guards against any new
   ``DeprecationWarning`` escaping ``_chat.py``).
@@ -164,7 +164,7 @@ class TestChatAuthuserParam:
 
 
 class TestChatReqid:
-    """``ChatAPI.ask`` must call ``core.next_reqid()`` — not poke
+    """``ChatAPI.ask`` must call ``self._reqid.next_reqid()`` — not poke
     ``_reqid_counter`` directly, which would emit ``DeprecationWarning``."""
 
     @pytest.mark.asyncio

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -490,7 +490,7 @@ class TestSaveCookiesUnification:
         core = Session(auth, cookie_saver=spy)
         core_ref["core"] = core
 
-        await core.save_cookies(httpx.Cookies())
+        await core._lifecycle.save_cookies(core, httpx.Cookies())
 
         assert lock_held_during_save == [True], (
             "save_cookies must hold _save_lock for the duration of "

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -86,7 +86,7 @@ async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thre
     monkeypatch.setattr("notebooklm._session_lifecycle.asyncio.to_thread", fake_to_thread)
     core = Session(_auth_tokens(tmp_path / "storage_state.json"), cookie_saver=fake_save)
 
-    await core.save_cookies(_jar())
+    await core._lifecycle.save_cookies(core, _jar())
 
     assert calls == ["to_thread", "save"]
 

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -37,7 +37,6 @@ def _make_api():
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
     core.poll_registry = PollRegistry()
     core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
-    core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
     mind_maps = MagicMock(spec=NoteBackedMindMapService)
     note_service = MagicMock(spec=NoteService)

--- a/tests/unit/test_reqid_counter.py
+++ b/tests/unit/test_reqid_counter.py
@@ -44,21 +44,6 @@ def test_default_step_constant_matches_signature_default() -> None:
     assert DEFAULT_STEP == 100000
 
 
-def test_client_core_next_reqid_default_matches_default_step() -> None:
-    """``Session.next_reqid``'s ``step`` default is sourced from
-    :data:`notebooklm._reqid_counter.DEFAULT_STEP`.
-
-    Pins the facade signature to the helper's constant so a silent change to
-    one cannot drift past the other. ``Session`` imports
-    ``DEFAULT_STEP as _REQID_DEFAULT_STEP``; this test introspects the bound
-    default to confirm the wiring stays in lockstep.
-    """
-    from notebooklm._session import Session
-
-    sig = inspect.signature(Session.next_reqid)
-    assert sig.parameters["step"].default == DEFAULT_STEP
-
-
 def test_custom_baseline() -> None:
     """Constructor accepts a non-default baseline (used by future fixtures)."""
     counter = ReqidCounter(baseline=42)

--- a/tests/unit/test_save_lock_contract.py
+++ b/tests/unit/test_save_lock_contract.py
@@ -88,7 +88,7 @@ async def test_save_lock_acquired_off_event_loop_thread(
     core = _make_core(tmp_path, cookie_saver=spy)
     core_ref["core"] = core
 
-    await core.save_cookies(httpx.Cookies())
+    await core._lifecycle.save_cookies(core, httpx.Cookies())
 
     assert observed["lock_held"] is True, (
         "save_cookies must hold _save_lock for the duration of "
@@ -156,7 +156,7 @@ async def test_save_lock_does_not_block_event_loop(
         loop_observations.append(core.cookie_persistence.save_lock.locked())
         release_save.set()
 
-    await asyncio.gather(core.save_cookies(httpx.Cookies()), heartbeat())
+    await asyncio.gather(core._lifecycle.save_cookies(core, httpx.Cookies()), heartbeat())
 
     assert loop_observations == [True], (
         "Event loop must remain responsive while _save_lock is held by a "

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -164,19 +164,19 @@ def test_session_retains_adr_014_rule_4_middleware_chain_seams() -> None:
 
     - ``_await_refresh`` — captured by ``wire_middleware_chain`` as
       ``refresh_callable=host._await_refresh``.
-    - ``_perform_authed_post`` — direct callers in ``_chat_transport`` and
-      external client code reach it here; live middleware-chain seam.
     - ``_kernel`` — Session owns the transport core (instance attribute).
 
     Wave 11b of session-decoupling deleted the ``_increment_metrics`` /
     ``metrics_snapshot`` / ``_emit_rpc_event`` / ``record_upload_queue_wait``
     forwards; live capture sites read ``ClientMetrics`` directly via
-    ``session.collaborators.metrics`` per ADR-014 Rule 3.
+    ``session.collaborators.metrics`` per ADR-014 Rule 3. Wave 11c
+    deleted the ``_perform_authed_post`` forward; production callers
+    (``_chat_transport`` and the ``RpcExecutor``) reach the canonical
+    method on ``SessionTransport.perform_authed_post`` directly, and
+    there are no remaining production callers of the Session-level
+    forward.
     """
-    for name in (
-        "_await_refresh",
-        "_perform_authed_post",
-    ):
+    for name in ("_await_refresh",):
         assert hasattr(Session, name), f"Session missing Rule-4 retained member: {name}"
         assert callable(getattr(Session, name)), f"Session.{name} not callable"
 

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -14,8 +14,8 @@ Specifically pinned here:
   cleanly** — the task exits and is set to ``None``; the call doesn't leak a
   ``CancelledError``.
 * ``_bound_loop`` **mismatch raises ``RuntimeError``** — the cross-loop guard
-  in :meth:`Session._perform_authed_post` reads ``_bound_loop`` through the
-  lifecycle and raises actionably when the loops differ.
+  in :meth:`SessionTransport.perform_authed_post` reads ``_bound_loop`` through
+  the lifecycle and raises actionably when the loops differ.
 * :meth:`ClientLifecycle.save_cookies` **invokes** the host's
   ``cookie_persistence.save`` collaborator with the right ``jar`` and
   ``path`` arguments AND with the ``save_cookies_to_storage`` value resolved
@@ -445,9 +445,9 @@ async def test_bound_loop_get_returns_running_loop_after_open() -> None:
     """``get_bound_loop()`` returns the captured loop after open().
 
     The cross-loop affinity ``RuntimeError`` is raised by
-    ``Session._perform_authed_post`` on actual cross-loop reuse — see
-    ``tests/integration/concurrency/test_cross_loop_affinity.py`` for the
-    end-to-end exercise. Here we only assert the lifecycle exposes the
+    ``SessionTransport.perform_authed_post`` on actual cross-loop reuse —
+    see ``tests/integration/concurrency/test_cross_loop_affinity.py`` for
+    the end-to-end exercise. Here we only assert the lifecycle exposes the
     captured loop via :meth:`get_bound_loop`.
     """
     lifecycle = _make_lifecycle()
@@ -497,7 +497,7 @@ def test_bound_loop_mismatch_via_session_raises_runtime_error() -> None:
         # populated, this is a no-op and ``_bound_loop`` stays bound to loop A.
         await core.open()
         try:
-            await core._perform_authed_post(
+            await core._transport.perform_authed_post(
                 build_request=_build_request_stub,
                 log_label="test.cross_loop",
             )

--- a/tests/unit/test_session_reqid.py
+++ b/tests/unit/test_session_reqid.py
@@ -1,14 +1,17 @@
-"""Unit tests for ``Session.next_reqid``.
+"""Unit tests for ``Session._reqid.next_reqid``.
 
 Covers:
 - ``next_reqid()`` returns monotonic, post-increment values.
 - Custom ``step`` parameter works.
 - ``next_reqid()`` itself does NOT emit a ``DeprecationWarning``.
 
-The ``_reqid_counter`` compat property + setter (the read-bridge and the
-deprecation gesture on direct mutation) were retired in the session-shrink
-arc; tests read ``core._reqid.value`` directly and use
-``core._reqid.set_value(...)`` to seed a baseline.
+The ``Session.next_reqid`` compatibility forward was deleted in Wave 11c
+of session-decoupling; callers reach the canonical counter directly via
+``core._reqid.next_reqid(...)``. The ``_reqid_counter`` compat property +
+setter (the read-bridge and the deprecation gesture on direct mutation)
+were retired earlier in the session-shrink arc; tests read
+``core._reqid.value`` directly and use ``core._reqid.set_value(...)`` to
+seed a baseline.
 """
 
 import warnings
@@ -34,9 +37,9 @@ async def test_next_reqid_returns_post_increment_values() -> None:
     core = _make_core()
     assert core._reqid.value == 100000  # baseline
 
-    first = await core.next_reqid()
-    second = await core.next_reqid()
-    third = await core.next_reqid()
+    first = await core._reqid.next_reqid()
+    second = await core._reqid.next_reqid()
+    third = await core._reqid.next_reqid()
 
     assert first == 200000
     assert second == 300000
@@ -49,9 +52,9 @@ async def test_next_reqid_returns_post_increment_values() -> None:
 async def test_next_reqid_custom_step() -> None:
     """A non-default ``step`` parameter is honoured."""
     core = _make_core()
-    assert await core.next_reqid(step=1) == 100001
-    assert await core.next_reqid(step=7) == 100008
-    assert await core.next_reqid(step=1000) == 101008
+    assert await core._reqid.next_reqid(step=1) == 100001
+    assert await core._reqid.next_reqid(step=7) == 100008
+    assert await core._reqid.next_reqid(step=1000) == 101008
 
 
 @pytest.mark.asyncio
@@ -60,8 +63,8 @@ async def test_next_reqid_does_not_warn() -> None:
     core = _make_core()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        await core.next_reqid()
-        await core.next_reqid()
+        await core._reqid.next_reqid()
+        await core._reqid.next_reqid()
     deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert deprecations == [], (
         "next_reqid() must not emit DeprecationWarning; "
@@ -74,7 +77,7 @@ async def test_next_reqid_rejects_zero_step() -> None:
     """``step=0`` would break uniqueness (two callers see the same value)."""
     core = _make_core()
     with pytest.raises(ValueError, match="step must be positive"):
-        await core.next_reqid(step=0)
+        await core._reqid.next_reqid(step=0)
     # Counter must not have moved.
     assert core._reqid.value == 100000
 
@@ -84,7 +87,7 @@ async def test_next_reqid_rejects_negative_step() -> None:
     """``step<0`` would break monotonicity (counter moves backwards)."""
     core = _make_core()
     with pytest.raises(ValueError, match="step must be positive"):
-        await core.next_reqid(step=-1)
+        await core._reqid.next_reqid(step=-1)
     assert core._reqid.value == 100000
 
 
@@ -93,7 +96,7 @@ async def test_next_reqid_rejects_non_int_step() -> None:
     """Non-``int`` ``step`` (e.g. ``str``) must raise ``TypeError`` early."""
     core = _make_core()
     with pytest.raises(TypeError, match="step must be int"):
-        await core.next_reqid(step="100")  # type: ignore[arg-type]
+        await core._reqid.next_reqid(step="100")  # type: ignore[arg-type]
     assert core._reqid.value == 100000
 
 
@@ -104,7 +107,7 @@ async def test_next_reqid_rejects_bool_step() -> None:
     """
     core = _make_core()
     with pytest.raises(TypeError, match="step must be int"):
-        await core.next_reqid(step=True)  # type: ignore[arg-type]
+        await core._reqid.next_reqid(step=True)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="step must be int"):
-        await core.next_reqid(step=False)  # type: ignore[arg-type]
+        await core._reqid.next_reqid(step=False)  # type: ignore[arg-type]
     assert core._reqid.value == 100000

--- a/tests/unit/test_session_reqid_concurrent.py
+++ b/tests/unit/test_session_reqid_concurrent.py
@@ -1,10 +1,14 @@
-"""Concurrency test for ``Session.next_reqid``.
+"""Concurrency test for ``Session._reqid.next_reqid``.
 
 Covers 100 concurrent ``next_reqid()`` callers (via
 ``asyncio.gather``) must each see a unique, monotonic counter value. Without
 the ``asyncio.Lock`` guard, the underlying read-modify-write would race and
 produce duplicate values — exactly the bug Google's chat backend rejects
 when two concurrent ``ChatAPI.ask`` calls happen on the same client.
+
+The ``Session.next_reqid`` compatibility forward was deleted in Wave 11c
+of session-decoupling; tests now reach the canonical counter directly via
+``core._reqid.next_reqid(...)``.
 """
 
 import asyncio
@@ -31,7 +35,7 @@ async def test_next_reqid_concurrent_unique_and_monotonic() -> None:
     step = 100000
     baseline = core._reqid.value  # 100000
 
-    results = await asyncio.gather(*[core.next_reqid(step=step) for _ in range(100)])
+    results = await asyncio.gather(*[core._reqid.next_reqid(step=step) for _ in range(100)])
 
     # Uniqueness: no two callers got the same value.
     assert len(set(results)) == 100, (
@@ -58,7 +62,7 @@ async def test_next_reqid_concurrent_custom_step() -> None:
     step = 7  # small step exercises the increment math under heavy contention
     baseline = core._reqid.value
 
-    results = await asyncio.gather(*[core.next_reqid(step=step) for _ in range(50)])
+    results = await asyncio.gather(*[core._reqid.next_reqid(step=step) for _ in range(50)])
 
     assert len(set(results)) == 50
     assert sorted(results) == [baseline + step * (i + 1) for i in range(50)]

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -61,10 +61,11 @@ def mock_core():
     core.auth.session_id = "test_session"
     core.auth.authuser = 0
     core.auth.account_email = None
-    # Reqid counter is bumped via ``await core.next_reqid()``; the mock
-    # short-circuits the increment to a fixed post-bump value.
+    # Reqid counter is bumped via ``await self._reqid.next_reqid()`` inside
+    # ``ChatAPI.ask`` (Wave 8 of session-decoupling); the mock_core fixture
+    # is passed as the ``reqid=`` collaborator by ``_chat_from_mock_core``
+    # below, so this attribute stub is what the chat path actually calls.
     core.next_reqid = AsyncMock(return_value=100000)
-    core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
     core.get_http_client = MagicMock()
 


### PR DESCRIPTION
## Summary

Wave 11c (the third and final Wave-11 sub-wave) of the session-decoupling plan deletes the remaining `transport/reqid/save_cookies` compatibility forwards on `Session` and tightens `tests/_lint/test_session_retention.py` to its **final form** — `retain — <reason>` is now the only accepted disposition.

Plan: [`docs/session-decoupling-plan-2026-05-26.md`](https://github.com/teng-lin/notebooklm-py/blob/main/docs/session-decoupling-plan-2026-05-26.md) (Phase 3, Task 5.2 cluster 3). ADR: [`docs/adr/0014-feature-local-runtime-adapters.md`](https://github.com/teng-lin/notebooklm-py/blob/main/docs/adr/0014-feature-local-runtime-adapters.md).

**Depends on the merged Wave 11 sub-waves:**
- Wave 11a — `drain-and-operation` cluster (#1076, commit `0f3efda0`)
- Wave 11b — `metrics-and-kernel` cluster (#1077, commit `2cc1d3f9`)

## Methods deleted from `Session`

| Method | Migration target | Production callers |
|---|---|---|
| `next_reqid` | `ReqidCounter.next_reqid` (`self._reqid`) | `ChatAPI.ask` already uses `self._reqid.next_reqid()` since Wave 8 |
| `bound_loop` (property) | `ClientLifecycle.get_bound_loop` (`self._lifecycle`) | None — tests only |
| `_refresh_request_for_current_auth` | `SessionTransport.refresh_request_for_current_auth` (`self._transport`) | None — AST guard already inspects collaborator method directly |
| `_perform_authed_post` | `SessionTransport.perform_authed_post` (`self._transport`) | `_chat_transport` and `RpcExecutor` already call `SessionTransport.perform_authed_post` directly |
| `transport_post` | `SessionTransport.perform_authed_post` directly | None — Tier-13 chat contract; chat moved off it in Wave 8 |
| `save_cookies` | `ClientLifecycle.save_cookies` (`self._lifecycle`) | `refresh_auth_session` migrated in this PR (see below) |

`assert_bound_loop` is intentionally **kept** — it remains a provider-closure capture target wired into `build_session_transport` via `bound_loop_check=lambda: host.assert_bound_loop()`.

## Contract changes (`RefreshAuthCore` Protocol)

The `RefreshAuthCore` Protocol in `_auth/session.py` previously required `save_cookies` on the core; this PR narrows it to expose the Stage-A `collaborators` accessor instead. `refresh_auth_session(core)` now persists rotated cookies through `core.collaborators.lifecycle.save_cookies(core, jar)` — the canonical chokepoint that already serialises with keepalive and close saves. The Session-host argument is widened to the lifecycle's `_LifecycleHost` Protocol via `typing.cast`; the production `Session` satisfies both Protocols structurally.

## Retention doc transition

`docs/session-method-retention.md` moves to its post-Wave-11 final shape:
- The 6 `transport-and-reqid` rows move from **Inventory** to a new `### Wave 11c — transport-and-reqid cluster (commit 579c7a35)` sub-section under **Deleted**.
- The **Status** preamble switches from future-tense to past-tense ("Wave 11 is complete").
- The **Dispositions** glossary drops the transitional `delete in Wave 11 (<cluster>)` row and notes that the lint rejects it.
- The live **Inventory** now contains ONLY `retain — <reason>` rows.

## Lint tightening (`tests/_lint/test_session_retention.py`)

`VALID_DISPOSITION_PREFIXES` narrows from `(retain, delete in Wave 11)` to `(retain,)`. The retired prefix is kept as a named constant (`_RETIRED_DELETE_PREFIX`) for a new self-coverage test (`test_disposition_validator_rejects_retired_delete_prefix`) that pins the rejection for all three cluster keys (`drain-and-operation` / `metrics-and-kernel` / `transport-and-reqid`).

## Commits (4 for revertability)

1. `579c7a35` — `refactor(session): delete transport/reqid/save_cookies forward cluster (Wave 11c / step 1)` — Session source deletions + RefreshAuthCore Protocol narrowing
2. `a357c878` — `test: migrate transport/reqid/save_cookies test sites off Session forwards (Wave 11c / step 2)` — 21 test files migrated to canonical collaborator methods
3. `275dfa84` — `docs(session): mark transport/reqid forwards Deleted in retention.md (Wave 11c / step 3)` — Inventory rows moved to Deleted section
4. `5c460cbc` — `test(lint): tighten test_session_retention.py to retain-only invariant (Wave 11c / step 4)` — Final-form lint

## Test plan

- [x] `uv run pytest tests/_lint tests/unit/concurrency -v` — 98 passed
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm` — clean
- [x] `uv run pytest tests/unit tests/_lint -x -q` — 5866 passed, 10 skipped
- [x] `uv run pytest tests/integration -x -q` — 636 passed, 2 skipped
- [ ] GitHub CI passes across Linux / macOS / Windows × Python 3.10–3.14
- [ ] `@claude review` + `coderabbitai` + `cubic` reviews are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Completed session architecture decoupling (Wave 11c): removed internal session compatibility methods and simplified authentication cookie persistence through a refined collaborator interface.
  * Streamlined session API by retiring internal forwarding methods and consolidating core functionality.

* **Documentation**
  * Updated session retention guidelines to reflect completion of compatibility layer removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->