### PR TITLE
fix(ci): make e2e retry fail closed

### DIFF
--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -186,4 +186,4 @@ jobs:
         fi
         echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
         sleep 600
-        pytest --last-failed -v
+        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -s -v --tb=short

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -5,6 +5,7 @@ Covers `scripts/check_workflow_permissions.py` and `scripts/check_coverage_thres
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import sys
 import textwrap
@@ -144,9 +145,10 @@ def test_verify_package_e2e_retry_is_scoped_to_last_failed_e2e_tests():
     marker = "Retry failed E2E tests after 10-min cool-down"
     assert marker in text
     retry_step = text.split(marker, 1)[1].split("\n    - name:", 1)[0]
+    retry_args = shlex.split(retry_step)
 
     assert "uv run pytest tests/e2e" in retry_step
-    assert "--last-failed" in retry_step
+    assert "--last-failed" in retry_args
     assert "--last-failed-no-failures=none" in retry_step
     assert "pytest --last-failed -v" not in retry_step
 

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -137,6 +137,20 @@ def test_workflow_permissions_allowlist(tmp_path):
     assert result.returncode == 0
 
 
+def test_verify_package_e2e_retry_is_scoped_to_last_failed_e2e_tests():
+    """The protected E2E retry must fail closed instead of running an unintended suite."""
+    workflow = REPO_ROOT / ".github" / "workflows" / "verify-package.yml"
+    text = workflow.read_text(encoding="utf-8")
+    marker = "Retry failed E2E tests after 10-min cool-down"
+    assert marker in text
+    retry_step = text.split(marker, 1)[1].split("\n    - name:", 1)[0]
+
+    assert "uv run pytest tests/e2e" in retry_step
+    assert "--last-failed" in retry_step
+    assert "--last-failed-no-failures=none" in retry_step
+    assert "pytest --last-failed -v" not in retry_step
+
+
 # ---------------------------------------------------------------------------
 # check_coverage_thresholds.py
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- scope the verify-package E2E retry to tests/e2e
- add --last-failed-no-failures=none so the retry fails closed
- add a regression test for the retry command

## Tests
- uv run pytest tests/unit/test_ci_audit_scripts.py::test_verify_package_e2e_retry_is_scoped_to_last_failed_e2e_tests -q
- uv run python scripts/check_workflow_secret_gates.py
- uv run python scripts/check_action_pinning.py
- uv run python scripts/check_workflow_permissions.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI retry behavior updated to target only end-to-end tests after cooldown, preventing broader test reruns.
  * Added a unit test to validate the retry configuration remains scoped to end-to-end tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->