### PR TITLE
refactor(session): explicit auth-refresh collaborators (delete _AuthRefreshHost)

### DIFF
--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -123,7 +123,9 @@ class AuthRefreshMiddleware:
     - ``snapshot_provider``: optional async callable returning a fresh
       :class:`AuthSnapshot` after refresh. Production wires a lambda
       that invokes :meth:`AuthRefreshCoordinator.snapshot` with the
-      live ``Session`` host (the previously-load-bearing
+      explicit ``auth=session.auth`` collaborator (the
+      Session-shaped ``_AuthRefreshHost`` Protocol was deleted in
+      favor of per-method explicit args; the previously-load-bearing
       ``Session._snapshot`` thin wrapper was inlined in PR #4b of the
       session-refactor arc); tests that omit ``snapshot_provider``
       preserve the older "retry the same request" unit shape.

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -67,8 +67,12 @@ logger = logging.getLogger(__name__)
 # ``Session.update_auth_tokens`` into thin delegates that forwarded
 # through ``self._auth_coord``. PR #4b of the session-refactor arc
 # then inlined ``Session._snapshot`` entirely — every site that needs
-# an :class:`AuthSnapshot` now reads ``self._auth_coord.snapshot(self)``
-# directly. ``Session.update_auth_tokens`` is retained as a delegate
+# an :class:`AuthSnapshot` now reads
+# ``self._auth_coord.snapshot(auth=self.auth)`` directly. The
+# coordinator method signatures take explicit ``auth`` / ``kernel``
+# collaborators (the Session-shaped ``_AuthRefreshHost`` Protocol was
+# deleted in favor of per-method explicit args).
+# ``Session.update_auth_tokens`` is retained as a delegate
 # because :class:`RefreshAuthCore` in ``_auth/session.py`` is the
 # structural Protocol used by ``refresh_auth_session`` and still
 # requires that method on the core. The AST guards in
@@ -319,20 +323,24 @@ def compose_session_internals(
     chain_host._bind_transport(transport)
     # Stage B2 PR 2 split the historical ``host=session`` parameter
     # into ``chain_host`` (owns the retry tunables + the
-    # ``await_refresh`` delegate) and ``auth_snapshot_host`` (= the
-    # :class:`Session` — the auth-snapshot lookup reads
-    # ``session.auth`` / ``session._metrics_obj`` / ``session._kernel``,
-    # which live on Session, not the chain host). The chain leaf still
-    # wires to the :class:`Session`-side descriptor forward
-    # (:attr:`_authed_post_chain_terminal`) so a fixture-time rebind via
-    # ``session._authed_post_chain_terminal = fake_terminal`` keeps
-    # steering the live chain leaf — the descriptor setter writes
+    # ``await_refresh`` delegate) and an auth-snapshot host (formerly
+    # ``auth_snapshot_host: _AuthRefreshHost`` = the :class:`Session`).
+    # The follow-up "explicit auth-refresh collaborators" change
+    # narrowed the auth-snapshot lookup further: it now passes
+    # ``auth=auth`` (the live :class:`AuthTokens`) directly, because the
+    # coordinator method no longer needs a Session-shaped host (the
+    # ``_AuthRefreshHost`` Protocol that re-declared Session's private
+    # ``auth`` / ``_metrics_obj`` / ``_kernel`` slots was deleted). The
+    # chain leaf still wires to the :class:`Session`-side descriptor
+    # forward (:attr:`_authed_post_chain_terminal`) so a fixture-time
+    # rebind via ``session._authed_post_chain_terminal = fake_terminal``
+    # keeps steering the live chain leaf — the descriptor setter writes
     # through to ``chain_host._authed_post_chain_terminal``.
     wired = wire_middleware_chain(
         config,
         collaborators,
         chain_host=chain_host,
-        auth_snapshot_host=session,
+        auth=auth,
         authed_post_chain_terminal=session._authed_post_chain_terminal,
         rpc_semaphore_factory=session._get_rpc_semaphore,
     )
@@ -742,12 +750,14 @@ class Session:
         to :meth:`AuthRefreshCoordinator.update_auth_headers`; the cookie
         jar source is fetched via ``self._kernel.get_http_client()`` so the
         ``open()`` precondition (and its ``RuntimeError`` if not initialised)
-        is enforced at one site.
+        is enforced at one site. The coordinator no longer accepts a
+        Session-shaped host — the two collaborators it reads (``auth`` /
+        ``kernel``) are passed explicitly per call.
 
         Raises:
             RuntimeError: If client is not initialized.
         """
-        self._auth_coord.update_auth_headers(self)
+        self._auth_coord.update_auth_headers(auth=self.auth, kernel=self._kernel)
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
         """Delegate to :meth:`AuthRefreshCoordinator.update_auth_tokens`.
@@ -758,13 +768,15 @@ class Session:
         on the core. PR 8 collapsed the previously real body into a
         delegate that forwards through ``self._auth_coord``; PR #4b of
         the session-refactor arc inlined sibling delegates but kept
-        this one for the Protocol caller. The coordinator routes the
-        lock-wait metric through ``host._metrics_obj`` directly. The
-        AST guard for the no-await mutation-block invariant now lives
-        on :meth:`AuthRefreshCoordinator.update_auth_tokens`
+        this one for the Protocol caller. The coordinator now takes
+        ``auth`` explicitly and routes the lock-wait metric through its
+        own ``self._metrics`` (supplied at construction) instead of
+        reaching through a Session-shaped host. The AST guard for the
+        no-await mutation-block invariant lives on
+        :meth:`AuthRefreshCoordinator.update_auth_tokens`
         (``test_concurrency_refresh_race.test_update_auth_tokens_has_no_await_inside_mutation_block``).
         """
-        await self._auth_coord.update_auth_tokens(self, csrf, session_id)
+        await self._auth_coord.update_auth_tokens(auth=self.auth, csrf=csrf, session_id=session_id)
 
     # ------------------------------------------------------------------
     # Stage B2 PR 1 — writable descriptor forwards to MiddlewareChainHost

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -29,15 +29,29 @@ tests/integration/concurrency/test_refresh_cancellation_propagation.py):
   The refresh lock gates *task creation* only; the await on the task itself
   happens outside the lock so other waiters can join. Mixing this contract
   would silently deadlock waiters on a slow callback.
-* :meth:`update_auth_tokens` writes ONLY ``host.auth.csrf_token`` and
-  ``host.auth.session_id`` under the snapshot lock. It does NOT touch the
+* :meth:`update_auth_tokens` writes ONLY ``auth.csrf_token`` and
+  ``auth.session_id`` under the snapshot lock. It does NOT touch the
   http client. The cookie-jar sync is a separate concern handled by
   :meth:`update_auth_headers` (sync, no await — it runs the
-  ``host._kernel.get_http_client().cookies`` read outside any auth lock).
+  ``kernel.get_http_client().cookies`` read outside any auth lock).
 * The ``_refresh_task`` slot is intentionally NOT cleared when a waiter is
   cancelled mid-shield — concurrency tests assert task identity across
   cancellation so siblings joined to the same single-flight refresh see the
   same completion. Per ``_core.py`` history at the relocated comment site.
+
+Collaborator surface (no Session-shaped host):
+
+The coordinator was historically wired through a structural
+``_AuthRefreshHost`` Protocol that re-declared three private ``Session``
+slots (``auth`` / ``_metrics_obj`` / ``_kernel``). That Protocol coupled
+the coordinator to ``Session``'s private attribute names and forced
+fake-host shims in tests. It was deleted in favor of explicit per-method
+collaborators: :meth:`snapshot` and :meth:`update_auth_tokens` take an
+``auth: AuthTokens`` kwarg, :meth:`update_auth_headers` takes
+``auth: AuthTokens`` plus ``kernel: Kernel``, and the lock-wait metric is
+recorded through ``self._metrics`` (already supplied at construction).
+This keeps every dependency on the coordinator's surface concrete and
+narrow — there is no Session shape to fake.
 """
 
 from __future__ import annotations
@@ -46,7 +60,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ._loop_affinity import assert_bound_loop
 from ._request_types import AuthSnapshot
@@ -61,21 +75,6 @@ if TYPE_CHECKING:
 # tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
 # keep matching after the extraction.
 logger = logging.getLogger(CORE_LOGGER_NAME)
-
-
-class _AuthRefreshHost(Protocol):
-    """Structural host boundary required by :class:`AuthRefreshCoordinator`.
-
-    Mirrors the ``RefreshAuthCore`` shape in ``_auth/session.py``. Wave 11b
-    of session-decoupling (ADR-014) deleted the ``Session.get_http_client``
-    forward; the coordinator now reaches the live ``httpx.AsyncClient`` via
-    ``host._kernel.get_http_client()``, mirroring the ``RefreshAuthCore``
-    migration in ``_auth/session.py``.
-    """
-
-    auth: AuthTokens
-    _metrics_obj: ClientMetrics
-    _kernel: Kernel
 
 
 class AuthRefreshCoordinator:
@@ -99,9 +98,12 @@ class AuthRefreshCoordinator:
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = refresh_callback
         # Wave 3b of session-decoupling: ``await_refresh`` records lock-wait
-        # latency via this metrics dep (was previously read off the
-        # ``_AuthRefreshHost`` parameter — see plan Task 1.0). ``None`` is a
-        # safe fallback for tests that construct the coordinator standalone
+        # latency via this metrics dep (was previously read off the host
+        # parameter — see plan Task 1.0). The same ``self._metrics`` slot is
+        # now read by :meth:`snapshot` and :meth:`update_auth_tokens` too —
+        # the deleted ``_AuthRefreshHost`` Protocol's ``_metrics_obj`` slot
+        # is no longer threaded through method args. ``None`` is a safe
+        # fallback for tests that construct the coordinator standalone
         # without a metrics collaborator; the lock-wait latency is simply not
         # recorded in that case.
         self._metrics: ClientMetrics | None = metrics
@@ -184,7 +186,7 @@ class AuthRefreshCoordinator:
     # longer a "second body" to keep in sync.
     # ------------------------------------------------------------------
 
-    async def snapshot(self, host: _AuthRefreshHost) -> AuthSnapshot:
+    async def snapshot(self, *, auth: AuthTokens) -> AuthSnapshot:
         """Capture the current auth scalars as a frozen snapshot.
 
         Acquires :attr:`_auth_snapshot_lock` for the four scalar reads so a
@@ -200,20 +202,27 @@ class AuthRefreshCoordinator:
         guard in ``tests/unit/test_concurrency_refresh_race.py``). The lock
         guarantees the four scalars in the snapshot are coherent with each
         other; the no-await rule keeps the cookie axis aligned with them.
+
+        ``auth`` is passed explicitly per call (the previous
+        ``_AuthRefreshHost`` Protocol re-declared the ``auth`` slot from
+        ``Session``); the lock-wait metric is recorded through
+        ``self._metrics`` (supplied at construction).
         """
         wait_start = time.perf_counter()
         async with self.get_auth_snapshot_lock():
-            host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+            if self._metrics is not None:
+                self._metrics.record_lock_wait(time.perf_counter() - wait_start)
             return AuthSnapshot(
-                csrf_token=host.auth.csrf_token,
-                session_id=host.auth.session_id,
-                authuser=host.auth.authuser,
-                account_email=host.auth.account_email,
+                csrf_token=auth.csrf_token,
+                session_id=auth.session_id,
+                authuser=auth.authuser,
+                account_email=auth.account_email,
             )
 
     async def update_auth_tokens(
         self,
-        host: _AuthRefreshHost,
+        *,
+        auth: AuthTokens,
         csrf: str,
         session_id: str,
     ) -> None:
@@ -224,18 +233,21 @@ class AuthRefreshCoordinator:
         snapshot acquired between this method and the header sync observe a
         new token pair against stale cookies, which is exactly the torn-state
         scenario the snapshot lock exists to prevent.
+
+        ``auth`` is passed explicitly (no ``_AuthRefreshHost`` shape).
         """
         lock = self.get_auth_snapshot_lock()
         wait_start = time.perf_counter()
         await lock.acquire()
-        host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+        if self._metrics is not None:
+            self._metrics.record_lock_wait(time.perf_counter() - wait_start)
         try:
-            host.auth.csrf_token = csrf
-            host.auth.session_id = session_id
+            auth.csrf_token = csrf
+            auth.session_id = session_id
         finally:
             lock.release()
 
-    def update_auth_headers(self, host: _AuthRefreshHost) -> None:
+    def update_auth_headers(self, *, auth: AuthTokens, kernel: Kernel) -> None:
         """Sync ``auth.cookie_jar`` with the live HTTP client's jar.
 
         Synchronous on purpose — no await — so callers can run this without
@@ -244,11 +256,16 @@ class AuthRefreshCoordinator:
         overwrite cookies refreshed during redirects to
         ``accounts.google.com``.
 
+        ``auth`` and ``kernel`` are passed explicitly per call so the
+        coordinator does not need a ``_AuthRefreshHost``-shaped host (the
+        Protocol that re-declared Session's ``auth`` / ``_kernel`` slots was
+        deleted alongside this signature change).
+
         Raises:
-            RuntimeError: If the host's HTTP client is not initialised (the
+            RuntimeError: If the kernel's HTTP client is not initialised (the
                 error originates from :meth:`Kernel.get_http_client`).
         """
-        host.auth.cookie_jar = host._kernel.get_http_client().cookies
+        auth.cookie_jar = kernel.get_http_client().cookies
 
     # ------------------------------------------------------------------
     # Single-flight refresh task.
@@ -272,11 +289,12 @@ class AuthRefreshCoordinator:
         refresh wave once the current task transitions to ``done()``.
 
         Wave 3b of the session-decoupling plan (Task 1.0): this method no
-        longer takes an ``_AuthRefreshHost`` parameter — the only host
-        attribute it touched (``_metrics_obj``) is now supplied via the
-        ``metrics`` kwarg on :meth:`__init__`. The other coordinator
-        methods (``snapshot``, ``update_auth_tokens``, ``update_auth_headers``)
-        still take ``host`` — out of scope for this PR.
+        longer takes a host parameter — the only host attribute it touched
+        (``_metrics_obj``) is supplied via the ``metrics`` kwarg on
+        :meth:`__init__`. The other coordinator methods (``snapshot``,
+        ``update_auth_tokens``, ``update_auth_headers``) were migrated to
+        explicit per-method collaborators in a follow-up so the
+        coordinator no longer depends on any Session-shaped Protocol.
         """
         # P0-2: catch cross-loop refresh before touching ``_refresh_lock``.
         # The lock is lazily bound to the loop that first awaited
@@ -315,4 +333,4 @@ class AuthRefreshCoordinator:
         await asyncio.shield(refresh_task)
 
 
-__all__ = ["AuthRefreshCoordinator", "_AuthRefreshHost"]
+__all__ = ["AuthRefreshCoordinator"]

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -239,9 +239,16 @@ class AuthRefreshCoordinator:
         lock = self.get_auth_snapshot_lock()
         wait_start = time.perf_counter()
         await lock.acquire()
-        if self._metrics is not None:
-            self._metrics.record_lock_wait(time.perf_counter() - wait_start)
         try:
+            # ``record_lock_wait`` lives INSIDE the ``try`` so a metric-side
+            # exception (e.g. a misconfigured spy in tests, or a runtime bug
+            # in :class:`ClientMetrics`) cannot leave the snapshot lock held
+            # — the ``finally`` releases unconditionally. The call is
+            # synchronous so the no-await guard pinned by
+            # ``test_update_auth_tokens_has_no_await_inside_mutation_block``
+            # still holds.
+            if self._metrics is not None:
+                self._metrics.record_lock_wait(time.perf_counter() - wait_start)
             auth.csrf_token = csrf
             auth.session_id = session_id
         finally:

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     # defensive guard against the ``types.py`` → session cycle (see the
     # inline comment in the function body).
     from ._middleware_chain_host import MiddlewareChainHost
-    from ._session_auth import _AuthRefreshHost
     from .types import ConnectionLimits, RpcTelemetryEvent
 
 
@@ -284,8 +283,11 @@ def build_collaborators(
     # inter-helper contract for the upcoming B2/C1 extractions; do not
     # rename.
     # Wave 3b of session-decoupling (Task 1.0): supply ``metrics`` so
-    # ``await_refresh`` records lock-wait latency without needing an
-    # ``_AuthRefreshHost`` parameter.
+    # ``await_refresh`` records lock-wait latency without needing a host
+    # parameter. The remaining coordinator methods (``snapshot``,
+    # ``update_auth_tokens``, ``update_auth_headers``) take their explicit
+    # ``auth`` / ``kernel`` collaborators per call — the ``_AuthRefreshHost``
+    # Protocol was deleted alongside that signature change.
     auth_coord = AuthRefreshCoordinator(
         refresh_callback=refresh_callback,
         metrics=metrics,
@@ -375,16 +377,16 @@ def build_session_transport(
     descriptor to ``chain_host._authed_post_chain``, which this lambda
     re-reads on the next dispatch.
 
-    The ``snapshot_provider`` closure captures ``host`` (the
-    :class:`Session` instance) so :meth:`AuthRefreshCoordinator.snapshot`
-    sees the auth-snapshot host — that lookup intentionally stays on
-    :class:`Session` because the snapshot reads ``host.auth`` /
-    ``host._metrics_obj`` / ``host._kernel``, which live on Session, not
-    the chain host. The ``bound_loop_check`` lambda re-reads
-    ``host.assert_bound_loop`` on every call rather than freezing the
-    bound method at construction time, so a test that reassigns
-    ``core.assert_bound_loop = mock`` after construction still steers
-    the live check. The lookup goes through ``host.assert_bound_loop``
+    The ``snapshot_provider`` closure passes ``host.auth`` (re-read on
+    every call) to :meth:`AuthRefreshCoordinator.snapshot` so the
+    coordinator receives the live :class:`AuthTokens` collaborator
+    directly — the Session-shaped ``_AuthRefreshHost`` Protocol was
+    deleted, and the coordinator routes its lock-wait metric through
+    ``self._metrics`` (supplied at construction). The ``bound_loop_check``
+    lambda re-reads ``host.assert_bound_loop`` on every call rather than
+    freezing the bound method at construction time, so a test that
+    reassigns ``core.assert_bound_loop = mock`` after construction still
+    steers the live check. The lookup goes through ``host.assert_bound_loop``
     rather than the lifecycle's ``_bound_loop`` directly so a Mock-based
     Session fixture (which sets ``_lifecycle`` to a MagicMock) still
     short-circuits the guard.
@@ -404,7 +406,7 @@ def build_session_transport(
     """
     return SessionTransport(
         kernel=collaborators.kernel,
-        snapshot_provider=lambda: collaborators.auth_coord.snapshot(host),
+        snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=host.auth),
         chain_provider=lambda: chain_host._authed_post_chain,
         metrics=collaborators.metrics,
         bound_loop_check=lambda: host.assert_bound_loop(),
@@ -417,7 +419,7 @@ def wire_middleware_chain(
     collaborators: SessionCollaborators,
     *,
     chain_host: MiddlewareChainHost,
-    auth_snapshot_host: _AuthRefreshHost,
+    auth: AuthTokens,
     authed_post_chain_terminal: Callable[..., Awaitable[Any]],
     rpc_semaphore_factory: Callable[[], AbstractAsyncContextManager[Any]],
 ) -> WiredMiddleware:
@@ -434,13 +436,20 @@ def wire_middleware_chain(
       tunable provider lambdas and the ``refresh_callable`` reference
       capture this host directly so the chain does not depend on the
       :class:`Session`'s descriptor forwards.
-    * ``auth_snapshot_host`` — the auth-snapshot lookup intentionally
-      stays on :class:`Session` (the structural :class:`_AuthRefreshHost`
-      Protocol). The snapshot reads ``host.auth`` / ``host._metrics_obj``
-      / ``host._kernel``, which live on Session and are NOT proxied
-      through the chain host. The ``auth_snapshot_provider`` lambda
-      captures this host so :meth:`AuthRefreshCoordinator.snapshot`
-      receives the correct caller.
+    * ``auth`` — the live :class:`AuthTokens` collaborator passed
+      explicitly to :meth:`AuthRefreshCoordinator.snapshot` on every
+      call. The provider lambda captures this object by reference; the
+      capture is safe because production never reassigns
+      ``Session.auth`` after construction (the only mutation path is
+      in-place scalar updates via
+      :meth:`AuthRefreshCoordinator.update_auth_tokens`, which mutate
+      the captured instance directly). This replaced the previous
+      ``auth_snapshot_host: _AuthRefreshHost`` (= Session) parameter
+      when the ``_AuthRefreshHost`` Protocol was deleted in favor of
+      per-method explicit collaborators; the coordinator routes its
+      lock-wait metric through its own ``self._metrics`` (supplied at
+      construction), so it no longer needs a host-shaped collaborator
+      for the metric either.
 
     Post-construction mutation on ``chain_host._<attr>`` (or on
     ``session._<attr>``, which writes through the descriptor to the
@@ -462,7 +471,7 @@ def wire_middleware_chain(
         server_error_max_retries_provider=lambda: chain_host._server_error_max_retries,
         refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
         refresh_callable=chain_host.await_refresh,
-        auth_snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth_snapshot_host),
+        auth_snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=auth),
         is_auth_error=config.is_auth_error,
         refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
     )

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -480,16 +480,25 @@ async def test_first_terminal_attempt_rebuilds_when_snapshot_changed(monkeypatch
             ]
         )
 
-        async def fake_snapshot(_host: object) -> AuthSnapshot:
+        async def fake_snapshot(*, auth: AuthTokens) -> AuthSnapshot:
+            # Tightened signature pins the explicit-collaborator contract:
+            # the production caller MUST pass ``auth=<live AuthTokens>``,
+            # not the legacy positional host. ``auth is core.auth`` proves
+            # the chain captured the same ``AuthTokens`` instance Session
+            # holds (identity-stable per the live-reference contract in
+            # ``wire_middleware_chain``).
+            assert auth is core.auth
             try:
                 return next(snapshots)
             except StopIteration:
                 pytest.fail("unexpected extra auth snapshot")
 
         # PR #4b inlined ``Session._snapshot``; the production call
-        # sites now read ``self._auth_coord.snapshot(self)`` directly,
-        # so this test swaps the canonical coordinator method instead
-        # of the (now-deleted) Session delegate.
+        # sites now read ``self._auth_coord.snapshot(auth=self.auth)``
+        # directly (the Session-shaped ``_AuthRefreshHost`` was deleted
+        # in favor of an explicit ``auth: AuthTokens`` kwarg), so this
+        # test swaps the canonical coordinator method instead of the
+        # (now-deleted) Session delegate.
         core._auth_coord.snapshot = fake_snapshot  # type: ignore[method-assign]
         calls: list[AuthSnapshot] = []
 

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -286,6 +286,47 @@ async def test_update_auth_tokens_records_lock_wait_through_constructor_metrics(
     assert metrics.lock_waits[0] >= 0.0
 
 
+class _ExplodingMetrics:
+    """Lock-wait recorder that raises on every call — simulates a bug or
+    misconfigured test spy inside the metrics path.
+    """
+
+    def record_lock_wait(self, duration: float) -> None:
+        raise RuntimeError("metrics blew up")
+
+
+@pytest.mark.asyncio
+async def test_update_auth_tokens_releases_lock_when_metric_raises(
+    auth: AuthTokens,
+) -> None:
+    """A metric-side exception must NOT leave the snapshot lock held.
+
+    Pins the deadlock-safety property that the metric write lives inside
+    the ``try`` block guarded by the ``finally: lock.release()``. Without
+    this guard, a buggy metrics implementation (or a test spy that
+    raises) would silently hang every subsequent ``snapshot`` /
+    ``update_auth_tokens`` caller on the leaked lock.
+    """
+    metrics = _ExplodingMetrics()
+    coord = AuthRefreshCoordinator(metrics=cast(ClientMetrics, metrics))
+
+    with pytest.raises(RuntimeError, match="metrics blew up"):
+        await coord.update_auth_tokens(auth=auth, csrf="X", session_id="Y")
+
+    # The lock must be released even though the metric write raised.
+    # A second call must acquire the lock without blocking. Wrap in
+    # ``wait_for`` so a leaked lock surfaces as a fast failure rather
+    # than hanging the suite.
+    metrics2 = _RecordingMetrics()
+    coord._metrics = cast(ClientMetrics, metrics2)
+    await asyncio.wait_for(
+        coord.update_auth_tokens(auth=auth, csrf="Z", session_id="W"),
+        timeout=EVENT_TIMEOUT_S,
+    )
+    assert auth.csrf_token == "Z"
+    assert auth.session_id == "W"
+
+
 # ---------------------------------------------------------------------------
 # update_auth_headers — syncs auth.cookie_jar from get_http_client().cookies
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -12,31 +12,38 @@ Specifically pinned here:
   in-flight refresh task;
 * lazy lock allocation — ``_refresh_lock`` and ``_auth_snapshot_lock`` are
   ``None`` at construction and materialize on first use;
-* ``update_auth_tokens`` writes ONLY ``host.auth.csrf_token`` and
-  ``host.auth.session_id`` (does NOT touch the http client);
-* ``update_auth_headers`` syncs ``host.auth.cookie_jar`` from
-  ``host._kernel.get_http_client().cookies`` (the SEPARATE cookie-jar sync
-  surface; Wave 11b of session-decoupling routes the live HTTP client through
-  the Kernel collaborator rather than a ``Session.get_http_client`` forward);
+* ``update_auth_tokens`` writes ONLY ``auth.csrf_token`` and
+  ``auth.session_id`` (does NOT touch the http client);
+* ``update_auth_headers`` syncs ``auth.cookie_jar`` from
+  ``kernel.get_http_client().cookies`` (the SEPARATE cookie-jar sync
+  surface; Wave 11b of session-decoupling routes the live HTTP client
+  through the :class:`Kernel` collaborator rather than a
+  ``Session.get_http_client`` forward);
 * ``await_refresh`` cancellation propagation — a cancelled waiter unwinds
   locally without killing the shared refresh task, and the task slot is
   preserved across cancellation.
 
-Tests are intentionally helper-shaped (instantiate ``AuthRefreshCoordinator``
-directly with a Protocol-conformant stub host) so they cover the coordinator
-without taking on a ``Session`` dependency.
+The coordinator no longer accepts a Session-shaped ``_AuthRefreshHost``
+host — :meth:`snapshot` and :meth:`update_auth_tokens` take an explicit
+``auth: AuthTokens`` kwarg, :meth:`update_auth_headers` takes ``auth`` +
+``kernel: Kernel`` kwargs, and lock-wait latency is recorded through the
+coordinator's own ``self._metrics`` (supplied at construction). The
+tests below pass each collaborator explicitly; there is no host shape
+to fake.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import Any
+from collections.abc import AsyncIterator
+from typing import cast
 
 import httpx
 import pytest
 
 from notebooklm._client_metrics import ClientMetrics
+from notebooklm._kernel import Kernel
 from notebooklm._session_auth import AuthRefreshCoordinator
 from notebooklm.auth import AuthTokens
 
@@ -45,53 +52,45 @@ from notebooklm.auth import AuthTokens
 EVENT_TIMEOUT_S = 5.0
 
 
-class _StubHost:
-    """Minimal :class:`_AuthRefreshHost`-conformant host for unit tests.
+class _KernelStub:
+    """Minimal kernel-shaped stub exposing only :meth:`get_http_client`.
 
-    Mirrors the live ``Session`` shape:
-    * ``auth`` is a real :class:`AuthTokens` — :meth:`update_auth_tokens`
-      writes ``csrf_token`` / ``session_id`` directly on it.
-    * ``_metrics_obj`` is a real :class:`ClientMetrics` — the coordinator's
-      :meth:`record_lock_wait` calls land on it.
-    * ``_kernel`` aliases ``self`` so ``host._kernel.get_http_client()``
-      resolves to the stub's own :meth:`get_http_client`. Wave 11b of
-      session-decoupling moved the live-HTTP-client read off
-      ``Session.get_http_client`` and onto ``host._kernel.get_http_client()``
-      to match the canonical :class:`Kernel` ownership; the stub is its
-      own kernel-shaped collaborator because it already exposes the
-      one-method surface the Protocol requires.
+    The coordinator's :meth:`update_auth_headers` reads
+    ``kernel.get_http_client().cookies`` and nothing else; an
+    ``httpx.AsyncClient``-backed shim satisfies that surface without
+    pulling in the full :class:`Kernel`.
     """
 
     def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
-        self.auth = AuthTokens(
-            csrf_token="CSRF_OLD",
-            session_id="SID_OLD",
-            cookies={"SID": "old_cookie"},
-        )
-        self._metrics_obj = ClientMetrics(on_rpc_event=None)
         self.http_client = http_client
-        self._kernel = self
 
     def get_http_client(self) -> httpx.AsyncClient:
         assert self.http_client is not None, "Test forgot to wire an http client."
         return self.http_client
 
 
-@pytest.fixture
-def stub_host() -> _StubHost:
-    """A coordinator host with no http client wired."""
-    return _StubHost()
+def _fresh_auth() -> AuthTokens:
+    return AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "old_cookie"},
+    )
 
 
 @pytest.fixture
-async def http_host() -> Any:
-    """A coordinator host with a real ``httpx.AsyncClient`` wired."""
+def auth() -> AuthTokens:
+    """A fresh :class:`AuthTokens` per test (the coordinator mutates it)."""
+    return _fresh_auth()
+
+
+@pytest.fixture
+async def auth_with_kernel() -> AsyncIterator[tuple[AuthTokens, _KernelStub]]:
+    """``(auth, kernel)`` with a real ``httpx.AsyncClient`` wired."""
     async with httpx.AsyncClient() as client:
         # Pre-populate a cookie so ``update_auth_headers`` has something to
         # observe propagating from the live jar to ``auth.cookie_jar``.
         client.cookies.set("SID", "live_jar_cookie")
-        host = _StubHost(http_client=client)
-        yield host
+        yield _fresh_auth(), _KernelStub(http_client=client)
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +157,7 @@ async def test_snapshot_and_refresh_locks_are_distinct() -> None:
 
 @pytest.mark.asyncio
 async def test_update_auth_tokens_writes_csrf_and_session_id_only(
-    http_host: _StubHost,
+    auth_with_kernel: tuple[AuthTokens, _KernelStub],
 ) -> None:
     """``update_auth_tokens`` mutates ONLY ``auth.csrf_token`` + ``auth.session_id``.
 
@@ -167,23 +166,24 @@ async def test_update_auth_tokens_writes_csrf_and_session_id_only(
     prevents a "helpful" maintainer from conflating the two and reopening
     the torn-state window the snapshot lock exists to close.
     """
+    auth, kernel = auth_with_kernel
     coord = AuthRefreshCoordinator()
-    pre_client_cookies = dict(http_host.get_http_client().cookies)
-    pre_auth_cookies = dict(http_host.auth.cookies)
+    pre_client_cookies = dict(kernel.get_http_client().cookies)
+    pre_auth_cookies = dict(auth.cookies)
 
-    await coord.update_auth_tokens(http_host, csrf="CSRF_NEW", session_id="SID_NEW")
+    await coord.update_auth_tokens(auth=auth, csrf="CSRF_NEW", session_id="SID_NEW")
 
-    assert http_host.auth.csrf_token == "CSRF_NEW"
-    assert http_host.auth.session_id == "SID_NEW"
+    assert auth.csrf_token == "CSRF_NEW"
+    assert auth.session_id == "SID_NEW"
     # http_client untouched
-    assert dict(http_host.get_http_client().cookies) == pre_client_cookies
+    assert dict(kernel.get_http_client().cookies) == pre_client_cookies
     # auth.cookies untouched (cookie sync is update_auth_headers's job)
-    assert dict(http_host.auth.cookies) == pre_auth_cookies
+    assert dict(auth.cookies) == pre_auth_cookies
 
 
 @pytest.mark.asyncio
 async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
-    stub_host: _StubHost,
+    auth: AuthTokens,
 ) -> None:
     """The write happens under the snapshot lock — proved by contention.
 
@@ -207,7 +207,7 @@ async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
     holder = asyncio.create_task(hold_lock())
     await asyncio.wait_for(enter_held.wait(), EVENT_TIMEOUT_S)
 
-    write_task = asyncio.create_task(coord.update_auth_tokens(stub_host, csrf="X", session_id="Y"))
+    write_task = asyncio.create_task(coord.update_auth_tokens(auth=auth, csrf="X", session_id="Y"))
     # Yield a few times so the writer reaches lock.acquire() and blocks.
     for _ in range(5):
         await asyncio.sleep(0)
@@ -221,8 +221,69 @@ async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
     await asyncio.wait_for(holder, EVENT_TIMEOUT_S)
     await asyncio.wait_for(write_task, EVENT_TIMEOUT_S)
 
-    assert stub_host.auth.csrf_token == "X"
-    assert stub_host.auth.session_id == "Y"
+    assert auth.csrf_token == "X"
+    assert auth.session_id == "Y"
+
+
+# ---------------------------------------------------------------------------
+# Lock-wait metrics — record_lock_wait routes through self._metrics
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMetrics:
+    """Captures every :meth:`record_lock_wait` call (test seam only).
+
+    Production code uses :class:`notebooklm._client_metrics.ClientMetrics`;
+    this spy mirrors only the one method ``AuthRefreshCoordinator`` calls
+    so the test asserts the metric path independent of the broader
+    ``ClientMetrics`` API surface.
+    """
+
+    def __init__(self) -> None:
+        self.lock_waits: list[float] = []
+
+    def record_lock_wait(self, duration: float) -> None:
+        self.lock_waits.append(duration)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_records_lock_wait_through_constructor_metrics(
+    auth: AuthTokens,
+) -> None:
+    """``snapshot`` routes ``record_lock_wait`` through the coordinator's
+    own ``self._metrics`` (supplied at construction), NOT through a
+    host-shaped collaborator.
+
+    Pin matters because the explicit-collaborator migration removed the
+    ``host._metrics_obj`` route; without this assertion a future revert
+    that forgets to call ``self._metrics.record_lock_wait`` would still
+    pass the existing behavior tests (which check only auth scalars).
+    """
+    metrics = _RecordingMetrics()
+    coord = AuthRefreshCoordinator(metrics=cast(ClientMetrics, metrics))
+
+    snapshot = await coord.snapshot(auth=auth)
+
+    assert snapshot.csrf_token == auth.csrf_token
+    assert snapshot.session_id == auth.session_id
+    assert len(metrics.lock_waits) == 1
+    assert metrics.lock_waits[0] >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_update_auth_tokens_records_lock_wait_through_constructor_metrics(
+    auth: AuthTokens,
+) -> None:
+    """Companion pin for :meth:`update_auth_tokens` — same routing."""
+    metrics = _RecordingMetrics()
+    coord = AuthRefreshCoordinator(metrics=cast(ClientMetrics, metrics))
+
+    await coord.update_auth_tokens(auth=auth, csrf="C", session_id="S")
+
+    assert auth.csrf_token == "C"
+    assert auth.session_id == "S"
+    assert len(metrics.lock_waits) == 1
+    assert metrics.lock_waits[0] >= 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -232,24 +293,29 @@ async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
 
 @pytest.mark.asyncio
 async def test_update_auth_headers_syncs_cookie_jar_from_get_http_client(
-    http_host: _StubHost,
+    auth_with_kernel: tuple[AuthTokens, _KernelStub],
 ) -> None:
-    """``update_auth_headers`` copies ``get_http_client().cookies`` onto auth.
+    """``update_auth_headers`` copies ``kernel.get_http_client().cookies`` onto auth.
 
     Pins:
-    * the read is via the ``get_http_client()`` METHOD (not a ``_http_client``
-      attribute), matching :class:`_AuthRefreshHost` and ``_auth/session.py``;
-    * the destination is ``host.auth.cookie_jar`` (the cookie jar reference,
+    * the read is via the ``kernel.get_http_client()`` METHOD on the
+      explicit ``kernel`` collaborator (not a host-shaped attribute);
+    * the destination is ``auth.cookie_jar`` (the cookie jar reference,
       not a dict copy).
     """
+    auth, kernel = auth_with_kernel
     coord = AuthRefreshCoordinator()
     # Sanity: pre-call, auth.cookie_jar is whatever AuthTokens initialised.
-    live_jar = http_host.get_http_client().cookies
+    live_jar = kernel.get_http_client().cookies
 
-    coord.update_auth_headers(http_host)
+    # _KernelStub structurally satisfies the surface that
+    # ``update_auth_headers`` actually reads (``get_http_client()``) but is
+    # not the nominal :class:`Kernel`; ``cast`` is cheaper than introducing
+    # a Protocol just for one test seam.
+    coord.update_auth_headers(auth=auth, kernel=cast(Kernel, kernel))
 
     # The auth.cookie_jar attribute is now identically the live jar.
-    assert http_host.auth.cookie_jar is live_jar
+    assert auth.cookie_jar is live_jar
 
 
 def test_update_auth_headers_is_synchronous() -> None:
@@ -269,7 +335,7 @@ def test_update_auth_headers_is_synchronous() -> None:
 
 
 @pytest.mark.asyncio
-async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
+async def test_await_refresh_is_single_flight() -> None:
     """Concurrent ``await_refresh`` callers share one in-flight refresh task.
 
     Mirrors ``test_refresh_state_machine.py::test_concurrent_callers_share_single_refresh``
@@ -312,9 +378,7 @@ async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
 
 
 @pytest.mark.asyncio
-async def test_await_refresh_creates_new_task_after_first_done(
-    stub_host: _StubHost,
-) -> None:
+async def test_await_refresh_creates_new_task_after_first_done() -> None:
     """A second refresh wave creates a *new* task once the first is done."""
     call_count = 0
 
@@ -342,9 +406,7 @@ async def test_await_refresh_creates_new_task_after_first_done(
 
 
 @pytest.mark.asyncio
-async def test_await_refresh_cancellation_preserves_task_slot(
-    stub_host: _StubHost,
-) -> None:
+async def test_await_refresh_cancellation_preserves_task_slot() -> None:
     """A cancelled waiter does not kill the shared task; slot is preserved.
 
     Mirrors

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -9,7 +9,8 @@ logic into Session. The pin still guards against the reverse direction
 PR #4b of the session-refactor arc (inline-pure-delegates) deleted
 most of the previously-pinned delegates entirely — every caller now
 talks to the canonical collaborator directly
-(``core._auth_coord.snapshot(self)``, ``core._rpc_executor.build_url(...)``,
+(``core._auth_coord.snapshot(auth=core.auth)``,
+``core._rpc_executor.build_url(...)``,
 ``core._drain_tracker.begin_transport_post(...)``, etc.). The
 surviving delegates retained on Session are kept because each has a
 structural protocol caller, a Protocol-imposed call site, or an


### PR DESCRIPTION
## Summary

`AuthRefreshCoordinator` previously took a Session-shaped `_AuthRefreshHost` Protocol on `snapshot()` / `update_auth_tokens()` / `update_auth_headers()`. The Protocol re-declared three private `Session` slots (`auth` / `_metrics_obj` / `_kernel`), which coupled the coordinator to Session's private attribute names and forced fake-host shims in tests.

This change deletes `_AuthRefreshHost` and routes each capability through explicit per-method collaborators:

- `snapshot(*, auth: AuthTokens)`
- `update_auth_tokens(*, auth: AuthTokens, csrf, session_id)`
- `update_auth_headers(*, auth: AuthTokens, kernel: Kernel)`
- Lock-wait metrics → `self._metrics` (already wired at construction; same routing as `await_refresh` already used).

Builds on the `RpcExecutor` collaborator-decoupling pattern landed in #1068 and the `MiddlewareChainHost` carve-out in #1090 / #1092.

## Architectural rationale

- No Session-shaped Protocol remains on the coordinator's dependency surface — every dependency is now a concrete narrow type (`AuthTokens`, `Kernel`, `ClientMetrics`) that the coordinator already imports.
- No new host class is introduced (per the dependency-minimization constraint: avoid adding another host object unless multiple production consumers need it).
- `Session.update_auth_headers()` / `Session.update_auth_tokens()` keep their public signatures unchanged, so `RefreshAuthCore` in `_auth/session.py` (consumed by `refresh_auth_session`) remains structurally satisfied.
- `wire_middleware_chain` now takes `auth: AuthTokens` directly instead of `auth_snapshot_host: _AuthRefreshHost`. The chain captures `auth` by reference; production never reassigns `Session.auth` and refresh mutates in place, so the captured reference stays live (documented in the helper's docstring).

## Preserved invariants

- Loop-guard semantics in `await_refresh` (`assert_bound_loop`).
- Refresh-coalescing semantics (`_refresh_lock` + `_refresh_task` slot, single-flight task).
- No-await mutation block in `update_auth_tokens` — AST-guarded by `tests/unit/test_concurrency_refresh_race.py::test_update_auth_tokens_has_no_await_inside_mutation_block`.
- Snapshot-lock acquisition in `snapshot` — AST-guarded by `tests/unit/test_concurrency_refresh_race.py::test_snapshot_acquires_auth_snapshot_lock`.
- Auth-refresh middleware's `_rebuild_request_after_refresh` AST guard (`test_auth_refresh_rebuild_has_no_await_after_snapshot_capture`).

## Test changes

- `tests/unit/test_session_auth.py`: `_StubHost` replaced by a small `_KernelStub` plus explicit `auth` and `auth_with_kernel` fixtures — no host shape to fake.
- New `_RecordingMetrics` spy + two tests pin that `snapshot` and `update_auth_tokens` route `record_lock_wait` through the coordinator's own `self._metrics`.
- `tests/unit/test_authed_post_pipeline.py::test_first_terminal_attempt_rebuilds_when_snapshot_changed` tightens its `fake_snapshot` signature to `(*, auth: AuthTokens)` and asserts `auth is core.auth` so the explicit-collaborator contract is pinned end-to-end.

## Test plan

- [x] `uv run pytest tests/unit/test_auth_refresh_middleware.py tests/unit/test_concurrency_refresh_race.py -q` — passing.
- [x] `uv run pytest tests/unit/test_session_auth.py -q` — 13 passing (was 11; +2 metrics-spy tests).
- [x] `uv run pytest tests/unit tests/integration -k 'refresh or auth' -q` — 957 passed, 5 skipped.
- [x] `uv run pytest tests/unit tests/integration tests/_lint -q` — 6558 passed, 12 skipped.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues found in 174 source files.
- [x] `uv run ruff check src/notebooklm tests/unit` — All checks passed.
- [x] `uv run ruff format --check src/notebooklm tests/unit` — All formatted.

## Deferred polish findings

A reviewer suggested introducing a small kernel-shaped Protocol so the `_KernelStub` test wouldn't need `cast(Kernel, ...)`. Deferred — introducing a new Protocol for one test seam is more ceremony than the dependency-minimization goal warrants, and `cast` documents the intent inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal auth-refresh wiring converted to explicit per-call collaborator arguments; no user-facing API changes.

* **Tests**
  * Unit tests updated to validate the new auth contracts, snapshot-lock serialization, single-flight refresh behavior, and metrics handling.

* **Documentation / Chores**
  * Inline docs and module descriptions clarified to reflect the refactor and updated auth-refresh semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->