### PR TITLE
refactor(cli): lift source clean rendering

### DIFF
--- a/src/notebooklm/cli/services/source_clean.py
+++ b/src/notebooklm/cli/services/source_clean.py
@@ -1,4 +1,12 @@
-"""Service helpers for the ``source clean`` command."""
+"""Service helpers for the ``source clean`` command.
+
+This module owns the pure orchestration of source cleanup (classifying
+junk sources, batched deletion, returning a typed
+:class:`SourceCleanResult`). Presentation (Rich text vs. JSON envelope),
+confirmation prompting, and exit-code policy live in the Click command
+layer (:mod:`notebooklm.cli.source_cmd`) — the service never imports
+``click``, ``..rendering``, or ``..error_handler``.
+"""
 
 from __future__ import annotations
 
@@ -6,15 +14,10 @@ import asyncio
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Literal
 from urllib.parse import urlparse, urlunparse
 
 from ...types import Source, source_status_to_str
-
-if TYPE_CHECKING:
-    import click
-
-    from ...client import NotebookLMClient
 
 CleanCandidate = tuple[str, str, str, str]
 CleanFailure = tuple[str, str]
@@ -172,151 +175,4 @@ async def run_source_clean(
         candidates=tuple(candidates),
         deleted_count=deleted,
         failures=tuple(failures),
-    )
-
-
-@dataclass(frozen=True)
-class SourceCleanPlan:
-    """Click-shaped inputs for ``execute_source_clean``."""
-
-    notebook_id: str
-    dry_run: bool
-    yes: bool
-    json_output: bool
-    quiet_mode: bool
-
-
-async def execute_source_clean(
-    client: NotebookLMClient,
-    plan: SourceCleanPlan,
-    *,
-    ctx: click.Context | None = None,
-    classify_sources: Callable[[list[Source]], list[CleanCandidate]] = classify_junk_sources,
-    on_candidates: Callable[[list[CleanCandidate]], None] | None = None,
-) -> None:
-    """Run the ``source clean`` workflow with progress + JSON / text rendering.
-
-    Caller may pass ``classify_sources`` and ``on_candidates`` callbacks so
-    tests that patch the source-cmd compatibility wrappers (e.g.
-    ``_classify_junk_sources``, ``_print_clean_candidates``) continue to see
-    their patched implementations exercised end-to-end. Defaults are the
-    canonical service-layer implementations.
-    """
-    # Local imports keep this service module light at import time and avoid
-    # pulling click / rendering into non-CLI callers of ``run_source_clean``.
-    import click as _click
-
-    from ..error_handler import exit_with_code
-    from ..rendering import cli_print, cli_status, json_output_response
-    from .source_mutations import require_yes_in_json
-
-    async def _list_sources(notebook_id: str) -> list[Source]:
-        if plan.json_output:
-            return await client.sources.list(notebook_id)
-        with cli_status("Fetching sources for cleanup...", ctx=ctx):
-            return await client.sources.list(notebook_id)
-
-    # P1.T2 bug 3: in --json mode, never prompt — automation cannot answer
-    # the question. Pass a non-interactive ``confirm_delete`` that always
-    # declines; once the service returns ``cancelled`` we synthesize a
-    # structured ``CONFIRM_REQUIRED`` error below.
-    confirm_delete: Callable[[int], bool] = (
-        (lambda count: False)
-        if plan.json_output
-        else (lambda count: _click.confirm(f"Delete {count} source(s)?"))
-    )
-
-    suppress_status = plan.json_output or plan.quiet_mode
-    cb_candidates = None if suppress_status else on_candidates
-    cb_delete_start: Callable[[int], None] | None = (
-        None
-        if suppress_status
-        else lambda count: cli_print(
-            f"[dim]Cleaning {count} source(s) (in chunks of 10)...[/dim]",
-            ctx=ctx,
-        )
-    )
-
-    result = await run_source_clean(
-        notebook_id=plan.notebook_id,
-        dry_run=plan.dry_run,
-        yes=plan.yes,
-        list_sources=_list_sources,
-        delete_source=client.sources.delete,
-        confirm_delete=confirm_delete,
-        on_candidates=cb_candidates,
-        on_delete_start=cb_delete_start,
-        classify_sources=classify_sources,
-    )
-
-    candidate_payload = candidates_payload(result.candidates)
-
-    if plan.json_output:
-        # P1.T2 bug 3: synthesize structured error when --json + no --yes
-        # left candidates uncleaned.
-        if result.status == "cancelled" and not plan.yes:
-            require_yes_in_json(
-                action="clean",
-                extra={
-                    "notebook_id": result.notebook_id,
-                    "candidate_count": result.candidate_count,
-                    "candidates": candidate_payload,
-                },
-            )
-
-        payload: dict[str, Any] = {
-            "action": "clean",
-            "notebook_id": result.notebook_id,
-            "status": result.status,
-            "candidates": candidate_payload,
-            "deleted_count": result.deleted_count,
-            "failure_count": result.failure_count,
-        }
-        if result.status != "already_clean":
-            payload["candidate_count"] = result.candidate_count
-        if result.status == "completed":
-            payload["failures"] = [{"id": sid, "error": err} for sid, err in result.failures]
-        json_output_response(payload)
-        # P1.T2 bug 8: partial-failure exits non-zero so shell automation
-        # (set -e, CI) sees the failure.
-        if result.failures:
-            exit_with_code(1)
-        return
-
-    if result.status == "already_clean":
-        cli_print(
-            "[green]Notebook is already clean. No junk sources found.[/green]",
-            ctx=ctx,
-        )
-        return
-
-    if result.status == "dry_run":
-        cli_print(
-            f"[yellow]Dry run: would delete {result.candidate_count} source(s).[/yellow]",
-            ctx=ctx,
-        )
-        return
-
-    if result.status == "cancelled":
-        return
-
-    if result.failures:
-        cli_print(
-            f"[yellow]Cleaned {result.deleted_count} source(s). "
-            f"{len(result.failures)} deletion(s) failed.[/yellow]",
-            ctx=ctx,
-        )
-        for sid, err in result.failures[:5]:
-            cli_print(f"  [red]{sid}:[/red] {err}", ctx=ctx)
-        if len(result.failures) > 5:
-            cli_print(
-                f"  [dim]...and {len(result.failures) - 5} more[/dim]",
-                ctx=ctx,
-            )
-        # P1.T2 bug 8: text-mode parity with JSON-mode exit code.
-        exit_with_code(1)
-
-    cli_print(
-        f"[green]Successfully cleaned {result.deleted_count} source(s).[/green]",
-        ctx=ctx,
     )

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -10,7 +10,8 @@ to its executor:
 * ``services/source_research.py``  — add-research
 * ``services/source_wait.py``      — wait
 * ``services/source_add.py``       — add  (pre-T5; T5 added the executor)
-* ``services/source_clean.py``     — clean (pre-T5; T5 added the executor)
+* ``services/source_clean.py``     — clean (pure orchestration: classify +
+  batched delete; rendering + exit codes live here in the command layer)
 
 The full per-command listing lives in the ``source`` click group docstring
 below (it is what ``notebooklm source --help`` shows).
@@ -37,6 +38,8 @@ from .options import (
     wait_polling_options,
 )
 from .rendering import (
+    cli_print,
+    cli_status,
     console,
     display_report,
     display_research_sources,
@@ -48,7 +51,11 @@ from .runtime import is_quiet
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
 from .services.source_add import SourceAddExecutionPlan, execute_source_add
-from .services.source_clean import SourceCleanPlan, execute_source_clean
+from .services.source_clean import (
+    SourceCleanResult,
+    candidates_payload,
+    run_source_clean,
+)
 from .services.source_content import (
     SourceFulltextPlan,
     SourceFulltextResult,
@@ -75,6 +82,7 @@ from .services.source_mutations import (
     execute_source_delete_by_title,
     execute_source_refresh,
     execute_source_rename,
+    require_yes_in_json,
 )
 from .services.source_research import (
     SourceAddResearchPlan,
@@ -1026,18 +1034,139 @@ def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_clean(
-                client,
-                SourceCleanPlan(
-                    notebook_id=nb_id_resolved,
-                    dry_run=dry_run,
-                    yes=yes,
-                    json_output=json_output,
-                    quiet_mode=quiet_mode,
-                ),
-                ctx=ctx,
-                classify_sources=_classify_junk_sources,
-                on_candidates=_print_clean_candidates,
+
+            async def _list_sources(notebook_id_inner):
+                if json_output:
+                    return await client.sources.list(notebook_id_inner)
+                with cli_status("Fetching sources for cleanup...", ctx=ctx):
+                    return await client.sources.list(notebook_id_inner)
+
+            # P1.T2 bug 3: in --json mode, never prompt — automation cannot
+            # answer the question. Pass a non-interactive ``confirm_delete``
+            # that always declines; once the service returns ``cancelled`` we
+            # synthesize a structured ``CONFIRM_REQUIRED`` error below.
+            confirm_delete = (
+                (lambda count: False)
+                if json_output
+                else (lambda count: click.confirm(f"Delete {count} source(s)?"))
             )
 
+            suppress_status = json_output or quiet_mode
+            cb_candidates = None if suppress_status else _print_clean_candidates
+            cb_delete_start = (
+                None
+                if suppress_status
+                else lambda count: cli_print(
+                    f"[dim]Cleaning {count} source(s) (in chunks of 10)...[/dim]",
+                    ctx=ctx,
+                )
+            )
+
+            result: SourceCleanResult = await run_source_clean(
+                notebook_id=nb_id_resolved,
+                dry_run=dry_run,
+                yes=yes,
+                list_sources=_list_sources,
+                delete_source=client.sources.delete,
+                confirm_delete=confirm_delete,
+                on_candidates=cb_candidates,
+                on_delete_start=cb_delete_start,
+                classify_sources=_classify_junk_sources,
+            )
+
+            _dispatch_source_clean_result(result, json_output=json_output, yes=yes, ctx=ctx)
+
     return _run()
+
+
+def _dispatch_source_clean_result(
+    result: SourceCleanResult,
+    *,
+    json_output: bool,
+    yes: bool,
+    ctx,
+) -> None:
+    """Render the source-clean outcome and exit per the result's status.
+
+    Owns the Click-side rendering + exit-code policy that used to live
+    inside ``execute_source_clean`` in :mod:`.services.source_clean`.
+    Keeping presentation here lets the service module stay free of
+    ``click`` / ``..rendering`` / ``..error_handler`` imports (audit C4
+    Pattern A).
+    """
+    candidate_payload = candidates_payload(result.candidates)
+
+    if json_output:
+        # P1.T2 bug 3: synthesize structured error when --json + no --yes
+        # left candidates uncleaned. ``require_yes_in_json`` raises
+        # ``SystemExit(1)`` via ``output_error`` — it never returns.
+        if result.status == "cancelled" and not yes:
+            require_yes_in_json(
+                action="clean",
+                extra={
+                    "notebook_id": result.notebook_id,
+                    "candidate_count": result.candidate_count,
+                    "candidates": candidate_payload,
+                },
+            )
+
+        payload: dict[str, Any] = {
+            "action": "clean",
+            "notebook_id": result.notebook_id,
+            "status": result.status,
+            "candidates": candidate_payload,
+            "deleted_count": result.deleted_count,
+            "failure_count": result.failure_count,
+        }
+        if result.status != "already_clean":
+            payload["candidate_count"] = result.candidate_count
+        if result.status == "completed":
+            payload["failures"] = [{"id": sid, "error": err} for sid, err in result.failures]
+        json_output_response(payload)
+        # P1.T2 bug 8: partial-failure exits non-zero so shell automation
+        # (set -e, CI) sees the failure.
+        if result.failures:
+            exit_with_code(1)
+        return
+
+    if result.status == "already_clean":
+        cli_print(
+            "[green]Notebook is already clean. No junk sources found.[/green]",
+            ctx=ctx,
+        )
+        return
+
+    if result.status == "dry_run":
+        cli_print(
+            f"[yellow]Dry run: would delete {result.candidate_count} source(s).[/yellow]",
+            ctx=ctx,
+        )
+        return
+
+    if result.status == "cancelled":
+        return
+
+    if result.failures:
+        # Failure summary is an error diagnostic, so it must remain visible
+        # under root ``--quiet`` (policy: errors are never silenced; see
+        # ``cli/rendering.py``). Use ``console.print`` directly here instead
+        # of ``cli_print`` so the diagnostic is not swallowed when the user
+        # passes ``--quiet``.
+        console.print(
+            f"[yellow]Cleaned {result.deleted_count} source(s). "
+            f"{len(result.failures)} deletion(s) failed.[/yellow]",
+        )
+        for sid, err in result.failures[:5]:
+            console.print(f"  [red]{sid}:[/red] {err}")
+        if len(result.failures) > 5:
+            console.print(
+                f"  [dim]...and {len(result.failures) - 5} more[/dim]",
+            )
+        # P1.T2 bug 8: text-mode parity with JSON-mode exit code.
+        exit_with_code(1)
+        return
+
+    cli_print(
+        f"[green]Successfully cleaned {result.deleted_count} source(s).[/green]",
+        ctx=ctx,
+    )

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -1035,7 +1035,7 @@ def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
-            async def _list_sources(notebook_id_inner):
+            async def _list_sources(notebook_id_inner: str) -> list[Source]:
                 if json_output:
                     return await client.sources.list(notebook_id_inner)
                 with cli_status("Fetching sources for cleanup...", ctx=ctx):
@@ -1084,7 +1084,7 @@ def _dispatch_source_clean_result(
     *,
     json_output: bool,
     yes: bool,
-    ctx,
+    ctx: click.Context | None,
 ) -> None:
     """Render the source-clean outcome and exit per the result's status.
 

--- a/tests/unit/cli/test_quiet_flag.py
+++ b/tests/unit/cli/test_quiet_flag.py
@@ -301,6 +301,28 @@ class TestQuietSourceClean:
         # appear in the candidate table, which is the prose we suppress.
         assert result.output == ""
 
+    def test_quiet_source_clean_partial_failure_still_emits_error(
+        self, runner, mock_auth, fetch_tokens
+    ):
+        """``--quiet`` suppresses status prose, not deletion failure diagnostics."""
+        junk = Source(id="src_junk_1", title="Access Denied", url="https://example.test/a")
+
+        async def fail_delete(_notebook_id, _source_id):
+            raise RuntimeError("delete failed")
+
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(return_value=[junk])
+            mock_client.sources.delete = AsyncMock(side_effect=fail_delete)
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["--quiet", "source", "clean", "-n", "nb_123", "-y"])
+
+        assert result.exit_code != 0, result.output
+        assert "1 deletion(s) failed" in result.output
+        assert "src_junk_1" in result.output
+        assert "delete failed" in result.output
+
     def test_non_quiet_source_clean_still_prints_success(self, runner, mock_auth, fetch_tokens):
         """Baseline: non-quiet ``source clean -y`` still emits the success
         line (or already-clean line)."""

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -77,6 +77,7 @@ GUARDED_PATHS = {
     "cli/services/login/profile_targets.py": SERVICES_ROOT / "login" / "profile_targets.py",
     "cli/services/research.py": SERVICES_ROOT / "research.py",
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",
+    "cli/services/source_clean.py": SERVICES_ROOT / "source_clean.py",
     "cli/services/source_content.py": SERVICES_ROOT / "source_content.py",
     "cli/services/source_research.py": SERVICES_ROOT / "source_research.py",
 }
@@ -389,26 +390,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "rationale": (
             "``source add`` workflow still pulls ``console`` for spinner "
             "messages; presentation reach-in to be inverted."
-        ),
-    },
-    "cli/services/source_clean.py": {
-        "path": SERVICES_ROOT / "source_clean.py",
-        "forbidden_imports": [
-            "source_clean.py:207: forbidden top-level import: 'click'",
-            "source_clean.py:209: forbidden relative import: '..error_handler'",
-            "source_clean.py:210: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "pattern_b_violations": (
-            "uses click.confirm via a function-local import; lift to "
-            "an injected confirmer callback."
-        ),
-        "rationale": (
-            "``source clean`` executor owns the full Click + rendering + "
-            "exit-code matrix; uses ``cli_print`` rather than direct "
-            "``console.print`` so Pattern A is empty (helpers + "
-            "``exit_with_code`` live in the same function but no direct "
-            "console.print co-occurrence)."
         ),
     },
     "cli/services/source_listing.py": {


### PR DESCRIPTION
## Summary
- Move `source clean` rendering, confirmation, and exit-code policy out of `cli/services/source_clean.py` and into the Click command layer.
- Promote `cli/services/source_clean.py` into the cleaned service boundary inventory.
- Add a quiet-mode regression for partial source-clean deletion failures.

## Task
Continues `.sisyphus/plans/cli-audit-2026-05-27-fixes.md` for `task/source-clean-pattern-a-refactor`.

## Test plan
- [x] `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_services_boundary.py tests/unit/cli/test_source.py tests/unit/cli/test_source_characterization.py -q`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_quiet_flag.py::TestQuietSourceClean -q`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown ruff check src/notebooklm/cli/services/source_clean.py src/notebooklm/cli/source_cmd.py tests/unit/cli/test_services_boundary.py tests/unit/cli/test_quiet_flag.py`
- [x] `git diff --check -- src/notebooklm/cli/services/source_clean.py src/notebooklm/cli/source_cmd.py tests/unit/cli/test_services_boundary.py tests/unit/cli/test_quiet_flag.py`

## Deferred polish findings
- Optional: direct unit tests for `_dispatch_source_clean_result` branches. Existing Click-level source-clean tests cover the user-visible contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture of the `source clean` command for better error handling and code organization.
  * Error messages are now consistently displayed even when using the `--quiet` flag, ensuring users are informed of failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->