### PR TITLE
docs(adr): flip ADR-014 to Accepted (Wave 6 / Task 6.2)

### DIFF
--- a/docs/adr/0014-feature-local-runtime-adapters.md
+++ b/docs/adr/0014-feature-local-runtime-adapters.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (2026-05-26).
+Accepted (#1082; Stage-B issue #1084; MiddlewareChainHost issue #1085).
 
 ## Context
 
@@ -42,7 +42,7 @@ satisfier of every Protocol. This produces four observable consequences:
    [ADR-007](./0007-test-monkeypatch-policy.md) forbidden-monkeypatch
    allowlist (~30 file-level entries today) is the visible gravity well this
    creates — every entry pins a Session-shaped surface that ADR-013's narrow
-   Protocols *should* have eliminated.
+   Protocols _should_ have eliminated.
 
 4. **`RpcOwner` Protocol carries underscore-prefixed `Session` internals.**
    `RpcExecutor` declares an `RpcOwner` dependency
@@ -54,8 +54,8 @@ satisfier of every Protocol. This produces four observable consequences:
 
 The architectural pressure is real and ongoing. Every feature added between v0.5.0
 and today has either grown `Session` or required a new compatibility forward.
-ADR-013 framed the *interface* model correctly; what was missing is the matching
-*implementation* model.
+ADR-013 framed the _interface_ model correctly; what was missing is the matching
+_implementation_ model.
 
 ## Decision
 
@@ -65,15 +65,15 @@ implementation rules change how those interfaces are satisfied at runtime.
 
 ### Rule 1 — Single-collaborator Protocols are satisfied directly (after method push-down)
 
-| Protocol | Satisfier (post-migration) | Migration prerequisite |
-|---|---|---|
-| `RpcCaller` | `RpcExecutor` directly | none — already structurally satisfies (TYPE_CHECKING assertion at [`_rpc_executor.py:463`](../../src/notebooklm/_rpc_executor.py)) |
-| `LoopGuard` | `ClientLifecycle` directly | **push down `assert_bound_loop()`** — currently lives on `Session.assert_bound_loop` ([`_session.py:486`](../../src/notebooklm/_session.py)), which calls `_loop_affinity.assert_bound_loop(self.bound_loop)`. `ClientLifecycle` already owns `get_bound_loop` ([`_session_lifecycle.py:271`](../../src/notebooklm/_session_lifecycle.py)); the push-down adds a trivial `assert_bound_loop()` method that calls the free function with `self.get_bound_loop()`. |
-| `OperationScopeProvider` | `TransportDrainTracker` directly | **push down `operation_scope(label)`** — currently lives on `Session.operation_scope` ([`_session.py:495`](../../src/notebooklm/_session.py)) as an async context manager wrapping `begin_transport_post` / `finish_transport_post` (both already on `TransportDrainTracker` at [`_transport_drain.py:139,196`](../../src/notebooklm/_transport_drain.py)). The push-down moves the contextmanager wrapper to the tracker. |
-| `DrainHookRegistration` (feature-local in `_artifacts.py`) | `TransportDrainTracker` directly | **push down `register_drain_hook(name, hook)` + the underlying `_drain_hooks` storage** — currently lives on `Session.register_drain_hook` ([`_session.py:421`](../../src/notebooklm/_session.py)). The push-down moves both the method and the storage onto the tracker. |
-| `AsyncWorkRuntime` (composes `LoopGuard` + `OperationScopeProvider`) | satisfied **transitively** by `ArtifactsRuntimeAdapter` / `UploadRuntimeAdapter` (Rule 2) | depends on the push-downs above. No dedicated `_AsyncWorkAdapter` — per Rule 2, trivial composites do not get adapter middlemen. |
-| `AuthMetadata` | `AuthRefreshCoordinator` directly | verify with grep at migration time — likely already satisfies the Protocol |
-| `Kernel` (Protocol) | the concrete `Kernel` class | none — unchanged |
+| Protocol                                                             | Satisfier (post-migration)                                                                | Migration prerequisite                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RpcCaller`                                                          | `RpcExecutor` directly                                                                    | none — already structurally satisfies (TYPE_CHECKING assertion at [`_rpc_executor.py:463`](../../src/notebooklm/_rpc_executor.py))                                                                                                                                                                                                                                                                                                                               |
+| `LoopGuard`                                                          | `ClientLifecycle` directly                                                                | **push down `assert_bound_loop()`** — currently lives on `Session.assert_bound_loop` ([`_session.py:486`](../../src/notebooklm/_session.py)), which calls `_loop_affinity.assert_bound_loop(self.bound_loop)`. `ClientLifecycle` already owns `get_bound_loop` ([`_session_lifecycle.py:271`](../../src/notebooklm/_session_lifecycle.py)); the push-down adds a trivial `assert_bound_loop()` method that calls the free function with `self.get_bound_loop()`. |
+| `OperationScopeProvider`                                             | `TransportDrainTracker` directly                                                          | **push down `operation_scope(label)`** — currently lives on `Session.operation_scope` ([`_session.py:495`](../../src/notebooklm/_session.py)) as an async context manager wrapping `begin_transport_post` / `finish_transport_post` (both already on `TransportDrainTracker` at [`_transport_drain.py:139,196`](../../src/notebooklm/_transport_drain.py)). The push-down moves the contextmanager wrapper to the tracker.                                       |
+| `DrainHookRegistration` (feature-local in `_artifacts.py`)           | `TransportDrainTracker` directly                                                          | **push down `register_drain_hook(name, hook)` + the underlying `_drain_hooks` storage** — currently lives on `Session.register_drain_hook` ([`_session.py:421`](../../src/notebooklm/_session.py)). The push-down moves both the method and the storage onto the tracker.                                                                                                                                                                                        |
+| `AsyncWorkRuntime` (composes `LoopGuard` + `OperationScopeProvider`) | satisfied **transitively** by `ArtifactsRuntimeAdapter` / `UploadRuntimeAdapter` (Rule 2) | depends on the push-downs above. No dedicated `_AsyncWorkAdapter` — per Rule 2, trivial composites do not get adapter middlemen.                                                                                                                                                                                                                                                                                                                                 |
+| `AuthMetadata`                                                       | `AuthRefreshCoordinator` directly                                                         | verify with grep at migration time — likely already satisfies the Protocol                                                                                                                                                                                                                                                                                                                                                                                       |
+| `Kernel` (Protocol)                                                  | the concrete `Kernel` class                                                               | none — unchanged                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 **Why the push-downs are part of this ADR's mandate, not pre-existing.** The
 Protocol satisfiers were synthesised on `Session` because `Session` was the
@@ -88,7 +88,7 @@ collaborators) but they are non-trivial enough to be sequenced as
 **Adapter threshold (intent-based).** Introduce a frozen-dataclass adapter when
 **at least one** of the following holds:
 
-- a downstream module *intentionally* consumes the composite Protocol as a
+- a downstream module _intentionally_ consumes the composite Protocol as a
   single dependency (e.g. an HTTP-level helper that takes the whole runtime),
   **or**
 - delegation changes the call shape (the adapter method does more than forward
@@ -102,7 +102,7 @@ middleman.
 
 The earlier numeric heuristic ("≥3 capabilities OR ≥1 non-trivial delegate")
 was a proxy for the intent test above. It is replaced because counting
-capabilities does not capture *why* you would want a named runtime satisfier:
+capabilities does not capture _why_ you would want a named runtime satisfier:
 either some consumer demands it, or the call shape adapts. Counting alone
 incentivises adapters where they bring no value.
 
@@ -204,7 +204,7 @@ After migration, `Session` owns:
   seams** documented in the helpers' own module docstring; they are not
   forwards-to-remove.
 
-`Session` stops being passed *to* feature APIs. It stops satisfying capability
+`Session` stops being passed _to_ feature APIs. It stops satisfying capability
 Protocols intended for feature consumption. The compatibility forwards on
 `Session` (drain/metrics/kernel/authuser/save_cookies forwards that exist only
 because features used to reach through `Session`) are removed as Wave 5
@@ -287,10 +287,12 @@ takes the underlying collaborators as keyword-only constructor parameters
 instead.
 
 The ADR-013 promotion rule (≥2 consumers ⇒ shared Protocol in
-`_session_contracts.py`) is unchanged. Adapters are *not* promoted to
+`_session_contracts.py`) is unchanged. Adapters are _not_ promoted to
 `_session_contracts.py`; the file stays interface-only.
 
 ## Consequences
+
+**Migration outcome:** Migration completed in PRs #1064–#1082; ADR-007 Session-shaped allowlist entries drained; Session reduced to lifecycle root + retention list (see [`docs/session-method-retention.md`](../session-method-retention.md)). Two Wave-7 follow-ups are tracked in issues #1084 (Stage B: move `build_collaborators` to `NotebookLMClient`) and #1085 (MiddlewareChainHost extraction).
 
 **Wanted:**
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-This directory holds the canonical decisions that shape the `notebooklm-py` codebase. Each record explains *why* a load-bearing pattern exists so that future contributors don't re-litigate (or silently re-introduce) the trade-off.
+This directory holds the canonical decisions that shape the `notebooklm-py` codebase. Each record explains _why_ a load-bearing pattern exists so that future contributors don't re-litigate (or silently re-introduce) the trade-off.
 
 ## How to use this directory
 
@@ -8,11 +8,11 @@ This directory holds the canonical decisions that shape the `notebooklm-py` code
 - Numbering is append-only. Retired ADR numbers are never re-used.
 - Filenames follow `NNNN-short-title.md` (lowercase, kebab-case).
 - Status values: `Proposed`, `Accepted`, `Accepted (Sunset = <event>)`, `Superseded by ADR-NNN (#PR)`, `Deprecated`, `Rejected`.
-- Format: lightweight hybrid — six sections in this exact order: *Title heading* (`# ADR-NNN: <Title>`), *Status*, *Context*, *Decision*, *Consequences*, *Alternatives considered*. See [0000-template.md](0000-template.md).
+- Format: lightweight hybrid — six sections in this exact order: _Title heading_ (`# ADR-NNN: <Title>`), _Status_, _Context_, _Decision_, _Consequences_, _Alternatives considered_. See [0000-template.md](0000-template.md).
 
 ## When an ADR is required
 
-The pull-request template asks contributors to confirm that any change to the *architectural shape* of the codebase carries an ADR addition or update. "Architectural shape" means any of:
+The pull-request template asks contributors to confirm that any change to the _architectural shape_ of the codebase carries an ADR addition or update. "Architectural shape" means any of:
 
 - New / removed / relocated modules in `src/notebooklm/_core*.py`, `src/notebooklm/_capabilities.py`, `src/notebooklm/auth.py`, `src/notebooklm/_auth/`, `src/notebooklm/cli/services/`.
 - Changes to the contracts between layers (CLI ↔ Client ↔ Core ↔ RPC).
@@ -24,6 +24,7 @@ Pure bug fixes, additive RPC method IDs, and CLI ergonomics changes do not requi
 ### Status Format Legend
 
 The ADR Index table utilizes four eras of Status notation to reflect the lifecycle of decisions:
+
 1. **`Accepted` / `Accepted (retroactive)`** — The decision is currently active and adopted.
 2. **`Accepted (Tier X PR Y.Z)`** — Historical PR-naming convention from the early refactoring tiers (Tiers 11-12).
 3. **`Superseded by ADR-NNN (#PR)`** — Canonical post-Tier-12 supersession form, linking to the replacing ADR and PR.
@@ -31,22 +32,22 @@ The ADR Index table utilizes four eras of Status notation to reflect the lifecyc
 
 ## Index
 
-| ADR | Title | Status |
-|-----|-------|--------|
-| [0001](0001-layered-core-seams-and-property-bridge-policy.md) | Layered `_core` seams and the property-bridge policy | Superseded — bridge policy retired in session-shrink arc |
-| [0002](0002-capability-protocol-pattern.md) | Capability Protocol pattern (`SessionCapabilities` fat union) | Superseded by [arch-d2-cutover](https://github.com/teng-lin/notebooklm-py/pull/835) (#835) |
-| [0003](0003-auth-facade-write-through.md) | `auth.py` write-through facade (`_AuthFacadeModule`) | Superseded — closed by [ADR-014](0014-feature-local-runtime-adapters.md) (session-decoupling Waves 3a + 4 T2.2 + 5) |
-| [0004](0004-loop-affinity-contract.md) | Loop-affinity contract for `NotebookLMClient` | Accepted (retroactive) |
-| [0005](0005-idempotency-taxonomy.md) | Mutating-RPC idempotency taxonomy | Accepted (retroactive) |
-| [0006](0006-vcr-scrubber-strategy.md) | VCR cassette scrubber strategy | Accepted (retroactive) |
-| [0007](0007-test-monkeypatch-policy.md) | Test monkeypatch policy | Accepted |
-| [0008](0008-cli-services-extraction-pattern.md) | `cli/services/` extraction pattern | Accepted (retroactive) |
-| [0009](0009-middleware-chain.md) | Middleware chain for cross-cutting transport concerns | Accepted (Tier 12 PR 12.1); context refined by [ADR-013](0013-composable-session-capabilities.md) (#866) |
-| [0010](0010-session-kernel-split.md) | Session/Kernel split | Superseded by [ADR-013](0013-composable-session-capabilities.md) (#866) |
-| [0011](0011-schema-validation-policy.md) | Schema validation policy (strict-decode default) | Accepted (Tier 13 PR 13.9a) |
-| [0012](0012-implementation-surface-convention.md) | Implementation surface convention (underscore-prefix policy) | Accepted (Tier 13 PR 13.9a) |
-| [0013](0013-composable-session-capabilities.md) | Composable Session Capabilities and Feature-Local Runtimes | Accepted |
-| [0014](0014-feature-local-runtime-adapters.md) | Feature-local runtime adapters as Protocol satisfiers | Proposed |
+| ADR                                                           | Title                                                         | Status                                                                                                              |
+| ------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [0001](0001-layered-core-seams-and-property-bridge-policy.md) | Layered `_core` seams and the property-bridge policy          | Superseded — bridge policy retired in session-shrink arc                                                            |
+| [0002](0002-capability-protocol-pattern.md)                   | Capability Protocol pattern (`SessionCapabilities` fat union) | Superseded by [arch-d2-cutover](https://github.com/teng-lin/notebooklm-py/pull/835) (#835)                          |
+| [0003](0003-auth-facade-write-through.md)                     | `auth.py` write-through facade (`_AuthFacadeModule`)          | Superseded — closed by [ADR-014](0014-feature-local-runtime-adapters.md) (session-decoupling Waves 3a + 4 T2.2 + 5) |
+| [0004](0004-loop-affinity-contract.md)                        | Loop-affinity contract for `NotebookLMClient`                 | Accepted (retroactive)                                                                                              |
+| [0005](0005-idempotency-taxonomy.md)                          | Mutating-RPC idempotency taxonomy                             | Accepted (retroactive)                                                                                              |
+| [0006](0006-vcr-scrubber-strategy.md)                         | VCR cassette scrubber strategy                                | Accepted (retroactive)                                                                                              |
+| [0007](0007-test-monkeypatch-policy.md)                       | Test monkeypatch policy                                       | Accepted                                                                                                            |
+| [0008](0008-cli-services-extraction-pattern.md)               | `cli/services/` extraction pattern                            | Accepted (retroactive)                                                                                              |
+| [0009](0009-middleware-chain.md)                              | Middleware chain for cross-cutting transport concerns         | Accepted (Tier 12 PR 12.1); context refined by [ADR-013](0013-composable-session-capabilities.md) (#866)            |
+| [0010](0010-session-kernel-split.md)                          | Session/Kernel split                                          | Superseded by [ADR-013](0013-composable-session-capabilities.md) (#866)                                             |
+| [0011](0011-schema-validation-policy.md)                      | Schema validation policy (strict-decode default)              | Accepted (Tier 13 PR 13.9a)                                                                                         |
+| [0012](0012-implementation-surface-convention.md)             | Implementation surface convention (underscore-prefix policy)  | Accepted (Tier 13 PR 13.9a)                                                                                         |
+| [0013](0013-composable-session-capabilities.md)               | Composable Session Capabilities and Feature-Local Runtimes    | Accepted                                                                                                            |
+| [0014](0014-feature-local-runtime-adapters.md)                | Feature-local runtime adapters as Protocol satisfiers         | Accepted (#1082)                                                                                                    |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 


### PR DESCRIPTION
## Summary

- Flips ADR-014 status from `Proposed` to `Accepted` — the full session-decoupling migration (Waves 0–6) is complete.
- Updates `docs/adr/README.md` index entry.
- Adds a migration-outcome note to the Consequences section.
- Files two Wave-7 follow-up issues before closing (as required by Task 6.2):
  - #1084: Stage B — move `build_collaborators` ownership to `NotebookLMClient`
  - #1085: MiddlewareChainHost extraction (Rule 4 completion)

## Migration summary (PRs #1064–#1082)

| Wave | Work | PR(s) |
|---|---|---|
| 0 | ADR-014 docs + session-decoupling plan | #1064 |
| 0.5 | Push `operation_scope` / `register_drain_hook` / `assert_bound_loop` to collaborators | #1065 |
| 1 | `AuthRefreshCoordinator.await_refresh` drops host; `RpcExecutor` direct collaborators; `RpcOwner` deleted | #1066–#1068 |
| 2 | Auth-facade split: `load_auth_from_storage` move, `_validate_required_cookies` inversion, ADR-003 close | #1066, #1070, #1072 |
| 3 | `Session.collaborators` bundle accessor + late-bound accessors; 6 simple features wired | #1069, #1071 |
| 4 | Chat direct injection + `ChatRuntime` deleted; `ArtifactsRuntimeAdapter`; `UploadRuntimeAdapter` | #1073, #1074 |
| 5 | Session forward inventory + cluster deletions (3 PRs); final ADR-007 allowlist sweep | #1075–#1078, #1080 |
| 6 | `docs/architecture.md` + `test_client_composition` AST guard + `CLAUDE.md` update | #1079 |

## Test plan

- [x] `uv run pytest tests/_lint` — 77/77 passed
- [x] `uv run pytest tests/unit` — 5867/5868 passed (1 pre-existing Windows string-wrap failure in `test_login_multi_account.py` unrelated to this change)
- [x] No production code changed — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision record documentation with clarified status notations and expanded guidance for decision record usage and maintenance.
  * Refined existing decision record entries for improved discoverability and historical context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->