### PR TITLE
fix(artifacts): harden generation defaults and nulls

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -201,6 +201,8 @@ class ArtifactDownloadService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
+        if result is None:
+            return None
         return safe_index(
             result,
             0,

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -70,8 +70,10 @@ class ArtifactGenerationService:
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
 
-        format_code = audio_format.value if audio_format else None
-        length_code = audio_length.value if audio_length else None
+        format_code = (
+            audio_format.value if audio_format is not None else AudioFormat.DEEP_DIVE.value
+        )
+        length_code = audio_length.value if audio_length is not None else AudioLength.DEFAULT.value
 
         params = [
             [2],
@@ -97,7 +99,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="audio",
+        )
 
     async def generate_video(
         self,
@@ -126,8 +132,10 @@ class ArtifactGenerationService:
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
 
-        format_code = video_format.value if video_format else None
-        style_code = video_style.value if video_style else None
+        format_code = (
+            video_format.value if video_format is not None else VideoFormat.EXPLAINER.value
+        )
+        style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
 
         video_config = [
             source_ids_double,
@@ -159,7 +167,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="video",
+        )
 
     async def generate_cinematic_video(
         self,
@@ -202,7 +214,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="cinematic video",
+        )
 
     async def generate_report(
         self,
@@ -287,7 +303,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="report",
+        )
 
     async def generate_study_guide(
         self,
@@ -320,8 +340,10 @@ class ArtifactGenerationService:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity else None
-        difficulty_code = difficulty.value if difficulty else None
+        quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
+        difficulty_code = (
+            difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+        )
 
         params = [
             [2],
@@ -351,7 +373,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="quiz",
+        )
 
     async def generate_flashcards(
         self,
@@ -366,8 +392,10 @@ class ArtifactGenerationService:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity else None
-        difficulty_code = difficulty.value if difficulty else None
+        quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
+        difficulty_code = (
+            difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+        )
 
         params = [
             [2],
@@ -396,7 +424,11 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="flashcards",
+        )
 
     async def generate_infographic(
         self,
@@ -466,8 +498,12 @@ class ArtifactGenerationService:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
-        format_code = slide_format.value if slide_format else None
-        length_code = slide_length.value if slide_length else None
+        format_code = (
+            slide_format.value if slide_format is not None else SlideDeckFormat.DETAILED_DECK.value
+        )
+        length_code = (
+            slide_length.value if slide_length is not None else SlideDeckLength.DEFAULT.value
+        )
 
         params = [
             [2],
@@ -492,7 +528,11 @@ class ArtifactGenerationService:
                 [[instructions, language, format_code, length_code]],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="slide deck",
+        )
 
     async def revise_slide(
         self,
@@ -528,6 +568,10 @@ class ArtifactGenerationService:
             raise
         if result is None:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
+            raise ArtifactFeatureUnavailableError(
+                "slide revision",
+                method_id=RPCMethod.REVISE_SLIDE.value,
+            )
         return self.parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
 
     async def generate_data_table(
@@ -570,7 +614,11 @@ class ArtifactGenerationService:
                 [None, [instructions, language]],
             ],
         ]
-        return await self.call_generate(notebook_id, params)
+        return await self.call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="data table",
+        )
 
     async def generate_mind_map(
         self,

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -32,6 +32,7 @@ from notebooklm.rpc import (
     VideoStyle,
 )
 from notebooklm.types import (
+    ArtifactDownloadError,
     ArtifactFeatureUnavailableError,
     ArtifactNotReadyError,
     ArtifactParseError,
@@ -722,6 +723,43 @@ class TestArtifactsAPI:
         assert err.artifact_type == "infographic"
         assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
         assert str(err) == "Infographic generation is unavailable"
+
+    @pytest.mark.parametrize(
+        ("method_name", "artifact_type"),
+        [
+            ("generate_audio", "audio"),
+            ("generate_video", "video"),
+            ("generate_cinematic_video", "cinematic video"),
+            ("generate_report", "report"),
+            ("generate_study_guide", "report"),
+            ("generate_quiz", "quiz"),
+            ("generate_flashcards", "flashcards"),
+            ("generate_infographic", "infographic"),
+            ("generate_slide_deck", "slide deck"),
+            ("generate_data_table", "data table"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_public_create_artifact_null_result_raises_feature_unavailable(
+        self,
+        method_name,
+        artifact_type,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Every public CREATE_ARTIFACT generator classifies null before parsing."""
+        null_response = build_rpc_response(RPCMethod.CREATE_ARTIFACT, None)
+        httpx_mock.add_response(content=null_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            method = getattr(client.artifacts, method_name)
+            with pytest.raises(ArtifactFeatureUnavailableError) as exc_info:
+                await method("nb_123", source_ids=["src_001"])
+
+        err = exc_info.value
+        assert err.artifact_type == artifact_type
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
 
     @pytest.mark.asyncio
     async def test_generate_data_table(
@@ -1558,36 +1596,28 @@ class TestReviseSlide:
                 )
 
     @pytest.mark.asyncio
-    async def test_revise_slide_null_result_returns_generation_status(
+    async def test_revise_slide_null_result_raises_feature_unavailable(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
-        monkeypatch,
     ):
-        """revise_slide logs warning and returns GenerationStatus when RPC returns null.
-
-        Soft-mode opt-out (post-PR 13.9a default is strict): pins the legacy
-        warn-and-failed-GenerationStatus contract for null RPC results.
-        Strict-mode coverage of the same shape lives in
-        ``tests/unit/test_artifacts_drift.py``.
-        """
-        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
-        # Build a null response (allow_null=True path)
+        """revise_slide classifies a null RPC result before parser drift handling."""
         null_response = build_rpc_response(RPCMethod.REVISE_SLIDE, None)
         httpx_mock.add_response(content=null_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
-                result = await client.artifacts.revise_slide(
+            with pytest.raises(ArtifactFeatureUnavailableError) as exc_info:
+                await client.artifacts.revise_slide(
                     notebook_id="nb_123",
                     artifact_id="artifact_456",
                     slide_index=0,
                     prompt="Remove taxonomy section",
                 )
 
-        assert result is not None
-        assert result.status == "failed"
+        err = exc_info.value
+        assert err.artifact_type == "slide revision"
+        assert err.method_id == RPCMethod.REVISE_SLIDE.value
 
     @pytest.mark.asyncio
     async def test_revise_slide_user_displayable_error_returns_failed_status(
@@ -2295,17 +2325,13 @@ class TestParseGenerationResult:
         assert result.task_id == ""
 
     @pytest.mark.asyncio
-    async def test_generate_returns_failed_status_when_result_is_none(
+    async def test_generate_null_result_raises_feature_unavailable(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
-        monkeypatch,
     ):
-        """_parse_generation_result returns failed status when result is None."""
-        # Post-PR 13.9a default is strict; pin soft mode to preserve the
-        # legacy GenerationStatus(failed) sentinel this test covers.
-        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+        """Public generators classify null CREATE_ARTIFACT before parser drift handling."""
         notebook_response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [
@@ -2325,10 +2351,12 @@ class TestParseGenerationResult:
         httpx_mock.add_response(content=null_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.warns(DeprecationWarning, match="safe_index soft-mode"):
-                result = await client.artifacts.generate_audio("nb_123")
+            with pytest.raises(ArtifactFeatureUnavailableError) as exc_info:
+                await client.artifacts.generate_audio("nb_123")
 
-        assert result.status == "failed"
+        err = exc_info.value
+        assert err.artifact_type == "audio"
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
 
     @pytest.mark.asyncio
     async def test_generate_returns_status_from_artifact_data(
@@ -2637,6 +2665,80 @@ class TestDownloadQuizFlashcardParsing:
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ArtifactNotReadyError):
                 await client.artifacts.download_quiz("nb_123", "/tmp/quiz.json")
+
+    @pytest.mark.asyncio
+    async def test_download_quiz_null_interactive_html_raises_download_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """download_quiz maps null GET_INTERACTIVE_HTML to ArtifactDownloadError."""
+        artifact_data = [
+            "quiz_null_html",  # [0] id
+            "Null HTML Quiz",  # [1] title
+            4,  # [2] QUIZ type
+            None,  # [3]
+            3,  # [4] COMPLETED
+            None,  # [5]
+            None,  # [6]
+            None,  # [7]
+            None,  # [8]
+            [None, [2]],  # [9] options: [9][1][0] = 2 => quiz variant
+            None,  # [10]
+            None,  # [11]
+            None,  # [12]
+            None,  # [13]
+            None,  # [14]
+            [[1704067200]],  # [15] created_at
+        ]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        null_html_response = build_rpc_response(RPCMethod.GET_INTERACTIVE_HTML, None)
+        httpx_mock.add_response(content=list_response.encode())
+        httpx_mock.add_response(content=null_html_response.encode())
+
+        output_path = str(tmp_path / "quiz.json")
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactDownloadError, match="Failed to fetch content"):
+                await client.artifacts.download_quiz("nb_123", output_path)
+
+    @pytest.mark.asyncio
+    async def test_download_flashcards_null_interactive_html_raises_download_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """download_flashcards maps null GET_INTERACTIVE_HTML to ArtifactDownloadError."""
+        artifact_data = [
+            "flashcards_null_html",  # [0] id
+            "Null HTML Flashcards",  # [1] title
+            4,  # [2] QUIZ type
+            None,  # [3]
+            3,  # [4] COMPLETED
+            None,  # [5]
+            None,  # [6]
+            None,  # [7]
+            None,  # [8]
+            [None, [1]],  # [9] options: [9][1][0] = 1 => flashcards variant
+            None,  # [10]
+            None,  # [11]
+            None,  # [12]
+            None,  # [13]
+            None,  # [14]
+            [[1704067200]],  # [15] created_at
+        ]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        null_html_response = build_rpc_response(RPCMethod.GET_INTERACTIVE_HTML, None)
+        httpx_mock.add_response(content=list_response.encode())
+        httpx_mock.add_response(content=null_html_response.encode())
+
+        output_path = str(tmp_path / "flashcards.json")
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactDownloadError, match="Failed to fetch content"):
+                await client.artifacts.download_flashcards("nb_123", output_path)
 
     @pytest.mark.asyncio
     async def test_download_quiz_html_format_returns_raw_html(

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -61,8 +61,7 @@ class TestDownloadInteractiveArtifact:
     @pytest.mark.asyncio
     async def test_get_artifact_content_null_result_returns_none(self):
         """Null GET_INTERACTIVE_HTML is a missing-content result, not schema drift."""
-        runtime = MagicMock()
-        runtime.rpc_call = AsyncMock(return_value=None)
+        runtime = MagicMock(rpc_call=AsyncMock(return_value=None))
         service = artifact_downloads.ArtifactDownloadService(
             runtime=runtime,
             listing=MagicMock(),

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -59,6 +59,21 @@ class TestDownloadInteractiveArtifact:
     """Test shared quiz/flashcard download parsing behavior."""
 
     @pytest.mark.asyncio
+    async def test_get_artifact_content_null_result_returns_none(self):
+        """Null GET_INTERACTIVE_HTML is a missing-content result, not schema drift."""
+        runtime = MagicMock()
+        runtime.rpc_call = AsyncMock(return_value=None)
+        service = artifact_downloads.ArtifactDownloadService(
+            runtime=runtime,
+            listing=MagicMock(),
+            mind_maps=MagicMock(),
+        )
+
+        result = await service._get_artifact_content("nb_123", "quiz_001")
+
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_extract_app_data_value_error_propagates(self, monkeypatch, tmp_path):
         """Bare ValueError from helper internals is not converted to parse drift."""
         artifact = MagicMock(

--- a/tests/unit/test_artifacts_drift.py
+++ b/tests/unit/test_artifacts_drift.py
@@ -170,6 +170,17 @@ class TestParseGenerationResultStrictDrift:
         # Top-level descent: failing path is empty (we failed at the first index).
         assert err.path == ()
 
+    def test_none_result_raises_for_revise_slide(self, artifacts_api, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            artifacts_api._parse_generation_result(None, method_id=RPCMethod.REVISE_SLIDE.value)
+
+        err = exc_info.value
+        assert err.method_id == RPCMethod.REVISE_SLIDE.value
+        assert err.source == "_parse_generation_result"
+        assert err.path == ()
+
     def test_empty_list_raises_for_revise_slide(self, artifacts_api, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
 

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -18,9 +18,15 @@ from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._chat import ChatAPI
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import (
+    AudioFormat,
+    AudioLength,
     InfographicDetail,
     InfographicOrientation,
     InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    SlideDeckFormat,
+    SlideDeckLength,
     VideoFormat,
     VideoStyle,
 )
@@ -325,10 +331,33 @@ class TestArtifactsSourceSelection:
         # ]
         inner_params = params[2]
         source_ids_triple = inner_params[3]
-        source_ids_double = inner_params[6][1][3]
+        audio_config = inner_params[6][1]
+        source_ids_double = audio_config[3]
 
         assert source_ids_triple == [[["src_001"]], [["src_002"]]]
         assert source_ids_double == [["src_001"], ["src_002"]]
+        assert audio_config[1] == AudioLength.DEFAULT.value
+        assert audio_config[6] == AudioFormat.DEEP_DIVE.value
+
+    @pytest.mark.asyncio
+    async def test_generate_audio_explicit_options_override_defaults(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Explicit audio format and length are encoded instead of API defaults."""
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
+        mock_core.rpc_call.return_value = [["artifact_123", "Audio", 1, None, 1]]
+
+        await api.generate_audio(
+            notebook_id="nb_123",
+            source_ids=["src_001"],
+            audio_format=AudioFormat.DEBATE,
+            audio_length=AudioLength.LONG,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        audio_config = params[2][6][1]
+        assert audio_config[1] == AudioLength.LONG.value
+        assert audio_config[6] == AudioFormat.DEBATE.value
 
     @pytest.mark.asyncio
     async def test_generate_audio_with_none_fetches_all_sources(
@@ -390,6 +419,28 @@ class TestArtifactsSourceSelection:
 
         assert source_ids_triple == [[["src_a"]], [["src_b"]]]
         assert source_ids_double == [["src_a"], ["src_b"]]
+        assert video_config[4] == VideoFormat.EXPLAINER.value
+        assert video_config[5] == VideoStyle.AUTO_SELECT.value
+
+    @pytest.mark.asyncio
+    async def test_generate_video_explicit_options_override_defaults(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Explicit video format and style are encoded instead of API defaults."""
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
+        mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
+
+        await api.generate_video(
+            notebook_id="nb_123",
+            source_ids=["src_a"],
+            video_format=VideoFormat.BRIEF,
+            video_style=VideoStyle.ANIME,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        video_config = params[2][8][2]
+        assert video_config[4] == VideoFormat.BRIEF.value
+        assert video_config[5] == VideoStyle.ANIME.value
 
     @pytest.mark.asyncio
     async def test_generate_video_custom_style_prompt_encoding(
@@ -577,8 +628,29 @@ class TestArtifactsSourceSelection:
         # ]
         inner_params = params[2]
         source_ids_triple = inner_params[3]
+        quiz_options = inner_params[9][1][7]
 
         assert source_ids_triple == [[["src_1"]], [["src_2"]]]
+        assert quiz_options == [QuizQuantity.STANDARD.value, QuizDifficulty.MEDIUM.value]
+
+    @pytest.mark.asyncio
+    async def test_generate_quiz_explicit_options_override_defaults(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Explicit quiz quantity and difficulty are encoded instead of defaults."""
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
+        mock_core.rpc_call.return_value = [["artifact_quiz", "Quiz", 4, None, 1]]
+
+        await api.generate_quiz(
+            notebook_id="nb_123",
+            source_ids=["src_1"],
+            quantity=QuizQuantity.FEWER,
+            difficulty=QuizDifficulty.HARD,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        quiz_options = params[2][9][1][7]
+        assert quiz_options == [QuizQuantity.FEWER.value, QuizDifficulty.HARD.value]
 
     @pytest.mark.asyncio
     async def test_generate_flashcards_source_encoding(self, mock_core, mock_mind_map_service):
@@ -597,8 +669,29 @@ class TestArtifactsSourceSelection:
 
         inner_params = params[2]
         source_ids_triple = inner_params[3]
+        flashcard_options = inner_params[9][1][6]
 
         assert source_ids_triple == [[["src_flash"]]]
+        assert flashcard_options == [QuizDifficulty.MEDIUM.value, QuizQuantity.STANDARD.value]
+
+    @pytest.mark.asyncio
+    async def test_generate_flashcards_explicit_options_override_defaults(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Explicit flashcard quantity and difficulty preserve flashcard option order."""
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
+        mock_core.rpc_call.return_value = [["artifact_fc", "Flashcards", 4, None, 1]]
+
+        await api.generate_flashcards(
+            notebook_id="nb_123",
+            source_ids=["src_flash"],
+            quantity=QuizQuantity.FEWER,
+            difficulty=QuizDifficulty.EASY,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        flashcard_options = params[2][9][1][6]
+        assert flashcard_options == [QuizDifficulty.EASY.value, QuizQuantity.FEWER.value]
 
     @pytest.mark.asyncio
     async def test_generate_infographic_source_encoding(self, mock_core, mock_mind_map_service):
@@ -668,8 +761,31 @@ class TestArtifactsSourceSelection:
 
         inner_params = params[2]
         source_ids_triple = inner_params[3]
+        slide_config = inner_params[16][0]
 
         assert source_ids_triple == [[["src_slide"]]]
+        assert slide_config[2] == SlideDeckFormat.DETAILED_DECK.value
+        assert slide_config[3] == SlideDeckLength.DEFAULT.value
+
+    @pytest.mark.asyncio
+    async def test_generate_slide_deck_explicit_options_override_defaults(
+        self, mock_core, mock_mind_map_service
+    ):
+        """Explicit slide deck format and length are encoded instead of defaults."""
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
+        mock_core.rpc_call.return_value = [["artifact_slide", "Slides", 8, None, 1]]
+
+        await api.generate_slide_deck(
+            notebook_id="nb_123",
+            source_ids=["src_slide"],
+            slide_format=SlideDeckFormat.PRESENTER_SLIDES,
+            slide_length=SlideDeckLength.SHORT,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        slide_config = params[2][16][0]
+        assert slide_config[2] == SlideDeckFormat.PRESENTER_SLIDES.value
+        assert slide_config[3] == SlideDeckLength.SHORT.value
 
     @pytest.mark.asyncio
     async def test_generate_data_table_source_encoding(self, mock_core, mock_mind_map_service):


### PR DESCRIPTION
## Summary
- Align Python artifact generation defaults with CLI defaults for audio, video, slide decks, quizzes, and flashcards.
- Classify null `CREATE_ARTIFACT`/`REVISE_SLIDE` responses as `ArtifactFeatureUnavailableError` before parser drift handling.
- Treat null `GET_INTERACTIVE_HTML` as missing content so public quiz/flashcard downloads raise `ArtifactDownloadError`.

## Task
- Phase task: `.sisyphus/phases/rpc-generation-defaults-and-null-handling-plan/phase-1.md#task-harden-artifact-generation-defaults-and-null-handling`
- Follow-up to #1063 and #1082.

## Test plan
- [x] `uv run pytest tests/unit/test_source_selection.py tests/integration/test_artifacts_integration.py tests/unit/test_artifacts_drift.py tests/unit/test_artifact_downloads.py`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm`
- [x] `NOTEBOOKLM_PROFILE=default uv run notebooklm doctor`
- [x] `NOTEBOOKLM_PROFILE=default uv run python scripts/probe_generation_defaults.py` (scratch script removed before commit)

## Live API smoke summary
```json
{
  "profile": "default",
  "notebook_id_suffix": "965f6a53",
  "generation_cases": {
    "audio.default_kwargs": {"status": "in_progress", "deleted": true},
    "video.default_kwargs": {"status": "in_progress", "deleted": true},
    "slide_deck.default_kwargs": {"status": "in_progress", "deleted": true},
    "quiz.default_kwargs": {"status": "in_progress", "deleted": true},
    "flashcards.default_kwargs": {"status": "in_progress", "deleted": true},
    "data_table.default_kwargs": {"status": "in_progress", "deleted": true},
    "infographic.default_kwargs": {"status": "in_progress", "deleted": true},
    "cinematic_video.default_kwargs": {"status": "in_progress", "deleted": true}
  },
  "invalid_artifact_cases": {
    "revise_slide.invalid_artifact": {
      "outcome": "exception",
      "class_name": "ArtifactFeatureUnavailableError",
      "method_id": "KmcKPe"
    },
    "interactive_html.invalid_artifact": {"outcome": "ok"}
  },
  "unknown_rpc_method_errors": 0
}
```

## Deferred polish findings
- Kept the `revise_slide()` warning because it preserves artifact-id observability before raising the domain error.
- Kept explicit `null_result_artifact_type` labels to preserve the optional compatibility-shim strategy chosen by the phase plan.
- Left payload tests explicit rather than collapsing them so each acceptance criterion remains easy to audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default format/length options added for audio, video, quiz/flashcards, and slide deck generation when not specified.

* **Bug Fixes**
  * More specific error reporting when artifact generation is unavailable (includes artifact-type and method context).
  * Null RPC results for artifact content now return a clear "no content" outcome instead of causing indexing errors.
  * Slide revision now reports unavailable-feature errors for null responses.

* **Tests**
  * Expanded integration and unit tests for generation, download, and null-result error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->