### PR TITLE
test(cli): add JSON purity dynamic inventory + new sweep entries

### DIFF
--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -29,6 +29,28 @@ from notebooklm.types import (
 )
 
 # ---------------------------------------------------------------------------
+# Coverage-gap markers — see ``test_json_stdout_purity.py``'s dynamic
+# inventory test. These commands currently lack the canonical JSON envelope
+# on unhandled exceptions: ``doctor`` and ``profile list`` are not wrapped in
+# ``handle_errors`` and raise the underlying ``OSError`` straight through
+# Click. The xfail entries document the gap and pressure a future PR to wrap
+# them in the standard envelope path (e.g. via ``handle_errors`` or a
+# command-local ``try`` that calls ``json_error_response``). When that lands,
+# the xfail flips to XPASS — at which point the marker should be removed and
+# the assertions become hard.
+# ---------------------------------------------------------------------------
+_DOCTOR_GAP_REASON = (
+    "doctor --json currently propagates OSError uncaught (no handle_errors "
+    "wrap, no command-local json_error_response). Tracked as meta-audit G9; "
+    "remove xfail when doctor adopts the canonical JSON error envelope."
+)
+_PROFILE_LIST_GAP_REASON = (
+    "profile list --json currently propagates OSError uncaught (no "
+    "handle_errors wrap). Remove xfail when profile list adopts the canonical "
+    "JSON error envelope."
+)
+
+# ---------------------------------------------------------------------------
 # Fixtures + helpers
 # ---------------------------------------------------------------------------
 
@@ -277,6 +299,16 @@ def _artifact_wait_timeout(client: MagicMock) -> None:
     client.artifacts.wait_for_completion = AsyncMock(side_effect=TimeoutError("timed out"))
 
 
+def _fail_notebook_create(client: MagicMock) -> None:
+    """`notebook create --json` failure: client.notebooks.create raises.
+
+    ``with_client`` wraps the body in ``handle_errors``, which catches
+    ``Exception`` and routes to ``_output_error`` with code
+    ``UNEXPECTED_ERROR`` (exit 2 — canonical envelope on stdout).
+    """
+    client.notebooks.create = AsyncMock(side_effect=RuntimeError("notebook quota exceeded"))
+
+
 # ---------------------------------------------------------------------------
 # Parametrized sweep
 # ---------------------------------------------------------------------------
@@ -372,13 +404,58 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
     ("share_status_failure", ["share", "status", "-n", "abc", "--json"], _fail_share_status),
     ("notebook_list_failure", ["list", "--json"], _fail_notebook_list),
     ("chat_ask_failure", ["ask", "hi", "-n", "abc", "--json"], _fail_chat_ask),
+    # notebook create: with_client + RuntimeError -> UNEXPECTED_ERROR envelope.
+    (
+        "notebook_create_failure",
+        ["create", "My Notebook", "--json"],
+        _fail_notebook_create,
+    ),
+    # doctor + profile-list: documented coverage gaps (see _DOCTOR_GAP_REASON /
+    # _PROFILE_LIST_GAP_REASON above). The argv lives here so the dynamic
+    # inventory test sees error-path coverage for these commands; the xfail
+    # absorbs the assertion failure until the src is wrapped in the canonical
+    # JSON error envelope.
+    pytest.param(
+        "doctor_failure",
+        ["doctor", "--json"],
+        None,  # customizer is irrelevant — mocking happens via the test body
+        marks=pytest.mark.xfail(strict=False, reason=_DOCTOR_GAP_REASON),
+    ),
+    pytest.param(
+        "profile_list_unauthorized",
+        ["profile", "list", "--json"],
+        None,  # ditto
+        marks=pytest.mark.xfail(strict=False, reason=_PROFILE_LIST_GAP_REASON),
+    ),
 ]
+
+
+# ``pytest.param`` wraps tuple entries with marks; harvest ids from the raw
+# values so ``parametrize(..., ids=...)`` continues to receive plain strings.
+def _case_ids(cases) -> list[str]:
+    out: list[str] = []
+    for entry in cases:
+        if hasattr(entry, "values"):  # pytest.ParameterSet
+            out.append(entry.values[0])
+        else:
+            out.append(entry[0])
+    return out
+
+
+# Filesystem-driven failure cases bypass the mock-client harness — they
+# trigger errors by mocking module-level filesystem helpers instead of
+# raising on a mock client method. See the xfail rationale at the top of
+# the file for why these don't currently emit the canonical envelope.
+_FS_FAILURE_PATCH_TARGETS = {
+    "doctor_failure": "notebooklm.cli.doctor_cmd.get_storage_path",
+    "profile_list_unauthorized": "notebooklm.cli.profile_cmd.list_profiles",
+}
 
 
 @pytest.mark.parametrize(
     "case_id,argv,customize",
     JSON_ERROR_CASES,
-    ids=[c[0] for c in JSON_ERROR_CASES],
+    ids=_case_ids(JSON_ERROR_CASES),
 )
 def test_json_error_exit_contract(
     case_id: str,
@@ -388,8 +465,16 @@ def test_json_error_exit_contract(
     mock_auth_env,
 ) -> None:
     """Failure paths in --json mode must exit nonzero AND emit valid JSON."""
-    client = _make_client(customize)
-    result = _run_with_mock_client(runner, argv, client)
+    fs_patch_target = _FS_FAILURE_PATCH_TARGETS.get(case_id)
+    if fs_patch_target is not None:
+        # doctor / profile-list: patch the module-level helper to raise OSError,
+        # then invoke without the mock-client harness (these commands don't
+        # construct NotebookLMClient at all).
+        with patch(fs_patch_target, side_effect=OSError("permission denied")):
+            result = runner.invoke(cli, argv, catch_exceptions=True)
+    else:
+        client = _make_client(customize)
+        result = _run_with_mock_client(runner, argv, client)
     _assert_json_error_contract(result, case_id)
 
 

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -8,19 +8,29 @@ Rich live status) belong on stderr.
 This test suite locks the contract for the two known violators called out in
 audit K2 / codex #4 — and adds a parametrized sweep across every CLI command
 that exposes a ``--json`` flag so future regressions surface immediately.
+
+It also walks the live Click tree to assert that every ``--json``-capable
+command has a sweep entry (or an explicitly-justified waiver) in both this
+file's ``JSON_COMMANDS`` (success path) AND the sibling
+``test_json_error_exit.py``'s ``JSON_ERROR_CASES`` (error path). Adding a new
+``--json`` command without coverage fails this inventory test by name.
 """
 
 from __future__ import annotations
 
 import json
 import math
+import sys
 from collections.abc import Generator
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
+from notebooklm import paths as paths_module
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc.types import ShareAccess, ShareViewLevel
 from notebooklm.types import (
@@ -294,6 +304,83 @@ def _customize_research_wait(client: MagicMock) -> None:
     )
 
 
+def _customize_notebook_create(client: MagicMock) -> None:
+    # `notebook create --json` calls `client.notebooks.create(title)`
+    # and emits a JSON payload with the new notebook's id/title/created_at.
+    client.notebooks.create = AsyncMock(
+        return_value=Notebook(
+            id="newxyz123abc456def789",
+            title="My Notebook",
+            created_at=datetime(2024, 1, 1),
+            is_owner=True,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filesystem-driven --json commands (doctor, profile list).
+# These cases bypass NotebookLMClient entirely and read ~/.notebooklm/...,
+# so the mock-client harness can't drive them. The parametrized sweep
+# dispatches on case_id and invokes them via the ``_setup_fs_<case>`` helpers
+# below, which take ``tmp_path`` + ``monkeypatch`` like the live doctor test
+# suite (tests/unit/cli/test_doctor.py) does.
+# ---------------------------------------------------------------------------
+
+
+FILESYSTEM_DRIVEN_CASES = frozenset({"doctor", "profile_list"})
+
+
+def _setup_fs_doctor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lay out a clean profile so ``doctor --json`` reports all-pass.
+
+    Mirrors the ``test_doctor_reports_clean_profile_layout`` fixture in
+    tests/unit/cli/test_doctor.py — without those files the doctor command
+    would still exit 0 but emit ``status: "fail"`` entries inside the
+    ``checks`` payload (the JSON document is still well-formed either way,
+    but a clean layout exercises every code branch the success-path sweep
+    cares about).
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths_module.set_active_profile(None)
+    paths_module._reset_config_cache()
+    profile_dir = tmp_path / "profiles" / "default"
+    profile_dir.mkdir(parents=True)
+    if sys.platform != "win32":
+        profile_dir.chmod(0o700)
+    storage = profile_dir / "storage_state.json"
+    storage.write_text(
+        json.dumps({"cookies": [{"name": "SID", "value": "x"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps({"default_profile": "default"}),
+        encoding="utf-8",
+    )
+
+
+def _setup_fs_profile_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lay out at least one profile so ``profile list --json`` emits a list."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths_module.set_active_profile(None)
+    paths_module._reset_config_cache()
+    profile_dir = tmp_path / "profiles" / "default"
+    profile_dir.mkdir(parents=True)
+    if sys.platform != "win32":
+        profile_dir.chmod(0o700)
+    # No storage_state.json -> authenticated=False in the payload, which
+    # is still a valid success case (profile list emits the row regardless).
+
+
+_FS_SETUPS = {
+    "doctor": _setup_fs_doctor,
+    "profile_list": _setup_fs_profile_list,
+}
+
+
 JSON_COMMANDS: list[tuple[str, list[str], object]] = [
     # source group
     ("source_list", ["source", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
@@ -365,6 +452,15 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
         ["history", "-n", "abc123def456ghi789jkl", "--json"],
         None,
     ),
+    # doctor / profile / notebook-create coverage (meta-audit G9 + I7 + I9):
+    # `doctor` and `profile list` read NOTEBOOKLM_HOME directly and don't
+    # build a NotebookLMClient — the parametrized test dispatches on these
+    # case_ids and uses the ``_setup_fs_<case>`` helpers above instead of
+    # the mock-client harness. `notebook_create` goes through the standard
+    # `with_client` path, so its customizer just preps the mock client.
+    ("doctor", ["doctor", "--json"], None),
+    ("profile_list", ["profile", "list", "--json"], None),
+    ("notebook_create", ["create", "My Notebook", "--json"], _customize_notebook_create),
 ]
 
 
@@ -379,10 +475,25 @@ def test_json_mode_stdout_is_parseable(
     customize,
     runner: CliRunner,
     mock_auth_env,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``--json`` stdout must be a single parseable JSON document."""
-    client = _make_client(customize)
-    result = _run_with_mock_client(runner, argv, client)
+    if case_id in FILESYSTEM_DRIVEN_CASES:
+        # Filesystem-driven commands (doctor, profile list) skip the mock-client
+        # harness — they read NOTEBOOKLM_HOME directly. Stage a clean layout
+        # under tmp_path so the command emits valid JSON without touching the
+        # caller's real profile. The active-profile/config cache lives at module
+        # scope; reset on exit so a later test doesn't inherit our tmp profile.
+        _FS_SETUPS[case_id](tmp_path, monkeypatch)
+        try:
+            result = runner.invoke(cli, argv, catch_exceptions=False)
+        finally:
+            paths_module.set_active_profile(None)
+            paths_module._reset_config_cache()
+    else:
+        client = _make_client(customize)
+        result = _run_with_mock_client(runner, argv, client)
 
     assert result.exit_code == 0, (
         f"{case_id} failed (exit={result.exit_code})\n"
@@ -400,6 +511,380 @@ def test_json_mode_stdout_is_parseable(
             f"--- stdout ---\n{result.stdout}\n"
             f"--- stderr ---\n{result.stderr}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic inventory: every --json command in the Click tree must have a
+# sweep entry (success + error) or an explicit waiver with rationale.
+# ---------------------------------------------------------------------------
+
+
+def _walk_json_command_paths(root: click.BaseCommand) -> set[tuple[str, ...]]:
+    """Walk the Click tree and return the path tuple of every leaf command
+    that exposes a ``--json`` option.
+
+    The path is the sequence of group/command names from the root (e.g.
+    ``("source", "list")``). Top-level commands have a 1-tuple path
+    (e.g. ``("doctor",)``).
+    """
+    paths: set[tuple[str, ...]] = set()
+
+    def visit(node: click.BaseCommand, path: tuple[str, ...]) -> None:
+        if isinstance(node, click.Group):
+            for name, child in node.commands.items():
+                visit(child, path + (name,))
+            return
+        for param in node.params:
+            if isinstance(param, click.Option) and "--json" in param.opts:
+                paths.add(path)
+                return
+
+    visit(root, ())
+    return paths
+
+
+def _resolve_path_from_argv(argv: list[str], root: click.BaseCommand = cli) -> tuple[str, ...]:
+    """Walk the Click tree using ``argv`` tokens to derive the command path.
+
+    Stops on the first token that's not a sub-command name (a flag, a
+    positional argument like a notebook ID, etc.) — so ``["ask", "hi",
+    "-n", "abc", "--json"]`` resolves to ``("ask",)`` because ``ask`` is
+    a leaf Command (not a Group).
+    """
+    path: list[str] = []
+    current: click.BaseCommand = root
+    for token in argv:
+        if token.startswith("-"):
+            break
+        if isinstance(current, click.Group) and token in current.commands:
+            current = current.commands[token]
+            path.append(token)
+        else:
+            break
+    return tuple(path)
+
+
+# Waivers are dict[path -> rationale]. The dynamic inventory test accepts a
+# --json command as "covered" if it's either in the sweep list OR in the
+# matching waiver dict. Every waiver must carry a rationale string; silent
+# waivers are forbidden (the lint below enforces non-empty rationale text).
+#
+# Goal: each entry that lands a real test moves out of the waiver dict and
+# into JSON_COMMANDS / JSON_ERROR_CASES. The waiver dicts shrink monotonically
+# as coverage grows.
+_GENERATE_RATIONALE = (
+    "RPC-side artifact generation; covered by integration tests against the "
+    "real backend, not the JSON stdout-purity unit sweep."
+)
+_DOWNLOAD_RATIONALE_SUCCESS = (
+    "Download success requires a real completed artifact + HTTP fetch; out of "
+    "scope for the unit-level JSON stdout sweep — covered by e2e tests."
+)
+_DOWNLOAD_RATIONALE_ERROR = (
+    "Download error envelope is covered for audio/video/infographic/slide-deck/"
+    "report/mind-map/data-table in the error sweep; the remaining variants "
+    "share the same generic download path and can grow sweep entries "
+    "incrementally."
+)
+_AUTH_RATIONALE = (
+    "Auth-flow command; success path depends on browser/cookie state and is "
+    "covered by tests/unit/cli/test_session_*.py + test_doctor.py."
+)
+_MUTATION_RATIONALE_SUCCESS = (
+    "Mutation command (delete/rename/save/refresh/clean/add); success path is "
+    "covered by tests/unit/cli/test_<group>_*.py — sweep entries can land here "
+    "incrementally as the JSON purity contract reaches each command."
+)
+_MUTATION_RATIONALE_ERROR = (
+    "Mutation command; error path is covered by tests/unit/cli/test_<group>_*.py — "
+    "sweep entries can land here incrementally as the JSON error envelope "
+    "contract reaches each command."
+)
+_INTROSPECTION_RATIONALE = (
+    "Read-only introspection command without a network round-trip in the "
+    "success path; ``--json`` purity is checked indirectly by the format unit "
+    "tests in tests/unit/cli/."
+)
+
+
+JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
+    # artifact group — get/poll/wait need a real or fully-stubbed generation
+    # status payload that round-trips through the artifact formatter chain.
+    ("artifact", "delete"): _MUTATION_RATIONALE_SUCCESS,
+    ("artifact", "export"): _MUTATION_RATIONALE_SUCCESS,
+    ("artifact", "get"): _MUTATION_RATIONALE_SUCCESS,
+    ("artifact", "poll"): _MUTATION_RATIONALE_SUCCESS,
+    ("artifact", "rename"): _MUTATION_RATIONALE_SUCCESS,
+    ("artifact", "wait"): _MUTATION_RATIONALE_SUCCESS,
+    # auth-flow commands (covered by dedicated test files).
+    ("auth", "check"): _AUTH_RATIONALE,
+    ("auth", "inspect"): _AUTH_RATIONALE,
+    ("configure",): _AUTH_RATIONALE,
+    # download group — success path needs a real artifact + HTTP fetch.
+    ("download", "audio"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "cinematic-video"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "data-table"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "flashcards"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "infographic"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "mind-map"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "quiz"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "report"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "slide-deck"): _DOWNLOAD_RATIONALE_SUCCESS,
+    ("download", "video"): _DOWNLOAD_RATIONALE_SUCCESS,
+    # generate group — RPC-driven artifact creation, covered by integration tests.
+    ("generate", "audio"): _GENERATE_RATIONALE,
+    ("generate", "cinematic-video"): _GENERATE_RATIONALE,
+    ("generate", "data-table"): _GENERATE_RATIONALE,
+    ("generate", "flashcards"): _GENERATE_RATIONALE,
+    ("generate", "infographic"): _GENERATE_RATIONALE,
+    ("generate", "mind-map"): _GENERATE_RATIONALE,
+    ("generate", "quiz"): _GENERATE_RATIONALE,
+    ("generate", "report"): _GENERATE_RATIONALE,
+    ("generate", "revise-slide"): _GENERATE_RATIONALE,
+    ("generate", "slide-deck"): _GENERATE_RATIONALE,
+    ("generate", "video"): _GENERATE_RATIONALE,
+    # language group — read-only introspection of the current notebook's
+    # language setting.
+    ("language", "get"): _INTROSPECTION_RATIONALE,
+    ("language", "list"): _INTROSPECTION_RATIONALE,
+    ("language", "set"): _MUTATION_RATIONALE_SUCCESS,
+    # note group — note list/save success is covered; remaining are mutations.
+    ("note", "create"): _MUTATION_RATIONALE_SUCCESS,
+    ("note", "delete"): _MUTATION_RATIONALE_SUCCESS,
+    ("note", "get"): _MUTATION_RATIONALE_SUCCESS,
+    ("note", "rename"): _MUTATION_RATIONALE_SUCCESS,
+    ("note", "save"): _MUTATION_RATIONALE_SUCCESS,
+    # share mutations (status/public/view-level are covered).
+    ("share", "add"): _MUTATION_RATIONALE_SUCCESS,
+    ("share", "remove"): _MUTATION_RATIONALE_SUCCESS,
+    ("share", "update"): _MUTATION_RATIONALE_SUCCESS,
+    # source group — list/fulltext/guide success are covered; remaining are
+    # mutations or wait-loops.
+    ("source", "add"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "add-drive"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "clean"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "delete"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "delete-by-title"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "get"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "refresh"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "rename"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "stale"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "wait"): _MUTATION_RATIONALE_SUCCESS,
+    # `use` mutates the active notebook context (filesystem state); a sweep
+    # entry would duplicate tests/unit/cli/test_session_characterization.py.
+    ("use",): _MUTATION_RATIONALE_SUCCESS,
+}
+
+
+JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
+    # artifact group — error envelope is covered for list + wait. Remaining
+    # entries are mutations that surface @with_client's UNEXPECTED_ERROR
+    # envelope on RPC failure; coverage can grow with the suite.
+    ("artifact", "delete"): _MUTATION_RATIONALE_ERROR,
+    ("artifact", "export"): _MUTATION_RATIONALE_ERROR,
+    ("artifact", "get"): _MUTATION_RATIONALE_ERROR,
+    ("artifact", "poll"): _MUTATION_RATIONALE_ERROR,
+    ("artifact", "rename"): _MUTATION_RATIONALE_ERROR,
+    ("artifact", "suggestions"): _MUTATION_RATIONALE_ERROR,
+    # auth-flow error paths (covered by dedicated test files).
+    ("auth", "check"): _AUTH_RATIONALE,
+    ("auth", "inspect"): _AUTH_RATIONALE,
+    ("configure",): _AUTH_RATIONALE,
+    # download group — these error paths are covered for audio/video/...; the
+    # remaining download_* cases below haven't been added yet.
+    ("download", "cinematic-video"): _DOWNLOAD_RATIONALE_ERROR,
+    ("download", "flashcards"): _DOWNLOAD_RATIONALE_ERROR,
+    ("download", "quiz"): _DOWNLOAD_RATIONALE_ERROR,
+    # generate group — RPC-driven; error envelope covered by integration tests.
+    ("generate", "audio"): _GENERATE_RATIONALE,
+    ("generate", "cinematic-video"): _GENERATE_RATIONALE,
+    ("generate", "data-table"): _GENERATE_RATIONALE,
+    ("generate", "flashcards"): _GENERATE_RATIONALE,
+    ("generate", "infographic"): _GENERATE_RATIONALE,
+    ("generate", "mind-map"): _GENERATE_RATIONALE,
+    ("generate", "quiz"): _GENERATE_RATIONALE,
+    ("generate", "report"): _GENERATE_RATIONALE,
+    ("generate", "revise-slide"): _GENERATE_RATIONALE,
+    ("generate", "slide-deck"): _GENERATE_RATIONALE,
+    ("generate", "video"): _GENERATE_RATIONALE,
+    # history / metadata / research-status / status: success-only sweep is the
+    # primary contract; error envelope can grow with the suite.
+    ("history",): _INTROSPECTION_RATIONALE,
+    ("metadata",): _INTROSPECTION_RATIONALE,
+    ("research", "status"): _INTROSPECTION_RATIONALE,
+    ("status",): _INTROSPECTION_RATIONALE,
+    # language group — see success rationale.
+    ("language", "get"): _INTROSPECTION_RATIONALE,
+    ("language", "list"): _INTROSPECTION_RATIONALE,
+    ("language", "set"): _MUTATION_RATIONALE_ERROR,
+    # note + share error paths for the remaining mutations.
+    ("note", "create"): _MUTATION_RATIONALE_ERROR,
+    ("note", "delete"): _MUTATION_RATIONALE_ERROR,
+    ("note", "get"): _MUTATION_RATIONALE_ERROR,
+    ("note", "rename"): _MUTATION_RATIONALE_ERROR,
+    ("note", "save"): _MUTATION_RATIONALE_ERROR,
+    ("share", "add"): _MUTATION_RATIONALE_ERROR,
+    ("share", "public"): _MUTATION_RATIONALE_ERROR,
+    ("share", "remove"): _MUTATION_RATIONALE_ERROR,
+    ("share", "update"): _MUTATION_RATIONALE_ERROR,
+    ("share", "view-level"): _MUTATION_RATIONALE_ERROR,
+    # source group — list error is covered; remaining mutations + introspection.
+    ("source", "add"): _MUTATION_RATIONALE_ERROR,
+    ("source", "add-drive"): _MUTATION_RATIONALE_ERROR,
+    ("source", "clean"): _MUTATION_RATIONALE_ERROR,
+    ("source", "delete"): _MUTATION_RATIONALE_ERROR,
+    ("source", "delete-by-title"): _MUTATION_RATIONALE_ERROR,
+    ("source", "fulltext"): _INTROSPECTION_RATIONALE,
+    ("source", "get"): _MUTATION_RATIONALE_ERROR,
+    ("source", "guide"): _INTROSPECTION_RATIONALE,
+    ("source", "refresh"): _MUTATION_RATIONALE_ERROR,
+    ("source", "rename"): _MUTATION_RATIONALE_ERROR,
+    ("source", "stale"): _INTROSPECTION_RATIONALE,
+    ("source", "wait"): _MUTATION_RATIONALE_ERROR,
+    # `use` context mutation — covered by session_characterization.
+    ("use",): _MUTATION_RATIONALE_ERROR,
+}
+
+
+def _success_covered_paths() -> set[tuple[str, ...]]:
+    return {_resolve_path_from_argv(argv) for _case_id, argv, _customize in JSON_COMMANDS}
+
+
+def _load_error_cases() -> list[tuple[str, list[str], object]]:
+    """Side-load ``JSON_ERROR_CASES`` from the sibling test file.
+
+    ``tests/`` is collected by pytest but not exposed as a Python package
+    (no ``__init__.py``), so a plain ``from tests.unit.test_json_error_exit
+    import JSON_ERROR_CASES`` fails at runtime. Load the sibling module by
+    file path instead — this also keeps the import lazy so a parse error in
+    the sibling file surfaces here as a clear inventory-test failure
+    instead of polluting this module's collection.
+    """
+    import importlib.util
+
+    sibling_path = Path(__file__).parent / "test_json_error_exit.py"
+    spec = importlib.util.spec_from_file_location(
+        "tests.unit._test_json_error_exit_sibling", sibling_path
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load sibling test module from {sibling_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    cases = module.JSON_ERROR_CASES
+    # ``pytest.param(..., marks=...)`` wraps entries in ParameterSet (exposed
+    # via ``.values``). Raw tuples have no such attribute. Normalize both.
+    unwrapped: list[tuple[str, list[str], object]] = []
+    for entry in cases:
+        values = tuple(entry.values) if hasattr(entry, "values") else tuple(entry)
+        unwrapped.append((values[0], list(values[1]), values[2]))
+    return unwrapped
+
+
+def _error_covered_paths() -> set[tuple[str, ...]]:
+    return {_resolve_path_from_argv(argv) for _case_id, argv, _customize in _load_error_cases()}
+
+
+def _build_coverage_report(
+    discovered: set[tuple[str, ...]],
+    success_paths: set[tuple[str, ...]],
+    error_paths: set[tuple[str, ...]],
+) -> str:
+    """Render the inventory coverage report.
+
+    Format intentionally matches the audit plan's "X of Y --json commands have
+    success + error entries" wording so the line is grep-friendly.
+    """
+    total = len(discovered)
+    both = len({p for p in discovered if p in success_paths and p in error_paths})
+    return (
+        "\nJSON purity coverage report:\n"
+        f"  {len(success_paths)} of {total} --json commands have a success entry "
+        "(JSON_COMMANDS sweep)\n"
+        f"  {len(error_paths)} of {total} --json commands have an error entry "
+        "(JSON_ERROR_CASES sweep)\n"
+        f"  {both} of {total} --json commands have success + error entries\n"
+        f"  Waivers (with rationale): {len(JSON_SUCCESS_WAIVED)} success, "
+        f"{len(JSON_ERROR_WAIVED)} error\n"
+    )
+
+
+def test_all_json_commands_have_sweep_entry() -> None:
+    """Every ``--json`` CLI command must appear in the sweep or in a waiver.
+
+    The Click tree is the source of truth: any leaf command with a ``--json``
+    flag MUST be covered by
+
+      * a ``JSON_COMMANDS`` entry **or** ``JSON_SUCCESS_WAIVED`` rationale
+        (success-path coverage), **and**
+      * a ``JSON_ERROR_CASES`` entry **or** ``JSON_ERROR_WAIVED`` rationale
+        (error-path coverage).
+
+    Adding a new ``--json`` command without coverage fails this test by name —
+    the message lists exactly which paths are uncovered, so the fix is to
+    either land a sweep entry or add a justified waiver row to the relevant
+    dict above.
+
+    The coverage report is always rendered: on assertion failure it's
+    appended to the message, and on pass it goes through pytest's captured
+    stdout (visible under ``pytest -s`` or in test artifacts). The waiver
+    dicts are designed to shrink monotonically as real sweep entries land.
+    """
+    discovered = _walk_json_command_paths(cli)
+    success_paths = _success_covered_paths()
+    error_paths = _error_covered_paths()
+
+    missing_success = sorted(
+        path for path in discovered if path not in success_paths and path not in JSON_SUCCESS_WAIVED
+    )
+    missing_error = sorted(
+        path for path in discovered if path not in error_paths and path not in JSON_ERROR_WAIVED
+    )
+
+    # Stale-waiver lint: a waiver for a command that no longer has --json
+    # (or no longer exists) is a footgun — remove it from the dict.
+    stale_success_waivers = sorted(p for p in JSON_SUCCESS_WAIVED if p not in discovered)
+    stale_error_waivers = sorted(p for p in JSON_ERROR_WAIVED if p not in discovered)
+
+    # Silent-waiver lint: every waiver entry must carry a non-empty rationale.
+    empty_success_rationale = sorted(p for p, r in JSON_SUCCESS_WAIVED.items() if not r.strip())
+    empty_error_rationale = sorted(p for p, r in JSON_ERROR_WAIVED.items() if not r.strip())
+
+    report = _build_coverage_report(discovered, success_paths, error_paths)
+    # Emit to the captured stdout so ``pytest -s`` surfaces the line; pytest
+    # also replays captured stdout on assertion failure, which is when the
+    # operator most wants to see the split.
+    print(report)
+
+    failures: list[str] = []
+    if missing_success:
+        failures.append(
+            "Missing success-path coverage (add to JSON_COMMANDS or "
+            f"JSON_SUCCESS_WAIVED): {missing_success}"
+        )
+    if missing_error:
+        failures.append(
+            "Missing error-path coverage (add to JSON_ERROR_CASES in "
+            f"test_json_error_exit.py or JSON_ERROR_WAIVED): {missing_error}"
+        )
+    if stale_success_waivers:
+        failures.append(
+            "Stale entries in JSON_SUCCESS_WAIVED (no longer have --json or "
+            f"don't exist): {stale_success_waivers}"
+        )
+    if stale_error_waivers:
+        failures.append(
+            "Stale entries in JSON_ERROR_WAIVED (no longer have --json or "
+            f"don't exist): {stale_error_waivers}"
+        )
+    if empty_success_rationale:
+        failures.append(
+            f"Silent waiver(s) in JSON_SUCCESS_WAIVED (empty rationale): {empty_success_rationale}"
+        )
+    if empty_error_rationale:
+        failures.append(
+            f"Silent waiver(s) in JSON_ERROR_WAIVED (empty rationale): {empty_error_rationale}"
+        )
+    assert not failures, "\n".join(failures) + "\n" + report
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Walk the Click tree to assert every `--json` command has a sweep entry (success + error) or an explicitly-justified waiver — a new `--json` command without coverage fails the inventory test by name.
- Add three success entries to `JSON_COMMANDS`: `doctor`, `profile_list`, `notebook_create`.
- Add three error entries to `JSON_ERROR_CASES`: `doctor_failure` (mocks `get_storage_path` -> `OSError`), `profile_list_unauthorized`, `notebook_create_failure`. The doctor and profile-list cases are `xfail`-marked with rationale because the commands currently propagate `OSError` uncaught instead of emitting the canonical JSON envelope; the marker pressures a future PR to wrap them in `handle_errors`.
- Emit a coverage report: today the sweep covers 19/71 success and 19/71 error entries, with 10/71 commands in both. The remaining 52 success + 53 error commands are listed in `JSON_SUCCESS_WAIVED` / `JSON_ERROR_WAIVED` waiver dicts, each with a rationale string. Stale-waiver and empty-rationale lints prevent the waivers from rotting.
- Pre-existing 16 entries in each list preserved verbatim.

## Task

Test-infrastructure task from `.sisyphus/plans/cli-audit-2026-05-27-fixes.md`.

## Test plan

- [x] `uv run pytest tests/unit/test_json_stdout_purity.py tests/unit/test_json_error_exit.py -q` -> 41 passed, 2 xfailed
- [x] `uv run pytest tests/unit/cli -q` -> 1493 passed, 36 skipped
- [x] `uv run pytest tests/unit -q` -> 5949 passed, 89 skipped, 2 xfailed (the new ones)
- [x] `uv run ruff format --check` + `uv run ruff check` on the two test files -> clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` -> 174 src files clean
- [x] Sanity-checked: removing a `--json` entry from `JSON_COMMANDS` triggers the inventory test with a precise diagnostic (e.g. `missing_success: [('doctor',)]`)

## Deferred polish findings

none