### PR TITLE
refactor(cli): emit JSON envelope for download flag conflicts under --json

### DIFF
--- a/src/notebooklm/cli/services/download.py
+++ b/src/notebooklm/cli/services/download.py
@@ -26,7 +26,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, NoReturn, Protocol
 
 import click
 
@@ -37,6 +37,7 @@ from ..download_helpers import (
     resolve_partial_artifact_id,
     select_artifact,
 )
+from ..error_handler import output_error
 from ..resolve import require_notebook, resolve_notebook_id
 
 # Format → extension map shared with the runtime extension-override path
@@ -218,6 +219,22 @@ def _resolve_format_extension(
     return effective_ext
 
 
+def _emit_flag_conflict(message: str, *, json_output: bool) -> NoReturn:
+    """Surface a download flag-conflict via the active CLI error contract.
+
+    Per ADR-015, post-parse flag-combination failures are routed through
+    the typed JSON envelope under ``--json`` (exit ``1``) and via Click's
+    parser-style ``UsageError`` otherwise (exit ``2`` with usage text on
+    stderr). Never returns — both branches raise.
+    """
+    if json_output:
+        # ``output_error`` emits {"error": true, "code": ..., "message": ...}
+        # on stdout and raises SystemExit(1).
+        output_error(message, "VALIDATION_ERROR", True, 1)
+        raise AssertionError("unreachable")  # pragma: no cover
+    raise click.UsageError(message)
+
+
 def build_download_plan(
     config: DownloadTypeSpec,
     args: dict[str, Any],
@@ -227,11 +244,21 @@ def build_download_plan(
 ) -> DownloadPlan:
     """Validate + assemble a :class:`DownloadPlan` from raw Click args.
 
-    Synchronous: rejects flag conflicts with ``click.UsageError`` so the
-    error surfaces through Click's standard usage path; resolves the
-    notebook id via the shared ``require_notebook`` helper (no I/O). Does
-    NOT perform the async :func:`resolve_notebook_id` lookup — that runs
-    inside :func:`execute_download`.
+    Synchronous: rejects flag conflicts via the canonical CLI error path,
+    routing through the typed JSON envelope under ``--json`` and Click's
+    standard usage path otherwise; resolves the notebook id via the shared
+    ``require_notebook`` helper (no I/O). Does NOT perform the async
+    :func:`resolve_notebook_id` lookup — that runs inside
+    :func:`execute_download`.
+
+    Flag-conflict policy (see ADR-015):
+
+    - Under ``--json``: emit the typed envelope
+      ``{"error": true, "code": "VALIDATION_ERROR", "message": ...}`` on
+      stdout via :func:`output_error` and exit ``1``. The function never
+      returns in this branch.
+    - Under text mode: raise :class:`click.UsageError` so Click's parser
+      renders ``Usage: ... / Error: ...`` on stderr and exits ``2``.
 
     Args:
         config: One ``DownloadTypeSpec`` row from the registry.
@@ -250,15 +277,22 @@ def build_download_plan(
         Frozen ``DownloadPlan`` ready for :func:`execute_download`.
 
     Raises:
-        click.UsageError: when flag combinations conflict.
+        click.UsageError: when flag combinations conflict in text mode
+            (i.e. ``args["json_output"]`` is falsy).
+        SystemExit: when flag combinations conflict under ``--json``;
+            :func:`output_error` emits the envelope on stdout and raises
+            ``SystemExit(1)``.
     """
     # Flag conflicts — same checks as the pre-refactor _download_artifacts_generic.
+    # Under --json, route through the typed JSON envelope (ADR-015); otherwise
+    # preserve Click's UsageError path (exit 2 + usage text on stderr).
+    json_output = bool(args.get("json_output", False))
     if args.get("force") and args.get("no_clobber"):
-        raise click.UsageError("Cannot specify both --force and --no-clobber")
+        _emit_flag_conflict("Cannot specify both --force and --no-clobber", json_output=json_output)
     if args.get("latest") and args.get("earliest"):
-        raise click.UsageError("Cannot specify both --latest and --earliest")
+        _emit_flag_conflict("Cannot specify both --latest and --earliest", json_output=json_output)
     if args.get("download_all") and args.get("artifact_id"):
-        raise click.UsageError("Cannot specify both --all and --artifact")
+        _emit_flag_conflict("Cannot specify both --all and --artifact", json_output=json_output)
 
     nb_id = require_notebook(args.get("notebook_id"))
 

--- a/src/notebooklm/cli/services/download.py
+++ b/src/notebooklm/cli/services/download.py
@@ -14,10 +14,13 @@ Public API (the three names ADR-008 / phase-3.md P3.T2 requires):
 - :func:`build_download_plan` — synchronous validation + plan assembly.
 - :func:`execute_download` — coroutine that performs the actual download.
 
-The split is deliberate: ``build_download_plan`` raises ``UsageError`` on flag
-conflicts at the Click decorator boundary (so users see standard Click error
-messaging); ``execute_download`` performs all I/O. The Click handler wires
-the two together inside ``run_client_workflow``.
+The split is deliberate: ``build_download_plan`` rejects flag conflicts
+synchronously at the Click decorator boundary, while ``execute_download``
+performs all I/O. Per ADR-015, the conflict-rejection path is dual: under
+``--json`` it emits the typed JSON envelope on stdout via ``output_error``
+and exits 1; in text mode it raises ``click.UsageError`` so Click's parser
+renders standard usage messaging on stderr and exits 2. The Click handler
+wires the two together inside ``run_client_workflow``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -360,8 +360,10 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         ["download", "data-table", "-n", "abc123def456ghi789jkl", "--json"],
         _download_no_artifacts,
     ),
-    # download flag-conflict: post-parse UsageError site routed through the
+    # download flag-conflict: post-parse UsageError sites routed through the
     # JSON envelope per ADR-015 (services/download.py build_download_plan).
+    # One entry per conflict pair so a future regression in any of the three
+    # _emit_flag_conflict call sites surfaces here.
     (
         "download_flag_conflict_json",
         [
@@ -371,6 +373,33 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
             "abc123def456ghi789jkl",
             "--force",
             "--no-clobber",
+            "--json",
+        ],
+        None,
+    ),
+    (
+        "download_flag_conflict_latest_earliest_json",
+        [
+            "download",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--latest",
+            "--earliest",
+            "--json",
+        ],
+        None,
+    ),
+    (
+        "download_flag_conflict_all_artifact_json",
+        [
+            "download",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--all",
+            "--artifact",
+            "art123def456ghi789jkl",
             "--json",
         ],
         None,

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -360,6 +360,21 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         ["download", "data-table", "-n", "abc123def456ghi789jkl", "--json"],
         _download_no_artifacts,
     ),
+    # download flag-conflict: post-parse UsageError site routed through the
+    # JSON envelope per ADR-015 (services/download.py build_download_plan).
+    (
+        "download_flag_conflict_json",
+        [
+            "download",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--force",
+            "--no-clobber",
+            "--json",
+        ],
+        None,
+    ),
     # research group: no research running -> nonzero exit.
     (
         "research_wait_no_research",
@@ -436,4 +451,68 @@ def test_download_audio_non_json_mode_still_exits_nonzero(runner: CliRunner, moc
     assert result.exit_code != 0, (
         f"non-JSON failure must keep exiting nonzero; got {result.exit_code}\n"
         f"stdout:\n{result.stdout}\nstderr:\n{_safe_stderr(result)}"
+    )
+
+
+def test_download_flag_conflict_json_emits_typed_envelope(runner: CliRunner, mock_auth_env) -> None:
+    """ADR-015 spot-check: ``--force --no-clobber --json`` emits the typed
+    ``VALIDATION_ERROR`` envelope and exits 1, not Click's exit-2 usage text.
+    """
+    client = _make_client()
+    result = _run_with_mock_client(
+        runner,
+        [
+            "download",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--force",
+            "--no-clobber",
+            "--json",
+        ],
+        client,
+    )
+    assert result.exit_code == 1, (
+        f"expected exit 1 (VALIDATION_ERROR), got {result.exit_code}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{_safe_stderr(result)}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "error": True,
+        "code": "VALIDATION_ERROR",
+        "message": "Cannot specify both --force and --no-clobber",
+    }, payload
+
+
+def test_download_flag_conflict_text_mode_raises_click_usage_error(
+    runner: CliRunner, mock_auth_env
+) -> None:
+    """Regression guard: in text mode (no ``--json``) the flag conflict still
+    raises ``click.UsageError`` so Click's parser renders usage text on stderr
+    and exits 2 (ADR-015 Rule 4 — text-mode path preserved for this site).
+    """
+    client = _make_client()
+    result = _run_with_mock_client(
+        runner,
+        [
+            "download",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--force",
+            "--no-clobber",
+        ],
+        client,
+    )
+    assert result.exit_code == 2, (
+        f"expected Click UsageError exit 2, got {result.exit_code}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{_safe_stderr(result)}"
+    )
+    # Click writes the message to stderr (or to stdout when CliRunner mixes
+    # streams). Don't depend on stream split; just verify the message text
+    # surfaced and stdout has no JSON payload.
+    combined = result.stdout + _safe_stderr(result)
+    assert "Cannot specify both --force and --no-clobber" in combined, combined
+    assert not result.stdout.strip().startswith("{"), (
+        f"text mode must not emit JSON on stdout; got: {result.stdout!r}"
     )


### PR DESCRIPTION
## Summary

- `build_download_plan` raised `click.UsageError` for the three flag-combination checks (`--force`/`--no-clobber`, `--latest`/`--earliest`, `--all`/`--artifact`). Under `--json` that bypassed `handle_errors` and exited 2 with Click's usage text on stderr — automation branching on `json.loads(stdout)` saw no payload.
- Per [ADR-015](../blob/main/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md): route post-parse `ClickException`-subclass failures through `output_error(...)` under `--json` (typed envelope, exit 1); preserve `click.UsageError` (exit 2 + Click's usage text) in text mode.
- Introduces `_emit_flag_conflict(message, *, json_output)` (`NoReturn`) used by all three conflict sites in `services/download.py`.

## Acceptance criteria

- [x] Under `--json`: `download audio -n abc... --force --no-clobber --json` emits `{"error": true, "code": "VALIDATION_ERROR", "message": "..."}` on stdout and exits 1.
- [x] Under non-`--json`: same invocation still raises `click.UsageError` → Click writes usage text on stderr and exits 2 (unchanged behavior).
- [x] New `download_flag_conflict_json` entry in `JSON_ERROR_CASES` plus two spot-check tests covering exact envelope shape and text-mode regression.

## Contract reference

ADR-015 (`docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md`, landed in #1107) — Rule 2 (route post-parse `ClickException` through `output_error`), Rule 3 (wire shape unchanged), Rule 4 (text-mode UsageError path preserved for this site).

## Test plan

- [x] `uv run ruff format` + `uv run ruff check` on changed files
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (`NoReturn` annotation typechecks cleanly)
- [x] `uv run pytest tests/unit/test_json_error_exit.py -v -k download` (11/11 passed)
- [x] `uv run pytest tests/unit/cli` (1493 passed, 36 skipped — no regressions)
- [x] Full sweep `tests/unit/cli + test_json_error_exit + test_download_service + test_cli_boundary + tests/_lint` (1638 passed, 36 skipped)
- [x] Existing unit test `test_build_download_plan_rejects_force_and_no_clobber` (pins text-mode `UsageError`) still passes unchanged.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent handling of conflicting download flags: JSON mode emits a typed error and exits with code 1; text mode raises a usage error and prints the conflict message.
* **Tests**
  * Added coverage for multiple download-flag conflict cases in both JSON and text modes.
* **Documentation**
  * Clarified CLI behavior and exit guarantees for flag-conflict scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->