### PR TITLE
refactor(artifacts): delete _ARTIFACT_COMPAT_EXPORTS tuple + 7 wrappers (Stage C2 PR 1)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -54,77 +54,12 @@ from .rpc import (
 )
 from .types import (
     Artifact,
-    ArtifactDownloadError,
-    ArtifactNotFoundError,
-    ArtifactNotReadyError,
-    ArtifactParseError,
     ArtifactType,
     GenerationStatus,
     ReportSuggestion,
-    _extract_artifact_url,
 )
 
 logger = logging.getLogger(__name__)
-
-
-# Private compatibility exports that remain intentionally available through
-# ``notebooklm._artifacts``. Downloads no longer patch through this module, but
-# a few whitebox tests and downstream users still import these private names.
-_ARTIFACT_COMPAT_EXPORTS = (
-    DownloadResult,
-    ArtifactDownloadError,
-    ArtifactNotFoundError,
-    ArtifactNotReadyError,
-    ArtifactParseError,
-    _extract_artifact_url,
-)
-
-
-# Backward-compatible private helper wrappers.
-def _extract_app_data(html_content: str) -> dict:
-    return _artifact_formatters._extract_app_data(html_content)
-
-
-def _format_quiz_markdown(title: str, questions: list[dict]) -> str:
-    return _artifact_formatters._format_quiz_markdown(title, questions)
-
-
-def _format_flashcards_markdown(title: str, cards: list[dict]) -> str:
-    return _artifact_formatters._format_flashcards_markdown(title, cards)
-
-
-def _extract_cell_text(cell: Any) -> str:
-    return _artifact_formatters._extract_cell_text(cell)
-
-
-def _extract_data_table_rows(raw_data: Any) -> list[Any]:
-    return _artifact_formatters._extract_data_table_rows(raw_data)
-
-
-def _parse_data_table(raw_data: list) -> tuple[list[str], list[list[str]]]:
-    return _artifact_formatters._parse_data_table(
-        raw_data,
-        rows_extractor=_extract_data_table_rows,
-        cell_text_extractor=_extract_cell_text,
-    )
-
-
-def _format_interactive_content(
-    app_data: dict,
-    title: str,
-    output_format: str,
-    html_content: str,
-    is_quiz: bool,
-) -> str:
-    return _artifact_formatters._format_interactive_content(
-        app_data,
-        title,
-        output_format,
-        html_content,
-        is_quiz,
-        quiz_markdown_formatter=_format_quiz_markdown,
-        flashcards_markdown_formatter=_format_flashcards_markdown,
-    )
 
 
 class DrainHookRegistration(Protocol):
@@ -654,7 +589,15 @@ class ArtifactsAPI:
         Returns:
             Formatted content string.
         """
-        return _format_interactive_content(app_data, title, output_format, html_content, is_quiz)
+        return _artifact_formatters._format_interactive_content(
+            app_data,
+            title,
+            output_format,
+            html_content,
+            is_quiz,
+            quiz_markdown_formatter=_artifact_formatters._format_quiz_markdown,
+            flashcards_markdown_formatter=_artifact_formatters._format_flashcards_markdown,
+        )
 
     async def download_report(
         self,

--- a/tests/unit/test_artifacts_helpers.py
+++ b/tests/unit/test_artifacts_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for module-level helpers in ``notebooklm._artifacts``.
+"""Unit tests for module-level helpers in ``notebooklm._artifact_formatters``.
 
 Focuses on ``_extract_data_table_rows`` — the named extractor that replaces
 the raw ``raw_data[0][0][0][0][4][2]`` deep-index chain in
@@ -13,8 +13,7 @@ import logging
 
 import pytest
 
-import notebooklm._artifacts as artifacts_module
-from notebooklm._artifacts import (
+from notebooklm._artifact_formatters import (
     _extract_data_table_rows,
     _parse_data_table,
 )
@@ -151,68 +150,6 @@ def test_parse_data_table_raises_on_empty_rows() -> None:
 
     with pytest.raises(ArtifactParseError, match="Empty data table"):
         _parse_data_table(raw_data)
-
-
-def test_parse_data_table_wrapper_honors_artifacts_private_helper_seams(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The _artifacts wrapper keeps sibling helper monkeypatch seams intact."""
-    rows_payload = [
-        [0, 5, ["header_cell"]],
-        [5, 10, ["value_cell"]],
-    ]
-
-    monkeypatch.setattr(
-        artifacts_module,
-        "_extract_data_table_rows",
-        lambda raw_data: rows_payload,
-    )
-    monkeypatch.setattr(
-        artifacts_module,
-        "_extract_cell_text",
-        lambda cell: f"text:{cell}",
-    )
-
-    headers, rows = artifacts_module._parse_data_table(["patched raw data"])
-
-    assert headers == ["text:header_cell"]
-    assert rows == [["text:value_cell"]]
-
-
-@pytest.mark.parametrize(
-    ("app_data", "is_quiz", "patched_name", "expected_items"),
-    [
-        ({"quiz": [{"question": "Q"}]}, True, "_format_quiz_markdown", [{"question": "Q"}]),
-        ({"flashcards": [{"f": "front"}]}, False, "_format_flashcards_markdown", [{"f": "front"}]),
-    ],
-)
-def test_format_interactive_content_wrapper_honors_artifacts_markdown_seams(
-    monkeypatch: pytest.MonkeyPatch,
-    app_data: dict,
-    is_quiz: bool,
-    patched_name: str,
-    expected_items: list[dict],
-) -> None:
-    """Interactive markdown wrappers keep sibling formatter monkeypatch seams intact."""
-    captured: dict[str, object] = {}
-
-    def formatter(title: str, items: list[dict]) -> str:
-        captured["title"] = title
-        captured["items"] = items
-        return "patched markdown"
-
-    monkeypatch.setattr(artifacts_module, patched_name, formatter)
-
-    result = artifacts_module._format_interactive_content(
-        app_data,
-        "Patched Title",
-        "markdown",
-        "<html></html>",
-        is_quiz,
-    )
-
-    assert result == "patched markdown"
-    assert captured == {"title": "Patched Title", "items": expected_items}
 
 
 def test_parse_data_table_happy_path() -> None:

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from notebooklm._artifacts import DownloadResult
+from notebooklm.exceptions import ArtifactDownloadError
 
 # A trusted-domain prefix accepted by `_download_urls_batch`'s domain check.
 TRUSTED_URL_PREFIX = "https://storage.googleapis.com/"
@@ -57,13 +58,23 @@ def test_failed_preserves_url_and_exception():
 
 
 def test_artifacts_module_preserves_download_patch_targets():
-    """Public download result remains available without facade patch targets."""
+    """Public download result remains available without facade patch targets.
+
+    Post-C2 the artifact-compat tuple and its unused exception-class
+    re-exports were removed from ``_artifacts.py``. The artifact
+    exception classes now resolve only from their canonical home
+    (``notebooklm.exceptions``); ``_artifacts`` no longer carries
+    ``ArtifactDownloadError`` as an attribute. ``DownloadResult`` and
+    the ``_mind_map`` re-export remain because ``_artifacts.py`` uses
+    them internally.
+    """
     import notebooklm._artifacts as artifacts_module
 
     assert artifacts_module.DownloadResult is DownloadResult
-    assert artifacts_module.ArtifactDownloadError is not None
     assert artifacts_module._mind_map is not None
     assert not hasattr(artifacts_module, "load_httpx_cookies")
+    # The exception classes are no longer reachable through `_artifacts`.
+    assert not hasattr(artifacts_module, "ArtifactDownloadError")
 
 
 # ---------------------------------------------------------------------------
@@ -177,8 +188,6 @@ async def test_html_response_aggregated_into_failed(mock_artifacts_api, tmp_path
     ``tests/integration/test_artifacts_integration.py``'s download-URL
     contract tests for that surface.
     """
-    from notebooklm._artifacts import ArtifactDownloadError
-
     api, _ = mock_artifacts_api
     html_response = _mock_response(b"<html>...</html>", "text/html")
 
@@ -200,8 +209,6 @@ async def test_html_response_aggregated_into_failed(mock_artifacts_api, tmp_path
 @pytest.mark.asyncio
 async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_path):
     """Untrusted-domain ``ArtifactDownloadError`` lands in ``failed``, not raised."""
-    from notebooklm._artifacts import ArtifactDownloadError
-
     api, _ = mock_artifacts_api
 
     with patch("notebooklm._artifact_downloads.load_httpx_cookies", return_value={}):
@@ -265,8 +272,6 @@ async def test_download_batch_isolates_bad_url_from_good_one(mock_artifacts_api,
     the good URL still completes — caller can pick up the partial result
     and retry just the failure.
     """
-    from notebooklm._artifacts import ArtifactDownloadError
-
     api, _ = mock_artifacts_api
     bad_url = "https://untrusted.example/x.mp4"
     good_url = f"{TRUSTED_URL_PREFIX}y.mp4"


### PR DESCRIPTION
## Summary

Stage C2 / Step 1 from `docs/post-refactoring-plan-2026-05-27.md` — one coherent PR deleting the explicit `_ARTIFACT_COMPAT_EXPORTS` compat-contract tuple and the seven module-level private wrapper helpers in `_artifacts.py`. All wrappers were pure forwards to the canonical `_artifact_formatters.<name>` definitions.

- **`src/notebooklm/_artifacts.py`** — delete the tuple, the seven wrappers, the five unused exception/URL imports from `.types` (F401 after deletion), and fix the same-module call previously at `_artifacts.py:657` to use `_artifact_formatters._format_interactive_content(...)` with kwarg-injection re-supplied at the call site.
- **`tests/unit/test_artifacts_helpers.py`** — migrate the direct imports of `_extract_data_table_rows` / `_parse_data_table` to the canonical `notebooklm._artifact_formatters` home; delete the two wrapper-seam tests (`test_parse_data_table_wrapper_honors_artifacts_private_helper_seams`, `test_format_interactive_content_wrapper_honors_artifacts_markdown_seams`).
- **`tests/unit/test_download_result.py`** — import `ArtifactDownloadError` from `notebooklm.exceptions` (canonical home), replace the `assert artifacts_module.ArtifactDownloadError is not None` seam-pin with an `assert not hasattr(...)` guard that protects against reintroducing the leaky re-export, and drop three now-redundant inner `from notebooklm._artifacts import ArtifactDownloadError` imports.

The `from . import _mind_map` re-export at `_artifacts.py:24` is retained — the module uses `_mind_map.NoteBackedMindMapService` internally, and `test_init_order.py` continues to assert the `artifacts._mind_map is mind_map` identity.

## Pre-verification grep inventory (per plan's "Before C2 PR 1" section)

| Grep | Pre-PR result | Action |
|---|---|---|
| `rg --multiline 'from notebooklm\._artifacts import\s*\('` (src+tests) | 1 hit: `tests/unit/test_artifacts_helpers.py` direct-import block for `_extract_data_table_rows`/`_parse_data_table` | Migrated to `_artifact_formatters` |
| `rg 'from notebooklm\._artifacts import (_ARTIFACT_COMPAT_EXPORTS\|_extract_app_data\|_format_quiz_markdown\|_format_flashcards_markdown\|_extract_cell_text\|_extract_data_table_rows\|_parse_data_table\|_format_interactive_content)'` | 0 explicit-name hits | (n/a — names were imported via the multiline form above) |
| `rg 'import notebooklm\._artifacts as\|from notebooklm import _artifacts'` | 3 hits: `test_init_order.py` (uses only `artifacts._mind_map`), `test_download_result.py` (uses only `DownloadResult` + `_mind_map`), `test_artifacts_helpers.py` (only the 2 seam tests now deleted) | `test_artifacts_helpers.py` import removed with the seam tests; other 2 unaffected |
| `rg 'notebooklm\._artifacts\.(<wrapper-names>)'` (module-dot access) | 0 hits | n/a |
| `rg 'ArtifactDownloadError\|ArtifactNotFoundError\|ArtifactNotReadyError\|ArtifactParseError\|_extract_artifact_url' src/notebooklm/_artifacts.py` | All matches in the tuple + import block + docstrings → confirmed F401 after deletion | Deleted unused imports |
| `rg 'artifacts_module\.(ArtifactDownloadError\|DownloadResult)' tests/unit/test_download_result.py` | Both assertions present | `DownloadResult is DownloadResult` kept; `ArtifactDownloadError is not None` flipped to `not hasattr(...)` guard |

## Canonical-home migrations

| Symbol | Old reachability | New canonical home |
|---|---|---|
| `_extract_app_data`, `_format_quiz_markdown`, `_format_flashcards_markdown`, `_extract_cell_text`, `_extract_data_table_rows`, `_parse_data_table`, `_format_interactive_content` | `notebooklm._artifacts.<name>` (thin wrapper) | `notebooklm._artifact_formatters.<name>` |
| `ArtifactDownloadError`, `ArtifactNotFoundError`, `ArtifactNotReadyError`, `ArtifactParseError` | also reachable via `notebooklm._artifacts.<name>` | `notebooklm.exceptions.<name>` |
| `_extract_artifact_url` | also reachable via `notebooklm._artifacts.<name>` | `notebooklm._types.artifacts._extract_artifact_url` |

## Same-module call fix

Previously at `_artifacts.py:657`:
```python
return _format_interactive_content(app_data, title, output_format, html_content, is_quiz)
```

Now (in `ArtifactsAPI._format_interactive_content`):
```python
return _artifact_formatters._format_interactive_content(
    app_data, title, output_format, html_content, is_quiz,
    quiz_markdown_formatter=_artifact_formatters._format_quiz_markdown,
    flashcards_markdown_formatter=_artifact_formatters._format_flashcards_markdown,
)
```

The kwarg-injection that the deleted wrapper previously supplied is re-supplied explicitly at the call site.

## Test plan

- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean (catches F401 the plan flagged)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (173 source files)
- [x] `uv run pytest tests/_lint` — 77 passed
- [x] `uv run pytest tests/unit/test_artifacts_helpers.py tests/unit/test_download_result.py` — 20 passed
- [x] `uv run pytest tests/unit tests/integration` — 6394 passed, 49 skipped
- [x] `uv run pre-commit run --all-files` — passed

## Acceptance grep gates

- `rg '_ARTIFACT_COMPAT_EXPORTS' src tests` → empty
- `rg 'def _(extract_app_data|format_quiz_markdown|format_flashcards_markdown|extract_cell_text|extract_data_table_rows|parse_data_table)' src/notebooklm/_artifacts.py` → empty
- (Caveat: `def _format_interactive_content` matches the unrelated `ArtifactsAPI._format_interactive_content` instance method, which is intentionally retained per the task spec's "Do NOT widen scope beyond the tuple + 7 wrappers" constraint.)

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal artifact processing utilities for improved code structure and maintainability.
  * Updated test imports to reflect internal code reorganization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->