### PR TITLE
fix(artifacts): default infographic generation options

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -232,12 +232,18 @@ sit at the intersection — they're catchable as **any** of `NotFoundError`
 | `NotebookNotFoundError` | `NotFoundError`, `RPCError`, `NotebookError`, `NotebookLMError` |
 | `SourceNotFoundError` | `NotFoundError`, `RPCError`, `SourceError`, `NotebookLMError` |
 | `ArtifactNotFoundError` | `NotFoundError`, `RPCError`, `ArtifactError`, `NotebookLMError` |
+| `ArtifactFeatureUnavailableError` | `RPCError`, `ArtifactError`, `NotebookLMError` |
 
 Use the table to pick the right level of catch. `client.sources.get(...)`
 returns `None` for a missing source rather than raising; the workflows that
 do raise `SourceNotFoundError` are `client.sources.get_fulltext(...)` and
 `client.sources.wait_until_ready(...)`. Artifact-download workflows raise
 `ArtifactNotFoundError` when a requested artifact ID is not in the listing.
+Artifact generation workflows may raise `ArtifactFeatureUnavailableError`
+when NotebookLM accepts the RPC but returns no generation task for a specific
+artifact feature. For infographic generation, a null `CREATE_ARTIFACT` result
+is reported this way instead of surfacing as schema drift or a failed
+`GenerationStatus`.
 
 ##### Catching any "not found" across domains
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -89,7 +89,7 @@ ClientError, ConfigurationError, ValidationError
 # found" types — see docs/python-api.md#error-handling for migration prose.
 SourceError, SourceAddError, SourceProcessingError, SourceTimeoutError, SourceNotFoundError
 NotebookError, NotebookNotFoundError
-ArtifactError, ArtifactDownloadError, ArtifactNotFoundError, ArtifactNotReadyError, ArtifactParseError
+ArtifactError, ArtifactDownloadError, ArtifactFeatureUnavailableError, ArtifactNotFoundError, ArtifactNotReadyError, ArtifactParseError
 ChatError
 
 # Enums

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -57,6 +57,7 @@ from .exceptions import (
     # Domain: Artifacts
     ArtifactDownloadError,
     ArtifactError,
+    ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
@@ -226,6 +227,7 @@ __all__ = [
     "SourceNotFoundError",
     # Domain Exceptions: Artifacts
     "ArtifactError",
+    "ArtifactFeatureUnavailableError",
     "ArtifactNotFoundError",
     "ArtifactNotReadyError",
     "ArtifactParseError",

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ._env import get_default_language
-from .exceptions import ValidationError
+from .exceptions import ArtifactFeatureUnavailableError, ValidationError
 from .rpc import (
     ArtifactTypeCode,
     AudioFormat,
@@ -415,9 +415,13 @@ class ArtifactGenerationService:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
-        orientation_code = orientation.value if orientation else None
-        detail_code = detail_level.value if detail_level else None
-        style_code = style.value if style else None
+        orientation_code = (
+            orientation.value if orientation is not None else InfographicOrientation.LANDSCAPE.value
+        )
+        detail_code = (
+            detail_level.value if detail_level is not None else InfographicDetail.STANDARD.value
+        )
+        style_code = style.value if style is not None else InfographicStyle.AUTO_SELECT.value
 
         params = [
             [2],
@@ -440,7 +444,11 @@ class ArtifactGenerationService:
                 [[instructions, language, None, orientation_code, detail_code, style_code]],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="infographic",
+        )
 
     async def generate_slide_deck(
         self,
@@ -673,7 +681,13 @@ class ArtifactGenerationService:
 
         return suggestions
 
-    async def call_generate(self, notebook_id: str, params: list[Any]) -> GenerationStatus:
+    async def call_generate(
+        self,
+        notebook_id: str,
+        params: list[Any],
+        *,
+        null_result_artifact_type: str | None = None,
+    ) -> GenerationStatus:
         """Make a generation RPC call with error handling."""
         artifact_type = params[2][2] if len(params) > 2 and len(params[2]) > 2 else "unknown"
         logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
@@ -700,6 +714,11 @@ class ArtifactGenerationService:
                     error_code=str(e.rpc_code) if e.rpc_code is not None else None,
                 )
             raise
+        if result is None and null_result_artifact_type is not None:
+            raise ArtifactFeatureUnavailableError(
+                null_result_artifact_type,
+                method_id=RPCMethod.CREATE_ARTIFACT.value,
+            )
         return self.parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
     def parse_generation_result(

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -81,6 +81,7 @@ __all__ = [
     "ArtifactNotReadyError",
     "ArtifactParseError",
     "ArtifactDownloadError",
+    "ArtifactFeatureUnavailableError",
     # Domain: Research
     "ResearchTaskMismatchError",
 ]
@@ -1002,6 +1003,36 @@ class ArtifactDownloadError(ArtifactError):
         if details:
             msg += f": {details}"
         super().__init__(msg)
+
+
+class ArtifactFeatureUnavailableError(RPCError, ArtifactError):
+    """Artifact generation feature is unavailable for this request.
+
+    NotebookLM can accept a ``CREATE_ARTIFACT`` request but return a null
+    result when a specific artifact feature is disabled, gated, or rejected
+    before a generation task is created. This is not schema drift: the RPC
+    decoded successfully, but no task row exists to parse.
+
+    Attributes:
+        artifact_type: The artifact type being generated.
+        method_id: The RPC method ID (inherited from :class:`RPCError`).
+        raw_response: First 80 chars of the raw response, if any
+            (``NOTEBOOKLM_DEBUG=1`` preserves the full body).
+    """
+
+    def __init__(
+        self,
+        artifact_type: str,
+        *,
+        method_id: str | None = None,
+        raw_response: str | None = None,
+    ):
+        self.artifact_type = artifact_type
+        super().__init__(
+            f"{artifact_type.replace('_', ' ').capitalize()} generation is unavailable",
+            method_id=method_id,
+            raw_response=raw_response,
+        )
 
 
 # =============================================================================

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -52,6 +52,7 @@ from ._types.sources import (
 from .exceptions import (
     ArtifactDownloadError,
     ArtifactError,
+    ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
@@ -142,6 +143,7 @@ __all__ = [
     "SourceTimeoutError",
     "SourceNotFoundError",
     "ArtifactError",
+    "ArtifactFeatureUnavailableError",
     "ArtifactNotFoundError",
     "ArtifactNotReadyError",
     "ArtifactParseError",

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -32,6 +32,7 @@ from notebooklm.rpc import (
     VideoStyle,
 )
 from notebooklm.types import (
+    ArtifactFeatureUnavailableError,
     ArtifactNotReadyError,
     ArtifactParseError,
     ArtifactType,
@@ -687,6 +688,40 @@ class TestArtifactsAPI:
 
         assert result is not None
         assert result.task_id == "ig_456"
+
+    @pytest.mark.asyncio
+    async def test_generate_infographic_null_result_raises_feature_unavailable(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A null CREATE_ARTIFACT result is an unavailable artifact feature."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["source_123"], "Source", [None, 0], [None, 2]]],
+                    "nb_123",
+                    "📘",
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        null_response = build_rpc_response(RPCMethod.CREATE_ARTIFACT, None)
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=null_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactFeatureUnavailableError) as exc_info:
+                await client.artifacts.generate_infographic("nb_123")
+
+        err = exc_info.value
+        assert err.artifact_type == "infographic"
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
+        assert str(err) == "Infographic generation is unavailable"
 
     @pytest.mark.asyncio
     async def test_generate_data_table(

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -7,6 +7,7 @@ from notebooklm._env import DEFAULT_BASE_URL
 from notebooklm.exceptions import (
     ArtifactDownloadError,
     ArtifactError,
+    ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
@@ -69,6 +70,7 @@ class TestExceptionHierarchy:
             ArtifactNotReadyError,
             ArtifactParseError,
             ArtifactDownloadError,
+            ArtifactFeatureUnavailableError,
         ]
         for exc_class in exceptions:
             assert issubclass(exc_class, NotebookLMError), (
@@ -102,6 +104,7 @@ class TestExceptionHierarchy:
         assert issubclass(ArtifactNotReadyError, ArtifactError)
         assert issubclass(ArtifactParseError, ArtifactError)
         assert issubclass(ArtifactDownloadError, ArtifactError)
+        assert issubclass(ArtifactFeatureUnavailableError, ArtifactError)
 
     def test_not_found_errors_are_rpc_errors(self):
         """All ``*NotFoundError`` classes mix in :class:`RPCError`.
@@ -572,6 +575,15 @@ class TestDomainExceptions:
         assert e.artifact_type == "audio"
         assert e.details == "404 Not Found"
         assert e.artifact_id == "art_789"
+
+    def test_artifact_feature_unavailable_error_has_rpc_metadata(self):
+        """ArtifactFeatureUnavailableError stores artifact type and RPC metadata."""
+        e = ArtifactFeatureUnavailableError("infographic", method_id="R7cb6c")
+        assert e.artifact_type == "infographic"
+        assert e.method_id == "R7cb6c"
+        assert isinstance(e, ArtifactError)
+        assert isinstance(e, RPCError)
+        assert str(e) == "Infographic generation is unavailable"
 
 
 class TestAuthExtractionErrorScrubbing:

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -272,6 +272,7 @@ _FROZEN_TYPES_ALL = [
     "SourceTimeoutError",
     "SourceNotFoundError",
     "ArtifactError",
+    "ArtifactFeatureUnavailableError",
     "ArtifactNotFoundError",
     "ArtifactNotReadyError",
     "ArtifactParseError",
@@ -360,6 +361,7 @@ _TYPES_EXCEPTION_REEXPORTS = [
     "SourceTimeoutError",
     "SourceNotFoundError",
     "ArtifactError",
+    "ArtifactFeatureUnavailableError",
     "ArtifactNotFoundError",
     "ArtifactNotReadyError",
     "ArtifactParseError",
@@ -369,6 +371,7 @@ _TYPES_EXCEPTION_REEXPORTS = [
 _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "ArtifactDownloadError",
     "ArtifactError",
+    "ArtifactFeatureUnavailableError",
     "ArtifactNotFoundError",
     "ArtifactNotReadyError",
     "ArtifactParseError",

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -17,7 +17,13 @@ import pytest
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._chat import ChatAPI
 from notebooklm.exceptions import ValidationError
-from notebooklm.rpc import InfographicStyle, VideoFormat, VideoStyle
+from notebooklm.rpc import (
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    VideoFormat,
+    VideoStyle,
+)
 
 
 @pytest.fixture
@@ -611,12 +617,18 @@ class TestArtifactsSourceSelection:
 
         inner_params = params[2]
         source_ids_triple = inner_params[3]
+        infographic_config = inner_params[14][0]
 
         assert source_ids_triple == [[["src_info_1"]], [["src_info_2"]]]
+        assert infographic_config[3] == InfographicOrientation.LANDSCAPE.value
+        assert infographic_config[4] == InfographicDetail.STANDARD.value
+        assert infographic_config[5] == InfographicStyle.AUTO_SELECT.value
 
     @pytest.mark.asyncio
-    async def test_generate_infographic_style_encoding(self, mock_core, mock_mind_map_service):
-        """Test generate_infographic encodes style in config slot 5."""
+    async def test_generate_infographic_visual_option_encoding(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Test generate_infographic encodes explicit visual options in config slots."""
         api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
@@ -624,6 +636,8 @@ class TestArtifactsSourceSelection:
         await api.generate_infographic(
             notebook_id="nb_123",
             source_ids=["src_info_1"],
+            orientation=InfographicOrientation.PORTRAIT,
+            detail_level=InfographicDetail.DETAILED,
             style=InfographicStyle.PROFESSIONAL,
         )
 
@@ -633,6 +647,8 @@ class TestArtifactsSourceSelection:
         inner_params = params[2]
         infographic_config = inner_params[14][0]
 
+        assert infographic_config[3] == InfographicOrientation.PORTRAIT.value
+        assert infographic_config[4] == InfographicDetail.DETAILED.value
         assert infographic_config[5] == InfographicStyle.PROFESSIONAL.value
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fixes Python API `generate_infographic()` defaults so it sends the same concrete visual options as the CLI (`LANDSCAPE`, `STANDARD`, `AUTO_SELECT`)
- preserves explicit infographic visual option overrides in the RPC payload
- classifies a null CREATE_ARTIFACT response as `ArtifactFeatureUnavailableError` instead of a schema-drift `UnknownRPCMethodError`

Fixes #1063.

## Root Cause
The CLI already supplied concrete defaults for infographic orientation/detail/style. The Python API accepted `None` defaults and encoded those as null visual option slots. The live NotebookLM API now rejects that null infographic config before task creation, returning a null RPC result.

## Live API Verification
- Before the default-option fix, `client.artifacts.generate_infographic(notebook_id)` reproduced the issue path as a null CREATE_ARTIFACT result.
- Explicit CLI-equivalent defaults succeeded.
- After this fix, the default Python call started task `a10be54f-3b63-4946-82ae-4c843c8f3c79`, poll returned `in_progress`, and cleanup delete returned `true`.

## Local Verification
- `uv run notebooklm doctor`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pytest tests/unit/test_source_selection.py::TestArtifactsSourceSelection::test_generate_infographic_source_encoding tests/unit/test_source_selection.py::TestArtifactsSourceSelection::test_generate_infographic_visual_option_encoding tests/integration/test_artifacts_integration.py::TestArtifactsAPI::test_generate_infographic_null_result_raises_feature_unavailable -q`
- `uv run pytest` (`6511 passed, 12 skipped`)
- `uv run pre-commit run --all-files`
