### PR TITLE
refactor(cli): move wait auth rendering to command layer

### DIFF
--- a/src/notebooklm/cli/services/auth_diagnostics.py
+++ b/src/notebooklm/cli/services/auth_diagnostics.py
@@ -1,17 +1,19 @@
 """``auth check`` diagnostic service.
 
 Extracted from :mod:`notebooklm.cli.session_cmd` in P3.T3. Owns the
-"validate the cookies on disk" probe plus the renderer for both text
-(rich table) and JSON envelope modes.
+"validate the cookies on disk" probe and returns a structured
+:class:`AuthCheckResult` to the caller. Rendering and exit-code policy
+live in the command layer (see ``cli/session_cmd.py``).
 
 Public surface
 ==============
 
 * :class:`AuthCheckPlan` — frozen description of one ``auth check`` run.
 * :class:`AuthCheckResult` — the structured outcome.
-* :func:`run_auth_check` — sync executor. Reads the auth source, runs
+* :func:`run_auth_check` — async executor. Reads the auth source, runs
   every check up to the user's opt-in level (``--test`` for token fetch),
-  renders the result, and exits with the appropriate code.
+  and returns the typed result. The caller renders the result and
+  decides the exit code.
 """
 
 from __future__ import annotations
@@ -23,10 +25,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from rich.table import Table
-
-from ..error_handler import exit_with_code
-from ..rendering import console, json_output_response
 from .auth_source import AUTH_JSON_ENV_NAME, AuthSource, read_env_auth_json
 
 logger = logging.getLogger(__name__)
@@ -47,8 +45,10 @@ class AuthCheckPlan:
             the ``auth_source`` display string.
         test_fetch: When ``True``, also exercise the token-fetch path
             (network round-trip). Off by default.
-        json_output: When ``True``, render the result as a JSON envelope
-            and propagate non-zero exit on failure.
+        json_output: When ``True``, signals the caller to render a JSON
+            envelope and propagate non-zero exit on failure. Carried on
+            the plan so the renderer (which lives in the command layer)
+            can pick the right shape without re-resolving the flag.
     """
 
     storage_path: Path
@@ -71,6 +71,7 @@ class AuthCheckResult:
     into the table / JSON envelope.
     """
 
+    plan: AuthCheckPlan
     checks: dict[str, bool | None]
     details: dict[str, Any] = field(default_factory=dict)
 
@@ -110,7 +111,12 @@ def plan_from_click_context(ctx, *, test_fetch: bool, json_output: bool) -> Auth
     )
 
 
-def _format_auth_source(plan: AuthCheckPlan) -> str:
+def format_auth_source(plan: AuthCheckPlan) -> str:
+    """Human-readable description of where ``plan`` reads auth from.
+
+    Public helper so the command-layer renderer can re-use the same
+    string in the Rich table and the JSON ``details.auth_source`` field.
+    """
     if plan.has_env_auth:
         return AUTH_JSON_ENV_NAME
     if plan.has_home_env:
@@ -145,20 +151,22 @@ def _read_storage_state(plan: AuthCheckPlan) -> tuple[dict[str, Any] | None, str
         return None, f"Storage unreadable: {exc}"
 
 
-def run_auth_check(plan: AuthCheckPlan) -> AuthCheckResult:
-    """Execute an ``auth check`` plan, render the result, and exit on failure.
+async def run_auth_check(plan: AuthCheckPlan) -> AuthCheckResult:
+    """Execute an ``auth check`` plan and return the structured outcome.
 
-    The function performs side effects (console output + ``exit_with_code``
-    when ``--json`` and a check fails) so the handler can be a one-liner.
-    Returns the :class:`AuthCheckResult` for tests / callers that want to
-    inspect the structured outcome before the renderer runs.
+    No side effects — the caller is responsible for rendering the result
+    and choosing an exit code based on :attr:`AuthCheckResult.all_passed`.
+    The function is ``async`` so the optional ``--test`` token-fetch path
+    can ``await`` the network round-trip directly; the caller wraps the
+    coroutine with ``cli.runtime.run_async`` to bridge into Click's sync
+    handler.
     """
     from ...auth import extract_cookies_from_storage
 
     checks = _make_initial_checks()
     details: dict[str, Any] = {
         "storage_path": str(plan.storage_path),
-        "auth_source": _format_auth_source(plan),
+        "auth_source": format_auth_source(plan),
         "cookies_found": [],
         "cookie_domains": [],
         "error": None,
@@ -172,13 +180,13 @@ def run_auth_check(plan: AuthCheckPlan) -> AuthCheckResult:
 
     if not checks["storage_exists"]:
         details["error"] = f"Storage file not found: {plan.storage_path}"
-        return _finalize(plan, checks, details)
+        return AuthCheckResult(plan=plan, checks=checks, details=details)
 
     # Check 2: JSON valid.
     storage_state, read_error = _read_storage_state(plan)
     if storage_state is None:
         details["error"] = read_error
-        return _finalize(plan, checks, details)
+        return AuthCheckResult(plan=plan, checks=checks, details=details)
     checks["json_valid"] = True
 
     # Check 3: cookies present + SID lookup.
@@ -198,16 +206,15 @@ def run_auth_check(plan: AuthCheckPlan) -> AuthCheckResult:
         details["cookie_domains"] = sorted(cookies_by_domain.keys())
     except ValueError as exc:
         details["error"] = str(exc)
-        return _finalize(plan, checks, details)
+        return AuthCheckResult(plan=plan, checks=checks, details=details)
 
     # Check 4: optional token-fetch round-trip.
     if plan.test_fetch:
         try:
             from ...auth import fetch_tokens_with_domains
-            from ..runtime import run_async
 
             token_path = None if plan.has_env_auth else plan.storage_path
-            csrf, session_id = run_async(fetch_tokens_with_domains(token_path, plan.profile))
+            csrf, session_id = await fetch_tokens_with_domains(token_path, plan.profile)
             checks["token_fetch"] = True
             details["csrf_length"] = len(csrf)
             details["session_id_length"] = len(session_id)
@@ -215,172 +222,13 @@ def run_auth_check(plan: AuthCheckPlan) -> AuthCheckResult:
             checks["token_fetch"] = False
             details["error"] = f"Token fetch failed: {exc}"
 
-    return _finalize(plan, checks, details)
-
-
-def _finalize(
-    plan: AuthCheckPlan, checks: dict[str, bool | None], details: dict[str, Any]
-) -> AuthCheckResult:
-    """Render the result, exit on JSON failure, return the structured outcome."""
-    result = AuthCheckResult(checks=checks, details=details)
-    render_auth_check(result, json_output=plan.json_output)
-    return result
-
-
-def render_auth_check(result: AuthCheckResult, *, json_output: bool) -> None:
-    """Render an :class:`AuthCheckResult` to the console.
-
-    Exits non-zero via :func:`exit_with_code` when ``--json`` and any
-    check failed, matching the legacy contract.
-    """
-    all_passed = result.all_passed
-    checks = result.checks
-    details = result.details
-
-    if json_output:
-        json_output_response(
-            {
-                "status": "ok" if all_passed else "error",
-                "checks": checks,
-                "details": details,
-            }
-        )
-        if not all_passed:
-            exit_with_code(1)
-        return
-
-    # Rich-table render.
-    table = Table(title="Authentication Check")
-    table.add_column("Check", style="dim")
-    table.add_column("Status")
-    table.add_column("Details", style="cyan")
-
-    def status_icon(val: bool | None) -> str:
-        if val is None:
-            return "[dim]⊘ skipped[/dim]"
-        return "[green]✓ pass[/green]" if val else "[red]✗ fail[/red]"
-
-    table.add_row(
-        "Storage exists",
-        status_icon(checks["storage_exists"]),
-        details["auth_source"],
-    )
-    table.add_row("JSON valid", status_icon(checks["json_valid"]), "")
-    table.add_row(
-        "Cookies present",
-        status_icon(checks["cookies_present"]),
-        f"{len(details.get('cookies_found', []))} cookies" if checks["cookies_present"] else "",
-    )
-    table.add_row(
-        "SID cookie",
-        status_icon(checks["sid_cookie"]),
-        ", ".join(details.get("cookie_domains", [])[:3]) or "",
-    )
-    table.add_row(
-        "Token fetch",
-        status_icon(checks["token_fetch"]),
-        "use --test to check" if checks["token_fetch"] is None else "",
-    )
-
-    console.print(table)
-
-    cookies_by_domain = details.get("cookies_by_domain", {})
-    if cookies_by_domain:
-        console.print()
-        cookie_table = Table(title="Cookies by Domain")
-        cookie_table.add_column("Domain", style="cyan")
-        cookie_table.add_column("Cookies")
-
-        key_cookies = {"SID", "HSID", "SSID", "APISID", "SAPISID", "SIDCC"}
-
-        def format_cookie_name(name: str) -> str:
-            if name in key_cookies:
-                return f"[green]{name}[/green]"
-            if name.startswith("__Secure-"):
-                return f"[blue]{name}[/blue]"
-            return f"[dim]{name}[/dim]"
-
-        for domain in sorted(cookies_by_domain.keys()):
-            cookie_names = cookies_by_domain[domain]
-            formatted = [format_cookie_name(name) for name in sorted(cookie_names)]
-            cookie_table.add_row(domain, ", ".join(formatted))
-
-        console.print(cookie_table)
-
-    if details.get("error"):
-        console.print(f"\n[red]Error:[/red] {details['error']}")
-
-    if all_passed:
-        console.print("\n[green]Authentication is valid.[/green]")
-    elif not checks["storage_exists"]:
-        console.print("\n[yellow]Run 'notebooklm login' to authenticate.[/yellow]")
-    elif checks["token_fetch"] is False:
-        console.print(
-            "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
-        )
-
-
-def render_auth_inspect(
-    browser_name: str,
-    accounts: list,
-    *,
-    json_output: bool,
-    verbose: bool,
-) -> None:
-    """Render ``auth inspect`` results (text table or JSON envelope).
-
-    The handler stays a thin Click wrapper around :func:`_enumerate_browser_accounts`
-    + this renderer.
-    """
-    if json_output:
-        json_output_response(
-            {
-                "browser": browser_name,
-                "accounts": [
-                    {
-                        "email": a.email,
-                        "is_default": a.is_default,
-                        "browser_profile": a.browser_profile,
-                    }
-                    for a in accounts
-                ],
-            }
-        )
-        return
-
-    console.print(f"\n[bold]Browser:[/bold] {browser_name}")
-    console.print(f"[bold]Found {len(accounts)} signed-in Google account(s):[/bold]\n")
-    show_browser_profile = verbose and any(a.browser_profile for a in accounts)
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("email")
-    if show_browser_profile:
-        table.add_column(f"{browser_name} user")
-    table.add_column("default", justify="center")
-    for a in accounts:
-        row = [a.email]
-        if show_browser_profile:
-            row.append(a.browser_profile or "")
-        row.append("[green]✓[/green]" if a.is_default else "")
-        table.add_row(*row)
-    console.print(table)
-    hint = (
-        f"Pick one with: [cyan]notebooklm login --browser-cookies "
-        f"{browser_name} --account EMAIL[/cyan]\n"
-        f"Or extract them all: [cyan]notebooklm login --browser-cookies "
-        f"{browser_name} --all-accounts[/cyan]"
-    )
-    if not verbose and any(a.browser_profile for a in accounts):
-        hint = (
-            "[dim]Pass -v to see which browser user-profile each account came from.[/dim]\n" + hint
-        )
-    console.print("\n" + hint)
+    return AuthCheckResult(plan=plan, checks=checks, details=details)
 
 
 __all__ = [
     "AuthCheckPlan",
     "AuthCheckResult",
+    "format_auth_source",
     "plan_from_click_context",
-    "render_auth_check",
-    "render_auth_inspect",
     "run_auth_check",
 ]

--- a/src/notebooklm/cli/services/source_wait.py
+++ b/src/notebooklm/cli/services/source_wait.py
@@ -4,8 +4,17 @@ Owns the dataclass + executor pair so ``cli/source_cmd.py`` stays a thin
 Click handler. The executor wraps the underlying
 ``client.sources.wait_until_ready`` call in a transient
 ``status_with_elapsed`` spinner (suppressed under JSON) and translates the
-three ``SourceWaitError`` subclasses into the documented exit-code +
-envelope contract.
+three ``SourceWaitError`` subclasses into a typed
+:class:`SourceWaitOutcome`. The caller renders the outcome and decides the
+exit code.
+
+Typed-outcome contract (matches ``source_cmd.source_wait`` pre-extraction
+exit policy, now owned by the caller):
+
+* :class:`SourceWaitReady`           — source reached READY before timeout (caller exits 0).
+* :class:`SourceWaitNotFound`        — :class:`SourceNotFoundError` (caller exits 1).
+* :class:`SourceWaitProcessingError` — :class:`SourceProcessingError` (caller exits 1).
+* :class:`SourceWaitTimeout`         — :class:`SourceTimeoutError` (caller exits 2).
 """
 
 from __future__ import annotations
@@ -19,8 +28,6 @@ from ...types import (
     SourceProcessingError,
     SourceTimeoutError,
 )
-from ..error_handler import exit_with_code
-from ..rendering import console, json_output_response
 from .polling import status_with_elapsed
 
 if TYPE_CHECKING:
@@ -38,76 +45,48 @@ class SourceWaitPlan:
     json_output: bool
 
 
-def _emit_ready_payload(source: Source, *, json_output: bool) -> None:
-    if json_output:
-        json_output_response(
-            {
-                "source_id": source.id,
-                "title": source.title,
-                "status": "ready",
-                "status_code": source.status,
-            }
-        )
-        return
-    console.print(f"[green]✓ Source ready:[/green] {source.id}")
-    if source.title:
-        console.print(f"[bold]Title:[/bold] {source.title}")
+@dataclass(frozen=True)
+class SourceWaitReady:
+    """Source reached READY before timeout. Caller exits 0."""
+
+    source: Source
 
 
-def _emit_not_found(exc: SourceNotFoundError, *, json_output: bool) -> None:
-    if json_output:
-        json_output_response(
-            {
-                "source_id": exc.source_id,
-                "status": "not_found",
-                "error": str(exc),
-            }
-        )
-    else:
-        console.print(f"[red]✗ Source not found:[/red] {exc.source_id}")
+@dataclass(frozen=True)
+class SourceWaitNotFound:
+    """``client.sources.wait_until_ready`` raised :class:`SourceNotFoundError`."""
+
+    error: SourceNotFoundError
 
 
-def _emit_processing_error(exc: SourceProcessingError, *, json_output: bool) -> None:
-    if json_output:
-        json_output_response(
-            {
-                "source_id": exc.source_id,
-                "status": "error",
-                "status_code": exc.status,
-                "error": str(exc),
-            }
-        )
-    else:
-        console.print(f"[red]✗ Source processing failed:[/red] {exc.source_id}")
+@dataclass(frozen=True)
+class SourceWaitProcessingError:
+    """``client.sources.wait_until_ready`` raised :class:`SourceProcessingError`."""
+
+    error: SourceProcessingError
 
 
-def _emit_timeout(exc: SourceTimeoutError, *, json_output: bool) -> None:
-    if json_output:
-        json_output_response(
-            {
-                "source_id": exc.source_id,
-                "status": "timeout",
-                "last_status_code": exc.last_status,
-                "timeout_seconds": int(exc.timeout),
-                "error": str(exc),
-            }
-        )
-    else:
-        console.print(f"[yellow]⚠ Timeout waiting for source:[/yellow] {exc.source_id}")
-        console.print(f"[dim]Last status: {exc.last_status}[/dim]")
+@dataclass(frozen=True)
+class SourceWaitTimeout:
+    """``client.sources.wait_until_ready`` raised :class:`SourceTimeoutError`."""
+
+    error: SourceTimeoutError
 
 
-async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) -> None:
-    """Run the ``source wait`` workflow with status spinner + error mapping.
+SourceWaitOutcome = (
+    SourceWaitReady | SourceWaitNotFound | SourceWaitProcessingError | SourceWaitTimeout
+)
 
-    Exit-code contract (matches ``source_cmd.source_wait`` pre-extraction):
-        * 0 — source reached READY before timeout.
-        * 1 — :class:`SourceNotFoundError` or :class:`SourceProcessingError`.
-        * 2 — :class:`SourceTimeoutError`.
 
-    Caller is responsible for resolving ``plan.source_id`` to a full UUID
-    BEFORE calling this executor (so the spinner message and JSON envelope
-    carry the resolved id consistently).
+async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) -> SourceWaitOutcome:
+    """Run the ``source wait`` workflow and return a typed outcome.
+
+    The caller is responsible for resolving ``plan.source_id`` to a full
+    UUID BEFORE calling this executor (so the spinner message and the
+    caller's JSON envelope carry the resolved id consistently).
+
+    Presentation and exit-code policy live in the caller — this executor
+    only owns the polling loop and exception-to-outcome mapping.
     """
     try:
         async with status_with_elapsed(
@@ -124,16 +103,20 @@ async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) ->
                 initial_interval=plan.interval,
             )
     except SourceNotFoundError as exc:
-        _emit_not_found(exc, json_output=plan.json_output)
-        exit_with_code(1)
+        return SourceWaitNotFound(error=exc)
     except SourceProcessingError as exc:
-        _emit_processing_error(exc, json_output=plan.json_output)
-        exit_with_code(1)
+        return SourceWaitProcessingError(error=exc)
     except SourceTimeoutError as exc:
-        _emit_timeout(exc, json_output=plan.json_output)
-        exit_with_code(2)
-    else:
-        _emit_ready_payload(source, json_output=plan.json_output)
+        return SourceWaitTimeout(error=exc)
+    return SourceWaitReady(source=source)
 
 
-__all__ = ["SourceWaitPlan", "execute_source_wait"]
+__all__ = [
+    "SourceWaitNotFound",
+    "SourceWaitOutcome",
+    "SourceWaitPlan",
+    "SourceWaitProcessingError",
+    "SourceWaitReady",
+    "SourceWaitTimeout",
+    "execute_source_wait",
+]

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -58,8 +58,8 @@ from .rendering import console, json_output_response
 from .resolve import resolve_notebook_id  # noqa: F401 — preserved patch surface
 from .runtime import run_async
 from .services.auth_diagnostics import (
+    AuthCheckResult,
     plan_from_click_context,
-    render_auth_inspect,
     run_auth_check,
 )
 from .services.auth_source import AUTH_JSON_ENV_NAME, has_env_auth_json
@@ -357,6 +357,157 @@ def _render_logout_outcome(outcome: LogoutOutcome) -> None:
         console.print("[green]Logged out.[/green] Run 'notebooklm login' to sign in again.")
     else:
         console.print("[yellow]No active session found.[/yellow] Already logged out.")
+
+
+def _render_auth_check_result(result: AuthCheckResult) -> None:
+    """Render an :class:`AuthCheckResult` (table or JSON) and exit on failure.
+
+    The presentation + exit-code policy lives here in the command layer
+    so ``services/auth_diagnostics.py`` can stay free of rendering and
+    exit imports (ADR-008 boundary).
+    """
+    plan = result.plan
+    all_passed = result.all_passed
+    checks = result.checks
+    details = result.details
+
+    if plan.json_output:
+        json_output_response(
+            {
+                "status": "ok" if all_passed else "error",
+                "checks": checks,
+                "details": details,
+            }
+        )
+        if not all_passed:
+            exit_with_code(1)
+        return
+
+    # Rich-table render.
+    table = Table(title="Authentication Check")
+    table.add_column("Check", style="dim")
+    table.add_column("Status")
+    table.add_column("Details", style="cyan")
+
+    def status_icon(val: bool | None) -> str:
+        if val is None:
+            return "[dim]⊘ skipped[/dim]"
+        return "[green]✓ pass[/green]" if val else "[red]✗ fail[/red]"
+
+    table.add_row(
+        "Storage exists",
+        status_icon(checks["storage_exists"]),
+        details["auth_source"],
+    )
+    table.add_row("JSON valid", status_icon(checks["json_valid"]), "")
+    table.add_row(
+        "Cookies present",
+        status_icon(checks["cookies_present"]),
+        f"{len(details.get('cookies_found', []))} cookies" if checks["cookies_present"] else "",
+    )
+    table.add_row(
+        "SID cookie",
+        status_icon(checks["sid_cookie"]),
+        ", ".join(details.get("cookie_domains", [])[:3]) or "",
+    )
+    table.add_row(
+        "Token fetch",
+        status_icon(checks["token_fetch"]),
+        "use --test to check" if checks["token_fetch"] is None else "",
+    )
+
+    console.print(table)
+
+    cookies_by_domain = details.get("cookies_by_domain", {})
+    if cookies_by_domain:
+        console.print()
+        cookie_table = Table(title="Cookies by Domain")
+        cookie_table.add_column("Domain", style="cyan")
+        cookie_table.add_column("Cookies")
+
+        key_cookies = {"SID", "HSID", "SSID", "APISID", "SAPISID", "SIDCC"}
+
+        def format_cookie_name(name: str) -> str:
+            if name in key_cookies:
+                return f"[green]{name}[/green]"
+            if name.startswith("__Secure-"):
+                return f"[blue]{name}[/blue]"
+            return f"[dim]{name}[/dim]"
+
+        for domain in sorted(cookies_by_domain.keys()):
+            cookie_names = cookies_by_domain[domain]
+            formatted = [format_cookie_name(name) for name in sorted(cookie_names)]
+            cookie_table.add_row(domain, ", ".join(formatted))
+
+        console.print(cookie_table)
+
+    if details.get("error"):
+        console.print(f"\n[red]Error:[/red] {details['error']}")
+
+    if all_passed:
+        console.print("\n[green]Authentication is valid.[/green]")
+    elif not checks["storage_exists"]:
+        console.print("\n[yellow]Run 'notebooklm login' to authenticate.[/yellow]")
+    elif checks["token_fetch"] is False:
+        console.print(
+            "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
+        )
+
+
+def _render_auth_inspect(
+    browser_name: str,
+    accounts: list,
+    *,
+    json_output: bool,
+    verbose: bool,
+) -> None:
+    """Render ``auth inspect`` results (text table or JSON envelope).
+
+    Moved here from ``services/auth_diagnostics.py`` so the service module
+    stays free of rendering imports (ADR-008 boundary).
+    """
+    if json_output:
+        json_output_response(
+            {
+                "browser": browser_name,
+                "accounts": [
+                    {
+                        "email": a.email,
+                        "is_default": a.is_default,
+                        "browser_profile": a.browser_profile,
+                    }
+                    for a in accounts
+                ],
+            }
+        )
+        return
+
+    console.print(f"\n[bold]Browser:[/bold] {browser_name}")
+    console.print(f"[bold]Found {len(accounts)} signed-in Google account(s):[/bold]\n")
+    show_browser_profile = verbose and any(a.browser_profile for a in accounts)
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("email")
+    if show_browser_profile:
+        table.add_column(f"{browser_name} user")
+    table.add_column("default", justify="center")
+    for a in accounts:
+        row = [a.email]
+        if show_browser_profile:
+            row.append(a.browser_profile or "")
+        row.append("[green]✓[/green]" if a.is_default else "")
+        table.add_row(*row)
+    console.print(table)
+    hint = (
+        f"Pick one with: [cyan]notebooklm login --browser-cookies "
+        f"{browser_name} --account EMAIL[/cyan]\n"
+        f"Or extract them all: [cyan]notebooklm login --browser-cookies "
+        f"{browser_name} --all-accounts[/cyan]"
+    )
+    if not verbose and any(a.browser_profile for a in accounts):
+        hint = (
+            "[dim]Pass -v to see which browser user-profile each account came from.[/dim]\n" + hint
+        )
+    console.print("\n" + hint)
 
 
 def register_session_commands(cli):
@@ -785,7 +936,7 @@ def register_session_commands(cli):
         _, accounts = _enumerate_browser_accounts(
             browser_name, verbose=not json_output, include_domains=include_domains
         )
-        render_auth_inspect(browser_name, list(accounts), json_output=json_output, verbose=verbose)
+        _render_auth_inspect(browser_name, list(accounts), json_output=json_output, verbose=verbose)
 
     @auth_group.command("check")
     @click.option(
@@ -812,7 +963,8 @@ def register_session_commands(cli):
           notebooklm auth check --json    # Machine-readable output
         """
         plan = plan_from_click_context(ctx, test_fetch=test_fetch, json_output=json_output)
-        run_auth_check(plan)
+        result = run_async(run_auth_check(plan))
+        _render_auth_check_result(result)
 
     @auth_group.command("refresh")
     @click.option(

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -456,7 +456,7 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
 
 def _render_auth_inspect(
     browser_name: str,
-    accounts: list,
+    accounts: list[Any],
     *,
     json_output: bool,
     verbose: bool,

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -265,7 +265,7 @@ def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool
             console.print(f"[bold]Title:[/bold] {source.title}")
         return
 
-    if isinstance(outcome, SourceWaitNotFound):
+    elif isinstance(outcome, SourceWaitNotFound):
         not_found_error = outcome.error
         if json_output:
             json_output_response(
@@ -278,8 +278,9 @@ def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool
         else:
             console.print(f"[red]✗ Source not found:[/red] {not_found_error.source_id}")
         exit_with_code(1)
+        raise AssertionError("unreachable")  # pragma: no cover
 
-    if isinstance(outcome, SourceWaitProcessingError):
+    elif isinstance(outcome, SourceWaitProcessingError):
         processing_error = outcome.error
         if json_output:
             json_output_response(
@@ -293,8 +294,9 @@ def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool
         else:
             console.print(f"[red]✗ Source processing failed:[/red] {processing_error.source_id}")
         exit_with_code(1)
+        raise AssertionError("unreachable")  # pragma: no cover
 
-    if isinstance(outcome, SourceWaitTimeout):
+    elif isinstance(outcome, SourceWaitTimeout):
         timeout_error = outcome.error
         if json_output:
             json_output_response(
@@ -312,6 +314,9 @@ def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool
             )
             console.print(f"[dim]Last status: {timeout_error.last_status}[/dim]")
         exit_with_code(2)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    raise AssertionError(f"unreachable: {type(outcome)}")
 
 
 def _render_source_stale_result(

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -291,9 +291,7 @@ def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool
                 }
             )
         else:
-            console.print(
-                f"[red]✗ Source processing failed:[/red] {processing_error.source_id}"
-            )
+            console.print(f"[red]✗ Source processing failed:[/red] {processing_error.source_id}")
         exit_with_code(1)
 
     if isinstance(outcome, SourceWaitTimeout):

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -81,7 +81,15 @@ from .services.source_research import (
     SourceAddResearchResult,
     execute_source_add_research,
 )
-from .services.source_wait import SourceWaitPlan, execute_source_wait
+from .services.source_wait import (
+    SourceWaitNotFound,
+    SourceWaitOutcome,
+    SourceWaitPlan,
+    SourceWaitProcessingError,
+    SourceWaitReady,
+    SourceWaitTimeout,
+    execute_source_wait,
+)
 
 # Compatibility wrappers — tests patch these names on this module. Each
 # one is a one-liner forwarder to the canonical service-layer home.
@@ -230,6 +238,82 @@ def _render_source_guide_result(result: SourceGuideResult, *, json_output: bool)
     if result.keywords:
         console.print("[bold cyan]Keywords:[/bold cyan]")
         console.print(", ".join(result.keywords))
+
+
+def _render_source_wait_outcome(outcome: SourceWaitOutcome, *, json_output: bool) -> None:
+    """Render the ``source wait`` outcome and exit with the documented code.
+
+    Exit codes (preserved from the pre-extraction service-side contract):
+        * 0 — :class:`SourceWaitReady`.
+        * 1 — :class:`SourceWaitNotFound` or :class:`SourceWaitProcessingError`.
+        * 2 — :class:`SourceWaitTimeout`.
+    """
+    if isinstance(outcome, SourceWaitReady):
+        source = outcome.source
+        if json_output:
+            json_output_response(
+                {
+                    "source_id": source.id,
+                    "title": source.title,
+                    "status": "ready",
+                    "status_code": source.status,
+                }
+            )
+            return
+        console.print(f"[green]✓ Source ready:[/green] {source.id}")
+        if source.title:
+            console.print(f"[bold]Title:[/bold] {source.title}")
+        return
+
+    if isinstance(outcome, SourceWaitNotFound):
+        not_found_error = outcome.error
+        if json_output:
+            json_output_response(
+                {
+                    "source_id": not_found_error.source_id,
+                    "status": "not_found",
+                    "error": str(not_found_error),
+                }
+            )
+        else:
+            console.print(f"[red]✗ Source not found:[/red] {not_found_error.source_id}")
+        exit_with_code(1)
+
+    if isinstance(outcome, SourceWaitProcessingError):
+        processing_error = outcome.error
+        if json_output:
+            json_output_response(
+                {
+                    "source_id": processing_error.source_id,
+                    "status": "error",
+                    "status_code": processing_error.status,
+                    "error": str(processing_error),
+                }
+            )
+        else:
+            console.print(
+                f"[red]✗ Source processing failed:[/red] {processing_error.source_id}"
+            )
+        exit_with_code(1)
+
+    if isinstance(outcome, SourceWaitTimeout):
+        timeout_error = outcome.error
+        if json_output:
+            json_output_response(
+                {
+                    "source_id": timeout_error.source_id,
+                    "status": "timeout",
+                    "last_status_code": timeout_error.last_status,
+                    "timeout_seconds": int(timeout_error.timeout),
+                    "error": str(timeout_error),
+                }
+            )
+        else:
+            console.print(
+                f"[yellow]⚠ Timeout waiting for source:[/yellow] {timeout_error.source_id}"
+            )
+            console.print(f"[dim]Last status: {timeout_error.last_status}[/dim]")
+        exit_with_code(2)
 
 
 def _render_source_stale_result(
@@ -996,7 +1080,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
             resolved_id = await resolve_source_id(
                 client, nb_id_resolved, source_id, json_output=json_output
             )
-            await execute_source_wait(
+            outcome = await execute_source_wait(
                 client,
                 SourceWaitPlan(
                     notebook_id=nb_id_resolved,
@@ -1006,6 +1090,7 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                     json_output=json_output,
                 ),
             )
+            _render_source_wait_outcome(outcome, json_output=json_output)
 
     return _run()
 

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -72,6 +72,7 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 # Fully cleaned service modules. Each must have zero ``_boundary_violations``
 # AND zero Pattern A pairs (see :func:`_pattern_a_pairs`).
 GUARDED_PATHS = {
+    "cli/services/auth_diagnostics.py": SERVICES_ROOT / "auth_diagnostics.py",
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
     "cli/services/login/exceptions.py": SERVICES_ROOT / "login" / "exceptions.py",
     "cli/services/login/profile_targets.py": SERVICES_ROOT / "login" / "profile_targets.py",
@@ -79,6 +80,7 @@ GUARDED_PATHS = {
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",
     "cli/services/source_content.py": SERVICES_ROOT / "source_content.py",
     "cli/services/source_research.py": SERVICES_ROOT / "source_research.py",
+    "cli/services/source_wait.py": SERVICES_ROOT / "source_wait.py",
 }
 
 # Stage 3 migration inventory. These modules currently own presentation
@@ -117,19 +119,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "Owns rendering imports + ``console.print`` for artifact "
             "generation progress; exit policy already delegated to the "
             "command layer."
-        ),
-    },
-    "cli/services/auth_diagnostics.py": {
-        "path": SERVICES_ROOT / "auth_diagnostics.py",
-        "forbidden_imports": [
-            "auth_diagnostics.py:28: forbidden relative import: '..error_handler'",
-            "auth_diagnostics.py:29: forbidden relative import: '..rendering'",
-            "auth_diagnostics.py:207: forbidden relative import: '..runtime'",
-        ],
-        "pattern_a_violations": [("render_auth_check", 249)],
-        "rationale": (
-            "Status renderer still owns ``--json`` exit handling and runtime "
-            "import for cookie-keepalive probing."
         ),
     },
     "cli/services/auth_source.py": {
@@ -437,20 +426,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "rationale": (
             "Source mutation pipeline still owns presentation + Click "
             "confirmer defaults + exit policy."
-        ),
-    },
-    "cli/services/source_wait.py": {
-        "path": SERVICES_ROOT / "source_wait.py",
-        "forbidden_imports": [
-            "source_wait.py:22: forbidden relative import: '..error_handler'",
-            "source_wait.py:23: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "``source wait`` executor owns exit policy but routes "
-            "presentation through ``_emit_*`` helpers, so no direct "
-            "console.print + exit_with_code co-occurrence inside a single "
-            "function body."
         ),
     },
 }

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -28,7 +28,11 @@ from notebooklm.cli.services.source_research import (
     SourceAddResearchResult,
     execute_source_add_research,
 )
-from notebooklm.cli.services.source_wait import SourceWaitPlan, execute_source_wait
+from notebooklm.cli.services.source_wait import (
+    SourceWaitPlan,
+    SourceWaitTimeout,
+    execute_source_wait,
+)
 from notebooklm.types import Source, SourceFulltext, SourceTimeoutError
 
 
@@ -607,49 +611,34 @@ async def test_source_add_research_delegates_timeout_budget_to_research_api() ->
 
 
 @pytest.mark.asyncio
-async def test_source_wait_timeout_maps_to_json_envelope_and_exit_code(
+async def test_source_wait_timeout_returns_typed_outcome(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    payloads: list[dict[str, object]] = []
-
     @contextlib.asynccontextmanager
     async def fake_status_with_elapsed(*args: object, **kwargs: object) -> AsyncIterator[None]:
         yield
 
-    def fake_exit_with_code(code: int) -> None:
-        raise SystemExit(code)
-
     monkeypatch.setattr(source_wait, "status_with_elapsed", fake_status_with_elapsed)
-    monkeypatch.setattr(source_wait, "json_output_response", payloads.append)
-    monkeypatch.setattr(source_wait, "exit_with_code", fake_exit_with_code)
+    timeout_exc = SourceTimeoutError("src_1", 10.0, 2)
     client = SimpleNamespace(
-        sources=SimpleNamespace(
-            wait_until_ready=AsyncMock(side_effect=SourceTimeoutError("src_1", 10.0, 2))
-        )
+        sources=SimpleNamespace(wait_until_ready=AsyncMock(side_effect=timeout_exc))
     )
 
-    with pytest.raises(SystemExit) as exc_info:
-        await execute_source_wait(
-            client,
-            SourceWaitPlan(
-                notebook_id="nb_1",
-                source_id="src_1",
-                timeout=10.0,
-                interval=0.5,
-                json_output=True,
-            ),
-        )
+    outcome = await execute_source_wait(
+        client,
+        SourceWaitPlan(
+            notebook_id="nb_1",
+            source_id="src_1",
+            timeout=10.0,
+            interval=0.5,
+            json_output=True,
+        ),
+    )
 
-    assert exc_info.value.code == 2
-    assert payloads == [
-        {
-            "source_id": "src_1",
-            "status": "timeout",
-            "last_status_code": 2,
-            "timeout_seconds": 10,
-            "error": "Source src_1 not ready after 10.0s (last status: 2)",
-        }
-    ]
+    # Service now returns a typed outcome; presentation + exit code are the
+    # caller's responsibility (covered by tests/unit/cli/test_source.py).
+    assert isinstance(outcome, SourceWaitTimeout)
+    assert outcome.error is timeout_exc
     client.sources.wait_until_ready.assert_awaited_once_with(
         "nb_1",
         "src_1",


### PR DESCRIPTION
## Summary
- Move `source wait` presentation and exit-code handling from the service layer into `source_cmd.py` using typed service outcomes.
- Move `auth check` / `auth inspect` rendering into `session_cmd.py`, leaving `auth_diagnostics.py` as an async structured diagnostic executor.
- Update the services boundary inventory and source service tests for the cleaned modules.

## Test plan
- `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_services_boundary.py tests/unit/test_cli_source_services.py tests/unit/cli/test_source.py tests/unit/cli/test_session_characterization.py -q`
- `uv run --frozen --extra browser --extra dev --extra markdown ruff check src/notebooklm/cli/services/auth_diagnostics.py src/notebooklm/cli/services/source_wait.py src/notebooklm/cli/session_cmd.py src/notebooklm/cli/source_cmd.py tests/unit/cli/test_services_boundary.py tests/unit/test_cli_source_services.py`
- `uv run --frozen --extra browser --extra dev --extra markdown mypy src/notebooklm`
- `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_auth_subcommands.py tests/unit/cli/test_source_characterization.py tests/unit/test_json_error_exit.py -q`

## Deferred polish findings
none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Services now return structured outcomes (no direct rendering/exit); CLI command handlers take responsibility for presentation and exit codes.

* **Bug Fixes**
  * Adjusted CLI exception-site mappings to improve error reporting during login validation.

* **Tests**
  * Updated unit tests to match the new service contracts and outcome types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->