### PR TITLE
refactor(session): delete chain-internal descriptor forwards on Session

### DIFF
--- a/docs/adr/0014-feature-local-runtime-adapters.md
+++ b/docs/adr/0014-feature-local-runtime-adapters.md
@@ -227,41 +227,20 @@ deletes them.
   is the documented raw-RPC escape hatch and it forwards through
   `Session.rpc_call`. Internally `Session.rpc_call` now delegates to
   `self.rpc_executor.rpc_call(...)` (via the late-bound accessor added by the migration plan's Task 3.0).
-- `Session._authed_post_chain_terminal` (writable `@property`) — **test-seam
-  forwards to MiddlewareChainHost** (chain-ownership carve-out; Stage B2 PR 1
-  #1090 moved storage to `chain_host._authed_post_chain_terminal`). The
-  Session-side descriptor preserves the canonical fixture-rebind seam
-  (`core._authed_post_chain_terminal = fake_terminal` writes through to the
-  host). `compose_session_internals()` still passes
-  `session._authed_post_chain_terminal` to `wire_middleware_chain` at
-  [`_session.py:336`](../../src/notebooklm/_session.py); the live leaf
-  dereferences the descriptor once at wiring time, which resolves to
-  `chain_host._authed_post_chain_terminal`. The chain's per-attempt path
-  reads `chain_host._authed_post_chain` directly after Stage B2 PR 2 (see
-  the `_authed_post_chain` bullet below), so this terminal descriptor is
-  not on the hot path on a per-RPC basis.
-- `Session._authed_post_chain` (writable `@property`) — **test-seam forwards
-  to MiddlewareChainHost** (chain-ownership carve-out; storage on
-  `chain_host._authed_post_chain`). The transport's `chain_provider` closure
-  reads the host directly after Stage B2 PR 2; the Session-side descriptor is
-  retained for the long-standing rebind seam in
-  `tests/unit/test_authed_post_pipeline.py`.
-- `Session._rate_limit_max_retries`, `Session._server_error_max_retries`,
-  `Session._refresh_retry_delay` (writable `@property` each) — **test-seam
-  forwards to MiddlewareChainHost** (chain-ownership carve-out; storage on
-  `chain_host._<attr>`). The chain's `MiddlewareChainBuilder` provider lambdas
-  read the host directly after Stage B2 PR 2; the Session-side descriptors
-  preserve the integration-test mutation-after-construction contract
-  (`core._<attr> = N` writes through to the host so the next attempt sees the
-  new budget).
-- `Session._await_refresh` — **test-seam forwards to MiddlewareChainHost**
-  (chain-ownership carve-out; the method's body routes through
-  `MiddlewareChainHost.await_refresh`, which dynamically delegates to
-  `host._auth_refresh.await_refresh()`). Stage B2 PR 2 moved the chain's
-  capture site off this method onto `chain_host.await_refresh` directly, so
-  the chain no longer reaches through the Session-side delegate on the hot
-  path. The method is retained as a test seam for the long-standing
-  `session._await_refresh` patch point.
+- `Session._chain_host` — instance reference to the `MiddlewareChainHost`
+  that owns the live middleware chain. The host owns
+  `_authed_post_chain_terminal` (chain leaf), `_authed_post_chain`
+  (installed chain slot), the three retry-budget tunables
+  (`_rate_limit_max_retries`, `_server_error_max_retries`,
+  `_refresh_retry_delay`), and the dynamic `await_refresh` delegate.
+  `wire_middleware_chain` and `build_session_transport` take
+  `chain_host: MiddlewareChainHost` directly; the chain's provider
+  lambdas and the transport's `chain_provider` closure read the host
+  attributes live. Tests rebind through `core._chain_host._<attr>`.
+  The transitional Session-side writable `@property` descriptors and
+  the `Session._await_refresh` delegate that briefly forwarded reads
+  / writes to the host during the chain-ownership carve-out have been
+  removed; the host is now the sole owner with no Session-side aliases.
 - `Session.update_auth_tokens` — AST-guarded by `test_concurrency_refresh_race.py`.
 - `Session.open` / `close` / `is_open` / `_keepalive_loop` — lifecycle.
 - ~~`Session.collaborators`, `Session.session_transport`, `Session.rpc_executor`~~
@@ -426,11 +405,11 @@ deleted. Feature wiring now reads `composed.collaborators` /
 returned by the helper. The deletion is recorded in the **Deleted**
 section of [`docs/session-method-retention.md`](../session-method-retention.md).
 
-### 2026-05-27 — Rule 4 chain-ownership carve-out (post-refactoring plan 2026-05-27 Stage B2, #1090 / #1092 / this PR)
+### 2026-05-27 — Rule 4 chain-ownership carve-out (post-refactoring plan 2026-05-27 Stage B2, #1090 / #1092)
 
 Issue #1085 (deferred `MiddlewareChainHost` extraction) closed.
 
-- **PR 1 (#1090)** introduced
+- **#1090** introduced
   [`_middleware_chain_host.py`](../../src/notebooklm/_middleware_chain_host.py).
   The chain's tunable storage (`_authed_post_chain_terminal`,
   `_authed_post_chain`, `_rate_limit_max_retries`,
@@ -442,7 +421,7 @@ Issue #1085 (deferred `MiddlewareChainHost` extraction) closed.
   the move. `_await_refresh` was routed through
   `MiddlewareChainHost.await_refresh` (dynamic delegation to
   `host._auth_refresh.await_refresh()`) for the same reason.
-- **PR 2 (#1092)** split
+- **#1092** split
   `_session_init.wire_middleware_chain` / `build_session_transport`
   to take `chain_host: MiddlewareChainHost` directly. The chain's
   provider lambdas (`chain_provider`,
@@ -450,29 +429,24 @@ Issue #1085 (deferred `MiddlewareChainHost` extraction) closed.
   `server_error_max_retries_provider`, `refresh_retry_delay_provider`)
   and the transport's `chain_provider` closure now dereference
   `chain_host.<attr>` directly on every attempt, instead of routing
-  through the Session descriptors. The chain leaf coroutine
-  (`authed_post_chain_terminal=session._authed_post_chain_terminal`
-  at [`_session.py:336`](../../src/notebooklm/_session.py)) is still
-  passed via the Session descriptor at wiring time, but that
-  descriptor resolves to `chain_host._authed_post_chain_terminal` and
-  is read once at chain-construction time — not per-RPC. After PR 2
-  the Session-side descriptors are **test-seam only** — they preserve
-  the fixture-rebind contract but no longer carry a per-attempt
-  dereference.
-- **PR 3 (this PR)** amends Rule 4's retention list to mark the five
-  writable descriptors + `_await_refresh` as `test-seam forwards to
-  MiddlewareChainHost` and adds the canonical per-attr disposition
-  string `retain — forwards to MiddlewareChainHost` to the inventory
-  in [`docs/session-method-retention.md`](../session-method-retention.md).
+  through the Session descriptors.
 
-**Carve-out scope.** The rule that `Session` should not satisfy
-collaborator-shaped Protocols for feature consumption is unchanged.
-The carve-out covers only the five `Session`-side descriptor forwards
-(plus the `_await_refresh` method) that are kept as test seams for
-the chain's storage; they are explicitly **not** part of the public
-API surface and are documented in the retention doc as
-`test-seam forwards to MiddlewareChainHost`. Live chain dereferences
-go through `MiddlewareChainHost` directly.
+### 2026-05-27 — Carve-out close-out (delete Session-side chain descriptors)
+
+The Session-side writable `@property` descriptors
+(`_authed_post_chain_terminal`, `_authed_post_chain`,
+`_rate_limit_max_retries`, `_server_error_max_retries`,
+`_refresh_retry_delay`) and the `_await_refresh` delegate that briefly
+bridged tests to `MiddlewareChainHost` during the carve-out have been
+deleted. The chain host is the sole owner; the composition root
+addresses it directly (`chain_host._authed_post_chain =
+wired.authed_post_chain`, `authed_post_chain_terminal=chain_host._authed_post_chain_terminal`)
+and tests rebind through `core._chain_host._<attr>` /
+`core._chain_host.await_refresh()`. The Session-side retention list
+keeps only the `_chain_host` reference (so feature code and tests can
+reach the host); the descriptors and the `_await_refresh` delegate
+are recorded in the **Deleted** section of
+[`docs/session-method-retention.md`](../session-method-retention.md).
 
 ### 2026-05-27 — Rule 2 adapter retirement (runtime-adapter decision)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ CLI command or user code
   -> SessionTransport.perform_authed_post(...)
        - loop-affinity guard, auth snapshot, RpcRequest materialization
   -> ADR-009 middleware chain
-  -> Session._authed_post_chain_terminal(...)   # retained chain leaf (ADR-014 Rule 4)
+  -> MiddlewareChainHost._authed_post_chain_terminal(...)   # chain leaf (ADR-014 Rule 4)
   -> SessionTransport.terminal(...)
        - final auth-freshness rebuild immediately before POST
   -> Kernel.post(...) -> _streaming_post -> httpx.AsyncClient
@@ -314,13 +314,14 @@ as keyword-only parameters, plus the previously-existing
 constructor-injected providers for timeout, refresh-callback enablement,
 and retry-delay values. The executor enters transport through
 `SessionTransport.perform_authed_post` directly; the middleware
-terminal remains `Session._authed_post_chain_terminal →
-SessionTransport.terminal → Kernel.post` because the chain leaf is the
-load-bearing seam Wave 5 of the session-decoupling plan retained on
-`Session` per ADR-014 Rule 4. Request types, transport errors, and
-streaming helpers live in separate owning modules instead of one
-catch-all transport helper. This keeps feature APIs on narrow capability
-Protocols and the executor on direct collaborator dependencies.
+terminal remains `MiddlewareChainHost._authed_post_chain_terminal →
+SessionTransport.terminal → Kernel.post`. The chain leaf moved off
+`Session` onto `MiddlewareChainHost` so the chain owns its own
+terminal and retry tunables (ADR-014 Rule 4 chain-ownership
+carve-out). Request types, transport errors, and streaming helpers
+live in separate owning modules instead of one catch-all transport
+helper. This keeps feature APIs on narrow capability Protocols and
+the executor on direct collaborator dependencies.
 
 ## Post-refactor `Session` collaborator graph
 
@@ -365,7 +366,8 @@ Exec  Ref    Life    Chain Trans Drain  Tracker Coun  Pers
 | Collaborator | Module | Responsibility |
 |--------------|--------|----------------|
 | `RpcExecutor` | [`_rpc_executor.py`](../src/notebooklm/_rpc_executor.py) | Single logical batchexecute RPC dispatch path. Owns request-id/started-metric bracketing, idempotency policy lookup, method-ID resolution, request encoding, response decode, RPC error mapping, and decode-time auth refresh retry. Takes its `Kernel`, `SessionTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5; the historical `RpcOwner` Protocol was deleted in Wave 4 of session-decoupling). Enters transport through `SessionTransport.perform_authed_post`. |
-| `SessionTransport` | [`_session_transport.py`](../src/notebooklm/_session_transport.py) | Authed POST collaborator. Owns `perform_authed_post()` (loop guard, auth snapshot, request materialization, chain dispatch, queue-wait recording), `refresh_request_for_current_auth()`, and `terminal()` (freshness rebuild + `Kernel.post`). Called directly by `RpcExecutor` and by `chat_aware_authed_post` (ChatAPI's chat-flavoured transport call); the middleware chain leaf at `Session._authed_post_chain_terminal` continues to dispatch through `SessionTransport.terminal` per ADR-014 Rule 4. |
+| `SessionTransport` | [`_session_transport.py`](../src/notebooklm/_session_transport.py) | Authed POST collaborator. Owns `perform_authed_post()` (loop guard, auth snapshot, request materialization, chain dispatch, queue-wait recording), `refresh_request_for_current_auth()`, and `terminal()` (freshness rebuild + `Kernel.post`). Called directly by `RpcExecutor` and by `chat_aware_authed_post` (ChatAPI's chat-flavoured transport call); the middleware chain leaf at `MiddlewareChainHost._authed_post_chain_terminal` continues to dispatch through `SessionTransport.terminal` per ADR-014 Rule 4. |
+| `MiddlewareChainHost` | [`_middleware_chain_host.py`](../src/notebooklm/_middleware_chain_host.py) | Owns the wired middleware chain (`_authed_post_chain`), the chain leaf (`_authed_post_chain_terminal`), the three retry-budget tunables (`_rate_limit_max_retries`, `_server_error_max_retries`, `_refresh_retry_delay`), and the dynamic `await_refresh` delegate that the auth-refresh middleware captures. The chain's provider lambdas and the transport's `chain_provider` closure read the host's attributes live, so post-construction mutation (e.g. tests setting `core._chain_host._rate_limit_max_retries = 0`) still steers the live chain. `Session` references the host as `self._chain_host` but exposes no Session-side aliases. |
 | `AuthRefreshCoordinator` | [`_session_auth.py`](../src/notebooklm/_session_auth.py) | Owns the auth-snapshot lock and the refresh task. Canonical implementation for `AuthRefreshCoordinator.snapshot(host)` and token updates. `Session.update_auth_tokens()` remains a one-line delegate for the `RefreshAuthCore` Protocol; the old `Session._snapshot` delegate was inlined. |
 | `ClientLifecycle` | [`_session_lifecycle.py`](../src/notebooklm/_session_lifecycle.py) | HTTP-client open/close, keepalive task, cookie save coordination. Holds `_timeout`, `_bound_loop`, `_http_client`, `_keepalive_*`. |
 | `MiddlewareChainBuilder` | [`_middleware_chain.py`](../src/notebooklm/_middleware_chain.py) | Constructs the middleware chain in the canonical ADR-009 order. Extracted in Phase 3 PR 7. |
@@ -522,14 +524,18 @@ Concretely, `Session` retains:
    so they cannot become a discoverability hub. Stage B (Wave 7
    follow-up) moves `build_collaborators` ownership to `NotebookLMClient`
    and deletes all three accessors.
-3. **Middleware-chain seams.** `_authed_post_chain_terminal` is the
-   live chain leaf wired by `wire_middleware_chain`. Provider-closure
-   capture targets (`_await_refresh`, `_rate_limit_max_retries`,
-   `_server_error_max_retries`, `_refresh_retry_delay`, `assert_bound_loop`)
-   are reached as `host.X` from `build_session_transport` /
-   `wire_middleware_chain`. Per ADR-014 Rule 4 these stay on
-   `Session` until a `MiddlewareChainHost` collaborator extracts them
-   (Wave 7 follow-up).
+3. **Middleware-chain seams.** The chain leaf
+   (`_authed_post_chain_terminal`), the chain slot (`_authed_post_chain`),
+   the dynamic refresh delegate (`await_refresh`), and the three
+   retry-budget tunables (`_rate_limit_max_retries`,
+   `_server_error_max_retries`, `_refresh_retry_delay`) all live on
+   `MiddlewareChainHost` after the chain-ownership carve-out (ADR-014
+   Rule 4). `wire_middleware_chain` and `build_session_transport` take
+   `chain_host: MiddlewareChainHost` directly and read the host
+   attributes live; tests rebind through `core._chain_host._<attr>`.
+   The only middleware-chain capture target that remains on `Session`
+   is `assert_bound_loop`, which is reached as `host.assert_bound_loop`
+   from `build_session_transport`'s `bound_loop_check` lambda.
 4. **Lifecycle methods.** `open`, `close`, `is_open`, `_keepalive_loop`,
    and `assert_bound_loop` (now a one-line forward to
    `ClientLifecycle.assert_bound_loop` since

--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -59,35 +59,27 @@ lint at PR time.
 | `is_open` (property) | lifecycle | retain — public open-state read |
 | `_keepalive_loop` | lifecycle | retain — background task body; introspected by `test_client_keepalive` |
 | `rpc_call` | public API forward | retain — pinned by `tests/unit/test_public_shims.py:1048-1089` (`NotebookLMClient.rpc_call` forwards through it) |
-| `_authed_post_chain_terminal` (property) | middleware chain leaf | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the canonical seam (a fixture-time rebind via `core._authed_post_chain_terminal = fake_terminal` writes through to `chain_host._authed_post_chain_terminal`, mirroring [`test_observability.py:77`](../tests/unit/test_observability.py)). The host's bound method is wired as the live chain leaf by `_session_init.wire_middleware_chain` (`authed_post_chain_terminal=session._authed_post_chain_terminal`, which resolves through the descriptor to the host). |
-| `_authed_post_chain` (property) | middleware chain leaf | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the canonical seam (a fixture-time rebind via `core._authed_post_chain = fake_chain` writes through to `chain_host._authed_post_chain`, mirroring [`test_authed_post_pipeline.py:113`](../tests/unit/test_authed_post_pipeline.py)). After Stage B2 PR 2 the transport's `chain_provider` closure reads `chain_host._authed_post_chain` directly — see `_session_init.py:408` (`chain_provider=lambda: chain_host._authed_post_chain`); the Session-side descriptor is exclusively the rebind seam. |
-| `_rate_limit_max_retries` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the integration-test seam (mid-flight `core._rate_limit_max_retries = N` writes through to the host so the chain's `rate_limit_max_retries_provider` lambda picks up the new budget on the next attempt). |
-| `_server_error_max_retries` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the same mutation-after-construction contract as `_rate_limit_max_retries`. |
-| `_refresh_retry_delay` (property) | provider-closure capture target | retain — forwards to MiddlewareChainHost (Stage B2 PR 1 of the post-refactoring plan 2026-05-27); the writable @property descriptor preserves the mutation-after-construction contract for both the chain's `refresh_retry_delay_provider` lambda and the executor's `refresh_retry_delay_provider` closure built in `compose_session_internals`. |
-| `_await_refresh` | session-side refresh delegate | retain — forwards to MiddlewareChainHost (test-seam forward; Stage B2 PR 1 routed the body through `MiddlewareChainHost.await_refresh` — dynamic delegation to `host._auth_refresh.await_refresh()` so a fixture rebinding the coordinator still steers the live refresh). Stage B2 PR 2 moved the chain's capture site off this method onto `chain_host.await_refresh` directly (the chain no longer reaches through this Session-side delegate on every refresh) — see [`_session_init.py`](../src/notebooklm/_session_init.py) `wire_middleware_chain` `refresh_callable=chain_host.await_refresh`. The method is retained as a test seam (the long-standing `session._await_refresh` patch point survives — it routes through the host, which dynamically delegates to the coordinator). |
 | `assert_bound_loop` | provider-closure capture target | retain — captured via lambda (`bound_loop_check=lambda: host.assert_bound_loop()`) by `build_session_transport` at [`_session_init.py:395`](../src/notebooklm/_session_init.py); late-bound so a test reassigning `core.assert_bound_loop = mock` still steers the live check |
 | `_get_rpc_semaphore` | provider-closure capture target | retain — passed as `rpc_semaphore_factory=self._get_rpc_semaphore` to `wire_middleware_chain` at [`_session.py:416`](../src/notebooklm/_session.py); has real body (lazy semaphore creation) reading `self._max_concurrent_rpcs` / `self._rpc_semaphore`, not a forward |
 | `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core, lifecycle)` calls `core.update_auth_tokens(...)` from [`_auth/session.py`](../src/notebooklm/_auth/session.py); also referenced in the AST-guard prose at `tests/unit/test_concurrency_refresh_race.py:386` (the guard inspects `AuthRefreshCoordinator.update_auth_tokens` directly, but the Session-side delegate is the Protocol seam) |
 | `update_auth_headers` | RefreshAuthCore Protocol surface | retain — `refresh_auth_session(core, lifecycle)` calls `core.update_auth_headers()` from [`_auth/session.py`](../src/notebooklm/_auth/session.py) |
 | `_bind_transport` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._transport`. Load-bearing after PR 2 — `Session.__init__` leaves `_transport` at `None` and `compose_session_internals` is the single assignment site. |
-| `_bind_chain_metadata` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for the auxiliary chain artifacts (`_chain_builder` / `_middlewares`). Renamed from `_bind_chain` in Stage B2 PR 2 when the `_authed_post_chain` slot moved off Session onto `MiddlewareChainHost` — the chain slot now has exactly one assignment site (`session._authed_post_chain = wired.authed_post_chain`, which writes through the Session descriptor to `chain_host._authed_post_chain`). Load-bearing after Stage B1 PR 2 — `Session.__init__` leaves the metadata slots at `None` and `compose_session_internals` is the single assignment site. |
+| `_bind_chain_metadata` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for the auxiliary chain artifacts (`_chain_builder` / `_middlewares`). The `_authed_post_chain` slot itself is owned by `MiddlewareChainHost` and assigned exactly once by `compose_session_internals` (`chain_host._authed_post_chain = wired.authed_post_chain`); this binder stores only the auxiliary metadata. Load-bearing — `Session.__init__` leaves the metadata slots at `None` and `compose_session_internals` is the single assignment site. |
 | `_bind_executor` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._rpc_executor`. Load-bearing after PR 2 — the lazy `_get_rpc_executor` factory was deleted; `compose_session_internals` is the single assignment site and the binding is never re-nulled by `close()`. |
 | `_require_constructed` | composition guard | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); fail-fast helper used by `rpc_call` / `_get_rpc_semaphore` / `open` / `close` to assert the named binding is non-None. Load-bearing after PR 2 — `Session.__init__` leaves the late-bound slots at `None`, and any caller that exercises a Session outside `compose_session_internals` trips the guard. |
 
-## Stage-A and Rule-4 attribute capture targets (context, not lint-enumerated)
+## Chain-ownership carve-out (closed)
 
-Stage B2 PR 1 of the post-refactoring plan (2026-05-27) moved the
-`_rate_limit_max_retries` / `_server_error_max_retries` /
-`_refresh_retry_delay` tunables off `Session` onto
-:class:`MiddlewareChainHost`. The names still resolve on `Session` —
-via writable `@property` descriptors enumerated in the **Inventory**
-table above — but the storage lives on the host. Reads and writes via
-`session._<attr>` route through the descriptor to the host so the
-chain's `MiddlewareChainBuilder` provider lambdas
-([`_session_init.py:427-429`](../src/notebooklm/_session_init.py))
-continue to dereference `host._<attr>` live and integration-test
-mutation (`session._rate_limit_max_retries = 0`) still steers the live
-chain.
+The chain-ownership carve-out is closed. The retry-budget tunables
+(`_rate_limit_max_retries` / `_server_error_max_retries` /
+`_refresh_retry_delay`), the chain slot (`_authed_post_chain`), the
+chain leaf (`_authed_post_chain_terminal`), and the dynamic
+`_await_refresh` delegate are all owned by `MiddlewareChainHost`
+([`_middleware_chain_host.py`](../src/notebooklm/_middleware_chain_host.py)).
+The chain's `MiddlewareChainBuilder` provider lambdas and the
+transport's `chain_provider` closure read the host attributes live;
+tests rebind through `core._chain_host._<attr>`. There are no
+Session-side aliases or descriptor forwards in front of the host.
 
 ## Follow-up ADR-014 issues
 
@@ -104,22 +96,11 @@ The two follow-up issues filed per ADR-014 close-out (Wave 6 / Task 6.2):
   `MiddlewareChainHost` collaborator owning `_authed_post_chain_terminal` +
   the `_rate_limit_max_retries` / `_server_error_max_retries` /
   `_refresh_retry_delay` tunables; `Session` holds it like any other
-  collaborator. **CLOSED by Stage B2 of the post-refactoring plan
-  (2026-05-27)** — PR 1 (#1090) introduced the host skeleton
-  (`_middleware_chain_host.py`), moved the storage off `Session`, and
-  added the five writable `@property` descriptor forwards
-  (`_authed_post_chain_terminal`, `_authed_post_chain`,
-  `_rate_limit_max_retries`, `_server_error_max_retries`,
-  `_refresh_retry_delay`) plus the `_await_refresh` delegate to preserve
-  the historical test seams. PR 2 (#1092) split
-  `wire_middleware_chain` / `build_session_transport` so they take
-  `chain_host: MiddlewareChainHost` directly and the live chain reads
-  the host (the descriptors are now exclusively a test-seam forward, no
-  longer a load-bearing dereference on the hot path). PR 3 (this doc
-  change) amends ADR-014 Rule 4's retention list to record the five
-  writable descriptors + `_await_refresh` as `test-seam forwards to
-  MiddlewareChainHost` and notes the chain-ownership carve-out in the
-  ADR's revision history.
+  collaborator. **CLOSED** — the host owns the storage and the live chain
+  reads from the host directly. The transitional Session-side writable
+  `@property` descriptors and the `_await_refresh` delegate that
+  preserved the historical test seams during the carve-out have been
+  removed; tests rebind on the host (`core._chain_host._<attr>`).
 
 ## Deleted
 

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -159,8 +159,8 @@ async def _coalesced_run_refresh_cmd(
       survives cancellation of any individual awaiter.
     - Each awaiter wraps the future in ``asyncio.shield`` so local
       cancellation of the awaiter does NOT cancel the shared subprocess —
-      mirrors the ``Session._await_refresh`` pattern used for the RPC
-      refresh path.
+      mirrors the ``AuthRefreshCoordinator.await_refresh`` pattern used
+      for the RPC refresh path.
     - The caller in ``_fetch_tokens_with_refresh`` keeps re-awaiting the
       shielded future under the per-loop asyncio lock so the lock is not
       released until the subprocess settles. This prevents a duplicate

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -98,7 +98,7 @@ class AuthRefreshMiddleware:
 
     - ``refresh_callable``: a zero-arg async callable that drives one
       coalesced auth refresh. Production wires
-      ``lambda: Session._await_refresh(self)`` which delegates to
+      ``chain_host.await_refresh``, which dynamically delegates to
       :meth:`AuthRefreshCoordinator.await_refresh`. The middleware never
       reaches into the coordinator directly; this keeps the seam thin
       and testable.
@@ -117,9 +117,9 @@ class AuthRefreshMiddleware:
       ``host._refresh_callback is not None``).
     - ``refresh_retry_delay``: zero-arg callable returning the
       post-refresh sleep duration. Production wires
-      ``lambda: self._refresh_retry_delay`` so a test that mutates the
-      attr on the live client still takes effect (matches the live-binding
-      contract preserved for retry budgets in PR 12.7).
+      ``lambda: chain_host._refresh_retry_delay`` so a test that mutates
+      the attr on the live host still takes effect (matches the
+      live-binding contract preserved for retry budgets in PR 12.7).
     - ``snapshot_provider``: optional async callable returning a fresh
       :class:`AuthSnapshot` after refresh. Production wires a lambda
       that invokes :meth:`AuthRefreshCoordinator.snapshot` with the

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -1,9 +1,9 @@
 """Composes the ADR-009 middleware chain.
 
 Tier-12 PR 12.2 wired an empty middleware chain around
-``Kernel.post`` through ``Session._authed_post_chain_terminal`` (the shared
-seam covering ``Session._perform_authed_post`` and ``RpcExecutor._execute_once``'s
-call to ``self._owner._perform_authed_post``).
+``Kernel.post`` through ``MiddlewareChainHost._authed_post_chain_terminal``
+(the shared seam covering ``SessionTransport.perform_authed_post`` and
+``RpcExecutor._execute_once``'s dispatch into the transport).
 
 PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
 ``MetricsMiddleware``, PR 12.5 prepended ``DrainMiddleware`` outermost,
@@ -59,9 +59,9 @@ class MiddlewareChainBuilder:
 
     Provider callables (``rate_limit_max_retries_provider`` etc.) are
     used by ``RetryMiddleware`` / ``AuthRefreshMiddleware`` so
-    post-construction mutations on ``Session`` still take effect — the
-    integration-test idiom of poking
-    ``session._rate_limit_max_retries = 0`` must keep working.
+    post-construction mutations on ``MiddlewareChainHost`` still take
+    effect — the integration-test idiom of poking
+    ``core._chain_host._rate_limit_max_retries = 0`` must keep working.
     """
 
     def __init__(
@@ -110,8 +110,8 @@ class MiddlewareChainBuilder:
             # ``async with`` collapses to a no-op for opted-out clients.
             SemaphoreMiddleware(self._rpc_semaphore_factory),
             # Pass callable budgets so post-construction mutation of
-            # ``self._rate_limit_max_retries`` /
-            # ``self._server_error_max_retries`` (an integration-test
+            # ``chain_host._rate_limit_max_retries`` /
+            # ``chain_host._server_error_max_retries`` (an integration-test
             # idiom; production never mutates these) still takes effect —
             # bit-for-bit preserving the pre-PR-12.7 live-binding
             # contract where the retry loop read these attrs LIVE.

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -120,10 +120,11 @@ class MiddlewareChainBuilder:
                 server_error_max_retries=self._server_error_max_retries_provider,
                 metrics=self._metrics,
             ),
-            # AuthRefresh callbacks: ``refresh_callable`` invokes the
-            # same ``_await_refresh`` path the leaf used pre-PR-12.8, so
-            # the coalesced single-flight refresh contract from
-            # ``AuthRefreshCoordinator`` is preserved end-to-end.
+            # AuthRefresh callbacks: ``refresh_callable`` invokes
+            # ``MiddlewareChainHost.await_refresh``, which dynamically
+            # delegates to ``AuthRefreshCoordinator.await_refresh``, so
+            # the coalesced single-flight refresh contract from the
+            # coordinator is preserved end-to-end.
             # ``refresh_callback_enabled_provider`` reads the
             # coordinator's internal callback slot to skip refresh when
             # no callback was configured (matches the legacy

--- a/src/notebooklm/_middleware_chain_host.py
+++ b/src/notebooklm/_middleware_chain_host.py
@@ -1,4 +1,4 @@
-"""Middleware-chain host (Stage B2 PR 1 of the post-refactoring plan).
+"""Middleware-chain host.
 
 The :class:`MiddlewareChainHost` owns the four pieces of state that the
 wired middleware chain reads on every authed POST plus the chain leaf
@@ -13,8 +13,9 @@ itself:
   chain;
 * the chain leaf coroutine (``_authed_post_chain_terminal``) that
   forwards to :meth:`SessionTransport.terminal`;
-* the dynamic refresh delegate (``await_refresh``) that callers reach
-  through :meth:`Session._await_refresh`.
+* the dynamic refresh delegate (``await_refresh``) reached by the
+  middleware chain (``wire_middleware_chain`` captures
+  ``chain_host.await_refresh`` directly).
 
 This module is intentionally narrow:
 
@@ -24,18 +25,13 @@ This module is intentionally narrow:
 * The host has no back-reference to :class:`Session` — it is reachable
   from :class:`Session` (via ``self._chain_host``) but not the other
   way around. This breaks the historical Session ↔ transport cycle the
-  way ADR-014 Rule 4 (post-refactoring plan, Stage B2) anticipated.
+  way ADR-014 Rule 4 anticipated.
 
-Stage B2 PR 1 wires the host into :class:`Session.__init__` and routes
-the five mutable test seams (``_authed_post_chain_terminal``,
-``_authed_post_chain``, ``_rate_limit_max_retries``,
-``_server_error_max_retries``, ``_refresh_retry_delay``) through
-writable ``@property`` descriptors on :class:`Session` that write
-through to the host. Transport / wire signatures are still ``host=
-session`` in PR 1 — providers continue to read ``session._<attr>``
-which now writes through to the host. Stage B2 PR 2 will split
-``build_session_transport`` and ``wire_middleware_chain`` so the chain
-reads from the host directly.
+The transport / wire helpers take the host directly via the
+``chain_host`` parameter; the chain reads ``chain_host._<attr>`` on
+every attempt. Tests that need a mid-flight mutation rebind on the
+host (``core._chain_host._<attr> = ...``); there are no Session-side
+forwards in front of the host.
 """
 
 from __future__ import annotations
@@ -67,17 +63,16 @@ class MiddlewareChainHost:
             the live refresh-and-retry path.
         _rate_limit_max_retries: Budget consumed by the retry middleware
             on 429 responses. Stored on the host (the chain's provider
-            lambda reads ``host._rate_limit_max_retries`` live, so
-            mid-flight rebinding takes effect on the next attempt).
+            lambda reads this attribute live, so mid-flight rebinding
+            takes effect on the next attempt).
         _server_error_max_retries: Budget consumed by the retry
             middleware on 5xx responses. Same live-read contract.
         _refresh_retry_delay: Backoff between refresh-retry attempts
             in the auth-refresh middleware. Same live-read contract.
         _authed_post_chain: The wired middleware chain. ``None`` until
-            :func:`compose_session_internals` assigns it through the
-            :class:`Session` descriptor forward (which writes through
-            to this slot). The transport's ``chain_provider`` lambda
-            reads this attribute every authed POST.
+            :func:`compose_session_internals` assigns it directly here.
+            The transport's ``chain_provider`` lambda reads this
+            attribute every authed POST.
         _transport: The :class:`SessionTransport` collaborator. ``None``
             until :meth:`_bind_transport` fires; after that bind the
             chain leaf (:meth:`_authed_post_chain_terminal`) can forward
@@ -109,18 +104,15 @@ class MiddlewareChainHost:
     async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
         """Middleware-chain leaf — forwards to :meth:`SessionTransport.terminal`.
 
-        Reachable through the :class:`Session` writable descriptor
-        forward (``session._authed_post_chain_terminal`` resolves to
-        this bound method until a test installs a fake terminal via
-        ``session._authed_post_chain_terminal = fake_terminal``; the
-        descriptor's setter writes the fake through to this host so
-        subsequent reads pick it up).
+        Tests that install a fake terminal rebind directly on the host
+        (``core._chain_host._authed_post_chain_terminal = fake_terminal``)
+        and rebuild the chain around the new terminal.
 
         Raises :class:`RuntimeError` if the transport is not yet bound.
         This can only happen if a caller exercised the chain before
         the composition root finished — the fail-fast guard mirrors
         the corresponding :meth:`Session._require_constructed` guard
-        on the Session entry points (introduced in Stage B1 PR 2).
+        on the Session entry points.
         """
         transport = self._transport
         if transport is None:

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -110,13 +110,14 @@ class RetryMiddleware:
     ) -> None:
         # Budgets accept either a static int OR a zero-arg callable. The
         # callable form preserves the historical contract where the retry
-        # loop read ``host._rate_limit_max_retries`` /
-        # ``host._server_error_max_retries`` LIVE, so tests (and any
-        # production tweaks) that mutate those attrs on the core after
-        # ``open()`` still take effect. ``Session.__init__``
-        # wires the callable form via a ``lambda: self._rate_limit_max_retries``
-        # closure; tests that build a middleware in isolation typically pass
-        # the int form.
+        # loop read ``chain_host._rate_limit_max_retries`` /
+        # ``chain_host._server_error_max_retries`` LIVE, so tests (and any
+        # production tweaks) that mutate those attrs on the chain host
+        # after ``open()`` still take effect. ``wire_middleware_chain``
+        # passes the callable form via a
+        # ``lambda: chain_host._rate_limit_max_retries`` closure; tests
+        # that build a middleware in isolation typically pass the int
+        # form.
         self._rate_limit_max = rate_limit_max_retries
         self._server_error_max = server_error_max_retries
         # Late-binding rationale lives on ``_session_helpers.resolve_sleep``;

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -288,11 +288,10 @@ def compose_session_internals(
         cookie_saver=cookie_saver,
         cookie_rotator=cookie_rotator,
     )
-    # Stage B2 PR 1: the :class:`MiddlewareChainHost` owns the retry
-    # tunables, the chain slot, and the chain leaf. It is constructed
-    # BEFORE :class:`Session` so the Session's writable descriptor
-    # forwards (``_rate_limit_max_retries`` etc.) can write through to
-    # the host on the very first assignment inside ``Session.__init__``.
+    # The :class:`MiddlewareChainHost` owns the retry tunables, the
+    # chain slot, and the chain leaf. It is constructed BEFORE
+    # :class:`Session` because :func:`build_session_transport` and
+    # :func:`wire_middleware_chain` both take it as a direct parameter.
     chain_host = MiddlewareChainHost(
         _auth_refresh=collaborators.auth_coord,
         _rate_limit_max_retries=config.rate_limit_max_retries,

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -12,10 +12,6 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ._error_injection import _refuse_synthetic_error_outside_test_context
-from ._middleware import (
-    RpcRequest,
-    RpcResponse,
-)
 from ._middleware_chain_host import MiddlewareChainHost
 from ._rpc_executor import RpcExecutor
 from ._session_config import (
@@ -39,7 +35,7 @@ from .auth import (
 from .types import RpcTelemetryEvent
 
 if TYPE_CHECKING:
-    from ._middleware import Middleware, NextCall
+    from ._middleware import Middleware
     from ._middleware_chain import MiddlewareChainBuilder
     from ._session_init import (
         SessionCollaborators,
@@ -321,46 +317,34 @@ def compose_session_internals(
     # forward to it. Both sides are write-once and bound in this same
     # composition root, so the symmetric bind is safe.
     chain_host._bind_transport(transport)
-    # Stage B2 PR 2 split the historical ``host=session`` parameter
-    # into ``chain_host`` (owns the retry tunables + the
-    # ``await_refresh`` delegate) and an auth-snapshot host (formerly
-    # ``auth_snapshot_host: _AuthRefreshHost`` = the :class:`Session`).
-    # The follow-up "explicit auth-refresh collaborators" change
-    # narrowed the auth-snapshot lookup further: it now passes
-    # ``auth=auth`` (the live :class:`AuthTokens`) directly, because the
-    # coordinator method no longer needs a Session-shaped host (the
-    # ``_AuthRefreshHost`` Protocol that re-declared Session's private
-    # ``auth`` / ``_metrics_obj`` / ``_kernel`` slots was deleted). The
-    # chain leaf still wires to the :class:`Session`-side descriptor
-    # forward (:attr:`_authed_post_chain_terminal`) so a fixture-time
-    # rebind via ``session._authed_post_chain_terminal = fake_terminal``
-    # keeps steering the live chain leaf — the descriptor setter writes
-    # through to ``chain_host._authed_post_chain_terminal``.
+    # The chain leaf wires through ``chain_host._authed_post_chain_terminal``
+    # directly. Tests that need a fake terminal rebind on the host
+    # (``core._chain_host._authed_post_chain_terminal = fake_terminal``);
+    # the chain is rebuilt by the test around that new terminal. The
+    # auth-snapshot lookup passes ``auth=auth`` (the live
+    # :class:`AuthTokens`) directly — the coordinator method takes the
+    # tokens explicitly instead of reaching through a Session-shaped
+    # host (the ``_AuthRefreshHost`` Protocol that re-declared Session's
+    # private slots was deleted).
     wired = wire_middleware_chain(
         config,
         collaborators,
         chain_host=chain_host,
         auth=auth,
-        authed_post_chain_terminal=session._authed_post_chain_terminal,
+        authed_post_chain_terminal=chain_host._authed_post_chain_terminal,
         rpc_semaphore_factory=session._get_rpc_semaphore,
     )
-    # Stage B2 PR 2: the chain slot lives on the host
-    # (``chain_host._authed_post_chain``). It is set ONCE here via the
-    # :class:`Session` descriptor setter, which writes through to the
-    # host slot — that single assignment is the canonical install site.
-    # The transport's ``chain_provider`` lambda reads
-    # ``chain_host._authed_post_chain`` directly (Stage B2 PR 2 signature
-    # split), and the long-standing test pattern
-    # ``session._authed_post_chain = fake_chain`` still steers the live
-    # chain because the descriptor write-through routes the fake into
-    # the same host slot.
-    session._authed_post_chain = wired.authed_post_chain
+    # The chain slot lives on the host (``chain_host._authed_post_chain``)
+    # and is installed exactly once here. The transport's ``chain_provider``
+    # lambda reads ``chain_host._authed_post_chain`` directly on every
+    # authed POST, so a test that swaps the chain via
+    # ``core._chain_host._authed_post_chain = fake_chain`` continues to
+    # steer the live chain.
+    chain_host._authed_post_chain = wired.authed_post_chain
     # ``_bind_chain_metadata`` stores only the auxiliary chain artifacts
-    # (``_chain_builder`` / ``_middlewares``) — it does NOT touch
-    # ``_authed_post_chain`` (the host's slot, assigned via the
-    # descriptor above). This avoids the double-bind ambiguity flagged
-    # in the rev-5 review of the post-refactoring plan: the chain slot
-    # has exactly one assignment site, the descriptor write above.
+    # (``_chain_builder`` / ``_middlewares``) — the chain slot is owned
+    # by the host and assigned above, so this binder has no role in the
+    # canonical install site for ``_authed_post_chain``.
     session._bind_chain_metadata(wired)
     # Lambdas preserve the late-binding contract pinned by
     # ``tests/unit/test_init_order.py``:
@@ -385,7 +369,7 @@ def compose_session_internals(
         sleep=lambda *a, **kw: session._sleep(*a, **kw),
         timeout_provider=lambda: collaborators.lifecycle._timeout,
         refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
-        refresh_retry_delay_provider=lambda: session._refresh_retry_delay,
+        refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
     )
     session._bind_executor(executor)
     return ComposedSession(
@@ -419,30 +403,23 @@ class Session:
     ) -> None:
         """Initialise a Session from a pre-built collaborator bundle.
 
-        Stage B1 PR 2 of the post-refactoring plan inverted the
-        composition root — :class:`Session` no longer constructs the
-        bundle / transport / chain inline. Instead,
-        :func:`compose_session_internals` builds all three, then calls
-        this constructor with the validated config + the bundle + the
-        auth tokens. The transport / chain / executor are written into
-        the late-bound slots by the composition root via the
-        :meth:`_bind_transport` / :meth:`_bind_chain_metadata` /
-        :meth:`_bind_executor` write-once setters (plus the single
-        :attr:`_authed_post_chain` descriptor write that installs the
-        wired chain into the host).
+        :class:`Session` does not construct the bundle / transport /
+        chain inline — :func:`compose_session_internals` builds all
+        three, then calls this constructor with the validated config +
+        the bundle + the auth tokens. The transport / chain / executor
+        are written into the late-bound slots by the composition root
+        via the :meth:`_bind_transport` / :meth:`_bind_chain_metadata`
+        / :meth:`_bind_executor` write-once setters.
 
-        Stage B2 PR 1 added ``chain_host``: the
-        :class:`MiddlewareChainHost` constructed by
-        :func:`compose_session_internals` BEFORE this constructor. The
-        host owns the retry tunables, the installed chain slot, and the
-        chain leaf; :class:`Session` exposes them through writable
-        ``@property`` descriptors that write through to the host (the
-        descriptors are permanent, load-bearing test seams pinned by
-        ``test_observability.py:77`` and ``test_authed_post_pipeline.py:113``).
-        ``self._chain_host = chain_host`` MUST be the first assignment
-        in this constructor because every subsequent ``self._<attr>``
-        write that targets a descriptor-managed name routes through the
-        host — assigning the host last would dereference ``None``.
+        ``chain_host`` is the :class:`MiddlewareChainHost` constructed
+        by :func:`compose_session_internals` BEFORE this constructor.
+        The host owns the retry tunables, the installed chain slot,
+        and the chain leaf; :class:`Session` keeps a reference to it
+        as ``self._chain_host`` so feature code and tests that need
+        to rebind one of those slots can reach the host directly
+        (``core._chain_host._rate_limit_max_retries = N``,
+        ``core._chain_host._authed_post_chain = fake_chain``,
+        ``core._chain_host._authed_post_chain_terminal = fake_terminal``).
 
         Production callers DO NOT instantiate :class:`Session` directly
         — :class:`NotebookLMClient` calls
@@ -463,18 +440,15 @@ class Session:
             chain_host: The :class:`MiddlewareChainHost` constructed by
                 :func:`compose_session_internals` for this session. The
                 host owns the chain leaf, the chain slot, and the three
-                retry-budget tunables; the descriptor forwards below
-                require it.
+                retry-budget tunables.
         """
-        # CHAIN HOST FIRST — the writable descriptors below
-        # (``_authed_post_chain_terminal``, ``_authed_post_chain``,
-        # ``_rate_limit_max_retries``, ``_server_error_max_retries``,
-        # ``_refresh_retry_delay``) all dereference ``self._chain_host``
-        # in their setters and getters, so assigning the host has to
-        # precede any descriptor-managed attribute write. See the
-        # ``Session.__init__ ordering`` section of
-        # ``docs/post-refactoring-plan-2026-05-27.md`` for the
-        # invariant.
+        # ``_chain_host`` owns the retry tunables (``_rate_limit_max_retries``,
+        # ``_server_error_max_retries``, ``_refresh_retry_delay``), the
+        # chain slot (``_authed_post_chain``), and the chain leaf
+        # (``_authed_post_chain_terminal``). :func:`compose_session_internals`
+        # constructed the host with the live values BEFORE this Session
+        # was instantiated, and it remains the canonical owner — there
+        # are no Session-side aliases or descriptor forwards.
         self._chain_host = chain_host
 
         # The seam callables ``_decode_response`` / ``_sleep`` /
@@ -485,17 +459,6 @@ class Session:
         self._decode_response: Callable[..., Any] = config.decode_response
         self._sleep: Callable[[float], Awaitable[Any]] = config.sleep
         self._is_auth_error: Callable[[Exception], bool] = config.is_auth_error
-        # B2 PR 1: ``_rate_limit_max_retries`` / ``_server_error_max_retries``
-        # / ``_refresh_retry_delay`` are no longer stored on Session —
-        # the assignments below route through writable @property
-        # descriptors that write through to ``self._chain_host``. The
-        # chain provider lambdas in :func:`wire_middleware_chain` read
-        # ``host._<attr>`` live (now resolving through the descriptor
-        # to the host) so integration tests that SET them
-        # post-construction continue to steer the live chain.
-        self._rate_limit_max_retries = config.rate_limit_max_retries
-        self._server_error_max_retries = config.server_error_max_retries
-        self._refresh_retry_delay = config.refresh_retry_delay
         self._max_concurrent_rpcs: int | None = config.max_concurrent_rpcs
         # Lazy-created per-instance — see :meth:`_get_rpc_semaphore`.
         self._rpc_semaphore: asyncio.Semaphore | None = None
@@ -526,12 +489,8 @@ class Session:
         # use-before-bind via :meth:`_require_constructed`. Types
         # mirror the corresponding :class:`WiredMiddleware` fields so
         # downstream readers see precise types rather than ``Any``
-        # (claude[bot] review on PR #1089).
-        #
-        # B2 PR 1: ``_authed_post_chain`` slot moved to the host. The
-        # ``_authed_post_chain`` name on :class:`Session` is now a
-        # writable @property descriptor that writes through to
-        # ``self._chain_host._authed_post_chain``.
+        # (claude[bot] review on PR #1089). The ``_authed_post_chain``
+        # slot is owned by ``_chain_host``; it is not duplicated here.
         self._transport: SessionTransport | None = None
         self._chain_builder: MiddlewareChainBuilder | None = None
         self._middlewares: list[Middleware] | None = None
@@ -576,7 +535,7 @@ class Session:
         return self._rpc_semaphore
 
     # ------------------------------------------------------------------
-    # Stage B1 PR 2 — write-once binders + fail-fast guards (live)
+    # Write-once binders + fail-fast guards
     # ------------------------------------------------------------------
     #
     # The three ``_bind_*`` setters below accept exactly one bind per
@@ -586,19 +545,15 @@ class Session:
     # ``_rpc_executor`` at ``None``, so the composition root is the
     # single assignment site for each.
     #
-    # Stage B2 PR 2 renamed ``_bind_chain`` to ``_bind_chain_metadata``:
-    # ``_authed_post_chain`` is no longer a slot on :class:`Session`; it
-    # lives on :class:`MiddlewareChainHost` and is installed by the
-    # composition root via the :class:`Session` descriptor setter
-    # (``session._authed_post_chain = wired.authed_post_chain``), which
-    # writes through to ``chain_host._authed_post_chain``. The binder
-    # below stores only the auxiliary chain artifacts (``_chain_builder``
-    # / ``_middlewares``) so the chain slot has exactly one assignment
-    # site.
+    # ``_authed_post_chain`` is owned by :class:`MiddlewareChainHost`;
+    # the composition root installs it via
+    # ``chain_host._authed_post_chain = wired.authed_post_chain``. The
+    # binder below stores only the auxiliary chain artifacts
+    # (``_chain_builder`` / ``_middlewares``) so the chain slot has
+    # exactly one assignment site.
     #
-    # The legacy lazy ``_get_rpc_executor`` factory was deleted in PR 2;
-    # post-construction the executor is reachable directly via
-    # ``self._rpc_executor`` (and never re-nulled by ``close()`` — see
+    # The executor is reachable directly via ``self._rpc_executor``
+    # (and never re-nulled by ``close()`` — see
     # ``_session_lifecycle.py:close`` for the corresponding contract).
 
     def _bind_transport(self, transport: "SessionTransport") -> None:
@@ -616,25 +571,20 @@ class Session:
     def _bind_chain_metadata(self, wired: "WiredMiddleware") -> None:
         """Write-once setter for the auxiliary chain-metadata artifacts.
 
-        Stage B2 PR 2 of the post-refactoring plan split the chain-slot
-        assignment off this binder: the canonical install site for
-        ``_authed_post_chain`` is now
-        ``session._authed_post_chain = wired.authed_post_chain`` in
-        :func:`compose_session_internals` (which writes through the
-        :class:`Session` descriptor to ``chain_host._authed_post_chain``).
-        This binder is left to store only the *auxiliary* artifacts —
+        The canonical install site for ``_authed_post_chain`` is
+        ``chain_host._authed_post_chain = wired.authed_post_chain`` in
+        :func:`compose_session_internals`. This binder is left to store
+        only the *auxiliary* artifacts —
         :class:`MiddlewareChainBuilder` (introspected by builder-level
         unit tests) and the ``middlewares`` list (introspected by
-        ``test_chain_wiring.test_chain_seeded_with_final_adr_009_ordering``)
-        — so the chain slot has exactly one assignment site. Raises
-        ``RuntimeError`` on a second bind attempt.
+        ``test_chain_wiring.test_chain_seeded_with_final_adr_009_ordering``).
+        Raises ``RuntimeError`` on a second bind attempt.
 
-        The ``_authed_post_chain`` attribute itself remains a mutable
-        seam — the long-standing test pattern of reassigning
-        ``core._authed_post_chain = fake_chain`` post-construction is
-        unaffected because that path routes through the Session-side
-        descriptor setter to the host slot. Only repeated calls to
-        :meth:`_bind_chain_metadata` itself raise.
+        Tests that need to swap the live chain after construction
+        rebind ``core._chain_host._authed_post_chain = fake_chain`` so
+        the transport's ``chain_provider`` lambda picks up the fake on
+        the next authed POST; this binder does not participate in that
+        post-construction rebind path.
         """
         if getattr(self, "_chain_builder", None) is not None:
             raise RuntimeError("Session._chain_metadata already bound")
@@ -777,147 +727,6 @@ class Session:
         (``test_concurrency_refresh_race.test_update_auth_tokens_has_no_await_inside_mutation_block``).
         """
         await self._auth_coord.update_auth_tokens(auth=self.auth, csrf=csrf, session_id=session_id)
-
-    # ------------------------------------------------------------------
-    # Stage B2 PR 1 — writable descriptor forwards to MiddlewareChainHost
-    # ------------------------------------------------------------------
-    #
-    # The five names below (``_authed_post_chain_terminal``,
-    # ``_authed_post_chain``, ``_rate_limit_max_retries``,
-    # ``_server_error_max_retries``, ``_refresh_retry_delay``) plus the
-    # async method :meth:`_await_refresh` are permanent, load-bearing
-    # test seams. ADR-014 Rule 4's retention list records them as
-    # "test-seam forwards to MiddlewareChainHost" once Stage B2 PR 3
-    # lands.
-    #
-    # The setters all *write through* to the host — the historical
-    # tests assign ``core._authed_post_chain_terminal = fake_terminal``
-    # (test_observability.py:77), ``core._authed_post_chain =
-    # fake_chain`` (test_authed_post_pipeline.py:113), and
-    # ``core._rate_limit_max_retries = 0`` (integration tests). After
-    # B2 PR 1 those writes route to ``chain_host.<attr>``, where the
-    # chain's provider lambdas dereference them live — preserving the
-    # mutation-after-construction contract.
-    #
-    # The ``_authed_post_chain_terminal`` setter intentionally does NOT
-    # re-route an already-built chain. ``test_observability.py:82``
-    # follows the assignment with ``core._authed_post_chain =
-    # build_chain(core._middlewares, fake_terminal)`` to rebuild the
-    # chain around the new terminal. The setter's only job is to
-    # accept the write; chain rebuild is the test's responsibility.
-
-    @property
-    def _authed_post_chain_terminal(
-        self,
-    ) -> Callable[[RpcRequest], Awaitable[RpcResponse]]:
-        """Forward to :attr:`MiddlewareChainHost._authed_post_chain_terminal`.
-
-        Resolves to the host's bound method (the live chain leaf that
-        forwards to :meth:`SessionTransport.terminal`) until a test
-        reassigns ``session._authed_post_chain_terminal = fake_terminal``;
-        the setter writes the fake through to the host so subsequent
-        reads via the descriptor pick it up.
-        """
-        return self._chain_host._authed_post_chain_terminal
-
-    @_authed_post_chain_terminal.setter
-    def _authed_post_chain_terminal(
-        self,
-        value: Callable[[RpcRequest], Awaitable[RpcResponse]],
-    ) -> None:
-        # Writes through so ``test_observability.py:77`` can install a
-        # fake terminal on the host. The setter does NOT re-route an
-        # already-built chain — chain rebuild is the test's job (see
-        # the ``build_chain`` call at line 82 of that test).
-        # ``method-assign`` covers shadowing the dataclass's async
-        # method with a plain callable; ``assignment`` covers the
-        # ``Awaitable``/``Coroutine`` return-type variance between the
-        # descriptor's value annotation and the host's declared
-        # ``async def`` signature.
-        self._chain_host._authed_post_chain_terminal = value  # type: ignore[method-assign,assignment]
-
-    @property
-    def _authed_post_chain(self) -> "NextCall | None":
-        """Forward to :attr:`MiddlewareChainHost._authed_post_chain`.
-
-        Stage B2 PR 2 switched the transport's ``chain_provider``
-        closure to ``lambda: chain_host._authed_post_chain`` — it now
-        reads the host slot directly rather than going through this
-        descriptor. A ``session._authed_post_chain = fake_chain`` write
-        still keeps steering the live transport because the descriptor
-        setter below writes through to the same host slot the transport
-        reads.
-        """
-        return self._chain_host._authed_post_chain
-
-    @_authed_post_chain.setter
-    def _authed_post_chain(self, value: "NextCall | None") -> None:
-        # Writes through so ``test_authed_post_pipeline.py:113`` can
-        # install a fake chain on the host.
-        self._chain_host._authed_post_chain = value
-
-    @property
-    def _rate_limit_max_retries(self) -> int:
-        """Forward to :attr:`MiddlewareChainHost._rate_limit_max_retries`."""
-        return self._chain_host._rate_limit_max_retries
-
-    @_rate_limit_max_retries.setter
-    def _rate_limit_max_retries(self, value: int) -> None:
-        # Writes through so the chain's
-        # ``rate_limit_max_retries_provider`` lambda picks up the new
-        # budget on the next attempt (integration tests SET this
-        # mid-flight at ``test_max_concurrent_rpcs.py``).
-        self._chain_host._rate_limit_max_retries = value
-
-    @property
-    def _server_error_max_retries(self) -> int:
-        """Forward to :attr:`MiddlewareChainHost._server_error_max_retries`."""
-        return self._chain_host._server_error_max_retries
-
-    @_server_error_max_retries.setter
-    def _server_error_max_retries(self, value: int) -> None:
-        # Writes through so the chain's
-        # ``server_error_max_retries_provider`` lambda picks up the new
-        # budget on the next attempt.
-        self._chain_host._server_error_max_retries = value
-
-    @property
-    def _refresh_retry_delay(self) -> float:
-        """Forward to :attr:`MiddlewareChainHost._refresh_retry_delay`."""
-        return self._chain_host._refresh_retry_delay
-
-    @_refresh_retry_delay.setter
-    def _refresh_retry_delay(self, value: float) -> None:
-        # Writes through so both the chain's
-        # ``refresh_retry_delay_provider`` lambda AND the executor's
-        # ``refresh_retry_delay_provider`` closure (built in
-        # :func:`compose_session_internals`) pick up the new delay on
-        # the next refresh wave.
-        self._chain_host._refresh_retry_delay = value
-
-    async def _await_refresh(self) -> None:
-        """Run / join the shared refresh task via :class:`MiddlewareChainHost`.
-
-        Stage B2 PR 1 routed this delegate through the host —
-        :meth:`MiddlewareChainHost.await_refresh` looks up the
-        coordinator's ``await_refresh`` method dynamically on every
-        call, preserving the long-standing pattern where a fixture
-        rebinds the coordinator's behavior to inject a fake refresh.
-        The single-flight semantics, lock contract, and
-        :func:`asyncio.shield` cancellation handling all still live
-        inside :meth:`AuthRefreshCoordinator.await_refresh`.
-
-        After Stage B2 PR 2, the middleware chain no longer captures
-        this method — :func:`wire_middleware_chain` now captures
-        ``chain_host.await_refresh`` directly so the refresh path skips
-        the Session-side descriptor on every call. This Session-side
-        method is retained as a test seam (the long-standing
-        ``session._await_refresh`` patch point survives — it routes
-        through the host, which dynamically delegates to the
-        coordinator) and as a stable name the
-        ``docs/session-method-retention.md`` invariant pins.
-        """
-        await self._chain_host.await_refresh()
 
     async def rpc_call(
         self,

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -368,14 +368,11 @@ def build_session_transport(
     through a live-binding ``chain_provider`` closure that reads
     ``chain_host._authed_post_chain`` on every authed POST; that
     attribute is assigned by :func:`compose_session_internals`
-    immediately after :func:`wire_middleware_chain` returns, via the
-    :class:`Session` descriptor that writes through to the host. Using a
+    immediately after :func:`wire_middleware_chain` returns. Using a
     provider closure (rather than a frozen reference) preserves the
     pre-extraction behavior where tests reassign
-    ``core._authed_post_chain = fake_chain`` to install a fake chain and
-    expect the next call to honor it — that write routes through the
-    descriptor to ``chain_host._authed_post_chain``, which this lambda
-    re-reads on the next dispatch.
+    ``core._chain_host._authed_post_chain = fake_chain`` to install a
+    fake chain and expect the next call to honor it.
 
     The ``snapshot_provider`` closure passes ``host.auth`` (re-read on
     every call) to :meth:`AuthRefreshCoordinator.snapshot` so the
@@ -391,11 +388,9 @@ def build_session_transport(
     Session fixture (which sets ``_lifecycle`` to a MagicMock) still
     short-circuits the guard.
 
-    Stage B2 PR 2 of the post-refactoring plan added the explicit
-    ``chain_host`` parameter so the chain-slot lookup no longer goes
-    through ``host._authed_post_chain`` (the :class:`Session` descriptor
-    forward) — going through the host directly removes the descriptor
-    indirection on the hot path.
+    The ``chain_host`` parameter lets the chain-slot lookup go through
+    the host directly, with no Session-side indirection on the hot
+    path.
 
     The ``logger`` is forwarded as-is — typically the module logger of
     ``notebooklm._session`` — so transport-error log lines keep
@@ -426,16 +421,14 @@ def wire_middleware_chain(
     """Construct the :class:`MiddlewareChainBuilder`, build the seven-middleware
     list, and wire the final chain via :func:`build_chain`.
 
-    Stage B2 PR 2 of the post-refactoring plan split the historical
-    ``host: Session`` parameter into two narrower hosts:
+    Two narrow host parameters:
 
     * ``chain_host`` — the :class:`MiddlewareChainHost` owns the three
       retry-budget tunables (``_rate_limit_max_retries`` /
       ``_server_error_max_retries`` / ``_refresh_retry_delay``) plus the
       dynamic-delegate refresh entry point (:meth:`await_refresh`). The
       tunable provider lambdas and the ``refresh_callable`` reference
-      capture this host directly so the chain does not depend on the
-      :class:`Session`'s descriptor forwards.
+      capture this host directly.
     * ``auth`` — the live :class:`AuthTokens` collaborator passed
       explicitly to :meth:`AuthRefreshCoordinator.snapshot` on every
       call. The provider lambda captures this object by reference; the
@@ -451,14 +444,13 @@ def wire_middleware_chain(
       construction), so it no longer needs a host-shaped collaborator
       for the metric either.
 
-    Post-construction mutation on ``chain_host._<attr>`` (or on
-    ``session._<attr>``, which writes through the descriptor to the
-    host) still takes effect through the middleware live-binding
-    contract documented in :class:`MiddlewareChainBuilder`. The
-    ``rpc_semaphore_factory`` is passed in explicitly so the helper does
-    not need to know that the live semaphore lives on
-    ``Session._get_rpc_semaphore`` — that surface stays on Session
-    because the semaphore is per-loop session state (not chain state).
+    Post-construction mutation on ``chain_host._<attr>`` still takes
+    effect through the middleware live-binding contract documented in
+    :class:`MiddlewareChainBuilder`. The ``rpc_semaphore_factory`` is
+    passed in explicitly so the helper does not need to know that the
+    live semaphore lives on ``Session._get_rpc_semaphore`` — that
+    surface stays on Session because the semaphore is per-loop session
+    state (not chain state).
     """
     # ADR-009 chain construction. PR history, leaf exception shape,
     # and ``RpcRequest.context`` contract live in

--- a/src/notebooklm/_session_transport.py
+++ b/src/notebooklm/_session_transport.py
@@ -17,39 +17,32 @@ pieces of the authed POST hot path that used to live on :class:`Session`:
   the request envelope, dispatches it through the wired middleware
   chain, and records the semaphore queue-wait latency.
 
-``Session`` keeps :meth:`Session._authed_post_chain_terminal`,
-:meth:`Session._refresh_request_for_current_auth`, and
-:meth:`Session._perform_authed_post` as one-line forwards to the
-collaborator so the long-standing call surfaces (``RpcOwner`` Protocol,
-``core._perform_authed_post(...)`` direct callers, and the test-side
-``core._authed_post_chain_terminal = fake`` monkeypatch point) keep
-working unchanged. The two AST guards in
-``tests/unit/test_concurrency_refresh_race.py`` follow the source by
-inspecting the collaborator methods directly — the Session forwards
-carry only the dispatch hop, so there is no try/await structure on the
-Session side for those guards to inspect after the move.
-
-``_refresh_retry_delay`` deliberately stays on :class:`Session`.
-``perform_authed_post`` does not read it — the retry/backoff budget for
-the refresh path is owned by ``AuthRefreshMiddleware`` and by
+:class:`MiddlewareChainHost` owns the chain leaf
+(:meth:`MiddlewareChainHost._authed_post_chain_terminal`), the chain
+slot (``chain_host._authed_post_chain``), and the three retry-budget
+tunables (``_rate_limit_max_retries`` / ``_server_error_max_retries`` /
+``_refresh_retry_delay``). ``perform_authed_post`` does not read the
+retry-delay directly — the retry/backoff budget for the refresh path
+is owned by ``AuthRefreshMiddleware`` and by
 ``RpcExecutor.try_refresh_and_retry``, both of which read
-``host._refresh_retry_delay`` live through provider lambdas wired in
-``_session_init.wire_middleware_chain``. Integration tests that assign
-``client._session._refresh_retry_delay = 0`` keep steering the live
-delay without migration.
+``chain_host._refresh_retry_delay`` live through provider lambdas wired
+in ``_session_init.wire_middleware_chain``. Integration tests that
+assign ``client._session._chain_host._refresh_retry_delay = 0`` keep
+steering the live delay.
 
-Construction order in :class:`Session.__init__`:
+Construction order in :func:`compose_session_internals`:
 :func:`notebooklm._session_init.build_session_transport` constructs the
 transport **before** :func:`wire_middleware_chain`. The wired chain
-leaf is :meth:`Session._authed_post_chain_terminal` (a one-line forward
-to :meth:`SessionTransport.terminal`) — wiring through the Session
-forward preserves the canonical seam for a subclass override or
-fixture-time class-level monkeypatch of that method. The chain itself
-is reached by the transport through an injected ``chain_provider``
-closure that reads ``host._authed_post_chain`` live, late on every
+leaf is :meth:`MiddlewareChainHost._authed_post_chain_terminal` (a
+one-line forward to :meth:`SessionTransport.terminal`) — wiring through
+the host preserves the canonical fixture-rebind seam (tests that
+swap the chain leaf or the chain itself rebind on the host directly).
+The chain itself is reached by the transport through an injected
+``chain_provider`` closure that reads
+``chain_host._authed_post_chain`` live, late on every
 :meth:`perform_authed_post` call; this both breaks the construction
 cycle and preserves the long-standing test pattern of reassigning
-``core._authed_post_chain`` to install a fake chain. The
+``core._chain_host._authed_post_chain`` to install a fake chain. The
 :class:`AuthRefreshCoordinator` snapshot is reached via an injected
 ``snapshot_provider`` callable so :class:`SessionTransport` never has
 to hold a direct back-reference to :class:`Session`.
@@ -91,16 +84,17 @@ class SessionTransport:
 
     Owns the three methods extracted from :class:`Session` in move #4c.
     Does NOT own lifecycle (that stays on :class:`ClientLifecycle`) nor
-    retry/refresh budget state (that stays on :class:`Session` and is
-    threaded into middleware via provider lambdas).
+    retry/refresh budget state (that lives on
+    :class:`MiddlewareChainHost` and is threaded into middleware via
+    provider lambdas).
 
     The chain reference is fetched late on every
     :meth:`perform_authed_post` — just before chain dispatch, after
     snapshot + materialization — through the injected ``chain_provider``
-    closure (typically ``lambda: host._authed_post_chain``). The lookup
-    is intentionally deferred so a chain reassignment that happens
-    while the snapshot capture awaits still steers the dispatch,
-    matching the pre-extraction behavior where ``self._authed_post_chain``
+    closure (typically ``lambda: chain_host._authed_post_chain``). The
+    lookup is intentionally deferred so a chain reassignment that
+    happens while the snapshot capture awaits still steers the
+    dispatch, matching the pre-extraction behavior where the chain
     was read at the dispatch site.
 
     The injected ``logger`` is held so error messages mapped through
@@ -123,13 +117,14 @@ class SessionTransport:
         self._kernel = kernel
         self._snapshot_provider = snapshot_provider
         # Live-binding chain accessor. The wired chain is installed onto
-        # :class:`Session` AFTER :class:`SessionTransport` is constructed
-        # (the chain's leaf is :meth:`terminal`, so the transport must
-        # exist first). Tests also reassign ``core._authed_post_chain``
-        # post-construction to install a fake chain — going through a
-        # provider closure (called late in :meth:`perform_authed_post`)
-        # ensures those reassignments take effect on the next call
-        # without any further mutation here.
+        # :class:`MiddlewareChainHost` AFTER :class:`SessionTransport`
+        # is constructed (the chain's leaf is :meth:`terminal`, so the
+        # transport must exist first). Tests also reassign
+        # ``core._chain_host._authed_post_chain`` post-construction to
+        # install a fake chain — going through a provider closure
+        # (called late in :meth:`perform_authed_post`) ensures those
+        # reassignments take effect on the next call without any
+        # further mutation here.
         self._chain_provider = chain_provider
         self._metrics = metrics
         self._bound_loop_check = bound_loop_check
@@ -302,17 +297,17 @@ class SessionTransport:
         #
         # Chain resolution is deferred to here — AFTER snapshot capture +
         # materialization, immediately before dispatch — so a reassignment
-        # of ``host._authed_post_chain`` that lands while the snapshot
-        # call awaits still steers this dispatch. Pre-extraction, the
-        # equivalent ``self._authed_post_chain(request)`` read happened
-        # at the dispatch site for the same live-binding reason; the
-        # provider closure preserves that timing.
+        # of ``chain_host._authed_post_chain`` that lands while the
+        # snapshot call awaits still steers this dispatch. Pre-extraction,
+        # the equivalent read happened at the dispatch site for the same
+        # live-binding reason; the provider closure preserves that timing.
         chain = self._chain_provider()
         if chain is None:  # pragma: no cover - wiring bug guard
             raise RuntimeError(
                 "SessionTransport.perform_authed_post called before the "
-                "wired chain was installed on Session; Session construction "
-                "must assign self._authed_post_chain before any authed POST."
+                "wired chain was installed on MiddlewareChainHost; the "
+                "composition root must assign chain_host._authed_post_chain "
+                "before any authed POST."
             )
         try:
             result = await chain(request)

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -29,10 +29,10 @@ and :mod:`tests._lint.test_no_core_imports`):
   that carried it moved to the **Deleted** section at the bottom of
   the retention doc (which the parser scopes out).
 
-The lint enumerates methods only — not instance attributes like
-``Session._rate_limit_max_retries`` (those are assigned in ``__init__`` and
-documented in the "Stage-A and Rule-4 attribute capture targets" section of
-the retention doc for context).
+The lint enumerates methods only — not instance attributes. The
+retry-budget tunables and chain-leaf slots live on
+:class:`MiddlewareChainHost` (reached as ``core._chain_host._<attr>``),
+not on Session.
 """
 
 from __future__ import annotations

--- a/tests/integration/concurrency/test_max_concurrent_rpcs.py
+++ b/tests/integration/concurrency/test_max_concurrent_rpcs.py
@@ -282,7 +282,7 @@ async def test_slot_held_across_retry_middleware_retries(
 
     core = await _open_core_with_transport(transport, max_concurrent_rpcs=1)
     # Force fast retry so the test finishes promptly even on a slow box.
-    core._rate_limit_max_retries = 3
+    core._chain_host._rate_limit_max_retries = 3
 
     try:
         results = await asyncio.gather(

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -84,7 +84,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
 
     # NotebookLMClient default — NO ``rate_limit_max_retries`` kwarg.
     client = NotebookLMClient(auth_tokens)
-    assert client._session._rate_limit_max_retries == 3, (
+    assert client._session._chain_host._rate_limit_max_retries == 3, (
         "rate_limit_max_retries default must be 3; check that NotebookLMClient.__init__ "
         "forwards the Session default."
     )
@@ -117,7 +117,7 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._session._rate_limit_max_retries == 3
+    assert client._session._chain_host._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
@@ -206,7 +206,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._session._rate_limit_max_retries == 3
+    assert client._session._chain_host._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post

--- a/tests/integration/concurrency/test_refresh_cancellation_propagation.py
+++ b/tests/integration/concurrency/test_refresh_cancellation_propagation.py
@@ -1,7 +1,8 @@
 """shielded shared refresh task survives waiter cancellation.
 
 Regression test for the cancellation-propagation bug at
-``src/notebooklm/_core.py:_await_refresh``: prior to the fix, a caller
+``AuthRefreshCoordinator.await_refresh`` (reached today through
+``MiddlewareChainHost.await_refresh``): prior to the fix, a caller
 cancelled via ``asyncio.wait_for(timeout=...)`` while
 ``await self._refresh_task`` was pending would propagate the
 ``CancelledError`` into the *shared* refresh task itself, taking down
@@ -72,19 +73,20 @@ async def _opened_core(refresh_callback):
 async def test_waiter_cancellation_does_not_kill_shared_refresh():
     """Cancelling one waiter must not cancel the shared refresh task.
 
-    Two coroutines call ``_await_refresh()`` concurrently. The first is
-    wrapped in ``asyncio.wait_for(timeout=0.01)`` so it gets cancelled
-    while the gated refresh callback is still blocked. The second
-    coroutine continues awaiting the shared task. After the callback is
-    released, the second coroutine must observe a successful refresh
-    (no ``CancelledError`` leaking from the shared task).
+    Two coroutines call ``chain_host.await_refresh()`` concurrently.
+    The first is wrapped in ``asyncio.wait_for(timeout=0.01)`` so it
+    gets cancelled while the gated refresh callback is still blocked.
+    The second coroutine continues awaiting the shared task. After the
+    callback is released, the second coroutine must observe a
+    successful refresh (no ``CancelledError`` leaking from the shared
+    task).
 
     Pre-fix (unshielded ``await self._refresh_task``): the cancelled
     waiter's ``CancelledError`` propagates into the shared task,
     cancelling it; the second waiter raises ``CancelledError``.
     Post-fix (``await asyncio.shield(self._refresh_task)``): the
     cancelled waiter unwinds locally; the shared task completes; the
-    second waiter resolves to ``None`` (``_await_refresh`` returns
+    second waiter resolves to ``None`` (the refresh entry point returns
     ``None`` on success).
     """
     callback_entered = asyncio.Event()
@@ -118,13 +120,13 @@ async def test_waiter_cancellation_does_not_kill_shared_refresh():
         # we never release until both callers are joined, so #1 is
         # guaranteed to time out.
         async def cancelled_waiter():
-            await asyncio.wait_for(core._await_refresh(), timeout=0.01)
+            await asyncio.wait_for(core._chain_host.await_refresh(), timeout=0.01)
 
         # Caller #2: plain await — represents a parallel 401 retry path
         # that should observe a successful shared refresh regardless of
         # what happens to caller #1.
         async def surviving_waiter():
-            return await core._await_refresh()
+            return await core._chain_host.await_refresh()
 
         task1 = asyncio.create_task(cancelled_waiter())
         task2 = asyncio.create_task(surviving_waiter())
@@ -155,8 +157,8 @@ async def test_waiter_cancellation_does_not_kill_shared_refresh():
         )
 
         # Release the gate. The shared task should complete successfully
-        # and caller #2 should resolve to ``None`` (``_await_refresh``
-        # returns None on success).
+        # and caller #2 should resolve to ``None`` (the refresh entry
+        # point returns None on success).
         release_refresh.set()
         result = await asyncio.wait_for(task2, EVENT_TIMEOUT_S)
 
@@ -206,7 +208,7 @@ async def test_refresh_task_slot_not_cleared_on_waiter_cancellation():
     async with _opened_core(refresh_callback=cb) as core:
 
         async def cancelled_waiter():
-            await asyncio.wait_for(core._await_refresh(), timeout=0.01)
+            await asyncio.wait_for(core._chain_host.await_refresh(), timeout=0.01)
 
         task = asyncio.create_task(cancelled_waiter())
         await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -124,7 +124,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     client = await _build_client_for_test()
     # Eliminate the post-refresh retry delay so the test runs fast.
-    client._session._refresh_retry_delay = 0
+    client._session._chain_host._refresh_retry_delay = 0
 
     # Track whether refresh_auth ran. We wrap the bound method so the
     # mutation is observable from outside the test. Using ``list[object]``

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -49,7 +49,7 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Override retry delay for faster tests
-        client._session._refresh_retry_delay = 0
+        client._session._chain_host._refresh_retry_delay = 0
 
         # Track refresh calls
         refresh_calls = []
@@ -103,7 +103,7 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._session._refresh_retry_delay = 0
+        client._session._chain_host._refresh_retry_delay = 0
 
         refresh_calls = []
 
@@ -152,7 +152,7 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._session._refresh_retry_delay = 0.1  # 100ms delay
+        client._session._chain_host._refresh_retry_delay = 0.1  # 100ms delay
 
         async def mock_refresh():
             return auth
@@ -197,7 +197,7 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._session._refresh_retry_delay = 0
+        client._session._chain_host._refresh_retry_delay = 0
 
         async def failing_refresh():
             # Simulates refresh_auth detecting redirect to login

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -123,7 +123,7 @@ class TestErrorPaths:
         # has ONE interaction; with the default retry budget the client would
         # ask for a second cassette response that doesn't exist and VCR would
         # raise ``CannotOverwriteExistingCassetteException``.
-        client._session._rate_limit_max_retries = 0
+        client._session._chain_host._rate_limit_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_429_rate_limit.yaml") as cassette:
             async with client:
@@ -163,7 +163,7 @@ class TestErrorPaths:
         # is exercised separately by the unit tests in
         # ``test_rate_limit_retry.py`` — here we focus on the terminal
         # exception-mapping branch.
-        client._session._server_error_max_retries = 0
+        client._session._chain_host._server_error_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_500_server.yaml") as cassette:
             async with client:
@@ -202,7 +202,7 @@ class TestErrorPaths:
         client = NotebookLMClient(_synthetic_auth())
         # Eliminate the post-refresh retry delay so the test runs fast under
         # replay (mirrors ``test_auth_refresh_vcr.py``).
-        client._session._refresh_retry_delay = 0
+        client._session._chain_host._refresh_retry_delay = 0
 
         # In-process refresh callback that issues NO HTTP traffic. This is
         # what lets the cassette capture only the TWO synthetic batchexecute

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -128,7 +128,7 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
         captured.append(request)
         return RpcResponse(response=_ok_response(), context=request.context)
 
-    core._chain_host._authed_post_chain = fake_chain  # type: ignore[method-assign]
+    core._chain_host._authed_post_chain = fake_chain
 
     calls: list[AuthSnapshot] = []
 

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -128,7 +128,7 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
         captured.append(request)
         return RpcResponse(response=_ok_response(), context=request.context)
 
-    core._authed_post_chain = fake_chain  # type: ignore[method-assign]
+    core._chain_host._authed_post_chain = fake_chain  # type: ignore[method-assign]
 
     calls: list[AuthSnapshot] = []
 
@@ -170,7 +170,7 @@ async def test_perform_authed_post_populates_request_envelope_for_chain() -> Non
 async def test_chain_reads_live_retry_budget(monkeypatch):
     """Tier-12 PR 12.7 lifted the 429 / 5xx retry loop into ``RetryMiddleware``.
 
-    The middleware reads ``self._rate_limit_max_retries`` on the host LIVE
+    The middleware reads ``chain_host._rate_limit_max_retries`` LIVE
     (via the callable factory the chain seed installs) so a test that
     mutates the budget AFTER ``open()`` still takes effect — preserving
     the pre-PR-12.7 contract where the retry loop read the same attr live.
@@ -183,7 +183,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
     try:
         # Mutate AFTER open() — middleware reads via lambda closure so this
         # bump from 0 → 1 grants a single retry on the next chain call.
-        core._rate_limit_max_retries = 1
+        core._chain_host._rate_limit_max_retries = 1
         sleeps: list[float] = []
 
         async def fake_sleep(seconds: float) -> None:

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -1,11 +1,12 @@
-"""Integration tests for the authed-post middleware chain wired into ``Session``.
+"""Integration tests for the authed-post middleware chain.
 
-The Tier-12/13 greenfield migration wires
-:func:`notebooklm._middleware.build_chain` into :meth:`Session.__init__`.
-The chain leaf (:meth:`Session._authed_post_chain_terminal`) consumes the
-populated ``RpcRequest.url`` / ``headers`` / ``body`` envelope and delegates
-directly to ``Kernel.post`` — the transport seam under both
-:meth:`SessionTransport.perform_authed_post` AND
+:func:`notebooklm._middleware.build_chain` is wired by
+:func:`compose_session_internals` against the chain leaf on
+:class:`MiddlewareChainHost`
+(:meth:`MiddlewareChainHost._authed_post_chain_terminal`), which
+consumes the populated ``RpcRequest.url`` / ``headers`` / ``body``
+envelope and delegates directly to ``Kernel.post`` — the transport
+seam under both :meth:`SessionTransport.perform_authed_post` AND
 ``RpcExecutor._execute_once``. The ``Session._perform_authed_post``
 compatibility forward was deleted in Wave 11c of session-decoupling;
 tests now drive the canonical collaborator method directly.
@@ -183,7 +184,7 @@ async def test_chain_terminal_reads_context_keys() -> None:
         },
     )
 
-    result = await core._authed_post_chain_terminal(request)
+    result = await core._chain_host._authed_post_chain_terminal(request)
 
     assert isinstance(result, RpcResponse)
     assert result.response is expected_response
@@ -220,7 +221,7 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
         },
     )
 
-    await core._authed_post_chain_terminal(request)
+    await core._chain_host._authed_post_chain_terminal(request)
 
     assert fake.call_count == 1
     assert fake.calls[0]["url"] == "https://fake/no-retry-flag"
@@ -249,7 +250,7 @@ async def test_chain_terminal_log_label_defaults_for_direct_calls() -> None:
     )
 
     with pytest.raises(TransportServerError, match="<unknown-chain-call> network error"):
-        await core._authed_post_chain_terminal(request)
+        await core._chain_host._authed_post_chain_terminal(request)
 
 
 @pytest.mark.asyncio
@@ -329,7 +330,7 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
     # terminal. This per-test composition validates the leaf's contract
     # against ``build_chain`` without mutating ``Session.__init__``'s
     # production chain.
-    chain: NextCall = build_chain([observer], core._authed_post_chain_terminal)
+    chain: NextCall = build_chain([observer], core._chain_host._authed_post_chain_terminal)
 
     request = RpcRequest(
         url="https://fake/observe",
@@ -355,8 +356,8 @@ def test_build_chain_empty_returns_terminal_unchanged() -> None:
     """:func:`build_chain` returns the terminal unchanged when ``middlewares`` is empty.
 
     Pins the contract that ``_middleware.build_chain([], terminal) is terminal``
-    so :meth:`Session.__init__`'s ``self._authed_post_chain is
-    self._authed_post_chain_terminal`` invariant from
+    so the ``chain_host._authed_post_chain is
+    chain_host._authed_post_chain_terminal`` invariant from
     :func:`test_chain_is_empty_by_default` does not silently flip if
     ``build_chain``'s identity behavior changes. Synchronous test —
     no event-loop overhead.

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -234,25 +234,26 @@ def test_compose_session_internals_preserves_late_binding_for_sleep() -> None:
 
 
 def test_compose_session_internals_preserves_late_binding_for_refresh_retry_delay() -> None:
-    """Post-construction ``session._refresh_retry_delay = X`` MUST be seen
+    """Post-construction ``chain_host._refresh_retry_delay = X`` MUST be seen
     by the executor's ``refresh_retry_delay_provider`` lambda on the next
     call.
 
-    The plan's "Design Invariants" section explicitly calls out this
-    contract: ``client._session._refresh_retry_delay = 0`` continues to
-    steer the live chain after construction. The lambda
-    ``refresh_retry_delay_provider=lambda: session._refresh_retry_delay``
+    The integration-test contract is that
+    ``client._session._chain_host._refresh_retry_delay = 0`` continues
+    to steer the live chain after construction. The lambda
+    ``refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay``
     re-reads the attribute on every invocation, so this is a live binding,
     not a frozen snapshot.
     """
     composed = compose_session_internals(auth=_make_auth())
 
+    chain_host = composed.session._chain_host
     # The provider lambda must dereference the *current* attribute on
     # each call — not the value captured at construction time.
-    initial = composed.session._refresh_retry_delay
+    initial = chain_host._refresh_retry_delay
     assert composed.executor._refresh_retry_delay_provider() == initial
 
-    composed.session._refresh_retry_delay = 0.99
+    chain_host._refresh_retry_delay = 0.99
     assert composed.executor._refresh_retry_delay_provider() == 0.99
 
 
@@ -309,17 +310,12 @@ def test_bind_transport_raises_on_double_bind() -> None:
 def test_bind_chain_metadata_raises_on_double_bind() -> None:
     """:meth:`_bind_chain_metadata` accepts exactly one bind.
 
-    Same shape as :func:`test_bind_transport_raises_on_double_bind`:
-    Stage B1 PR 2 moved chain wiring into
-    :func:`compose_session_internals`, so re-driving the binder after
-    composition raises. Stage B2 PR 2 renamed ``_bind_chain`` to
-    ``_bind_chain_metadata`` because the ``_authed_post_chain`` slot
-    moved off Session onto :class:`MiddlewareChainHost` — the binder
-    now stores only the auxiliary chain artifacts (``_chain_builder``
-    / ``_middlewares``) and the chain slot has exactly one assignment
-    site (`session._authed_post_chain = wired.authed_post_chain`,
-    which writes through the Session descriptor to
-    ``chain_host._authed_post_chain``).
+    Re-driving the binder after composition raises. The binder stores
+    only the auxiliary chain artifacts (``_chain_builder`` /
+    ``_middlewares``); the chain slot itself lives on
+    :class:`MiddlewareChainHost` and is assigned exactly once by the
+    composition root (``chain_host._authed_post_chain =
+    wired.authed_post_chain``).
     """
     composed = compose_session_internals(auth=_make_auth())
 
@@ -330,7 +326,7 @@ def test_bind_chain_metadata_raises_on_double_bind() -> None:
     wired = WiredMiddleware(
         chain_builder=composed.session._chain_builder,
         middlewares=composed.session._middlewares,
-        authed_post_chain=composed.session._authed_post_chain,
+        authed_post_chain=composed.session._chain_host._authed_post_chain,
     )
     with pytest.raises(RuntimeError, match="_chain_metadata already bound"):
         composed.session._bind_chain_metadata(wired)

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -99,12 +99,10 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
     would let a concurrent refresh change the cookie jar between request
     rebuild and wire send.
 
-    The terminal body lives on :meth:`SessionTransport.terminal` after
-    move #4c — ``Session._authed_post_chain_terminal`` is now a one-line
-    forward to it, so the AST guard must inspect the collaborator method
-    that carries the actual body. The error messages still mention
-    ``Session._authed_post_chain_terminal`` as the conceptual entry point
-    because that is still where chain-leaf callers reach the behavior.
+    The terminal body lives on :meth:`SessionTransport.terminal`; the
+    chain leaf (:meth:`MiddlewareChainHost._authed_post_chain_terminal`)
+    forwards to it. The AST guard inspects the collaborator method
+    that carries the actual body.
     """
     src = textwrap.dedent(inspect.getsource(SessionTransport.terminal))
     tree = ast.parse(src)
@@ -133,7 +131,7 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
     found_try = _find_first_try(func)
     assert found_try is not None, (
         "Could not locate the ``try:`` block guarding the POST in "
-        "Session._authed_post_chain_terminal. Update this guard to match."
+        "SessionTransport.terminal. Update this guard to match."
     )
 
     def is_post_await(node):
@@ -190,7 +188,7 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
     post_await_position = min(post_await_positions, default=None)
     assert post_await_position is not None, (
         "Could not locate `await ...post(...)` in the try body of "
-        "Session._authed_post_chain_terminal. If the call site was refactored (e.g. to "
+        "SessionTransport.terminal. If the call site was refactored (e.g. to "
         "``client.request(...)``), update this guard to match — the "
         "invariant is 'no await between snapshot read and the POST per "
         "iteration', not specifically the `.post` attribute."
@@ -202,7 +200,7 @@ def test_kernel_post_terminal_has_no_await_before_post_per_attempt():
         if isinstance(n, ast.Await) and (n.lineno, n.col_offset) < post_await_position
     ]
     assert not earlier_awaits, (
-        f"Session._authed_post_chain_terminal gained an await before the per-attempt POST "
+        f"SessionTransport.terminal gained an await before the per-attempt POST "
         f"at {post_await_position}: "
         f"{[(n.lineno, ast.dump(n)) for n in earlier_awaits]}. "
         "This breaks the snapshot-invariant — auth state could be mutated "

--- a/tests/unit/test_middleware_chain_host.py
+++ b/tests/unit/test_middleware_chain_host.py
@@ -1,12 +1,11 @@
-"""Stage B2 PR 2 — :class:`MiddlewareChainHost` live-binding contract.
+""":class:`MiddlewareChainHost` live-binding contract.
 
 The host owns the chain leaf, the chain slot, the three retry-budget
 tunables, and the dynamic ``await_refresh`` delegate. The chain's
 provider lambdas and the transport's ``chain_provider`` lambda both
-capture the host directly (Stage B2 PR 2 signature split), so the
-long-standing post-construction mutation patterns are now load-bearing
-on the host itself rather than on :class:`Session`. These tests pin
-that contract end-to-end:
+capture the host directly, so post-construction mutation patterns
+are load-bearing on the host itself. These tests pin that contract
+end-to-end:
 
 * ``chain_host._rate_limit_max_retries = 0`` mid-flight steers the live
   retry budget (the :class:`RetryMiddleware` provider lambda reads the
@@ -14,15 +13,16 @@ that contract end-to-end:
 * ``chain_host._auth_refresh.await_refresh = fake`` rebind steers the
   live refresh path (dynamic delegation via
   :meth:`MiddlewareChainHost.await_refresh`).
-* ``core._authed_post_chain = fake_chain`` writes through to
-  ``chain_host._authed_post_chain``; the transport's ``chain_provider``
-  lambda returns ``fake_chain`` on the next call.
-* ``core._authed_post_chain_terminal = fake_terminal`` writes through to
-  the host (mirrors the ``test_observability.py:77`` pattern).
+* ``chain_host._authed_post_chain = fake_chain`` installs a fake chain
+  that the transport's ``chain_provider`` lambda returns on the next
+  call.
+* ``chain_host._authed_post_chain_terminal = fake_terminal`` installs
+  a fake chain leaf (mirrors the ``test_observability.py`` rebind
+  pattern).
 
 The first two tests drive a real chain through
 :meth:`SessionTransport.perform_authed_post`; the last two assert the
-write-through descriptor contract without a live chain.
+host-side rebind contract without a live chain.
 """
 
 from __future__ import annotations
@@ -106,13 +106,12 @@ def _status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPSta
 async def test_chain_host_rate_limit_max_retries_steers_live_chain(monkeypatch) -> None:
     """Mid-flight ``chain_host._rate_limit_max_retries = N`` steers the retry budget.
 
-    Pins the Stage B2 PR 2 contract: the :class:`RetryMiddleware`'s
+    Pins the contract: the :class:`RetryMiddleware`'s
     ``rate_limit_max_retries`` provider lambda (built by
     :func:`wire_middleware_chain`) captures the host directly and reads
     ``chain_host._rate_limit_max_retries`` LIVE on every attempt. A test
     that bumps the budget AFTER ``open()`` still takes effect on the
-    next chain call — preserving the pre-Stage-B2 contract where the
-    provider lambda read ``session._rate_limit_max_retries``.
+    next chain call.
 
     Drives the chain via :meth:`SessionTransport.perform_authed_post`
     so the assertion exercises the production seam used by
@@ -122,9 +121,9 @@ async def test_chain_host_rate_limit_max_retries_steers_live_chain(monkeypatch) 
     chain_host = core._chain_host
     await core.open()
     try:
-        # Mutate the host slot directly (Stage B2 PR 2: the provider
-        # lambda captures chain_host, NOT session). The bump from
-        # 0 -> 1 grants a single retry on the next chain call.
+        # Mutate the host slot directly — the provider lambda captures
+        # chain_host. The bump from 0 -> 1 grants a single retry on
+        # the next chain call.
         chain_host._rate_limit_max_retries = 1
         sleeps: list[float] = []
 
@@ -205,26 +204,23 @@ async def test_chain_host_auth_refresh_rebind_steers_live_refresh() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 3 — core._authed_post_chain writes through to host slot;
-#          transport's chain_provider returns the new chain on next call
+# Test 3 — chain_host._authed_post_chain steers the transport's chain_provider
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_authed_post_chain_write_through_to_host_steers_transport() -> None:
-    """``core._authed_post_chain = fake_chain`` writes through to the host slot.
+async def test_authed_post_chain_on_host_steers_transport() -> None:
+    """``chain_host._authed_post_chain = fake_chain`` steers the live transport.
 
-    The :class:`Session` descriptor setter writes through to
-    ``chain_host._authed_post_chain``. The transport's
-    ``chain_provider`` lambda (built in :func:`build_session_transport`
-    after Stage B2 PR 2) captures the host directly and reads
-    ``chain_host._authed_post_chain`` on every authed POST, so a
+    The transport's ``chain_provider`` lambda (built in
+    :func:`build_session_transport`) captures the host directly and
+    reads ``chain_host._authed_post_chain`` on every authed POST, so a
     post-construction fake-chain install reaches the next dispatch
     without any further mutation.
 
-    Mirrors the ``test_authed_post_pipeline.py:113`` pattern but exists
-    at this level to pin the host-side write-through contract
-    independently of the larger pipeline test.
+    Mirrors the ``test_authed_post_pipeline.py`` rebind pattern but
+    exists at this level to pin the host-side contract independently
+    of the larger pipeline test.
     """
     core = _make_core()
     chain_host = core._chain_host
@@ -235,13 +231,11 @@ async def test_authed_post_chain_write_through_to_host_steers_transport() -> Non
         captured.append(request)
         return RpcResponse(response=_ok_response("fake-chain"), context=request.context)
 
-    # Assignment goes through the :class:`Session` descriptor setter,
-    # which writes through to ``chain_host._authed_post_chain``.
-    core._authed_post_chain = fake_chain  # type: ignore[method-assign]
+    # Install the fake chain directly on the host — there is no
+    # Session-side alias.
+    chain_host._authed_post_chain = fake_chain
 
-    # The Session descriptor read MUST resolve to the host slot.
-    assert core._authed_post_chain is fake_chain
-    # The host slot itself MUST hold the fake chain.
+    # The host slot holds the fake chain.
     assert chain_host._authed_post_chain is fake_chain
 
     # The transport's chain_provider lambda must return the fake on
@@ -257,7 +251,7 @@ async def test_authed_post_chain_write_through_to_host_steers_transport() -> Non
 
         response = await core._transport.perform_authed_post(
             build_request=build,
-            log_label="test-chain-write-through",
+            log_label="test-chain-host-steers-transport",
         )
 
         # The fake chain produced the response — proves the transport's
@@ -272,30 +266,19 @@ async def test_authed_post_chain_write_through_to_host_steers_transport() -> Non
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — core._authed_post_chain_terminal writes through to host
-#          (mirrors test_observability.py:77 pattern)
+# Test 4 — chain_host._authed_post_chain_terminal can be rebound directly
 # ---------------------------------------------------------------------------
 
 
-def test_authed_post_chain_terminal_write_through_to_host() -> None:
-    """``core._authed_post_chain_terminal = fake`` writes through to the host.
+def test_authed_post_chain_terminal_on_host_is_rebindable() -> None:
+    """``chain_host._authed_post_chain_terminal = fake`` installs a fake terminal.
 
-    Mirrors the ``test_observability.py:77`` pattern: a test reassigns
-    the chain leaf via the :class:`Session` descriptor setter to install
-    a fake terminal; the setter writes the value through to
-    ``chain_host._authed_post_chain_terminal``. Subsequent reads via
-    either the descriptor (``core._authed_post_chain_terminal``) or the
-    host slot directly (``chain_host._authed_post_chain_terminal``)
-    resolve to the fake.
-
-    The setter intentionally does NOT re-route an already-built chain —
-    ``test_observability.py:82`` follows the assignment with
-    ``core._authed_post_chain = build_chain(core._middlewares,
-    fake_terminal)`` to rebuild the chain around the new terminal. The
-    setter's only job is to accept the write; chain rebuild is the
-    test's responsibility. This test only asserts the write-through
-    contract; chain rebuild integration is covered by
-    ``test_observability.py``.
+    Mirrors the ``test_observability.py`` rebind pattern: a test
+    swaps the chain leaf on the host and rebuilds the chain around
+    the new terminal (``chain_host._authed_post_chain =
+    build_chain(core._middlewares, fake_terminal)``). This test only
+    asserts the host-side rebind contract; chain-rebuild integration
+    is covered by ``test_observability.py``.
     """
     auth = MagicMock()
     auth.storage_path = None
@@ -309,24 +292,18 @@ def test_authed_post_chain_terminal_write_through_to_host() -> None:
     async def fake_terminal(request: RpcRequest) -> RpcResponse:
         return RpcResponse(response=_ok_response("fake-terminal"), context=request.context)
 
-    # Assignment goes through the :class:`Session` descriptor setter,
-    # which writes through to ``chain_host._authed_post_chain_terminal``.
-    core._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
-
-    # Both surfaces must resolve to the fake.
-    assert core._authed_post_chain_terminal is fake_terminal
+    # Rebind directly on the host.
+    chain_host._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
     assert chain_host._authed_post_chain_terminal is fake_terminal
 
 
-def test_chain_host_tunable_descriptor_read_after_write() -> None:
-    """Session-side descriptor reads reflect host-side mutations.
+def test_chain_host_tunable_attributes_are_writable() -> None:
+    """The chain-host retry-budget attributes accept post-construction writes.
 
-    Stage B2 PR 2 makes the chain's provider lambdas capture the host
-    directly, so a write to ``chain_host._refresh_retry_delay`` (or
-    siblings) is visible through both surfaces — the host slot
-    directly, and the :class:`Session` descriptor that forwards to it.
-    Pins both directions so future refactors cannot break the read /
-    write symmetry between the two surfaces.
+    The chain's provider lambdas capture the host directly, so a
+    write to ``chain_host._refresh_retry_delay`` (or siblings) is
+    visible to the live chain on the next attempt. Pins the
+    plain-attribute contract on :class:`MiddlewareChainHost`.
     """
     auth = MagicMock()
     auth.storage_path = None
@@ -337,18 +314,16 @@ def test_chain_host_tunable_descriptor_read_after_write() -> None:
     core = build_session_for_tests(auth=auth)
     chain_host = core._chain_host
 
-    # Write through host -> read through Session descriptor.
     chain_host._refresh_retry_delay = 0.5
     chain_host._rate_limit_max_retries = 7
     chain_host._server_error_max_retries = 11
-    assert core._refresh_retry_delay == 0.5
-    assert core._rate_limit_max_retries == 7
-    assert core._server_error_max_retries == 11
+    assert chain_host._refresh_retry_delay == 0.5
+    assert chain_host._rate_limit_max_retries == 7
+    assert chain_host._server_error_max_retries == 11
 
-    # Write through Session descriptor -> read through host slot.
-    core._refresh_retry_delay = 1.25
-    core._rate_limit_max_retries = 2
-    core._server_error_max_retries = 3
+    chain_host._refresh_retry_delay = 1.25
+    chain_host._rate_limit_max_retries = 2
+    chain_host._server_error_max_retries = 3
     assert chain_host._refresh_retry_delay == 1.25
     assert chain_host._rate_limit_max_retries == 2
     assert chain_host._server_error_max_retries == 3

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -76,12 +76,12 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
             context=request.context,  # type: ignore[attr-defined]
         )
 
-    core._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
+    core._chain_host._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
     # Rebuild the chain so it wraps the new terminal (the original chain
-    # was built in ``__init__`` against the original bound method).
+    # was built in the composition root against the original bound method).
     from notebooklm._middleware import build_chain
 
-    core._authed_post_chain = build_chain(core._middlewares, fake_terminal)
+    core._chain_host._authed_post_chain = build_chain(core._middlewares, fake_terminal)
 
     with correlation_id("batch-42"):
         result = await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])

--- a/tests/unit/test_session_compat_delegates.py
+++ b/tests/unit/test_session_compat_delegates.py
@@ -17,17 +17,17 @@ structural protocol caller, a Protocol-imposed call site, or an
 established test-seam swap point that would require its own follow-up
 to migrate:
 
-    Middleware-chain seam (ADR-014 Rule 4, retained on Session by design)
-        _await_refresh — captured via ``refresh_callable=host._await_refresh``
-        in ``wire_middleware_chain``; deleting it would break the chain
-        wiring. (``RpcOwner`` Protocol was deleted in Wave 4 of session-decoupling
-        when ``RpcExecutor`` migrated to direct collaborator dependencies.)
-
     External Protocol surface (``RefreshAuthCore`` in ``_auth/session.py``)
         update_auth_tokens
 
     Feature-facing Protocol surface (``RpcCaller`` in ``_session_contracts.py``)
         rpc_call
+
+The middleware-chain refresh seam (formerly ``Session._await_refresh``)
+was removed when :class:`MiddlewareChainHost` took ownership of the
+chain wiring; ``wire_middleware_chain`` now captures
+``chain_host.await_refresh`` directly, and tests reach the refresh
+entry point through ``core._chain_host.await_refresh()``.
 
 A delegate body must be at most three top-level statements with at
 least one outbound collaborator call AND no forbidden control-flow
@@ -54,10 +54,10 @@ from notebooklm._session import Session
 # load-bearing test seam still resolves them. See module docstring for
 # the per-method rationale; the deleted ones (``_build_url``,
 # ``_raise_rpc_error_from_http_status``, ``_raise_rpc_error_from_request_error``,
-# ``_try_refresh_and_retry``, ``_snapshot``) were inlined when their
-# external callers migrated to the canonical collaborator method.
+# ``_try_refresh_and_retry``, ``_snapshot``, ``_await_refresh``) were
+# inlined or moved when their external callers migrated to the
+# canonical collaborator method.
 _DELEGATE_METHODS = [
-    "_await_refresh",
     "rpc_call",
     "update_auth_tokens",
 ]
@@ -160,13 +160,10 @@ def test_session_retains_adr_014_rule_4_middleware_chain_seams() -> None:
     """ADR-014 Rule 4 retention list: Session keeps the surfaces the
     middleware-chain wiring + downstream Protocol consumers depend on.
 
-    These names were previously the ``RpcOwner`` Protocol surface (deleted
-    in Wave 4 of the session-decoupling plan when ``RpcExecutor`` migrated
-    to direct collaborator dependencies). They remain on Session because:
-
-    - ``_await_refresh`` — captured by ``wire_middleware_chain`` as
-      ``refresh_callable=host._await_refresh``.
-    - ``_kernel`` — Session owns the transport core (instance attribute).
+    The chain-host extraction moved the middleware-chain seams off
+    Session onto :class:`MiddlewareChainHost`. Session keeps the
+    chain host as ``_chain_host`` and the transport core as
+    ``_kernel`` so feature code and tests can reach them.
 
     Wave 11b of session-decoupling deleted the ``_increment_metrics`` /
     ``metrics_snapshot`` / ``_emit_rpc_event`` / ``record_upload_queue_wait``
@@ -178,16 +175,19 @@ def test_session_retains_adr_014_rule_4_middleware_chain_seams() -> None:
     there are no remaining production callers of the Session-level
     forward.
     """
-    for name in ("_await_refresh",):
-        assert hasattr(Session, name), f"Session missing Rule-4 retained member: {name}"
-        assert callable(getattr(Session, name)), f"Session.{name} not callable"
-
+    from notebooklm._middleware_chain_host import MiddlewareChainHost
     from notebooklm.auth import AuthTokens
 
     core = build_session_for_tests(
         AuthTokens(cookies={"SID": "sid"}, csrf_token="csrf", session_id="sid"),
     )
     assert hasattr(core, "_kernel"), "Session missing Rule-4 retained member: _kernel"
+    assert isinstance(core._chain_host, MiddlewareChainHost), (
+        "Session must expose ``_chain_host`` as a ``MiddlewareChainHost`` "
+        "instance — chain wiring (``wire_middleware_chain``) and tests "
+        "reach the chain leaf / chain slot / retry tunables / refresh "
+        "delegate through it."
+    )
 
 
 def test_session_keeps_drain_tracker_seam() -> None:


### PR DESCRIPTION
## Summary

- Delete the five writable `@property` descriptor forwards on
  `Session` (`_authed_post_chain_terminal`, `_authed_post_chain`,
  `_rate_limit_max_retries`, `_server_error_max_retries`,
  `_refresh_retry_delay`) plus the `_await_refresh` delegate. The host
  is now the sole owner; the composition root and tests address it
  directly (`chain_host._authed_post_chain = ...`,
  `core._chain_host._<attr> = ...`, `core._chain_host.await_refresh()`).
- Migrate every in-tree call site: the composition root in `_session.py`,
  the executor's `refresh_retry_delay_provider` lambda, all production
  middleware doc comments, the chain-host module docstring, and 16
  test files (`tests/unit/test_observability.py`,
  `tests/unit/test_authed_post_pipeline.py`,
  `tests/unit/test_middleware_chain_host.py`,
  `tests/unit/test_composition_primitives.py`,
  `tests/unit/test_chain_wiring.py`,
  `tests/unit/test_session_compat_delegates.py`,
  `tests/unit/test_concurrency_refresh_race.py`,
  `tests/integration/test_error_paths_vcr.py`,
  `tests/integration/test_auth_refresh_vcr.py`,
  `tests/integration/test_auto_refresh.py`,
  `tests/integration/concurrency/test_max_concurrent_rpcs.py`,
  `tests/integration/concurrency/test_rate_limit_default.py`,
  `tests/integration/concurrency/test_refresh_cancellation_propagation.py`).
- Drop the descriptor rows from
  [`docs/session-method-retention.md`](docs/session-method-retention.md);
  the Inventory shrinks by six rows and a new Deleted sub-section
  records the carve-out close-out. Drop `_await_refresh` from
  `_DELEGATE_METHODS` in
  [`tests/unit/test_session_compat_delegates.py`](tests/unit/test_session_compat_delegates.py);
  the retained-seam test now asserts `Session._chain_host` is a
  `MiddlewareChainHost` instance.
- Update
  [`docs/adr/0014-feature-local-runtime-adapters.md`](docs/adr/0014-feature-local-runtime-adapters.md)
  to close the Rule 4 chain-ownership carve-out (Session retains only
  the `_chain_host` reference; the descriptor / delegate row is gone)
  and add a revision-history entry.

## Verification

```bash
uv run pytest tests/unit tests/integration -q   # 6000 unit + 726 int passing (50 + 2 skipped)
uv run pytest tests/_lint -q                    # 77 passing
uv run mypy src/notebooklm --ignore-missing-imports
```

Per-attribute grep verification:

```bash
rg "\b(self|core|session|client\._session)\._(authed_post_chain|authed_post_chain_terminal|await_refresh|rate_limit_max_retries|server_error_max_retries|refresh_retry_delay)\b" tests src/notebooklm
```

Returns only legitimate non-Session matches: `AuthRefreshMiddleware._refresh_retry_delay`
(production middleware's own constructor-injected callable) and
`_StubRpcOwner._refresh_retry_delay` in
`tests/unit/test_rpc_executor.py` (test stub's own attribute). No
Session-side reach-through remains.

## Test plan

- [ ] CI green on Linux + macOS
- [ ] Lint suite green (`tests/_lint`)
- [ ] mypy clean (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [ ] Manual smoke: `core._chain_host._rate_limit_max_retries = 0` /
      `core._chain_host._authed_post_chain = fake_chain` /
      `core._chain_host._authed_post_chain_terminal = fake_terminal` /
      `await core._chain_host.await_refresh()` all continue to steer
      the live chain through the existing provider-lambda capture sites.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture and design records to reflect the middleware chain ownership and wiring changes.

* **Refactor**
  * Moved middleware chain and retry/refresh tunables to a dedicated host component; no changes to public APIs or user-facing behavior.

* **Tests**
  * Updated tests and integration scenarios to align with the new composition/wiring model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->