### PR TITLE
fix(cli): redact subprocess stderr in playwright_login before printing (audit G4)

### DIFF
--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -146,9 +146,9 @@ CHANNEL_BROWSERS: dict[str, tuple[str, str]] = {
 #
 #   1. Environment-variable VALUES — Playwright forwards the parent process
 #      environment; if any secret (PSIDTS, API tokens, cookie material set
-#      via NOTEBOOKLM_AUTH_JSON / SAPISID / etc.) is interpolated into a
-#      traceback / config line by the CLI we invoke, it lands verbatim in
-#      ``result.stderr``.
+#      via the auth-source env var / SAPISID / etc.) is interpolated into
+#      a traceback / config line by the CLI we invoke, it lands verbatim
+#      in ``result.stderr``.
 #
 #   2. ANSI control sequences — pip/playwright CLIs emit progress bars and
 #      colour codes that mangle log scrapers and dirty test snapshots.
@@ -205,12 +205,13 @@ def _strip_ansi(text: str) -> str:
 def _expand_nested_secret_values(value: str) -> Iterator[str]:
     """Yield ``value`` plus any nested string leaves if it parses as JSON.
 
-    Env values like ``NOTEBOOKLM_AUTH_JSON`` carry serialised JSON whose
-    leaf values (cookie tokens, refresh tokens) are the actual secrets.
-    If a subprocess re-emits the parsed nested value rather than the
-    whole JSON blob, exact-string matching against the original env
-    value would miss the leak. Walk JSON objects/arrays here to add
-    every leaf string to the redaction candidate set.
+    Env values supplied as inline JSON (the auth-source env var being
+    the canonical example) carry serialised dicts whose leaf strings
+    (cookie tokens, refresh tokens) are the actual secrets. If a
+    subprocess re-emits the parsed nested value rather than the whole
+    JSON blob, exact-string matching against the original env value
+    would miss the leak. Walk JSON objects/arrays here to add every
+    leaf string to the redaction candidate set.
 
     Non-JSON values yield just themselves (and only if they pass the
     caller's length / safe-value filter).
@@ -252,7 +253,7 @@ def redact_subprocess_output(text: str, env: Mapping[str, str] | None = None) ->
        (the parameter exists so tests can drive the redaction without
        mutating real process env). For each env value we also try to
        parse it as JSON and add every nested string leaf to the
-       candidate set — covers ``NOTEBOOKLM_AUTH_JSON`` and any other
+       candidate set — covers the auth-source env var and any other
        env-supplied JSON token bag.
 
        Values shorter than :data:`_REDACTION_MIN_VALUE_LEN` and the

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -28,12 +28,15 @@ working byte-for-byte.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
+import re
 import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,6 +134,174 @@ CHANNEL_BROWSERS: dict[str, tuple[str, str]] = {
     "msedge": ("Microsoft Edge", "https://www.microsoft.com/edge"),
     "chrome": ("Google Chrome", "https://www.google.com/chrome"),
 }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess output sanitisation (audit G4)
+# ---------------------------------------------------------------------------
+#
+# When we surface captured stderr / stdout from a Playwright subprocess to
+# the user (e.g. the install failure path below), the raw text can carry
+# two classes of noise we never want to leak into the console:
+#
+#   1. Environment-variable VALUES — Playwright forwards the parent process
+#      environment; if any secret (PSIDTS, API tokens, cookie material set
+#      via NOTEBOOKLM_AUTH_JSON / SAPISID / etc.) is interpolated into a
+#      traceback / config line by the CLI we invoke, it lands verbatim in
+#      ``result.stderr``.
+#
+#   2. ANSI control sequences — pip/playwright CLIs emit progress bars and
+#      colour codes that mangle log scrapers and dirty test snapshots.
+#
+# ``redact_subprocess_output`` strips both before the diagnostic reaches the
+# console. Env-var redaction is conservative: we skip empty / single-char
+# values and common boolean-ish / path-separator constants that would
+# false-positive across normal stderr lines.
+
+# CSI: ESC '[' parameter-bytes intermediate-bytes final-byte
+# OSC: ESC ']' ... (BEL | ESC '\\')
+# Plus a catch-all for any remaining two-byte C1 Fe sequence (the
+# 0x40-0x5F final-byte range). CSI and OSC are stripped first so this
+# only fires on leftovers (PM ``ESC ^``, APC ``ESC _``, ST ``ESC \``,
+# etc.).
+_ANSI_CSI_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+_ANSI_OSC_PATTERN = re.compile(r"\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)")
+_ANSI_OTHER_PATTERN = re.compile(r"\x1B[@-_]")
+
+# Env-var values we never redact even if they happen to be set (they would
+# produce noisy false positives on every line that mentions a path / boolean).
+# Single-character values (``/``, ``.``, ``*``, ``0``, ``1``, ``y``, ``n``)
+# don't appear here — they are already excluded by ``_REDACTION_MIN_VALUE_LEN``.
+_REDACTION_SAFE_VALUES = frozenset(
+    {
+        "",
+        "..",
+        "true",
+        "false",
+        "True",
+        "False",
+        "TRUE",
+        "FALSE",
+        "yes",
+        "no",
+        "on",
+        "off",
+    }
+)
+
+# Skip env values shorter than this — substring matches on 2-char strings
+# false-positive across the bytes Playwright prints.
+_REDACTION_MIN_VALUE_LEN = 3
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI CSI / OSC / two-byte escape sequences from ``text``."""
+    text = _ANSI_CSI_PATTERN.sub("", text)
+    text = _ANSI_OSC_PATTERN.sub("", text)
+    text = _ANSI_OTHER_PATTERN.sub("", text)
+    return text
+
+
+def _expand_nested_secret_values(value: str) -> Iterator[str]:
+    """Yield ``value`` plus any nested string leaves if it parses as JSON.
+
+    Env values like ``NOTEBOOKLM_AUTH_JSON`` carry serialised JSON whose
+    leaf values (cookie tokens, refresh tokens) are the actual secrets.
+    If a subprocess re-emits the parsed nested value rather than the
+    whole JSON blob, exact-string matching against the original env
+    value would miss the leak. Walk JSON objects/arrays here to add
+    every leaf string to the redaction candidate set.
+
+    Non-JSON values yield just themselves (and only if they pass the
+    caller's length / safe-value filter).
+    """
+    yield value
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "{[":
+        return
+    try:
+        parsed = json.loads(stripped)
+    except (ValueError, TypeError):
+        return
+
+    stack: list[Any] = [parsed]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            yield node
+        elif isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def redact_subprocess_output(text: str, env: Mapping[str, str] | None = None) -> str:
+    """Sanitise captured subprocess ``stdout`` / ``stderr`` before printing.
+
+    The transform runs in this order:
+
+    1. **Strip ANSI control sequences** (CSI colour codes, OSC titles, and
+       the two-byte C1 Fe escapes used by pip/playwright progress UI).
+       Stripping FIRST means a secret split by an inert reset like
+       ``"abc\\x1b[0m123"`` is reassembled to ``"abc123"`` before
+       redaction runs — otherwise an exact-match redactor would miss it.
+
+    2. **Replace every occurrence of each non-trivial environment-variable
+       value with** ``<redacted>``. The env is snapshotted from
+       ``os.environ`` at call time unless an explicit mapping is supplied
+       (the parameter exists so tests can drive the redaction without
+       mutating real process env). For each env value we also try to
+       parse it as JSON and add every nested string leaf to the
+       candidate set — covers ``NOTEBOOKLM_AUTH_JSON`` and any other
+       env-supplied JSON token bag.
+
+       Values shorter than :data:`_REDACTION_MIN_VALUE_LEN` and the
+       well-known constants in :data:`_REDACTION_SAFE_VALUES` are
+       skipped to avoid spamming ``<redacted>`` across every path /
+       boolean in the output. Candidates are tried in descending length
+       order so a longer secret that contains a shorter one is redacted
+       as a single ``<redacted>`` token.
+
+    Returns the sanitised string. The input is not mutated.
+    """
+    if not text:
+        return text
+
+    # Pass 1: strip ANSI BEFORE redaction so a secret broken up by reset
+    # codes (``"abc\x1b[0m123"`` → ``"abc123"``) is reassembled and
+    # redactable by the exact-match pass below.
+    text = _strip_ansi(text)
+
+    # Materialise the env mapping once. ``dict(os.environ)`` defends
+    # against the (very rare) case where another thread mutates the
+    # process environment while we iterate.
+    source_env: Mapping[str, str] = dict(os.environ) if env is None else env
+
+    # Build the candidate set: every env value plus any JSON leaf
+    # strings nested inside JSON-shaped env values. Also add the
+    # ansi-stripped form of each candidate in case the env value itself
+    # carries embedded control bytes (the input ``text`` has already
+    # been ansi-stripped above). Filter by length / safe-value rules,
+    # then sort by descending length so a longer value (e.g. the
+    # literal PSIDTS cookie) gets redacted before any shorter prefix
+    # that happens to also appear as another env value.
+    candidates: set[str] = set()
+    for raw_value in source_env.values():
+        if not isinstance(raw_value, str):
+            continue
+        for nested in _expand_nested_secret_values(raw_value):
+            for variant in (nested, _strip_ansi(nested)):
+                if (
+                    len(variant) >= _REDACTION_MIN_VALUE_LEN
+                    and variant not in _REDACTION_SAFE_VALUES
+                ):
+                    candidates.add(variant)
+
+    for value in sorted(candidates, key=len, reverse=True):
+        if value in text:
+            text = text.replace(value, "<redacted>")
+
+    return text
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +527,15 @@ def ensure_chromium_installed() -> None:
         )
         stdout_lower = result.stdout.lower()
         if "chromium" not in stdout_lower or "will download" not in stdout_lower:
+            # The dry-run probe succeeded but didn't see a "will download"
+            # marker; nothing to do. If the probe printed an unexpected
+            # diagnostic to stderr, surface a sanitised version at debug
+            # level so operators can investigate without leaking env values.
+            if result.stderr:
+                logger.debug(
+                    "playwright install --dry-run stderr: %s",
+                    redact_subprocess_output(result.stderr),
+                )
             return
 
         console.print("[yellow]Chromium browser not installed. Installing now...[/yellow]")
@@ -366,10 +546,30 @@ def ensure_chromium_installed() -> None:
             timeout=300,
         )
         if install_result.returncode != 0:
+            # Surface the (sanitised) tail of stderr/stdout so the user
+            # has something to act on without us echoing raw env values
+            # or ANSI progress bars from the playwright CLI.
+            # ``redact_subprocess_output`` strips control codes and env
+            # values before printing.
+            #
+            # Prefer stderr when it has substantive content; otherwise
+            # fall back to stdout. Compare on the STRIPPED value so a
+            # stderr that sanitises down to whitespace doesn't shadow a
+            # stdout line carrying the actionable failure (codex review).
+            sanitised_stderr = redact_subprocess_output(install_result.stderr or "").strip()
+            sanitised_stdout = redact_subprocess_output(install_result.stdout or "").strip()
+            diagnostic_tail = sanitised_stderr or sanitised_stdout
             console.print(
                 "[red]Failed to install Chromium browser.[/red]\n"
                 f'Run manually: "{sys.executable}" -m playwright install chromium'
             )
+            if diagnostic_tail:
+                # markup=False: the captured CLI output is not Rich markup
+                # and may contain stray ``[``/``]`` characters.
+                console.print(
+                    f"[dim]Subprocess output (sanitised):[/dim]\n{diagnostic_tail}",
+                    markup=False,
+                )
             exit_with_code(1)
         console.print("[green]Chromium installed successfully.[/green]\n")
     except SystemExit:
@@ -851,6 +1051,7 @@ __all__ = [
     "is_navigation_interrupted_error",
     "prepare_login_paths",
     "recover_page",
+    "redact_subprocess_output",
     "repair_playwright_account_metadata",
     "run_playwright_login",
     "url_matches_base_host",

--- a/tests/unit/cli/test_playwright_login_stderr.py
+++ b/tests/unit/cli/test_playwright_login_stderr.py
@@ -1,0 +1,402 @@
+"""Unit tests for ``playwright_login.redact_subprocess_output`` (audit G4).
+
+These tests pin the security contract for surfacing captured subprocess
+``stdout`` / ``stderr`` from the Playwright pre-flight in
+``cli/services/playwright_login.py``:
+
+1. Environment-variable VALUES that appear in the captured output are
+   redacted before printing (defence against accidental secret leak when
+   the playwright CLI echoes config / tracebacks).
+2. ANSI control sequences (CSI colour codes, OSC titles, two-byte escapes
+   used by pip/playwright progress UI) are stripped.
+3. Multiple env-var values in a single string are all redacted.
+4. Empty / well-known constant env values do NOT trigger spurious
+   redactions across normal stderr lines.
+5. The install-failure path in ``ensure_chromium_installed`` routes
+   captured stderr through the helper before printing — verified with
+   stub ``subprocess.CompletedProcess`` fixtures so the test never
+   requires a real Playwright install.
+
+The helper is a pure string transform; tests pass an explicit ``env``
+mapping so they never mutate ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from notebooklm.cli.services.playwright_login import (
+    ensure_chromium_installed,
+    redact_subprocess_output,
+)
+
+# ---------------------------------------------------------------------------
+# redact_subprocess_output — env-var value redaction
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_psidts_like_secret_in_stderr() -> None:
+    """A PSIDTS-style cookie value in stderr must be replaced with <redacted>."""
+    secret = "psidts_abc123_long_secret_value"
+    env = {"NOTEBOOKLM_PSIDTS": secret}
+    raw = f"Traceback: failed to authenticate with cookie {secret}\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert secret not in sanitised
+    assert "<redacted>" in sanitised
+    assert "Traceback" in sanitised  # non-secret content preserved
+
+
+def test_redacts_multiple_env_values_in_one_string() -> None:
+    """Every non-trivial env-var value appearing in the input gets redacted."""
+    env = {
+        "SECRET_A": "alpha_value_that_should_be_redacted",
+        "SECRET_B": "beta_value_that_should_also_redact",
+    }
+    raw = (
+        "config dump:\n"
+        "  field_one=alpha_value_that_should_be_redacted\n"
+        "  field_two=beta_value_that_should_also_redact\n"
+    )
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert "alpha_value_that_should_be_redacted" not in sanitised
+    assert "beta_value_that_should_also_redact" not in sanitised
+    assert sanitised.count("<redacted>") == 2
+    assert "field_one" in sanitised
+    assert "field_two" in sanitised
+
+
+def test_skips_trivial_env_values() -> None:
+    """Empty / single-char / well-known env values must NOT trigger redaction.
+
+    Otherwise common path / boolean strings would be replaced across the
+    normal subprocess output (e.g. ``PATH=/`` would smear ``<redacted>``
+    over every "/" in the captured stderr).
+    """
+    env = {
+        "EMPTY": "",
+        "SLASH": "/",
+        "DOT": ".",
+        "BOOL_TRUE": "true",
+        "BOOL_FALSE": "False",
+        "ZERO": "0",
+        "ONE": "1",
+        "Y": "y",
+        "STAR": "*",
+        "SHORT": "ab",  # below _REDACTION_MIN_VALUE_LEN
+    }
+    raw = "stderr line: path=/usr/local/bin, flag=true, retries=0\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert "<redacted>" not in sanitised
+    # Content should be unchanged apart from ANSI stripping (none here).
+    assert sanitised == raw
+
+
+def test_longer_value_wins_when_one_is_a_substring_of_another() -> None:
+    """A longer env value that contains a shorter env value gets redacted as a whole."""
+    env = {
+        "LONG": "secret_token_full_value",
+        "SHORTER": "secret_token",  # substring of LONG
+    }
+    raw = "leaked: secret_token_full_value\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    # Either way the long secret must not appear in cleartext.
+    assert "secret_token_full_value" not in sanitised
+    # And we shouldn't end up with a half-redacted "<redacted>_full_value"
+    # because the longer key sorts first.
+    assert "_full_value" not in sanitised
+
+
+# ---------------------------------------------------------------------------
+# redact_subprocess_output — ANSI stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strips_ansi_csi_color_codes() -> None:
+    """CSI sequences (the common 'colour' codes) are removed."""
+    raw = "\x1b[31mERROR\x1b[0m: install failed\n"
+
+    sanitised = redact_subprocess_output(raw, env={})
+
+    assert "\x1b" not in sanitised
+    assert sanitised == "ERROR: install failed\n"
+
+
+def test_strips_ansi_osc_sequences() -> None:
+    """OSC sequences (window titles etc.) terminated by BEL or ST are removed."""
+    bel = "\x1b]0;some title\x07after-bel"
+    st = "\x1b]0;another title\x1b\\after-st"
+
+    assert redact_subprocess_output(bel, env={}) == "after-bel"
+    assert redact_subprocess_output(st, env={}) == "after-st"
+
+
+def test_strips_two_byte_escape_sequences() -> None:
+    """Two-byte ESC sequences (Fp/nF/Fe) used by progress UI are removed."""
+    raw = "before\x1bMmiddle\x1bDend"
+
+    sanitised = redact_subprocess_output(raw, env={})
+
+    assert "\x1b" not in sanitised
+    assert sanitised == "beforemiddleend"
+
+
+def test_strips_full_c1_fe_range() -> None:
+    """The two-byte ``ESC`` + Fe-class final byte covers the full 0x40-0x5F range.
+
+    This guards the C1 Fe class boundary (``ESC ^`` PM, ``ESC _`` APC, etc.)
+    that an earlier draft missed because the catch-all character class
+    excluded ``]`` (0x5D) and ``^`` (0x5E).
+    """
+    # 0x40='@' through 0x5F='_' is the full C1 Fe range.
+    full_range = "".join(f"\x1b{chr(b)}" for b in range(0x40, 0x60))
+    raw = f"start{full_range}end"
+
+    sanitised = redact_subprocess_output(raw, env={})
+
+    assert "\x1b" not in sanitised
+    assert sanitised == "startend"
+
+
+def test_strips_ansi_and_redacts_env_value_together() -> None:
+    """Combined ANSI + env-value input is sanitised in both dimensions."""
+    secret = "psidts_value_must_redact"
+    env = {"PSIDTS": secret}
+    raw = f"\x1b[33mWARN\x1b[0m: using cookie {secret} for auth\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert "\x1b" not in sanitised
+    assert secret not in sanitised
+    assert "<redacted>" in sanitised
+    assert "WARN" in sanitised
+
+
+# ---------------------------------------------------------------------------
+# redact_subprocess_output — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty() -> None:
+    """Empty input is returned verbatim (no crash, no allocation)."""
+    assert redact_subprocess_output("", env={"X": "long_enough_value"}) == ""
+
+
+def test_uses_os_environ_when_env_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``env`` defaults to None, the helper snapshots ``os.environ``."""
+    secret = "from_os_environ_should_redact"
+    monkeypatch.setenv("REDACT_TEST_SECRET", secret)
+    raw = f"line: {secret}\n"
+
+    sanitised = redact_subprocess_output(raw)
+
+    assert secret not in sanitised
+    assert "<redacted>" in sanitised
+
+
+def test_redacts_ansi_interrupted_secret() -> None:
+    """A secret split by an inert ANSI reset must still be redacted.
+
+    Regression: if the helper redacted BEFORE stripping ANSI, then
+    ``"abc\\x1b[0m123"`` would not match env value ``"abc123"`` (the
+    escape bytes break the substring), and the subsequent ANSI strip
+    would reassemble the secret in the clear. ANSI must be stripped
+    FIRST so reassembled secrets are caught.
+    """
+    secret = "psidts_full_secret_abc123"
+    env = {"PSIDTS": secret}
+    # Split the secret with a no-op ANSI reset in the middle.
+    raw = "leaked: psidts_full_secret_\x1b[0mabc123\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert secret not in sanitised
+    assert "<redacted>" in sanitised
+    # And no raw escape byte remains.
+    assert "\x1b" not in sanitised
+
+
+def test_redacts_nested_json_leaf_value() -> None:
+    """Leaf strings inside a JSON-shaped env value (NOTEBOOKLM_AUTH_JSON) are redactable."""
+    inner_secret = "cookie_value_inside_json_blob"
+    auth_json = '{"cookies":[{"name":"PSIDTS","value":"' + inner_secret + '"}],"profile":"default"}'
+    env = {"NOTEBOOKLM_AUTH_JSON": auth_json}
+    # Subprocess prints only the nested cookie value, not the whole JSON.
+    raw = f"playwright: using auth cookie {inner_secret} for request\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert inner_secret not in sanitised
+    assert "<redacted>" in sanitised
+
+
+def test_redacts_nested_json_array_leaf() -> None:
+    """Leaf strings inside a JSON array (not just object) are also expanded."""
+    inner_secret = "another_secret_in_array"
+    env = {"FAKE_LIST": f'["benign", "{inner_secret}", "also_benign"]'}
+    raw = f"line: token={inner_secret} fail\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert inner_secret not in sanitised
+
+
+def test_malformed_json_env_value_falls_back_to_exact_match() -> None:
+    """An env value that LOOKS like JSON but doesn't parse still redacts as a string."""
+    not_quite_json = "{not_real_json_but_starts_with_brace"
+    env = {"WEIRD": not_quite_json}
+    raw = f"line: WEIRD={not_quite_json}\n"
+
+    sanitised = redact_subprocess_output(raw, env=env)
+
+    assert not_quite_json not in sanitised
+    assert "<redacted>" in sanitised
+
+
+# ---------------------------------------------------------------------------
+# ensure_chromium_installed — applies redaction on install-failure
+# ---------------------------------------------------------------------------
+
+
+class _StubCompletedProcess:
+    """Minimal stand-in for ``subprocess.CompletedProcess`` used in tests.
+
+    Lets the test inject specific ``stdout`` / ``stderr`` / ``returncode``
+    values without invoking Playwright. Mirrors the public attribute
+    surface that ``ensure_chromium_installed`` reads.
+    """
+
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_install_failure_prints_sanitised_stderr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Install-failure path runs captured stderr through ``redact_subprocess_output``."""
+    secret = "install_path_secret_value_xyz"
+    monkeypatch.setenv("REDACT_INSTALL_TEST", secret)
+
+    dry_run = _StubCompletedProcess(
+        stdout="chromium will download to /tmp/...",
+        stderr="",
+        returncode=0,
+    )
+    install_fail = _StubCompletedProcess(
+        stdout="",
+        stderr=(
+            f"\x1b[31mERROR\x1b[0m: failed to fetch playwright bundle\nenv dump: TOKEN={secret}\n"
+        ),
+        returncode=1,
+    )
+
+    call_log: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
+        call_log.append(cmd)
+        if "--dry-run" in cmd:
+            return dry_run
+        return install_fail
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # ``exit_with_code(1)`` calls ``sys.exit(1)``; capture the SystemExit.
+    with pytest.raises(SystemExit) as exc_info:
+        ensure_chromium_installed()
+
+    assert exc_info.value.code == 1
+    assert len(call_log) == 2  # dry-run probe + install attempt
+
+    captured = capsys.readouterr().out
+    # Secret env value must NOT appear in cleartext.
+    assert secret not in captured
+    # The sanitised diagnostic block should have been emitted.
+    assert "Failed to install Chromium browser" in captured
+    assert "Subprocess output (sanitised)" in captured
+    assert "<redacted>" in captured
+    # ANSI codes from the stub stderr must have been stripped.
+    assert "\x1b" not in captured
+
+
+def test_install_failure_falls_back_to_stdout_when_stderr_is_only_whitespace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If sanitised stderr is whitespace-only, the diagnostic falls back to stdout.
+
+    Regression: an earlier draft used ``sanitised_stderr or sanitised_stdout``
+    which short-circuits on any truthy stderr (including ``"   \\n"``),
+    so a stderr that contained only ANSI progress noise would shadow a
+    stdout line carrying the actual failure message.
+    """
+    dry_run = _StubCompletedProcess(
+        stdout="chromium will download to /tmp/...",
+        stderr="",
+        returncode=0,
+    )
+    install_fail = _StubCompletedProcess(
+        stdout="actual actionable error from stdout\n",
+        # Stderr that sanitises down to whitespace (ANSI progress only).
+        stderr="\x1b[2K\x1b[1G\n   \n",
+        returncode=1,
+    )
+
+    def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
+        if "--dry-run" in cmd:
+            return dry_run
+        return install_fail
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit):
+        ensure_chromium_installed()
+
+    captured = capsys.readouterr().out
+    assert "actual actionable error from stdout" in captured
+    assert "Subprocess output (sanitised)" in captured
+
+
+def test_dry_run_unexpected_stderr_routed_through_redactor(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dry-run stderr (debug log path) also goes through the redactor."""
+    import logging as _logging
+
+    secret = "dry_run_secret_value_abc"
+    monkeypatch.setenv("REDACT_DRY_RUN_TEST", secret)
+
+    dry_run = _StubCompletedProcess(
+        # "will download" marker absent → take the early-return branch.
+        stdout="chromium is already installed",
+        stderr=f"warning: TOKEN={secret}\n",
+        returncode=0,
+    )
+
+    def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
+        return dry_run
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with caplog.at_level(_logging.DEBUG, logger="notebooklm.cli.services.playwright_login"):
+        ensure_chromium_installed()
+
+    # The debug log line should be present but redacted.
+    matching = [
+        record.getMessage()
+        for record in caplog.records
+        if "playwright install --dry-run stderr" in record.getMessage()
+    ]
+    assert matching, "expected a debug log line for dry-run stderr"
+    assert all(secret not in msg for msg in matching)
+    assert any("<redacted>" in msg for msg in matching)


### PR DESCRIPTION
Implements: meta-audit **G4** (`/.sisyphus/plans/cli-audit-2026-05-27-fixes.md` task F16).

## Summary

- Adds `redact_subprocess_output(text, env=None) -> str` to `cli/services/playwright_login.py` — strips ANSI control sequences and replaces every occurrence of each non-trivial environment-variable value with `<redacted>`. Walks JSON-shaped env values (e.g. `NOTEBOOKLM_AUTH_JSON`) so nested leaf strings are also redaction candidates.
- Applies the helper at both subprocess result sites in `ensure_chromium_installed`: the dry-run probe (unexpected stderr → sanitised debug log) and the install-failure path (sanitised diagnostic tail printed alongside the existing "run manually" hint).
- Pins the contract with 18 unit tests using stub `CompletedProcess` fixtures — no Playwright install required.

## Why

`ensure_chromium_installed` invokes the playwright CLI via `subprocess.run(..., capture_output=True)`. The captured stderr/stdout can carry two classes of noise we never want to surface raw:

1. **Environment-variable values** — the playwright CLI inherits the parent environment; if any secret (PSIDTS / cookie material set via `NOTEBOOKLM_AUTH_JSON` / SAPISID / etc.) ever gets interpolated into a traceback or config line by the CLI, it lands verbatim in `result.stderr`. Today nothing prints those streams, but the audit flagged the gap for the "next time we want to surface diagnostics" failure mode — and this PR makes the install-failure path actually emit a (sanitised) diagnostic tail so users have something to act on.
2. **ANSI control sequences** — pip/playwright progress bars and colour codes that dirty log scrapers and console output.

## Implementation notes

- **ANSI is stripped BEFORE redaction.** Otherwise a secret split by an inert reset (`"abc\x1b[0m123"`) wouldn't match the env value `"abc123"`, and the subsequent ANSI strip would reassemble the secret in cleartext.
- **JSON-nested values are expanded.** `NOTEBOOKLM_AUTH_JSON` carries a dict whose leaf strings (cookie tokens) are the actual secrets; a subprocess that re-emits a parsed value would otherwise bypass exact-string matching.
- **Stderr/stdout short-circuit compares on `.strip()`** so a stderr that sanitises down to whitespace (e.g. pure ANSI progress noise) doesn't shadow a stdout line carrying the actionable failure.
- **Candidate values are ansi-stripped too**, in case an env value itself carries embedded escape bytes (rare, but the input `text` has already been stripped above).
- Conservative skip-list: empty / short (`< 3 chars`) / well-known constants (`true`, `false`, `yes`, `no`, …) never trigger redaction, to avoid spamming `<redacted>` across normal path / boolean output.
- `dict(os.environ)` snapshot defends against concurrent env mutation.

## Test plan

`tests/unit/cli/test_playwright_login_stderr.py` (18 tests, all using stub `CompletedProcess` fixtures):

- [x] PSIDTS-style secret in stderr → `<redacted>`.
- [x] Multiple env values in one string → all redacted.
- [x] Trivial values (`""`, `/`, `true`, single-char, < 3-char, …) → never redacted.
- [x] Longer secret wins when one is a substring of another.
- [x] CSI / OSC / two-byte / full C1 Fe (0x40-0x5F) ANSI sequences stripped.
- [x] ANSI-interrupted secret reassembled and redacted (regression).
- [x] Nested JSON leaf values redacted (NOTEBOOKLM_AUTH_JSON case + array case).
- [x] Malformed JSON falls back to exact-match redaction.
- [x] Empty input returns empty.
- [x] Defaults to `os.environ` when `env=None`.
- [x] `ensure_chromium_installed` install-failure path routes captured stderr through helper, with no raw secret or ANSI in output.
- [x] Whitespace-only sanitised stderr falls back to sanitised stdout.
- [x] Dry-run debug log path also sanitised.

Verification:

```
uv run ruff format src/notebooklm/cli/services/playwright_login.py tests/unit/cli/test_playwright_login_stderr.py
uv run ruff check src/notebooklm/cli/services/playwright_login.py tests/unit/cli/test_playwright_login_stderr.py
uv run mypy src/notebooklm --ignore-missing-imports                       # Success: no issues found in 174 source files
uv run pytest tests/unit/cli/test_playwright_login_stderr.py -v           # 18 passed
uv run pytest tests/unit/cli -q                                           # 1547 passed
```

## Deferred polish findings

None.