### PR TITLE
docs(architecture): add Boundary moratorium subsection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -601,13 +601,15 @@ one of the named modules.
 ## Boundary moratorium
 
 New architectural carve-outs are expensive: every ADR amendment,
-retention-doc entry, and `tests/_lint/` pin becomes load-bearing for
-contributors who have to read the docs before touching the relevant
-seam. To keep that surface from drifting upward without bound, the
-following discipline applies to any future change that would *expand*
-the documented boundary set:
+[`session-method-retention.md`](./session-method-retention.md) entry,
+and `tests/_lint/` pin becomes load-bearing for contributors who have
+to read the docs before touching the relevant seam. To keep that
+surface from drifting upward without bound, the following discipline
+applies to any future change that would *expand* the documented
+boundary set:
 
-- **Justify by failure mode.** A new ADR amendment, retention-doc row,
+- **Justify by failure mode.** A new ADR amendment,
+  [`session-method-retention.md`](./session-method-retention.md) row,
   or `tests/_lint/` pin must cite a concrete user-visible failure mode
   it prevents (loop-affinity break, auth-snapshot tear, transport drain
   regression, public-API breakage, etc.). "Future-proofing" or "in case

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -598,6 +598,30 @@ The corollary for contributors: if you find yourself reaching into
 `notebooklm._foo`, prefer a capability Protocol or a public function in
 one of the named modules.
 
+## Boundary moratorium
+
+New architectural carve-outs are expensive: every ADR amendment,
+retention-doc entry, and `tests/_lint/` pin becomes load-bearing for
+contributors who have to read the docs before touching the relevant
+seam. To keep that surface from drifting upward without bound, the
+following discipline applies to any future change that would *expand*
+the documented boundary set:
+
+- **Justify by failure mode.** A new ADR amendment, retention-doc row,
+  or `tests/_lint/` pin must cite a concrete user-visible failure mode
+  it prevents (loop-affinity break, auth-snapshot tear, transport drain
+  regression, public-API breakage, etc.). "Future-proofing" or "in case
+  someone refactors X" is not sufficient.
+- **Prefer deletion over carve-out.** When a compatibility seam can be
+  removed instead of documented, remove it. Carve-outs are the fallback
+  when removal is genuinely infeasible, not the default.
+- **One owner per rule.** A pin without a corresponding ADR clause (and
+  vice versa) is a smell — it means the rule is enforced but not
+  explained, or explained but not enforced.
+
+The intent is architectural: shrink the boundary set whenever the
+underlying code allows it, and resist growing it on speculative grounds.
+
 ## Glossary
 
 Vocabulary that recurs in this document and the surrounding code.


### PR DESCRIPTION
## Summary

- Adds a short **Boundary moratorium** subsection to `docs/architecture.md` (183 words), sitting between the `Implementation surface convention (ADR-012)` section and the `Glossary`.
- States that new ADR amendments, retention-doc entries, and `tests/_lint/` pins require a concrete user-visible failure mode, and that deleting compatibility seams is preferred over documenting new carve-outs.
- Intent is architectural governance: shrink the documented boundary set when the code allows it; resist growing it on speculative grounds.

## Scope

- Documentation only — no `src/` changes.
- No ADRs rewritten, no `_lint/` pins added, no retention-doc edits.
- Three pre-existing untracked scratch plan docs in the orchestrator's working tree are intentionally **not** included in this change (decision (a) — they were never committed and the boundary lint already passes without them).

## Test plan

- [x] `uv run pytest tests/unit/test_type_boundaries.py -q` — 14 passed.
- [x] `uv run ruff format docs/` — 6 files left unchanged (ruff does not lint markdown).
- [x] Word count of the new subsection ≤ 200 words.

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Boundary moratorium" section defining contributor discipline for changes that expand the documented architectural boundary: require concrete failure-mode justification for expansions, prefer removing compatibility seams over adding carve-outs, ensure documentation pins align with corresponding decision records, and commit to shrinking boundaries when possible while avoiding speculative growth.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->