### PR TITLE
feat(cli): skill install hardening with --dry-run / --no-clobber / --force

### DIFF
--- a/src/notebooklm/cli/skill_cmd.py
+++ b/src/notebooklm/cli/skill_cmd.py
@@ -1,6 +1,8 @@
 """Skill management commands."""
 
+import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -100,6 +102,62 @@ def get_installed_content(target: str, scope: str) -> str | None:
     return skill_path.read_text(encoding="utf-8")
 
 
+# Per-target classification used by ``skill install`` to decide whether each
+# target needs a write, would clobber differing content, or is already in sync.
+TARGET_CREATE = "create"
+TARGET_UP_TO_DATE = "up_to_date"
+TARGET_OVERWRITE = "overwrite"
+
+
+def classify_target(target: str, scope: str, stamped_content: str) -> tuple[str, Path]:
+    """Classify what an install would do for a single target.
+
+    Returns ``(status, skill_path)`` where ``status`` is one of
+    :data:`TARGET_CREATE`, :data:`TARGET_UP_TO_DATE`, or :data:`TARGET_OVERWRITE`.
+    """
+    skill_path = get_skill_path(target, scope)
+    if not skill_path.exists():
+        return TARGET_CREATE, skill_path
+    try:
+        existing = skill_path.read_text(encoding="utf-8")
+    except OSError:
+        # Unreadable existing file -- treat as differing so we surface intent.
+        return TARGET_OVERWRITE, skill_path
+    if existing == stamped_content:
+        return TARGET_UP_TO_DATE, skill_path
+    return TARGET_OVERWRITE, skill_path
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically write ``content`` to ``path`` (temp file + ``os.replace``).
+
+    Mirrors the same-directory tempfile + ``os.replace`` pattern used by
+    :func:`notebooklm._atomic_io.atomic_write_json` so a crash mid-write cannot
+    leave a partially-written ``SKILL.md`` on disk.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(content)
+        os.replace(temp_path, path)
+    except Exception:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+        raise
+
+
 @click.group()
 def skill():
     """Manage NotebookLM agent skill integration."""
@@ -122,8 +180,51 @@ def skill():
     show_default=True,
     help="Install for Claude Code, universal agent skill directories, or both.",
 )
-def install(scope: str, target_name: str):
-    """Install or update the NotebookLM skill for supported agent directories."""
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Project scope only. Print what would be written without touching the "
+        "filesystem; combine with --force or --no-clobber to preview that mode."
+    ),
+)
+@click.option(
+    "--no-clobber",
+    is_flag=True,
+    default=False,
+    help=(
+        "Project scope only. Skip target files whose existing content differs "
+        "from the packaged skill; still creates targets that do not yet exist."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Project scope only. Overwrite differing target files unconditionally.",
+)
+def install(scope: str, target_name: str, dry_run: bool, no_clobber: bool, force: bool):
+    """Install or update the NotebookLM skill for supported agent directories.
+
+    With ``--scope project`` the install is hardened against accidental
+    overwrites: by default, if any target file exists with content that differs
+    from the packaged skill, no files are written and the command exits 1.
+    Pass ``--force`` to overwrite, ``--no-clobber`` to skip differing targets,
+    or ``--dry-run`` to preview without writing.
+    """
+    # Hardening flags are project-scope only -- user scope is per-user setup and
+    # keeps the historical "always overwrite" behavior.
+    if scope == "user" and (dry_run or no_clobber or force):
+        console.print(
+            "[red]Error:[/red] --dry-run, --no-clobber, and --force require --scope project."
+        )
+        exit_with_code(1)
+
+    if force and no_clobber:
+        console.print("[red]Error:[/red] --force and --no-clobber are mutually exclusive.")
+        exit_with_code(1)
+
     # Read skill content from package data
     content = get_skill_source_content()
     if content is None:
@@ -134,15 +235,64 @@ def install(scope: str, target_name: str):
 
     version = get_package_version()
     stamped_content = add_version_comment(content, version)
-    installed_paths = []
-    failed_targets = []
 
-    for target in iter_targets(target_name):
-        skill_path = get_skill_path(target, scope)
+    # Per-target classification drives every downstream decision.
+    targets = iter_targets(target_name)
+    classifications: list[tuple[str, str, Path]] = [
+        (target, *classify_target(target, scope, stamped_content)) for target in targets
+    ]
+    differing = [
+        (target, path) for target, status, path in classifications if status == TARGET_OVERWRITE
+    ]
+
+    # Default behavior on project scope: refuse to clobber differing files.
+    if scope == "project" and differing and not (dry_run or no_clobber or force):
+        console.print(
+            "[red]Refusing to overwrite[/red] differing skill files (use --force to "
+            "overwrite or --no-clobber to skip differing files):"
+        )
+        for target, path in differing:
+            console.print(f"  {TARGETS[target].label}: {path}")
+        exit_with_code(1)
+
+    if dry_run:
+        console.print("[cyan]Dry run[/cyan] -- no files will be written")
+        console.print(f"  Version: {version}")
+        console.print(f"  Scope:   {scope}")
+        for target, status, path in classifications:
+            label = TARGETS[target].label
+            if status == TARGET_CREATE:
+                console.print(f"  Would create  {label}: {path}")
+            elif status == TARGET_UP_TO_DATE:
+                console.print(f"  Up to date    {label}: {path}")
+            elif status == TARGET_OVERWRITE:
+                if no_clobber:
+                    console.print(f"  Would skip    {label}: {path} (differs; --no-clobber)")
+                else:
+                    # Default or --force preview both reach here; --force is the
+                    # only mode where writing differing files is possible.
+                    action = "Would overwrite" if force else "Would refuse"
+                    console.print(f"  {action} {label}: {path}")
+        return
+
+    installed_paths: list[tuple[str, Path]] = []
+    skipped_up_to_date: list[tuple[str, Path]] = []
+    skipped_no_clobber: list[tuple[str, Path]] = []
+    failed_targets: list[tuple[str, OSError]] = []
+
+    for target, status, path in classifications:
+        if status == TARGET_UP_TO_DATE:
+            # Already in sync -- nothing to do, but report it.
+            skipped_up_to_date.append((target, path))
+            continue
+        if status == TARGET_OVERWRITE and no_clobber:
+            skipped_no_clobber.append((target, path))
+            continue
+        # Reaches here for TARGET_CREATE (any mode) or TARGET_OVERWRITE with
+        # --force (project) or implicit overwrite (user scope, legacy path).
         try:
-            skill_path.parent.mkdir(parents=True, exist_ok=True)
-            skill_path.write_text(stamped_content, encoding="utf-8")
-            installed_paths.append((target, skill_path))
+            atomic_write_text(path, stamped_content)
+            installed_paths.append((target, path))
         except OSError as e:
             failed_targets.append((target, e))
 
@@ -154,6 +304,17 @@ def install(scope: str, target_name: str):
             console.print(f"  {TARGETS[target].label}: {skill_path}")
         console.print("")
         console.print("NotebookLM commands are now available in the selected skill directories.")
+
+    if skipped_no_clobber:
+        console.print(
+            f"[yellow]Skipped[/yellow] {len(skipped_no_clobber)} differing target(s) (--no-clobber)"
+        )
+
+    if not installed_paths and not failed_targets and skipped_up_to_date and not skipped_no_clobber:
+        # All targets were already up to date and no writes happened.
+        console.print("[green]Up to date[/green] -- no changes needed")
+        console.print(f"  Version: {version}")
+        console.print(f"  Scope:   {scope}")
 
     for target, err in failed_targets:
         console.print(f"[red]Failed[/red] to install {TARGETS[target].label}: {err}")

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -7894,6 +7894,60 @@
             ],
             "name": "choice"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Project scope only. Print what would be written without touching the filesystem; combine with --force or --no-clobber to preview that mode.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Project scope only. Skip target files whose existing content differs from the packaged skill; still creates targets that do not yet exist.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Project scope only. Overwrite differing target files unconditionally.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Install or update the NotebookLM skill for..."

--- a/tests/unit/cli/test_skill.py
+++ b/tests/unit/cli/test_skill.py
@@ -1,6 +1,7 @@
 """Tests for skill CLI commands."""
 
 import importlib
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -106,6 +107,332 @@ class TestSkillInstall:
         assert "failed" in result.output.lower()
         # agents target should still have succeeded
         assert (home / ".agents" / "skills" / "notebooklm" / "SKILL.md").exists()
+
+
+class TestSkillInstallProjectHardening:
+    """Tests for the project-scope hardening flags (--dry-run / --no-clobber / --force).
+
+    Every test in this class uses ``--scope project`` and patches ``Path.cwd()``
+    so the install rooted under ``tmp_path``.
+    """
+
+    SOURCE_CONTENT = "---\nname: notebooklm\n---\n# Source body v1"
+
+    def _stamped(self, version: str = "1.0.0") -> str:
+        return skill_module.add_version_comment(self.SOURCE_CONTENT, version)
+
+    def _seed(self, project: Path, *, claude: str | None, agents: str | None) -> None:
+        """Pre-create one or both target files with the supplied content."""
+        if claude is not None:
+            path = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(claude, encoding="utf-8")
+        if agents is not None:
+            path = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(agents, encoding="utf-8")
+
+    def _invoke(self, runner, project: Path, *extra_args: str):
+        """Run ``skill install --scope project`` with the patched cwd."""
+        with (
+            patch.object(
+                skill_module, "get_skill_source_content", return_value=self.SOURCE_CONTENT
+            ),
+            patch.object(skill_module, "get_package_version", return_value="1.0.0"),
+            patch.object(skill_module.Path, "cwd", return_value=project),
+        ):
+            return runner.invoke(cli, ["skill", "install", "--scope", "project", *extra_args])
+
+    # --- fresh install (no existing files) -----------------------------------
+
+    def test_fresh_install_creates_both_targets(self, runner, tmp_path):
+        """No existing files: install writes both targets with stamped content."""
+        project = tmp_path / "project"
+        result = self._invoke(runner, project)
+
+        assert result.exit_code == 0, result.output
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == self._stamped()
+        assert agents.read_text(encoding="utf-8") == self._stamped()
+        assert "installed" in result.output.lower()
+
+    # --- unchanged content (no-op) -------------------------------------------
+
+    def test_unchanged_content_is_noop(self, runner, tmp_path):
+        """Both targets already contain stamped content: no write, exit 0, 'up to date'."""
+        project = tmp_path / "project"
+        stamped = self._stamped()
+        self._seed(project, claude=stamped, agents=stamped)
+
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        claude_mtime = claude.stat().st_mtime_ns
+        agents_mtime = agents.stat().st_mtime_ns
+
+        result = self._invoke(runner, project)
+
+        assert result.exit_code == 0, result.output
+        # No write happened: mtime is preserved (atomic_write would have replaced inode).
+        assert claude.stat().st_mtime_ns == claude_mtime
+        assert agents.stat().st_mtime_ns == agents_mtime
+        assert "up to date" in result.output.lower()
+
+    # --- differing content, default mode (refuse + exit 1) -------------------
+
+    def test_default_refuses_to_clobber_differing_targets(self, runner, tmp_path):
+        """Differing content + no flags: exit 1, list differing files, no writes."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old claude content", agents="old agents content")
+
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+
+        result = self._invoke(runner, project)
+
+        assert result.exit_code == 1, result.output
+        # Files are not modified.
+        assert claude.read_text(encoding="utf-8") == "old claude content"
+        assert agents.read_text(encoding="utf-8") == "old agents content"
+        # Error mentions both targets and surfaces the canonical flag hint.
+        assert "claude code" in result.output.lower()
+        assert "agent skills" in result.output.lower()
+        assert "--force" in result.output
+        assert "--no-clobber" in result.output
+
+    # --- --dry-run -----------------------------------------------------------
+
+    def test_dry_run_on_fresh_project_writes_nothing(self, runner, tmp_path):
+        """--dry-run on a fresh project prints intended creates without writing."""
+        project = tmp_path / "project"
+        result = self._invoke(runner, project, "--dry-run")
+
+        assert result.exit_code == 0, result.output
+        assert "dry run" in result.output.lower()
+        assert "would create" in result.output.lower()
+        # No filesystem changes -- the skill files do not exist.
+        assert not (project / ".claude" / "skills" / "notebooklm" / "SKILL.md").exists()
+        assert not (project / ".agents" / "skills" / "notebooklm" / "SKILL.md").exists()
+
+    def test_dry_run_with_differing_files_writes_nothing(self, runner, tmp_path):
+        """--dry-run with differing files: announces refuse, exit 0, no writes."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old claude content", agents=self._stamped())
+
+        result = self._invoke(runner, project, "--dry-run")
+
+        assert result.exit_code == 0, result.output
+        output = result.output.lower()
+        assert "dry run" in output
+        # The differing target is flagged as would-refuse (or similar wording).
+        assert "would refuse" in output
+        # The matching target appears as up-to-date.
+        assert "up to date" in output
+        # Differing file is unchanged.
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == "old claude content"
+
+    def test_dry_run_with_force_previews_overwrite(self, runner, tmp_path):
+        """--dry-run --force: previews overwrites without writing."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old", agents=None)
+
+        result = self._invoke(runner, project, "--dry-run", "--force")
+
+        assert result.exit_code == 0, result.output
+        output = result.output.lower()
+        assert "would overwrite" in output
+        assert "would create" in output
+        # Nothing actually written.
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == "old"
+        assert not agents.exists()
+
+    def test_dry_run_with_no_clobber_previews_skip(self, runner, tmp_path):
+        """--dry-run --no-clobber: previews which differing files would be skipped."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old", agents=None)
+
+        result = self._invoke(runner, project, "--dry-run", "--no-clobber")
+
+        assert result.exit_code == 0, result.output
+        output = result.output.lower()
+        assert "would skip" in output
+        assert "would create" in output
+        # Nothing actually written.
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == "old"
+        assert not agents.exists()
+
+    # --- --no-clobber --------------------------------------------------------
+
+    def test_no_clobber_skips_differing_creates_missing(self, runner, tmp_path):
+        """--no-clobber: skip differing files, still create missing targets."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old claude content", agents=None)
+
+        result = self._invoke(runner, project, "--no-clobber")
+
+        assert result.exit_code == 0, result.output
+        # Existing differing file is preserved.
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == "old claude content"
+        # Missing target was created with stamped content.
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert agents.read_text(encoding="utf-8") == self._stamped()
+        # Informative summary surfaces the skip count.
+        assert "skipped" in result.output.lower()
+        assert "--no-clobber" in result.output
+
+    def test_no_clobber_all_differing_writes_nothing(self, runner, tmp_path):
+        """--no-clobber with both targets differing: no writes, exit 0, summary printed."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old claude", agents="old agents")
+
+        result = self._invoke(runner, project, "--no-clobber")
+
+        assert result.exit_code == 0, result.output
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == "old claude"
+        assert agents.read_text(encoding="utf-8") == "old agents"
+        assert "skipped" in result.output.lower()
+        assert "2" in result.output  # count surfaced
+
+    # --- --force -------------------------------------------------------------
+
+    def test_force_overwrites_differing_targets(self, runner, tmp_path):
+        """--force: overwrites differing content unconditionally."""
+        project = tmp_path / "project"
+        self._seed(project, claude="old claude", agents="old agents")
+
+        result = self._invoke(runner, project, "--force")
+
+        assert result.exit_code == 0, result.output
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert claude.read_text(encoding="utf-8") == self._stamped()
+        assert agents.read_text(encoding="utf-8") == self._stamped()
+        assert "installed" in result.output.lower()
+
+    # --- mixed (per-target diff detection) -----------------------------------
+
+    def test_mixed_one_identical_one_differing_default_refuses(self, runner, tmp_path):
+        """Mixed targets: identical claude + differing agents -> default refuses, lists agents only."""
+        project = tmp_path / "project"
+        self._seed(project, claude=self._stamped(), agents="old agents")
+
+        result = self._invoke(runner, project)
+
+        assert result.exit_code == 1, result.output
+        # The error lists the differing target.
+        assert "agent skills" in result.output.lower()
+        # The identical target should NOT appear in the differing list.
+        differing_section = (
+            result.output.split("Refusing")[1] if "Refusing" in result.output else ""
+        )
+        assert "Claude Code:" not in differing_section
+        # No mutation.
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        assert agents.read_text(encoding="utf-8") == "old agents"
+
+    def test_mixed_no_clobber_skips_differing_only(self, runner, tmp_path):
+        """Mixed targets: --no-clobber preserves the differing one, leaves identical untouched."""
+        project = tmp_path / "project"
+        self._seed(project, claude=self._stamped(), agents="old agents")
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        claude_mtime = claude.stat().st_mtime_ns
+
+        result = self._invoke(runner, project, "--no-clobber")
+
+        assert result.exit_code == 0, result.output
+        # Identical target: byte-equal, mtime preserved (no rewrite).
+        assert claude.read_text(encoding="utf-8") == self._stamped()
+        assert claude.stat().st_mtime_ns == claude_mtime
+        # Differing target preserved as-is.
+        assert agents.read_text(encoding="utf-8") == "old agents"
+
+    def test_mixed_force_overwrites_differing_only(self, runner, tmp_path):
+        """Mixed targets: --force overwrites differing, identical target is a no-op."""
+        project = tmp_path / "project"
+        self._seed(project, claude=self._stamped(), agents="old agents")
+        claude = project / ".claude" / "skills" / "notebooklm" / "SKILL.md"
+        agents = project / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        claude_mtime = claude.stat().st_mtime_ns
+
+        result = self._invoke(runner, project, "--force")
+
+        assert result.exit_code == 0, result.output
+        # Identical target untouched (mtime preserved).
+        assert claude.stat().st_mtime_ns == claude_mtime
+        # Differing target overwritten.
+        assert agents.read_text(encoding="utf-8") == self._stamped()
+
+    # --- flag validation -----------------------------------------------------
+
+    def test_user_scope_rejects_dry_run(self, runner, tmp_path):
+        """--scope user + --dry-run is rejected (hardening is project-only)."""
+        home = tmp_path / "home"
+        with (
+            patch.object(
+                skill_module, "get_skill_source_content", return_value=self.SOURCE_CONTENT
+            ),
+            patch.object(skill_module.Path, "home", return_value=home),
+        ):
+            result = runner.invoke(cli, ["skill", "install", "--scope", "user", "--dry-run"])
+
+        assert result.exit_code == 1
+        assert "--scope project" in result.output
+
+    def test_user_scope_rejects_force(self, runner, tmp_path):
+        """--scope user + --force is rejected."""
+        home = tmp_path / "home"
+        with (
+            patch.object(
+                skill_module, "get_skill_source_content", return_value=self.SOURCE_CONTENT
+            ),
+            patch.object(skill_module.Path, "home", return_value=home),
+        ):
+            result = runner.invoke(cli, ["skill", "install", "--scope", "user", "--force"])
+
+        assert result.exit_code == 1
+        assert "--scope project" in result.output
+
+    def test_user_scope_rejects_no_clobber(self, runner, tmp_path):
+        """--scope user + --no-clobber is rejected."""
+        home = tmp_path / "home"
+        with (
+            patch.object(
+                skill_module, "get_skill_source_content", return_value=self.SOURCE_CONTENT
+            ),
+            patch.object(skill_module.Path, "home", return_value=home),
+        ):
+            result = runner.invoke(cli, ["skill", "install", "--scope", "user", "--no-clobber"])
+
+        assert result.exit_code == 1
+        assert "--scope project" in result.output
+
+    def test_force_and_no_clobber_are_mutually_exclusive(self, runner, tmp_path):
+        """--force + --no-clobber together is rejected."""
+        project = tmp_path / "project"
+        result = self._invoke(runner, project, "--force", "--no-clobber")
+
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_atomic_write_no_partial_on_fresh_install(self, runner, tmp_path):
+        """Successful install leaves no temp files in the target directory."""
+        project = tmp_path / "project"
+        result = self._invoke(runner, project)
+
+        assert result.exit_code == 0, result.output
+        claude_dir = project / ".claude" / "skills" / "notebooklm"
+        # No stray ``.SKILL.md.*.tmp`` siblings should remain.
+        leftovers = [p.name for p in claude_dir.iterdir() if p.name != "SKILL.md"]
+        assert leftovers == [], f"unexpected leftover files: {leftovers}"
 
 
 class TestSkillStatus:


### PR DESCRIPTION
## Summary

- Add `--dry-run`, `--no-clobber`, and `--force` to `notebooklm skill install` for `--scope project`, so running the command inside a project with hand-edited `SKILL.md` files no longer overwrites them silently.
- Default project-scope behavior now refuses to clobber differing targets, exits 1, lists which files differ, and points the user at `--force` or `--no-clobber`.
- All writes go through a new `atomic_write_text` helper (same-dir tempfile + `os.replace`, mirroring `_atomic_io.atomic_write_json`) so a crash mid-write can never leave a partial `SKILL.md` on disk.

## Behavior matrix (`--scope project`)

| Flag | Existing identical | Existing differing | Missing |
|---|---|---|---|
| (none) | no-op | exit 1, list differing | create |
| `--dry-run` | "Up to date" | "Would refuse" | "Would create" |
| `--dry-run --force` | "Up to date" | "Would overwrite" | "Would create" |
| `--dry-run --no-clobber` | "Up to date" | "Would skip" | "Would create" |
| `--no-clobber` | no-op | skip silently, summary line | create |
| `--force` | no-op | overwrite | create |

`--scope user` keeps the historical "always overwrite" behavior; the new flags are rejected when paired with `--scope user`. `--force` and `--no-clobber` are mutually exclusive.

## Test plan

- [x] `uv run ruff format src/notebooklm/cli/skill_cmd.py tests/unit/cli/test_skill.py`
- [x] `uv run ruff check src/notebooklm/cli/skill_cmd.py tests/unit/cli/test_skill.py`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit/cli/test_skill.py -v` (44 passed, 18 new in `TestSkillInstallProjectHardening`)
- [x] `uv run pytest tests/unit/cli -q` (1511 passed, 36 skipped) -- phase10 CLI contract baseline regenerated to include the three new options
- [x] `uv run pytest tests/unit -q` (5964 passed, 89 skipped)

New tests cover: fresh install, no-op on unchanged content, default refusal, each flag in isolation, dry-run preview for default / force / no-clobber, mixed targets (one identical + one differing) per flag, user-scope flag rejection, mutual-exclusion of `--force` and `--no-clobber`, and a leftover-tempfile check that asserts atomic writes leave no `.SKILL.md.*.tmp` siblings.