### PR TITLE
refactor(cli): type source add-research outcomes

### DIFF
--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -2,25 +2,35 @@
 
 Owns research start orchestration and the optional ``--import-all`` step.
 The protocol-level wait loop and task-id pinning live in
-``ResearchAPI.wait_for_completion``. Stays in service-layer territory:
-imports the rendering helpers + ``import_research_sources`` directly rather than
-threading display callbacks through the executor.
+``ResearchAPI.wait_for_completion``. ADR-008 boundary: this module returns
+a discriminated :class:`SourceAddResearchResult` and never touches
+``console``/``exit_with_code`` — the command layer in
+``cli/source_cmd.py`` owns rendering and exit-code policy. It MAY call the
+shared importer, which emits text-mode status messages; under ``--json`` the
+plan routes ``json_output=True`` into that helper so stdout stays parseable.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
 
-from ..error_handler import exit_with_code
-from ..rendering import console, display_report, display_research_sources
-from ..research_import import import_research_sources
+from ..research_import import ResearchImportResult, import_research_sources
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
 
 SearchSource = Literal["web", "drive"]
 SearchMode = Literal["fast", "deep"]
+SourceAddResearchOutcome = Literal[
+    "started_no_wait",
+    "start_failed",
+    "completed",
+    "no_research",
+    "failed",
+    "timeout",
+    "unknown_status",
+]
 
 # Pinned at 5 seconds to match the legacy ``cli/source.py`` poll cadence
 # and the explanatory comment in the original ``source add-research``
@@ -41,17 +51,53 @@ class SourceAddResearchPlan:
     cited_only: bool
     no_wait: bool
     timeout: int
+    json_output: bool = False
+
+
+@dataclass(frozen=True)
+class SourceAddResearchResult:
+    """Discriminated outcome of an ``execute_source_add_research`` invocation.
+
+    The command handler renders text or JSON off ``outcome`` and exits with
+    the appropriate code. Non-success outcomes (``start_failed``,
+    ``no_research``, ``failed``, ``timeout``, ``unknown_status``) map to
+    exit code 1; ``completed`` and ``started_no_wait`` map to exit 0.
+    """
+
+    outcome: SourceAddResearchOutcome
+    plan: SourceAddResearchPlan
+    start_task_id: str | None = None
+    poll_task_id: str | None = None
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    report: str = ""
+    status: str | None = None
+    import_result: ResearchImportResult | None = None
 
 
 async def execute_source_add_research(
     client: NotebookLMClient, plan: SourceAddResearchPlan
-) -> None:
+) -> SourceAddResearchResult:
     """Start research, poll until completion, and optionally import sources.
 
-    Exit-code contract (matches the pre-extraction handler):
-        * 0 — research started + completed (or ``--no-wait`` returned early).
-        * 1 — research failed to start (``research.start`` returned empty, or
-          the wait API reports no active research before a task is known).
+    Returns a :class:`SourceAddResearchResult` whose ``outcome`` discriminates
+    every terminal state the pre-extraction handler distinguished:
+
+    * ``started_no_wait`` — ``--no-wait`` returned early after ``research.start``.
+    * ``start_failed`` — ``research.start`` returned empty.
+    * ``completed`` — wait finished with ``status == "completed"`` (may include
+      an ``import_result`` if ``--import-all`` was active and sources were
+      returned).
+    * ``no_research`` — wait returned ``status == "no_research"`` (the wait
+      API reports no active research before a task is known).
+    * ``failed`` / ``timeout`` — wait returned ``status == "failed"`` or the
+      wait API raised :class:`TimeoutError`.
+    * ``unknown_status`` — wait returned an unexpected status string (the
+      raw value is preserved in :attr:`SourceAddResearchResult.status`).
+
+    The service is fully I/O-free except for the underlying ``client``
+    awaits: it never calls ``console.print``, ``click.echo``, or
+    ``exit_with_code``. The command handler owns rendering and exit-code
+    policy per ADR-008.
 
     The wait call passes the task discriminator returned by ``research.start``
     so a second research task started mid-wait (e.g. concurrent caller, web UI,
@@ -59,13 +105,11 @@ async def execute_source_add_research(
     Deep research uses the returned ``report_id`` for polling/import because
     ``START_DEEP_RESEARCH`` slot 0 is not stable for those follow-up RPCs.
     """
-    console.print(f"[yellow]Starting {plan.mode} research on {plan.search_source}...[/yellow]")
     result = await client.research.start(
         plan.notebook_id, plan.query, plan.search_source, plan.mode
     )
     if not result:
-        console.print("[red]Research failed to start[/red]")
-        exit_with_code(1)
+        return SourceAddResearchResult(outcome="start_failed", plan=plan)
 
     start_task_id = result["task_id"]
     # Deep research polls under the report id returned in slot 1 of the
@@ -73,21 +117,17 @@ async def execute_source_add_research(
     # POLL_RESEARCH / IMPORT_RESEARCH.
     task_id = result.get("report_id") if plan.mode == "deep" else start_task_id
     task_id = task_id or start_task_id
-    console.print(f"[dim]Task ID: {start_task_id}[/dim]")
-    if task_id != start_task_id:
-        console.print(f"[dim]Poll ID: {task_id}[/dim]")
 
     # Non-blocking mode: return immediately. Research will keep running
     # server-side; until something fires IMPORT_RESEARCH the NotebookLM
     # web UI will show an "Add sources?" modal (issue #315).
     if plan.no_wait:
-        console.print(
-            "[green]Research started.[/green] "
-            "Run 'notebooklm research wait --import-all' to commit "
-            "sources once it completes, otherwise the NotebookLM web "
-            "UI will keep an 'Add sources?' modal open."
+        return SourceAddResearchResult(
+            outcome="started_no_wait",
+            plan=plan,
+            start_task_id=start_task_id,
+            poll_task_id=task_id,
         )
-        return
 
     try:
         status = await client.research.wait_for_completion(
@@ -97,38 +137,75 @@ async def execute_source_add_research(
             interval=float(_POLL_INTERVAL_S),
         )
     except TimeoutError:
-        status = {"status": "timeout"}
+        return SourceAddResearchResult(
+            outcome="timeout",
+            plan=plan,
+            start_task_id=start_task_id,
+            poll_task_id=task_id,
+        )
 
     status_val = status.get("status", "unknown")
+    sources = status.get("sources", []) or []
+    report = status.get("report", "") or ""
 
     if status_val == "completed":
-        sources = status.get("sources", [])
-        console.print()
-        display_research_sources(sources)
-
-        display_report(status.get("report", ""), json_hint=False)
-
+        import_result: ResearchImportResult | None = None
         if plan.import_all and sources and task_id:
+            import_kwargs: dict[str, Any] = {
+                "report": report,
+                "cited_only": plan.cited_only,
+                "max_elapsed": plan.timeout,
+            }
+            if plan.json_output:
+                import_kwargs["json_output"] = True
             import_result = await import_research_sources(
                 client,
                 plan.notebook_id,
                 task_id,
                 sources,
-                report=status.get("report", ""),
-                cited_only=plan.cited_only,
-                max_elapsed=plan.timeout,
+                **import_kwargs,
             )
-            console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
-    elif status_val == "no_research":
-        console.print("[red]Research failed to start[/red]")
-        exit_with_code(1)
-    elif status_val in ("failed", "timeout"):
-        message = "Research timed out" if status_val == "timeout" else "Research failed"
-        console.print(f"[red]{message}[/red]")
-        exit_with_code(1)
-    else:
-        console.print(f"[yellow]Status: {status_val}[/yellow]")
-        exit_with_code(1)
+        return SourceAddResearchResult(
+            outcome="completed",
+            plan=plan,
+            start_task_id=start_task_id,
+            poll_task_id=task_id,
+            sources=sources,
+            report=report,
+            import_result=import_result,
+        )
+    if status_val == "no_research":
+        return SourceAddResearchResult(
+            outcome="no_research",
+            plan=plan,
+            start_task_id=start_task_id,
+            poll_task_id=task_id,
+        )
+    if status_val in ("failed", "timeout"):
+        return SourceAddResearchResult(
+            outcome="failed" if status_val == "failed" else "timeout",
+            plan=plan,
+            start_task_id=start_task_id,
+            poll_task_id=task_id,
+            sources=sources,
+            report=report,
+        )
+    return SourceAddResearchResult(
+        outcome="unknown_status",
+        plan=plan,
+        start_task_id=start_task_id,
+        poll_task_id=task_id,
+        sources=sources,
+        report=report,
+        status=status_val,
+    )
 
 
-__all__ = ["SourceAddResearchPlan", "execute_source_add_research"]
+__all__ = [
+    "SearchMode",
+    "SearchSource",
+    "SourceAddResearchOutcome",
+    "SourceAddResearchPlan",
+    "SourceAddResearchResult",
+    "execute_source_add_research",
+]

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -19,6 +19,7 @@ below (it is what ``notebooklm source --help`` shows).
 import asyncio  # noqa: F401 — re-exported for P1.T2 regression tests that patch source_cmd.asyncio.sleep
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any, NoReturn
 
 import click
 from rich.table import Table
@@ -35,7 +36,13 @@ from .options import (
     prompt_file_option,
     wait_polling_options,
 )
-from .rendering import console, get_source_type_display, json_output_response
+from .rendering import (
+    console,
+    display_report,
+    display_research_sources,
+    get_source_type_display,
+    json_output_response,
+)
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_id
 from .runtime import is_quiet
 from .services import source_add as source_add_service
@@ -69,7 +76,11 @@ from .services.source_mutations import (
     execute_source_refresh,
     execute_source_rename,
 )
-from .services.source_research import SourceAddResearchPlan, execute_source_add_research
+from .services.source_research import (
+    SourceAddResearchPlan,
+    SourceAddResearchResult,
+    execute_source_add_research,
+)
 from .services.source_wait import SourceWaitPlan, execute_source_wait
 
 # Compatibility wrappers — tests patch these names on this module. Each
@@ -602,6 +613,133 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
     return _run()
 
 
+def _emit_add_research_flag_conflict(message: str, *, json_output: bool) -> NoReturn:
+    """Surface a ``source add-research`` flag conflict via the active CLI error contract.
+
+    Per ADR-015, post-parse flag-combination failures route through the typed
+    JSON envelope under ``--json`` (exit ``1`` with
+    ``{"error": true, "code": "VALIDATION_ERROR", ...}`` on stdout) and via
+    Click's parser-style ``UsageError`` otherwise (exit ``2`` with usage text
+    on stderr). Never returns — both branches raise.
+    """
+    if json_output:
+        _output_error(message, "VALIDATION_ERROR", True, 1)
+        raise AssertionError("unreachable")  # pragma: no cover
+    raise click.UsageError(message)
+
+
+def _print_add_research_task_ids(result: SourceAddResearchResult) -> None:
+    if result.start_task_id:
+        console.print(f"[dim]Task ID: {result.start_task_id}[/dim]")
+    if result.poll_task_id and result.poll_task_id != result.start_task_id:
+        console.print(f"[dim]Poll ID: {result.poll_task_id}[/dim]")
+
+
+def _exit_with_add_research_status(status: str, message: str, **extra: Any) -> NoReturn:
+    payload: dict[str, Any] = {"status": status, "error": message}
+    payload.update(extra)
+    json_output_response(payload)
+    exit_with_code(1)
+
+
+def _render_add_research_result(result: SourceAddResearchResult, *, json_output: bool) -> None:
+    """Render :class:`SourceAddResearchResult` and exit on non-success outcomes.
+
+    The handler owns all CLI I/O — text vs JSON, exit codes, the
+    ``Starting ... research`` info line, and the ``Imported N sources``
+    summary — so the service layer can stay pure (ADR-008) and exit-policy
+    free (no Pattern A).
+    """
+    if result.outcome == "start_failed":
+        if json_output:
+            _output_error("Research failed to start", "VALIDATION_ERROR", True, 1)
+        else:
+            console.print("[red]Research failed to start[/red]")
+            exit_with_code(1)
+        return  # pragma: no cover — both branches above terminate
+
+    if not json_output:
+        _print_add_research_task_ids(result)
+
+    if result.outcome == "started_no_wait":
+        if json_output:
+            payload: dict[str, Any] = {
+                "status": "started",
+                "task_id": result.start_task_id,
+            }
+            if result.poll_task_id and result.poll_task_id != result.start_task_id:
+                payload["poll_task_id"] = result.poll_task_id
+            json_output_response(payload)
+            return
+        console.print(
+            "[green]Research started.[/green] "
+            "Run 'notebooklm research wait --import-all' to commit "
+            "sources once it completes, otherwise the NotebookLM web "
+            "UI will keep an 'Add sources?' modal open."
+        )
+        return
+
+    if result.outcome == "no_research":
+        if json_output:
+            _exit_with_add_research_status("no_research", "Research failed to start")
+        else:
+            console.print("[red]Research failed to start[/red]")
+            exit_with_code(1)
+        return  # pragma: no cover
+
+    if result.outcome in ("failed", "timeout"):
+        message = "Research timed out" if result.outcome == "timeout" else "Research failed"
+        if json_output:
+            _exit_with_add_research_status(result.outcome, message)
+        else:
+            console.print(f"[red]{message}[/red]")
+            exit_with_code(1)
+        return  # pragma: no cover
+
+    if result.outcome == "unknown_status":
+        status_val = result.status or "unknown"
+        if json_output:
+            _exit_with_add_research_status(
+                "unknown_status",
+                f"Unexpected research status: {status_val}",
+                raw_status=status_val,
+            )
+        else:
+            console.print(f"[yellow]Status: {status_val}[/yellow]")
+            exit_with_code(1)
+        return  # pragma: no cover
+
+    # outcome == "completed"
+    if json_output:
+        completed_payload: dict[str, Any] = {
+            "status": "completed",
+            "task_id": result.poll_task_id,
+            "sources_found": len(result.sources),
+            "sources": result.sources,
+            "report": result.report,
+        }
+        import_result = result.import_result
+        if import_result is not None:
+            if import_result.cited_selection is not None:
+                completed_payload["cited_only"] = True
+                completed_payload["cited_sources_selected"] = len(import_result.sources)
+                completed_payload["cited_only_fallback"] = (
+                    import_result.cited_selection.used_fallback
+                )
+            completed_payload["imported"] = len(import_result.imported)
+            completed_payload["imported_sources"] = import_result.imported
+        json_output_response(completed_payload)
+        return
+
+    # Text mode
+    console.print()
+    display_research_sources(result.sources)
+    display_report(result.report, json_hint=False)
+    import_result = result.import_result
+    if import_result is not None:
+        console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
+
+
 @source.command("add-research")
 @click.argument("query", default="", required=False)
 @prompt_file_option
@@ -641,6 +779,7 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
         "the NotebookLM web UI is left showing an 'Add sources?' modal."
     ),
 )
+@json_option
 @with_client
 def source_add_research(
     ctx,
@@ -653,6 +792,7 @@ def source_add_research(
     cited_only,
     no_wait,
     timeout,
+    json_output,
     client_auth,
 ):
     """Search web or drive and add sources from results.
@@ -663,20 +803,28 @@ def source_add_research(
     """
     query = resolve_prompt(query, prompt_file, "query", required=True)
     if cited_only and not import_all:
-        raise click.UsageError("--cited-only requires --import-all")
+        # ADR-015 §2: under --json route through the typed envelope; preserve
+        # Click's parser-style ``UsageError`` (exit 2 with usage text) in text
+        # mode so interactive callers still see the canonical conflict prose.
+        _emit_add_research_flag_conflict(
+            "--cited-only requires --import-all", json_output=json_output
+        )
     # P1.T2 bug 7: --no-wait + --import-all is silently broken — refuse it.
     if no_wait and import_all:
-        raise click.UsageError(
+        _emit_add_research_flag_conflict(
             "--import-all requires --wait (the default) or a separate "
-            "'research wait --import-all' after --no-wait."
+            "'research wait --import-all' after --no-wait.",
+            json_output=json_output,
         )
 
     nb_id = require_notebook(notebook_id)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            await execute_source_add_research(
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            if not json_output:
+                console.print(f"[yellow]Starting {mode} research on {search_source}...[/yellow]")
+            result = await execute_source_add_research(
                 client,
                 SourceAddResearchPlan(
                     notebook_id=nb_id_resolved,
@@ -687,8 +835,10 @@ def source_add_research(
                     cited_only=cited_only,
                     no_wait=no_wait,
                     timeout=timeout,
+                    json_output=json_output,
                 ),
             )
+            _render_add_research_result(result, json_output=json_output)
 
     return _run()
 

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -8551,6 +8551,24 @@
           "type": {
             "name": "integer"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Search web or drive and add sources from..."

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -75,6 +75,7 @@ GUARDED_PATHS = {
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
     "cli/services/research.py": SERVICES_ROOT / "research.py",
     "cli/services/source_content.py": SERVICES_ROOT / "source_content.py",
+    "cli/services/source_research.py": SERVICES_ROOT / "source_research.py",
 }
 
 # Stage 3 migration inventory. These modules currently own presentation
@@ -461,23 +462,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "rationale": (
             "Source mutation pipeline still owns presentation + Click "
             "confirmer defaults + exit policy."
-        ),
-    },
-    "cli/services/source_research.py": {
-        "path": SERVICES_ROOT / "source_research.py",
-        "forbidden_imports": [
-            "source_research.py:15: forbidden relative import: '..error_handler'",
-            "source_research.py:16: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [
-            ("execute_source_add_research", 68),
-            ("execute_source_add_research", 124),
-            ("execute_source_add_research", 128),
-            ("execute_source_add_research", 131),
-        ],
-        "rationale": (
-            "``source add --research`` executor owns presentation + exit "
-            "codes for the research-import failure modes."
         ),
     },
     "cli/services/source_wait.py": {

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from notebooklm.cli import source_cmd
 from notebooklm.cli.services import source_mutations, source_research, source_wait
 from notebooklm.cli.services.source_content import (
     SourceFulltextPlan,
@@ -24,6 +25,7 @@ from notebooklm.cli.services.source_mutations import (
 )
 from notebooklm.cli.services.source_research import (
     SourceAddResearchPlan,
+    SourceAddResearchResult,
     execute_source_add_research,
 )
 from notebooklm.cli.services.source_wait import SourceWaitPlan, execute_source_wait
@@ -194,12 +196,9 @@ async def test_source_guide_service_treats_non_mapping_payload_as_empty() -> Non
 async def test_source_add_research_waits_with_started_task_id_and_imports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    imported = SimpleNamespace(imported=["src_1"])
+    imported = SimpleNamespace(imported=["src_1"], cited_selection=None, sources=[])
     import_research_sources = AsyncMock(return_value=imported)
     monkeypatch.setattr(source_research, "import_research_sources", import_research_sources)
-    monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
-    monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
-    monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
@@ -214,7 +213,7 @@ async def test_source_add_research_waits_with_started_task_id_and_imports(
         )
     )
 
-    await execute_source_add_research(
+    result = await execute_source_add_research(
         client,
         SourceAddResearchPlan(
             notebook_id="nb_1",
@@ -228,6 +227,11 @@ async def test_source_add_research_waits_with_started_task_id_and_imports(
         ),
     )
 
+    assert result.outcome == "completed"
+    assert result.poll_task_id == "task_123"
+    assert result.sources == [{"title": "Result"}]
+    assert result.report == "Report"
+    assert result.import_result is imported
     client.research.start.assert_awaited_once_with("nb_1", "topic", "web", "deep")
     client.research.wait_for_completion.assert_awaited_once_with(
         "nb_1",
@@ -246,32 +250,154 @@ async def test_source_add_research_waits_with_started_task_id_and_imports(
     )
 
 
-@pytest.mark.parametrize("status", ["failed", "timeout"])
 @pytest.mark.asyncio
-async def test_source_add_research_failed_or_timeout_exits_nonzero(
+async def test_source_add_research_json_import_stays_silent(
     monkeypatch: pytest.MonkeyPatch,
-    status: str,
 ) -> None:
-    printed: list[str] = []
-
-    def fake_exit_with_code(code: int) -> None:
-        raise SystemExit(code)
-
-    monkeypatch.setattr(
-        source_research.console, "print", lambda message, *_, **__: printed.append(message)
-    )
-    monkeypatch.setattr(source_research, "exit_with_code", fake_exit_with_code)
+    imported = SimpleNamespace(imported=["src_1"], cited_selection=None, sources=[])
+    import_research_sources = AsyncMock(return_value=imported)
+    monkeypatch.setattr(source_research, "import_research_sources", import_research_sources)
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
-            wait_for_completion=AsyncMock(return_value={"status": status, "task_id": "task_123"}),
+            wait_for_completion=AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [{"title": "Result"}],
+                    "report": "Report",
+                }
+            ),
         )
     )
 
-    with pytest.raises(SystemExit) as exc_info:
-        await execute_source_add_research(
-            client,
-            SourceAddResearchPlan(
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="fast",
+            import_all=True,
+            cited_only=True,
+            no_wait=False,
+            timeout=30,
+            json_output=True,
+        ),
+    )
+
+    assert result.outcome == "completed"
+    import_research_sources.assert_awaited_once_with(
+        client,
+        "nb_1",
+        "task_123",
+        [{"title": "Result"}],
+        report="Report",
+        cited_only=True,
+        max_elapsed=30,
+        json_output=True,
+    )
+
+
+def test_render_add_research_started_no_wait_json_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(source_cmd, "json_output_response", payloads.append)
+
+    source_cmd._render_add_research_result(
+        SourceAddResearchResult(
+            outcome="started_no_wait",
+            plan=SourceAddResearchPlan(
+                notebook_id="nb_1",
+                query="topic",
+                search_source="web",
+                mode="deep",
+                import_all=False,
+                cited_only=False,
+                no_wait=True,
+                timeout=30,
+                json_output=True,
+            ),
+            start_task_id="task_123",
+            poll_task_id="report_456",
+        ),
+        json_output=True,
+    )
+
+    assert payloads == [
+        {
+            "status": "started",
+            "task_id": "task_123",
+            "poll_task_id": "report_456",
+        }
+    ]
+
+
+def test_render_add_research_completed_json_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(source_cmd, "json_output_response", payloads.append)
+    import_result = SimpleNamespace(
+        imported=[{"id": "src_1", "title": "Result"}],
+        cited_selection=SimpleNamespace(used_fallback=False),
+        sources=[{"title": "Result"}],
+    )
+
+    source_cmd._render_add_research_result(
+        SourceAddResearchResult(
+            outcome="completed",
+            plan=SourceAddResearchPlan(
+                notebook_id="nb_1",
+                query="topic",
+                search_source="web",
+                mode="fast",
+                import_all=True,
+                cited_only=True,
+                no_wait=False,
+                timeout=30,
+                json_output=True,
+            ),
+            start_task_id="task_123",
+            poll_task_id="task_123",
+            sources=[{"title": "Result"}],
+            report="Report",
+            import_result=import_result,
+        ),
+        json_output=True,
+    )
+
+    assert payloads == [
+        {
+            "status": "completed",
+            "task_id": "task_123",
+            "sources_found": 1,
+            "sources": [{"title": "Result"}],
+            "report": "Report",
+            "cited_only": True,
+            "cited_sources_selected": 1,
+            "cited_only_fallback": False,
+            "imported": 1,
+            "imported_sources": [{"id": "src_1", "title": "Result"}],
+        }
+    ]
+
+
+def test_render_add_research_completed_text_keeps_task_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    printed: list[object] = []
+    monkeypatch.setattr(
+        source_cmd.console, "print", lambda message="", *_, **__: printed.append(message)
+    )
+    monkeypatch.setattr(source_cmd, "display_research_sources", lambda sources: None)
+    monkeypatch.setattr(source_cmd, "display_report", lambda report, json_hint=False: None)
+
+    source_cmd._render_add_research_result(
+        SourceAddResearchResult(
+            outcome="completed",
+            plan=SourceAddResearchPlan(
                 notebook_id="nb_1",
                 query="topic",
                 search_source="web",
@@ -281,26 +407,110 @@ async def test_source_add_research_failed_or_timeout_exits_nonzero(
                 no_wait=False,
                 timeout=30,
             ),
-        )
+            start_task_id="task_123",
+            poll_task_id="report_456",
+            sources=[{"title": "Result"}],
+            report="Report",
+        ),
+        json_output=False,
+    )
 
-    assert exc_info.value.code == 1
-    expected = "Research failed" if status == "failed" else "Research timed out"
-    assert any(expected in line for line in printed)
+    assert "[dim]Task ID: task_123[/dim]" in printed
+    assert "[dim]Poll ID: report_456[/dim]" in printed
+
+
+@pytest.mark.parametrize("status", ["failed", "timeout"])
+@pytest.mark.asyncio
+async def test_source_add_research_failed_or_timeout_returns_terminal_outcome(
+    status: str,
+) -> None:
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            wait_for_completion=AsyncMock(return_value={"status": status, "task_id": "task_123"}),
+        )
+    )
+
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="deep",
+            import_all=False,
+            cited_only=False,
+            no_wait=False,
+            timeout=30,
+        ),
+    )
+
+    # status="failed" -> outcome="failed"; status="timeout" from the wait_for_completion
+    # return (not the TimeoutError branch) is treated as the same terminal class.
+    assert result.outcome == status
+    assert result.start_task_id == "task_123"
+    assert result.poll_task_id == "task_123"
 
 
 @pytest.mark.asyncio
-async def test_source_add_research_unknown_status_exits_nonzero(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    printed: list[str] = []
-
-    def fake_exit_with_code(code: int) -> None:
-        raise SystemExit(code)
-
-    monkeypatch.setattr(
-        source_research.console, "print", lambda message, *_, **__: printed.append(message)
+async def test_source_add_research_start_failed_returns_outcome() -> None:
+    """``research.start`` returning falsy maps to ``outcome='start_failed'``."""
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value=None),
+            wait_for_completion=AsyncMock(),
+        )
     )
-    monkeypatch.setattr(source_research, "exit_with_code", fake_exit_with_code)
+
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="fast",
+            import_all=False,
+            cited_only=False,
+            no_wait=False,
+            timeout=30,
+        ),
+    )
+
+    assert result.outcome == "start_failed"
+    assert result.start_task_id is None
+    client.research.wait_for_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_timeout_error_maps_to_timeout_outcome() -> None:
+    """``wait_for_completion`` raising :class:`TimeoutError` maps to ``timeout``."""
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            wait_for_completion=AsyncMock(side_effect=TimeoutError("budget exhausted")),
+        )
+    )
+
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="fast",
+            import_all=False,
+            cited_only=False,
+            no_wait=False,
+            timeout=30,
+        ),
+    )
+
+    assert result.outcome == "timeout"
+    assert result.poll_task_id == "task_123"
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_unknown_status_returns_unknown_outcome() -> None:
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
@@ -310,32 +520,55 @@ async def test_source_add_research_unknown_status_exits_nonzero(
         )
     )
 
-    with pytest.raises(SystemExit) as exc_info:
-        await execute_source_add_research(
-            client,
-            SourceAddResearchPlan(
-                notebook_id="nb_1",
-                query="topic",
-                search_source="web",
-                mode="deep",
-                import_all=False,
-                cited_only=False,
-                no_wait=False,
-                timeout=30,
-            ),
-        )
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="deep",
+            import_all=False,
+            cited_only=False,
+            no_wait=False,
+            timeout=30,
+        ),
+    )
 
-    assert exc_info.value.code == 1
-    assert any("Status: cancelled" in line for line in printed)
+    assert result.outcome == "unknown_status"
+    assert result.status == "cancelled"
 
 
 @pytest.mark.asyncio
-async def test_source_add_research_delegates_timeout_budget_to_research_api(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(source_research.console, "print", lambda *args, **kwargs: None)
-    monkeypatch.setattr(source_research, "display_research_sources", lambda sources: None)
-    monkeypatch.setattr(source_research, "display_report", lambda report, json_hint=False: None)
+async def test_source_add_research_no_wait_returns_early_outcome() -> None:
+    """``--no-wait`` skips the wait loop and returns ``started_no_wait``."""
+    client = SimpleNamespace(
+        research=SimpleNamespace(
+            start=AsyncMock(return_value={"task_id": "task_123"}),
+            wait_for_completion=AsyncMock(),
+        )
+    )
+
+    result = await execute_source_add_research(
+        client,
+        SourceAddResearchPlan(
+            notebook_id="nb_1",
+            query="topic",
+            search_source="web",
+            mode="fast",
+            import_all=False,
+            cited_only=False,
+            no_wait=True,
+            timeout=30,
+        ),
+    )
+
+    assert result.outcome == "started_no_wait"
+    assert result.start_task_id == "task_123"
+    client.research.wait_for_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_source_add_research_delegates_timeout_budget_to_research_api() -> None:
     client = SimpleNamespace(
         research=SimpleNamespace(
             start=AsyncMock(return_value={"task_id": "task_123"}),
@@ -350,7 +583,7 @@ async def test_source_add_research_delegates_timeout_budget_to_research_api(
         )
     )
 
-    await execute_source_add_research(
+    result = await execute_source_add_research(
         client,
         SourceAddResearchPlan(
             notebook_id="nb_1",
@@ -364,6 +597,7 @@ async def test_source_add_research_delegates_timeout_budget_to_research_api(
         ),
     )
 
+    assert result.outcome == "completed"
     client.research.wait_for_completion.assert_awaited_once_with(
         "nb_1",
         task_id="task_123",

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -254,6 +254,16 @@ def _research_no_research(client: MagicMock) -> None:
     client.research.poll = AsyncMock(return_value={"status": "no_research"})
 
 
+def _source_add_research_start_failed(client: MagicMock) -> None:
+    """``source add-research --json`` failure: ``client.research.start`` returns falsy.
+
+    The service returns ``outcome="start_failed"`` which the command handler
+    converts to the typed JSON envelope (``VALIDATION_ERROR``, exit 1) per
+    ADR-015.
+    """
+    client.research.start = AsyncMock(return_value={})
+
+
 def _download_no_artifacts(client: MagicMock) -> None:
     # No completed artifacts of the requested kind -> the generic download path
     # returns {"error": "No completed ... artifacts found"} and now must exit 1.
@@ -441,6 +451,44 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         "research_wait_no_research",
         ["research", "wait", "-n", "abc123def456ghi789jkl", "--json"],
         _research_no_research,
+    ),
+    # source add-research failure-to-start: ADR-015 typed envelope on the
+    # `start_failed` outcome from services/source_research.py.
+    (
+        "source_add_research_failure_json",
+        ["source", "add-research", "topic", "-n", "abc123def456ghi789jkl", "--json"],
+        _source_add_research_start_failed,
+    ),
+    # source add-research --cited-only without --import-all: post-parse
+    # UsageError site routed through the JSON envelope per ADR-015.
+    (
+        "source_research_cited_only_conflict_json",
+        [
+            "source",
+            "add-research",
+            "topic",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--cited-only",
+            "--json",
+        ],
+        None,
+    ),
+    # source add-research --no-wait with --import-all: same post-parse
+    # flag-conflict path, same ADR-015 JSON envelope.
+    (
+        "source_add_research_no_wait_import_all_conflict_json",
+        [
+            "source",
+            "add-research",
+            "topic",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--no-wait",
+            "--import-all",
+            "--json",
+        ],
+        None,
     ),
     # note + share + notebook + chat: client raising trips @with_client's json
     # error path (which already exits 1 -> regression guard).

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -291,6 +291,10 @@ def _customize_source_guide(client: MagicMock) -> None:
     )
 
 
+def _customize_source_add_research(client: MagicMock) -> None:
+    client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+
+
 def _customize_research_wait(client: MagicMock) -> None:
     # research wait polls until status == "completed". Return a completed
     # payload immediately so the loop exits on the first iteration.
@@ -407,6 +411,19 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
             "--json",
         ],
         _customize_source_guide,
+    ),
+    (
+        "source_add_research",
+        [
+            "source",
+            "add-research",
+            "topic",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--no-wait",
+            "--json",
+        ],
+        _customize_source_add_research,
     ),
     # artifact group
     ("artifact_list", ["artifact", "list", "-n", "abc123def456ghi789jkl", "--json"], None),


### PR DESCRIPTION
## Summary
- Implements: ADR-015 §2 for `source add-research` post-parse flag conflicts and failure-to-start JSON errors.
- Refactors `services/source_research.py` to return typed outcomes instead of printing/exiting from the service layer.
- Moves `source add-research` rendering and JSON output into `source_cmd.py`, including JSON success payload coverage and importer stdout-purity handling.

## Task
F6 from `.sisyphus/plans/cli-audit-2026-05-27-fixes.md`: source_research consolidated refactor (P1#2 + meta-audit I8 + C4 Pattern A).

## Test plan
- [x] `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_services_boundary.py tests/unit/test_cli_source_services.py tests/unit/test_json_error_exit.py -q`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown ruff check src/notebooklm/cli/services/source_research.py src/notebooklm/cli/source_cmd.py tests/unit/cli/test_services_boundary.py tests/unit/test_cli_source_services.py tests/unit/test_json_error_exit.py`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown ruff format --check src/notebooklm/cli/services/source_research.py src/notebooklm/cli/source_cmd.py tests/unit/cli/test_services_boundary.py tests/unit/test_cli_source_services.py tests/unit/test_json_error_exit.py`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_source.py -q`
- [x] `uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli/test_phase10_cli_contract.py -q`

## Deferred polish findings
- Optional: keep the `_output_error(...)` unreachable assertion in the flag-conflict helper because `_output_error` is typed as returning `None` even though it exits.
- Optional: no schema change to emit `imported: 0` when import was requested but skipped because no import result exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --json output for the source add-research command and structured result payloads (including started/no-wait states).
* **Bug Fixes**
  * Improved outcome mapping and robust handling of post-parse flag conflicts and terminal states (failed/timeout/unknown).
* **Tests**
  * Expanded test coverage for JSON output, rendering, no-wait behavior, and outcome cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->