### PR TITLE
fix(session): rebuild authed POST envelope on every terminal attempt

### DIFF
--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -41,7 +41,10 @@ the initial ``RpcRequest.url`` / ``.headers`` / ``.body`` populated and the
 terminal consumes that envelope through ``Kernel.post``. After a successful
 refresh this middleware re-snapshots auth state and replaces the request
 envelope before retrying so the terminal never sends stale URL/body/header
-values.
+values. See :meth:`AuthRefreshMiddleware._rebuild_request_after_refresh`
+for the full in-place context-mutation contract and the paired terminal
+rebuild invariant that keeps the post-refresh 429 retry from sending a
+stale envelope.
 
 This regression-fix from PR 12.7 also closes here: pre-PR-12.7 the leaf's
 ``refreshed_this_call`` lived in the same loop as 429/5xx retries (one
@@ -255,6 +258,42 @@ class AuthRefreshMiddleware:
         envelope materialization synchronous. The terminal still performs a
         final freshness check immediately before ``Kernel.post`` because inner
         middlewares may await between this retry rebuild and the wire.
+
+        **In-place context mutation is the deliberate cross-boundary carrier
+        for refreshed auth state and the once-per-call refresh guard.** This
+        method (and its caller :meth:`__call__`) intentionally mutates the
+        inbound ``request.context`` rather than copying it, because two
+        pieces of shared state must survive the ``Retry`` ↔ ``AuthRefresh``
+        boundary:
+
+        - ``RPC_CONTEXT_AUTH_REFRESHED`` is written by :meth:`__call__` on
+          the **original** ``request.context`` just before this rebuild
+          runs. ``RetryMiddleware`` lives one layer *outside* this
+          middleware and, on a 429 / 5xx caught after the refresh, re-invokes
+          the chain with that same original ``RpcRequest``. The marker on
+          the shared context suppresses a second refresh on the
+          original-request retry, preserving the "exactly one refresh per
+          logical call" contract pinned in ADR-009 §"Retry semantics".
+
+        - ``RPC_CONTEXT_AUTH_SNAPSHOT`` is updated below to the freshly
+          captured snapshot. Because :func:`materialize_rpc_request`
+          retains the inbound ``context`` dict by reference (see
+          :func:`notebooklm._middleware.materialize_rpc_request`), the
+          returned ``retry_request`` and the original ``request`` share
+          that same context dict and therefore see the same updated
+          snapshot. This mutation is what lets the terminal freshness
+          guard (:meth:`SessionTransport.refresh_request_for_current_auth`)
+          observe the post-refresh snapshot when ``RetryMiddleware`` later
+          retries the original request after a 429.
+
+        The companion invariant — and the reason the in-place mutation is
+        safe even though the original request's ``url`` / ``headers`` /
+        ``body`` are still pre-refresh — is that
+        :meth:`SessionTransport.refresh_request_for_current_auth` rebuilds
+        URL / body / cookies from the current snapshot on **every** terminal
+        attempt, unconditionally. Both halves are load-bearing and must be
+        preserved together; deleting the unconditional rebuild reintroduces
+        the stale-envelope path on the post-refresh 429 retry.
         """
         if self._snapshot_provider is None:
             return request

--- a/src/notebooklm/_session_transport.py
+++ b/src/notebooklm/_session_transport.py
@@ -136,32 +136,66 @@ class SessionTransport:
         self._logger = logger
 
     async def refresh_request_for_current_auth(self, request: RpcRequest) -> RpcRequest:
-        """Rebuild the envelope if auth changed before the terminal POST.
+        """Rebuild the envelope from the current auth snapshot before every POST.
 
-        :meth:`perform_authed_post` materializes the request before the
-        outer chain runs, so the request may wait behind Drain / Semaphore
-        before the leaf sends it. Compare the materialization snapshot to
-        a fresh snapshot immediately before :meth:`Kernel.post`; if auth
-        moved, rebuild the envelope synchronously from
-        ``RPC_CONTEXT_BUILD_REQUEST``.
+        This guard is **load-bearing**: it runs on *every* terminal attempt
+        (including retries driven by ``RetryMiddleware`` for 429 / 5xx) and
+        unconditionally rebuilds ``RpcRequest.url`` / ``.headers`` / ``.body``
+        from a freshly captured :class:`AuthSnapshot` whenever
+        ``RPC_CONTEXT_BUILD_REQUEST`` is present. The unconditional rebuild
+        is the runtime correctness fix for the stale-envelope path that
+        existed when the freshness check short-circuited on snapshot
+        equality:
+
+        1. Initial attempt: snapshot ``S_old`` is captured by
+           :meth:`perform_authed_post`, the envelope is materialized, and
+           the request enters the chain.
+        2. Terminal POSTs and the response is HTTP 401.
+        3. :class:`AuthRefreshMiddleware` (just inside ``RetryMiddleware``)
+           catches the auth error, refreshes credentials, mutates
+           ``request.context[RPC_CONTEXT_AUTH_SNAPSHOT]`` to ``S_new``
+           in-place (see
+           :meth:`AuthRefreshMiddleware._rebuild_request_after_refresh`
+           for the contract — that mutation is the carrier of the new
+           snapshot across the ``Retry`` ↔ ``AuthRefresh`` boundary), and
+           hands a freshly built ``retry_request`` to the chain leaf.
+        4. The retry attempt POSTs with the refreshed envelope and the
+           response is HTTP 429.
+        5. The 429 propagates back up to ``RetryMiddleware`` (outside
+           ``AuthRefreshMiddleware``), which retries by re-invoking the
+           chain with the **original** ``RpcRequest`` from step 1. That
+           request's ``.url`` / ``.headers`` / ``.body`` were built from
+           ``S_old`` even though its shared ``context`` dict now carries
+           ``S_new`` (mutated in step 3).
+        6. Without an unconditional rebuild here, a snapshot-equality
+           short-circuit would compare ``S_new`` (in context) against
+           ``S_new`` (freshly captured), declare "no change," and send the
+           stale ``S_old`` envelope. The unconditional rebuild keeps
+           ``URL`` / ``headers`` / ``body`` aligned with
+           :attr:`Kernel._client.cookies` (which carries the refreshed
+           cookie jar) for every attempt.
+
+        Idempotence on the happy path: when no refresh ran, the snapshot
+        captured here equals the snapshot used by
+        :meth:`perform_authed_post`, so the rebuilt envelope is
+        byte-identical to the inbound one. The extra ``build_request``
+        invocation per attempt is the cost of the freshness invariant.
 
         AST guarded — see
         :func:`tests.unit.test_concurrency_refresh_race.test_terminal_freshness_check_has_no_await_after_materialization`
         which reads the source of this method to assert no ``await``
         follows :func:`materialize_rpc_request`. Any restructuring here
         must keep that invariant: the snapshot and the rebuilt envelope
-        must be produced together with no suspension point between them.
+        must be produced together with no suspension point between them
+        so a concurrent refresh cannot move the cookie jar between the
+        rebuild and :meth:`Kernel.post`.
         """
         context = request.context
-        request_snapshot = context.get(RPC_CONTEXT_AUTH_SNAPSHOT)
         build_request = context.get(RPC_CONTEXT_BUILD_REQUEST)
-        if not isinstance(request_snapshot, AuthSnapshot) or build_request is None:
+        if build_request is None:
             return request
 
         current_snapshot = await self._snapshot_provider()
-        if current_snapshot == request_snapshot:
-            return request
-
         context[RPC_CONTEXT_AUTH_SNAPSHOT] = current_snapshot
         return materialize_rpc_request(
             build_request=build_request,

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -5,14 +5,29 @@ used by the RPC executor path (the ``Session._perform_authed_post``
 compatibility forward was deleted in Wave 11c of session-decoupling;
 tests now drive the canonical collaborator method directly):
 
-- ``build_request`` factory is called once per HTTP attempt.
-- On a single auth-error retry, the factory is called TWICE, and the second
-  invocation observes a fresh ``AuthSnapshot`` capturing whatever the
-  refresh callback mutated.
+- ``build_request`` factory is invoked once at chain entry (in
+  :meth:`SessionTransport.perform_authed_post`) and once again at the
+  terminal freshness rebuild (in
+  :meth:`SessionTransport.refresh_request_for_current_auth`). The
+  terminal rebuild runs unconditionally on every attempt so a 429
+  retry that re-enters the chain on the original request after an
+  auth refresh always sends an envelope built from the current
+  :class:`AuthSnapshot`; the happy-path rebuild is byte-identical to
+  the chain-entry materialization because the snapshot has not moved.
+- On a 401 + successful refresh + 200 retry, ``build_request`` is
+  invoked four times — chain-entry + terminal pre-401 (both with the
+  stale snapshot), then refresh-rebuild + terminal pre-200 (both with
+  the refreshed snapshot). The post-refresh invocations observe a
+  fresh ``AuthSnapshot`` capturing whatever the refresh callback
+  mutated.
 - The request-id correlation tag (``[req=<id>]``) is stable across the retry
   chain.
 - ``rate_limit_max_retries`` bounds 429 retries; exhausting the budget
   raises ``TransportRateLimited``.
+- A 401 → refresh → 429 → 200 sequence with the retry budget enabled
+  must send the post-429 retry with the refreshed auth envelope, not
+  the stale pre-refresh one — see
+  ``test_stale_envelope_rebuilt_after_refresh_then_retry``.
 - The historical ``rpc_call`` happy path is unchanged byte-for-byte
   (URL + body identical to pre-extraction).
 
@@ -412,7 +427,11 @@ async def test_perform_authed_post_disable_internal_retries_short_circuits(monke
 
 
 @pytest.mark.asyncio
-async def test_build_request_called_once_on_happy_path(monkeypatch):
+async def test_build_request_rebuilt_at_terminal_on_happy_path(monkeypatch):
+    """``build_request`` is invoked at chain entry AND at the terminal
+    freshness rebuild — both with the same (unmoved) snapshot on the
+    happy path, so the rebuilt envelope is byte-identical to the
+    chain-entry materialization."""
     core = _make_core()
     await core.open()
     try:
@@ -432,8 +451,14 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
         response = await core._transport.perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
-        assert len(calls) == 1
+        # The terminal freshness rebuild is load-bearing: it runs on every
+        # attempt so a 429-retry after auth refresh always sends fresh auth
+        # values (see ``test_stale_envelope_rebuilt_after_refresh_then_retry``).
+        # On the happy path the snapshot has not moved, so both invocations
+        # observe the same ``AuthSnapshot``.
+        assert len(calls) == 2
         assert calls[0].csrf_token == "CSRF_OLD"
+        assert calls[1].csrf_token == "CSRF_OLD"
     finally:
         await core.close()
 
@@ -489,9 +514,16 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch):
-    """On a 401 + successful refresh, the factory is invoked twice — and the
-    second call sees the refreshed CSRF / session-id, not the stale ones."""
+async def test_build_request_observes_fresh_snapshot_after_401_refresh(monkeypatch):
+    """On a 401 + successful refresh, the second HTTP attempt carries the
+    refreshed CSRF / session-id, not the stale ones.
+
+    ``build_request`` is invoked four times across the two-attempt flow:
+    chain-entry + terminal pre-401 (both stale snapshot), then
+    refresh-rebuild + terminal pre-200 (both refreshed snapshot). The
+    pre-rebuild invocations carry the stale snapshot and the post-rebuild
+    invocations carry the refreshed one.
+    """
     refresh_calls = []
 
     async def refresh() -> AuthTokens:
@@ -527,12 +559,139 @@ async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch
         assert response.status_code == 200
         assert len(refresh_calls) == 1
         assert call_count["n"] == 2
-        assert len(snapshots) == 2
-        # First snapshot pre-refresh; second snapshot post-refresh.
+        # Four ``build_request`` invocations: chain-entry + terminal pre-401
+        # (stale snapshot) and refresh-rebuild + terminal pre-200 (refreshed
+        # snapshot).
+        assert len(snapshots) == 4
+        # First two invocations observe the pre-refresh snapshot.
         assert snapshots[0].csrf_token == "CSRF_OLD"
         assert snapshots[0].session_id == "SID_OLD"
-        assert snapshots[1].csrf_token == "CSRF_NEW"
-        assert snapshots[1].session_id == "SID_NEW"
+        assert snapshots[1].csrf_token == "CSRF_OLD"
+        assert snapshots[1].session_id == "SID_OLD"
+        # Refresh runs after the 401; the last two invocations observe the
+        # refreshed snapshot, and the actual HTTP body carries CSRF_NEW.
+        assert snapshots[-1].csrf_token == "CSRF_NEW"
+        assert snapshots[-1].session_id == "SID_NEW"
+        assert snapshots[-2].csrf_token == "CSRF_NEW"
+        assert snapshots[-2].session_id == "SID_NEW"
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_envelope_rebuilt_after_refresh_then_retry(monkeypatch):
+    """Regression: 401 → refresh → 429 → 200 sends post-429 retry with fresh auth.
+
+    The bug being guarded:
+
+    - ``AuthRefreshMiddleware`` lives just inside ``RetryMiddleware``. After a
+      401, it refreshes auth, updates ``request.context[RPC_CONTEXT_AUTH_SNAPSHOT]``
+      in-place on the shared context dict, and re-invokes the chain with a
+      freshly built ``retry_request`` carrying refreshed URL / body / headers.
+    - When that retry attempt receives a 429, the ``TransportRateLimited``
+      bubbles back up through ``AuthRefreshMiddleware`` (which does not catch
+      transport errors) and is caught by ``RetryMiddleware``, which then
+      retries the chain with the **original** ``RpcRequest`` — whose
+      ``url`` / ``body`` were built from the pre-refresh snapshot.
+    - Without the load-bearing terminal rebuild
+      (:meth:`SessionTransport.refresh_request_for_current_auth` running on
+      every attempt), the original request would be sent verbatim and the
+      backend would see stale CSRF / session-id / authuser values even though
+      the cookie jar carries the refreshed cookies.
+
+    Assertions:
+
+    - The third terminal-side request (the post-429 retry) carries the
+      refreshed CSRF / session-id / authuser values, NOT the pre-refresh
+      snapshot.
+    - The refresh callback is invoked exactly once across the whole flow —
+      the once-per-call marker on ``request.context`` prevents
+      ``AuthRefreshMiddleware`` from running a second refresh when the
+      original request re-enters the chain on the 429-retry path.
+    """
+    refresh_calls: list[bool] = []
+
+    async def refresh() -> AuthTokens:
+        refresh_calls.append(True)
+        # Mutate auth state so a subsequent snapshot captures the new values.
+        core.auth.csrf_token = "CSRF_NEW"
+        core.auth.session_id = "SID_NEW"
+        return core.auth
+
+    # ``rate_limit_max_retries=1`` lets the 429 burn one retry slot so the
+    # post-refresh-then-429 retry path actually fires; the regression depends
+    # on ``RetryMiddleware`` re-invoking the chain with the original request.
+    core = _make_core(refresh_callback=refresh, rate_limit_max_retries=1)
+    await core.open()
+    try:
+        # Avoid actually sleeping during the 429 backoff.
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            # Encode CSRF in the body and session-id + authuser in the URL,
+            # mirroring how ``RpcExecutor._build`` composes the real envelope
+            # (see ``RpcExecutor.build_url`` and ``build_request_body``).
+            url = f"https://example.test/x?f.sid={snapshot.session_id}&authuser={snapshot.authuser}"
+            body = f"at={snapshot.csrf_token}&payload=1"
+            return url, body, {"X-Goog-AuthUser": str(snapshot.authuser)}
+
+        terminal_urls: list[str] = []
+        terminal_bodies: list[bytes] = []
+        terminal_headers: list[dict[str, str]] = []
+        call_count = {"n": 0}
+
+        async def fake_post(url, *, content, headers=None, **kwargs):
+            call_count["n"] += 1
+            terminal_urls.append(url)
+            terminal_bodies.append(content)
+            terminal_headers.append(dict(headers or {}))
+            if call_count["n"] == 1:
+                # First attempt: 401 → triggers AuthRefreshMiddleware refresh.
+                raise _status_error(401)
+            if call_count["n"] == 2:
+                # Second attempt (the refreshed retry inside AuthRefresh):
+                # 429 → bubbles up through ``RetryMiddleware`` which then
+                # retries the chain with the ORIGINAL request.
+                raise _status_error(429, retry_after="1")
+            # Third attempt (RetryMiddleware retry of the original request):
+            # must carry the refreshed auth envelope, not the stale one.
+            return _ok_response()
+
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
+
+        response = await core._transport.perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert call_count["n"] == 3, "expected three terminal attempts (401, 429, 200)"
+        # The 429 retry-after backoff fires exactly once between attempts 2 and 3.
+        assert sleeps == [1]
+        # The refresh callback runs exactly ONCE; the once-per-call marker on
+        # the shared ``request.context`` prevents a second refresh on the
+        # RetryMiddleware-driven re-entry.
+        assert refresh_calls == [True]
+
+        # First attempt: pre-refresh snapshot on the wire.
+        assert terminal_urls[0] == "https://example.test/x?f.sid=SID_OLD&authuser=0"
+        assert terminal_bodies[0] == b"at=CSRF_OLD&payload=1"
+        assert terminal_headers[0]["X-Goog-AuthUser"] == "0"
+        # Second attempt (refreshed retry inside AuthRefreshMiddleware):
+        # refreshed snapshot on the wire.
+        assert terminal_urls[1] == "https://example.test/x?f.sid=SID_NEW&authuser=0"
+        assert terminal_bodies[1] == b"at=CSRF_NEW&payload=1"
+        assert terminal_headers[1]["X-Goog-AuthUser"] == "0"
+        # Third attempt (RetryMiddleware re-invoking the chain with the
+        # ORIGINAL request after the 429): MUST carry the refreshed envelope.
+        # This is the stale-envelope regression assertion — without the
+        # unconditional terminal rebuild, this attempt would carry
+        # ``f.sid=SID_OLD`` / ``at=CSRF_OLD``.
+        assert terminal_urls[2] == "https://example.test/x?f.sid=SID_NEW&authuser=0"
+        assert terminal_bodies[2] == b"at=CSRF_NEW&payload=1"
+        assert terminal_headers[2]["X-Goog-AuthUser"] == "0"
     finally:
         await core.close()
 
@@ -671,7 +830,12 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
             reset_request_id(token)
 
         assert call_count["n"] == 2
-        assert observed_request_ids == ["REQ-stable-1234", "REQ-stable-1234"]
+        # ``build_request`` is invoked four times across two terminal
+        # attempts (chain-entry + terminal-rebuild per attempt; see module
+        # docstring); the correlation id must be identical for every
+        # invocation regardless of attempt index.
+        assert len(observed_request_ids) == 4
+        assert all(rid == "REQ-stable-1234" for rid in observed_request_ids)
     finally:
         await core.close()
 


### PR DESCRIPTION
## Summary

Fixes a stale-envelope path on the `401 → refresh → 429 → retry` flow where `RetryMiddleware` re-invoked the chain with the original `RpcRequest` and the terminal freshness guard's snapshot-equality short-circuit POSTed the pre-refresh URL / headers / body against the refreshed cookie jar.

- `SessionTransport.refresh_request_for_current_auth` now rebuilds the envelope from a freshly captured `AuthSnapshot` on every terminal attempt whenever `RPC_CONTEXT_BUILD_REQUEST` is present (load-bearing on the post-refresh retry path; byte-identical to the inbound envelope on the happy path).
- `AuthRefreshMiddleware._rebuild_request_after_refresh` docstring now documents the deliberate in-place `request.context` mutation contract — the refresh-once marker and the refreshed snapshot ride the shared context across the `Retry` ↔ `AuthRefresh` boundary, paired with the unconditional terminal rebuild as the safety invariant.
- New regression test `test_stale_envelope_rebuilt_after_refresh_then_retry` scripts a `[401, 429, 200]` terminal sequence and asserts the post-429 retry carries refreshed `f.sid` / CSRF / `X-Goog-AuthUser`, plus that the refresh callback fires exactly once.

## Carrier strategy

**γ — keep in-place mutation but document the contract** (recommended default).

The mutation of `request.context[RPC_CONTEXT_AUTH_REFRESHED]` and `request.context[RPC_CONTEXT_AUTH_SNAPSHOT]` in `_middleware_auth_refresh.py` is preserved as the deliberate carrier of refreshed auth state and the once-per-call refresh guard across the `Retry` ↔ `AuthRefresh` boundary; the load-bearing terminal rebuild on every attempt is what keeps the mutation safe.

## Code-change scope

**transport + refresh-middleware docstring + tests.**

- `src/notebooklm/_session_transport.py` — drop the snapshot-equality short-circuit in `refresh_request_for_current_auth`; always rebuild when `build_request` is present. Expand docstring with the six-step scenario the unconditional rebuild guards against and the happy-path idempotence note.
- `src/notebooklm/_middleware_auth_refresh.py` — docstring-only. Document the in-place `request.context` mutation contract on `_rebuild_request_after_refresh` (which two keys cross the `Retry` ↔ `AuthRefresh` boundary, why, and which paired invariant on `SessionTransport` keeps it safe). Module-level docstring gets a cross-reference.
- `tests/unit/test_authed_post_pipeline.py` — module docstring + three existing assertion updates for the new `build_request` call cadence (chain-entry + terminal-rebuild per attempt), plus the new `test_stale_envelope_rebuilt_after_refresh_then_retry` regression test.

`_middleware_retry.py` and `_session.py` are untouched.

## Hard constraints

- ✅ Public APIs of `_middleware_auth_refresh`, `_middleware_retry`, `SessionTransport` unchanged.
- ✅ No new session-level collaborator wired into the collaborator graph.
- ✅ `_session.py` untouched.
- ✅ Refresh-loop guard (`RPC_CONTEXT_AUTH_REFRESHED`) preserved.
- ✅ Terminal AST guards (`test_terminal_freshness_check_has_no_await_after_materialization`, `test_auth_refresh_rebuild_has_no_await_after_snapshot_capture`) preserved.

## Test plan

- [x] `uv run pytest tests/unit/test_auth_refresh_middleware.py tests/unit/test_retry_middleware.py tests/unit/test_authed_post_pipeline.py tests/unit/test_concurrency_refresh_race.py -q` — 81 passed, 2 skipped.
- [x] `uv run pytest tests/unit -q` — 5831 passed, 10 skipped.
- [x] `uv run pytest tests/integration -q` — 649 passed, 2 skipped.
- [x] `uv run pytest tests/_lint -q` — 77 passed.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues found in 174 source files.
- [x] `uv run ruff check src/notebooklm tests/unit` — All checks passed.
- [x] Regression test verified load-bearing: temporarily reverting the `_session_transport.py` change causes `test_stale_envelope_rebuilt_after_refresh_then_retry` to fail with `terminal_urls[2]` containing `f.sid=SID_OLD` instead of `f.sid=SID_NEW`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a reliability issue where requests retried after authentication token refresh would fail by using stale credentials instead of the current authenticated session.

* **Documentation**
  * Improved documentation of authentication refresh and request retry flow semantics.

* **Tests**
  * Updated test suite to validate corrected authentication refresh behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->