### PR TITLE
refactor(cli): route generate validation through JSON envelope (ADR-015)

### DIFF
--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -74,8 +74,12 @@ def resolve_language(language: str | None) -> str:
     env_lang = os.environ.get("NOTEBOOKLM_HL", "").strip()
     if env_lang:
         if env_lang not in SUPPORTED_LANGUAGES:
+            # Distinguish the env-var source so the user knows which input is
+            # at fault (the ``in config`` branch below already disambiguates;
+            # the CLI flag is the unqualified default since it's the most
+            # common path).
             output_error(
-                f"Unknown language code: {env_lang}\n"
+                f"Unknown language code from NOTEBOOKLM_HL: {env_lang}\n"
                 "Run 'notebooklm language list' to see supported codes.",
                 "VALIDATION_ERROR",
                 current_json_output(),

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -16,6 +16,7 @@ import click
 
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
+from .error_handler import current_json_output, output_error
 from .input import resolve_prompt
 from .language_cmd import SUPPORTED_LANGUAGES, get_language
 from .options import (
@@ -51,31 +52,45 @@ def resolve_language(language: str | None) -> str:
     Priority: ``--language`` flag > ``NOTEBOOKLM_HL`` env var > config file
     > "en" default. Uses explicit None checks to avoid treating empty
     string as falsy. Validates each candidate against the supported list.
+
+    Invalid codes route through :func:`output_error` per ADR-015: under
+    ``--json`` the typed JSON envelope is emitted on stdout
+    (``code: "VALIDATION_ERROR"``, exit 1); in text mode the same message
+    is written to stderr (exit 1, no Click usage footer). The active
+    ``--json`` flag is inferred via :func:`current_json_output` so this
+    helper stays callable from both the Click handler and the service-layer
+    plan builder without threading the flag through its signature.
     """
     if language is not None:
         if language not in SUPPORTED_LANGUAGES:
-            raise click.BadParameter(
+            output_error(
                 f"Unknown language code: {language}\n"
                 "Run 'notebooklm language list' to see supported codes.",
-                param_hint="'--language'",
+                "VALIDATION_ERROR",
+                current_json_output(),
+                1,
             )
         return language
     env_lang = os.environ.get("NOTEBOOKLM_HL", "").strip()
     if env_lang:
         if env_lang not in SUPPORTED_LANGUAGES:
-            raise click.BadParameter(
+            output_error(
                 f"Unknown language code: {env_lang}\n"
                 "Run 'notebooklm language list' to see supported codes.",
-                param_hint="'NOTEBOOKLM_HL'",
+                "VALIDATION_ERROR",
+                current_json_output(),
+                1,
             )
         return env_lang
     config_lang = get_language()
     if config_lang is not None:
         if config_lang not in SUPPORTED_LANGUAGES:
-            raise click.BadParameter(
+            output_error(
                 f"Unknown language code in config: {config_lang}\n"
                 "Run 'notebooklm language list' to see supported codes.",
-                param_hint="config",
+                "VALIDATION_ERROR",
+                current_json_output(),
+                1,
             )
         return config_lang
     return DEFAULT_LANGUAGE

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -55,6 +55,7 @@ from ...types import (
     VideoFormat,
     VideoStyle,
 )
+from ..error_handler import output_error
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -291,9 +292,13 @@ def build_generation_plan(
         A frozen :class:`GenerationPlan` ready for :func:`execute_generation`.
 
     Raises:
-        click.UsageError: For invalid parameter combinations (cinematic
-            video + ``--style-prompt``, ``--style custom`` without
+        SystemExit: For invalid parameter combinations (cinematic video +
+            ``--style-prompt``, ``--style custom`` without
             ``--style-prompt``, ``cinematic-video --format <non-cinematic>``).
+            Routed through :func:`cli.error_handler.output_error` per
+            ADR-015: under ``--json`` the typed JSON envelope is emitted on
+            stdout (``code: "VALIDATION_ERROR"``, exit 1); in text mode the
+            same message is written to stderr (exit 1, no usage footer).
         ValueError: When ``kind`` is not recognized.
     """
     source: Callable[[str], ParameterSource] = parameter_source or (
@@ -369,11 +374,14 @@ def _build_video_plan_for_kind(
     """Shared builder for ``video`` and the ``cinematic-video`` alias.
 
     ``alias=True`` enforces the cinematic-video flag rules: an explicit
-    ``--format <non-cinematic>`` raises UsageError, the format is coerced
-    to cinematic when not passed, and the timeout defaults to 3600s when
-    the user did not pass ``--timeout``.
+    ``--format <non-cinematic>`` is rejected through ``output_error`` (per
+    ADR-015 the typed JSON envelope covers post-parse validation under
+    ``--json``; text mode writes the same message to stderr and exits 1),
+    the format is coerced to cinematic when not passed, and the timeout
+    defaults to 3600s when the user did not pass ``--timeout``.
     """
     common = _common(raw_args)
+    json_output = common["json_output"]
     video_format = raw_args.get("video_format", "explainer")
     style = raw_args.get("style", "auto")
     style_prompt_raw = raw_args.get("style_prompt")
@@ -381,9 +389,12 @@ def _build_video_plan_for_kind(
     if alias:
         format_explicit = source("video_format") == ParameterSource.COMMANDLINE
         if format_explicit and video_format != "cinematic":
-            raise click.UsageError(
+            output_error(
                 "--format must be 'cinematic' for the cinematic-video subcommand "
-                "(use 'generate video --format <other>' for other formats)"
+                "(use 'generate video --format <other>' for other formats)",
+                "VALIDATION_ERROR",
+                json_output,
+                1,
             )
         video_format = "cinematic"
 
@@ -392,11 +403,26 @@ def _build_video_plan_for_kind(
         style_prompt_raw.strip() if isinstance(style_prompt_raw, str) else None
     )
     if is_cinematic and normalized_style_prompt:
-        raise click.UsageError("--style-prompt cannot be used with cinematic video")
+        output_error(
+            "--style-prompt cannot be used with cinematic video",
+            "VALIDATION_ERROR",
+            json_output,
+            1,
+        )
     if not is_cinematic and style == "custom" and not normalized_style_prompt:
-        raise click.UsageError("--style custom requires --style-prompt")
+        output_error(
+            "--style custom requires --style-prompt",
+            "VALIDATION_ERROR",
+            json_output,
+            1,
+        )
     if not is_cinematic and normalized_style_prompt and style != "custom":
-        raise click.UsageError("--style-prompt requires --style custom")
+        output_error(
+            "--style-prompt requires --style custom",
+            "VALIDATION_ERROR",
+            json_output,
+            1,
+        )
 
     timeout_value = common["timeout"]
     if is_cinematic and source("timeout") != ParameterSource.COMMANDLINE:

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1445,7 +1445,9 @@ class TestResolveLanguageDirect:
     def test_invalid_env_exits_via_output_error(self, monkeypatch, capsys):
         """An unsupported NOTEBOOKLM_HL value still gets validated. Per ADR-015
         it routes through ``output_error`` (exit 1, message on stderr) rather
-        than ``click.BadParameter``."""
+        than ``click.BadParameter``. The message must name ``NOTEBOOKLM_HL`` so
+        the user can tell which input source is at fault — mirroring the
+        ``in config`` disambiguation that the config-file branch already does."""
         import importlib
 
         monkeypatch.setenv("NOTEBOOKLM_HL", "xx_INVALID")
@@ -1456,7 +1458,9 @@ class TestResolveLanguageDirect:
         ):
             generate_module.resolve_language(None)
         assert exc_info.value.code == 1
-        assert "xx_INVALID" in capsys.readouterr().err
+        captured = capsys.readouterr()
+        assert "xx_INVALID" in captured.err
+        assert "NOTEBOOKLM_HL" in captured.err
 
     def test_resolve_language_rejects_invalid_config_value(self, capsys):
         """An unsupported language stored in the config file gets validated.

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -358,8 +358,9 @@ class TestGenerateVideo:
             ["generate", "video", "--style", "custom", "-n", "nb_123"],
         )
 
-        # ``click.UsageError`` exits 2 — Click's standard convention.
-        assert result.exit_code == 2
+        # Per ADR-015, post-parse validation failures exit 1 via
+        # ``output_error`` (VALIDATION_ERROR), not 2 via Click's UsageError.
+        assert result.exit_code == 1
         assert "--style custom requires --style-prompt" in result.output
 
     def test_generate_video_custom_style_rejects_blank_prompt(
@@ -379,7 +380,7 @@ class TestGenerateVideo:
             ],
         )
 
-        assert result.exit_code == 2
+        assert result.exit_code == 1
         assert "--style custom requires --style-prompt" in result.output
 
     def test_generate_video_style_prompt_requires_custom_style(
@@ -399,7 +400,7 @@ class TestGenerateVideo:
             ],
         )
 
-        assert result.exit_code == 2
+        assert result.exit_code == 1
         assert "--style-prompt requires --style custom" in result.output
 
 
@@ -487,14 +488,16 @@ class TestGenerateCinematicVideo:
             ],
         )
 
-        assert result.exit_code == 2
+        # Per ADR-015, post-parse validation exits 1 via ``output_error``.
+        assert result.exit_code == 1
         assert "--style-prompt cannot be used with cinematic video" in result.output
 
     def test_generate_cinematic_video_rejects_non_cinematic_format(
         self, runner, mock_auth, mock_fetch_tokens
     ):
-        """`cinematic-video --format explainer` (or any non-cinematic value) must
-        raise UsageError, not silently override the format."""
+        """`cinematic-video --format explainer` (or any non-cinematic value) is
+        rejected through ``output_error`` (per ADR-015) — exit 1, not a silent
+        format override."""
         for bad_format in ("explainer", "brief"):
             result = runner.invoke(
                 cli,
@@ -508,8 +511,8 @@ class TestGenerateCinematicVideo:
                 ],
             )
 
-            assert result.exit_code == 2, (
-                f"--format {bad_format} should exit 2, got {result.exit_code}: {result.output}"
+            assert result.exit_code == 1, (
+                f"--format {bad_format} should exit 1, got {result.exit_code}: {result.output}"
             )
             assert "--format" in result.output
             assert "cinematic" in result.output.lower()
@@ -1367,17 +1370,19 @@ class TestRateLimitDetection:
 class TestResolveLanguageDirect:
     """Direct tests for resolve_language() covering uncovered branches."""
 
-    def test_invalid_language_raises_bad_parameter(self):
-        """Line 111: language not in SUPPORTED_LANGUAGES raises click.BadParameter."""
+    def test_invalid_language_exits_via_output_error(self, capsys):
+        """Invalid language code routes through ``output_error`` (per ADR-015):
+        exit 1, message on stderr. Replaces the old ``click.BadParameter``
+        contract — the post-parse JSON envelope contract supersedes it."""
         import importlib
 
-        import click
-
         generate_module = importlib.import_module("notebooklm.cli.generate_cmd")
-        with pytest.raises(click.BadParameter) as exc_info:
+        with pytest.raises(SystemExit) as exc_info:
             generate_module.resolve_language("xx_INVALID")
-        assert "Unknown language code: xx_INVALID" in str(exc_info.value)
-        assert "notebooklm language list" in str(exc_info.value)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Unknown language code: xx_INVALID" in captured.err
+        assert "notebooklm language list" in captured.err
 
     def test_none_language_with_config_returns_config(self):
         """Line 118: language is None, config_lang is not None → returns config_lang."""
@@ -1437,35 +1442,38 @@ class TestResolveLanguageDirect:
             result = generate_module.resolve_language(None)
         assert result == "zh_Hans"
 
-    def test_invalid_env_raises_bad_parameter(self, monkeypatch):
-        """An unsupported NOTEBOOKLM_HL value still gets validated."""
+    def test_invalid_env_exits_via_output_error(self, monkeypatch, capsys):
+        """An unsupported NOTEBOOKLM_HL value still gets validated. Per ADR-015
+        it routes through ``output_error`` (exit 1, message on stderr) rather
+        than ``click.BadParameter``."""
         import importlib
-
-        import click
 
         monkeypatch.setenv("NOTEBOOKLM_HL", "xx_INVALID")
         generate_module = importlib.import_module("notebooklm.cli.generate_cmd")
         with (
             patch.object(generate_module, "get_language", return_value=None),
-            pytest.raises(click.BadParameter) as exc_info,
+            pytest.raises(SystemExit) as exc_info,
         ):
             generate_module.resolve_language(None)
-        assert "xx_INVALID" in str(exc_info.value)
+        assert exc_info.value.code == 1
+        assert "xx_INVALID" in capsys.readouterr().err
 
-    def test_resolve_language_rejects_invalid_config_value(self):
-        """An unsupported language stored in the config file gets validated."""
+    def test_resolve_language_rejects_invalid_config_value(self, capsys):
+        """An unsupported language stored in the config file gets validated.
+        Per ADR-015, routes through ``output_error`` (exit 1, message on
+        stderr) rather than ``click.BadParameter``."""
         import importlib
-
-        import click
 
         generate_module = importlib.import_module("notebooklm.cli.generate_cmd")
         with (
             patch.object(generate_module, "get_language", return_value="xx_INVALID"),
-            pytest.raises(click.BadParameter) as exc_info,
+            pytest.raises(SystemExit) as exc_info,
         ):
             generate_module.resolve_language(None)
-        assert "xx_INVALID" in str(exc_info.value)
-        assert "notebooklm language list" in str(exc_info.value)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "xx_INVALID" in captured.err
+        assert "notebooklm language list" in captured.err
 
     def test_resolve_language_accepts_valid_config_value(self):
         """A supported language stored in the config file is returned as-is."""

--- a/tests/unit/cli/test_generate_characterization.py
+++ b/tests/unit/cli/test_generate_characterization.py
@@ -304,7 +304,11 @@ def test_generate_audio_rate_limit_retry_exhausted_text(
 def test_video_cinematic_rejects_style_prompt(
     authed_invoke: Callable[..., Result],
 ) -> None:
-    """``--style-prompt`` is rejected when the video format is cinematic."""
+    """``--style-prompt`` is rejected when the video format is cinematic.
+
+    Per ADR-015, the post-parse validation routes through ``output_error``:
+    exit 1 (VALIDATION_ERROR), message on stderr, no usage footer.
+    """
     result = authed_invoke(
         [
             "generate",
@@ -317,9 +321,9 @@ def test_video_cinematic_rejects_style_prompt(
             "nb_123",
         ],
     )
-    assert result.exit_code == 2
-    # ``click.UsageError.show()`` writes to stderr — pin the assertion
-    # there so a stdout leak would surface.
+    assert result.exit_code == 1
+    # ``output_error`` writes the message to stderr in text mode — pin the
+    # assertion there so a stdout leak would surface.
     assert "--style-prompt cannot be used with cinematic video" in result.stderr
 
 
@@ -328,8 +332,8 @@ def test_video_style_custom_requires_style_prompt(
 ) -> None:
     """``--style custom`` requires ``--style-prompt`` for non-cinematic video."""
     result = authed_invoke(["generate", "video", "--style", "custom", "-n", "nb_123"])
-    assert result.exit_code == 2
-    # ``click.UsageError.show()`` writes to stderr.
+    assert result.exit_code == 1
+    # ``output_error`` writes the message to stderr in text mode.
     assert "--style custom requires --style-prompt" in result.stderr
 
 
@@ -338,8 +342,8 @@ def test_video_style_prompt_requires_style_custom(
 ) -> None:
     """``--style-prompt`` requires ``--style custom`` for non-cinematic video."""
     result = authed_invoke(["generate", "video", "--style-prompt", "foo", "-n", "nb_123"])
-    assert result.exit_code == 2
-    # ``click.UsageError.show()`` writes to stderr.
+    assert result.exit_code == 1
+    # ``output_error`` writes the message to stderr in text mode.
     assert "--style-prompt requires --style custom" in result.stderr
 
 
@@ -358,8 +362,8 @@ def test_cinematic_video_alias_rejects_non_cinematic_format(
             "nb_123",
         ],
     )
-    assert result.exit_code == 2
-    # ``click.UsageError.show()`` writes to stderr.
+    assert result.exit_code == 1
+    # ``output_error`` writes the message to stderr in text mode.
     assert "--format must be 'cinematic' for the cinematic-video subcommand" in result.stderr
 
 

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -182,16 +182,20 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "forbidden_imports": [
             "generate.py:41: forbidden top-level import: 'click'",
             "generate.py:42: forbidden top-level import: 'click.core'",
+            "generate.py:58: forbidden relative import: '..error_handler'",
         ],
         "pattern_a_violations": [],
         "pattern_b_violations": (
-            "raises click.UsageError on incompatible generation flags; "
+            "raises click.UsageError on incompatible generation flags, "
+            "uses output_error for ADR-015 JSON envelopes, and "
             "reads click.core.ParameterSource to distinguish flag-set vs. "
             "default."
         ),
         "rationale": (
             "Generation flag-validation depends on Click's ParameterSource "
-            "to detect explicit vs. default; lift to command-layer."
+            "to detect explicit vs. default and currently emits ADR-015 "
+            "JSON envelopes from the service layer. Lift validation/output "
+            "handling to the command layer."
         ),
     },
     "cli/services/login/browser_accounts.py": {

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import click
 import pytest
 from click.core import ParameterSource
 
@@ -256,9 +255,9 @@ def test_build_plan_unknown_kind_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cinematic_video_rejects_explicit_non_cinematic_format() -> None:
-    """``cinematic-video --format explainer`` raises UsageError when the
-    source reports COMMANDLINE for ``video_format``."""
+def test_cinematic_video_rejects_explicit_non_cinematic_format(capsys) -> None:
+    """``cinematic-video --format explainer`` exits 1 through ``output_error``
+    (per ADR-015) when the source reports COMMANDLINE for ``video_format``."""
 
     def source(name: str) -> ParameterSource:
         if name == "video_format":
@@ -266,10 +265,13 @@ def test_cinematic_video_rejects_explicit_non_cinematic_format() -> None:
         return ParameterSource.DEFAULT
 
     args = _base_args(video_format="explainer", style="auto", style_prompt=None, language="en")
-    with pytest.raises(click.UsageError, match="--format must be 'cinematic'"):
+    with pytest.raises(SystemExit) as exc_info:
         build_generation_plan(
             "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
         )
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "--format must be 'cinematic'" in captured.err
 
 
 def test_cinematic_video_explicit_cinematic_format_is_accepted() -> None:
@@ -335,48 +337,59 @@ def test_video_raw_timeout_is_preserved_when_not_commandline() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_video_cinematic_rejects_style_prompt() -> None:
-    """Cinematic video + non-empty ``--style-prompt`` raises UsageError."""
+def test_video_cinematic_rejects_style_prompt(capsys) -> None:
+    """Cinematic video + non-empty ``--style-prompt`` exits 1 through
+    ``output_error`` (per ADR-015)."""
     args = _base_args(
         video_format="cinematic",
         style="auto",
         style_prompt="foo",
         language="en",
     )
-    with pytest.raises(click.UsageError, match="--style-prompt cannot be used"):
+    with pytest.raises(SystemExit) as exc_info:
         build_generation_plan(
             "video", args, parameter_source=_default_source, language_resolver=_identity_language
         )
+    assert exc_info.value.code == 1
+    assert "--style-prompt cannot be used" in capsys.readouterr().err
 
 
-def test_video_style_custom_requires_style_prompt() -> None:
-    """``--style custom`` without ``--style-prompt`` raises UsageError."""
+def test_video_style_custom_requires_style_prompt(capsys) -> None:
+    """``--style custom`` without ``--style-prompt`` exits 1 through
+    ``output_error`` (per ADR-015)."""
     args = _base_args(video_format="explainer", style="custom", style_prompt=None, language="en")
-    with pytest.raises(click.UsageError, match="--style custom requires --style-prompt"):
+    with pytest.raises(SystemExit) as exc_info:
         build_generation_plan(
             "video", args, parameter_source=_default_source, language_resolver=_identity_language
         )
+    assert exc_info.value.code == 1
+    assert "--style custom requires --style-prompt" in capsys.readouterr().err
 
 
-def test_video_style_prompt_requires_style_custom() -> None:
-    """Non-empty ``--style-prompt`` with ``--style != custom`` raises UsageError."""
+def test_video_style_prompt_requires_style_custom(capsys) -> None:
+    """Non-empty ``--style-prompt`` with ``--style != custom`` exits 1 through
+    ``output_error`` (per ADR-015)."""
     args = _base_args(
         video_format="explainer", style="anime", style_prompt="hand-drawn", language="en"
     )
-    with pytest.raises(click.UsageError, match="--style-prompt requires --style custom"):
+    with pytest.raises(SystemExit) as exc_info:
         build_generation_plan(
             "video", args, parameter_source=_default_source, language_resolver=_identity_language
         )
+    assert exc_info.value.code == 1
+    assert "--style-prompt requires --style custom" in capsys.readouterr().err
 
 
-def test_video_style_prompt_strips_whitespace() -> None:
+def test_video_style_prompt_strips_whitespace(capsys) -> None:
     """Whitespace-only ``--style-prompt`` is treated as unset (still triggers
     the ``--style custom`` requirement when style is custom)."""
     args = _base_args(video_format="explainer", style="custom", style_prompt="   ", language="en")
-    with pytest.raises(click.UsageError, match="--style custom requires --style-prompt"):
+    with pytest.raises(SystemExit) as exc_info:
         build_generation_plan(
             "video", args, parameter_source=_default_source, language_resolver=_identity_language
         )
+    assert exc_info.value.code == 1
+    assert "--style custom requires --style-prompt" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -471,6 +471,42 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         None,  # ditto
         marks=pytest.mark.xfail(strict=False, reason=_PROFILE_LIST_GAP_REASON),
     ),
+    # Per ADR-015, post-parse ``ClickException`` validation failures in command
+    # bodies and the service layer they call now flow through ``output_error``
+    # and must emit a typed JSON envelope on stdout under ``--json``. The two
+    # cases below cover both subclasses in the generate command tree:
+    #   * ``click.UsageError`` from ``services/generate.py`` — flag-conflict
+    #     validation inside the plan builder.
+    #   * ``click.BadParameter`` from ``generate_cmd.py:resolve_language`` —
+    #     language-code validation.
+    # Both subclasses route through the same envelope shape (the shape is
+    # determined by ``output_error``, not by the exception type).
+    (
+        "generate_video_style_conflict_json",
+        [
+            "generate",
+            "video",
+            "--style",
+            "custom",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--json",
+        ],
+        None,
+    ),
+    (
+        "generate_audio_language_invalid_json",
+        [
+            "generate",
+            "audio",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--language",
+            "xx_INVALID",
+            "--json",
+        ],
+        None,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

- Per [ADR-015](docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md), post-parse `ClickException`-subclass failures from a CLI command body or its service layer must emit the typed JSON error envelope under `--json` (and exit 1 with the message on stderr in text mode).
- Converts seven such sites in the `generate` command tree to call `error_handler.output_error` instead of raising `click.UsageError` / `click.BadParameter` directly. Both subclasses now route through the same envelope shape; the shape is determined by `output_error`, not the exception type.

## Sites converted

`src/notebooklm/cli/services/generate.py` (`_build_video_plan_for_kind`):
- `--format must be 'cinematic'` (cinematic-video alias rejecting non-cinematic `--format`)
- `--style-prompt cannot be used with cinematic video`
- `--style custom requires --style-prompt`
- `--style-prompt requires --style custom`

`src/notebooklm/cli/generate_cmd.py` (`resolve_language`):
- Invalid `--language` flag
- Invalid `NOTEBOOKLM_HL` env value
- Invalid value in the language config file

`resolve_language` uses `current_json_output()` to infer the active `--json` flag from the Click context, so the helper stays callable from both the Click handler and the service-layer plan builder without threading the flag through its signature.

## Behavior

Under `--json`:
```json
{
  "error": true,
  "code": "VALIDATION_ERROR",
  "message": "--style custom requires --style-prompt"
}
```
on stdout, exit 1, stderr empty.

Under text mode: message on stderr, stdout empty (clean for shell pipelines), exit 1, no Click usage footer (ADR-015 rule 4 — intentional trade).

## Test plan

- [x] Two new error-path entries in `tests/unit/test_json_error_exit.py` (`generate_video_style_conflict_json` for the UsageError path, `generate_audio_language_invalid_json` for the BadParameter path) exercise the parametrized JSON-envelope sweep.
- [x] Six existing tests updated from the pre-ADR-015 contract (exit 2 via Click) to the new contract (exit 1 via `output_error`, message preserved on stderr without Click's usage footer):
  - `tests/unit/test_generate_service.py` — four service-layer tests now assert `SystemExit(1)` + capsys-captured stderr.
  - `tests/unit/cli/test_generate.py` — style/format conflict tests and the three `resolve_language` direct tests.
  - `tests/unit/cli/test_generate_characterization.py` — four CLI-shell characterization tests.
- [x] Live spot-check with `CliRunner` confirms ADR-015 contract in both JSON and text modes for both UsageError-path (style conflict) and BadParameter-path (language) failures.
- [x] `uv run ruff format` + `uv run ruff check` clean on modified files.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 174 source files.
- [x] `uv run pytest tests/unit` — 5946 passed, 89 skipped.
- [x] `uv run pytest tests/integration` — 646 passed, 5 skipped.
- [x] `uv run pytest tests/_lint` — 78 passed (allowlist lint unaffected because `click.UsageError` / `click.BadParameter` are not covered by `ALLOWED_CLICK_EXCEPTION_SITES`, which is scoped to bare `click.ClickException(...)`).

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors are standardized: invalid language inputs (flag, env, or config) now report the source and exit with code 1; --json errors are emitted in a consistent JSON envelope.
  * Video generation validation (style/format and cinematic vs non-cinematic) now produces consistent validation messages and exit behavior.

* **Tests**
  * Updated tests to expect exit code 1 and to assert updated stderr and --json error-output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->