### PR TITLE
refactor(cli): emit JSON envelope for research wait + chat conversation UsageError under --json

### DIFF
--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -190,10 +190,24 @@ def register_chat_commands(cli):
           notebooklm ask "explain X" --save-as-note     # Save response as a note
         """
         if new_conversation and conversation_id:
-            raise click.UsageError(
+            # Per ADR-015 §2: under --json this mutual-exclusion conflict
+            # must emit the typed JSON envelope and exit 1 (VALIDATION_ERROR),
+            # not ride Click's parse-time UsageError path (exit 2, usage
+            # text on stderr, no JSON on stdout). Under text mode we
+            # preserve the existing Click UX so interactive users still
+            # get the ``Usage: ... / Error: ...`` formatting.
+            mutual_exclusion_message = (
                 "--new and --conversation-id are mutually exclusive: "
                 "--new starts a fresh conversation while --conversation-id resumes a specific one."
             )
+            if json_output:
+                _output_error(
+                    mutual_exclusion_message,
+                    "VALIDATION_ERROR",
+                    json_output,
+                    1,
+                )
+            raise click.UsageError(mutual_exclusion_message)
         question = resolve_prompt(question, prompt_file, "question", required=True)
         nb_id = require_notebook(notebook_id)
 

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -49,8 +49,8 @@ ALLOWED_CLICK_EXCEPTION_SITES: list[tuple[str, int, str]] = [
     ("src/notebooklm/cli/profile_cmd.py", 269, "profile rename source validation"),
     ("src/notebooklm/cli/profile_cmd.py", 271, "profile rename destination validation"),
     ("src/notebooklm/cli/resolve.py", 58, "entity ID argument validation"),
-    ("src/notebooklm/cli/session_cmd.py", 156, "login profile-name validation translation"),
     ("src/notebooklm/cli/session_cmd.py", 157, "login profile-name validation translation"),
+    ("src/notebooklm/cli/session_cmd.py", 158, "login profile-name validation translation"),
 ]
 
 # Raw ``raise SystemExit`` should live in this module. If a future path truly

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -16,7 +16,7 @@ import click
 
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
-from .error_handler import exit_with_code
+from .error_handler import _output_error, exit_with_code
 from .options import notebook_option
 from .rendering import (
     console,
@@ -155,6 +155,19 @@ def research_wait(
       notebooklm research wait --json
     """
     if cited_only and not import_all:
+        # Per ADR-015 §2: under --json this flag-combination conflict must
+        # emit the typed JSON envelope and exit 1 (VALIDATION_ERROR), not
+        # ride Click's parse-time UsageError path (exit 2, usage text on
+        # stderr, no JSON on stdout). Under text mode we preserve the
+        # existing Click UX so interactive users still get the
+        # ``Usage: ... / Error: ...`` formatting.
+        if json_output:
+            _output_error(
+                "--cited-only requires --import-all",
+                "VALIDATION_ERROR",
+                json_output,
+                1,
+            )
         raise click.UsageError("--cited-only requires --import-all")
 
     nb_id = require_notebook(notebook_id)

--- a/tests/unit/cli/test_quiet_enforcement.py
+++ b/tests/unit/cli/test_quiet_enforcement.py
@@ -78,9 +78,9 @@ QUIET_WAIVED_SITES: dict[tuple[str, str, int], str] = {
     (
         "src/notebooklm/cli/chat_cmd.py",
         "_run",
-        330,
+        344,
     ): (
-        "TODO(quiet-policy): note-save fallback inside `ask` reports the "
+        "TODO(quiet-policy): note-save failure inside `ask` reports the "
         "underlying exception via `emit_status` so the warning is colored "
         "and routed alongside other chat status text. Switching to "
         "`output_error` here would also `SystemExit(1)`, aborting the "

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -474,6 +474,22 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         ],
         None,
     ),
+    # ADR-015 §2: post-parse UsageError under --json must route through the
+    # typed JSON envelope rather than Click's parse-time usage text. The
+    # gate fires synchronously at the top of ``research_wait`` before any
+    # client call, so no customizer is needed.
+    (
+        "research_wait_cited_only_conflict_json",
+        [
+            "research",
+            "wait",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--cited-only",
+            "--json",
+        ],
+        None,
+    ),
     # source add-research --no-wait with --import-all: same post-parse
     # flag-conflict path, same ADR-015 JSON envelope.
     (
@@ -551,6 +567,23 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
             "abc123def456ghi789jkl",
             "--language",
             "xx_INVALID",
+            "--json",
+        ],
+        None,
+    ),
+    # ADR-015 §2: ``ask`` ``--new`` and ``--conversation-id`` are mutually
+    # exclusive. Under --json the gate emits the typed JSON envelope and
+    # exits 1; under text mode it still raises Click's UsageError.
+    (
+        "chat_new_and_conversation_id_conflict_json",
+        [
+            "ask",
+            "hi",
+            "-n",
+            "abc",
+            "--new",
+            "--conversation-id",
+            "existing-conv",
             "--json",
         ],
         None,


### PR DESCRIPTION
## Summary

Under `--json`, two post-parse `ClickException` sites now emit the typed JSON error envelope instead of bypassing it via Click's parse-time path:

- `research wait --cited-only` without `--import-all` (`research_cmd.py:158`)
- `ask --new` + `--conversation-id` mutual exclusion (`chat_cmd.py:193`)

Non-JSON behaviour preserved verbatim — both sites still raise `click.UsageError` and exit 2 with usage text on stderr when invoked without `--json`.

Implements [ADR-015](docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md) §2.

## Test plan

- [x] `uv run pytest tests/unit/test_json_error_exit.py -q` → 26 passed + 2 xfailed (pre-existing doctor/profile-list xfails)
- [x] `uv run ruff format` clean
- [x] `uv run ruff check` clean
- [ ] CI test matrix
- [ ] @claude review
- [ ] CodeRabbit / Gemini review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now consistently emits typed JSON error responses and exits with a nonzero code when conflicting flags are used together while `--json` is enabled (examples: combining `--new` with `--conversation-id`, or `--cited-only` without `--import-all`).

* **Tests**
  * Added contract tests for these JSON-formatted error scenarios and updated related test maintenance entries to match current behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->