### PR TITLE
test(lint): annotate VALID_DISPOSITION_PREFIXES as advisory-only (Wave 12 #1080 follow-up)

### DIFF
--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -58,10 +58,19 @@ SESSION_CLASS_NAME: str = "Session"
 # must be moved to the **Deleted** section at the bottom of the
 # retention doc, which the parser scopes out).
 _RETAIN_PREFIX: str = "retain"
+# **Advisory only** — left in place for documentation continuity and for
+# external readers grepping for "what dispositions does this lint
+# accept?". The actual validator is ``_DISPOSITION_RETAIN_RE`` below;
+# Wave 12 (claude PR #1080 review Finding 2) switched
+# ``_disposition_is_valid`` from
+# ``startswith(VALID_DISPOSITION_PREFIXES)`` to a strict regex match,
+# so adding a new entry to this tuple has **no effect** on validation.
+# Modify the regex if a new prefix needs to be recognised.
 VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX,)
 # Recognised but **rejected** prefix — kept as a named constant so the
 # self-coverage tests below can pin "Wave 11c rejects this" without
-# accidentally widening the live ``VALID_DISPOSITION_PREFIXES`` tuple.
+# accidentally widening the live retain-only invariant enforced by
+# ``_DISPOSITION_RETAIN_RE``.
 _RETIRED_DELETE_PREFIX: str = "delete in Wave 11"
 
 # Strict-shape validator (Wave 12, coderabbit Wave 11c deferred). The


### PR DESCRIPTION
## Summary

Follow-up to merged Wave 12 PR #1080. Addresses claude's Finding 2 from that review which landed after the merge — the fix commit was on the merged branch but didn't make it into the squash because the PR was merged before claude finished reviewing.

After Wave 12 switched ``_disposition_is_valid`` to use ``_DISPOSITION_RETAIN_RE.match(...)``, the ``VALID_DISPOSITION_PREFIXES`` tuple was orphaned (no longer referenced by the validator). Adding a new entry to it now has no effect on validation — the kind of silent lie the project's lint policy is built to catch.

Annotate the tuple as advisory-only with an explicit comment pointing readers to ``_DISPOSITION_RETAIN_RE`` as the actual validator, and update the sibling ``_RETIRED_DELETE_PREFIX`` comment to reference the regex rather than the now-toothless tuple.

## Test plan

- [x] ``uv run pytest tests/_lint -q`` → 77 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test documentation with clarifying comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->