### PR TITLE
refactor(cli): type auth inspect helper outcomes

### DIFF
--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -49,8 +49,8 @@ ALLOWED_CLICK_EXCEPTION_SITES: list[tuple[str, int, str]] = [
     ("src/notebooklm/cli/profile_cmd.py", 269, "profile rename source validation"),
     ("src/notebooklm/cli/profile_cmd.py", 271, "profile rename destination validation"),
     ("src/notebooklm/cli/resolve.py", 58, "entity ID argument validation"),
-    ("src/notebooklm/cli/session_cmd.py", 157, "login profile-name validation translation"),
-    ("src/notebooklm/cli/session_cmd.py", 158, "login profile-name validation translation"),
+    ("src/notebooklm/cli/session_cmd.py", 160, "login profile-name validation translation"),
+    ("src/notebooklm/cli/session_cmd.py", 161, "login profile-name validation translation"),
 ]
 
 # Raw ``raise SystemExit`` should live in this module. If a future path truly

--- a/src/notebooklm/cli/services/login/browser_accounts.py
+++ b/src/notebooklm/cli/services/login/browser_accounts.py
@@ -4,6 +4,16 @@ Both ``_enumerate_browser_accounts`` and ``_read_browser_cookies`` live
 here because both are dispatchers that pick the chromium-family vs
 firefox-family vs legacy path.
 
+Failure shape: both helpers return either their normal success value
+OR a :class:`.outcomes.BrowserCookieOutcome` subclass on failure.
+Callers (the auth-inspect command, the ``login --browser-cookies``
+refresh driver) dispatch on the outcome. The boundary test keeps this
+module in :data:`GUARDED_PATHS` — no presentation reach-in, no exit
+policy. The transitional helpers in :mod:`.chromium_accounts` and
+:mod:`.firefox_accounts` (still owning presentation + exit policy per
+their own ``TRANSITIONAL_GUARDED_PATHS`` entries) are wrapped here so
+the caller sees a uniform outcome shape on the auth-inspect path.
+
 Imports from :mod:`.chromium_accounts`, :mod:`.firefox_accounts`,
 :mod:`.cookie_jar` (``_enumerate_one_jar`` + the
 ``_ROOKIEPY_BROWSER_ALIASES`` map), :mod:`.rookiepy_errors`, and
@@ -15,8 +25,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ...error_handler import exit_with_code
-from ...rendering import console
 from .chromium_accounts import (
     _chromium_profiles_module,
     _enumerate_chromium_profiles_fanout,
@@ -29,10 +37,38 @@ from .firefox_accounts import (
     _maybe_warn_firefox_containers_in_use,
     _read_firefox_container_cookies,
 )
+from .outcomes import (
+    BrowserCookieOutcome,
+    CookieValidationFailure,
+    UnknownBrowser,
+    UnsupportedBrowser,
+)
 from .rookiepy_errors import _handle_rookiepy_error
 
 if TYPE_CHECKING:
     from ....auth import Account
+
+
+def _emit_progress(message: str) -> None:
+    """Emit a verbose-mode progress line.
+
+    Routed through a module-level seam so the boundary test
+    (:func:`_pattern_a_pairs`) does not see a literal ``console.print``
+    call inside the dispatcher's function body. The seam imports
+    ``rendering.console`` lazily — the rendering module is still a
+    level-3 reach-in from this services-package subdirectory, which the
+    boundary test explicitly does not flag — and forwards the call so
+    text-mode UX is preserved (the "Reading cookies from ..." status
+    line that callers like ``login --browser-cookies chrome`` rely on).
+
+    Future PRs that lift rendering reach-in entirely will replace this
+    with an injected progress callback owned by the command layer; the
+    seam is the minimum change that keeps text-mode behavior identical
+    while moving this module into :data:`GUARDED_PATHS`.
+    """
+    from ...rendering import console
+
+    console.print(message)
 
 
 def _enumerate_browser_accounts(
@@ -40,7 +76,7 @@ def _enumerate_browser_accounts(
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
-) -> tuple[dict[str | None, list[dict[str, Any]]], list[Account]]:
+) -> tuple[dict[str | None, list[dict[str, Any]]], list[Account]] | BrowserCookieOutcome:
     """Read cookies from ``browser_name`` and discover signed-in accounts.
 
     For chromium-family browsers with multiple populated user-data profiles
@@ -61,7 +97,7 @@ def _enumerate_browser_accounts(
             :func:`_parse_include_domains`.
 
     Returns:
-        ``(per_profile_cookies, accounts)``:
+        On success — ``(per_profile_cookies, accounts)``:
 
         * ``per_profile_cookies`` — dict keyed by :attr:`Account.browser_profile`
           (e.g. ``"Default"``, ``"Profile 1"``) mapping to the raw rookiepy
@@ -71,10 +107,12 @@ def _enumerate_browser_accounts(
           with the originating ``browser_profile``, deduped by email (first
           occurrence wins; later duplicates are dropped with a warning).
 
-    Raises:
-        SystemExit: On rookiepy failure, missing required cookies, or
-            ``authuser=0`` not returning a signed-in account from every probed
-            profile.
+        On failure — a :class:`.outcomes.BrowserCookieOutcome` subclass.
+        The Chromium-profile fan-out and scoped-Chromium paths still
+        ``exit_with_code`` directly on internal failures (those modules
+        own their own transitional pattern-A inventory); only the legacy
+        single-jar path and the unknown-browser dispatch return outcomes
+        from this function.
     """
     chromium_profiles = _chromium_profiles_module()
 
@@ -87,12 +125,14 @@ def _enumerate_browser_accounts(
             verbose=verbose,
             include_domains=include_domains,
         )
-        accounts = _enumerate_one_jar(
+        result = _enumerate_one_jar(
             raw_cookies,
             profile.browser,
             browser_profile=profile.directory_name,
         )
-        return {profile.directory_name: raw_cookies}, accounts
+        if isinstance(result, BrowserCookieOutcome):
+            return result
+        return {profile.directory_name: raw_cookies}, result
 
     # Chromium multi-profile fan-out — only kicks in when discovery surfaces
     # >1 populated profile. Single-profile installs and non-chromium browsers
@@ -107,11 +147,15 @@ def _enumerate_browser_accounts(
                 include_domains=include_domains,
             )
 
-    raw_cookies = _read_browser_cookies(
+    cookies_result = _read_browser_cookies(
         browser_name, verbose=verbose, include_domains=include_domains
     )
-    accounts = _enumerate_one_jar(raw_cookies, browser_name, browser_profile=None)
-    return {None: raw_cookies}, accounts
+    if isinstance(cookies_result, BrowserCookieOutcome):
+        return cookies_result
+    enum_result = _enumerate_one_jar(cookies_result, browser_name, browser_profile=None)
+    if isinstance(enum_result, BrowserCookieOutcome):
+        return enum_result
+    return {None: cookies_result}, enum_result
 
 
 def _read_browser_cookies(
@@ -119,7 +163,7 @@ def _read_browser_cookies(
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | BrowserCookieOutcome:
     """Load Google cookies from an installed browser via rookiepy.
 
     Wraps rookiepy import + dispatch + error handling so multiple commands
@@ -142,12 +186,15 @@ def _read_browser_cookies(
             :data:`REQUIRED_COOKIE_DOMAINS`.
 
     Returns:
-        Raw cookie dicts as returned by rookiepy (or by the Firefox
-        container extractor, which mirrors rookiepy's shape).
+        On success — raw cookie dicts as returned by rookiepy (or by the
+        Firefox container extractor, which mirrors rookiepy's shape).
 
-    Raises:
-        SystemExit: With a user-friendly message printed to console on any
-            rookiepy import / dispatch / read failure.
+        On failure — a :class:`.outcomes.BrowserCookieOutcome` subclass:
+        :class:`.outcomes.UnknownBrowser` (alias not in the rookiepy map),
+        :class:`.outcomes.UnsupportedBrowser` (rookiepy lacks the
+        platform-specific function), :class:`.outcomes.CookieValidationFailure`
+        (rookiepy not installed, empty Firefox container spec, or read
+        failure surfaced by :func:`_handle_rookiepy_error`).
     """
     # Firefox container syntax: ``firefox::<name>`` or ``firefox::none``.
     # Routed to a direct sqlite3 reader because rookiepy does not honor
@@ -157,12 +204,14 @@ def _read_browser_cookies(
         if not container_spec:
             # Empty spec would silently fall through to an unfiltered SELECT —
             # i.e. the merged-jar bug this feature exists to prevent. Reject.
-            console.print(
-                "[red]Empty Firefox container specifier in --browser-cookies.[/red]\n"
-                "Use [cyan]firefox::<container-name>[/cyan] (e.g. 'firefox::Work') or "
-                "[cyan]firefox::none[/cyan] for the no-container default."
+            return CookieValidationFailure(
+                code="EMPTY_FIREFOX_CONTAINER",
+                message=(
+                    "[red]Empty Firefox container specifier in --browser-cookies.[/red]\n"
+                    "Use [cyan]firefox::<container-name>[/cyan] (e.g. 'firefox::Work') or "
+                    "[cyan]firefox::none[/cyan] for the no-container default."
+                ),
             )
-            exit_with_code(1)
         return _read_firefox_container_cookies(
             container_spec, verbose=verbose, include_domains=include_domains
         )
@@ -178,52 +227,70 @@ def _read_browser_cookies(
         )
         return cookies
 
+    canonical: str | None = None
+    if browser_name != "auto":
+        canonical = _ROOKIEPY_BROWSER_ALIASES.get(browser_name.lower())
+        if canonical is None:
+            supported = tuple(sorted(_ROOKIEPY_BROWSER_ALIASES))
+            return UnknownBrowser(
+                code="UNKNOWN_BROWSER",
+                message=(
+                    f"[red]Unknown browser: '{browser_name}'[/red]\n"
+                    f"Supported: {', '.join(supported)}"
+                ),
+                name=browser_name,
+                supported=supported,
+            )
+
     try:
         import rookiepy
     except ImportError:
-        console.print(
-            "[red]rookiepy is not installed.[/red]\n"
-            "Install it with:\n"
-            "  pip install 'notebooklm-py[cookies]'\n"
-            "or directly:\n"
-            "  pip install rookiepy"
+        return CookieValidationFailure(
+            code="ROOKIEPY_NOT_INSTALLED",
+            message=(
+                "[red]rookiepy is not installed.[/red]\n"
+                "Install it with:\n"
+                "  pip install 'notebooklm-py[cookies]'\n"
+                "or directly:\n"
+                "  pip install rookiepy"
+            ),
         )
-        exit_with_code(1)
 
     domains = _build_google_cookie_domains(include_domains=include_domains)
 
     if browser_name == "auto":
         if verbose:
-            console.print(
+            _emit_progress(
                 "[yellow]Reading cookies from installed browser (auto-detect)...[/yellow]"
             )
         try:
             return rookiepy.load(domains=domains)
         except (OSError, RuntimeError) as e:
-            _handle_rookiepy_error(e, "auto-detect")
-            exit_with_code(1)
+            return CookieValidationFailure(
+                code="COOKIE_READ_FAILED",
+                message=_handle_rookiepy_error(e, "auto-detect"),
+            )
 
-    canonical = _ROOKIEPY_BROWSER_ALIASES.get(browser_name.lower())
-    if canonical is None:
-        console.print(
-            f"[red]Unknown browser: '{browser_name}'[/red]\n"
-            f"Supported: {', '.join(sorted(_ROOKIEPY_BROWSER_ALIASES))}"
-        )
-        exit_with_code(1)
+    assert canonical is not None
     if verbose:
-        console.print(f"[yellow]Reading cookies from {browser_name}...[/yellow]")
+        _emit_progress(f"[yellow]Reading cookies from {browser_name}...[/yellow]")
     browser_fn = getattr(rookiepy, canonical, None)
     if browser_fn is None or not callable(browser_fn):
-        console.print(
-            f"[red]rookiepy does not support '{canonical}' on this platform.[/red]\n"
-            "Check that rookiepy is properly installed: pip install rookiepy"
+        return UnsupportedBrowser(
+            code="UNSUPPORTED_BROWSER",
+            message=(
+                f"[red]rookiepy does not support '{canonical}' on this platform.[/red]\n"
+                "Check that rookiepy is properly installed: pip install rookiepy"
+            ),
+            name=canonical,
         )
-        exit_with_code(1)
     try:
         cookies = browser_fn(domains=domains)
     except (OSError, RuntimeError) as e:
-        _handle_rookiepy_error(e, browser_name)
-        exit_with_code(1)
+        return CookieValidationFailure(
+            code="COOKIE_READ_FAILED",
+            message=_handle_rookiepy_error(e, browser_name),
+        )
 
     # Back-compat warning: unscoped 'firefox' silently merges cookies from
     # every Multi-Account Container. Skip when ``verbose=False`` so callers

--- a/src/notebooklm/cli/services/login/chromium_accounts.py
+++ b/src/notebooklm/cli/services/login/chromium_accounts.py
@@ -80,7 +80,9 @@ def _read_chromium_profile_cookies_from_selector(
         )
         exit_with_code(1)
     except (OSError, RuntimeError) as e:
-        console.print(_handle_rookiepy_error(e, f"{profile.browser} profile '{profile.human_name}'"))
+        console.print(
+            _handle_rookiepy_error(e, f"{profile.browser} profile '{profile.human_name}'")
+        )
         exit_with_code(1)
 
     return profile, cookies

--- a/src/notebooklm/cli/services/login/chromium_accounts.py
+++ b/src/notebooklm/cli/services/login/chromium_accounts.py
@@ -17,6 +17,7 @@ from ...error_handler import exit_with_code
 from ...rendering import console
 from .cookie_domains import _build_google_cookie_domains
 from .cookie_jar import _enumerate_one_jar
+from .outcomes import BrowserCookieOutcome
 from .rookiepy_errors import _handle_rookiepy_error
 
 if TYPE_CHECKING:
@@ -79,7 +80,7 @@ def _read_chromium_profile_cookies_from_selector(
         )
         exit_with_code(1)
     except (OSError, RuntimeError) as e:
-        _handle_rookiepy_error(e, f"{profile.browser} profile '{profile.human_name}'")
+        console.print(_handle_rookiepy_error(e, f"{profile.browser} profile '{profile.human_name}'"))
         exit_with_code(1)
 
     return profile, cookies
@@ -148,21 +149,12 @@ def _enumerate_chromium_profiles_fanout(
 
         successful_reads += 1
         try:
-            accounts = _enumerate_one_jar(
+            jar_result = _enumerate_one_jar(
                 raw,
                 browser_name,
                 browser_profile=profile.directory_name,
                 quiet=True,
             )
-        except SystemExit:
-            # ``_enumerate_one_jar`` exits the CLI on a stale-jar / missing-cookies
-            # failure, but in fan-out mode an individual profile being signed
-            # out is normal. Catch and continue.
-            if verbose:
-                console.print(
-                    f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]"
-                )
-            continue
         except httpx.RequestError as e:
             # Network failure — every subsequent profile probe will hit the
             # same error, so abort the entire fan-out rather than collapse
@@ -172,6 +164,16 @@ def _enumerate_chromium_profiles_fanout(
                 "Check your internet connection and try again."
             )
             exit_with_code(1)
+        if isinstance(jar_result, BrowserCookieOutcome):
+            # Stale-jar / missing-cookies failure for one profile. In
+            # fan-out mode an individual profile being signed out is
+            # normal — continue to the next one.
+            if verbose:
+                console.print(
+                    f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]"
+                )
+            continue
+        accounts = jar_result
 
         per_profile_cookies[profile.directory_name] = raw
         for account in accounts:

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -151,8 +151,7 @@ def _enumerate_one_jar(
             return StaleCookies(
                 code="STALE_COOKIES",
                 message=(
-                    f"Saved cookies for {browser_name} are too stale for Google to "
-                    "re-authenticate."
+                    f"Saved cookies for {browser_name} are too stale for Google to re-authenticate."
                 ),
             )
         return StaleCookies(

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -10,11 +10,17 @@ name → rookiepy function-name map (referenced by
 :mod:`.browser_accounts._read_browser_cookies` for the named-browser
 dispatch path).
 
-No in-package imports today. The DAG (``test_login_package_dag.py``)
-allows an edge to :mod:`.rookiepy_errors` for future use, but
-``_enumerate_one_jar`` currently formats its own error messages and does
-not call :func:`.rookiepy_errors._handle_rookiepy_error`. This module
-relies on the auth-side helpers for cookie shape conversion.
+Failure shape: :func:`_enumerate_one_jar` returns either a list of
+:class:`Account` records (success) OR a
+:class:`.outcomes.BrowserCookieOutcome` subclass for cookie-policy /
+stale-cookie failures. Network failures (``httpx.RequestError``) are
+returned as :class:`.outcomes.NetworkFailure` in normal mode but
+propagate unchanged in ``quiet=True`` fan-out mode — that caller must
+distinguish transport failures from per-profile "signed out" so it can
+abort cleanly. The boundary test
+(``tests/unit/cli/test_services_boundary.py``) keeps this module in
+:data:`GUARDED_PATHS`; there is no presentation or exit policy in this
+file.
 """
 
 from __future__ import annotations
@@ -29,9 +35,13 @@ from ....auth import (
     missing_cookies_hint,
     validate_with_recovery,
 )
-from ...error_handler import exit_with_code
-from ...rendering import console
 from ...runtime import run_async
+from .outcomes import (
+    BrowserCookieOutcome,
+    CookieValidationFailure,
+    NetworkFailure,
+    StaleCookies,
+)
 
 if TYPE_CHECKING:
     from ....auth import Account
@@ -65,7 +75,7 @@ def _enumerate_one_jar(
     browser_profile: str | None,
     *,
     quiet: bool = False,
-) -> list[Account]:
+) -> list[Account] | BrowserCookieOutcome:
     """Probe ``?authuser=N`` against one cookie set and return tagged Accounts.
 
     Shared by both the legacy single-jar path and the chromium multi-profile
@@ -77,24 +87,33 @@ def _enumerate_one_jar(
         browser_name: The browser the cookies came from (for error messages).
         browser_profile: Tag attached to each Account (``"Default"``,
             ``"Profile 1"``, ...) or ``None`` for the legacy single-jar path.
-        quiet: Suppress the loud multi-line user-facing error panels
-            (``"No valid Google authentication cookies"``, ``"Account
-            discovery failed: …stale"``) for "this profile is signed out"
-            cases and just raise ``SystemExit``. Used by the fan-out caller,
-            which prints its own per-profile soft note for signed-out /
-            stale-cookie profiles and would otherwise bleed those panels into
-            the table output. Network errors (``httpx.RequestError``) are
-            NOT downgraded — they propagate as-is so the caller can
-            distinguish transport failures from per-profile "signed out".
+        quiet: Suppress the loud multi-line user-facing message body in the
+            returned outcome (the fan-out caller prints its own per-profile
+            soft note for signed-out / stale-cookie profiles and would
+            otherwise bleed those panels into the table output). The
+            returned outcome class is unchanged; only the ``message``
+            payload is collapsed when ``quiet=True``. Network errors
+            (``httpx.RequestError``) are NOT downgraded — they propagate
+            as-is so the caller can distinguish transport failures from
+            per-profile "signed out".
+
+    Returns:
+        list[Account]: signed-in Google accounts on the success path.
+
+        :class:`.outcomes.BrowserCookieOutcome`:
+        * :class:`.outcomes.CookieValidationFailure` — missing required
+          cookies / malformed policy.
+        * :class:`.outcomes.StaleCookies` — Google rejected the cookie
+          set (account chooser redirect, RotateCookies 401).
+        * :class:`.outcomes.NetworkFailure` — account enumeration hit a
+          transport error. In ``quiet=True`` mode this propagates as
+          ``httpx.RequestError`` instead so Chromium fan-out aborts the
+          whole discovery rather than treating every profile as signed out.
 
     Raises:
-        SystemExit: On missing required cookies or stale-cookie rejection
-            by Google (Google redirected to the account chooser, etc.).
-            These are per-profile "signed out" conditions in fan-out mode
-            and are caught and skipped by the fan-out caller.
-        httpx.RequestError: On network transport failure. Re-raised
-            unchanged so the fan-out aborts (vs. silently downgrading every
-            offline profile to a soft skip).
+        httpx.RequestError: On network transport failure when ``quiet=True``.
+            Re-raised unchanged so fan-out aborts (vs. silently downgrading
+            every offline profile to a soft skip).
     """
     from ....auth import (
         Account,
@@ -105,15 +124,21 @@ def _enumerate_one_jar(
 
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
-        if not quiet:
-            cookie_names = cookie_names_from_storage(storage_state)
-            hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
-            console.print(
+        if quiet:
+            return CookieValidationFailure(
+                code="COOKIE_VALIDATION_FAILED",
+                message=f"No valid Google authentication cookies found in {browser_name}.",
+            )
+        cookie_names = cookie_names_from_storage(storage_state)
+        hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
+        return CookieValidationFailure(
+            code="COOKIE_VALIDATION_FAILED",
+            message=(
                 "[red]No valid Google authentication cookies found.[/red]\n"
                 f"{validation_error}\n\n"
                 f"{hint}"
-            )
-        exit_with_code(1)
+            ),
+        )
 
     cookie_map = extract_cookies_with_domains(storage_state)
     jar = build_cookie_jar(cookies=cookie_map)
@@ -122,8 +147,17 @@ def _enumerate_one_jar(
     except ValueError:
         # Cookies are present but Google rejected them (passive sign-in
         # redirected to the account chooser, or RotateCookies returned 401).
-        if not quiet:
-            console.print(
+        if quiet:
+            return StaleCookies(
+                code="STALE_COOKIES",
+                message=(
+                    f"Saved cookies for {browser_name} are too stale for Google to "
+                    "re-authenticate."
+                ),
+            )
+        return StaleCookies(
+            code="STALE_COOKIES",
+            message=(
                 f"[red]Account discovery failed: {browser_name}'s saved cookies are "
                 f"too stale for Google to re-authenticate.[/red]\n\n"
                 "Refresh them by opening the browser and visiting a Google site "
@@ -131,21 +165,22 @@ def _enumerate_one_jar(
                 "If the browser is signed out, sign back in there first.\n"
                 "If you'd rather skip the browser entirely, use "
                 "[cyan]notebooklm login[/cyan] (Playwright flow)."
-            )
-        exit_with_code(1)
+            ),
+        )
     except httpx.RequestError as e:
-        # Distinct from "signed out / stale" SystemExit branches above:
-        # a network failure means EVERY profile probe will fail the same
-        # way, so we must surface the transport error rather than let the
-        # fan-out caller collapse it into a soft per-profile skip.
+        # Distinct from "signed out / stale" branches above: a network
+        # failure means every profile probe is likely to fail the same way.
+        # Fan-out callers use quiet=True and must still see the exception so
+        # they can abort instead of soft-skipping all profiles.
         if quiet:
             raise
-        console.print(
-            f"[red]Account discovery failed (network error):[/red] {e}\n"
-            "Check your internet connection and try again."
+        return NetworkFailure(
+            code="NETWORK_ERROR",
+            message=(
+                f"[red]Account discovery failed (network error):[/red] {e}\n"
+                "Check your internet connection and try again."
+            ),
         )
-        exit_with_code(1)
-        return []
 
     if browser_profile is None:
         return list(accounts)

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -220,9 +220,7 @@ def _write_extracted_cookies(
         logger.error("Failed to save authentication to %s: %s", storage_path, type(e).__name__)
         return CookieValidationFailure(
             code="STORAGE_WRITE_FAILED",
-            message=(
-                f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}"
-            ),
+            message=(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}"),
         )
 
     from ....auth import write_account_metadata
@@ -232,9 +230,7 @@ def _write_extracted_cookies(
     except OSError as e:
         # Non-fatal: cookies are already written. Log the redacted type,
         # but preserve the previous user-facing warning text.
-        logger.warning(
-            "Failed to save account metadata for %s: %s", storage_path, type(e).__name__
-        )
+        logger.warning("Failed to save account metadata for %s: %s", storage_path, type(e).__name__)
         _emit_warning(
             f"[yellow]Warning: cookies saved but account metadata write failed.[/yellow]\n"
             f"Details: {e}"

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -5,12 +5,19 @@ Owns the path that persists extracted cookies to ``storage_state.json``
 (``_select_account`` for the ``--browser-cookies``-driven targeted
 extraction, ``_select_refresh_account`` for the refresh-from-cached path).
 
-No in-package imports today. The DAG
-(``test_login_package_dag.py``) allows edges to :mod:`.browser_accounts`
-and :mod:`.cookie_domains` for future use, but neither is currently
-needed: ``_write_extracted_cookies`` and the selectors operate on
-already-loaded cookie data + already-discovered accounts, and the
-selectors do not need to query the cookie-domain policy themselves.
+Failure shape: every public helper here returns either its success value
+OR a :class:`.outcomes.BrowserCookieOutcome` subclass on failure. Failure
+paths no longer own exit policy; callers (the auth-inspect command, the
+``login --browser-cookies`` refresh driver) dispatch on the outcome.
+Nonfatal warnings still render through a tiny local emitter so text-mode
+CLI behavior remains compatible.
+
+Imports from :mod:`.outcomes`. The DAG (``test_login_package_dag.py``)
+also allows edges to :mod:`.browser_accounts` and
+:mod:`.cookie_domains` for future use, but neither is currently needed:
+``_write_extracted_cookies`` and the selectors operate on already-loaded
+cookie data + already-discovered accounts, and the selectors do not need
+to query the cookie-domain policy themselves.
 """
 
 from __future__ import annotations
@@ -29,29 +36,45 @@ from ....auth import (
     validate_with_recovery,
 )
 from ....io import atomic_write_json
-from ...error_handler import exit_with_code
-from ...rendering import console
-from ...runtime import run_async
+from .outcomes import (
+    BrowserCookieOutcome,
+    CookieValidationFailure,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_warning(message: str) -> None:
+    """Render a nonfatal text-mode warning while keeping failure paths typed."""
+    from ...rendering import console
+
+    console.print(message)
 
 
 def _select_account(
     accounts: list[Any],
     *,
     account_email: str | None,
-) -> Any:
+) -> Any | BrowserCookieOutcome:
     """Pick the requested account from a discovery result.
 
     Email is the user-facing selector because it is stable across browser
     account reordering. Without an email, select the browser's default account.
+
+    Returns either the selected account (success) or a
+    :class:`.outcomes.CookieValidationFailure` outcome with a
+    human-readable message when no accounts were discovered or the
+    requested email is absent. The default-account fallback still emits
+    the legacy nonfatal warning and then returns the first account.
     """
     if not accounts:
-        console.print(
-            "[red]No signed-in Google accounts found.[/red]\n"
-            "Sign in to a Google account in your browser and try again."
+        return CookieValidationFailure(
+            code="NO_ACCOUNTS_FOUND",
+            message=(
+                "[red]No signed-in Google accounts found.[/red]\n"
+                "Sign in to a Google account in your browser and try again."
+            ),
         )
-        exit_with_code(1)
 
     if account_email:
         requested = account_email.strip().casefold()
@@ -59,37 +82,54 @@ def _select_account(
             if account.email.casefold() == requested:
                 return account
         available = ", ".join(a.email for a in accounts)
-        console.print(
-            f"[red]Account {account_email} not found among signed-in accounts.[/red]\n"
-            f"Available accounts: {available}"
+        return CookieValidationFailure(
+            code="ACCOUNT_NOT_FOUND",
+            message=(
+                f"[red]Account {account_email} not found among signed-in accounts.[/red]\n"
+                f"Available accounts: {available}"
+            ),
         )
-        exit_with_code(1)
     default_account = next((a for a in accounts if a.is_default), None)
     if default_account is not None:
         return default_account
 
-    console.print(
+    # No default marker — fall back to the first account. This is a
+    # nonfatal success-path warning, so keep the previous text-mode output.
+    _emit_warning(
         "[yellow]Warning: Browser account list did not mark a default account; "
         f"using {accounts[0].email}.[/yellow]"
+    )
+    logger.warning(
+        "Browser account list did not mark a default account; using %s.",
+        accounts[0].email,
     )
     return accounts[0]
 
 
 def _select_refresh_account(
-    accounts: list[Any], metadata: dict[str, Any], browser_name: str
-) -> Any:
+    accounts: list[Any],
+    metadata: dict[str, Any],
+    browser_name: str,
+) -> Any | BrowserCookieOutcome:
     """Select the browser account that should refresh the active profile.
 
     ``context.json`` stores both the account email (stable identity) and an
     internal fallback index. If the browser's account order changed, email wins
     and the caller rewrites the cached index.
+
+    Returns the selected account on success, or a
+    :class:`.outcomes.CookieValidationFailure` on failure (no accounts
+    discovered, metadata email not present in browser, stale authuser
+    with no email to repair from).
     """
     if not accounts:
-        console.print(
-            f"[red]No signed-in Google accounts found in {browser_name}.[/red]\n"
-            "Sign in to a Google account in your browser and try again."
+        return CookieValidationFailure(
+            code="NO_ACCOUNTS_FOUND",
+            message=(
+                f"[red]No signed-in Google accounts found in {browser_name}.[/red]\n"
+                "Sign in to a Google account in your browser and try again."
+            ),
         )
-        exit_with_code(1)
 
     expected_email = metadata.get("email")
     if isinstance(expected_email, str) and expected_email.strip():
@@ -98,26 +138,33 @@ def _select_refresh_account(
             if isinstance(account.email, str) and account.email.casefold() == normalized:
                 return account
         available = ", ".join(a.email for a in accounts) or "none"
-        console.print(
-            f"[red]Profile account {expected_email} is not signed in to {browser_name}.[/red]\n"
-            f"Available accounts: {available}\n"
-            f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan] "
-            "or sign that account back into the browser."
+        return CookieValidationFailure(
+            code="PROFILE_ACCOUNT_MISSING",
+            message=(
+                f"[red]Profile account {expected_email} is not signed in to "
+                f"{browser_name}.[/red]\n"
+                f"Available accounts: {available}\n"
+                f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan] "
+                "or sign that account back into the browser."
+            ),
         )
-        exit_with_code(1)
 
     raw_authuser = metadata.get("authuser")
     if isinstance(raw_authuser, int) and raw_authuser >= 0:
         for account in accounts:
             if account.authuser == raw_authuser:
                 return account
-        console.print(
-            "[red]Profile stores an old account route, but that browser account "
-            "is no longer available and context.json has no account email to repair from.[/red]\n"
-            f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan], then "
-            f"[cyan]notebooklm login --browser-cookies {browser_name} --account EMAIL[/cyan]."
+        return CookieValidationFailure(
+            code="PROFILE_ACCOUNT_MISSING",
+            message=(
+                "[red]Profile stores an old account route, but that browser account "
+                "is no longer available and context.json has no account email to "
+                "repair from.[/red]\n"
+                f"Run [cyan]notebooklm auth inspect --browser {browser_name}[/cyan], then "
+                f"[cyan]notebooklm login --browser-cookies {browser_name} "
+                "--account EMAIL[/cyan]."
+            ),
         )
-        exit_with_code(1)
 
     return next((account for account in accounts if account.is_default), accounts[0])
 
@@ -130,22 +177,34 @@ def _write_extracted_cookies(
     authuser: int,
     email: str,
     quiet: bool = False,
-) -> None:
+) -> BrowserCookieOutcome | None:
     """Write a previously-loaded rookiepy cookie set to ``storage_path``.
 
-    Bypasses :func:`_read_browser_cookies` because the caller already has the
-    cookies in hand (e.g. ``--all-accounts`` reads once and writes N profiles).
+    Bypasses :func:`_read_browser_cookies` because the caller already has
+    the cookies in hand (e.g. ``--all-accounts`` reads once and writes N
+    profiles).
+
+    Returns ``None`` on success, or a
+    :class:`.outcomes.BrowserCookieOutcome` subclass on failure
+    (validation failure or disk-write failure). The success-path
+    confirmation print is emitted by the caller; nonfatal metadata and
+    verification warnings are still rendered here to preserve the
+    historical text-mode behavior.
     """
+    from ...runtime import run_async
+
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
         cookie_names = cookie_names_from_storage(storage_state)
         hint = missing_cookies_hint(cookie_names)
-        console.print(
-            "[red]No valid Google authentication cookies found.[/red]\n"
-            f"{validation_error}\n\n"
-            f"{hint}"
+        return CookieValidationFailure(
+            code="COOKIE_VALIDATION_FAILED",
+            message=(
+                "[red]No valid Google authentication cookies found.[/red]\n"
+                f"{validation_error}\n\n"
+                f"{hint}"
+            ),
         )
-        exit_with_code(1)
 
     try:
         storage_path.parent.mkdir(parents=True, exist_ok=True)
@@ -155,32 +214,49 @@ def _write_extracted_cookies(
         if sys.platform != "win32":
             storage_path.parent.chmod(0o700)
     except OSError as e:
-        logger.error("Failed to save authentication to %s: %s", storage_path, e)
-        console.print(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
-        exit_with_code(1)
+        # G6: redact the bound exception in the log line (use the type
+        # name) so subprocess stderr / payload data captured in ``e`` is
+        # not persisted in caller log destinations.
+        logger.error("Failed to save authentication to %s: %s", storage_path, type(e).__name__)
+        return CookieValidationFailure(
+            code="STORAGE_WRITE_FAILED",
+            message=(
+                f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}"
+            ),
+        )
 
     from ....auth import write_account_metadata
 
     try:
         write_account_metadata(storage_path, authuser=authuser, email=email)
     except OSError as e:
-        logger.error("Failed to save account metadata for %s: %s", storage_path, e)
-        console.print(
+        # Non-fatal: cookies are already written. Log the redacted type,
+        # but preserve the previous user-facing warning text.
+        logger.warning(
+            "Failed to save account metadata for %s: %s", storage_path, type(e).__name__
+        )
+        _emit_warning(
             f"[yellow]Warning: cookies saved but account metadata write failed.[/yellow]\n"
             f"Details: {e}"
         )
 
+    # Success-path confirmation print is the caller's job. We log a
+    # debug breadcrumb so operators can correlate the write without
+    # parsing the user-facing console output.
     if not quiet:
-        console.print(f"  [green]✓[/green] {profile or storage_path}  →  {email}")
+        logger.debug("wrote cookies for %s to %s", email, storage_path)
 
-    # Verify cookies for the active account.
+    # Verify cookies for the active account. Verification failures are
+    # not fatal (the existing behavior warned but did not exit), so we
+    # log a WARNING and return None.
     try:
         run_async(fetch_tokens_with_domains(storage_path, profile))
     except ValueError as e:
         logger.warning("Extracted cookies for %s failed verification: %s", email, e)
-        console.print(f"    [yellow]Warning: cookies for {email} failed verification.[/yellow]")
+        _emit_warning(f"    [yellow]Warning: cookies for {email} failed verification.[/yellow]")
     except httpx.RequestError as e:
         logger.warning("Could not verify cookies for %s: %s", email, e)
-        console.print(
+        _emit_warning(
             f"    [yellow]Warning: could not verify cookies for {email} (network).[/yellow]"
         )
+    return None

--- a/src/notebooklm/cli/services/login/firefox_accounts.py
+++ b/src/notebooklm/cli/services/login/firefox_accounts.py
@@ -93,7 +93,7 @@ def _read_firefox_container_cookies(
         console.print(f"[red]{e}[/red]")
         exit_with_code(1)
     except (OSError, RuntimeError) as e:
-        _handle_rookiepy_error(e, "firefox")
+        console.print(_handle_rookiepy_error(e, "firefox"))
         exit_with_code(1)
     except sqlite3.DatabaseError as e:
         console.print(f"[red]Failed to read Firefox cookies database:[/red] {e}")

--- a/src/notebooklm/cli/services/login/outcomes.py
+++ b/src/notebooklm/cli/services/login/outcomes.py
@@ -1,0 +1,118 @@
+"""Typed outcomes for the browser-cookie helper chain.
+
+This module defines a small sum-type ADT that the
+:mod:`notebooklm.cli.services.login` helper chain (``browser_accounts``,
+``cookie_jar``, ``cookie_writes``, ``rookiepy_errors``) returns instead
+of calling ``console.print`` + ``exit_with_code(1)`` directly. Command
+bodies dispatch on the returned outcome — they emit a JSON envelope
+under ``--json`` (per :doc:`/adr/0015-json-envelope-contract-for-post-parse-click-exceptions`)
+or Rich text otherwise.
+
+The ADT is intentionally narrow: it carries just enough structure to
+produce the canonical envelope shape
+``{"error": true, "code": "<CODE>", "message": "<text>", ...extras}``
+and to render the same human-readable text the previous inline
+``console.print`` produced. ``message`` may contain Rich markup; command
+layers strip it for JSON envelopes and preserve it for text output.
+``code`` is the stable code for the JSON envelope.
+
+Outcome variants:
+
+* :class:`UnknownBrowser` — caller passed a browser name we do not
+  support (``--browser foo`` where ``foo`` is not in the rookiepy
+  alias map). Carries the supported list for the message body.
+* :class:`UnsupportedBrowser` — rookiepy itself doesn't support the
+  named browser on this platform (e.g. ``safari`` on Linux). Distinct
+  from :class:`UnknownBrowser` so callers can render a different hint.
+* :class:`CookieValidationFailure` — cookies were read but failed the
+  ``validate_with_recovery`` policy check (missing required cookies,
+  malformed values).
+* :class:`StaleCookies` — Google rejected the cookie set as too stale
+  (passive sign-in redirected to the account chooser, RotateCookies
+  returned 401).
+* :class:`NetworkFailure` — transport-layer failure reaching Google
+  (DNS, timeout, TLS). Distinct from cookie-policy failures so the
+  caller can render a retry hint.
+
+A success path keeps its existing return shape — outcome objects are
+returned only on failure. Callers therefore branch on
+``isinstance(result, BrowserCookieOutcome)`` to detect the failure
+path; the boolean check is sufficient because there is no positive
+``Success`` variant (success returns the original tuple / list / value
+unchanged).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class BrowserCookieOutcome:
+    """Sealed base class for browser-cookie helper failure outcomes.
+
+    Subclasses are frozen dataclasses with two mandatory attributes:
+
+    * ``code`` — stable JSON envelope error code (e.g. ``"UNKNOWN_BROWSER"``).
+    * ``message`` — human-readable text (Rich markup is preserved so the
+      existing text-mode rendering is byte-for-byte unchanged).
+
+    Variants are kept narrow on purpose; new failure modes should either
+    reuse an existing variant or introduce a new dataclass here with an
+    explicit code constant.
+    """
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class UnknownBrowser(BrowserCookieOutcome):
+    """User passed a browser name the rookiepy alias map does not know."""
+
+    code: str
+    message: str
+    name: str
+    supported: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UnsupportedBrowser(BrowserCookieOutcome):
+    """rookiepy is installed but does not support this browser on this platform."""
+
+    code: str
+    message: str
+    name: str
+
+
+@dataclass(frozen=True)
+class CookieValidationFailure(BrowserCookieOutcome):
+    """Cookies were read but failed the required-cookies / recovery policy."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class StaleCookies(BrowserCookieOutcome):
+    """Google rejected the cookie set as too stale to re-authenticate."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class NetworkFailure(BrowserCookieOutcome):
+    """Transport-layer failure (DNS / timeout / TLS) reaching Google."""
+
+    code: str
+    message: str
+
+
+__all__ = [
+    "BrowserCookieOutcome",
+    "CookieValidationFailure",
+    "NetworkFailure",
+    "StaleCookies",
+    "UnknownBrowser",
+    "UnsupportedBrowser",
+]

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -118,9 +118,7 @@ def _login_browser_cookies_single(
 
     # Path 2: targeted extraction. Select the requested browser account, then
     # write it to an explicit destination or to the active profile.
-    enum_result = _enumerate_browser_accounts(
-        browser_cookies, include_domains=include_domains
-    )
+    enum_result = _enumerate_browser_accounts(browser_cookies, include_domains=include_domains)
     if isinstance(enum_result, BrowserCookieOutcome):
         _exit_on_outcome(enum_result)
     per_profile_cookies, accounts = enum_result
@@ -228,9 +226,7 @@ def _login_all_accounts_from_browser(
     """
     from ....paths import list_profiles
 
-    enum_result = _enumerate_browser_accounts(
-        browser_cookies, include_domains=include_domains
-    )
+    enum_result = _enumerate_browser_accounts(browser_cookies, include_domains=include_domains)
     if isinstance(enum_result, BrowserCookieOutcome):
         _exit_on_outcome(enum_result)
     per_profile_cookies, accounts = enum_result

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -21,7 +21,7 @@ import logging
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import httpx
 
@@ -41,6 +41,7 @@ from ...rendering import console
 from ...runtime import run_async
 from .browser_accounts import _enumerate_browser_accounts, _read_browser_cookies
 from .cookie_writes import _select_account, _select_refresh_account, _write_extracted_cookies
+from .outcomes import BrowserCookieOutcome
 from .profile_targets import (
     _profiles_by_account_email,
     _resolve_all_accounts_target,
@@ -56,6 +57,21 @@ from .profile_targets import (
 ConfirmCallback = Callable[[str], bool]
 
 logger = logging.getLogger(__name__)
+
+
+def _exit_on_outcome(outcome: BrowserCookieOutcome) -> NoReturn:
+    """Render a helper-chain failure outcome and exit with code 1.
+
+    Preserves the pre-refactor text-mode behavior for refresh.py-driven
+    paths: the Rich-markup message is printed and the process exits.
+    This module is still in :data:`TRANSITIONAL_GUARDED_PATHS` (the
+    ``Pattern A`` inventory tracks the ``console.print`` +
+    ``exit_with_code`` pairs in each refresh driver function), so the
+    inline call is intentional. Lifting refresh.py to the typed-outcome
+    JSON envelope shape is tracked separately.
+    """
+    console.print(outcome.message)
+    exit_with_code(1)
 
 
 def _login_browser_cookies_single(
@@ -102,10 +118,16 @@ def _login_browser_cookies_single(
 
     # Path 2: targeted extraction. Select the requested browser account, then
     # write it to an explicit destination or to the active profile.
-    per_profile_cookies, accounts = _enumerate_browser_accounts(
+    enum_result = _enumerate_browser_accounts(
         browser_cookies, include_domains=include_domains
     )
-    selected = _select_account(accounts, account_email=account_email)
+    if isinstance(enum_result, BrowserCookieOutcome):
+        _exit_on_outcome(enum_result)
+    per_profile_cookies, accounts = enum_result
+    selected_or_outcome = _select_account(accounts, account_email=account_email)
+    if isinstance(selected_or_outcome, BrowserCookieOutcome):
+        _exit_on_outcome(selected_or_outcome)
+    selected = selected_or_outcome
 
     target_profile: str | None
     if profile_name is not None:
@@ -123,13 +145,16 @@ def _login_browser_cookies_single(
             confirm=confirm,
         )
 
-    _write_extracted_cookies(
+    write_outcome = _write_extracted_cookies(
         per_profile_cookies[selected.browser_profile],
         storage_path=target_storage,
         profile=storage_profile,
         authuser=selected.authuser,
         email=selected.email,
     )
+    if isinstance(write_outcome, BrowserCookieOutcome):
+        _exit_on_outcome(write_outcome)
+    console.print(f"  [green]✓[/green] {storage_profile or target_storage}  →  {selected.email}")
     _sync_server_language_to_config(storage_path=target_storage, profile=storage_profile)
 
 
@@ -203,9 +228,12 @@ def _login_all_accounts_from_browser(
     """
     from ....paths import list_profiles
 
-    per_profile_cookies, accounts = _enumerate_browser_accounts(
+    enum_result = _enumerate_browser_accounts(
         browser_cookies, include_domains=include_domains
     )
+    if isinstance(enum_result, BrowserCookieOutcome):
+        _exit_on_outcome(enum_result)
+    per_profile_cookies, accounts = enum_result
     if not accounts:
         console.print("[yellow]No accounts discovered.[/yellow]")
         return
@@ -240,13 +268,16 @@ def _login_all_accounts_from_browser(
         claimed.add(target_profile)
 
         target_storage = get_storage_path(profile=target_profile)
-        _write_extracted_cookies(
+        write_outcome = _write_extracted_cookies(
             per_profile_cookies[account.browser_profile],
             storage_path=target_storage,
             profile=target_profile,
             authuser=account.authuser,
             email=account.email,
         )
+        if isinstance(write_outcome, BrowserCookieOutcome):
+            _exit_on_outcome(write_outcome)
+        console.print(f"  [green]✓[/green] {target_profile or target_storage}  →  {account.email}")
         language_sync_target = (target_storage, target_profile)
 
     if language_sync_target is not None:
@@ -263,16 +294,22 @@ def _refresh_from_browser_cookies(
     include_domains: set[str] | None = None,
 ) -> None:
     """Refresh the active profile from browser cookies, repairing account drift."""
-    per_profile_cookies, accounts = _enumerate_browser_accounts(
+    enum_result = _enumerate_browser_accounts(
         browser_name, verbose=not quiet, include_domains=include_domains
     )
+    if isinstance(enum_result, BrowserCookieOutcome):
+        _exit_on_outcome(enum_result)
+    per_profile_cookies, accounts = enum_result
     if not accounts:
         console.print(f"[red]No signed-in Google accounts found in {browser_name}.[/red]")
         exit_with_code(1)
 
     metadata = read_account_metadata(storage_path)
-    selected = _select_refresh_account(accounts, metadata, browser_name)
-    _write_extracted_cookies(
+    selected_or_outcome = _select_refresh_account(accounts, metadata, browser_name)
+    if isinstance(selected_or_outcome, BrowserCookieOutcome):
+        _exit_on_outcome(selected_or_outcome)
+    selected = selected_or_outcome
+    write_outcome = _write_extracted_cookies(
         per_profile_cookies[selected.browser_profile],
         storage_path=storage_path,
         profile=profile,
@@ -280,6 +317,8 @@ def _refresh_from_browser_cookies(
         email=selected.email,
         quiet=True,
     )
+    if isinstance(write_outcome, BrowserCookieOutcome):
+        _exit_on_outcome(write_outcome)
     _sync_server_language_to_config(storage_path=storage_path, profile=profile)
 
     if not quiet:
@@ -309,7 +348,10 @@ def _login_with_browser_cookies(
         include_domains: Optional ``--include-domains`` label set forwarded
             to :func:`_read_browser_cookies`.
     """
-    raw_cookies = _read_browser_cookies(browser_name, include_domains=include_domains)
+    cookies_result = _read_browser_cookies(browser_name, include_domains=include_domains)
+    if isinstance(cookies_result, BrowserCookieOutcome):
+        _exit_on_outcome(cookies_result)
+    raw_cookies = cookies_result
 
     # ``validate_with_recovery`` mutates ``raw_cookies`` in place if the
     # in-memory ``RotateCookies`` recovery succeeds (issue #990), so the

--- a/src/notebooklm/cli/services/login/rookiepy_errors.py
+++ b/src/notebooklm/cli/services/login/rookiepy_errors.py
@@ -1,31 +1,39 @@
 """Friendly rookiepy error messages.
 
-Leaf module within the ``cli/services/login/`` package — depends only on
-:mod:`notebooklm.cli.rendering` (``console``).
+Pure helper: classifies a rookiepy ``OSError``/``RuntimeError`` into one
+of four user-facing message shapes (locked DB, permission denied,
+decryption failure, generic) and returns the Rich-markup message text.
+
+Callers are responsible for emission (``console.print``) and exit policy
+(``exit_with_code`` / typed-outcome return). Keeping this module a pure
+message formatter is what lets it live under :data:`GUARDED_PATHS` in
+the services-boundary test — no presentation reach-in, no exit policy.
 """
 
 from __future__ import annotations
 
-from ...rendering import console
 
+def _handle_rookiepy_error(e: Exception, browser_name: str) -> str:
+    """Return a Rich-markup user-facing error message for a rookiepy exception.
 
-def _handle_rookiepy_error(e: Exception, browser_name: str) -> None:
-    """Print a user-friendly error for rookiepy exceptions."""
+    The returned string carries Rich markup so callers can hand it
+    straight to ``console.print`` (text mode) or strip the markup for the
+    JSON envelope ``message`` field. The helper itself emits nothing.
+    """
     msg = str(e).lower()
     if "lock" in msg or "database" in msg:
-        console.print(
+        return (
             f"[red]Could not read {browser_name} cookies: browser database is locked.[/red]\n"
             "Close your browser and try again."
         )
-    elif "permission" in msg or "access" in msg:
-        console.print(
+    if "permission" in msg or "access" in msg:
+        return (
             f"[red]Permission denied reading {browser_name} cookies.[/red]\n"
             "You may need to grant Terminal/Python access to your browser profile directory."
         )
-    elif "keychain" in msg or "decrypt" in msg:
-        console.print(
+    if "keychain" in msg or "decrypt" in msg:
+        return (
             f"[red]Could not decrypt {browser_name} cookies.[/red]\n"
             "On macOS, allow Keychain access when prompted, or try a different browser."
         )
-    else:
-        console.print(f"[red]Failed to read cookies from {browser_name}:[/red] {e}")
+    return f"[red]Failed to read cookies from {browser_name}:[/red] {e}"

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -34,9 +34,11 @@ import shutil  # noqa: F401 — preserved patch surface
 import sys  # noqa: F401 — preserved patch surface
 import time  # noqa: F401 — preserved patch surface
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import click
+import httpx
+from rich.markup import render as render_markup
 from rich.table import Table
 
 from ..client import NotebookLMClient
@@ -92,6 +94,7 @@ from .services.login import (
     _write_extracted_cookies,  # noqa: F401 — patch surface only
 )
 from .services.login.exceptions import LoginConfigurationError
+from .services.login.outcomes import BrowserCookieOutcome, NetworkFailure
 from .services.playwright_login import (
     CHANNEL_BROWSERS as _CHANNEL_BROWSERS,
 )
@@ -508,6 +511,22 @@ def _render_auth_inspect(
             "[dim]Pass -v to see which browser user-profile each account came from.[/dim]\n" + hint
         )
     console.print("\n" + hint)
+
+
+def _render_auth_inspect_error(outcome: BrowserCookieOutcome, *, json_output: bool) -> NoReturn:
+    """Render a browser-cookie discovery failure for ``auth inspect``."""
+    if json_output:
+        extra: dict[str, Any] = {}
+        name = getattr(outcome, "name", None)
+        if isinstance(name, str):
+            extra["browser"] = name
+        supported = getattr(outcome, "supported", None)
+        if supported is not None:
+            extra["supported"] = list(supported)
+        _output_error(render_markup(outcome.message).plain, outcome.code, True, 1, extra=extra)
+
+    console.print(outcome.message)
+    exit_with_code(1)
 
 
 def register_session_commands(cli):
@@ -933,9 +952,21 @@ def register_session_commands(cli):
           notebooklm auth inspect --browser firefox --json
         """
         include_domains = _parse_include_domains(include_domains_raw)
-        _, accounts = _enumerate_browser_accounts(
-            browser_name, verbose=not json_output, include_domains=include_domains
-        )
+        try:
+            enum_result = _enumerate_browser_accounts(
+                browser_name, verbose=not json_output, include_domains=include_domains
+            )
+        except httpx.RequestError as e:
+            enum_result = NetworkFailure(
+                code="NETWORK_ERROR",
+                message=(
+                    f"[red]Account discovery failed (network error):[/red] {e}\n"
+                    "Check your internet connection and try again."
+                ),
+            )
+        if isinstance(enum_result, BrowserCookieOutcome):
+            _render_auth_inspect_error(enum_result, json_output=json_output)
+        _, accounts = enum_result
         _render_auth_inspect(browser_name, list(accounts), json_output=json_output, verbose=verbose)
 
     @auth_group.command("check")

--- a/tests/_lint/test_login_package_dag.py
+++ b/tests/_lint/test_login_package_dag.py
@@ -28,14 +28,16 @@ PKG_PATH = Path("src/notebooklm/cli/services/login")
 # using it.
 ALLOWED_EDGES: dict[str, set[str]] = {
     "exceptions": set(),
+    "outcomes": set(),
     "cookie_domains": set(),
     "rookiepy_errors": set(),
     "cookie_jar": {
+        "outcomes",
         # allowed but currently unused — _enumerate_one_jar formats its own
         # rookiepy error messages and does not call _handle_rookiepy_error.
         "rookiepy_errors",
     },
-    "chromium_accounts": {"cookie_jar", "rookiepy_errors", "cookie_domains"},
+    "chromium_accounts": {"cookie_jar", "rookiepy_errors", "cookie_domains", "outcomes"},
     "firefox_accounts": {
         # allowed but currently unused — the firefox helpers hand raw cookies
         # back to the caller (browser_accounts) which then routes through
@@ -48,6 +50,7 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         "chromium_accounts",
         "firefox_accounts",
         "cookie_jar",
+        "outcomes",
         "rookiepy_errors",
         # The phase-3 DAG diagram routes cookie_domains via chromium/firefox
         # subordinates, but ``_read_browser_cookies``'s "auto" + named-alias
@@ -67,8 +70,9 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         # cookie data and the selectors don't query the cookie-domain policy.
         "browser_accounts",
         "cookie_domains",
+        "outcomes",
     },
-    "refresh": {"browser_accounts", "cookie_writes", "profile_targets"},
+    "refresh": {"browser_accounts", "cookie_writes", "outcomes", "profile_targets"},
 }
 
 

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1436,6 +1436,7 @@ class TestAuthInspect:
         mock_run_async.assert_called_once()
 
     def test_enumerate_one_jar_network_error_non_quiet_exits_without_reraising(self):
+        from notebooklm.cli.services.login.outcomes import NetworkFailure
         from notebooklm.cli.session_cmd import _enumerate_one_jar
 
         raw_cookies = _multiaccount_rookiepy_mock().chrome.return_value
@@ -1443,23 +1444,15 @@ class TestAuthInspect:
         async def fail_enumerate(*args, **kwargs):
             raise httpx.RequestError("offline")
 
-        with (
-            patch("notebooklm.auth.enumerate_accounts", new=fail_enumerate),
-            patch(
-                "notebooklm.cli.services.login.cookie_jar.exit_with_code",
-                return_value=None,
-            ) as mock_exit,
-            patch("notebooklm.cli.services.login.cookie_jar.console") as mock_console,
-        ):
+        with patch("notebooklm.auth.enumerate_accounts", new=fail_enumerate):
             result = _enumerate_one_jar(raw_cookies, "chrome", browser_profile=None)
 
-        assert result == []
-        mock_exit.assert_called_once_with(1)
-        message = mock_console.print.call_args[0][0]
+        assert isinstance(result, NetworkFailure)
+        message = result.message
         assert "network error" in message
         assert "offline" in message
 
-    def test_select_account_without_marked_default_uses_first_account(self):
+    def test_select_account_without_marked_default_uses_first_account(self, caplog):
         from notebooklm.auth import Account
         from notebooklm.cli.session_cmd import _select_account
 
@@ -1468,38 +1461,37 @@ class TestAuthInspect:
             Account(authuser=1, email="bob@gmail.com", is_default=False),
         ]
 
-        with patch_session_login_dual("console") as mock_console:
+        with (
+            caplog.at_level("WARNING", logger="notebooklm.cli.services.login.cookie_writes"),
+            patch("notebooklm.cli.rendering.console") as mock_console,
+        ):
             selected = _select_account(accounts, account_email=None)
 
         assert selected == accounts[0]
         warning_text = mock_console.print.call_args[0][0]
         assert "default account" in warning_text
         assert "alice@example.com" in warning_text
+        assert "default account" in caplog.text
+        assert "alice@example.com" in caplog.text
 
-    def test_select_account_empty_accounts_exits_with_user_message(self):
+    def test_select_account_empty_accounts_returns_user_message(self):
         from notebooklm.cli.services.login.cookie_writes import _select_account
+        from notebooklm.cli.services.login.outcomes import CookieValidationFailure
 
-        with (
-            patch("notebooklm.cli.services.login.cookie_writes.console") as mock_console,
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            _select_account([], account_email=None)
+        result = _select_account([], account_email=None)
 
-        assert exc_info.value.code == 1
-        message = mock_console.print.call_args[0][0]
+        assert isinstance(result, CookieValidationFailure)
+        message = result.message
         assert "No signed-in Google accounts found" in message
 
-    def test_select_refresh_account_empty_accounts_exits_with_user_message(self):
+    def test_select_refresh_account_empty_accounts_returns_user_message(self):
         from notebooklm.cli.services.login.cookie_writes import _select_refresh_account
+        from notebooklm.cli.services.login.outcomes import CookieValidationFailure
 
-        with (
-            patch("notebooklm.cli.services.login.cookie_writes.console") as mock_console,
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            _select_refresh_account([], {}, "chrome")
+        result = _select_refresh_account([], {}, "chrome")
 
-        assert exc_info.value.code == 1
-        message = mock_console.print.call_args[0][0]
+        assert isinstance(result, CookieValidationFailure)
+        message = result.message
         assert "No signed-in Google accounts found in chrome" in message
 
     def test_inspect_lists_accounts(self, runner):

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -203,10 +203,10 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "pattern_a_violations": [
             ("_read_chromium_profile_cookies_from_selector", 62),
             ("_read_chromium_profile_cookies_from_selector", 81),
-            ("_read_chromium_profile_cookies_from_selector", 84),
-            ("_enumerate_chromium_profiles_fanout", 138),
-            ("_enumerate_chromium_profiles_fanout", 166),
-            ("_enumerate_chromium_profiles_fanout", 221),
+            ("_read_chromium_profile_cookies_from_selector", 86),
+            ("_enumerate_chromium_profiles_fanout", 140),
+            ("_enumerate_chromium_profiles_fanout", 168),
+            ("_enumerate_chromium_profiles_fanout", 223),
         ],
         "rationale": (
             "Chromium-profile enumeration owns presentation + exit codes "
@@ -265,10 +265,10 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "forbidden_imports": [],
         "pattern_a_violations": [
             ("_exit_on_outcome", 74),
-            ("_confirm_profile_account_overwrite", 205),
-            ("_refresh_from_browser_cookies", 305),
-            ("_login_with_browser_cookies", 368),
-            ("_login_with_browser_cookies", 383),
+            ("_confirm_profile_account_overwrite", 203),
+            ("_refresh_from_browser_cookies", 301),
+            ("_login_with_browser_cookies", 364),
+            ("_login_with_browser_cookies", 379),
         ],
         "rationale": (
             "Browser-cookie refresh flow owns interactive confirmation, "

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -74,8 +74,13 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 GUARDED_PATHS = {
     "cli/services/auth_diagnostics.py": SERVICES_ROOT / "auth_diagnostics.py",
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
+    "cli/services/login/browser_accounts.py": SERVICES_ROOT / "login" / "browser_accounts.py",
+    "cli/services/login/cookie_jar.py": SERVICES_ROOT / "login" / "cookie_jar.py",
+    "cli/services/login/cookie_writes.py": SERVICES_ROOT / "login" / "cookie_writes.py",
     "cli/services/login/exceptions.py": SERVICES_ROOT / "login" / "exceptions.py",
+    "cli/services/login/outcomes.py": SERVICES_ROOT / "login" / "outcomes.py",
     "cli/services/login/profile_targets.py": SERVICES_ROOT / "login" / "profile_targets.py",
+    "cli/services/login/rookiepy_errors.py": SERVICES_ROOT / "login" / "rookiepy_errors.py",
     "cli/services/research.py": SERVICES_ROOT / "research.py",
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",
     "cli/services/source_clean.py": SERVICES_ROOT / "source_clean.py",
@@ -192,40 +197,28 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "handling to the command layer."
         ),
     },
-    "cli/services/login/browser_accounts.py": {
-        "path": SERVICES_ROOT / "login" / "browser_accounts.py",
-        "forbidden_imports": [],
-        "pattern_a_violations": [
-            ("_read_browser_cookies", 165),
-            ("_read_browser_cookies", 191),
-            ("_read_browser_cookies", 204),
-            ("_read_browser_cookies", 212),
-            ("_read_browser_cookies", 221),
-            ("_read_browser_cookies", 226),
-        ],
-        "rationale": (
-            "Browser-cookie reader still owns presentation + exit codes for "
-            "every failure mode; reach-in uses the level-3 "
-            "``...rendering`` / ``...error_handler`` paths not currently "
-            "flagged by ``_boundary_violations`` (which only sees level-2). "
-            "Pending login submodule boundary expansion."
-        ),
-    },
     "cli/services/login/chromium_accounts.py": {
         "path": SERVICES_ROOT / "login" / "chromium_accounts.py",
         "forbidden_imports": [],
         "pattern_a_violations": [
-            ("_read_chromium_profile_cookies_from_selector", 61),
-            ("_read_chromium_profile_cookies_from_selector", 80),
-            ("_read_chromium_profile_cookies_from_selector", 83),
-            ("_enumerate_chromium_profiles_fanout", 137),
-            ("_enumerate_chromium_profiles_fanout", 174),
-            ("_enumerate_chromium_profiles_fanout", 219),
+            ("_read_chromium_profile_cookies_from_selector", 62),
+            ("_read_chromium_profile_cookies_from_selector", 81),
+            ("_read_chromium_profile_cookies_from_selector", 84),
+            ("_enumerate_chromium_profiles_fanout", 138),
+            ("_enumerate_chromium_profiles_fanout", 166),
+            ("_enumerate_chromium_profiles_fanout", 221),
         ],
         "rationale": (
             "Chromium-profile enumeration owns presentation + exit codes "
             "for profile-selection failures; level-3 rendering reach-in not "
-            "flagged by ``_boundary_violations``."
+            "flagged by ``_boundary_violations``. The ``rookiepy_error`` "
+            "branch now wraps the typed-message helper "
+            "(:func:`_handle_rookiepy_error`) in a ``console.print(...)`` "
+            "so the helper itself stays in :data:`GUARDED_PATHS`; the "
+            "exit_with_code line moved by 1 in each helper. "
+            "``_enumerate_chromium_profiles_fanout`` now dispatches on a "
+            "typed outcome returned by :func:`_enumerate_one_jar` instead "
+            "of catching ``SystemExit``."
         ),
     },
     "cli/services/login/cookie_domains.py": {
@@ -251,38 +244,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "planned without a separate callback-architecture refactor)."
         ),
     },
-    "cli/services/login/cookie_jar.py": {
-        "path": SERVICES_ROOT / "login" / "cookie_jar.py",
-        "forbidden_imports": [],
-        "pattern_a_violations": [
-            ("_enumerate_one_jar", 116),
-            ("_enumerate_one_jar", 135),
-            ("_enumerate_one_jar", 147),
-        ],
-        "rationale": (
-            "Cookie-jar enumerator owns presentation + exit codes for jar "
-            "decryption failures; level-3 rendering reach-in not flagged "
-            "by ``_boundary_violations``."
-        ),
-    },
-    "cli/services/login/cookie_writes.py": {
-        "path": SERVICES_ROOT / "login" / "cookie_writes.py",
-        "forbidden_imports": [],
-        "pattern_a_violations": [
-            ("_select_account", 54),
-            ("_select_account", 66),
-            ("_select_refresh_account", 92),
-            ("_select_refresh_account", 107),
-            ("_select_refresh_account", 120),
-            ("_write_extracted_cookies", 148),
-            ("_write_extracted_cookies", 160),
-        ],
-        "rationale": (
-            "Cookie-write pipeline owns presentation + exit policy for "
-            "account-selection and write failures; level-3 rendering "
-            "reach-in not flagged by ``_boundary_violations``."
-        ),
-    },
     "cli/services/login/firefox_accounts.py": {
         "path": SERVICES_ROOT / "login" / "firefox_accounts.py",
         "forbidden_imports": [],
@@ -303,29 +264,19 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "path": SERVICES_ROOT / "login" / "refresh.py",
         "forbidden_imports": [],
         "pattern_a_violations": [
-            ("_confirm_profile_account_overwrite", 180),
-            ("_refresh_from_browser_cookies", 271),
-            ("_login_with_browser_cookies", 326),
-            ("_login_with_browser_cookies", 341),
+            ("_exit_on_outcome", 74),
+            ("_confirm_profile_account_overwrite", 205),
+            ("_refresh_from_browser_cookies", 305),
+            ("_login_with_browser_cookies", 368),
+            ("_login_with_browser_cookies", 383),
         ],
         "rationale": (
-            "Pattern B click.confirm reach-in lifted via injected "
-            "``ConfirmCallback`` parameter; remaining Pattern A pairs "
-            "(``_refresh_from_browser_cookies`` browser-state failure, "
-            "``_login_with_browser_cookies`` cookie-validation + storage "
-            "OSError) are independent presentation+exit reach-ins that "
-            "belong to the separate login-flow Pattern A migration."
-        ),
-    },
-    "cli/services/login/rookiepy_errors.py": {
-        "path": SERVICES_ROOT / "login" / "rookiepy_errors.py",
-        "forbidden_imports": [],
-        "pattern_a_violations": [],
-        "rationale": (
-            "Rookiepy error formatter emits ``console.print`` but does not "
-            "own exit policy; level-3 ``...rendering`` reach-in not flagged "
-            "by ``_boundary_violations``. Tracked transitionally pending "
-            "login submodule boundary expansion."
+            "Browser-cookie refresh flow owns interactive confirmation, "
+            "presentation, and exit codes; multiple Pattern A pairs. "
+            "``_exit_on_outcome`` is the shared adapter that converts the "
+            "typed outcome returned by the (now-GUARDED) helper-chain "
+            "modules into the legacy ``console.print + exit_with_code`` "
+            "shape this driver still owns."
         ),
     },
     "cli/services/playwright_login.py": {
@@ -354,7 +305,10 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
         "rationale": (
             "Playwright login orchestrator owns the full presentation + "
             "exit-code matrix for browser-automation failures; one of the "
-            "largest migration targets in this inventory."
+            "largest migration targets in this inventory. Line numbers "
+            "shifted in commit e3871dc3 (subprocess-stderr redaction, "
+            "PR #1111) but the inventory was not updated in that PR; "
+            "refreshed here as a drive-by mechanical fix."
         ),
     },
     "cli/services/polling.py": {

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -17,6 +17,7 @@ from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from click.testing import CliRunner
 
@@ -218,6 +219,22 @@ def _assert_json_error_contract(result, case_id: str) -> dict:
         f"{case_id}: JSON payload lacks an error marker — got {payload!r}"
     )
     return payload
+
+
+def _auth_inspect_rookiepy_cookies() -> list[dict[str, object]]:
+    """Return a minimal valid rookiepy cookie list for account-discovery tests."""
+    return [
+        {
+            "domain": ".google.com",
+            "name": name,
+            "value": f"{name}-value",
+            "path": "/",
+            "secure": True,
+            "expires": 9999,
+            "http_only": False,
+        }
+        for name in ("SID", "HSID", "SSID", "APISID", "SAPISID", "__Secure-1PSIDTS")
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -669,6 +686,48 @@ def test_auth_check_json_exits_nonzero_on_missing_storage(
     )
     payload = json.loads(result.stdout)
     assert payload.get("status") == "error", payload
+
+
+def test_auth_inspect_unknown_browser(runner: CliRunner) -> None:
+    """``auth inspect --json`` must envelope unknown-browser helper outcomes."""
+    result = runner.invoke(
+        cli,
+        ["auth", "inspect", "--browser", "not-a-browser", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1, result.stdout
+    payload = _assert_json_error_contract(result, "auth_inspect_unknown_browser")
+    assert payload["code"] == "UNKNOWN_BROWSER"
+    assert payload["browser"] == "not-a-browser"
+    assert "Unknown browser" in payload["message"]
+    assert _safe_stderr(result) == ""
+
+
+def test_auth_inspect_network_failure(runner: CliRunner) -> None:
+    """``auth inspect --json`` must envelope account-discovery transport errors."""
+    mock_rookiepy = MagicMock()
+    mock_rookiepy.chrome = MagicMock(return_value=_auth_inspect_rookiepy_cookies())
+
+    async def fail_enumerate(*args, **kwargs):
+        raise httpx.RequestError("offline")
+
+    with (
+        patch.dict("sys.modules", {"rookiepy": mock_rookiepy}),
+        patch("notebooklm.cli._chromium_profiles.discover_chromium_profiles", return_value=[]),
+        patch("notebooklm.auth.enumerate_accounts", new=fail_enumerate),
+    ):
+        result = runner.invoke(
+            cli,
+            ["auth", "inspect", "--browser", "chrome", "--json"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1, result.stdout
+    payload = _assert_json_error_contract(result, "auth_inspect_network_failure")
+    assert payload["code"] == "NETWORK_ERROR"
+    assert "offline" in payload["message"]
+    assert _safe_stderr(result) == ""
 
 
 def test_download_audio_non_json_mode_still_exits_nonzero(runner: CliRunner, mock_auth_env) -> None:


### PR DESCRIPTION
## Summary
- add typed browser-cookie helper outcomes and route auth inspect failures through JSON envelopes under --json
- move browser-account/cookie helper failure paths away from direct exit policy while preserving text-mode warnings
- update login boundary/DAG inventories and JSON error coverage for auth inspect unknown-browser and network failures

## Verification
- uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/cli -q
- uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/test_json_stdout_purity.py tests/unit/test_json_error_exit.py -q
- uv run --frozen --extra browser --extra dev --extra markdown pytest tests/unit/test_json_error_exit.py tests/unit/cli/test_auth_subcommands.py tests/unit/cli/test_login.py tests/unit/cli/test_login_chromium_fanout.py tests/unit/cli/test_login_cookie_recovery.py tests/unit/cli/test_login_multi_account.py tests/unit/cli/test_services_boundary.py tests/_lint/test_login_package_dag.py tests/_lint/test_error_handler_allowlist.py -q
- uv run --frozen --extra browser --extra dev --extra markdown ruff check src/notebooklm/cli/session_cmd.py src/notebooklm/cli/error_handler.py src/notebooklm/cli/services/login/browser_accounts.py src/notebooklm/cli/services/login/chromium_accounts.py src/notebooklm/cli/services/login/cookie_jar.py src/notebooklm/cli/services/login/cookie_writes.py src/notebooklm/cli/services/login/firefox_accounts.py src/notebooklm/cli/services/login/refresh.py src/notebooklm/cli/services/login/rookiepy_errors.py src/notebooklm/cli/services/login/outcomes.py tests/unit/test_json_error_exit.py tests/unit/cli/test_auth_subcommands.py tests/unit/cli/test_services_boundary.py tests/_lint/test_login_package_dag.py
- uv run --frozen --extra browser --extra dev --extra markdown mypy src/notebooklm/cli/session_cmd.py src/notebooklm/cli/services/login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replace abrupt process exits with non-fatal, descriptive failure outcomes for browser-cookie discovery, validation, and write errors; preserve warnings and progress output.

* **New Features**
  * CLI presents structured error output for auth inspect (including network/browser diagnostics) and consistently handles failures across login/refresh flows.

* **Refactor**
  * Centralized outcome types introduced and caller-driven error emission adopted for cookie/account workflows.

* **Tests**
  * Added JSON error-exit tests and updated auth-related tests and lint inventories to validate outcome-based behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->