### PR TITLE
test(rpc): pin golden envelope + decoder coverage per RPCMethod enum value

### DIFF
--- a/tests/fixtures/rpc_golden/ADD_SOURCE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE.json
@@ -1,0 +1,52 @@
+{
+  "method_name": "ADD_SOURCE",
+  "method_id": "izAoDd",
+  "description": "Attach a new source (URL / text / drive ref) to a notebook.",
+  "request": {
+    "params": [
+      [
+        [
+          [
+            "https://scrubbed.example.com/article"
+          ]
+        ],
+        "Scrubbed Source Title"
+      ],
+      "SCRUBBED_NB_001",
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "izAoDd",
+          "[[[[\"https://scrubbed.example.com/article\"]],\"Scrubbed Source Title\"],\"SCRUBBED_NB_001\",[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "izAoDd",
+          "[[\"SCRUBBED_SRC_NEW_001\"]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        "SCRUBBED_SRC_NEW_001"
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/ADD_SOURCE_FILE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE_FILE.json
@@ -1,0 +1,49 @@
+{
+  "method_name": "ADD_SOURCE_FILE",
+  "method_id": "o4cbdc",
+  "description": "Register an already-uploaded file as a notebook source.",
+  "request": {
+    "params": [
+      [
+        [
+          [
+            "scrubbed/upload/handle"
+          ]
+        ],
+        "scrubbed-file.pdf"
+      ],
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "o4cbdc",
+          "[[[[\"scrubbed/upload/handle\"]],\"scrubbed-file.pdf\"],\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "o4cbdc",
+          "[[\"SCRUBBED_SRC_NEW_002\"]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        "SCRUBBED_SRC_NEW_002"
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/CHECK_SOURCE_FRESHNESS.json
+++ b/tests/fixtures/rpc_golden/CHECK_SOURCE_FRESHNESS.json
@@ -1,0 +1,45 @@
+{
+  "method_name": "CHECK_SOURCE_FRESHNESS",
+  "method_id": "yR9Yof",
+  "description": "Check whether a URL-backed source has updated upstream (production shape [None, [source_id], [2]]).",
+  "request": {
+    "params": [
+      null,
+      [
+        "SCRUBBED_SRC_001"
+      ],
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "yR9Yof",
+          "[null,[\"SCRUBBED_SRC_001\"],[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "yR9Yof",
+          "[false]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      false
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/CREATE_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/CREATE_ARTIFACT.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "CREATE_ARTIFACT",
+  "method_id": "R7cb6c",
+  "description": "Generate an artifact (audio, video, report, quiz, infographic, slides, ...).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      [
+        1
+      ],
+      null
+    ],
+    "expected_f_req": [
+      [
+        [
+          "R7cb6c",
+          "[\"SCRUBBED_NB_001\",[1],null]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "R7cb6c",
+          "[\"SCRUBBED_ARTIFACT_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_ARTIFACT_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/CREATE_NOTE.json
+++ b/tests/fixtures/rpc_golden/CREATE_NOTE.json
@@ -1,0 +1,45 @@
+{
+  "method_name": "CREATE_NOTE",
+  "method_id": "CYK0Xb",
+  "description": "Create a free-form note attached to a notebook (production shape [notebook_id, '', [1], None, title]).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      "",
+      [
+        1
+      ],
+      null,
+      "Scrubbed Note Title"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "CYK0Xb",
+          "[\"SCRUBBED_NB_001\",\"\",[1],null,\"Scrubbed Note Title\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "CYK0Xb",
+          "[\"SCRUBBED_NOTE_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_NOTE_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/CREATE_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/CREATE_NOTEBOOK.json
@@ -1,0 +1,47 @@
+{
+  "method_name": "CREATE_NOTEBOOK",
+  "method_id": "CCqFvf",
+  "description": "Create a new notebook with a title.",
+  "request": {
+    "params": [
+      "Scrubbed Notebook Title",
+      null,
+      null,
+      [
+        2
+      ],
+      [
+        1
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "CCqFvf",
+          "[\"Scrubbed Notebook Title\",null,null,[2],[1]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "CCqFvf",
+          "[\"SCRUBBED_NB_NEW_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_NB_NEW_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/DELETE_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/DELETE_ARTIFACT.json
@@ -1,0 +1,40 @@
+{
+  "method_name": "DELETE_ARTIFACT",
+  "method_id": "V5N4be",
+  "description": "Delete an artifact by id (production shape [[type_code], artifact_id]).",
+  "request": {
+    "params": [
+      [
+        2
+      ],
+      "SCRUBBED_ARTIFACT_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "V5N4be",
+          "[[2],\"SCRUBBED_ARTIFACT_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "V5N4be",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/DELETE_CONVERSATION.json
+++ b/tests/fixtures/rpc_golden/DELETE_CONVERSATION.json
@@ -1,0 +1,40 @@
+{
+  "method_name": "DELETE_CONVERSATION",
+  "method_id": "J7Gthc",
+  "description": "Delete a conversation (production shape [[], conversation_id, None, 1]; trailing 1 is a fixed flag observed on the wire).",
+  "request": {
+    "params": [
+      [],
+      "SCRUBBED_CONV_001",
+      null,
+      1
+    ],
+    "expected_f_req": [
+      [
+        [
+          "J7Gthc",
+          "[[],\"SCRUBBED_CONV_001\",null,1]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "J7Gthc",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/DELETE_NOTE.json
+++ b/tests/fixtures/rpc_golden/DELETE_NOTE.json
@@ -1,0 +1,41 @@
+{
+  "method_name": "DELETE_NOTE",
+  "method_id": "AH0mwd",
+  "description": "Delete a note by id (production shape [notebook_id, None, [note_id]]).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      null,
+      [
+        "SCRUBBED_NOTE_001"
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "AH0mwd",
+          "[\"SCRUBBED_NB_001\",null,[\"SCRUBBED_NOTE_001\"]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "AH0mwd",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/DELETE_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/DELETE_NOTEBOOK.json
@@ -1,0 +1,42 @@
+{
+  "method_name": "DELETE_NOTEBOOK",
+  "method_id": "WWINqb",
+  "description": "Delete a notebook by id (matches production shape [[notebook_id], [2]]).",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_NB_001"
+      ],
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "WWINqb",
+          "[[\"SCRUBBED_NB_001\"],[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "WWINqb",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/DELETE_SOURCE.json
+++ b/tests/fixtures/rpc_golden/DELETE_SOURCE.json
@@ -1,0 +1,41 @@
+{
+  "method_name": "DELETE_SOURCE",
+  "method_id": "tGMBJ",
+  "description": "Delete a source from a notebook (production shape [[[source_id]]]).",
+  "request": {
+    "params": [
+      [
+        [
+          "SCRUBBED_SRC_001"
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "tGMBJ",
+          "[[[\"SCRUBBED_SRC_001\"]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "tGMBJ",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/EXPORT_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/EXPORT_ARTIFACT.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "EXPORT_ARTIFACT",
+  "method_id": "Krh3pd",
+  "description": "Export an artifact (e.g. report) to Google Docs / Sheets.",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_ARTIFACT_001"
+      ],
+      1,
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "Krh3pd",
+          "[[\"SCRUBBED_ARTIFACT_001\"],1,\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "Krh3pd",
+          "[\"https://scrubbed.example.com/docs/SCRUBBED_DOC_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "https://scrubbed.example.com/docs/SCRUBBED_DOC_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GENERATE_MIND_MAP.json
+++ b/tests/fixtures/rpc_golden/GENERATE_MIND_MAP.json
@@ -1,0 +1,42 @@
+{
+  "method_name": "GENERATE_MIND_MAP",
+  "method_id": "yyryJe",
+  "description": "Generate a mind map from a notebook's selected sources.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      [
+        5
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "yyryJe",
+          "[\"SCRUBBED_NB_001\",[5]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "yyryJe",
+          "[\"SCRUBBED_ARTIFACT_MINDMAP_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_ARTIFACT_MINDMAP_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_CONVERSATION_TURNS.json
+++ b/tests/fixtures/rpc_golden/GET_CONVERSATION_TURNS.json
@@ -1,0 +1,46 @@
+{
+  "method_name": "GET_CONVERSATION_TURNS",
+  "method_id": "khqZz",
+  "description": "Fetch Q&A turns for a conversation (representative shape; trailing list is a wire-observed slot).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      "SCRUBBED_CONV_001",
+      []
+    ],
+    "expected_f_req": [
+      [
+        [
+          "khqZz",
+          "[\"SCRUBBED_NB_001\",\"SCRUBBED_CONV_001\",[]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "khqZz",
+          "[[[\"Scrubbed user question.\",\"Scrubbed assistant answer.\"]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        [
+          "Scrubbed user question.",
+          "Scrubbed assistant answer."
+        ]
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_INTERACTIVE_HTML.json
+++ b/tests/fixtures/rpc_golden/GET_INTERACTIVE_HTML.json
@@ -1,0 +1,42 @@
+{
+  "method_name": "GET_INTERACTIVE_HTML",
+  "method_id": "v9rmvd",
+  "description": "Fetch quiz / flashcard HTML content.",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_ARTIFACT_001"
+      ],
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "v9rmvd",
+          "[[\"SCRUBBED_ARTIFACT_001\"],\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "v9rmvd",
+          "[\"<html><body>Scrubbed quiz content.</body></html>\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "<html><body>Scrubbed quiz content.</body></html>"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_LAST_CONVERSATION_ID.json
+++ b/tests/fixtures/rpc_golden/GET_LAST_CONVERSATION_ID.json
@@ -1,0 +1,39 @@
+{
+  "method_name": "GET_LAST_CONVERSATION_ID",
+  "method_id": "hPTbtc",
+  "description": "Fetch the most recent conversation id for a notebook.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "hPTbtc",
+          "[\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "hPTbtc",
+          "[\"SCRUBBED_CONV_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_CONV_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
@@ -1,0 +1,58 @@
+{
+  "method_name": "GET_NOTEBOOK",
+  "method_id": "rLM1Ne",
+  "description": "Fetch a notebook's sources and metadata by id.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      null,
+      [
+        2
+      ],
+      null,
+      0
+    ],
+    "expected_f_req": [
+      [
+        [
+          "rLM1Ne",
+          "[\"SCRUBBED_NB_001\",null,[2],null,0]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "rLM1Ne",
+          "[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",[[[\"SCRUBBED_SRC_001\"],\"Scrubbed Source\",[2,null]]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_NB_001",
+      "Scrubbed Notebook One",
+      [
+        [
+          [
+            "SCRUBBED_SRC_001"
+          ],
+          "Scrubbed Source",
+          [
+            2,
+            null
+          ]
+        ]
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_NOTES_AND_MIND_MAPS.json
+++ b/tests/fixtures/rpc_golden/GET_NOTES_AND_MIND_MAPS.json
@@ -1,0 +1,54 @@
+{
+  "method_name": "GET_NOTES_AND_MIND_MAPS",
+  "method_id": "cFji9",
+  "description": "Fetch all notes and mind-maps for a notebook (production shape [notebook_id]).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "cFji9",
+          "[\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "cFji9",
+          "[[[\"SCRUBBED_NOTE_001\",\"Scrubbed Note Title\",\"Scrubbed note body.\",1]],[[\"SCRUBBED_ARTIFACT_MINDMAP_001\",\"Scrubbed Mind Map\",null,5]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        [
+          "SCRUBBED_NOTE_001",
+          "Scrubbed Note Title",
+          "Scrubbed note body.",
+          1
+        ]
+      ],
+      [
+        [
+          "SCRUBBED_ARTIFACT_MINDMAP_001",
+          "Scrubbed Mind Map",
+          null,
+          5
+        ]
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_SHARE_STATUS.json
+++ b/tests/fixtures/rpc_golden/GET_SHARE_STATUS.json
@@ -1,0 +1,44 @@
+{
+  "method_name": "GET_SHARE_STATUS",
+  "method_id": "JFMDGd",
+  "description": "Get notebook share settings (production shape [notebook_id, [2]]).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "JFMDGd",
+          "[\"SCRUBBED_NB_001\",[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "JFMDGd",
+          "[1,0,[]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      1,
+      0,
+      []
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_SOURCE.json
+++ b/tests/fixtures/rpc_golden/GET_SOURCE.json
@@ -1,0 +1,49 @@
+{
+  "method_name": "GET_SOURCE",
+  "method_id": "hizoJc",
+  "description": "Fetch a single source's content / metadata (production shape [[source_id], [2], [2]]).",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_SRC_001"
+      ],
+      [
+        2
+      ],
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "hizoJc",
+          "[[\"SCRUBBED_SRC_001\"],[2],[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "hizoJc",
+          "[\"SCRUBBED_SRC_001\",\"Scrubbed Source Title\",\"Scrubbed source content.\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_SRC_001",
+      "Scrubbed Source Title",
+      "Scrubbed source content."
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_SOURCE_GUIDE.json
+++ b/tests/fixtures/rpc_golden/GET_SOURCE_GUIDE.json
@@ -1,0 +1,39 @@
+{
+  "method_name": "GET_SOURCE_GUIDE",
+  "method_id": "tr032e",
+  "description": "Fetch the auto-generated source-guide for a notebook.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "tr032e",
+          "[\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "tr032e",
+          "[\"Scrubbed source-guide markdown.\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "Scrubbed source-guide markdown."
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_SUGGESTED_REPORTS.json
+++ b/tests/fixtures/rpc_golden/GET_SUGGESTED_REPORTS.json
@@ -1,0 +1,46 @@
+{
+  "method_name": "GET_SUGGESTED_REPORTS",
+  "method_id": "ciyUvf",
+  "description": "Fetch AI-suggested report formats for a notebook.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "ciyUvf",
+          "[\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "ciyUvf",
+          "[[\"Scrubbed Briefing Doc\",\"Briefing doc on scrubbed topic.\"],[\"Scrubbed Study Guide\",\"Study guide on scrubbed topic.\"]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        "Scrubbed Briefing Doc",
+        "Briefing doc on scrubbed topic."
+      ],
+      [
+        "Scrubbed Study Guide",
+        "Study guide on scrubbed topic."
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_USER_SETTINGS.json
+++ b/tests/fixtures/rpc_golden/GET_USER_SETTINGS.json
@@ -1,0 +1,41 @@
+{
+  "method_name": "GET_USER_SETTINGS",
+  "method_id": "ZwVcOc",
+  "description": "Fetch user settings (production shape []; no params).",
+  "request": {
+    "params": [],
+    "expected_f_req": [
+      [
+        [
+          "ZwVcOc",
+          "[]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "ZwVcOc",
+          "[[\"en\"],null,null]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        "en"
+      ],
+      null,
+      null
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/GET_USER_TIER.json
+++ b/tests/fixtures/rpc_golden/GET_USER_TIER.json
@@ -1,0 +1,37 @@
+{
+  "method_name": "GET_USER_TIER",
+  "method_id": "ozz5Z",
+  "description": "Fetch the user's NotebookLM subscription tier.",
+  "request": {
+    "params": [],
+    "expected_f_req": [
+      [
+        [
+          "ozz5Z",
+          "[]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "ozz5Z",
+          "[1]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      1
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/IMPORT_RESEARCH.json
+++ b/tests/fixtures/rpc_golden/IMPORT_RESEARCH.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "IMPORT_RESEARCH",
+  "method_id": "LBwxtb",
+  "description": "Import a finished research task (production shape [None, [1], task_id, notebook_id, source_array]).",
+  "request": {
+    "params": [
+      null,
+      [
+        1
+      ],
+      "SCRUBBED_RESEARCH_001",
+      "SCRUBBED_NB_001",
+      []
+    ],
+    "expected_f_req": [
+      [
+        [
+          "LBwxtb",
+          "[null,[1],\"SCRUBBED_RESEARCH_001\",\"SCRUBBED_NB_001\",[]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "LBwxtb",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
+++ b/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
@@ -1,0 +1,58 @@
+{
+  "method_name": "LIST_ARTIFACTS",
+  "method_id": "gArtLc",
+  "description": "List all artifacts in a notebook (production shape [[type_code], notebook_id, filter_string]).",
+  "request": {
+    "params": [
+      [
+        2
+      ],
+      "SCRUBBED_NB_001",
+      "NOT artifact.status = \"ARTIFACT_STATUS_SUGGESTED\""
+    ],
+    "expected_f_req": [
+      [
+        [
+          "gArtLc",
+          "[[2],\"SCRUBBED_NB_001\",\"NOT artifact.status = \\\"ARTIFACT_STATUS_SUGGESTED\\\"\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "gArtLc",
+          "[[[\"SCRUBBED_ARTIFACT_001\",\"Scrubbed Audio Overview\",1,null,3],[\"SCRUBBED_ARTIFACT_002\",\"Scrubbed Briefing Doc\",2,null,3]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        [
+          "SCRUBBED_ARTIFACT_001",
+          "Scrubbed Audio Overview",
+          1,
+          null,
+          3
+        ],
+        [
+          "SCRUBBED_ARTIFACT_002",
+          "Scrubbed Briefing Doc",
+          2,
+          null,
+          3
+        ]
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
+++ b/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
@@ -1,0 +1,63 @@
+{
+  "method_name": "LIST_NOTEBOOKS",
+  "method_id": "wXbhsf",
+  "description": "List notebooks visible to the authenticated user.",
+  "request": {
+    "params": [
+      null,
+      1,
+      null,
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "wXbhsf",
+          "[null,1,null,[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "wXbhsf",
+          "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0],[\"SCRUBBED_NB_002\",\"Scrubbed Notebook Two\",null,null,null,null,0]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        [
+          "SCRUBBED_NB_001",
+          "Scrubbed Notebook One",
+          null,
+          null,
+          null,
+          null,
+          0
+        ],
+        [
+          "SCRUBBED_NB_002",
+          "Scrubbed Notebook Two",
+          null,
+          null,
+          null,
+          null,
+          0
+        ]
+      ]
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/POLL_RESEARCH.json
+++ b/tests/fixtures/rpc_golden/POLL_RESEARCH.json
@@ -1,0 +1,82 @@
+{
+  "method_name": "POLL_RESEARCH",
+  "method_id": "e3bVqc",
+  "description": "Poll for research-task results (returns one or more tasks with sources).",
+  "request": {
+    "params": [
+      null,
+      null,
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "e3bVqc",
+          "[null,null,\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "e3bVqc",
+          "[[[\"SCRUBBED_RESEARCH_001\",[null,[\"Scrubbed research prompt.\"],null,[[[\"https://scrubbed.example.com/research/page-1\",\"Scrubbed Research Source Title\",\"Scrubbed snippet.\",1]],\"Scrubbed research summary.\"],2]]]]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      [
+        [
+          "SCRUBBED_RESEARCH_001",
+          [
+            null,
+            [
+              "Scrubbed research prompt."
+            ],
+            null,
+            [
+              [
+                [
+                  "https://scrubbed.example.com/research/page-1",
+                  "Scrubbed Research Source Title",
+                  "Scrubbed snippet.",
+                  1
+                ]
+              ],
+              "Scrubbed research summary."
+            ],
+            2
+          ]
+        ]
+      ]
+    ]
+  },
+  "mapper": "notebooklm._research_task_parser:parse_research_task_models",
+  "mapper_expected": [
+    {
+      "task_id": "SCRUBBED_RESEARCH_001",
+      "status": "completed",
+      "query": "Scrubbed research prompt.",
+      "sources": [
+        {
+          "url": "https://scrubbed.example.com/research/page-1",
+          "title": "Scrubbed Research Source Title",
+          "result_type": 1,
+          "research_task_id": "SCRUBBED_RESEARCH_001"
+        }
+      ],
+      "summary": "Scrubbed research summary.",
+      "report": ""
+    }
+  ]
+}

--- a/tests/fixtures/rpc_golden/README.md
+++ b/tests/fixtures/rpc_golden/README.md
@@ -1,0 +1,113 @@
+# RPC golden payload fixtures
+
+One JSON file per `notebooklm.rpc.types.RPCMethod` enum member. These files
+are the on-disk goldens consumed by
+`tests/unit/test_rpc_golden_payloads.py`.
+
+Adding a new `RPCMethod` requires adding a fixture here, or the test suite
+fails with `Missing golden fixtures for: [...]`. Renaming or removing an
+enum member requires deleting (or renaming) the corresponding fixture file,
+or the orphan check fails with `Orphan fixtures with no corresponding
+RPCMethod member: [...]`.
+
+## File naming
+
+`<METHOD_NAME>.json` — using the **enum name** (e.g. `LIST_NOTEBOOKS.json`,
+not `wXbhsf.json`). This keeps the fixture human-readable and survives wire
+ID changes without renaming the file.
+
+## Schema
+
+```json
+{
+  "method_name": "LIST_NOTEBOOKS",
+  "method_id": "wXbhsf",
+  "description": "One sentence describing what this RPC does.",
+
+  "request": {
+    "params": [/* python list passed to encode_rpc_request */],
+    "expected_f_req": [[[/* exact triple-nested array the encoder must produce */]]]
+  },
+
+  "response": {
+    "chunks": [
+      [["wrb.fr", "<method_id>", "<json-encoded-result-string>", null, null, null, "generic"]]
+    ],
+    "allow_null": false,
+    "expected_decoded": /* the python payload decode_response must return */
+  },
+
+  "mapper": "notebooklm._research_task_parser:parse_research_task_models",
+  "mapper_expected": [/* the public-dict shape (or list thereof) produced by the mapper */]
+}
+```
+
+`mapper` and `mapper_expected` are **optional** — omit them for methods
+whose payload is consumed by inline feature-level extraction
+(`safe_index`-based) rather than a centralised mapper. When present, the
+mapper is imported via `module.path:attribute` form and applied to
+`expected_decoded`; the returned value (or its `to_public_dict()` form for
+dataclasses) is compared against `mapper_expected`.
+
+## Scrubbing rules
+
+All identifiers in these fixtures are **synthetic** and obviously scrubbed.
+This avoids any leak risk and is the simpler alternative to the
+cassette-scrubber pipeline documented in
+[ADR-0006](../../../docs/adr/0006-vcr-scrubber-strategy.md).
+
+| Class | Placeholder example |
+|---|---|
+| Notebook ID | `SCRUBBED_NB_<NNN>` |
+| Source ID | `SCRUBBED_SRC_<NNN>` |
+| Artifact ID | `SCRUBBED_ARTIFACT_<NNN>` |
+| Conversation ID | `SCRUBBED_CONV_<NNN>` |
+| Note ID | `SCRUBBED_NOTE_<NNN>` |
+| Research task ID | `SCRUBBED_RESEARCH_<NNN>` |
+| Title / text / prompt | `Scrubbed <noun>` |
+| URL | `https://scrubbed.example.com/<path>` |
+| Email | `scrubbed.user@example.invalid` |
+| Account user index | `0` |
+
+No real credentials, no real notebook IDs, no real account identifiers.
+The pre-commit `check_cassettes_clean.py` guard does not scan this
+directory because these fixtures are synthetic by construction — no
+recording pipeline produces them.
+
+## How the chunked response is reconstructed
+
+The test reassembles the chunked wire format from `response.chunks` like
+this:
+
+```text
+)]}'
+<byte_count_of_chunk_1_json>
+<chunk_1_json>
+<byte_count_of_chunk_2_json>
+<chunk_2_json>
+...
+```
+
+The byte count is the UTF-8 byte length of the chunk's compact JSON
+serialisation. The reconstructed body is fed to
+`notebooklm.rpc.decoder.decode_response`, which strips the anti-XSSI
+prefix, parses the chunks, and extracts the result for the requested RPC
+ID.
+
+## Why goldens and not VCR cassettes
+
+These fixtures cover the **shape** of the request envelope and the decoder
+output. A live cassette would also cover transport-layer details (headers,
+cookies, status codes) but at the cost of dragging the cassette-scrubber
+pipeline into a unit-level concern. The shape-only goldens here are
+sufficient to catch:
+
+- Enum-value drift in `RPCMethod` (each fixture pins the wire ID).
+- Encoder format drift (triple-nesting, JSON-compactness, trailing
+  marker).
+- Decoder format drift (anti-XSSI prefix, chunk parsing, JSON-decoding of
+  the inner result string, null-result handling).
+- Downstream mapper drift, where a mapper is documented.
+
+Live transport coverage is the job of the integration / VCR test suites,
+not this module.

--- a/tests/fixtures/rpc_golden/REFRESH_SOURCE.json
+++ b/tests/fixtures/rpc_golden/REFRESH_SOURCE.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "REFRESH_SOURCE",
+  "method_id": "FLmJqe",
+  "description": "Refresh a URL-backed source (production shape [None, [source_id], [2]]).",
+  "request": {
+    "params": [
+      null,
+      [
+        "SCRUBBED_SRC_001"
+      ],
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "FLmJqe",
+          "[null,[\"SCRUBBED_SRC_001\"],[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "FLmJqe",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/REMOVE_RECENTLY_VIEWED.json
+++ b/tests/fixtures/rpc_golden/REMOVE_RECENTLY_VIEWED.json
@@ -1,0 +1,37 @@
+{
+  "method_name": "REMOVE_RECENTLY_VIEWED",
+  "method_id": "fejl7e",
+  "description": "Remove a notebook from the 'recently viewed' list (no-op result; live API returns [13] at index 5 with null result_data).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "fejl7e",
+          "[\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "fejl7e",
+          null,
+          null,
+          null,
+          [13],
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/RENAME_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/RENAME_ARTIFACT.json
@@ -1,0 +1,45 @@
+{
+  "method_name": "RENAME_ARTIFACT",
+  "method_id": "rc3d8d",
+  "description": "Rename an artifact (production shape [[artifact_id, new_title], [['title']]]).",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_ARTIFACT_001",
+        "Scrubbed Renamed Artifact"
+      ],
+      [
+        [
+          "title"
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "rc3d8d",
+          "[[\"SCRUBBED_ARTIFACT_001\",\"Scrubbed Renamed Artifact\"],[[\"title\"]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "rc3d8d",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/RENAME_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/RENAME_NOTEBOOK.json
@@ -1,0 +1,48 @@
+{
+  "method_name": "RENAME_NOTEBOOK",
+  "method_id": "s0tc2d",
+  "description": "Rename a notebook (production shape [notebook_id, [[None, None, None, [None, new_title]]]]; also reused as SET_SHARE_ACCESS carrier with different inner params).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      [
+        [
+          null,
+          null,
+          null,
+          [
+            null,
+            "Scrubbed Renamed Title"
+          ]
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "s0tc2d",
+          "[\"SCRUBBED_NB_001\",[[null,null,null,[null,\"Scrubbed Renamed Title\"]]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "s0tc2d",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/REVISE_SLIDE.json
+++ b/tests/fixtures/rpc_golden/REVISE_SLIDE.json
@@ -1,0 +1,44 @@
+{
+  "method_name": "REVISE_SLIDE",
+  "method_id": "KmcKPe",
+  "description": "Revise an individual slide in a slide-deck artifact.",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_ARTIFACT_001"
+      ],
+      3,
+      "Scrubbed revision prompt.",
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "KmcKPe",
+          "[[\"SCRUBBED_ARTIFACT_001\"],3,\"Scrubbed revision prompt.\",\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "KmcKPe",
+          "[\"Scrubbed revised slide content.\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "Scrubbed revised slide content."
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/SET_USER_SETTINGS.json
+++ b/tests/fixtures/rpc_golden/SET_USER_SETTINGS.json
@@ -1,0 +1,52 @@
+{
+  "method_name": "SET_USER_SETTINGS",
+  "method_id": "hT54vc",
+  "description": "Set user settings (production shape [[[None, [[None, None, None, None, [language]]]]]]).",
+  "request": {
+    "params": [
+      [
+        [
+          null,
+          [
+            [
+              null,
+              null,
+              null,
+              null,
+              [
+                "en"
+              ]
+            ]
+          ]
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "hT54vc",
+          "[[[null,[[null,null,null,null,[\"en\"]]]]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "hT54vc",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/SHARE_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/SHARE_ARTIFACT.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "SHARE_ARTIFACT",
+  "method_id": "RGP97b",
+  "description": "Toggle artifact share state.",
+  "request": {
+    "params": [
+      [
+        "SCRUBBED_ARTIFACT_001"
+      ],
+      true,
+      "SCRUBBED_NB_001"
+    ],
+    "expected_f_req": [
+      [
+        [
+          "RGP97b",
+          "[[\"SCRUBBED_ARTIFACT_001\"],true,\"SCRUBBED_NB_001\"]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "RGP97b",
+          "[\"https://scrubbed.example.com/share/SCRUBBED_ARTIFACT_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "https://scrubbed.example.com/share/SCRUBBED_ARTIFACT_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/SHARE_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/SHARE_NOTEBOOK.json
@@ -1,0 +1,54 @@
+{
+  "method_name": "SHARE_NOTEBOOK",
+  "method_id": "QDyure",
+  "description": "Set notebook visibility / share state (production shape [[[notebook_id, None, [access], [access, '']]], 1, None, [2]]).",
+  "request": {
+    "params": [
+      [
+        [
+          "SCRUBBED_NB_001",
+          null,
+          [
+            1
+          ],
+          [
+            1,
+            ""
+          ]
+        ]
+      ],
+      1,
+      null,
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "QDyure",
+          "[[[\"SCRUBBED_NB_001\",null,[1],[1,\"\"]]],1,null,[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "QDyure",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/START_DEEP_RESEARCH.json
+++ b/tests/fixtures/rpc_golden/START_DEEP_RESEARCH.json
@@ -1,0 +1,41 @@
+{
+  "method_name": "START_DEEP_RESEARCH",
+  "method_id": "QA9ei",
+  "description": "Start a deep (long-running) research task on a notebook.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      "Scrubbed deep research prompt.",
+      null
+    ],
+    "expected_f_req": [
+      [
+        [
+          "QA9ei",
+          "[\"SCRUBBED_NB_001\",\"Scrubbed deep research prompt.\",null]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "QA9ei",
+          "[\"SCRUBBED_RESEARCH_002\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_RESEARCH_002"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/START_FAST_RESEARCH.json
+++ b/tests/fixtures/rpc_golden/START_FAST_RESEARCH.json
@@ -1,0 +1,41 @@
+{
+  "method_name": "START_FAST_RESEARCH",
+  "method_id": "Ljjv0c",
+  "description": "Start a fast (shallow) research task on a notebook.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      "Scrubbed research prompt.",
+      null
+    ],
+    "expected_f_req": [
+      [
+        [
+          "Ljjv0c",
+          "[\"SCRUBBED_NB_001\",\"Scrubbed research prompt.\",null]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "Ljjv0c",
+          "[\"SCRUBBED_RESEARCH_001\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "SCRUBBED_RESEARCH_001"
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/SUMMARIZE.json
+++ b/tests/fixtures/rpc_golden/SUMMARIZE.json
@@ -1,0 +1,43 @@
+{
+  "method_name": "SUMMARIZE",
+  "method_id": "VfAZjd",
+  "description": "Generate a notebook-level summary across selected sources.",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      null,
+      [
+        2
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "VfAZjd",
+          "[\"SCRUBBED_NB_001\",null,[2]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "VfAZjd",
+          "[\"Scrubbed summary paragraph describing the notebook.\"]",
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": false,
+    "expected_decoded": [
+      "Scrubbed summary paragraph describing the notebook."
+    ]
+  }
+}

--- a/tests/fixtures/rpc_golden/UPDATE_NOTE.json
+++ b/tests/fixtures/rpc_golden/UPDATE_NOTE.json
@@ -1,0 +1,48 @@
+{
+  "method_name": "UPDATE_NOTE",
+  "method_id": "cYAfTb",
+  "description": "Update a note's content and title (production shape [notebook_id, note_id, [[[content, title, [], 0]]]]).",
+  "request": {
+    "params": [
+      "SCRUBBED_NB_001",
+      "SCRUBBED_NOTE_001",
+      [
+        [
+          [
+            "Scrubbed updated body.",
+            "Scrubbed Updated Title",
+            [],
+            0
+          ]
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "cYAfTb",
+          "[\"SCRUBBED_NB_001\",\"SCRUBBED_NOTE_001\",[[[\"Scrubbed updated body.\",\"Scrubbed Updated Title\",[],0]]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "cYAfTb",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/fixtures/rpc_golden/UPDATE_SOURCE.json
+++ b/tests/fixtures/rpc_golden/UPDATE_SOURCE.json
@@ -1,0 +1,47 @@
+{
+  "method_name": "UPDATE_SOURCE",
+  "method_id": "b7Wfje",
+  "description": "Update a source's title (production shape [None, [source_id], [[[new_title]]]]).",
+  "request": {
+    "params": [
+      null,
+      [
+        "SCRUBBED_SRC_001"
+      ],
+      [
+        [
+          [
+            "Scrubbed Updated Title"
+          ]
+        ]
+      ]
+    ],
+    "expected_f_req": [
+      [
+        [
+          "b7Wfje",
+          "[null,[\"SCRUBBED_SRC_001\"],[[[\"Scrubbed Updated Title\"]]]]",
+          null,
+          "generic"
+        ]
+      ]
+    ]
+  },
+  "response": {
+    "chunks": [
+      [
+        [
+          "wrb.fr",
+          "b7Wfje",
+          null,
+          null,
+          null,
+          null,
+          "generic"
+        ]
+      ]
+    ],
+    "allow_null": true,
+    "expected_decoded": null
+  }
+}

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -49,7 +49,11 @@ class _FixtureSchemaError(AssertionError):
 
     Carries the file path and the dotted field name so a malformed fixture
     surfaces a structured failure instead of a raw KeyError / TypeError
-    from elsewhere in the test.
+    from elsewhere in the test. Inherits from :class:`AssertionError` (not
+    :class:`ValueError`) so pytest renders it with the same friendly
+    rewriting it applies to ``assert`` failures, and so any caller that
+    handles ``AssertionError`` (e.g. pytest hooks, ``--tb=short``) treats
+    it as a structured test failure rather than a generic exception.
     """
 
 
@@ -119,17 +123,37 @@ def _build_wire_response(chunks: list[Any]) -> str:
     return "\n".join(parts) + "\n"
 
 
-def _resolve_mapper(dotted: str) -> Any:
+def _resolve_mapper(dotted: str, *, method: RPCMethod) -> Any:
     """Resolve ``"module.path:attr"`` to a callable.
 
     Used by fixtures that pin a downstream mapper / parser output shape in
-    addition to the raw decoded payload.
+    addition to the raw decoded payload. Wraps the import + getattr step
+    in structured :class:`_FixtureSchemaError` so a missing module or
+    attribute surfaces the fixture file path rather than a raw
+    ``ModuleNotFoundError`` / ``AttributeError``.
     """
     module_name, _, attr = dotted.partition(":")
     if not module_name or not attr:
-        raise ValueError(f"Mapper reference {dotted!r} must be in 'module.path:attribute' form.")
-    module = importlib.import_module(module_name)
-    return getattr(module, attr)
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} declares mapper {dotted!r} "
+            f"but it is not in 'module.path:attribute' form "
+            f"(file: {_fixture_path(method)})."
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} mapper {dotted!r} references "
+            f"unknown module {module_name!r} (file: {_fixture_path(method)})."
+        ) from exc
+    try:
+        return getattr(module, attr)
+    except AttributeError as exc:
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} mapper {dotted!r}: module "
+            f"{module_name!r} has no attribute {attr!r} "
+            f"(file: {_fixture_path(method)})."
+        ) from exc
 
 
 ALL_METHODS: list[RPCMethod] = list(RPCMethod)
@@ -177,7 +201,13 @@ def test_fixture_corpus_is_scrubbed() -> None:
     documented in tests/fixtures/rpc_golden/README.md.
     """
     leaks: list[tuple[str, str]] = []
-    for path in sorted(FIXTURE_ROOT.glob("*.json")):
+    # Scan JSON fixtures AND the README — the README contains worked
+    # examples of placeholder shapes and is the most likely place for a
+    # well-meaning contributor to paste a "real-looking" URL when updating
+    # the schema docs.
+    for path in sorted(FIXTURE_ROOT.iterdir()):
+        if path.suffix not in (".json", ".md"):
+            continue
         text = path.read_text(encoding="utf-8")
         for needle in _FORBIDDEN_FIXTURE_SUBSTRINGS:
             if needle in text:
@@ -275,9 +305,11 @@ def test_request_envelope_matches_fixture(method: RPCMethod) -> None:
         f"Got: {encoded!r}\nExpected: {expected!r}"
     )
 
-    # Shape invariants — these are stable across every batchexecute call and
-    # are worth pinning per-method so a regression in encoder.py surfaces on
-    # any method, not just the one whose params happened to be edited.
+    # Shape invariants — strictly redundant once the equality assertion above
+    # passes (since ``encoded == expected`` means both share these properties),
+    # but kept as a machine-checked specification of the batchexecute wire
+    # format that survives even if a future contributor accidentally copies a
+    # regressed encoder output into the fixture.
     assert isinstance(encoded, list) and len(encoded) == 1
     assert isinstance(encoded[0], list) and len(encoded[0]) == 1
     inner = encoded[0][0]
@@ -360,7 +392,7 @@ def test_mapper_output_shape_when_documented(method: RPCMethod) -> None:
             f"but is missing 'mapper_expected' (file: {_fixture_path(method)})."
         )
     expected = fixture["mapper_expected"]
-    mapper = _resolve_mapper(mapper_ref)
+    mapper = _resolve_mapper(mapper_ref, method=method)
     decoded = fixture["response"]["expected_decoded"]
     mapped = mapper(decoded)
 

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -1,0 +1,381 @@
+"""Golden RPC envelope + decoder coverage, parameterised over ``RPCMethod``.
+
+This module pins, for every member of :class:`notebooklm.rpc.types.RPCMethod`:
+
+1. The string method ID itself (catches enum-value drift).
+2. The ``batchexecute`` ``f.req`` request envelope produced by
+   :func:`notebooklm.rpc.encoder.encode_rpc_request` for a representative
+   parameter list (catches encoder format drift and param-order regressions).
+3. The Python payload returned by
+   :func:`notebooklm.rpc.decoder.decode_response` when given a synthetic
+   scrubbed response chunk for that method (catches decoder format drift).
+
+For methods that have a documented downstream parser / dataclass mapper,
+the fixture additionally pins the mapper output shape so the seam between
+the raw decoded payload and the feature-level dataclass is also covered.
+
+Each method has a fixture file at
+``tests/fixtures/rpc_golden/<METHOD_NAME>.json``. A test that detects a
+missing fixture fails the suite loudly so that adding a new ``RPCMethod``
+member without also adding a fixture is a hard failure rather than a silent
+gap.
+
+Fixture schema is documented in ``tests/fixtures/rpc_golden/README.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from notebooklm.rpc.decoder import (
+    collect_rpc_ids,
+    decode_response,
+    parse_chunked_response,
+    strip_anti_xssi,
+)
+from notebooklm.rpc.encoder import encode_rpc_request
+from notebooklm.rpc.types import RPCMethod
+
+FIXTURE_ROOT: Path = Path(__file__).parents[1] / "fixtures" / "rpc_golden"
+
+
+class _FixtureSchemaError(AssertionError):
+    """Raised when a fixture is missing a required field or has the wrong type.
+
+    Carries the file path and the dotted field name so a malformed fixture
+    surfaces a structured failure instead of a raw KeyError / TypeError
+    from elsewhere in the test.
+    """
+
+
+def _fixture_path(method: RPCMethod) -> Path:
+    return FIXTURE_ROOT / f"{method.name}.json"
+
+
+def _load_fixture(method: RPCMethod) -> dict[str, Any]:
+    path = _fixture_path(method)
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Missing golden fixture for RPCMethod.{method.name} at {path}. "
+            f"Every RPCMethod enum value must have a fixture under "
+            f"tests/fixtures/rpc_golden/. See the README in that directory "
+            f"for the schema."
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _require_field(
+    fixture: dict[str, Any],
+    dotted: str,
+    expected_type: type | tuple[type, ...],
+    *,
+    method: RPCMethod,
+) -> Any:
+    """Look up ``dotted`` (e.g. ``"request.params"``) in ``fixture``.
+
+    Raises :class:`_FixtureSchemaError` with the method name and field
+    path if the key is missing or the value is the wrong type. Keeps the
+    failure message structured so a malformed fixture is debuggable
+    without grepping through raw stack traces.
+    """
+    current: Any = fixture
+    parts = dotted.split(".")
+    for i, part in enumerate(parts):
+        if not isinstance(current, dict) or part not in current:
+            raise _FixtureSchemaError(
+                f"Fixture for RPCMethod.{method.name} is missing required "
+                f"field {'.'.join(parts[: i + 1])!r} (file: {_fixture_path(method)})."
+            )
+        current = current[part]
+    if not isinstance(current, expected_type):
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} field {dotted!r} has type "
+            f"{type(current).__name__}, expected "
+            f"{getattr(expected_type, '__name__', expected_type)} "
+            f"(file: {_fixture_path(method)})."
+        )
+    return current
+
+
+def _build_wire_response(chunks: list[Any]) -> str:
+    """Serialise structured chunks back into the chunked-response wire format.
+
+    Mirrors the shape that :func:`decode_response` expects after
+    :func:`strip_anti_xssi`: each chunk is a JSON line preceded by a
+    byte-count line. The full body starts with the canonical anti-XSSI
+    prefix ``)]}'\\n`` so the decoder's prefix-stripping path is also
+    exercised.
+    """
+    parts: list[str] = [")]}'"]
+    for chunk in chunks:
+        chunk_json = json.dumps(chunk, separators=(",", ":"))
+        parts.append(str(len(chunk_json.encode("utf-8"))))
+        parts.append(chunk_json)
+    return "\n".join(parts) + "\n"
+
+
+def _resolve_mapper(dotted: str) -> Any:
+    """Resolve ``"module.path:attr"`` to a callable.
+
+    Used by fixtures that pin a downstream mapper / parser output shape in
+    addition to the raw decoded payload.
+    """
+    module_name, _, attr = dotted.partition(":")
+    if not module_name or not attr:
+        raise ValueError(f"Mapper reference {dotted!r} must be in 'module.path:attribute' form.")
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)
+
+
+ALL_METHODS: list[RPCMethod] = list(RPCMethod)
+
+
+def test_every_rpc_method_has_a_fixture() -> None:
+    """Adding a new ``RPCMethod`` without a fixture must fail the suite.
+
+    This is the load-bearing guard called out in the task spec: future enum
+    additions fail loudly rather than silently leaving coverage gaps.
+    """
+    missing = [m.name for m in ALL_METHODS if not _fixture_path(m).is_file()]
+    assert not missing, (
+        f"Missing golden fixtures for: {missing}. Add a JSON fixture under "
+        f"tests/fixtures/rpc_golden/ for each. See the README there for the "
+        f"schema."
+    )
+
+
+# Substrings that MUST NOT appear inside any fixture file. Catches future
+# edits that paste real account / cookie / OAuth material into a fixture by
+# mistake. The list mirrors the placeholder taxonomy in the directory README
+# — anything that would never appear in a synthetic scrubbed payload.
+_FORBIDDEN_FIXTURE_SUBSTRINGS: tuple[str, ...] = (
+    "@gmail.com",
+    "@google.com",
+    "__Secure-1PSID",
+    "__Secure-3PSID",
+    "Bearer ",
+    "ya29.",  # OAuth access-token prefix
+    "drive.google.com/",
+    "docs.google.com/",
+    "AIza",  # Google API-key prefix
+)
+
+
+def test_fixture_corpus_is_scrubbed() -> None:
+    """Lint guard: no fixture may contain real-credential / real-PII substrings.
+
+    The fixture directory sits outside the cassette-scrubber pipeline (per
+    ADR-0006) because these payloads are synthetic by construction. This
+    lint enforces that posture: if anyone edits a fixture and pastes a real
+    cookie / OAuth token / Drive URL / email, this test fails before the
+    leak lands in a commit. Pair the lint with the placeholder taxonomy
+    documented in tests/fixtures/rpc_golden/README.md.
+    """
+    leaks: list[tuple[str, str]] = []
+    for path in sorted(FIXTURE_ROOT.glob("*.json")):
+        text = path.read_text(encoding="utf-8")
+        for needle in _FORBIDDEN_FIXTURE_SUBSTRINGS:
+            if needle in text:
+                leaks.append((path.name, needle))
+    assert not leaks, (
+        f"Forbidden non-scrubbed substring(s) found in fixture corpus: "
+        f"{leaks}. Replace with the synthetic placeholders documented in "
+        f"tests/fixtures/rpc_golden/README.md."
+    )
+
+
+def test_fixture_directory_has_no_orphans() -> None:
+    """Every fixture file must correspond to a live ``RPCMethod`` member.
+
+    Catches the inverse drift: a method is renamed/removed but its fixture
+    file is left behind. Without this guard, the orphan would silently
+    persist in the corpus.
+    """
+    valid_names = {m.name for m in ALL_METHODS}
+    orphans = [path.stem for path in FIXTURE_ROOT.glob("*.json") if path.stem not in valid_names]
+    assert not orphans, (
+        f"Orphan fixtures with no corresponding RPCMethod member: {orphans}. "
+        f"Remove the fixture file or restore the enum member."
+    )
+
+
+@pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
+def test_fixture_has_required_schema(method: RPCMethod) -> None:
+    """Every fixture must expose the required top-level schema fields.
+
+    Runs the structural validator once per method so a malformed fixture
+    surfaces as a clear ``_FixtureSchemaError`` here instead of a raw
+    ``KeyError`` / ``TypeError`` from one of the downstream tests.
+    """
+    fixture = _load_fixture(method)
+    _require_field(fixture, "method_name", str, method=method)
+    _require_field(fixture, "method_id", str, method=method)
+    _require_field(fixture, "request.params", list, method=method)
+    _require_field(fixture, "request.expected_f_req", list, method=method)
+    _require_field(fixture, "response.chunks", list, method=method)
+    # expected_decoded is allowed to be None (allow_null path); we only
+    # require the key to be present.
+    if "expected_decoded" not in fixture.get("response", {}):
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} is missing required field "
+            f"'response.expected_decoded' (file: {_fixture_path(method)})."
+        )
+    if "mapper" in fixture:
+        _require_field(fixture, "mapper", str, method=method)
+        if "mapper_expected" not in fixture:
+            raise _FixtureSchemaError(
+                f"Fixture for RPCMethod.{method.name} declares 'mapper' "
+                f"but is missing 'mapper_expected' (file: {_fixture_path(method)})."
+            )
+
+
+@pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
+def test_method_id_matches_fixture(method: RPCMethod) -> None:
+    """The fixture's recorded ``method_id`` must match the enum value.
+
+    This is the primary guard against accidental enum-value edits: any
+    change to ``RPCMethod.<NAME>.value`` requires a matching fixture edit.
+    """
+    fixture = _load_fixture(method)
+    fixture_method_name = _require_field(fixture, "method_name", str, method=method)
+    fixture_method_id = _require_field(fixture, "method_id", str, method=method)
+    assert fixture_method_name == method.name, (
+        f"Fixture method_name {fixture_method_name!r} does not match "
+        f"enum name {method.name!r} (file mislabelled?)"
+    )
+    assert fixture_method_id == method.value, (
+        f"Fixture method_id {fixture_method_id!r} for {method.name} "
+        f"does not match enum value {method.value!r}. If the wire ID truly "
+        f"changed, update both rpc/types.py and the fixture together."
+    )
+
+
+@pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
+def test_request_envelope_matches_fixture(method: RPCMethod) -> None:
+    """The ``batchexecute`` ``f.req`` envelope must match the fixture.
+
+    The fixture records both the input ``params`` and the expected encoded
+    envelope. We re-encode and compare against the recorded envelope so any
+    drift in :func:`encode_rpc_request` (nesting depth, param JSON-encoding,
+    trailing markers) trips this assertion.
+    """
+    fixture = _load_fixture(method)
+    params = _require_field(fixture, "request.params", list, method=method)
+    expected = _require_field(fixture, "request.expected_f_req", list, method=method)
+
+    encoded = encode_rpc_request(method, params)
+
+    assert encoded == expected, (
+        f"Encoded f.req envelope for {method.name} drifted from the fixture. "
+        f"Got: {encoded!r}\nExpected: {expected!r}"
+    )
+
+    # Shape invariants — these are stable across every batchexecute call and
+    # are worth pinning per-method so a regression in encoder.py surfaces on
+    # any method, not just the one whose params happened to be edited.
+    assert isinstance(encoded, list) and len(encoded) == 1
+    assert isinstance(encoded[0], list) and len(encoded[0]) == 1
+    inner = encoded[0][0]
+    assert inner[0] == method.value
+    assert inner[2] is None
+    assert inner[3] == "generic"
+    # inner[1] is the JSON-encoded params string — re-decode and verify
+    # round-trip equivalence to params.
+    assert json.loads(inner[1]) == params
+
+
+@pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
+def test_response_decoder_returns_expected_payload(method: RPCMethod) -> None:
+    """The decoder must return the expected raw payload for the fixture.
+
+    Builds a wire-format response from the fixture's structured ``chunks``
+    field, feeds it to :func:`decode_response`, and compares the returned
+    Python value to the fixture's ``expected_decoded`` value.
+
+    Methods that legitimately return ``None`` on success (e.g. fire-and-
+    forget RPCs whose ``wrb.fr`` payload is ``null``) opt into
+    ``allow_null: true`` in the fixture; the decoder receives the same
+    flag. For those, this test ALSO asserts that the synthetic response
+    actually contains a ``wrb.fr`` row for ``method.value`` — without that
+    cross-check, an ``allow_null=True`` fixture would silently pass even
+    if its chunks named a wrong (or no) RPC ID, since
+    :func:`decode_response` returns ``None`` either way under ``allow_null``.
+    """
+    fixture = _load_fixture(method)
+    chunks = _require_field(fixture, "response.chunks", list, method=method)
+    response = fixture["response"]
+    allow_null = response.get("allow_null", False)
+    if "expected_decoded" not in response:
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} is missing required field "
+            f"'response.expected_decoded' (file: {_fixture_path(method)})."
+        )
+    expected = response["expected_decoded"]
+
+    raw_response = _build_wire_response(chunks)
+    decoded = decode_response(raw_response, method.value, allow_null=allow_null)
+
+    assert decoded == expected, (
+        f"decode_response({method.name}) returned a payload that does not "
+        f"match the fixture's expected_decoded.\n"
+        f"Got: {decoded!r}\nExpected: {expected!r}"
+    )
+
+    # Independent of allow_null, the response chunks MUST contain a row
+    # naming this method's RPC ID. This guards against the silent
+    # pass-through that allow_null=True otherwise enables.
+    parsed = parse_chunked_response(strip_anti_xssi(raw_response))
+    found_ids = collect_rpc_ids(parsed)
+    assert method.value in found_ids, (
+        f"Synthetic response for {method.name} does not include a "
+        f"'wrb.fr'/'er' row naming {method.value!r}; the fixture chunks "
+        f"would let an allow_null decode silently pass. Found IDs: {found_ids!r}"
+    )
+
+
+@pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
+def test_mapper_output_shape_when_documented(method: RPCMethod) -> None:
+    """Methods that document a downstream mapper must also pin its output.
+
+    Most methods have inline ``safe_index`` extraction at the feature level
+    and no centralised mapper; for those, this test is a no-op (the fixture
+    omits ``mapper`` / ``mapper_expected``). For methods that DO have a
+    clean importable mapper (e.g. research-task parsing), we invoke it on
+    the decoded payload and assert against the fixture's recorded shape so
+    the seam between decoder and feature-level dataclass is also covered.
+    """
+    fixture = _load_fixture(method)
+    mapper_ref = fixture.get("mapper")
+    if not mapper_ref:
+        pytest.skip(f"{method.name}: no documented downstream mapper")
+
+    if "mapper_expected" not in fixture:
+        raise _FixtureSchemaError(
+            f"Fixture for RPCMethod.{method.name} declares 'mapper' "
+            f"but is missing 'mapper_expected' (file: {_fixture_path(method)})."
+        )
+    expected = fixture["mapper_expected"]
+    mapper = _resolve_mapper(mapper_ref)
+    decoded = fixture["response"]["expected_decoded"]
+    mapped = mapper(decoded)
+
+    # Mappers commonly return dataclass instances or lists thereof; compare
+    # via the fixture-recorded shape (typically the public dict form or a
+    # list of public dicts). The fixture decides the representation.
+    if isinstance(mapped, list) and mapped and hasattr(mapped[0], "to_public_dict"):
+        mapped_repr: Any = [item.to_public_dict() for item in mapped]
+    elif hasattr(mapped, "to_public_dict"):
+        mapped_repr = mapped.to_public_dict()
+    else:
+        mapped_repr = mapped
+
+    assert mapped_repr == expected, (
+        f"Mapper {mapper_ref!r} for {method.name} returned a shape that "
+        f"does not match the fixture's mapper_expected.\n"
+        f"Got: {mapped_repr!r}\nExpected: {expected!r}"
+    )


### PR DESCRIPTION
## Summary

Add one scrubbed-JSON golden fixture per member of `notebooklm.rpc.types.RPCMethod` under `tests/fixtures/rpc_golden/`, plus a parameterised test module (`tests/unit/test_rpc_golden_payloads.py`) that pins four invariants for every method:

- the string wire method ID matches the enum value (catches enum-value drift),
- the `batchexecute` `f.req` request envelope matches the recorded fixture (catches encoder format drift: triple-nesting, JSON-compactness, trailing `"generic"` marker, param JSON-encoding),
- `decode_response` returns the recorded raw payload, AND the synthetic response chunks actually name the requested RPC ID (closes the silent pass-through that `allow_null=True` otherwise enables), and
- where a method has a documented downstream parser / dataclass mapper (currently `POLL_RESEARCH` → `parse_research_task_models`), the mapper output shape is pinned too.

## Why goldens, not VCR cassettes

These fixtures cover the **shape** of the request envelope and decoder output. Live transport coverage (headers, cookies, status codes) is the job of the integration / VCR suites. Synthetic scrubbed JSON sidesteps the cassette-scrubber pipeline documented in [ADR-0006](docs/adr/0006-vcr-scrubber-strategy.md) because there is no recording pipeline to leak from — every identifier in the corpus is a `SCRUBBED_*` placeholder by construction.

## Drift-catching properties

- **New enum member without fixture** → `test_every_rpc_method_has_a_fixture` fails with a list of missing fixtures and a pointer at the schema README.
- **Removed enum member with leftover fixture** → `test_fixture_directory_has_no_orphans` fails with the orphan list.
- **Malformed fixture** → `test_fixture_has_required_schema` raises `_FixtureSchemaError` naming the file and the missing / wrong-typed field instead of a raw `KeyError`.
- **Real credential / PII pasted into a fixture** → `test_fixture_corpus_is_scrubbed` blocks the commit (denylist: `@gmail.com`, `__Secure-1PSID`, `ya29.`, `AIza`, real Google domains, ...).

## What is NOT touched

No production source under `src/notebooklm/rpc/` (`types.py`, `encoder.py`, `decoder.py`) is touched. No new RPC IDs added. No e2e auth pulled.

## Test plan

- [x] `uv run pytest tests/unit -k "rpc or golden" -q` — 513 passed, 40 skipped (mapper-not-applicable methods)
- [x] `uv run mypy src/notebooklm tests/unit/test_rpc_golden_payloads.py --ignore-missing-imports` — clean (175 source files)
- [x] `uv run ruff check tests/unit/test_rpc_golden_payloads.py` — clean
- [x] `uv run ruff format --check tests/unit/test_rpc_golden_payloads.py` — clean
- [x] `uv run pytest tests/unit -q` — 5998 passed, 50 skipped (no regressions in the full unit suite)
- [x] `uv run pytest tests/_lint -q` — 77 passed
- [x] Manually verified negative path: corrupting a fixture's `method_id` produces a clear assertion message naming the method and the drifted value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive golden fixtures covering every RPC method to verify request encoding, wire-format framing, and response decoding.
  * Added a parameterized test suite that enforces fixture schema, method IDs, exact request encoding, decoded responses, mapper outputs, and scrubbed data hygiene; also detects orphan fixtures.

* **Documentation**
  * Added guidance describing the golden-fixture format, conventions, and maintenance rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->