### PR TITLE
docs+test(lint): Session-as-lifecycle-root + client-composition AST guards (Wave 13 / Tasks 6.1+6.3+6.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ RPC Layer (rpc/)
 | File | Purpose |
 |------|---------|
 | `client.py` | Main `NotebookLMClient` class |
-| `_session.py` | Concrete `Session` orchestrator; HTTP client lifecycle; late-binding wrappers |
+| `_session.py` | Concrete `Session` lifecycle root (no longer a compatibility facade as of Waves 5 + 11 of session-decoupling — see [ADR-014](docs/adr/0014-feature-local-runtime-adapters.md)). Constructs the collaborator graph in `__init__`; owns open/close lifecycle; exposes a narrow retention set (`rpc_call` public-API forward, Stage-A accessors `collaborators` / `session_transport` / `rpc_executor`, the `_authed_post_chain_terminal` middleware leaf, provider-closure capture targets, and AST-guarded auth surface). Retention list pinned by [`docs/session-method-retention.md`](docs/session-method-retention.md) + [`tests/_lint/test_session_retention.py`](tests/_lint/test_session_retention.py); Stage-A accessor leakage outside `client.py` / `_session.py` / `tests/` blocked by [`tests/_lint/test_client_composition.py`](tests/_lint/test_client_composition.py). |
 | `_kernel.py` | Concrete `Kernel` transport core (owns `httpx.AsyncClient` + cookie jar) |
 | `_session_config.py` | `DEFAULT_*` knobs and module-level constants |
 | `_session_helpers.py` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval` |
@@ -94,7 +94,7 @@ RPC Layer (rpc/)
 | `_reqid_counter.py` | `ReqidCounter` — monotonic `_reqid` for the chat backend |
 | `_session_auth.py` | `AuthRefreshCoordinator` — refresh task + auth-snapshot lock |
 | `_session_lifecycle.py` | `ClientLifecycle` — loop-affinity guard + keepalive task |
-| `_rpc_executor.py` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols |
+| `_rpc_executor.py` | RPC dispatch executor. Takes its `Kernel`, `SessionTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5). The `RpcOwner` Protocol that previously re-declared Session's private attribute surface was deleted in Wave 4 of session-decoupling (#1068); only the local `DecodeResponse` Protocol remains. |
 | `_request_types.py` | Shared authed POST request construction types: `AuthSnapshot`, `BuildRequest`, `PostBody`, and materialization helpers. |
 | `_transport_errors.py` | Transport exceptions, `Retry-After` parsing, and terminal `Kernel.post` error mapping for retry/auth middleware. |
 | `_streaming_post.py` | Size-capped streaming POST helper used by `Kernel.post`. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,18 +59,19 @@ Most public methods (`client.notebooks.list()`, `client.sources.rename()`,
 CLI command or user code
   -> NotebookLMClient.<feature>.<method>()
   -> feature API / service builds params and chooses RPCMethod
-  -> RpcCaller.rpc_call(...) (production: Session.rpc_call)
+  -> RpcCaller.rpc_call(...) (production: RpcExecutor wired directly into the feature
+                              per ADR-014 Rule 1; NotebookLMClient.rpc_call still
+                              forwards through Session.rpc_call for the public escape hatch)
   -> RpcExecutor.rpc_call(...)
        - pre-open guard via Kernel.get_http_client()
        - logical-RPC request id + rpc_calls_started metric
   -> RpcExecutor._execute_once(...)
        - idempotency policy / client-token injection
        - method-id override resolution, request encoding, URL/body builder
-  -> Session._perform_authed_post(...)
   -> SessionTransport.perform_authed_post(...)
        - loop-affinity guard, auth snapshot, RpcRequest materialization
   -> ADR-009 middleware chain
-  -> Session._authed_post_chain_terminal(...)
+  -> Session._authed_post_chain_terminal(...)   # retained chain leaf (ADR-014 Rule 4)
   -> SessionTransport.terminal(...)
        - final auth-freshness rebuild immediately before POST
   -> Kernel.post(...) -> _streaming_post -> httpx.AsyncClient
@@ -237,7 +238,15 @@ See [ADR-011](./adr/0011-schema-validation-policy.md).
 
 ADR-013 ("Composable Session Capabilities") is the design rationale:
 feature APIs depend on narrow capability Protocols rather than on the
-concrete `Session` class. Six Protocols live in
+concrete `Session` class.
+[ADR-014](./adr/0014-feature-local-runtime-adapters.md) extends that
+intent at runtime: each feature receives the *collaborator* (for
+single-capability Protocols) or a *feature-local frozen-dataclass
+adapter* (for composite Protocols) that satisfies its Protocol —
+never `Session` itself. `NotebookLMClient.__init__` is the composition
+root that wires each feature with the satisfier it needs.
+
+Six Protocols live in
 [`_session_contracts.py`](../src/notebooklm/_session_contracts.py) —
 four shared capability Protocols used by ≥2 features, plus `AuthMetadata`
 and `Kernel`, whose sole consumer today is `SourceUploadPipeline`. Per
@@ -277,27 +286,41 @@ collaborators (`rpc: RpcCaller`, `transport: SessionTransport`,
 constructor argument rather than reaching them through a feature-local
 runtime composite.
 
-Production satisfies the shared Protocols via `Session`; tests substitute
+Production satisfies the shared Protocols via the underlying
+collaborators (ADR-014 Rule 1: `RpcExecutor` satisfies `RpcCaller`,
+`ClientLifecycle` satisfies `LoopGuard`, `TransportDrainTracker`
+satisfies `OperationScopeProvider` and `DrainHookRegistration`) and the
+composite Protocols via feature-local adapters
+(`ArtifactsRuntimeAdapter`, `UploadRuntimeAdapter` — ADR-014 Rule 2).
+`Session` no longer claims to satisfy the shared Protocols itself.
+Tests substitute
 [`tests/_fixtures/fake_core.py:FakeSession`](../tests/_fixtures/fake_core.py)
 (constructed via `make_fake_core(...)`) — the sanctioned ADR-007 / ADR-013
-fixture pattern.
+fixture pattern; tests that inject narrow fakes into a single feature
+(e.g. `MagicMock(spec=RpcCaller, rpc_call=AsyncMock(...))`) construct
+the feature directly under ADR-014.
 
-### Executor protocols are narrow too
+### Executor takes its collaborators directly
 
-The executor-facing Protocols are intentionally implementation-local,
-but they no longer depend on Session's historical private attribute
-surface. `RpcOwner` in
-[`_rpc_executor.py`](../src/notebooklm/_rpc_executor.py) declares only
-the kernel plus the methods the executor still calls; timeout,
-refresh-callback, and retry-delay values are supplied through constructor
-providers. The executor enters transport through
-`Session._perform_authed_post`, which forwards to
-`SessionTransport.perform_authed_post`; the middleware terminal is
-`Session._authed_post_chain_terminal → SessionTransport.terminal → Kernel.post`.
-Request types, transport errors, and streaming helpers live in separate owning
-modules instead of one catch-all transport helper. This keeps feature APIs on
-narrow capability Protocols while avoiding a near-`Session` structural contract
-inside the RPC stack.
+Per ADR-014 Rule 5, `RpcExecutor` no longer reaches its kernel,
+transport, auth-refresh coordinator, or metrics tracker through a
+Session-shaped owner Protocol. The earlier `RpcOwner` Protocol — which
+re-declared the four private Session attributes the executor needed —
+was deleted in Wave 4 of the session-decoupling plan; the executor's
+constructor now takes
+`kernel: Kernel`, `transport: SessionTransport`,
+`auth_refresh: AuthRefreshCoordinator`, and `metrics: ClientMetrics`
+as keyword-only parameters, plus the previously-existing
+constructor-injected providers for timeout, refresh-callback enablement,
+and retry-delay values. The executor enters transport through
+`SessionTransport.perform_authed_post` directly; the middleware
+terminal remains `Session._authed_post_chain_terminal →
+SessionTransport.terminal → Kernel.post` because the chain leaf is the
+load-bearing seam Wave 5 of the session-decoupling plan retained on
+`Session` per ADR-014 Rule 4. Request types, transport errors, and
+streaming helpers live in separate owning modules instead of one
+catch-all transport helper. This keeps feature APIs on narrow capability
+Protocols and the executor on direct collaborator dependencies.
 
 ## Post-refactor `Session` collaborator graph
 
@@ -341,8 +364,8 @@ Exec  Ref    Life    Chain Trans Drain  Tracker Coun  Pers
 
 | Collaborator | Module | Responsibility |
 |--------------|--------|----------------|
-| `RpcExecutor` | [`_rpc_executor.py`](../src/notebooklm/_rpc_executor.py) | Single logical batchexecute RPC dispatch path. Owns request-id/started-metric bracketing, idempotency policy lookup, method-ID resolution, request encoding, response decode, RPC error mapping, and decode-time auth refresh retry. Consumes the `RpcOwner` Protocol declared at module top and enters transport through `Session._perform_authed_post`. |
-| `SessionTransport` | [`_session_transport.py`](../src/notebooklm/_session_transport.py) | Authed POST collaborator. Owns `perform_authed_post()` (loop guard, auth snapshot, request materialization, chain dispatch, queue-wait recording), `refresh_request_for_current_auth()`, and `terminal()` (freshness rebuild + `Kernel.post`). Reached through the Session forwards `_perform_authed_post`, `transport_post`, and `_authed_post_chain_terminal`. |
+| `RpcExecutor` | [`_rpc_executor.py`](../src/notebooklm/_rpc_executor.py) | Single logical batchexecute RPC dispatch path. Owns request-id/started-metric bracketing, idempotency policy lookup, method-ID resolution, request encoding, response decode, RPC error mapping, and decode-time auth refresh retry. Takes its `Kernel`, `SessionTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5; the historical `RpcOwner` Protocol was deleted in Wave 4 of session-decoupling). Enters transport through `SessionTransport.perform_authed_post`. |
+| `SessionTransport` | [`_session_transport.py`](../src/notebooklm/_session_transport.py) | Authed POST collaborator. Owns `perform_authed_post()` (loop guard, auth snapshot, request materialization, chain dispatch, queue-wait recording), `refresh_request_for_current_auth()`, and `terminal()` (freshness rebuild + `Kernel.post`). Called directly by `RpcExecutor` and by `chat_aware_authed_post` (ChatAPI's chat-flavoured transport call); the middleware chain leaf at `Session._authed_post_chain_terminal` continues to dispatch through `SessionTransport.terminal` per ADR-014 Rule 4. |
 | `AuthRefreshCoordinator` | [`_session_auth.py`](../src/notebooklm/_session_auth.py) | Owns the auth-snapshot lock and the refresh task. Canonical implementation for `AuthRefreshCoordinator.snapshot(host)` and token updates. `Session.update_auth_tokens()` remains a one-line delegate for the `RefreshAuthCore` Protocol; the old `Session._snapshot` delegate was inlined. |
 | `ClientLifecycle` | [`_session_lifecycle.py`](../src/notebooklm/_session_lifecycle.py) | HTTP-client open/close, keepalive task, cookie save coordination. Holds `_timeout`, `_bound_loop`, `_http_client`, `_keepalive_*`. |
 | `MiddlewareChainBuilder` | [`_middleware_chain.py`](../src/notebooklm/_middleware_chain.py) | Constructs the middleware chain in the canonical ADR-009 order. Extracted in Phase 3 PR 7. |
@@ -467,33 +490,59 @@ TracingMiddleware            innermost — structured-logging boundary
 Authed POST leaf             (SessionTransport.terminal → Kernel → httpx)
 ```
 
-## Session as facade
+## Session as lifecycle root
 
-`Session` is large (~780 lines) because it is the historical orchestration
-class plus a compatibility facade. The post-v0.5.0 collaborator graph above
-shows what `Session` actually delegates today; almost everything it exposes
-is a one-line forward to a focused collaborator (`AuthRefreshCoordinator`,
-`SessionTransport`, `RpcExecutor`, `ClientLifecycle`, `ClientMetrics`,
-`TransportDrainTracker`, `ReqidCounter`, `CookiePersistence`).
+`Session` is no longer a compatibility facade. Waves 5 + 11 of the
+session-decoupling plan
+([ADR-014](./adr/0014-feature-local-runtime-adapters.md)) deleted the
+historical drain/metrics/operation_scope/kernel/authuser/save_cookies
+forwards that existed only because feature APIs used to reach through
+`Session`. What remains is a narrow lifecycle root: `Session` constructs
+the collaborator graph at `__init__` time, owns the open/close lifecycle
+(loop-affinity binding, keepalive task), and exposes the few surfaces
+that remain load-bearing for the public API or the middleware chain. The
+exact retention list is checked-in at
+[`docs/session-method-retention.md`](./session-method-retention.md) and
+enforced by [`tests/_lint/test_session_retention.py`](../tests/_lint/test_session_retention.py)
+— a new method on `Session` cannot land without a documented
+disposition.
 
-The facade survives for three reasons:
+Concretely, `Session` retains:
 
-1. **Public API stability.** `NotebookLMClient.rpc_call(method, params)`
-   forwards to `Session.rpc_call`, and feature APIs satisfy `RpcCaller` via
-   `Session`. Removing the facade is a public-surface change.
-2. **Compatibility shims.** A handful of `Session` methods
-   (`_perform_authed_post`, `transport_post`,
-   `_authed_post_chain_terminal`, `update_auth_tokens`) are the
-   structural Protocol surface other collaborators or the
-   `RefreshAuthCore` Protocol depend on.
-3. **Test seams.** Module-level binding paths (e.g.
-   `notebooklm._session.asyncio.sleep`, `notebooklm._session.httpx.AsyncClient`)
-   are documented monkeypatch targets steered from `Session.__init__`.
-   See [ADR-007](./adr/0007-test-monkeypatch-policy.md).
+1. **Public-API forward.** `Session.rpc_call(method, params)` is
+   pinned by `tests/unit/test_public_shims.py` because
+   `NotebookLMClient.rpc_call` (the documented raw-RPC escape hatch)
+   forwards through it. Internally it delegates to
+   `self.rpc_executor.rpc_call(...)`.
+2. **Stage-A collaborator accessors** (ADR-014 Rule 3 Stage A —
+   transitional). `Session.collaborators`, `Session.session_transport`,
+   and `Session.rpc_executor` are the three typed accessors
+   `NotebookLMClient.__init__` reads while wiring features. They are
+   lint-guarded to the composition root + tests by
+   [`tests/_lint/test_client_composition.py`](../tests/_lint/test_client_composition.py)
+   so they cannot become a discoverability hub. Stage B (Wave 7
+   follow-up) moves `build_collaborators` ownership to `NotebookLMClient`
+   and deletes all three accessors.
+3. **Middleware-chain seams.** `_authed_post_chain_terminal` is the
+   live chain leaf wired by `wire_middleware_chain`. Provider-closure
+   capture targets (`_await_refresh`, `_rate_limit_max_retries`,
+   `_server_error_max_retries`, `_refresh_retry_delay`, `assert_bound_loop`)
+   are reached as `host.X` from `build_session_transport` /
+   `wire_middleware_chain`. Per ADR-014 Rule 4 these stay on
+   `Session` until a `MiddlewareChainHost` collaborator extracts them
+   (Wave 7 follow-up).
+4. **Lifecycle methods.** `open`, `close`, `is_open`, `_keepalive_loop`,
+   and `assert_bound_loop` (now a one-line forward to
+   `ClientLifecycle.assert_bound_loop` since
+   `ClientLifecycle` satisfies the `LoopGuard` Protocol directly).
+5. **AST-guarded auth surface.** `update_auth_tokens` is asserted by
+   `tests/unit/test_concurrency_refresh_race.py`.
 
-Known follow-up work is to narrow the executor/session callback cycle
-further and continue retiring facade-only compatibility surfaces as their
-callers move to collaborator-owned contracts.
+Feature APIs do **not** receive `Session`. They receive the collaborator
+(`RpcExecutor` for `RpcCaller`, `ClientLifecycle` for `LoopGuard`, etc.)
+or a frozen-dataclass adapter (`ArtifactsRuntimeAdapter`,
+`UploadRuntimeAdapter`) per ADR-014 Rules 1 + 2 + 3. The composition
+wiring is in [`client.py`](../src/notebooklm/client.py).
 
 ## Testing patterns
 

--- a/tests/_lint/test_client_composition.py
+++ b/tests/_lint/test_client_composition.py
@@ -95,7 +95,7 @@ def _passes_self_session(arg: ast.expr) -> bool:
 
 def test_no_feature_constructed_with_session_at_composition_root() -> None:
     """ADR-014 Rule 3: no feature constructor in ``client.py`` receives ``self._session``."""
-    tree = ast.parse(CLIENT_PATH.read_text())
+    tree = ast.parse(CLIENT_PATH.read_text(encoding="utf-8"))
     violations: list[str] = []
     for node in ast.walk(tree):
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
@@ -135,7 +135,7 @@ def test_stage_a_accessors_only_used_in_allowlist() -> None:
         rel = src.relative_to(REPO_ROOT).as_posix()
         if rel in ACCESSOR_ALLOWLIST:
             continue
-        tree = ast.parse(src.read_text())
+        tree = ast.parse(src.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if isinstance(node, ast.Attribute) and node.attr in STAGE_A_ACCESSORS:
                 violations.append(f"{rel}:{node.lineno}: reads .{node.attr}")

--- a/tests/_lint/test_client_composition.py
+++ b/tests/_lint/test_client_composition.py
@@ -42,6 +42,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CLIENT_PATH = REPO_ROOT / "src" / "notebooklm" / "client.py"
 SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
 
+# Top-level feature APIs + the two domain services that
+# ``NotebookLMClient.__init__`` constructs directly with the Session-
+# derived collaborators. Scope boundary: this set is intentionally the
+# constructor names that appear in ``client.py`` and that take a
+# ``RpcCaller`` (or richer composite) as a primary dependency. Second-
+# level services constructed *from* one of these (e.g.
+# ``NoteBackedMindMapService`` which receives ``NoteService`` only) are
+# out of scope — they cannot accidentally take ``self._session`` because
+# they don't see ``self`` at the composition root.
 FEATURE_API_NAMES = {
     "SettingsAPI",
     "SharingAPI",
@@ -109,8 +118,13 @@ def test_no_feature_constructed_with_session_at_composition_root() -> None:
                 )
         for kw in node.keywords:
             if _passes_self_session(kw.value):
+                # ``kw.arg`` is ``None`` for ``**spread`` unpacking
+                # (``FeatureAPI(**self._session)``); render that as
+                # ``**`` so the diagnostic is unambiguous instead of
+                # printing the literal string ``None``.
+                kwarg_name = kw.arg if kw.arg is not None else "**"
                 violations.append(
-                    f"{node.func.id} at line {node.lineno}: passes self._session via kwarg {kw.arg}"
+                    f"{node.func.id} at line {node.lineno}: passes self._session via kwarg {kwarg_name}"
                 )
     assert not violations, (
         "ADR-014 Rule 3 violation — feature APIs must receive their "

--- a/tests/_lint/test_client_composition.py
+++ b/tests/_lint/test_client_composition.py
@@ -1,0 +1,146 @@
+"""ADR-014 Rule 3 enforcement: features take collaborators, not Session.
+
+Two AST guards introduced in Wave 13 of the session-decoupling plan
+(see ``docs/session-decoupling-plan-2026-05-26.md`` Task 6.3):
+
+1. :func:`test_no_feature_constructed_with_session_at_composition_root`
+   parses ``src/notebooklm/client.py`` and fails if any feature-API
+   constructor call passes ``self._session`` (positionally or by keyword).
+   The composition root MUST wire features with the specific collaborator
+   or feature-local adapter that satisfies their Protocol — never the
+   whole ``Session``. This is the most likely future-drift vector ADR-014
+   names: a contributor under time pressure adds a new feature
+   constructor that takes ``self._session`` "just for now."
+
+2. :func:`test_stage_a_accessors_only_used_in_allowlist` walks every
+   module under ``src/notebooklm/`` and fails if any read of
+   ``Session.collaborators``, ``Session.session_transport``, or
+   ``Session.rpc_executor`` happens outside the allowlist
+   (``client.py`` + ``_session.py``). These three Stage-A accessors are
+   the transitional discovery surface ``NotebookLMClient.__init__`` uses
+   to wire features; feature modules MUST NOT reach for them or they
+   would re-establish ``Session`` as a discoverability hub — exactly the
+   pattern ADR-014 Rule 3 closes. Stage B (tracked as a Wave 7
+   follow-up) moves ``build_collaborators`` ownership to
+   ``NotebookLMClient`` and deletes the three accessors entirely.
+
+The AST shape is deliberate: a regex over the source would either
+over-match (e.g. ``collaborators`` as a variable name) or under-match
+(attribute chains like ``self._session.rpc_executor`` versus
+``session.rpc_executor`` versus ``foo.rpc_executor``). The AST walk
+checks the attribute name only, so any chain ending in ``.rpc_executor``
+outside the allowlist trips the guard regardless of how the receiver was
+spelled.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLIENT_PATH = REPO_ROOT / "src" / "notebooklm" / "client.py"
+SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+
+FEATURE_API_NAMES = {
+    "SettingsAPI",
+    "SharingAPI",
+    "ResearchAPI",
+    "NotesAPI",
+    "SourcesAPI",
+    "NotebooksAPI",
+    "ChatAPI",
+    "ArtifactsAPI",
+    "SourceUploadPipeline",
+    "NoteService",
+}
+
+STAGE_A_ACCESSORS = {"collaborators", "session_transport", "rpc_executor"}
+
+# Files allowed to read the Stage-A accessors. The composition root
+# (``client.py``) wires features with them; ``_session.py`` owns the
+# storage + the property bodies themselves. Everything under ``tests/``
+# is excluded by being outside ``src/notebooklm/`` rather than via this
+# allowlist. ``_session_init.py`` is intentionally NOT on this list
+# (verified at write time: ``_session_init.py`` constructs the
+# collaborators that the accessors expose, not the other way around —
+# it never reads the accessors back).
+#
+# ``_auth/session.py`` is allowlisted because :func:`refresh_auth_session`
+# operates on the ``RefreshAuthCore`` Protocol that explicitly declares
+# ``collaborators`` as a structural member (see Wave 11c of
+# session-decoupling, which deleted ``Session.save_cookies`` and routed
+# the auth-refresh persist call through ``core.collaborators.lifecycle.save_cookies``).
+# The read is on a Protocol member, not opportunistic discovery, so it
+# does not re-establish Session as a hub — it consumes a contract the
+# Protocol pins. When Stage B (Wave 7 follow-up) deletes the Stage-A
+# accessors entirely, ``RefreshAuthCore`` will be reshaped to take the
+# lifecycle collaborator directly and this allowlist entry goes away.
+ACCESSOR_ALLOWLIST = {
+    "src/notebooklm/client.py",
+    "src/notebooklm/_session.py",
+    "src/notebooklm/_auth/session.py",
+}
+
+
+def _passes_self_session(arg: ast.expr) -> bool:
+    """True if ``arg`` is the AST shape of ``self._session``."""
+    return (
+        isinstance(arg, ast.Attribute)
+        and isinstance(arg.value, ast.Name)
+        and arg.value.id == "self"
+        and arg.attr == "_session"
+    )
+
+
+def test_no_feature_constructed_with_session_at_composition_root() -> None:
+    """ADR-014 Rule 3: no feature constructor in ``client.py`` receives ``self._session``."""
+    tree = ast.parse(CLIENT_PATH.read_text())
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id not in FEATURE_API_NAMES:
+            continue
+        for arg in node.args:
+            if _passes_self_session(arg):
+                violations.append(
+                    f"{node.func.id} at line {node.lineno}: passes self._session positionally"
+                )
+        for kw in node.keywords:
+            if _passes_self_session(kw.value):
+                violations.append(
+                    f"{node.func.id} at line {node.lineno}: passes self._session via kwarg {kw.arg}"
+                )
+    assert not violations, (
+        "ADR-014 Rule 3 violation — feature APIs must receive their "
+        "specific collaborator or adapter, not the whole Session:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_stage_a_accessors_only_used_in_allowlist() -> None:
+    """ADR-014 Rule 3 Stage A: the three Session accessors are only
+    legitimate reads inside ``client.py`` / ``_session.py``. A read from
+    any other production module would re-establish Session as a
+    discoverability hub — exactly what Stage A is gated against until
+    Stage B deletes the accessors entirely.
+    """
+    violations: list[str] = []
+    for src in SRC_ROOT.rglob("*.py"):
+        # rglob can return absolute paths; normalize to a repo-relative
+        # POSIX form for stable allowlist matching (the round-4 fix in
+        # the plan calls out using ``as_posix()`` against the repo-rel
+        # path rather than ``relative_to(Path.cwd())`` so the lint is
+        # cwd-independent).
+        rel = src.relative_to(REPO_ROOT).as_posix()
+        if rel in ACCESSOR_ALLOWLIST:
+            continue
+        tree = ast.parse(src.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in STAGE_A_ACCESSORS:
+                violations.append(f"{rel}:{node.lineno}: reads .{node.attr}")
+    assert not violations, (
+        "ADR-014 Rule 3 Stage-A accessor leak — feature modules must "
+        "not reach Session.collaborators / .session_transport / "
+        ".rpc_executor:\n  " + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary

Wave 13 of the session-decoupling plan (see [`docs/session-decoupling-plan-2026-05-26.md`](https://github.com/teng-lin/notebooklm-py/blob/main/docs/session-decoupling-plan-2026-05-26.md) Tasks 6.1, 6.3, and 6.4). Three docs + lint commits that codify the post-Wave-11 reality per [ADR-014](https://github.com/teng-lin/notebooklm-py/blob/main/docs/adr/0014-feature-local-runtime-adapters.md):

- **Commit 1 / Task 6.1** — `docs/architecture.md`: renames "Session as facade" → "Session as lifecycle root" with an explicit retention list (`rpc_call` public-API forward, Stage-A accessors, middleware-chain leaf, provider-closure targets, AST-guarded auth surface) pointing at `docs/session-method-retention.md`. Updates "Per-capability protocol model" to note features receive collaborators/adapters (not `Session`). Rewrites "Executor protocols are narrow too" → "Executor takes its collaborators directly" — `RpcOwner` is gone (Wave 4), `RpcExecutor` takes `Kernel`/`SessionTransport`/`AuthRefreshCoordinator`/`ClientMetrics` directly via keyword-only constructor parameters (ADR-014 Rule 5). Library-call-flow diagram and collaborator-graph table updated to drop references to deleted `Session._perform_authed_post` / `Session.transport_post` forwards.

- **Commit 2 / Task 6.4** — `CLAUDE.md`: refreshes the `_session.py` and `_rpc_executor.py` rows to match the post-decoupling architecture. (The `auth.py` row was already updated to "pure re-exports" in a prior wave.)

- **Commit 3 / Task 6.3** — `tests/_lint/test_client_composition.py` (NEW): two AST lint guards enforcing ADR-014 Rule 3 at PR time —
  1. `test_no_feature_constructed_with_session_at_composition_root` parses `src/notebooklm/client.py` and fails if any feature-API constructor (`SettingsAPI`, `SharingAPI`, `ResearchAPI`, `NotesAPI`, `SourcesAPI`, `NotebooksAPI`, `ChatAPI`, `ArtifactsAPI`, `SourceUploadPipeline`, `NoteService`) receives `self._session`.
  2. `test_stage_a_accessors_only_used_in_allowlist` walks `src/notebooklm/` and fails if any read of `.collaborators` / `.session_transport` / `.rpc_executor` happens outside the allowlist (`client.py` + `_session.py` + `_auth/session.py`).

Both AST tests pass against the current code. The `_auth/session.py` allowlist entry is documented inline — it covers `refresh_auth_session`, which operates on the `RefreshAuthCore` Protocol that explicitly declares `collaborators` as a structural member (added in Wave 11c when `Session.save_cookies` was deleted).

Path matching uses `src.relative_to(REPO_ROOT).as_posix()` so the lint is cwd-independent (the round-4 plan fix).

This PR does **not** flip ADR-014 to `Accepted` — that is Wave 14, manually gated.

## Test plan

- [x] `uv run pytest tests/_lint/test_client_composition.py -v` (both tests pass)
- [x] `uv run ruff format --check .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm` clean (no issues found in 173 source files)
- [x] `uv run pytest tests/unit tests/_lint -x -q` — 5868 passed, 10 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified repository guidance and architecture to reflect session-decoupling, lifecycle responsibilities, and direct collaborator injection patterns.
  * Updated narratives on executor/session roles and collaborator dependency surfaces.

* **Tests**
  * Added lint checks enforcing composition rules: prohibit constructing feature APIs with a Session and restrict use of Stage-A session accessors outside allowed locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->