### PR TITLE
test(lint): drain ADR-007 forbidden-monkeypatch allowlist + pick up Wave 11c deferred findings (Wave 12 / Task 5.3)

### DIFF
--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -105,12 +105,25 @@ _PATTERN_OBJECT_ATTR = re.compile(r"monkeypatch\.setattr\(\s*notebooklm\.")
 # matches; with it, each occurrence is reported once with the natural
 # start position.
 _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
-    # Wave 11c of session-decoupling deleted ``Session._perform_authed_post``
-    # along with the ``_begin_transport_*`` / ``_finish_transport_*`` legacy
-    # names — once a method no longer exists on ``Session``, attempting to
-    # patch it with ``AsyncMock`` would surface immediately at runtime as an
-    # ``AttributeError``, so the lint pattern stops enumerating them.
-    r"(?<![\w.])[\w.]+\.(rpc_call)\s*=\s*(?:[\w]+\.)*AsyncMock"
+    # Method-name enumeration kept INTENTIONALLY broad — not narrowed to
+    # only the methods that still exist on ``Session`` (per gemini-code-
+    # assist's review on PR #1078 / Wave 11c). The lint exists precisely
+    # to catch dynamic attribute assignment of ``AsyncMock`` onto a fake
+    # or duck-typed collaborator — those targets are bag-of-attributes
+    # fakes (``MagicMock``, ``FakeSession``) that happily accept *any*
+    # attribute name regardless of whether the production class still
+    # defines it. Removing a deleted method name from this enumeration
+    # would create a silent escape hatch: a test that re-introduces the
+    # forbidden ``<chain>.transport_post = AsyncMock(...)`` pattern
+    # against a ``MagicMock(spec=...)`` would no longer surface, even
+    # though that is exactly the ADR-007 violation the lint is supposed
+    # to catch. ``rpc_call`` is the canonical core-RPC seam; the
+    # transport-side names retained here
+    # (``transport_post`` / ``_perform_authed_post`` / ``next_reqid`` /
+    # ``save_cookies``) were deleted from ``Session`` in Waves 11a-11c
+    # but remain in this enumeration so the lint keeps catching dynamic
+    # re-assignment of them on a fake.
+    r"(?<![\w.])[\w.]+\.(?:rpc_call|transport_post|_perform_authed_post|next_reqid|save_cookies)\s*=\s*(?:[\w]+\.)*AsyncMock"
 )
 
 _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -127,83 +127,100 @@ _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 
 _ALLOWLIST: frozenset[str] = frozenset(
     {
+        # CLI VCR test patches `notebooklm.cli.services.login.refresh.*` and
+        # `notebooklm.auth.account.*` module-level seams (browser-cookie
+        # extraction, account profile loaders) — these are CLI-side seams above
+        # the `NotebookLMClient` core that `make_fake_core(...)` covers.
+        # reason: CLI-side module seam — out of scope for `make_fake_core` (core-injection only)
         "tests/integration/cli_vcr/test_login_browser_cookies.py",
+        # reason: loop-affinity violation test — raw patch required
         "tests/integration/concurrency/test_aexit_exception_masking.py",
+        # reason: loop-affinity violation test — raw patch required
         "tests/integration/concurrency/test_download_blocks_loop.py",
+        # reason: loop-affinity violation test — raw patch required
         "tests/integration/concurrency/test_idempotency_create.py",
+        # reason: loop-affinity violation test — raw patch required
         "tests/integration/concurrency/test_upload_blocks_loop.py",
+        # reason: loop-affinity violation test — raw patch required
         "tests/integration/concurrency/test_upload_cancel_dangling_session.py",
-        "tests/integration/test_artifacts_integration.py",
+        # reason: integration test patches transport-side
+        # `notebooklm.<module>.*` stdlib seams (httpx-level overrides for
+        # side-effects/idempotency cassettes); these patches sit below the
+        # core-injection seam that `make_fake_core` covers.
         "tests/integration/test_side_effects_idempotency.py",
+        # reason: integration test patches transport-side `notebooklm.<module>.*`
+        # stdlib seams (httpx-level overrides for sources idempotency cassettes);
+        # below the core-injection seam covered by `make_fake_core`.
         "tests/integration/test_sources_idempotency.py",
-        "tests/unit/test_artifacts_drift.py",
-        "tests/unit/test_get_summary_drift.py",
+        # reason: CLI conftest patches `notebooklm.cli.*` module-level seams
+        # (resolvers, click context shims) above the `NotebookLMClient` core
+        # that `make_fake_core(...)` covers.
         "tests/unit/cli/conftest.py",
+        # reason: download-collision concurrency test exercises raw Session-attribute
+        # mutation to provoke download-id collision races; not a candidate for
+        # constructor injection since the test is *about* attribute-level races.
         "tests/unit/concurrency/test_download_collision.py",
+        # reason: public API coverage smoke-test imports `notebooklm.<feature>`
+        # facades to assert re-export shapes; the string-target patches verify
+        # the facade itself, not the core surface.
         "tests/unit/test_api_coverage.py",
-        "tests/unit/test_artifact_downloads.py",
-        "tests/unit/test_artifacts_coverage.py",
+        # reason: cookie save-race test patches module-level
+        # `_try_claim_rotation`, `_file_lock_try_exclusive`,
+        # `save_cookies_to_storage` rotation/lock helpers — outside the
+        # core-injection surface.
         "tests/unit/test_auth_cookie_save_race.py",
-        # PSIDTS inline recovery (issue #865) — patches module-level
-        # seams (``_try_claim_rotation``, ``_file_lock_try_exclusive``,
-        # ``save_cookies_to_storage``, ``_load_storage_state``, and
-        # ``get_storage_path``) that are NOT part of the core-injection
-        # surface ``tests/_fixtures/make_fake_core(...)`` covers. Same
-        # rationale as the neighboring ``test_auth_cookie_save_race.py``
-        # and ``test_auth_session.py`` entries; revisit when ADR-007's
-        # seam-substitution pattern is extended to cover module-level
-        # rotation/lock helpers.
+        # reason: PSIDTS inline recovery (issue #865) patches module-level
+        # rotation/lock seams (`_try_claim_rotation`, `_file_lock_try_exclusive`,
+        # `save_cookies_to_storage`, `_load_storage_state`, `get_storage_path`)
+        # — outside the core-injection surface `make_fake_core` covers.
         "tests/unit/test_auth_psidts_recovery.py",
+        # reason: backoff test patches `notebooklm._session_helpers` stdlib
+        # time/sleep seams (asyncio.sleep) — stdlib seam, not core attribute.
         "tests/unit/test_backoff.py",
-        # Phase 2 PR 5 migrated this file's ``asyncio.to_thread`` patch
-        # off the legacy ``notebooklm._core.asyncio.to_thread`` shim onto
-        # its canonical importing module
-        # (``notebooklm._session_lifecycle.asyncio.to_thread``, where
-        # ``ClientLifecycle.save_cookies`` sources it). The new patch
-        # target is still a string-target into the ``notebooklm.*``
-        # namespace, so the file lands on the allowlist with the rest of
-        # the stdlib-seam patchers (``test_authed_post_pipeline.py``,
-        # ``test_rpc_executor.py``, ``test_side_effects_idempotency.py``,
-        # …) until ADR-007's pattern is extended to stdlib seams.
+        # reason: Phase-2 PR-5 migrated this file's `asyncio.to_thread` patch
+        # to `notebooklm._session_lifecycle.asyncio.to_thread` (where
+        # `ClientLifecycle.save_cookies` sources it). Still a stdlib-seam
+        # string-target patch into `notebooklm.*` until ADR-007's pattern is
+        # extended to cover stdlib seams.
         "tests/unit/test_cookie_persistence.py",
-        # ``tests/unit/test_session_lifecycle.py`` removed from allowlist in
-        # Phase 4 (v0.5.0): the file's monkeypatch.setattr sites that targeted
-        # ``notebooklm._core.*`` were retargeted to the canonical seams
-        # (_auth.storage / _auth.keepalive / _error_injection) when the
-        # ``_core`` compatibility shim was deleted.
+        # reason: RPC executor unit test stub-patches `notebooklm._rpc_executor`
+        # module-level stdlib seams (asyncio.sleep, time providers) on the
+        # executor module itself — below the core-injection seam.
         "tests/unit/test_rpc_executor.py",
+        # reason: authed-post pipeline test patches `notebooklm._streaming_post`
+        # and `notebooklm._transport_errors` module-level stdlib seams (httpx
+        # response builders, time/retry helpers) — transport-layer seams below
+        # the core-injection surface.
         "tests/unit/test_authed_post_pipeline.py",
-        "tests/unit/test_download_url.py",
+        # reason: Firefox container detection test patches module-level
+        # `notebooklm.cli.services.login.firefox_accounts.*` filesystem and
+        # database-discovery helpers — CLI-side seam outside `make_fake_core`.
         "tests/unit/test_firefox_containers.py",
-        # P3.T1 generate-extraction service tests stub the CLI resolver
-        # functions (``notebooklm.cli.resolve.resolve_notebook_id`` and
-        # ``resolve_source_ids``) via ``monkeypatch.setattr`` string targets.
-        # Those resolvers are module-level CLI seams above the
-        # ``NotebookLMClient`` core that ``make_fake_core(...)`` covers, so
-        # the same string-target pattern that ``test_public_shims.py`` uses
-        # for its non-core seams is required here. Revisit when ADR-007's
-        # seam-substitution pattern is extended to cover the CLI resolver
-        # surface.
+        # reason: P3.T1 generate-extraction service tests patch CLI resolver
+        # functions (`notebooklm.cli.resolve.resolve_notebook_id`,
+        # `resolve_source_ids`) — module-level CLI seams above the
+        # `NotebookLMClient` core.
         "tests/unit/test_generate_service.py",
-        # tests/unit/test_idempotency_registry.py — removed in Wave 4 of
-        # session-decoupling: the test's RpcExecutor construction was
-        # migrated from a MagicMock-owner monkeypatch pattern to the
-        # ADR-014 Rule 5 keyword-collaborator constructor shape.
+        # reason: client __init__ ordering test patches `notebooklm._session.*`
+        # module-level constructors/factories to assert wiring order — verifies
+        # construction sequencing, not a core method seam.
         "tests/unit/test_init_order.py",
+        # reason: storage migration-lock test patches `notebooklm._auth.storage.*`
+        # filesystem lock helpers — module-level filesystem seam outside
+        # `make_fake_core`.
         "tests/unit/test_migration_lock.py",
-        "tests/unit/test_notebook_api.py",
-        "tests/unit/test_notes_unit.py",
+        # reason: public-API shim test asserts forwarding of `notebooklm.<x>`
+        # facades; the string-target patches *are* the test subject (shim
+        # routing) rather than an incidental implementation detail.
         "tests/unit/test_public_shims.py",
-        "tests/unit/test_quota_failure_detection.py",
+        # reason: RPC overrides test patches `notebooklm.rpc.types.RPC_METHOD_OVERRIDES`
+        # module-level mapping used during request encoding — module-level data
+        # seam, not a core attribute.
         "tests/unit/test_rpc_overrides.py",
-        "tests/unit/test_select_artifact.py",
-        "tests/unit/test_sharing_manager.py",
-        "tests/unit/test_sharing_types.py",
-        "tests/unit/test_source_selection.py",
+        # reason: source symlink test patches `notebooklm.cli.services.source_add.*`
+        # module-level filesystem helpers — CLI-side seam outside the
+        # `make_fake_core` core-injection surface.
         "tests/unit/test_source_symlink.py",
-        "tests/unit/test_sources_upload.py",
-        "tests/unit/test_swallow_observability.py",
-        "tests/unit/test_user_settings_api.py",
     }
 )
 

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -64,6 +64,15 @@ VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX,)
 # accidentally widening the live ``VALID_DISPOSITION_PREFIXES`` tuple.
 _RETIRED_DELETE_PREFIX: str = "delete in Wave 11"
 
+# Strict-shape validator (Wave 12, coderabbit Wave 11c deferred). The
+# disposition must read exactly ``retain — <reason>``: ``retain``,
+# whitespace, an em-dash (``—``), whitespace, and at least one
+# non-whitespace character of reason text. A loose ``startswith("retain")``
+# check would accept ``retainXYZ`` (no boundary), ``retain`` alone (no
+# reason), or ``retain — `` (empty reason); the regex below rejects all
+# three so the retention doc's vocabulary cannot rot into ambiguity.
+_DISPOSITION_RETAIN_RE = re.compile(r"^retain\s+—\s+\S.*$")
+
 
 def _enumerate_session_methods(source: str) -> list[str]:
     """Return the ordered list of method/property names defined on ``Session``.
@@ -148,7 +157,7 @@ def _parse_retention_doc(text: str) -> dict[str, str]:
 
 
 def _disposition_is_valid(disposition: str) -> bool:
-    """Return ``True`` iff ``disposition`` starts with a valid prefix.
+    """Return ``True`` iff ``disposition`` matches ``retain — <reason>``.
 
     After Wave 11c the retain branch is the only accepted shape — every
     row in the live Inventory must read ``retain — <reason>``. The
@@ -156,8 +165,16 @@ def _disposition_is_valid(disposition: str) -> bool:
     introduced is now rejected; any row that still carries it is doc
     drift and must be moved to the **Deleted** section at the bottom
     of the retention doc (which the inventory parser scopes out).
+
+    Wave 12 (coderabbit Wave 11c deferred): tightened from
+    ``startswith("retain")`` to a strict regex requiring a literal em-dash
+    separator plus at least one character of reason text. The looser form
+    silently accepted ``retainXYZ`` (no word boundary), bare ``retain``
+    (no reason), and ``retain — `` (empty reason); all three would let
+    a drifted disposition slip into the live inventory and undermine
+    the doc's "every row is justified" invariant.
     """
-    return disposition.startswith(VALID_DISPOSITION_PREFIXES)
+    return _DISPOSITION_RETAIN_RE.match(disposition) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +313,45 @@ def test_disposition_validator_rejects_retired_delete_prefix() -> None:
 def test_disposition_validator_rejects_unknown_prefix() -> None:
     assert not _disposition_is_valid("TODO — figure it out later")
     assert not _disposition_is_valid("")
+
+
+def test_disposition_validator_rejects_unbounded_retain() -> None:
+    """Wave 12 (coderabbit Wave 11c deferred): ``retainXYZ`` must be rejected.
+
+    The previous ``startswith("retain")`` form accepted any string that
+    happened to start with the substring ``retain`` (no word boundary).
+    The strict regex requires whitespace + em-dash after ``retain``.
+    """
+    assert not _disposition_is_valid("retainXYZ")
+    assert not _disposition_is_valid("retains for now")
+    assert not _disposition_is_valid("retaining a slot")
+
+
+def test_disposition_validator_rejects_retain_without_reason() -> None:
+    """Wave 12 (coderabbit Wave 11c deferred): the reason text is mandatory.
+
+    A bare ``retain``, ``retain —`` (no trailing reason), or ``retain — ``
+    (whitespace-only reason) all fail to communicate *why* the method
+    survives — the whole point of the retention doc. Reject every shape
+    short of ``retain — <non-whitespace reason>``.
+    """
+    assert not _disposition_is_valid("retain")
+    assert not _disposition_is_valid("retain —")
+    assert not _disposition_is_valid("retain — ")
+    assert not _disposition_is_valid("retain  —  ")
+
+
+def test_disposition_validator_accepts_reason_with_punctuation() -> None:
+    """The reason text may contain any characters once the prefix is satisfied.
+
+    ``retain — <reason>`` rows in the live doc carry compound reasons
+    that include parentheses, em-dashes inside the reason, backticks,
+    and pull-request links; the strict regex must not over-tighten and
+    block legitimate disposition cells.
+    """
+    assert _disposition_is_valid("retain — Stage A accessor (deleted in Wave 7)")
+    assert _disposition_is_valid("retain — public-API forward — `NotebookLMClient.rpc_call`")
+    assert _disposition_is_valid("retain — middleware chain leaf, see PR #1075")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -390,8 +390,9 @@ class TestArtifactsAPI:
     @pytest.mark.asyncio
     async def test_list_raw_preserves_rpc_call_shape(self):
         """_list_raw keeps the exact LIST_ARTIFACTS RPC contract."""
-        core = MagicMock()
-        core.rpc_call = AsyncMock(return_value=[[]])
+        from _fixtures.fake_core import make_fake_core
+
+        core = make_fake_core(rpc_call=AsyncMock(return_value=[[]]))
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
@@ -416,12 +417,13 @@ class TestArtifactsAPI:
     @pytest.mark.asyncio
     async def test_list_raw_preserves_already_flat_artifact_rows(self):
         """_list_raw must not collapse already-flat artifact rows."""
+        from _fixtures.fake_core import make_fake_core
+
         artifact_rows = [
             ["art_001", "My Report", 2, None, 3],
             ["art_002", "Audio Overview", 1, None, 3],
         ]
-        core = MagicMock()
-        core.rpc_call = AsyncMock(return_value=artifact_rows)
+        core = make_fake_core(rpc_call=AsyncMock(return_value=artifact_rows))
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -33,9 +33,12 @@ def mock_artifacts_api():
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 
-    mock_core = MagicMock()
-    mock_core.rpc_call = AsyncMock()
-    mock_core.get_source_ids = AsyncMock(return_value=[])
+    from _fixtures.fake_core import make_fake_core
+
+    mock_core = make_fake_core(
+        rpc_call=AsyncMock(),
+        get_source_ids=AsyncMock(return_value=[]),
+    )
     mock_notebooks = MagicMock()
     mock_notebooks.get_source_ids = AsyncMock(return_value=[])
     # Use real NoteService + NoteBackedMindMapService so the wire RPC

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -30,10 +30,9 @@ def mock_artifacts_api():
     ``mock_core.rpc_call`` (via ``side_effect``) since both new
     services delegate down to that single RPC seam.
     """
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
-
-    from _fixtures.fake_core import make_fake_core
 
     mock_core = make_fake_core(
         rpc_call=AsyncMock(),

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -20,17 +20,16 @@ from notebooklm.types import ArtifactDownloadError
 @pytest.fixture
 def mock_artifacts_api():
     """Create an ArtifactsAPI with mocked core and notes API."""
-    mock_core = MagicMock()
-    mock_core.rpc_call = AsyncMock()
-    mock_core.get_source_ids = AsyncMock(return_value=[])
+    from _fixtures.fake_core import make_fake_core
+
+    mock_core = make_fake_core(
+        rpc_call=AsyncMock(),
+        get_source_ids=AsyncMock(return_value=[]),
+        operation_scope=MagicMock(side_effect=lambda _label: _noop_operation_scope()),
+    )
     # Real registry backing. A MagicMock attribute would return a child Mock
     # and confuse the ``existing is not None`` branch.
     mock_core.poll_registry = PollRegistry()
-    mock_core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
-    # The affinity guard is consumed by feature APIs through
-    # ``assert_bound_loop()`` directly; the ``Session.bound_loop`` property
-    # forward was deleted in Wave 11c of session-decoupling.
-    mock_core.assert_bound_loop = MagicMock(return_value=None)
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 

--- a/tests/unit/test_artifacts_drift.py
+++ b/tests/unit/test_artifacts_drift.py
@@ -38,8 +38,9 @@ def artifacts_api():
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 
-    mock_core = MagicMock()
-    mock_core.rpc_call = AsyncMock()
+    from _fixtures.fake_core import make_fake_core
+
+    mock_core = make_fake_core(rpc_call=AsyncMock())
     return ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),

--- a/tests/unit/test_artifacts_drift.py
+++ b/tests/unit/test_artifacts_drift.py
@@ -35,10 +35,9 @@ from notebooklm.rpc import RPCMethod
 @pytest.fixture
 def artifacts_api():
     """Build a minimal ArtifactsAPI for direct parser invocation."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
-
-    from _fixtures.fake_core import make_fake_core
 
     mock_core = make_fake_core(rpc_call=AsyncMock())
     return ArtifactsAPI(

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -25,10 +25,9 @@ from notebooklm.types import ArtifactDownloadError
 @pytest.fixture
 def mock_artifacts_api():
     """ArtifactsAPI wired to MagicMocks -- no real I/O."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
-
-    from _fixtures.fake_core import make_fake_core
 
     mock_core = make_fake_core(
         rpc_call=AsyncMock(),

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -28,9 +28,12 @@ def mock_artifacts_api():
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 
-    mock_core = MagicMock()
-    mock_core.rpc_call = AsyncMock()
-    mock_core.get_source_ids = AsyncMock(return_value=[])
+    from _fixtures.fake_core import make_fake_core
+
+    mock_core = make_fake_core(
+        rpc_call=AsyncMock(),
+        get_source_ids=AsyncMock(return_value=[]),
+    )
     mind_maps = MagicMock(spec=NoteBackedMindMapService)
     mind_maps.list_mind_maps = AsyncMock(return_value=[])
     note_service = MagicMock(spec=NoteService)

--- a/tests/unit/test_get_summary_drift.py
+++ b/tests/unit/test_get_summary_drift.py
@@ -26,9 +26,10 @@ from notebooklm.rpc import RPCMethod
 
 
 def _make_api(rpc_return):
+    from _fixtures.fake_core import make_fake_core
+
     api = NotebooksAPI.__new__(NotebooksAPI)
-    core = MagicMock()
-    core.rpc_call = AsyncMock(return_value=rpc_return)
+    core = make_fake_core(rpc_call=AsyncMock(return_value=rpc_return))
     api._rpc = core
     return api
 

--- a/tests/unit/test_get_summary_drift.py
+++ b/tests/unit/test_get_summary_drift.py
@@ -16,7 +16,7 @@ to ``safe_index`` so:
 from __future__ import annotations
 
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -611,9 +611,7 @@ class TestGetNotebookFailsClosed:
         returns a Notebook rather than raising.
         """
         api = _make_api(
-            rpc_call=AsyncMock(
-                return_value=[["Title Only", None, "", None, None, [None, False]]]
-            )
+            rpc_call=AsyncMock(return_value=[["Title Only", None, "", None, None, [None, False]]])
         )
 
         notebook = await api.get("nb_partial")

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -21,14 +21,22 @@ from notebooklm.rpc import RPCMethod
 from notebooklm.types import AccountLimits, Notebook, NotebookMetadata, Source, SourceType
 
 
-def _make_core() -> MagicMock:
-    core = MagicMock()
-    core.rpc_call = AsyncMock()
-    return core
+def _make_core(rpc_call: AsyncMock | None = None):
+    """Return a fake collaborator core with a pre-wired ``rpc_call``.
+
+    ADR-007 substrate: built via :func:`make_fake_core` so the resulting
+    bag-of-attributes satisfies the capability Protocols without re-
+    introducing the forbidden post-construction AsyncMock attribute-
+    assignment pattern. Callers that need to control the dispatch
+    behaviour pass a pre-built ``rpc_call`` here.
+    """
+    from _fixtures.fake_core import make_fake_core
+
+    return make_fake_core(rpc_call=rpc_call if rpc_call is not None else AsyncMock())
 
 
-def _make_api() -> NotebooksAPI:
-    core = _make_core()
+def _make_api(rpc_call: AsyncMock | None = None) -> NotebooksAPI:
+    core = _make_core(rpc_call)
     return NotebooksAPI(core, sources_api=MagicMock())
 
 
@@ -328,9 +336,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_near_paid_limit_raises_limit_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         account_limits = _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(499))
 
@@ -348,9 +355,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_at_paid_limit_raises_limit_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
@@ -362,8 +368,7 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_near_free_limit_raises_limit_error(self):
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(side_effect=_create_invalid_argument_error())
+        api = _make_api(rpc_call=AsyncMock(side_effect=_create_invalid_argument_error()))
         _set_account_limit(api, 100)
         api.list = AsyncMock(return_value=_owned_notebooks(100))
 
@@ -375,9 +380,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_uses_account_limit_not_free_boundary(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(100))
 
@@ -388,9 +392,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_away_from_server_limit_preserves_rpc_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(250))
 
@@ -401,9 +404,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_non_quota_rpc_code_preserves_rpc_error_without_listing(self):
-        api = _make_api()
         original = _create_invalid_argument_error(rpc_code=13)
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             return_value=AccountLimits(notebook_limit=500)
         )
@@ -421,9 +423,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_non_create_method_preserves_rpc_error_without_listing(self):
-        api = _make_api()
         original = _create_invalid_argument_error(method_id=RPCMethod.GET_NOTEBOOK.value)
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             return_value=AccountLimits(notebook_limit=500)
         )
@@ -440,9 +441,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_shared_notebooks_do_not_trigger_owned_quota_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(20) + _shared_notebooks(479))
 
@@ -453,9 +453,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_account_limit_failure_preserves_original_create_error_without_listing(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             side_effect=NetworkError("settings failed")
         )
@@ -471,9 +470,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_account_limit_rpc_error_preserves_original_create_error_without_listing(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             side_effect=RPCError("settings failed")
         )
@@ -488,9 +486,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_missing_account_limit_preserves_original_create_error_without_listing(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, None)
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
@@ -503,9 +500,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_list_failure_preserves_original_create_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=NetworkError("list failed"))
 
@@ -516,9 +512,8 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_list_parse_bug_preserves_original_create_error(self):
-        api = _make_api()
         original = _create_invalid_argument_error()
-        api._rpc.rpc_call = AsyncMock(side_effect=original)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
         _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=ValueError("bad notebook data"))
 
@@ -529,8 +524,7 @@ class TestCreateNotebookQuotaDetection:
 
     @pytest.mark.asyncio
     async def test_get_account_limits_uses_user_settings_rpc(self):
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(return_value=[[None, [6, 500, 300, 500000, 2]]])
+        api = _make_api(rpc_call=AsyncMock(return_value=[[None, [6, 500, 300, 500000, 2]]]))
 
         limits = await api._get_account_limits()
 
@@ -557,10 +551,11 @@ class TestGetNotebookFailsClosed:
 
     @pytest.mark.asyncio
     async def test_get_returns_notebook_on_full_response(self):
-        api = _make_api()
         # Realistic shape: [[title, ?, id, ?, ?, [None, False, ...]], ...]
-        api._rpc.rpc_call = AsyncMock(
-            return_value=[["My Notebook", None, "nb_real_123", None, None, [None, False]]]
+        api = _make_api(
+            rpc_call=AsyncMock(
+                return_value=[["My Notebook", None, "nb_real_123", None, None, [None, False]]]
+            )
         )
 
         notebook = await api.get("nb_real_123")
@@ -571,8 +566,7 @@ class TestGetNotebookFailsClosed:
     @pytest.mark.asyncio
     async def test_get_raises_on_empty_outer_list(self):
         """Server returned ``[]`` — no notebook at all."""
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(return_value=[])
+        api = _make_api(rpc_call=AsyncMock(return_value=[]))
 
         with pytest.raises(NotebookNotFoundError) as exc_info:
             await api.get("nb_missing")
@@ -582,8 +576,7 @@ class TestGetNotebookFailsClosed:
 
     @pytest.mark.asyncio
     async def test_get_raises_on_none_response(self):
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(return_value=None)
+        api = _make_api(rpc_call=AsyncMock(return_value=None))
 
         with pytest.raises(NotebookNotFoundError):
             await api.get("nb_missing")
@@ -591,8 +584,7 @@ class TestGetNotebookFailsClosed:
     @pytest.mark.asyncio
     async def test_get_raises_on_degenerate_empty_inner(self):
         """``[[]]`` — outer wrapper present but inner notebook payload empty."""
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(return_value=[[]])
+        api = _make_api(rpc_call=AsyncMock(return_value=[[]]))
 
         with pytest.raises(NotebookNotFoundError) as exc_info:
             await api.get("nb_typo")
@@ -602,9 +594,10 @@ class TestGetNotebookFailsClosed:
     @pytest.mark.asyncio
     async def test_get_raises_when_id_and_title_both_blank(self):
         """Both id and title parsed to empty string → treat as not found."""
-        api = _make_api()
         # Same shape as the happy path but with empty strings in both fields.
-        api._rpc.rpc_call = AsyncMock(return_value=[["", None, "", None, None, [None, False]]])
+        api = _make_api(
+            rpc_call=AsyncMock(return_value=[["", None, "", None, None, [None, False]]])
+        )
 
         with pytest.raises(NotebookNotFoundError):
             await api.get("nb_typo")
@@ -617,9 +610,10 @@ class TestGetNotebookFailsClosed:
         blank, so a parser-quirk that strips the id but keeps the title still
         returns a Notebook rather than raising.
         """
-        api = _make_api()
-        api._rpc.rpc_call = AsyncMock(
-            return_value=[["Title Only", None, "", None, None, [None, False]]]
+        api = _make_api(
+            rpc_call=AsyncMock(
+                return_value=[["Title Only", None, "", None, None, [None, False]]]
+            )
         )
 
         notebook = await api.get("nb_partial")

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -1,6 +1,6 @@
 """Unit tests for NotesAPI private helpers and edge cases."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -19,9 +19,9 @@ def mock_core():
     note-row primitives and the mind-map facade — the same surface
     NotesAPI used to exercise via the legacy ``_mind_map`` module-level helpers.
     """
-    core = MagicMock()
-    core.rpc_call = AsyncMock()
-    return core
+    from _fixtures.fake_core import make_fake_core
+
+    return make_fake_core(rpc_call=AsyncMock())
 
 
 @pytest.fixture

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -29,10 +29,9 @@ from notebooklm.types import GenerationStatus
 
 def _make_api():
     """Return an ArtifactsAPI with mocked runtime + mind-map services."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
-
-    from _fixtures.fake_core import make_fake_core
 
     core = make_fake_core(
         rpc_call=AsyncMock(),

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -32,12 +32,14 @@ def _make_api():
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 
-    core = MagicMock()
-    core.rpc_call = AsyncMock()
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(
+        rpc_call=AsyncMock(),
+        operation_scope=MagicMock(side_effect=lambda _label: _noop_operation_scope()),
+    )
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
     core.poll_registry = PollRegistry()
-    core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
-    core.assert_bound_loop = MagicMock(return_value=None)
     mind_maps = MagicMock(spec=NoteBackedMindMapService)
     note_service = MagicMock(spec=NoteService)
     notebooks = MagicMock()

--- a/tests/unit/test_select_artifact.py
+++ b/tests/unit/test_select_artifact.py
@@ -47,10 +47,9 @@ def _artifact(
 @pytest.fixture
 def api() -> ArtifactsAPI:
     """Build an ArtifactsAPI with no-op runtime / mind-map — only the helper is exercised."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
-
-    from _fixtures.fake_core import make_fake_core
 
     mock_core = make_fake_core(rpc_call=AsyncMock())
     return ArtifactsAPI(

--- a/tests/unit/test_select_artifact.py
+++ b/tests/unit/test_select_artifact.py
@@ -50,8 +50,9 @@ def api() -> ArtifactsAPI:
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
 
-    mock_core = MagicMock()
-    mock_core.rpc_call = AsyncMock()
+    from _fixtures.fake_core import make_fake_core
+
+    mock_core = make_fake_core(rpc_call=AsyncMock())
     return ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -4,11 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from _fixtures.fake_core import make_fake_core
 from notebooklm._notebooks import NotebooksAPI
 from notebooklm._sharing_manager import ShareManager, build_share_url
 from notebooklm.rpc import RPCMethod
-
-from _fixtures.fake_core import make_fake_core
 
 BASE_URL = "https://notebooklm.google.com"
 

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -8,6 +8,8 @@ from notebooklm._notebooks import NotebooksAPI
 from notebooklm._sharing_manager import ShareManager, build_share_url
 from notebooklm.rpc import RPCMethod
 
+from _fixtures.fake_core import make_fake_core
+
 BASE_URL = "https://notebooklm.google.com"
 
 
@@ -17,8 +19,7 @@ def _make_rpc() -> AsyncMock:
 
 def _make_manager() -> tuple[ShareManager, AsyncMock]:
     rpc = _make_rpc()
-    core = MagicMock()
-    core.rpc_call = rpc
+    core = make_fake_core(rpc_call=rpc)
     return ShareManager(core, base_url_provider=lambda: BASE_URL), rpc
 
 
@@ -129,10 +130,12 @@ def test_get_share_url_is_sync_and_does_not_call_rpc() -> None:
 
 @pytest.mark.asyncio
 async def test_notebooks_api_default_share_manager_uses_late_bound_rpc_executor_call() -> None:
-    core = MagicMock()
-    core.rpc_call = AsyncMock(return_value=None)
+    core = make_fake_core(rpc_call=AsyncMock(return_value=None))
     api = NotebooksAPI(core, sources_api=MagicMock())
     replacement_rpc = AsyncMock(return_value=None)
+    # ShareManager binds to the core's rpc_call attribute lazily — swap it
+    # to verify the late-binding contract. This is intentional behavior
+    # under test, not the forbidden pattern (we're testing the binding).
     core.rpc_call = replacement_rpc
 
     with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -183,12 +183,13 @@ class TestSharingAPIValidation:
     @pytest.mark.asyncio
     async def test_add_user_rejects_owner_permission(self):
         """Test that add_user rejects OWNER permission."""
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock
 
         from notebooklm._sharing import SharingAPI
 
-        mock_core = MagicMock()
-        mock_core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        mock_core = make_fake_core(rpc_call=AsyncMock())
         api = SharingAPI(mock_core)
 
         with pytest.raises(ValueError, match="Cannot assign OWNER permission"):
@@ -200,12 +201,13 @@ class TestSharingAPIValidation:
     @pytest.mark.asyncio
     async def test_add_user_rejects_remove_permission(self):
         """Test that add_user rejects _REMOVE permission."""
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock
 
         from notebooklm._sharing import SharingAPI
 
-        mock_core = MagicMock()
-        mock_core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        mock_core = make_fake_core(rpc_call=AsyncMock())
         api = SharingAPI(mock_core)
 
         with pytest.raises(ValueError, match="Use remove_user"):
@@ -216,21 +218,24 @@ class TestSharingAPIValidation:
     @pytest.mark.asyncio
     async def test_add_user_accepts_editor_permission(self):
         """Test that add_user accepts EDITOR permission."""
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock
 
         from notebooklm._sharing import SharingAPI
 
-        mock_core = MagicMock()
+        from _fixtures.fake_core import make_fake_core
+
         # Return empty list for share call, then mock get_status
-        mock_core.rpc_call = AsyncMock(
-            side_effect=[
-                [],  # SHARE_NOTEBOOK response
-                [  # GET_SHARE_STATUS response
-                    [["test@example.com", 2, [], ["Test", "https://avatar"]]],
-                    [False],
-                    1000,
-                ],
-            ]
+        mock_core = make_fake_core(
+            rpc_call=AsyncMock(
+                side_effect=[
+                    [],  # SHARE_NOTEBOOK response
+                    [  # GET_SHARE_STATUS response
+                        [["test@example.com", 2, [], ["Test", "https://avatar"]]],
+                        [False],
+                        1000,
+                    ],
+                ]
+            )
         )
         api = SharingAPI(mock_core)
 
@@ -243,20 +248,23 @@ class TestSharingAPIValidation:
     @pytest.mark.asyncio
     async def test_add_user_accepts_viewer_permission(self):
         """Test that add_user accepts VIEWER permission (default)."""
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock
 
         from notebooklm._sharing import SharingAPI
 
-        mock_core = MagicMock()
-        mock_core.rpc_call = AsyncMock(
-            side_effect=[
-                [],  # SHARE_NOTEBOOK response
-                [  # GET_SHARE_STATUS response
-                    [["test@example.com", 3, [], ["Test", "https://avatar"]]],
-                    [False],
-                    1000,
-                ],
-            ]
+        from _fixtures.fake_core import make_fake_core
+
+        mock_core = make_fake_core(
+            rpc_call=AsyncMock(
+                side_effect=[
+                    [],  # SHARE_NOTEBOOK response
+                    [  # GET_SHARE_STATUS response
+                        [["test@example.com", 3, [], ["Test", "https://avatar"]]],
+                        [False],
+                        1000,
+                    ],
+                ]
+            )
         )
         api = SharingAPI(mock_core)
 

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -185,9 +185,8 @@ class TestSharingAPIValidation:
         """Test that add_user rejects OWNER permission."""
         from unittest.mock import AsyncMock
 
-        from notebooklm._sharing import SharingAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._sharing import SharingAPI
 
         mock_core = make_fake_core(rpc_call=AsyncMock())
         api = SharingAPI(mock_core)
@@ -203,9 +202,8 @@ class TestSharingAPIValidation:
         """Test that add_user rejects _REMOVE permission."""
         from unittest.mock import AsyncMock
 
-        from notebooklm._sharing import SharingAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._sharing import SharingAPI
 
         mock_core = make_fake_core(rpc_call=AsyncMock())
         api = SharingAPI(mock_core)
@@ -220,9 +218,8 @@ class TestSharingAPIValidation:
         """Test that add_user accepts EDITOR permission."""
         from unittest.mock import AsyncMock
 
-        from notebooklm._sharing import SharingAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._sharing import SharingAPI
 
         # Return empty list for share call, then mock get_status
         mock_core = make_fake_core(
@@ -250,9 +247,8 @@ class TestSharingAPIValidation:
         """Test that add_user accepts VIEWER permission (default)."""
         from unittest.mock import AsyncMock
 
-        from notebooklm._sharing import SharingAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._sharing import SharingAPI
 
         mock_core = make_fake_core(
             rpc_call=AsyncMock(

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -37,25 +37,26 @@ def mock_core():
     """
     from notebooklm._request_types import AuthSnapshot
 
-    core = MagicMock()
+    from _fixtures.fake_core import make_fake_core
 
     # ``ChatAPI.get_conversation_id`` uses ``core.rpc_call`` with the
     # ``hPTbtc`` (GET_LAST_CONVERSATION_ID) method. Issue #659: after a
     # new-conversation ask, ``ChatAPI.ask`` calls this to recover the real
     # conversation_id. Route only that method to a hPTbtc-shaped reply;
-    # every other RPC honors ``mock_core.rpc_call.return_value`` so the
-    # artifact tests in this module (which set ``return_value`` per call)
-    # are unaffected.
+    # every other RPC honors ``rpc_call.return_value`` so the artifact
+    # tests in this module (which set ``return_value`` per call) are
+    # unaffected.
     from notebooklm.rpc import RPCMethod as _RPC
 
-    core.rpc_call = AsyncMock(return_value=MagicMock())
+    rpc_call = AsyncMock(return_value=MagicMock())
+    core = make_fake_core(rpc_call=rpc_call)
 
     async def _rpc_call_dispatch(method, params, **kwargs):
         if method == _RPC.GET_LAST_CONVERSATION_ID:
             return [[["mock-core-conv-id"]]]
-        return core.rpc_call.return_value
+        return rpc_call.return_value
 
-    core.rpc_call.side_effect = _rpc_call_dispatch
+    rpc_call.side_effect = _rpc_call_dispatch
     core.auth = MagicMock()
     core.auth.csrf_token = "test_csrf"
     core.auth.session_id = "test_session"
@@ -68,6 +69,9 @@ def mock_core():
     core.next_reqid = AsyncMock(return_value=100000)
     core.assert_bound_loop = MagicMock(return_value=None)
     core.get_http_client = MagicMock()
+    # ``ChatAPI`` reaches transport through ``mock_core.session_transport``
+    # (see ``_chat_from_mock_core`` below); explicit slot on the fake.
+    core.session_transport = MagicMock()
 
     # Default ``perform_authed_post`` stub on the session-transport
     # collaborator: invokes the caller-supplied ``build_request`` factory
@@ -789,16 +793,17 @@ class TestGetSourceIds:
     async def test_get_source_ids_extracts_correctly(self, auth_tokens):
         """Test get_source_ids correctly extracts source IDs from notebook data."""
         from notebooklm._notebooks import NotebooksAPI
-        from notebooklm._session import Session
 
-        core = Session(auth_tokens)
-        core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        rpc = AsyncMock()
+        core = make_fake_core(rpc_call=rpc)
         api = NotebooksAPI(core)
 
         # Mock notebook data with multiple sources
         # Structure: notebook_data[0][1] = sources list
         # Each source: [["source_id"], "Source Title", ...]
-        core.rpc_call.return_value = [
+        rpc.return_value = [
             [
                 "nb_123",  # notebook_info[0]
                 [
@@ -818,13 +823,14 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_empty_notebook(self, auth_tokens):
         """Test get_source_ids handles notebook with no sources."""
         from notebooklm._notebooks import NotebooksAPI
-        from notebooklm._session import Session
 
-        core = Session(auth_tokens)
-        core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        rpc = AsyncMock()
+        core = make_fake_core(rpc_call=rpc)
         api = NotebooksAPI(core)
 
-        core.rpc_call.return_value = [["nb_123", []]]
+        rpc.return_value = [["nb_123", []]]
 
         source_ids = await api.get_source_ids("nb_123")
 
@@ -834,13 +840,14 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_null_response(self, auth_tokens):
         """Test get_source_ids handles null API response."""
         from notebooklm._notebooks import NotebooksAPI
-        from notebooklm._session import Session
 
-        core = Session(auth_tokens)
-        core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        rpc = AsyncMock()
+        core = make_fake_core(rpc_call=rpc)
         api = NotebooksAPI(core)
 
-        core.rpc_call.return_value = None
+        rpc.return_value = None
 
         source_ids = await api.get_source_ids("nb_123")
 
@@ -850,15 +857,16 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_malformed_data(self, auth_tokens):
         """Test get_source_ids handles malformed source data gracefully."""
         from notebooklm._notebooks import NotebooksAPI
-        from notebooklm._session import Session
 
-        core = Session(auth_tokens)
-        core.rpc_call = AsyncMock()
+        from _fixtures.fake_core import make_fake_core
+
+        rpc = AsyncMock()
+        core = make_fake_core(rpc_call=rpc)
         api = NotebooksAPI(core)
 
         # Malformed data - missing nested structure
         # Structure: source[0] must be a list, source[0][0] must be a string
-        core.rpc_call.return_value = [
+        rpc.return_value = [
             [
                 "nb_123",
                 [

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -826,9 +826,8 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_get_source_ids_extracts_correctly(self, auth_tokens):
         """Test get_source_ids correctly extracts source IDs from notebook data."""
-        from notebooklm._notebooks import NotebooksAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._notebooks import NotebooksAPI
 
         rpc = AsyncMock()
         core = make_fake_core(rpc_call=rpc)
@@ -856,9 +855,8 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_get_source_ids_handles_empty_notebook(self, auth_tokens):
         """Test get_source_ids handles notebook with no sources."""
-        from notebooklm._notebooks import NotebooksAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._notebooks import NotebooksAPI
 
         rpc = AsyncMock()
         core = make_fake_core(rpc_call=rpc)
@@ -873,9 +871,8 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_get_source_ids_handles_null_response(self, auth_tokens):
         """Test get_source_ids handles null API response."""
-        from notebooklm._notebooks import NotebooksAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._notebooks import NotebooksAPI
 
         rpc = AsyncMock()
         core = make_fake_core(rpc_call=rpc)
@@ -890,9 +887,8 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_get_source_ids_handles_malformed_data(self, auth_tokens):
         """Test get_source_ids handles malformed source data gracefully."""
-        from notebooklm._notebooks import NotebooksAPI
-
         from _fixtures.fake_core import make_fake_core
+        from notebooklm._notebooks import NotebooksAPI
 
         rpc = AsyncMock()
         core = make_fake_core(rpc_call=rpc)

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -824,7 +824,7 @@ class TestGetSourceIds:
     """Tests for NotebooksAPI.get_source_ids method."""
 
     @pytest.mark.asyncio
-    async def test_get_source_ids_extracts_correctly(self, auth_tokens):
+    async def test_get_source_ids_extracts_correctly(self):
         """Test get_source_ids correctly extracts source IDs from notebook data."""
         from _fixtures.fake_core import make_fake_core
         from notebooklm._notebooks import NotebooksAPI
@@ -853,7 +853,7 @@ class TestGetSourceIds:
         assert source_ids == ["source_aaa", "source_bbb", "source_ccc"]
 
     @pytest.mark.asyncio
-    async def test_get_source_ids_handles_empty_notebook(self, auth_tokens):
+    async def test_get_source_ids_handles_empty_notebook(self):
         """Test get_source_ids handles notebook with no sources."""
         from _fixtures.fake_core import make_fake_core
         from notebooklm._notebooks import NotebooksAPI
@@ -869,7 +869,7 @@ class TestGetSourceIds:
         assert source_ids == []
 
     @pytest.mark.asyncio
-    async def test_get_source_ids_handles_null_response(self, auth_tokens):
+    async def test_get_source_ids_handles_null_response(self):
         """Test get_source_ids handles null API response."""
         from _fixtures.fake_core import make_fake_core
         from notebooklm._notebooks import NotebooksAPI
@@ -885,7 +885,7 @@ class TestGetSourceIds:
         assert source_ids == []
 
     @pytest.mark.asyncio
-    async def test_get_source_ids_handles_malformed_data(self, auth_tokens):
+    async def test_get_source_ids_handles_malformed_data(self):
         """Test get_source_ids handles malformed source data gracefully."""
         from _fixtures.fake_core import make_fake_core
         from notebooklm._notebooks import NotebooksAPI

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -35,9 +35,9 @@ def mock_core():
     factory so URL/body assertions still exercise the production request
     builder.
     """
-    from notebooklm._request_types import AuthSnapshot
+    from types import SimpleNamespace
 
-    from _fixtures.fake_core import make_fake_core
+    from notebooklm._request_types import AuthSnapshot
 
     # ``ChatAPI.get_conversation_id`` uses ``core.rpc_call`` with the
     # ``hPTbtc`` (GET_LAST_CONVERSATION_ID) method. Issue #659: after a
@@ -49,7 +49,16 @@ def mock_core():
     from notebooklm.rpc import RPCMethod as _RPC
 
     rpc_call = AsyncMock(return_value=MagicMock())
-    core = make_fake_core(rpc_call=rpc_call)
+
+    # Forward declare so the dispatcher and default-transport closures can
+    # capture the eventual ``core`` symbol. The actual ``SimpleNamespace``
+    # assembly happens further below, after both closures are defined.
+    auth = SimpleNamespace(
+        csrf_token="test_csrf",
+        session_id="test_session",
+        authuser=0,
+        account_email=None,
+    )
 
     async def _rpc_call_dispatch(method, params, **kwargs):
         if method == _RPC.GET_LAST_CONVERSATION_ID:
@@ -57,21 +66,6 @@ def mock_core():
         return rpc_call.return_value
 
     rpc_call.side_effect = _rpc_call_dispatch
-    core.auth = MagicMock()
-    core.auth.csrf_token = "test_csrf"
-    core.auth.session_id = "test_session"
-    core.auth.authuser = 0
-    core.auth.account_email = None
-    # Reqid counter is bumped via ``await self._reqid.next_reqid()`` inside
-    # ``ChatAPI.ask`` (Wave 8 of session-decoupling); the mock_core fixture
-    # is passed as the ``reqid=`` collaborator by ``_chat_from_mock_core``
-    # below, so this attribute stub is what the chat path actually calls.
-    core.next_reqid = AsyncMock(return_value=100000)
-    core.assert_bound_loop = MagicMock(return_value=None)
-    core.get_http_client = MagicMock()
-    # ``ChatAPI`` reaches transport through ``mock_core.session_transport``
-    # (see ``_chat_from_mock_core`` below); explicit slot on the fake.
-    core.session_transport = MagicMock()
 
     # Default ``perform_authed_post`` stub on the session-transport
     # collaborator: invokes the caller-supplied ``build_request`` factory
@@ -82,10 +76,10 @@ def mock_core():
     # chat-side ``parse_label`` is forwarded as ``log_label``.
     async def _perform_authed_post_default(*, build_request, log_label):
         snapshot = AuthSnapshot(
-            csrf_token=core.auth.csrf_token,
-            session_id=core.auth.session_id,
-            authuser=core.auth.authuser,
-            account_email=core.auth.account_email,
+            csrf_token=auth.csrf_token,
+            session_id=auth.session_id,
+            authuser=auth.authuser,
+            account_email=auth.account_email,
         )
         url, body, headers = build_request(snapshot)
         core._last_chat_request = {"url": url, "body": body, "headers": headers}
@@ -107,11 +101,51 @@ def mock_core():
         resp.text = f")]}}'\n{len(chunk)}\n{chunk}\n"
         return resp
 
-    # Track call counts so tests can assert on transport invocation.
+    # Assemble the bag-of-attributes fixture in one ``SimpleNamespace`` call
+    # so every collaborator slot ``ChatAPI`` and ``ArtifactsAPI`` read from
+    # the fixture lands at construction time. ADR-007 specifically forbids
+    # the ``core.<attr> = <value>`` re-assignment pattern (which is why this
+    # is *not* built via ``make_fake_core`` + post-construction stubs); the
+    # SimpleNamespace constructor satisfies the policy by setting every
+    # attribute up-front.
+    #
     # Wave 8 of session-decoupling: chat now reaches the network through
     # ``session_transport.perform_authed_post`` rather than the legacy
-    # ``transport_post`` facade on Session.
-    core.session_transport.perform_authed_post = AsyncMock(side_effect=_perform_authed_post_default)
+    # ``transport_post`` facade on Session. Reqid is bumped via
+    # ``await self._reqid.next_reqid()``; the bag below is passed as the
+    # ``reqid=`` collaborator by ``_chat_from_mock_core``.
+    session_transport = SimpleNamespace(
+        perform_authed_post=AsyncMock(side_effect=_perform_authed_post_default),
+    )
+
+    # ArtifactsAPI uses the same fixture as its runtime collaborator and
+    # exercises ``register_drain_hook`` (close-time hook) and
+    # ``operation_scope`` (drain-coordinated scope). Stub both up-front so
+    # the fixture satisfies both ChatAPI's reqid/transport surfaces and
+    # ArtifactsAPI's runtime surface in one bag.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _operation_scope_factory(label: str):
+        yield None
+
+    drain_hooks: dict = {}
+
+    def _register_drain_hook(name: str, hook):
+        drain_hooks[name] = hook
+
+    core = SimpleNamespace(
+        rpc_call=rpc_call,
+        auth=auth,
+        next_reqid=AsyncMock(return_value=100000),
+        assert_bound_loop=MagicMock(return_value=None),
+        get_http_client=MagicMock(),
+        session_transport=session_transport,
+        _last_chat_request=None,
+        operation_scope=MagicMock(side_effect=_operation_scope_factory),
+        register_drain_hook=MagicMock(side_effect=_register_drain_hook),
+        _drain_hooks=drain_hooks,
+    )
     return core
 
 

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -22,8 +22,9 @@ from notebooklm.types import Source
 @pytest.fixture
 def mock_core():
     """Create a mocked Session for SourcesAPI."""
-    core = MagicMock()
-    core.rpc_call = AsyncMock()
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock())
     core.auth = MagicMock()
     core.auth.authuser = 0
     core.auth.account_email = None
@@ -33,6 +34,7 @@ def mock_core():
     auth_cookie_jar = MagicMock(name="auth_cookie_jar")
     live_cookie_jar = MagicMock(name="live_cookie_jar")
     core.auth.cookie_jar = auth_cookie_jar
+    core.get_http_client = MagicMock()
     core.get_http_client.return_value.cookies = live_cookie_jar
     core.kernel = core
     # The stateful upload pipeline reaches the live cookie jar through the

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -133,12 +133,13 @@ async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
     # the warn-and-return-"" legacy behavior the CLI's truthiness check relies on.
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
 
+    from _fixtures.fake_core import make_fake_core
+
     api = NotebooksAPI.__new__(NotebooksAPI)
-    mock_core = MagicMock()
     # result[0][0] is a string, so [0] returns a char; result[0][0][0] is fine
     # We need a shape that raises IndexError. result[0] is an empty list →
     # result[0][0] raises IndexError.
-    mock_core.rpc_call = AsyncMock(return_value=[[]])
+    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[]]))
     api._rpc = mock_core
 
     with (
@@ -172,10 +173,11 @@ async def test_description_partial_summary_logs_debug(caplog):
     """_notebooks.py:273 — partial summary (no topics) logs at DEBUG."""
     from notebooklm._notebooks import NotebooksAPI
 
+    from _fixtures.fake_core import make_fake_core
+
     api = NotebooksAPI.__new__(NotebooksAPI)
-    mock_core = MagicMock()
     # outer[0][0] works but outer[1] raises (no topics shape)
-    mock_core.rpc_call = AsyncMock(return_value=[[["the summary"]]])
+    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[["the summary"]]]))
     api._rpc = mock_core
 
     with caplog.at_level(logging.DEBUG, logger="notebooklm"):

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -171,9 +171,8 @@ async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
 @pytest.mark.asyncio
 async def test_description_partial_summary_logs_debug(caplog):
     """_notebooks.py:273 — partial summary (no topics) logs at DEBUG."""
-    from notebooklm._notebooks import NotebooksAPI
-
     from _fixtures.fake_core import make_fake_core
+    from notebooklm._notebooks import NotebooksAPI
 
     api = NotebooksAPI.__new__(NotebooksAPI)
     # outer[0][0] works but outer[1] raises (no topics shape)

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -157,8 +157,9 @@ def test_extract_account_tier_against_recorded_cassette_shape():
 
 @pytest.mark.asyncio
 async def test_get_account_limits_calls_user_settings_rpc():
-    core = MagicMock()
-    core.rpc_call = AsyncMock(return_value=[[None, [6, 200, 100, 500000, 1]]])
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[[None, [6, 200, 100, 500000, 1]]]))
     api = SettingsAPI(core)
 
     limits = await api.get_account_limits()
@@ -177,8 +178,9 @@ async def test_get_account_limits_calls_user_settings_rpc():
 
 @pytest.mark.asyncio
 async def test_get_account_tier_calls_user_tier_rpc():
-    core = MagicMock()
-    core.rpc_call = AsyncMock(return_value=[[[[None, "NOTEBOOKLM_TIER_STANDARD"]]]])
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[[[[None, "NOTEBOOKLM_TIER_STANDARD"]]]]))
     api = SettingsAPI(core)
 
     tier = await api.get_account_tier()

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -1,6 +1,6 @@
 """Unit tests for user settings parsing."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Wave 12 of the [session-decoupling plan](../blob/main/docs/session-decoupling-plan-2026-05-26.md) (Phase 3, Task 5.3). Drains the ADR-007 forbidden-monkeypatch allowlist from **40 → 25 entries** (a 37.5% reduction) by migrating 15 test files to the sanctioned ``make_fake_core(...)`` constructor-injection substrate, and also picks up two reviewer findings deferred from Wave 11c (#1078).

### Allowlist drainage (15 files removed)

Files migrated from the legacy ``MagicMock() + core.rpc_call = AsyncMock(...)`` pattern (pattern (c) in ADR-007) to direct ``make_fake_core(rpc_call=AsyncMock(...))`` construction:

- ``tests/integration/test_artifacts_integration.py``
- ``tests/unit/test_artifact_downloads.py``
- ``tests/unit/test_artifacts_coverage.py``
- ``tests/unit/test_artifacts_drift.py``
- ``tests/unit/test_download_url.py``
- ``tests/unit/test_get_summary_drift.py``
- ``tests/unit/test_notebook_api.py``
- ``tests/unit/test_notes_unit.py``
- ``tests/unit/test_quota_failure_detection.py``
- ``tests/unit/test_select_artifact.py``
- ``tests/unit/test_sharing_manager.py``
- ``tests/unit/test_sharing_types.py``
- ``tests/unit/test_source_selection.py``
- ``tests/unit/test_sources_upload.py``
- ``tests/unit/test_swallow_observability.py``
- ``tests/unit/test_user_settings_api.py``

(The migration commit also touches ``test_source_selection.py`` to use ``SimpleNamespace`` for its chat/artifacts collaborator bag — that file's ChatAPI fixture needed all attributes set at construction time, which neither plain ``MagicMock`` re-assignment nor ``make_fake_core``-then-mutate satisfies under ADR-007.)

### Surviving allowlist entries (25, all annotated)

Every remaining entry now carries an inline ``# reason: ...`` comment explaining why it stays:
- **5 loop-affinity violation tests** in ``tests/integration/concurrency/`` (the test subject *is* raw attribute mutation across loops)
- **1 download-collision concurrency test** (similar — the test exercises raw attribute-level races)
- **19 module-level seam patches** outside the core-injection surface ``make_fake_core(...)`` covers: CLI resolvers, stdlib seams (httpx, asyncio.sleep), filesystem helpers, auth rotation/lock helpers, public-API facades, RPC override tables. ADR-007 calls these out as out-of-scope for the constructor-injection substrate.

**Zero Session-shaped entries remain on the allowlist.** The acceptance criterion in the task spec is met.

### Wave 11c deferred-finding pickup

Two reviewer findings landed after Wave 11c (#1078) merged — both fix sites are tiny and touch files this PR already modifies, so they ship here rather than as separate PRs:

1. **gemini-code-assist HIGH on ``_PATTERN_ASYNCMOCK_ASSIGN``** — Wave 11c narrowed the regex to enumerate only ``rpc_call``, missing that the lint surface is bag-of-attributes *fakes* (which accept any attribute name regardless of whether the production class still defines it). Restored ``transport_post`` / ``_perform_authed_post`` / ``next_reqid`` / ``save_cookies`` to the enumeration so dynamic re-assignment of deleted methods is still caught. The broadened pattern caught one previously-hidden offender in ``test_source_selection.py``, fixed in the same commit.

2. **coderabbit MAJOR on ``test_session_retention.py``** — Wave 11c's ``_disposition_is_valid`` used ``startswith("retain")`` which accepts ``retainXYZ``, bare ``retain``, and ``retain — `` (empty reason). Tightened to regex ``^retain\s+—\s+\S.*$`` so the disposition must read exactly ``retain — <reason>`` with at least one non-whitespace character of reason text. Six new self-coverage tests pin the new rejection / acceptance shapes.

### Commit shape (5 commits, intentionally small for revertability)

1. ``test(adr-007): migrate 15 ADR-007 allowlist offenders to make_fake_core``
2. ``test(lint): drain 15 cleaned files from ADR-007 allowlist + add reason comments``
3. ``test(lint): restore deleted-method names in PATTERN_ASYNCMOCK_ASSIGN (gemini Wave 11c deferred)``
4. ``test(lint): tighten retention-doc disposition validator to require reason (coderabbit Wave 11c deferred)``
5. ``style: drop now-unused MagicMock imports + format migrated tests``

### Coordination with Wave 13 (#1079)

Wave 13 PR #1079 touches ``docs/architecture.md``, ``CLAUDE.md``, ``tests/_lint/test_client_composition.py`` (NEW). **Zero file overlap** with this PR.

## Test plan

- [x] ``uv run pytest tests/_lint -v`` → 75 passed
- [x] ``uv run ruff format --check .`` → 548 files already formatted
- [x] ``uv run ruff check .`` → All checks passed
- [x] ``uv run mypy src/notebooklm`` → no issues found in 173 source files
- [x] ``uv run pytest tests/unit tests/_lint -x -q`` → 5869 passed, 10 skipped
- [ ] CI green
- [ ] @claude review addressed
- [ ] coderabbit / cubic / gemini-code-assist findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored many tests to use a centralized fake core factory for consistent test doubles.
  * Tightened session-retention validation to require an explicit "retain — <reason>" format with expanded positive/negative coverage.
  * Updated fixtures and integration/unit tests for more consistent async RPC mocking and setup patterns.

* **Chores**
  * Strengthened monkeypatch/lint enforcement and reduced the allowed exceptions list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->