### PR TITLE
feat(cli): SSRF guard on source add --url

### DIFF
--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import contextlib
+import ipaddress
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol
+from urllib.parse import urlsplit
 
 from ...types import Source
 from ...urls import is_youtube_url
@@ -71,6 +73,90 @@ _PATH_SHAPED_EXTENSIONS = frozenset(
 )
 
 
+#: Schemes accepted by ``source add`` when content is URL-shaped. Any other
+#: scheme (``file://``, ``ftp://``, ``gopher://``, ...) is rejected outright
+#: as an SSRF / local-file-read risk — even with ``--allow-internal``.
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _is_url_shaped(content: str) -> bool:
+    """Return True if ``content`` looks like a URL (has a scheme delimiter).
+
+    This is a tight heuristic — we only treat content as URL-shaped when
+    ``"://"`` is present. ``urllib.parse.urlsplit`` happily produces single-
+    letter schemes for Windows-style paths like ``c:\\foo\\bar.pdf``, which
+    we still want to flow through to the file/text detection branch.
+    """
+    return "://" in content
+
+
+def validate_url(url: str, *, allow_internal: bool) -> None:
+    """Validate a URL for SSRF / local-file-read safety.
+
+    Replaces the previous ``startswith(("http://", "https://"))`` prefix
+    check with a structural parse + a scheme allowlist + a private/loopback/
+    link-local IP rejection (with ``localhost`` rejected by literal when the
+    host is a DNS name).
+
+    DNS is **never** resolved at validation time: resolving here would be
+    flaky in CI and would leak the caller's interest in the URL to whatever
+    resolver is configured. The DNS-name branch only matches the literal
+    ``"localhost"`` (case-insensitive).
+
+    Args:
+        url: The URL the user wants to add as a source.
+        allow_internal: If True, bypass the internal-host rejection (private
+            IPs, loopback, link-local, and the ``localhost`` literal). The
+            scheme allowlist still applies — ``file://`` / ``ftp://`` etc.
+            are rejected even with ``allow_internal=True``.
+
+    Raises:
+        SourceAddValidationError: if the URL is structurally invalid, has a
+            disallowed scheme, has no host, or (without ``allow_internal``)
+            targets an internal host.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError as exc:  # pragma: no cover — urlsplit is permissive
+        raise SourceAddValidationError(f"Invalid URL: {url} ({exc})") from exc
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_URL_SCHEMES:
+        raise SourceAddValidationError(
+            f"URL scheme {scheme!r} is not allowed; only http and https URLs "
+            f"are accepted as sources. Got: {url}"
+        )
+
+    # ``hostname`` strips port + IPv6 brackets, lowercases for us, and
+    # returns ``None`` for ``http:///path`` style inputs with no host.
+    host = parsed.hostname
+    if not host:
+        raise SourceAddValidationError(f"URL has no host component: {url}")
+
+    if allow_internal:
+        return
+
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Host is a DNS name (not an IP literal). DO NOT resolve it —
+        # resolving here would be flaky in CI and leaks intent. Reject
+        # only the ``localhost`` literal; everything else is accepted at
+        # this layer and the network stack handles connectivity later.
+        if host.lower() == "localhost":
+            raise SourceAddValidationError(
+                f"URL targets the local host {host!r}; pass --allow-internal "
+                f"to override. Got: {url}"
+            ) from None
+        return
+
+    if ip.is_private or ip.is_loopback or ip.is_link_local:
+        raise SourceAddValidationError(
+            f"URL targets an internal IP address {host}; pass --allow-internal "
+            f"to override. Got: {url}"
+        )
+
+
 def looks_like_path(content: str) -> bool:
     """Return True if ``content`` is path-shaped (slash OR known extension)."""
     if "/" in content or "\\" in content:
@@ -113,15 +199,32 @@ def build_source_add_plan(
     follow_symlinks: bool,
     validate_path: Callable[[str, bool], Path],
     looks_path_shaped: Callable[[str], bool],
+    allow_internal: bool = False,
 ) -> SourceAddPlan:
-    """Detect source-add mode, validate upload paths, and collect warnings."""
+    """Detect source-add mode, validate upload paths + URLs, collect warnings.
+
+    URL validation (SSRF guard): any URL-shaped content (``"://"`` present)
+    is passed through :func:`validate_url`, which enforces a http/https
+    scheme allowlist and rejects private / loopback / link-local IP hosts
+    (plus the ``localhost`` literal). The opt-in ``allow_internal=True``
+    flag bypasses the host check but still rejects non-http(s) schemes.
+
+    Args:
+        allow_internal: Forwarded to :func:`validate_url` to opt into
+            internal-host URLs (e.g. ``http://127.0.0.1:8080``).
+    """
     detected_type = source_type
     file_title = title
     upload_path: Path | None = None
     warnings: list[str] = []
 
     if detected_type is None:
-        if content.startswith(("http://", "https://")):
+        if _is_url_shaped(content):
+            # Validate before deciding url vs youtube — a bad scheme or an
+            # internal-IP host must raise before we even bind a type, so
+            # ``--type youtube`` cannot smuggle ``file:///etc/passwd`` past
+            # the gate via auto-detection.
+            validate_url(content, allow_internal=allow_internal)
             detected_type = "youtube" if is_youtube_url(content) else "url"
         elif Path(content).exists() or Path(content).is_symlink():
             upload_path = validate_path(content, follow_symlinks)
@@ -137,6 +240,11 @@ def build_source_add_plan(
             file_title = title or "Pasted Text"
     elif detected_type == "file":
         upload_path = validate_path(content, follow_symlinks)
+    elif detected_type in {"url", "youtube"}:
+        # Explicit ``--type url`` / ``--type youtube`` must honor the same
+        # gate as auto-detection: pre-fix, ``--type url file:///etc/passwd``
+        # would skip the prefix check entirely.
+        validate_url(content, allow_internal=allow_internal)
 
     return SourceAddPlan(
         content=content,

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -333,6 +333,18 @@ def source_list(ctx, notebook_id, json_output, limit, no_truncate, client_auth):
         "file it points at (e.g. ~/Downloads/foo.pdf -> /etc/passwd)."
     ),
 )
+@click.option(
+    "--allow-internal",
+    is_flag=True,
+    default=False,
+    help=(
+        "Allow URLs that point at internal hosts (``localhost``, "
+        "``127.0.0.1``, private IP ranges, link-local). By default these "
+        "are rejected to prevent the CLI from being used as an SSRF "
+        "trampoline. Non-http(s) schemes (``file://``, ``ftp://``, ...) "
+        "are rejected even with this flag."
+    ),
+)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
 def source_add(
@@ -344,6 +356,7 @@ def source_add(
     mime_type,
     timeout,
     follow_symlinks,
+    allow_internal,
     json_output,
     client_auth,
 ):
@@ -362,15 +375,20 @@ def source_add(
         source_type = "text"
 
     nb_id = require_notebook(notebook_id)
-    plan = source_add_service.build_source_add_plan(
-        content=content,
-        source_type=source_type,
-        title=title,
-        mime_type=mime_type,
-        follow_symlinks=follow_symlinks,
-        validate_path=_validate_upload_path,
-        looks_path_shaped=_looks_like_path,
-    )
+    try:
+        plan = source_add_service.build_source_add_plan(
+            content=content,
+            source_type=source_type,
+            title=title,
+            mime_type=mime_type,
+            follow_symlinks=follow_symlinks,
+            validate_path=_validate_upload_path,
+            looks_path_shaped=_looks_like_path,
+            allow_internal=allow_internal,
+        )
+    except source_add_service.SourceAddValidationError as exc:
+        _output_error(f"Error: {exc}", "VALIDATION_ERROR", json_output, 1)
+        raise AssertionError("unreachable") from None  # pragma: no cover
 
     for warning in plan.warnings:
         click.echo(warning, err=True)

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -8210,6 +8210,24 @@
           "default": false,
           "envvar": null,
           "has_custom_shell_complete": false,
+          "help": "Allow URLs that point at internal hosts (``localhost``, ``127.0.0.1``, private IP ranges, link-local). By default these are rejected to prevent the CLI from being used as an SSRF trampoline. Non-http(s) schemes (``file://``, ``ftp://``, ...) are rejected even with this flag.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "allow_internal",
+          "opts": [
+            "--allow-internal"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -11,6 +13,7 @@ import pytest
 
 from notebooklm._source_add import SourceAddService
 from notebooklm._sources import SourcesAPI
+from notebooklm.cli.services import source_add as cli_source_add
 from notebooklm.exceptions import NetworkError, NonIdempotentRetryError, SourceAddError
 from notebooklm.rpc import RPCError, RPCMethod
 from notebooklm.types import Source
@@ -360,3 +363,278 @@ async def test_sources_api_add_url_uses_late_bound_facade_hooks() -> None:
     api._add_youtube_source.assert_awaited_once_with("nb_1", "https://youtu.be/video")
     api._add_url_source.assert_not_awaited()
     api.wait_until_ready.assert_awaited_once_with("nb_1", "src_yt", timeout=3.0)
+
+
+# ---------------------------------------------------------------------------
+# CLI service layer: SSRF guard on `source add --url`
+#
+# These tests target ``notebooklm.cli.services.source_add.validate_url`` and
+# the routing inside ``build_source_add_plan``. They replace the previous
+# ``startswith(("http://", "https://"))`` prefix check, which let
+# ``file:///etc/passwd`` and ``http://169.254.169.254/`` through.
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlScheme:
+    """Scheme allowlist: only http/https accepted, even with --allow-internal."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "ftp://example.com/foo",
+            "gopher://example.com/",
+            "data:text/plain,hello",
+            "javascript:alert(1)",
+        ],
+    )
+    def test_disallowed_schemes_are_rejected_strict(self, url: str) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError) as exc_info:
+            cli_source_add.validate_url(url, allow_internal=False)
+
+        msg = str(exc_info.value)
+        assert "scheme" in msg.lower()
+        assert "http and https" in msg.lower()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "ftp://example.com/foo",
+        ],
+    )
+    def test_disallowed_schemes_still_rejected_with_allow_internal(self, url: str) -> None:
+        """``--allow-internal`` is for INTERNAL HOSTS, not for unsafe schemes.
+
+        ``file://`` would let the CLI read arbitrary local files; ``ftp://``
+        could probe internal services. Neither should be unlocked by the
+        internal-host opt-in.
+        """
+        with pytest.raises(cli_source_add.SourceAddValidationError) as exc_info:
+            cli_source_add.validate_url(url, allow_internal=True)
+
+        assert "scheme" in str(exc_info.value).lower()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com",
+            "https://example.com",
+            "https://example.com/path?q=1",
+            "https://sub.example.co.uk:8443/page",
+            "HTTPS://Example.Com/",  # mixed case scheme — urlsplit lowercases via .scheme
+        ],
+    )
+    def test_public_http_https_urls_pass(self, url: str) -> None:
+        # No raise — the call returns None on success.
+        cli_source_add.validate_url(url, allow_internal=False)
+
+    def test_empty_url_is_rejected(self) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.validate_url("", allow_internal=False)
+
+    def test_url_without_host_is_rejected(self) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError) as exc_info:
+            cli_source_add.validate_url("http:///path", allow_internal=False)
+
+        assert "no host" in str(exc_info.value).lower()
+
+
+class TestValidateUrlInternalHost:
+    """Host policy: reject private/loopback/link-local IPs + ``localhost`` literal."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Loopback IPv4
+            "http://127.0.0.1",
+            "http://127.0.0.1:8080/foo",
+            # Private RFC1918 ranges
+            "http://10.0.0.1",
+            "http://172.16.0.1",
+            "http://192.168.1.1",
+            # Link-local (the classic SSRF target — cloud metadata IP)
+            "http://169.254.169.254/latest/meta-data/",
+            # IPv6 loopback (urlsplit strips brackets via .hostname)
+            "http://[::1]/",
+            # DNS literal "localhost"
+            "http://localhost",
+            "https://localhost:3000/",
+            "http://LOCALHOST/",  # case-insensitive match
+        ],
+    )
+    def test_internal_hosts_rejected_strict(self, url: str) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError) as exc_info:
+            cli_source_add.validate_url(url, allow_internal=False)
+
+        msg = str(exc_info.value).lower()
+        assert "internal" in msg or "local" in msg
+        assert "--allow-internal" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:8080/api",
+            "http://10.0.0.1/",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://localhost:3000/health",
+            "http://[::1]/",
+        ],
+    )
+    def test_internal_hosts_pass_with_allow_internal(self, url: str) -> None:
+        """``--allow-internal`` opts into private/loopback/link-local hosts."""
+        cli_source_add.validate_url(url, allow_internal=True)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com",
+            "https://google.com",
+            "https://api.notebooklm.google.com/foo",
+            "http://1.1.1.1",  # public IP — must pass
+            "http://8.8.8.8/dns-query",  # public IP
+        ],
+    )
+    def test_public_dns_and_public_ips_pass_strict(self, url: str) -> None:
+        cli_source_add.validate_url(url, allow_internal=False)
+
+    def test_dns_validation_does_not_resolve(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Guard against accidentally introducing DNS resolution.
+
+        The validator must reject ``localhost`` by literal match, NOT by
+        resolving it (resolving would be flaky in CI and would leak the
+        caller's interest in the URL).
+        """
+        import socket
+
+        def _explode(*_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("validate_url must not resolve DNS at validation time")
+
+        monkeypatch.setattr(socket, "gethostbyname", _explode)
+        monkeypatch.setattr(socket, "getaddrinfo", _explode)
+
+        # Public DNS name — must NOT resolve.
+        cli_source_add.validate_url("https://example.com/", allow_internal=False)
+        # ``localhost`` rejection — must come from the literal match.
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.validate_url("http://localhost/", allow_internal=False)
+
+
+class TestBuildSourceAddPlanUrlRouting:
+    """``build_source_add_plan`` routes URL-shaped content through validate_url."""
+
+    def _make_validate_path(self) -> Callable[[str, bool], Path]:
+        return MagicMock(return_value=Path("/tmp/x"))
+
+    def _make_looks_path(self) -> Callable[[str], bool]:
+        return MagicMock(return_value=False)
+
+    def test_public_http_url_is_detected_as_url(self) -> None:
+        plan = cli_source_add.build_source_add_plan(
+            content="https://example.com/article",
+            source_type=None,
+            title=None,
+            mime_type=None,
+            follow_symlinks=False,
+            validate_path=self._make_validate_path(),
+            looks_path_shaped=self._make_looks_path(),
+        )
+        assert plan.detected_type == "url"
+
+    def test_internal_url_is_rejected_during_auto_detect(self) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.build_source_add_plan(
+                content="http://127.0.0.1:8080/admin",
+                source_type=None,
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=self._make_validate_path(),
+                looks_path_shaped=self._make_looks_path(),
+            )
+
+    def test_internal_url_accepted_with_allow_internal(self) -> None:
+        plan = cli_source_add.build_source_add_plan(
+            content="http://127.0.0.1:8080/admin",
+            source_type=None,
+            title=None,
+            mime_type=None,
+            follow_symlinks=False,
+            validate_path=self._make_validate_path(),
+            looks_path_shaped=self._make_looks_path(),
+            allow_internal=True,
+        )
+        assert plan.detected_type == "url"
+
+    def test_file_scheme_is_rejected_even_with_allow_internal(self) -> None:
+        """``--allow-internal`` must NOT unlock ``file://``."""
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.build_source_add_plan(
+                content="file:///etc/passwd",
+                source_type=None,
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=self._make_validate_path(),
+                looks_path_shaped=self._make_looks_path(),
+                allow_internal=True,
+            )
+
+    def test_explicit_type_url_still_validates(self) -> None:
+        """``--type url file:///etc/passwd`` must NOT bypass the gate.
+
+        Pre-fix, the prefix check only ran in the auto-detect branch — an
+        explicit ``--type url`` skipped validation entirely. The new gate
+        runs in both branches.
+        """
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.build_source_add_plan(
+                content="file:///etc/passwd",
+                source_type="url",
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=self._make_validate_path(),
+                looks_path_shaped=self._make_looks_path(),
+            )
+
+    def test_explicit_type_youtube_still_validates(self) -> None:
+        with pytest.raises(cli_source_add.SourceAddValidationError):
+            cli_source_add.build_source_add_plan(
+                content="http://169.254.169.254/latest/meta-data/",
+                source_type="youtube",
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=self._make_validate_path(),
+                looks_path_shaped=self._make_looks_path(),
+            )
+
+    def test_non_url_content_falls_through_to_text(self) -> None:
+        """Bare strings (no ``://``) must NOT be parsed as URLs."""
+        plan = cli_source_add.build_source_add_plan(
+            content="hello world",
+            source_type=None,
+            title=None,
+            mime_type=None,
+            follow_symlinks=False,
+            validate_path=self._make_validate_path(),
+            looks_path_shaped=self._make_looks_path(),
+        )
+        assert plan.detected_type == "text"
+
+    def test_youtube_url_still_routes_to_youtube_type(self) -> None:
+        plan = cli_source_add.build_source_add_plan(
+            content="https://www.youtube.com/watch?v=abc123",
+            source_type=None,
+            title=None,
+            mime_type=None,
+            follow_symlinks=False,
+            validate_path=self._make_validate_path(),
+            looks_path_shaped=self._make_looks_path(),
+        )
+        assert plan.detected_type == "youtube"


### PR DESCRIPTION
## Summary

- Replace the prefix-only URL check in `cli/services/source_add.py` with a structural `urlsplit` parse + scheme allowlist + private/loopback/link-local IP guard
- Add `--allow-internal` flag to `source add` for the rare case where users genuinely want to ingest a localhost/RFC-1918 URL
- DNS is never resolved at validation time (CI-safe; no resolver leakage)
- Tests cover the rejected URL set (`file://`, `ftp://`, `http://localhost`, `http://127.0.0.1`, `http://10.0.0.1`, `http://169.254.169.254`, `http://172.16.0.1`) and the `--allow-internal` opt-in

Addresses **meta-audit I5** (URL validation in `source add` was prefix-only and offered no local defence against SSRF / file-read URLs).

Implements per [ADR-015](docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md) — validation errors emit a JSON envelope under `--json`, Rich text under default.

## Test plan

- [x] `uv run pytest tests/unit/test_source_add_service.py -q` → 56 passed
- [x] `uv run ruff format` clean
- [x] `uv run ruff check` clean
- [ ] CI test matrix
- [ ] @claude review
- [ ] CodeRabbit / Gemini review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-internal` flag to the `source add` command, allowing URLs targeting internal hosts (localhost, loopback, private IP ranges, link-local addresses) to be used.
  * Implemented enhanced URL validation that rejects non-HTTP(S) schemes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->