### PR TITLE
fix(audit): address post-1064 review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ RPC Layer (rpc/)
 | `_middleware_chain.py` | Constructs the middleware chain in the canonical ADR-009 order |
 | `_middleware*.py` | Modular middleware implementations (drain, metrics, semaphore, retry, auth, error injection, tracing) |
 | `rpc/types.py` | RPC method IDs (source of truth) |
-| `auth.py` | Authentication facade — **now pure re-exports** (zero function/class bodies; verified via `grep -nE "^def \|^class " src/notebooklm/auth.py` returning empty). Every top-level name forwards from the relevant `_auth/*` module. The previous write-through (`_validate_required_cookies` copy-forwarding `MINIMUM_REQUIRED_COOKIES` / `_EXTRACTION_HINT` / `_has_valid_secondary_binding` into `_cookie_policy` and mirroring `_SECONDARY_BINDING_WARNED` back) was inverted in Wave 4 T2.2 (#1070); `auth._validate_required_cookies` is now identity-equal to `_auth.cookie_policy._validate_required_cookies`. `load_auth_from_storage` body was moved to `_auth/tokens.py` in Wave 3a (#1066). `AuthTokens` was moved to `_auth/tokens.py` in #1055. **ADR-003 flat-re-export goal closed by ADR-014** (session-decoupling Waves 3a + 4 T2.2 + 5). Tests that need to rebind policy names patch `_auth.cookie_policy.X` directly. |
+| `auth.py` | Authentication facade — **almost pure re-exports** (the only remaining function body is `async def enumerate_accounts`, which binds `_poke_session` as a default dependency; ADR-003 records the optional-`async` audit command). Every other top-level name forwards from the relevant `_auth/*` module. The previous write-through (`_validate_required_cookies` copy-forwarding `MINIMUM_REQUIRED_COOKIES` / `_EXTRACTION_HINT` / `_has_valid_secondary_binding` into `_cookie_policy` and mirroring `_SECONDARY_BINDING_WARNED` back) was inverted in Wave 4 T2.2 (#1070); `auth._validate_required_cookies` is now identity-equal to `_auth.cookie_policy._validate_required_cookies`. `load_auth_from_storage` body was moved to `_auth/tokens.py` in Wave 3a (#1066). `AuthTokens` was moved to `_auth/tokens.py` in #1055. **ADR-003 flat-re-export goal closed by ADR-014** (session-decoupling Waves 3a + 4 T2.2 + 5). Tests that need to rebind policy names patch `_auth.cookie_policy.X` directly. |
 | `_auth/paths.py` | Storage paths and filesystem helpers |
 | `_auth/extraction.py` | Cookie/token extraction from browser sessions |
 | `_auth/headers.py` | HTTP header construction |
@@ -145,7 +145,7 @@ RPC Layer (rpc/)
 src/notebooklm/
 ├── __init__.py                  # Public exports
 ├── client.py                    # NotebookLMClient
-├── auth.py                      # Authentication facade — now pure re-exports (ADR-003 flat-re-export goal closed by ADR-014; see file table above)
+├── auth.py                      # Authentication facade — almost pure re-exports (`enumerate_accounts` exception; ADR-003 flat-re-export goal closed by ADR-014; see file table above)
 ├── types.py                     # Dataclasses
 ├── _session.py                  # Concrete Session orchestration (NotebookLMClient internals)
 ├── _kernel.py                   # Concrete Kernel transport core

--- a/docs/adr/0003-auth-facade-write-through.md
+++ b/docs/adr/0003-auth-facade-write-through.md
@@ -4,7 +4,7 @@
 
 **Superseded — closed by [ADR-014](./0014-feature-local-runtime-adapters.md) (session-decoupling plan Waves 3a + 4 T2.2 + 5).**
 
-The deferred goal — reducing `auth.py` to a flat re-export module — was
+The deferred goal — reducing `auth.py` to an almost-flat re-export module — was
 completed across three PRs in the session-decoupling plan:
 
 - **#1066** (Wave 3a / Task 2.1) moved `load_auth_from_storage()` body into
@@ -20,11 +20,13 @@ completed across three PRs in the session-decoupling plan:
 - **#1055** (pre-plan groundwork) had already moved `AuthTokens` into
   `_auth/tokens.py`; the `auth.py`-level binding became a re-export.
 
-**Post-condition (verified by `grep -nE "^def |^class " src/notebooklm/auth.py`
-returning empty as of this PR's audit):** `auth.py` contains zero function
-bodies and zero class definitions. Every top-level name is a one-line
-re-export from the relevant `_auth/*` module. The historical write-through
-machinery is fully retired.
+**Post-condition (verified by
+`grep -nE "^(async[[:space:]]+)?def |^class " src/notebooklm/auth.py`):**
+`auth.py` contains exactly one function body, `async def enumerate_accounts`,
+which remains to bind `_poke_session` as a default dependency, and zero class
+definitions. Every other top-level name is a one-line re-export from the
+relevant `_auth/*` module. The historical write-through machinery is fully
+retired.
 
 **Why "Superseded by ADR-014" rather than "Accepted (completed)":** the
 original ADR-003 framing was a *write-through* approach (mirror writes
@@ -101,7 +103,7 @@ The mechanism is *Accepted* today because:
 - The `_REFRESH_DEP_MIRROR_NAMES` / `_KEEPALIVE_DEP_MIRROR_NAMES` cross-module mirror sets encode an even subtler invariant — names that are owned by one seam but aliased into another at import time. A reader has to trace the `from … import …` chains to verify the mirror is complete.
 - The whole apparatus exists to make tests pass under a pattern (`monkeypatch.setattr("notebooklm.auth.X", …)`) that the audit (`.sisyphus/plans/arch-biggest-problem-audit.md`, disease D1) wants to retire entirely.
 
-The retirement path was **partially completed** in the D1 auth-side PR ([#834](https://github.com/teng-lin/notebooklm-py/pull/834)): the monolithic `tests/unit/test_auth.py` was split into concern-aligned files (`test_auth_storage.py`, `test_auth_account.py`, `test_auth_refresh.py` etc.), monkeypatches were migrated to constructor injection, and `_AuthFacadeModule` itself was deleted. The second half — reducing `auth.py` to a flat re-export module — is **deferred**: at HEAD, `auth.py` still owns `AuthTokens`, `load_auth_from_storage()`, and a `_validate_required_cookies()` policy write-through (see the **Status** block above for the current contract).
+The retirement path began in the D1 auth-side PR ([#834](https://github.com/teng-lin/notebooklm-py/pull/834)): the monolithic `tests/unit/test_auth.py` was split into concern-aligned files (`test_auth_storage.py`, `test_auth_account.py`, `test_auth_refresh.py` etc.), monkeypatches were migrated to constructor injection, and `_AuthFacadeModule` itself was deleted. ADR-014's session-decoupling work finished the second half: `AuthTokens` and `load_auth_from_storage()` now live in `_auth/tokens.py`, `_validate_required_cookies` is a direct `_auth.cookie_policy` re-export, and `async def enumerate_accounts` is the only remaining `auth.py` function body (see the **Status** block above for the current contract).
 
 ## Alternatives considered
 

--- a/docs/adr/0012-implementation-surface-convention.md
+++ b/docs/adr/0012-implementation-surface-convention.md
@@ -87,7 +87,7 @@ three categories, signalled by its filename:
 src/notebooklm/
 ├── __init__.py                  # re-export hub; declares the stable surface
 ├── client.py                    # NotebookLMClient + lifecycle helpers
-├── auth.py                      # auth facade (flat re-exports from _auth/*)
+├── auth.py                      # auth facade (almost flat re-exports; enumerate_accounts exception)
 ├── types.py                     # public dataclasses (Notebook, Source, ...)
 ├── exceptions.py                # public exception hierarchy
 ├── config.py                    # process-level configuration helpers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -401,13 +401,12 @@ Beyond the Session-orchestration graph, several feature APIs are implemented via
 
 [`auth.py`](../src/notebooklm/auth.py) is a thin public facade that
 re-exports the canonical implementations under
-[`_auth/`](../src/notebooklm/_auth). The facade still hosts the public
-`AuthTokens` name (re-exported from `_auth.tokens`), owns
-`load_auth_from_storage()`, and owns the
-`_validate_required_cookies()` write-through that propagates
-`auth.py`-level policy rebindings into `_auth.cookie_policy` (the flat
-re-export goal in ADR-003 is **deferred** — see CLAUDE.md's `auth.py`
-row for the current status).
+[`_auth/`](../src/notebooklm/_auth). ADR-014 closed ADR-003's deferred
+flat-re-export goal: `AuthTokens` and `load_auth_from_storage()` now live
+in `_auth.tokens`, `_validate_required_cookies` is a direct
+`_auth.cookie_policy` re-export, and `async def enumerate_accounts` is the
+only remaining `auth.py` function body because it binds `_poke_session` as
+the default dependency.
 
 | Module | Responsibility |
 |--------|----------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -643,7 +643,7 @@ Vocabulary that recurs in this document and the surrounding code.
 
 - [ADR-001](./adr/0001-layered-core-seams-and-property-bridge-policy.md) — Layered seams + property-bridge policy (superseded; shims retired).
 - [ADR-002](./adr/0002-capability-protocol-pattern.md) — Capability Protocol pattern (Superseded by [arch-d2-cutover](https://github.com/teng-lin/notebooklm-py/pull/835) (#835)).
-- [ADR-003](./adr/0003-auth-facade-write-through.md) — `auth.py` write-through facade (Superseded by [arch-d1-auth-side](https://github.com/teng-lin/notebooklm-py/pull/834) (#834); flat re-export goal is deferred).
+- [ADR-003](./adr/0003-auth-facade-write-through.md) — `auth.py` write-through facade (Superseded — closed by [ADR-014](./adr/0014-feature-local-runtime-adapters.md); `auth.py` is now almost pure re-exports with `enumerate_accounts` as the sole function-body exception).
 - [ADR-004](./adr/0004-loop-affinity-contract.md) — Loop-affinity contract (Accepted; enforced by `_loop_affinity.assert_bound_loop`).
 - [ADR-005](./adr/0005-idempotency-taxonomy.md) — Mutating-RPC idempotency taxonomy (Accepted; enforced by `_idempotency.IdempotencyRegistry`).
 - [ADR-006](./adr/0006-vcr-scrubber-strategy.md) — VCR cassette scrubber strategy (Accepted).

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -595,8 +595,6 @@ class ArtifactsAPI:
             output_format,
             html_content,
             is_quiz,
-            quiz_markdown_formatter=_artifact_formatters._format_quiz_markdown,
-            flashcards_markdown_formatter=_artifact_formatters._format_flashcards_markdown,
         )
 
     async def download_report(

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -58,15 +58,6 @@ SESSION_CLASS_NAME: str = "Session"
 # must be moved to the **Deleted** section at the bottom of the
 # retention doc, which the parser scopes out).
 _RETAIN_PREFIX: str = "retain"
-# **Advisory only** — left in place for documentation continuity and for
-# external readers grepping for "what dispositions does this lint
-# accept?". The actual validator is ``_DISPOSITION_RETAIN_RE`` below;
-# Wave 12 (claude PR #1080 review Finding 2) switched
-# ``_disposition_is_valid`` from
-# ``startswith(VALID_DISPOSITION_PREFIXES)`` to a strict regex match,
-# so adding a new entry to this tuple has **no effect** on validation.
-# Modify the regex if a new prefix needs to be recognised.
-VALID_DISPOSITION_PREFIXES: tuple[str, ...] = (_RETAIN_PREFIX,)
 # Recognised but **rejected** prefix — kept as a named constant so the
 # self-coverage tests below can pin "Wave 11c rejects this" without
 # accidentally widening the live retain-only invariant enforced by
@@ -77,9 +68,10 @@ _RETIRED_DELETE_PREFIX: str = "delete in Wave 11"
 # disposition must read exactly ``retain — <reason>``: ``retain``,
 # whitespace, an em-dash (``—``), whitespace, and at least one
 # non-whitespace character of reason text. A loose ``startswith("retain")``
-# check would accept ``retainXYZ`` (no boundary), ``retain`` alone (no
-# reason), or ``retain — `` (empty reason); the regex below rejects all
-# three so the retention doc's vocabulary cannot rot into ambiguity.
+# style prefix check would accept ``retainXYZ`` (no boundary),
+# ``retain`` alone (no reason), or ``retain — `` (empty reason);
+# the regex below rejects all three so the retention doc's vocabulary
+# cannot rot into ambiguity.
 _DISPOSITION_RETAIN_RE = re.compile(r"^retain\s+—\s+\S.*$")
 
 


### PR DESCRIPTION
## Summary
- Correct stale auth facade docs so `enumerate_accounts` is documented as the sole remaining `auth.py` function-body exception.
- Remove redundant interactive artifact formatter kwargs now that the formatter supplies identical defaults.
- Delete the unused retention-lint advisory constant and keep the strict-disposition comment accurate.

## Audit
- Scanned PRs merged after #1064 (`2026-05-27T05:42:28Z`) through current `origin/main`.
- Reviewed PR review threads plus PR review/comment bodies for still-relevant feedback.

## Test plan
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Optional follow-up: remove the now-trivial `ArtifactsAPI._format_interactive_content` wrapper if no compatibility caller depends on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and design records to reflect that an authentication facade is now largely re-exports with one remaining explicit implementation and to document the completed retirement steps and history.

* **Refactor**
  * Simplified internal content-formatting callsites by relying on formatter defaults rather than passing redundant parameters.

* **Tests**
  * Removed an unused module-level constant and tightened explanatory comments in a session-retention lint test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->