### PR TITLE
docs(adr): add ADR-015 JSON envelope contract for post-parse Click exceptions

### DIFF
--- a/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
+++ b/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
@@ -1,0 +1,236 @@
+# ADR-015: Typed JSON error envelope covers post-parse `ClickException` failures
+
+## Status
+
+Accepted.
+
+## Context
+
+The CLI ships a stable error contract for automation: under `--json` (or
+`--json-output`), every fatal command path emits a *typed JSON error envelope*
+on stdout — a flat object of the shape
+
+```json
+{ "error": true, "code": "<STABLE_CODE>", "message": "<human text>", ...extras }
+```
+
+— and the process exits with the corresponding code from the table in
+[`docs/cli-exit-codes.md`](../cli-exit-codes.md). The canonical implementation
+is `_output_error(...)` in
+[`src/notebooklm/cli/error_handler.py`](../../src/notebooklm/cli/error_handler.py).
+
+That contract was clear for library exceptions (`AuthError`, `RateLimitError`,
+`ValidationError`, ...). It was **not** clear for `click.ClickException` and
+its subclasses (`click.UsageError`, `click.BadParameter`, and bare
+`ClickException`), because `handle_errors(...)` deliberately re-raises them
+unmodified at
+[`src/notebooklm/cli/error_handler.py:257-259`](../../src/notebooklm/cli/error_handler.py).
+Click then renders its own `Usage: ... / Error: ...` prose to stderr and exits
+with its class-level `exit_code` (`2` for `UsageError`/`BadParameter`, `1` for
+the base `ClickException`).
+
+Two different sites raise `ClickException` subclasses, and they behave
+identically at the Click level but mean very different things to a caller:
+
+- **Parse-time** raises happen *before* the command body runs. Click's own
+  parser raises `UsageError`/`BadParameter` when argv fails option/type
+  validation (e.g. `--limit foo` where `--limit` is `IntRange`, an unknown
+  flag, a missing required argument). The command function has not been
+  invoked; `handle_errors(...)` is not yet on the stack; `--json` may have
+  been *typed* on the command line but the parser never finished resolving
+  it, so the caller's expectation of a JSON envelope is structurally
+  impossible to honour from inside Click's parser.
+- **Post-parse** raises happen *inside* the command body or the service
+  layer it calls, after argv parsing succeeded and after the `--json` flag's
+  value is bound in `click.Context.params`. These are validation decisions
+  the program itself made — flag-combination conflicts, computed
+  preconditions, file-format checks — that happen to be expressed by
+  raising a `ClickException` subclass instead of one of the library
+  exception types. They reach the re-raise branch at `error_handler.py:257`
+  and skip the envelope.
+
+The CLI audit (`.sisyphus/plans/cli-audit-2026-05-27.md`, the **P1#2
+"command-body `UsageError`/`BadParameter` bypass"** finding at lines 54-90)
+enumerated post-parse raise sites that ride this bypass:
+
+- `src/notebooklm/cli/services/download.py:257` — `--include` / `--exclude`
+  conflict
+- `src/notebooklm/cli/services/generate.py:394` — `--style custom` requires
+  `--style-prompt`
+- `src/notebooklm/cli/research_cmd.py:158` — `--cited-only` requires
+  `--import-all`
+- `src/notebooklm/cli/source_cmd.py:626` — `--cited-only` requires
+  `--import-all`
+- `src/notebooklm/cli/chat_cmd.py:193` — `--new` mutually exclusive with
+  `--conversation-id`
+- `src/notebooklm/cli/generate_cmd.py:57` — language-code validation
+
+For each of these, `<cmd> ... --json` exits `2` with Click's usage text on
+stderr and **no JSON on stdout**. Automation branching on
+`json.loads(stdout)` (the published recipe in `docs/cli-exit-codes.md`)
+breaks. The meta-audit (`.sisyphus/plans/cli-audit-2026-05-27-audit.md`)
+reframed the finding in three ways that matter here:
+
+- **C1** declared the contract decision a stop-sentinel: no implementation
+  PR should reshape these sites until the contract is decided and recorded,
+  because two of the candidate fix shapes (route through the envelope
+  vs. waive `ClickException` from `--json` entirely) drive contradictory
+  patches.
+- **C3** widened the layer attribution: the same shape exists in service
+  modules (`cli/services/generate.py:383, 394, 396, 398`,
+  `cli/services/download.py:257, 259, 261`,
+  `cli/services/source_mutations.py:18`), so any contract decision applies
+  to both command and service code.
+- **I1** corrected the audit's claim that `docs/cli-exit-codes.md` was
+  "internally ambiguous". The doc was **silent** on post-parse
+  `UsageError`: line 52's table row describes Click re-raising its own
+  exceptions, line 64's JSON section describes envelopes for library
+  exceptions enumerated above, and the doc never crosses the two. This ADR
+  fills that gap.
+
+## Decision
+
+Under `--json` (or `--json-output`), **every post-parse
+`click.ClickException`-subclass failure raised from a command body or from
+the service layer it calls emits the typed JSON error envelope** defined in
+[`docs/cli-exit-codes.md`](../cli-exit-codes.md), exits with the
+corresponding standard code, and writes no usage text to stderr.
+
+Concretely:
+
+1. **Parse-time `ClickException` is unchanged.** Click's parser keeps raising
+   `UsageError` / `BadParameter` / `ClickException` for argv-level
+   validation failures; Click keeps rendering its own
+   `Usage: ... / Error: ...` text on stderr and exiting `2`
+   (`UsageError` / `BadParameter`) or `1` (base `ClickException`). The
+   re-raise at
+   [`src/notebooklm/cli/error_handler.py:257-259`](../../src/notebooklm/cli/error_handler.py)
+   stays. No JSON envelope is emitted in this case, because `handle_errors`
+   has not yet been entered when the parser fires.
+2. **Post-parse `ClickException` flows through the typed envelope.**
+   Command bodies and service-layer code that wish to signal a validation
+   failure under the JSON contract MUST NOT raise
+   `click.UsageError` / `click.BadParameter` / `click.ClickException`
+   directly; they must instead call `output_error(...)` from
+   `cli.error_handler` (or raise a library `ValidationError` /
+   `ConfigurationError` that `handle_errors(...)` already maps onto the
+   envelope). The natural code for a flag-combination or precondition
+   conflict is `VALIDATION_ERROR` (exit `1`); the existing exit-code table
+   in `docs/cli-exit-codes.md` lists the full mapping. No new error-code
+   keys are introduced by this ADR.
+3. **The wire shape is unchanged.** Envelopes remain the flat object
+   `{ "error": true, "code": "<CODE>", "message": "<text>", ...extras }`
+   already produced by `_output_error`. Callers that already parse
+   `json.loads(stdout)` and branch on `code` need no migration.
+4. **The text-mode contract is preserved.** When `--json` is *not* set,
+   post-parse validation failures still surface a human-readable message
+   on stderr and exit with the corresponding standard code. For sites
+   refactored under rule 2, the message comes from `output_error(...)`
+   rather than Click's `Usage: ... / Error: ...` formatter, so it omits
+   the command-usage footer; this is the smallest user-visible delta
+   consistent with rule 2. Allowlisted sites (rule 5) keep Click's
+   formatter unchanged.
+5. **Allowlist for residual `ClickException` raises.** A small number of
+   sites are correctly raising `ClickException` subclasses today and
+   should keep doing so — they sit on input-validation boundaries before
+   the command produces any output, and matching Click's own
+   parser-style error rendering is the right UX (e.g. UTF-8 / file-read
+   validation in `cli/input.py`, profile-name argument validation in
+   `cli/profile_cmd.py`, entity-ID argument validation in `cli/resolve.py`,
+   shared profile-name validation in `cli/services/login/profile_targets.py`).
+   These are tracked exhaustively by
+   `ALLOWED_CLICK_EXCEPTION_SITES` in
+   [`src/notebooklm/cli/error_handler.py`](../../src/notebooklm/cli/error_handler.py)
+   and pinned by `tests/_lint/test_error_handler_allowlist.py`. New sites
+   require an allowlist entry with a justification; the default for any
+   *other* post-parse validation failure is rule 2.
+
+## Consequences
+
+**Wanted:**
+
+- `--json` is a reliable machine contract for every command-body failure.
+  Automation branching on `json.loads(stdout)` and `code` works for
+  validation conflicts the same way it already works for `RATE_LIMITED`
+  and `AUTH_ERROR`.
+- `docs/cli-exit-codes.md` is no longer silent on post-parse `UsageError`,
+  which closes meta-audit item I1 and removes a class of "but the docs
+  said..." reports.
+- Command and service code converges on one error-emission path
+  (`output_error(...)` / library exceptions through `handle_errors(...)`),
+  which composes cleanly with the `cli/services/` extraction pattern in
+  [ADR-008](./0008-cli-services-extraction-pattern.md). Service modules no
+  longer need to choose between raising Click exceptions (skips the
+  envelope) and importing `output_error` (couples to the CLI layer); the
+  ADR-008 boundary becomes the right place to enforce typed-outcome
+  returns. Service-layer convergence work referenced under meta-audit C3
+  lands as separate per-site PRs that cite this ADR.
+- Tests can assert the envelope shape with the existing JSON-purity sweeps
+  (`tests/unit/test_json_error_exit.py`, `tests/unit/test_json_stdout_purity.py`)
+  by adding error-path argv cases for the previously-bypassed sites; no
+  new test infrastructure is required.
+
+**Unwanted:**
+
+- Some post-parse failures previously rendered with Click's
+  `Usage: ... / Error: ...` footer. Under rule 4, text-mode output for
+  those sites loses the usage footer in exchange for a consistent stderr
+  message. The audit considers this an acceptable trade because the
+  usage-footer convention is for argv-shape errors, and post-parse
+  failures are semantic-shape errors that already explain themselves in
+  the message body.
+- Exit codes for post-parse failures shift from `2` (Click's
+  `UsageError.exit_code`) to `1` (the standard `VALIDATION_ERROR` exit).
+  This is intentional: `2` is reserved for system/unexpected errors and
+  the parse-time path; a flag-combination failure is a user/application
+  error and belongs at `1`. Scripts that branched on `?==2` after a
+  post-parse `UsageError` would have been confusing "bad argv" with "bad
+  combination" anyway; the new code is unambiguous.
+- The ADR creates a permanent split between parse-time and post-parse
+  `ClickException` handling. Reviewers must apply rule 2 when adding new
+  validation in command/service code, and reviewers must apply rule 1
+  when changing Click parser configuration. The split is documented here
+  so the next reviewer does not re-litigate it.
+- Pattern A and Pattern B service-layer sites enumerated by meta-audit C4
+  (~10 modules) still need follow-up PRs to actually route through the
+  envelope; this ADR records the contract but does not in itself move any
+  code. Each follow-up PR cites this ADR and removes one site from the
+  bypass.
+
+## Alternatives considered
+
+- **Waive `ClickException` subclasses from `--json` entirely; document the
+  exception.** Rejected. This freezes the audit-flagged behaviour as
+  contractual: callers using `--json` for automation still cannot rely on
+  JSON output for command-body validation failures, and the doc would
+  have to enumerate which validations are "covered" and which are not.
+  The matrix is unstable as new commands are added, and the audit's P1
+  ranking specifically calls out automation breakage as the
+  highest-impact user-facing issue (meta-audit C2).
+- **Convert every `ClickException` raise to a library `ValidationError`.**
+  Rejected as a contract decision (but accepted as one valid *fix shape*
+  per site). Some current `ClickException` sites are genuinely argv-level
+  (the allowlisted ones in rule 5 of the Decision); forcing them through
+  `ValidationError` would surface less-helpful messages to interactive
+  users. The decision is "route through the envelope", not "stop using
+  Click exceptions"; the allowlist exists precisely so each site can
+  choose the right shape.
+- **Plumb `json_output` into every service helper and have each call
+  `output_error(..., json_output=...)` directly from the helper.**
+  Rejected as the *primary* contract shape (it would couple service
+  modules to the CLI error layer, contradicting ADR-008's boundary), but
+  accepted as the smallest viable patch for any single site under
+  remediation pressure. The preferred long-term shape is "service returns
+  a typed outcome; command routes outcome through `output_error`"; the
+  short-term patch is "service calls `output_error` directly". Both
+  satisfy this ADR.
+- **Have `handle_errors` catch `ClickException` and convert to the
+  envelope unconditionally.** Rejected. This would absorb parse-time
+  `ClickException` too — but `handle_errors` is entered *inside* the
+  command body, so the parse-time path never reaches it (Click renders
+  parser errors via `BaseCommand.main` before invoking the command).
+  Attempting to intercept parse-time errors would require subclassing
+  Click's command/group machinery, which is outside the scope of an
+  error-handling contract change. The post-parse path is the only one
+  `handle_errors` can address, and rule 2 already covers it via
+  `output_error(...)`.

--- a/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
+++ b/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
@@ -53,7 +53,7 @@ The CLI audit (`.sisyphus/plans/cli-audit-2026-05-27.md`, the **P1#2
 "command-body `UsageError`/`BadParameter` bypass"** finding at lines 54-90)
 enumerated post-parse raise sites that ride this bypass:
 
-- `src/notebooklm/cli/services/download.py:257` — `--include` / `--exclude`
+- `src/notebooklm/cli/services/download.py:257` — `--force` / `--no-clobber`
   conflict
 - `src/notebooklm/cli/services/generate.py:394` — `--style custom` requires
   `--style-prompt`

--- a/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
+++ b/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
@@ -29,8 +29,9 @@ Click then renders its own `Usage: ... / Error: ...` prose to stderr and exits
 with its class-level `exit_code` (`2` for `UsageError`/`BadParameter`, `1` for
 the base `ClickException`).
 
-Two different sites raise `ClickException` subclasses, and they behave
-identically at the Click level but mean very different things to a caller:
+There are two different phases in which `ClickException` subclasses are
+raised, and they behave identically at the Click level but mean very
+different things to a caller:
 
 - **Parse-time** raises happen *before* the command body runs. Click's own
   parser raises `UsageError`/`BadParameter` when argv fails option/type

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ The ADR Index table utilizes four eras of Status notation to reflect the lifecyc
 | [0012](0012-implementation-surface-convention.md)             | Implementation surface convention (underscore-prefix policy)  | Accepted (Tier 13 PR 13.9a)                                                                                         |
 | [0013](0013-composable-session-capabilities.md)               | Composable Session Capabilities and Feature-Local Runtimes    | Accepted                                                                                                            |
 | [0014](0014-feature-local-runtime-adapters.md)                | Feature-local runtime adapters as Protocol satisfiers         | Accepted (#1082)                                                                                                    |
+| [0015](0015-json-envelope-contract-for-post-parse-click-exceptions.md) | Typed JSON error envelope covers post-parse `ClickException` failures | Accepted                                                                                                            |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -1,12 +1,17 @@
 # CLI Exit-Code Convention
 
 **Status:** Active
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-27
 
 This document defines the exit-code policy for the `notebooklm` CLI. Shell
 scripts, CI pipelines, and AI-agent automations should rely on these codes for
 control flow rather than scraping stdout/stderr text — the text is intended for
 humans and may evolve, but the exit-code contract is stable.
+
+The companion architectural decision for the `--json` error contract is
+[ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md);
+this document is the surface-level reference for callers, and ADR-015 is the
+rationale for the post-parse `ClickException` rules called out below.
 
 For the canonical implementation, see the `handle_errors` context manager in
 [`src/notebooklm/cli/error_handler.py`](../src/notebooklm/cli/error_handler.py)
@@ -49,17 +54,33 @@ mapping in `error_handler.py`:
 | `NotebookLMError` (other) | `NOTEBOOKLM_ERROR` | `1` |
 | `KeyboardInterrupt`     | `CANCELLED`         | `130` |
 | Anything else (`Exception`) | `UNEXPECTED_ERROR` | `2` |
-| `click.UsageError` / `click.BadParameter` (bad CLI args) | — | re-raised; Click exits `2` |
-| Other `click.ClickException` subclasses                  | — | re-raised; Click exits `1` |
+| Parse-time `click.UsageError` / `click.BadParameter` (Click's parser, before command body runs) | — | re-raised; Click exits `2` |
+| Parse-time `click.ClickException` (other subclasses raised by Click's parser) | — | re-raised; Click exits `1` |
+| Post-parse `ClickException` raised from a command body or service module | `VALIDATION_ERROR` (or another standard code, per the raise site) | `1` (typed JSON envelope under `--json`; see ADR-015) |
 
-`click.ClickException` and its subclasses are intentionally re-raised so
-Click can render its own `Usage: ...` / `Error: ...` message. The exit code
-is whatever Click's own `exit_code` class attribute provides — `2` for
-`UsageError` (and `BadParameter`, which subclasses it), `1` for the base
-`ClickException` and other non-usage subclasses. This aligns Click's "bad
-arguments" exit (`2`) with our "system/unexpected" code, and Click's other
-exceptions with our "user/app error" code, so callers can branch on the
-exit code without distinguishing the two sources.
+`click.ClickException` raised by **Click's own parser** is intentionally
+re-raised so Click can render its own `Usage: ... / Error: ...` message.
+This is the *parse-time* path: argv parsing decides the command body
+should not run at all (unknown flag, type-validation failure, missing
+required argument), so `handle_errors(...)` is not yet on the stack and
+no JSON envelope is emitted. The exit code is whatever Click's own
+`exit_code` class attribute provides — `2` for `UsageError` (and
+`BadParameter`, which subclasses it), `1` for the base `ClickException`
+and other non-usage subclasses.
+
+`ClickException`-subclass failures raised from inside a **command body or
+its service-layer code** are *post-parse*: argv parsing succeeded, the
+command function entered, and `--json`'s value (if any) is bound on the
+Click context. These failures route through `output_error(...)` (the
+canonical envelope emitter) and exit `1` with the typed JSON error
+envelope under `--json` or a plain stderr message in text mode. The
+typical code is `VALIDATION_ERROR`. New command/service code MUST NOT
+raise `ClickException` for post-parse validation failures except at the
+small set of input-validation boundaries pinned by
+`ALLOWED_CLICK_EXCEPTION_SITES` in
+[`src/notebooklm/cli/error_handler.py`](../src/notebooklm/cli/error_handler.py);
+see [ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md)
+for the contract and rationale.
 
 ## JSON output mode (`--json`)
 
@@ -80,6 +101,21 @@ The `code` field is the stable identifier (see table above); `message` is the
 human string and may change. Some errors include extra fields
 (`retry_after`, `method_id` when `-v/--verbose` is set, etc.). Automation
 should branch on `code` (or, more simply, on the exit code).
+
+**Post-parse `ClickException` is covered.** Validation failures that a
+command body or its service-layer code chooses to express by raising
+`click.UsageError` / `click.BadParameter` / `click.ClickException` (for
+example, a flag-combination conflict detected after argv parsing
+succeeds) are routed through this same envelope under `--json` and exit
+`1` with `code: "VALIDATION_ERROR"` (or another standard code chosen by
+the raise site). The contract decision and its enumerated raise sites
+are recorded in
+[ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md).
+**Parse-time** `ClickException` raised by Click's own parser (before the
+command body runs) is unchanged — Click still renders its
+`Usage: ... / Error: ...` text on stderr and exits with its
+class-default code, because `handle_errors(...)` is not yet on the stack
+when the parser fires.
 
 ## Intentional exceptions to the standard convention
 


### PR DESCRIPTION
## Summary

- Adds **ADR-015** recording the decision: under `--json` (or `--json-output`), every post-parse `click.ClickException`-subclass failure raised from a command body or service module emits the typed JSON error envelope already produced by `_output_error(...)` and exits with the corresponding standard code (`VALIDATION_ERROR` / exit `1` for the common case).
- **Preserves parse-time behaviour**: `ClickException` raised by Click's own parser (before the command body runs) keeps its existing `Usage: ... / Error: ...` stderr rendering and class-default exit code. The re-raise at `src/notebooklm/cli/error_handler.py:257-259` is unchanged; this PR is documentation only.
- Rewrites `docs/cli-exit-codes.md` per meta-audit I1 — the doc was *silent* on post-parse `UsageError`, not contradictory. The existing JSON envelope shape definition and exception/exit-code table are preserved; new rows split parse-time vs post-parse, and a "post-parse `ClickException` is covered" paragraph follows the envelope shape block.
- Updates `docs/adr/README.md` index to list ADR-015.

The ADR cites the CLI audit P1#2 ("command-body `UsageError`/`BadParameter` bypass") finding at `.sisyphus/plans/cli-audit-2026-05-27.md` lines 54-90, and the meta-audit reframes C1 (contract-decision stop sentinel), C3 (service-layer attribution), and I1 (doc was silent, not contradictory) at `.sisyphus/plans/cli-audit-2026-05-27-audit.md`.

## Files

- `docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md` (new, ~165 lines)
- `docs/cli-exit-codes.md` (modified — `Last Updated` bumped, table split, two clarifying paragraphs added)
- `docs/adr/README.md` (modified — one index row appended)

## Test plan

- [x] `uv run ruff format --check docs/` — 6 files already formatted.
- [x] `uv run pytest tests/unit/cli -q` — 1,493 passed, 36 skipped on the rebased tip of `main`.
- [x] Cross-link targets exist (`docs/adr/0008-cli-services-extraction-pattern.md`, `src/notebooklm/cli/error_handler.py`, `src/notebooklm/cli/services/`, `docs/cli-exit-codes.md`, `docs/adr/0015-...`).
- [x] Click exit-code class attributes verified at runtime (`ClickException = 1`, `UsageError = 2`, `BadParameter = 2`) — match the table claims.
- [x] Wire-shape claim `{ "error": true, "code": "<CODE>", "message": "<text>", ...extras }` verified against `src/notebooklm/cli/error_handler.py:113-115`.

## Deferred polish findings

- One simplifier observation deferred: ADR-015 Decision rule 5 lists four illustrative allowlisted modules in addition to pointing at `ALLOWED_CLICK_EXCEPTION_SITES` in `src/notebooklm/cli/error_handler.py`. Kept for reader-accessibility — `ALLOWED_CLICK_EXCEPTION_SITES` remains the authoritative pin.

## Out of scope

- Refactoring the six audit-flagged post-parse `ClickException` sites to route through the envelope. The fix plan tracks those as separate per-site PRs; each one will cite ADR-015 and add a Migration note entry to `docs/cli-exit-codes.md`.
- Modifying `src/` code. The ADR explicitly preserves `error_handler.py:257-259`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified CLI error handling documentation with expanded and explicit exit code mappings for different failure scenarios.
* Distinguished parse-time and post-parse error handling patterns in JSON mode output.
* Added Architecture Decision Record documenting the typed JSON error envelope contract for CLI failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->