### PR TITLE
refactor(session): add MiddlewareChainHost + Session descriptor forwards (Stage B2 PR 1)

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -59,8 +59,12 @@ lint at PR time.
 | `is_open` (property) | lifecycle | retain — public open-state read |
 | `_keepalive_loop` | lifecycle | retain — background task body; introspected by `test_client_keepalive` |
 | `rpc_call` | public API forward | retain — pinned by `tests/unit/test_public_shims.py:1048-1089` (`NotebookLMClient.rpc_call` forwards through it) |
-| `_authed_post_chain_terminal` | middleware chain leaf | retain — live chain leaf wired by `_session_init.wire_middleware_chain` (`authed_post_chain_terminal=self._authed_post_chain_terminal` at [`_session.py:411-417`](../src/notebooklm/_session.py)) |
-| `_await_refresh` | provider-closure capture target | retain — captured as bound-method (`refresh_callable=host._await_refresh`) by [`_session_init.py:430`](../src/notebooklm/_session_init.py) |
+| `_authed_post_chain_terminal` (property) | middleware chain leaf | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the canonical seam (a fixture-time rebind via `core._authed_post_chain_terminal = fake_terminal` writes through to `chain_host._authed_post_chain_terminal`, mirroring [`test_observability.py:77`](../tests/unit/test_observability.py)). The host's bound method is wired as the live chain leaf by `_session_init.wire_middleware_chain` (`authed_post_chain_terminal=session._authed_post_chain_terminal`, which resolves through the descriptor to the host). |
+| `_authed_post_chain` (property) | middleware chain leaf | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the canonical seam (a fixture-time rebind via `core._authed_post_chain = fake_chain` writes through to `chain_host._authed_post_chain`, mirroring [`test_authed_post_pipeline.py:113`](../tests/unit/test_authed_post_pipeline.py)). The transport's `chain_provider` closure reads `host._authed_post_chain` live (B2 PR 1 still routes via the Session descriptor; B2 PR 2 will switch it to read `chain_host` directly). |
+| `_rate_limit_max_retries` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the integration-test seam (mid-flight `core._rate_limit_max_retries = N` writes through to the host so the chain's `rate_limit_max_retries_provider` lambda picks up the new budget on the next attempt). |
+| `_server_error_max_retries` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the same mutation-after-construction contract as `_rate_limit_max_retries`. |
+| `_refresh_retry_delay` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the mutation-after-construction contract for both the chain's `refresh_retry_delay_provider` lambda and the executor's `refresh_retry_delay_provider` closure built in `compose_session_internals`. |
+| `_await_refresh` | provider-closure capture target | retain — captured as bound-method (`refresh_callable=host._await_refresh`) by [`_session_init.py:430`](../src/notebooklm/_session_init.py); Stage B2 PR 1 routed the body through `MiddlewareChainHost.await_refresh` (dynamic delegation to `host._auth_refresh.await_refresh()`) so a fixture rebinding the coordinator still steers the live refresh. |
 | `assert_bound_loop` | provider-closure capture target | retain — captured via lambda (`bound_loop_check=lambda: host.assert_bound_loop()`) by `build_session_transport` at [`_session_init.py:395`](../src/notebooklm/_session_init.py); late-bound so a test reassigning `core.assert_bound_loop = mock` still steers the live check |
 | `_get_rpc_semaphore` | provider-closure capture target | retain — passed as `rpc_semaphore_factory=self._get_rpc_semaphore` to `wire_middleware_chain` at [`_session.py:416`](../src/notebooklm/_session.py); has real body (lazy semaphore creation) reading `self._max_concurrent_rpcs` / `self._rpc_semaphore`, not a forward |
 | `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core, lifecycle)` calls `core.update_auth_tokens(...)` from [`_auth/session.py`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
@@ -72,17 +76,18 @@ lint at PR time.
 
 ## Stage-A and Rule-4 attribute capture targets (context, not lint-enumerated)
 
-The `_rate_limit_max_retries`, `_server_error_max_retries`, and
-`_refresh_retry_delay` slots on `Session` are plain instance attributes (not
-methods), assigned in `__init__` from the validated config. They are
-**provider-closure capture targets**: the `MiddlewareChainBuilder` reads them
-through lambdas at [`_session_init.py:427-429`](../src/notebooklm/_session_init.py)
-so post-construction integration-test mutation (e.g.
-`session._rate_limit_max_retries = 0`) still steers the live chain. They are
-**retain**ed for the same reason `_await_refresh` is retained — deletion
-breaks the chain wiring. They are not enumerated by the AST lint (which scans
-method definitions, not assignments to `self.X` inside `__init__`); this
-section documents them for the next architecture refactor reader.
+Stage B2 PR 1 of the post-refactoring plan (2026-05-27) moved the
+`_rate_limit_max_retries` / `_server_error_max_retries` /
+`_refresh_retry_delay` tunables off `Session` onto
+:class:`MiddlewareChainHost`. The names still resolve on `Session` —
+via writable `@property` descriptors enumerated in the **Inventory**
+table above — but the storage lives on the host. Reads and writes via
+`session._<attr>` route through the descriptor to the host so the
+chain's `MiddlewareChainBuilder` provider lambdas
+([`_session_init.py:427-429`](../src/notebooklm/_session_init.py))
+continue to dereference `host._<attr>` live and integration-test
+mutation (`session._rate_limit_max_retries = 0`) still steers the live
+chain.
 
 ## Follow-up ADR-014 issues
 
@@ -99,13 +104,15 @@ The two follow-up issues filed per ADR-014 close-out (Wave 6 / Task 6.2):
   `MiddlewareChainHost` collaborator owning `_authed_post_chain_terminal` +
   the `_rate_limit_max_retries` / `_server_error_max_retries` /
   `_refresh_retry_delay` tunables; `Session` holds it like any other
-  collaborator. **DEFERRED to Stage B2 of the post-refactoring plan
-  (2026-05-27)** — Stage B1 landed `compose_session_internals` as the
-  composition root; B2 builds the host skeleton on top.
-
-The chain seams on Session (`_authed_post_chain_terminal` + the three
-`_rate_limit_max_retries` / `_server_error_max_retries` /
-`_refresh_retry_delay` tunables listed above) remain on Session pending B2.
+  collaborator. **STARTED by Stage B2 PR 1 of the post-refactoring plan
+  (2026-05-27)** — the host skeleton (`_middleware_chain_host.py`) is in
+  place, the storage moved off `Session`, and the five writable `@property`
+  descriptor forwards (`_authed_post_chain_terminal`, `_authed_post_chain`,
+  `_rate_limit_max_retries`, `_server_error_max_retries`,
+  `_refresh_retry_delay`) preserve the historical test seams. Stage B2 PR 2
+  will split `wire_middleware_chain` / `build_session_transport` signatures
+  so the chain reads the host directly; PR 3 closes out ADR-014 Rule 4 and
+  amends this doc.
 
 ## Deleted
 

--- a/src/notebooklm/_middleware_chain_host.py
+++ b/src/notebooklm/_middleware_chain_host.py
@@ -1,0 +1,146 @@
+"""Middleware-chain host (Stage B2 PR 1 of the post-refactoring plan).
+
+The :class:`MiddlewareChainHost` owns the four pieces of state that the
+wired middleware chain reads on every authed POST plus the chain leaf
+itself:
+
+* the three retry-budget tunables (``_rate_limit_max_retries`` /
+  ``_server_error_max_retries`` / ``_refresh_retry_delay``) that the
+  chain's provider lambdas dereference live (``getattr(host, …)``);
+* the installed chain reference (``_authed_post_chain``) that the
+  transport's ``chain_provider`` closure dereferences on every authed
+  POST so post-construction reassignment continues to steer the live
+  chain;
+* the chain leaf coroutine (``_authed_post_chain_terminal``) that
+  forwards to :meth:`SessionTransport.terminal`;
+* the dynamic refresh delegate (``await_refresh``) that callers reach
+  through :meth:`Session._await_refresh`.
+
+This module is intentionally narrow:
+
+* It does NOT know about metrics, the kernel, the http client, the
+  RPC semaphore, or the auth snapshot. Those live on :class:`Session`
+  (the auth-snapshot host) and the collaborator bundle.
+* The host has no back-reference to :class:`Session` — it is reachable
+  from :class:`Session` (via ``self._chain_host``) but not the other
+  way around. This breaks the historical Session ↔ transport cycle the
+  way ADR-014 Rule 4 (post-refactoring plan, Stage B2) anticipated.
+
+Stage B2 PR 1 wires the host into :class:`Session.__init__` and routes
+the five mutable test seams (``_authed_post_chain_terminal``,
+``_authed_post_chain``, ``_rate_limit_max_retries``,
+``_server_error_max_retries``, ``_refresh_retry_delay``) through
+writable ``@property`` descriptors on :class:`Session` that write
+through to the host. Transport / wire signatures are still ``host=
+session`` in PR 1 — providers continue to read ``session._<attr>``
+which now writes through to the host. Stage B2 PR 2 will split
+``build_session_transport`` and ``wire_middleware_chain`` so the chain
+reads from the host directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._middleware import NextCall, RpcRequest, RpcResponse
+    from ._session_auth import AuthRefreshCoordinator
+    from ._session_transport import SessionTransport
+
+
+@dataclass
+class MiddlewareChainHost:
+    """Owner of the middleware-chain mutable state and chain leaf.
+
+    Constructed by :func:`compose_session_internals` BEFORE
+    :class:`Session`. The transport is bound write-once via
+    :meth:`_bind_transport` after :func:`build_session_transport`
+    returns — this resolves the host ↔ transport construction cycle
+    without giving either side a permanent back-reference to the other.
+
+    Attributes:
+        _auth_refresh: The :class:`AuthRefreshCoordinator` collaborator.
+            :meth:`await_refresh` looks up the coordinator dynamically
+            on every call so a fixture-time rebind of
+            ``host._auth_refresh.await_refresh = fake`` keeps steering
+            the live refresh-and-retry path.
+        _rate_limit_max_retries: Budget consumed by the retry middleware
+            on 429 responses. Stored on the host (the chain's provider
+            lambda reads ``host._rate_limit_max_retries`` live, so
+            mid-flight rebinding takes effect on the next attempt).
+        _server_error_max_retries: Budget consumed by the retry
+            middleware on 5xx responses. Same live-read contract.
+        _refresh_retry_delay: Backoff between refresh-retry attempts
+            in the auth-refresh middleware. Same live-read contract.
+        _authed_post_chain: The wired middleware chain. ``None`` until
+            :func:`compose_session_internals` assigns it through the
+            :class:`Session` descriptor forward (which writes through
+            to this slot). The transport's ``chain_provider`` lambda
+            reads this attribute every authed POST.
+        _transport: The :class:`SessionTransport` collaborator. ``None``
+            until :meth:`_bind_transport` fires; after that bind the
+            chain leaf (:meth:`_authed_post_chain_terminal`) can forward
+            to ``transport.terminal``.
+    """
+
+    _auth_refresh: AuthRefreshCoordinator
+    _rate_limit_max_retries: int
+    _server_error_max_retries: int
+    _refresh_retry_delay: float
+    _authed_post_chain: NextCall | None = None
+    _transport: SessionTransport | None = None
+
+    def _bind_transport(self, transport: SessionTransport) -> None:
+        """Write-once setter for :attr:`_transport`.
+
+        Raises :class:`RuntimeError` on a second bind attempt — the
+        composition root (:func:`compose_session_internals`) is the
+        single legitimate caller, and it fires this once after
+        :func:`build_session_transport` returns. The same write-once
+        shape on :class:`Session` (:meth:`Session._bind_transport`)
+        guarantees both sides of the host ↔ transport relationship are
+        bound exactly once at composition time.
+        """
+        if self._transport is not None:
+            raise RuntimeError("MiddlewareChainHost._transport already bound")
+        self._transport = transport
+
+    async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
+        """Middleware-chain leaf — forwards to :meth:`SessionTransport.terminal`.
+
+        Reachable through the :class:`Session` writable descriptor
+        forward (``session._authed_post_chain_terminal`` resolves to
+        this bound method until a test installs a fake terminal via
+        ``session._authed_post_chain_terminal = fake_terminal``; the
+        descriptor's setter writes the fake through to this host so
+        subsequent reads pick it up).
+
+        Raises :class:`RuntimeError` if the transport is not yet bound.
+        This can only happen if a caller exercised the chain before
+        the composition root finished — the fail-fast guard mirrors
+        the corresponding :meth:`Session._require_constructed` guard
+        on the Session entry points (introduced in Stage B1 PR 2).
+        """
+        transport = self._transport
+        if transport is None:
+            raise RuntimeError("MiddlewareChainHost not fully constructed: _transport is None")
+        return await transport.terminal(request)
+
+    async def await_refresh(self) -> None:
+        """Run / join the shared refresh task on the coordinator.
+
+        Dynamic delegation — looks up ``self._auth_refresh.await_refresh``
+        on every call so a fixture-time rebind of the coordinator's
+        method (or of ``host._auth_refresh`` itself) keeps steering the
+        live refresh path. The single-flight semantics, lock contract,
+        and ``asyncio.shield`` cancellation handling all live inside
+        :meth:`AuthRefreshCoordinator.await_refresh` — this method is a
+        thin forward whose only job is to provide the chain a stable
+        ``refresh_callable`` reference at construction time while still
+        allowing the underlying implementation to be rebound for tests.
+        """
+        await self._auth_refresh.await_refresh()
+
+
+__all__ = ["MiddlewareChainHost"]

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -16,6 +16,7 @@ from ._middleware import (
     RpcRequest,
     RpcResponse,
 )
+from ._middleware_chain_host import MiddlewareChainHost
 from ._rpc_executor import RpcExecutor
 from ._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
@@ -287,15 +288,41 @@ def compose_session_internals(
         cookie_saver=cookie_saver,
         cookie_rotator=cookie_rotator,
     )
-    session = Session(collaborators=collaborators, config=config, auth=auth)
+    # Stage B2 PR 1: the :class:`MiddlewareChainHost` owns the retry
+    # tunables, the chain slot, and the chain leaf. It is constructed
+    # BEFORE :class:`Session` so the Session's writable descriptor
+    # forwards (``_rate_limit_max_retries`` etc.) can write through to
+    # the host on the very first assignment inside ``Session.__init__``.
+    chain_host = MiddlewareChainHost(
+        _auth_refresh=collaborators.auth_coord,
+        _rate_limit_max_retries=config.rate_limit_max_retries,
+        _server_error_max_retries=config.server_error_max_retries,
+        _refresh_retry_delay=config.refresh_retry_delay,
+    )
+    session = Session(
+        collaborators=collaborators,
+        config=config,
+        auth=auth,
+        chain_host=chain_host,
+    )
     transport = build_session_transport(collaborators, host=session, logger=logger)
     session._bind_transport(transport)
-    # The chain leaf wires to the :class:`Session`-side forward
-    # (:meth:`_authed_post_chain_terminal`), not directly to
+    # Bind the transport on the host as well so the chain leaf
+    # (:meth:`MiddlewareChainHost._authed_post_chain_terminal`) can
+    # forward to it. Both sides are write-once and bound in this same
+    # composition root, so the symmetric bind is safe.
+    chain_host._bind_transport(transport)
+    # The chain leaf wires to the :class:`Session`-side descriptor
+    # forward (:attr:`_authed_post_chain_terminal`), not directly to
     # :meth:`SessionTransport.terminal`. The forward is the canonical
-    # seam: a subclass override or fixture-time class-level
-    # monkeypatch of ``Session._authed_post_chain_terminal`` keeps
-    # steering the live chain leaf, matching pre-extraction behavior.
+    # seam: a fixture-time rebind via
+    # ``session._authed_post_chain_terminal = fake_terminal`` keeps
+    # steering the live chain leaf because the descriptor setter
+    # writes through to ``chain_host._authed_post_chain_terminal``.
+    # ``wire_middleware_chain`` signature is unchanged in B2 PR 1 — it
+    # still reads ``host=session`` and the chain's tunable providers
+    # dereference ``session._<attr>`` (which now resolves through
+    # the descriptor to the host).
     wired = wire_middleware_chain(
         config,
         collaborators,
@@ -357,6 +384,7 @@ class Session:
         collaborators: "SessionCollaborators",
         config: "ValidatedSessionConfig",
         auth: AuthTokens,
+        chain_host: MiddlewareChainHost,
     ) -> None:
         """Initialise a Session from a pre-built collaborator bundle.
 
@@ -369,6 +397,19 @@ class Session:
         the late-bound slots by the composition root via the
         :meth:`_bind_transport` / :meth:`_bind_chain` /
         :meth:`_bind_executor` write-once setters.
+
+        Stage B2 PR 1 added ``chain_host``: the
+        :class:`MiddlewareChainHost` constructed by
+        :func:`compose_session_internals` BEFORE this constructor. The
+        host owns the retry tunables, the installed chain slot, and the
+        chain leaf; :class:`Session` exposes them through writable
+        ``@property`` descriptors that write through to the host (the
+        descriptors are permanent, load-bearing test seams pinned by
+        ``test_observability.py:77`` and ``test_authed_post_pipeline.py:113``).
+        ``self._chain_host = chain_host`` MUST be the first assignment
+        in this constructor because every subsequent ``self._<attr>``
+        write that targets a descriptor-managed name routes through the
+        host — assigning the host last would dereference ``None``.
 
         Production callers DO NOT instantiate :class:`Session` directly
         — :class:`NotebookLMClient` calls
@@ -386,12 +427,24 @@ class Session:
                 :func:`validate_constructor_args` inside
                 :func:`compose_session_internals`.
             auth: Authentication tokens from browser login.
+            chain_host: The :class:`MiddlewareChainHost` constructed by
+                :func:`compose_session_internals` for this session. The
+                host owns the chain leaf, the chain slot, and the three
+                retry-budget tunables; the descriptor forwards below
+                require it.
         """
-        # The chain provider lambdas in :func:`wire_middleware_chain`
-        # read ``_rate_limit_max_retries`` / ``_server_error_max_retries``
-        # / ``_refresh_retry_delay`` from ``self`` live (integration
-        # tests SET them post-construction). Same for the seam
-        # callables ``_decode_response`` / ``_sleep`` /
+        # CHAIN HOST FIRST — the writable descriptors below
+        # (``_authed_post_chain_terminal``, ``_authed_post_chain``,
+        # ``_rate_limit_max_retries``, ``_server_error_max_retries``,
+        # ``_refresh_retry_delay``) all dereference ``self._chain_host``
+        # in their setters and getters, so assigning the host has to
+        # precede any descriptor-managed attribute write. See the
+        # ``Session.__init__ ordering`` section of
+        # ``docs/post-refactoring-plan-2026-05-27.md`` for the
+        # invariant.
+        self._chain_host = chain_host
+
+        # The seam callables ``_decode_response`` / ``_sleep`` /
         # ``_is_auth_error`` — the executor closures dereference these
         # via ``session._<attr>`` on every call, so post-construction
         # reassignment continues to take effect.
@@ -399,9 +452,17 @@ class Session:
         self._decode_response: Callable[..., Any] = config.decode_response
         self._sleep: Callable[[float], Awaitable[Any]] = config.sleep
         self._is_auth_error: Callable[[Exception], bool] = config.is_auth_error
-        self._refresh_retry_delay = config.refresh_retry_delay
+        # B2 PR 1: ``_rate_limit_max_retries`` / ``_server_error_max_retries``
+        # / ``_refresh_retry_delay`` are no longer stored on Session —
+        # the assignments below route through writable @property
+        # descriptors that write through to ``self._chain_host``. The
+        # chain provider lambdas in :func:`wire_middleware_chain` read
+        # ``host._<attr>`` live (now resolving through the descriptor
+        # to the host) so integration tests that SET them
+        # post-construction continue to steer the live chain.
         self._rate_limit_max_retries = config.rate_limit_max_retries
         self._server_error_max_retries = config.server_error_max_retries
+        self._refresh_retry_delay = config.refresh_retry_delay
         self._max_concurrent_rpcs: int | None = config.max_concurrent_rpcs
         # Lazy-created per-instance — see :meth:`_get_rpc_semaphore`.
         self._rpc_semaphore: asyncio.Semaphore | None = None
@@ -433,10 +494,14 @@ class Session:
         # mirror the corresponding :class:`WiredMiddleware` fields so
         # downstream readers see precise types rather than ``Any``
         # (claude[bot] review on PR #1089).
+        #
+        # B2 PR 1: ``_authed_post_chain`` slot moved to the host. The
+        # ``_authed_post_chain`` name on :class:`Session` is now a
+        # writable @property descriptor that writes through to
+        # ``self._chain_host._authed_post_chain``.
         self._transport: SessionTransport | None = None
         self._chain_builder: MiddlewareChainBuilder | None = None
         self._middlewares: list[Middleware] | None = None
-        self._authed_post_chain: NextCall | None = None
         self._rpc_executor: RpcExecutor | None = None
 
     def assert_bound_loop(self) -> None:
@@ -659,55 +724,138 @@ class Session:
         """
         await self._auth_coord.update_auth_tokens(self, csrf, session_id)
 
-    async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
-        """Middleware chain leaf — forwards to :meth:`SessionTransport.terminal`.
+    # ------------------------------------------------------------------
+    # Stage B2 PR 1 — writable descriptor forwards to MiddlewareChainHost
+    # ------------------------------------------------------------------
+    #
+    # The five names below (``_authed_post_chain_terminal``,
+    # ``_authed_post_chain``, ``_rate_limit_max_retries``,
+    # ``_server_error_max_retries``, ``_refresh_retry_delay``) plus the
+    # async method :meth:`_await_refresh` are permanent, load-bearing
+    # test seams. ADR-014 Rule 4's retention list records them as
+    # "test-seam forwards to MiddlewareChainHost" once Stage B2 PR 3
+    # lands.
+    #
+    # The setters all *write through* to the host — the historical
+    # tests assign ``core._authed_post_chain_terminal = fake_terminal``
+    # (test_observability.py:77), ``core._authed_post_chain =
+    # fake_chain`` (test_authed_post_pipeline.py:113), and
+    # ``core._rate_limit_max_retries = 0`` (integration tests). After
+    # B2 PR 1 those writes route to ``chain_host.<attr>``, where the
+    # chain's provider lambdas dereference them live — preserving the
+    # mutation-after-construction contract.
+    #
+    # The ``_authed_post_chain_terminal`` setter intentionally does NOT
+    # re-route an already-built chain. ``test_observability.py:82``
+    # follows the assignment with ``core._authed_post_chain =
+    # build_chain(core._middlewares, fake_terminal)`` to rebuild the
+    # chain around the new terminal. The setter's only job is to
+    # accept the write; chain rebuild is the test's responsibility.
 
-        The body moved to the collaborator in move #4c
-        (``docs/improvement.md`` §3.1). :func:`compose_session_internals`
-        wires this method as the chain leaf (``wire_middleware_chain``
-        receives ``self._authed_post_chain_terminal``), so this forward
-        IS the live chain leaf — not a test-only entry point. Routing
-        through the Session forward (rather than directly to
-        :meth:`SessionTransport.terminal`) preserves the canonical
-        seam: a subclass override or fixture-time class-level
-        monkeypatch of this method keeps steering the live chain leaf.
-        AST guard
-        (:func:`tests.unit.test_concurrency_refresh_race.test_kernel_post_terminal_has_no_await_before_post_per_attempt`)
-        inspects :meth:`SessionTransport.terminal` directly because the
-        forward carries no try/await structure.
+    @property
+    def _authed_post_chain_terminal(
+        self,
+    ) -> Callable[[RpcRequest], Awaitable[RpcResponse]]:
+        """Forward to :attr:`MiddlewareChainHost._authed_post_chain_terminal`.
 
-        ``_transport`` is statically typed ``Optional`` because the
-        composition root binds it lazily via :meth:`_bind_transport`,
-        but this method is only reachable from the wired middleware
-        chain (itself constructed AFTER the transport bind), so the
-        runtime invariant is "non-None whenever this method runs". The
-        local-variable + ``assert`` narrows the type for the type
-        checker without suppressing diagnostics.
+        Resolves to the host's bound method (the live chain leaf that
+        forwards to :meth:`SessionTransport.terminal`) until a test
+        reassigns ``session._authed_post_chain_terminal = fake_terminal``;
+        the setter writes the fake through to the host so subsequent
+        reads via the descriptor pick it up.
         """
-        transport = self._transport
-        assert transport is not None
-        return await transport.terminal(request)
+        return self._chain_host._authed_post_chain_terminal
+
+    @_authed_post_chain_terminal.setter
+    def _authed_post_chain_terminal(
+        self,
+        value: Callable[[RpcRequest], Awaitable[RpcResponse]],
+    ) -> None:
+        # Writes through so ``test_observability.py:77`` can install a
+        # fake terminal on the host. The setter does NOT re-route an
+        # already-built chain — chain rebuild is the test's job (see
+        # the ``build_chain`` call at line 82 of that test).
+        # ``method-assign`` covers shadowing the dataclass's async
+        # method with a plain callable; ``assignment`` covers the
+        # ``Awaitable``/``Coroutine`` return-type variance between the
+        # descriptor's value annotation and the host's declared
+        # ``async def`` signature.
+        self._chain_host._authed_post_chain_terminal = value  # type: ignore[method-assign,assignment]
+
+    @property
+    def _authed_post_chain(self) -> "NextCall | None":
+        """Forward to :attr:`MiddlewareChainHost._authed_post_chain`.
+
+        The transport's ``chain_provider`` closure (currently
+        ``lambda: getattr(host, "_authed_post_chain", None)`` —
+        Stage B2 PR 2 will switch it to read ``chain_host`` directly)
+        resolves this attribute on every authed POST so a
+        ``session._authed_post_chain = fake_chain`` write keeps
+        steering the live transport.
+        """
+        return self._chain_host._authed_post_chain
+
+    @_authed_post_chain.setter
+    def _authed_post_chain(self, value: "NextCall | None") -> None:
+        # Writes through so ``test_authed_post_pipeline.py:113`` can
+        # install a fake chain on the host.
+        self._chain_host._authed_post_chain = value
+
+    @property
+    def _rate_limit_max_retries(self) -> int:
+        """Forward to :attr:`MiddlewareChainHost._rate_limit_max_retries`."""
+        return self._chain_host._rate_limit_max_retries
+
+    @_rate_limit_max_retries.setter
+    def _rate_limit_max_retries(self, value: int) -> None:
+        # Writes through so the chain's
+        # ``rate_limit_max_retries_provider`` lambda picks up the new
+        # budget on the next attempt (integration tests SET this
+        # mid-flight at ``test_max_concurrent_rpcs.py``).
+        self._chain_host._rate_limit_max_retries = value
+
+    @property
+    def _server_error_max_retries(self) -> int:
+        """Forward to :attr:`MiddlewareChainHost._server_error_max_retries`."""
+        return self._chain_host._server_error_max_retries
+
+    @_server_error_max_retries.setter
+    def _server_error_max_retries(self, value: int) -> None:
+        # Writes through so the chain's
+        # ``server_error_max_retries_provider`` lambda picks up the new
+        # budget on the next attempt.
+        self._chain_host._server_error_max_retries = value
+
+    @property
+    def _refresh_retry_delay(self) -> float:
+        """Forward to :attr:`MiddlewareChainHost._refresh_retry_delay`."""
+        return self._chain_host._refresh_retry_delay
+
+    @_refresh_retry_delay.setter
+    def _refresh_retry_delay(self, value: float) -> None:
+        # Writes through so both the chain's
+        # ``refresh_retry_delay_provider`` lambda AND the executor's
+        # ``refresh_retry_delay_provider`` closure (built in
+        # :func:`compose_session_internals`) pick up the new delay on
+        # the next refresh wave.
+        self._chain_host._refresh_retry_delay = value
 
     async def _await_refresh(self) -> None:
-        """Run / join the shared refresh task.
+        """Run / join the shared refresh task via :class:`MiddlewareChainHost`.
 
-        Delegates to :meth:`AuthRefreshCoordinator.await_refresh`. The
-        coordinator preserves the single-flight semantics — concurrent
-        callers share one refresh task so a thundering herd of 401s on the
-        same client triggers exactly one token refresh. The lock protects
-        task-creation only; the await on the task itself happens outside
-        the lock so other callers can join, and the join is wrapped in
-        :func:`asyncio.shield` so a cancelled waiter unwinds locally
-        without propagating ``CancelledError`` into the shared task. The
-        ``_refresh_task`` slot is left intact across cancellation and is
-        replaced only on the next refresh wave once the current task
-        transitions to ``done()``.
+        Stage B2 PR 1 routed this delegate through the host —
+        :meth:`MiddlewareChainHost.await_refresh` looks up the
+        coordinator's ``await_refresh`` method dynamically on every
+        call, preserving the long-standing pattern where a fixture
+        rebinds the coordinator's behavior to inject a fake refresh.
+        The single-flight semantics, lock contract, and
+        :func:`asyncio.shield` cancellation handling all still live
+        inside :meth:`AuthRefreshCoordinator.await_refresh`; this
+        method's job is to keep ``Session._await_refresh`` reachable
+        as the ``refresh_callable`` reference the middleware chain
+        captures at construction time (``_session_init.py:430``).
         """
-        # Wave 3b of session-decoupling (Task 1.0): ``await_refresh`` no
-        # longer takes a host parameter — its only host attribute reach
-        # (``_metrics_obj``) is now supplied via the coordinator's
-        # constructor.
-        await self._auth_coord.await_refresh()
+        await self._chain_host.await_refresh()
 
     async def rpc_call(
         self,


### PR DESCRIPTION
> [!WARNING]
> **STACKED ON #1089 — DO NOT MERGE until parent merges.**
> Base branch will auto-update to `main` once #1089 is squashed. At that point: `git fetch origin main && git rebase origin/main && git push --force-with-lease`, verify `gh pr view --json mergeable` reports `MERGEABLE`, then merge.

## Summary

Stage B2 PR 1 of `docs/post-refactoring-plan-2026-05-27.md` (the "host skeleton" step). Adds the `MiddlewareChainHost` collaborator and routes the five mutable chain seams on `Session` through writable `@property` descriptors that write through to the host. The transport / `wire_middleware_chain` signatures are intentionally unchanged in this PR — providers continue to read `session._<attr>` (which now resolves through the descriptor to the host). Stage B2 PR 2 will split those signatures so the chain reads the host directly.

### What lives where after this PR

| Surface | Lives on host | Notes |
|---|---|---|
| `_authed_post_chain_terminal()` | yes | live chain leaf; Session exposes a writable @property descriptor forwarding to `chain_host._authed_post_chain_terminal` |
| `_authed_post_chain` (installed chain reference) | yes | transport's `chain_provider` lambda reads via `session._authed_post_chain` → descriptor → host |
| `_rate_limit_max_retries: int` | yes | mutable storage; Session descriptor forwards |
| `_server_error_max_retries: int` | yes | mutable storage; Session descriptor forwards |
| `_refresh_retry_delay: float` | yes | mutable storage; Session descriptor forwards |
| `await_refresh()` async method | yes | dynamic delegation to `self._auth_refresh.await_refresh()` |
| `Session._await_refresh` | Session (forwards) | now `await self._chain_host.await_refresh()` |
| auth-snapshot lookup | no | stays on Session |
| RPC semaphore | no | stays on Session |
| metrics / kernel / HTTP client | no | stays on Session / collaborator bundle |

### Composition sequence

1. `compose_session_internals` constructs `MiddlewareChainHost(_auth_refresh=collaborators.auth_coord, _rate_limit_max_retries=…, _server_error_max_retries=…, _refresh_retry_delay=…)` BEFORE `Session`.
2. `Session(*, collaborators, config, auth, chain_host=chain_host)` is instantiated. **First assignment** in `Session.__init__` is `self._chain_host = chain_host` — every subsequent descriptor-managed write (`self._rate_limit_max_retries = …` etc.) routes through the host.
3. `build_session_transport(collaborators, host=session, logger=logger)` (signature unchanged in PR 1).
4. `session._bind_transport(transport)` + `chain_host._bind_transport(transport)` — both write-once.
5. `wire_middleware_chain(config, collaborators, host=session, …)` (signature unchanged in PR 1). The chain's provider lambdas read `host._<attr>` live — which now goes through the descriptor to the host.
6. `session._bind_chain(wired)` — its `self._authed_post_chain = wired.authed_post_chain` write routes through the descriptor to the host.
7. `RpcExecutor` is built with the same closures as B1; `session._bind_executor(executor)`.

### Pre-verification greps (from the master plan)

```
$ rg --type py 'wire_middleware_chain\(' src/notebooklm tests/
src/notebooklm/_session.py: wired = wire_middleware_chain(
src/notebooklm/_session_init.py: def wire_middleware_chain(

$ rg --type py 'build_session_transport\(' src/notebooklm tests/
src/notebooklm/_session.py: transport = build_session_transport(collaborators, host=session, logger=logger)
src/notebooklm/_session_init.py: def build_session_transport(

$ rg --type py 'core\._(authed_post_chain|authed_post_chain_terminal|rate_limit_max_retries|server_error_max_retries|refresh_retry_delay)\b' tests/
tests/unit/test_observability.py: core._authed_post_chain_terminal = fake_terminal
tests/unit/test_observability.py: core._authed_post_chain = build_chain(core._middlewares, fake_terminal)
tests/unit/test_chain_wiring.py:    result = await core._authed_post_chain_terminal(request)
tests/unit/test_chain_wiring.py:    await core._authed_post_chain_terminal(request)
tests/unit/test_chain_wiring.py:        await core._authed_post_chain_terminal(request)
tests/unit/test_chain_wiring.py:    chain: NextCall = build_chain([observer], core._authed_post_chain_terminal)
tests/integration/concurrency/test_max_concurrent_rpcs.py: core._rate_limit_max_retries = 3
tests/unit/test_authed_post_pipeline.py: core._authed_post_chain = fake_chain
tests/unit/test_authed_post_pipeline.py:     core._rate_limit_max_retries = 1
```

All historical test seams continue to resolve — the descriptor setter writes through to the host so the next read picks up the fake.

## Test plan

- [x] `uv run ruff format .` — clean (1 file reformatted)
- [x] `uv run ruff check .` — clean (6 auto-fixed)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest tests/_lint` — 77 passed (retention doc lint now lists all five descriptor names)
- [x] `uv run pytest tests/unit tests/integration` — 6441 passed, 12 skipped
- [x] `uv run pytest tests/unit/test_public_shims.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_chain_wiring.py tests/unit/test_refresh_state_machine.py tests/unit/test_refresh_lock_lazy_init.py tests/unit/test_authed_post_pipeline.py tests/unit/test_observability.py tests/_lint/test_session_retention.py` (master-plan B2 focused set) — 335 passed, 2 skipped
- [x] `uv run pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)