### PR TITLE
fix(cli): stabilize source json schema

### DIFF
--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -17,6 +17,7 @@ from urllib.parse import urlsplit
 
 from ...types import Source
 from ...urls import is_youtube_url
+from .source_serializers import source_summary_payload
 
 if TYPE_CHECKING:
     import click
@@ -371,16 +372,7 @@ async def execute_source_add(
         )
 
     if plan.json_output:
-        json_output_response(
-            {
-                "source": {
-                    "id": src.id,
-                    "title": src.title,
-                    "type": str(src.kind),
-                    "url": src.url,
-                }
-            }
-        )
+        json_output_response({"source": source_summary_payload(src)})
         return
 
     cli_print(f"[green]Added source:[/green] {src.id}", ctx=ctx)

--- a/src/notebooklm/cli/services/source_listing.py
+++ b/src/notebooklm/cli/services/source_listing.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from ...types import Source, source_status_to_str
 from ..rendering import get_source_type_display, render_list
 from .listing import ListResult, ListSpec, prepare_list
+from .source_serializers import source_summary_payload
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -47,10 +48,7 @@ def _build_spec() -> ListSpec[Source]:
         items_key="sources",
         fetch=lambda client, notebook_id: client.sources.list(notebook_id),
         serialize=lambda src: {
-            "id": src.id,
-            "title": src.title,
-            "type": str(src.kind),
-            "url": src.url,
+            **source_summary_payload(src),
             "status": source_status_to_str(src.status),
             "status_id": src.status,
             "created_at": src.created_at.isoformat() if src.created_at else None,

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -502,17 +502,14 @@ async def execute_source_add_drive(
             src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
 
     if plan.json_output:
-        source_payload = source_summary_payload(src)
-        source_payload.update(
-            {
-                "drive_file_id": plan.file_id,
-                "mime_type": plan.mime_type,
-            }
-        )
         json_output_response(
             {
                 "action": "add-drive",
-                "source": source_payload,
+                "source": {
+                    **source_summary_payload(src),
+                    "drive_file_id": plan.file_id,
+                    "mime_type": plan.mime_type,
+                },
                 "notebook_id": plan.notebook_id,
             }
         )

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -28,6 +28,7 @@ from ..rendering import (
 )
 from ..resolve import resolve_source_id, validate_id
 from .confirming_mutation import MutationPlan, run_confirmed_mutation
+from .source_serializers import source_summary_payload
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -501,17 +502,17 @@ async def execute_source_add_drive(
             src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
 
     if plan.json_output:
+        source_payload = source_summary_payload(src)
+        source_payload.update(
+            {
+                "drive_file_id": plan.file_id,
+                "mime_type": plan.mime_type,
+            }
+        )
         json_output_response(
             {
                 "action": "add-drive",
-                "source": {
-                    "id": src.id,
-                    "title": src.title,
-                    "type": str(src.kind),
-                    "url": src.url,
-                    "drive_file_id": plan.file_id,
-                    "mime_type": plan.mime_type,
-                },
+                "source": source_payload,
                 "notebook_id": plan.notebook_id,
             }
         )

--- a/src/notebooklm/cli/services/source_serializers.py
+++ b/src/notebooklm/cli/services/source_serializers.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ...types import Source, SourceFulltext
+if TYPE_CHECKING:
+    from ...types import Source, SourceFulltext
+
+
+def source_kind_value(kind: Any) -> str | None:
+    """Return the public JSON value for a source kind."""
+    return kind.value if kind is not None else None
 
 
 def source_summary_payload(src: Source) -> dict[str, Any]:
@@ -12,7 +18,7 @@ def source_summary_payload(src: Source) -> dict[str, Any]:
     return {
         "id": src.id,
         "title": src.title,
-        "type": src.kind.value,
+        "type": source_kind_value(src.kind),
         "url": src.url,
     }
 
@@ -22,7 +28,7 @@ def source_fulltext_payload(fulltext: SourceFulltext) -> dict[str, Any]:
     return {
         "source_id": fulltext.source_id,
         "title": fulltext.title,
-        "kind": fulltext.kind.value,
+        "kind": source_kind_value(fulltext.kind),
         "content": fulltext.content,
         "url": fulltext.url,
         "char_count": fulltext.char_count,

--- a/src/notebooklm/cli/services/source_serializers.py
+++ b/src/notebooklm/cli/services/source_serializers.py
@@ -1,0 +1,29 @@
+"""Shared JSON serializers for source CLI output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...types import Source, SourceFulltext
+
+
+def source_summary_payload(src: Source) -> dict[str, Any]:
+    """Return the stable public JSON shape for source summaries."""
+    return {
+        "id": src.id,
+        "title": src.title,
+        "type": src.kind.value,
+        "url": src.url,
+    }
+
+
+def source_fulltext_payload(fulltext: SourceFulltext) -> dict[str, Any]:
+    """Return the stable public JSON shape for source fulltext."""
+    return {
+        "source_id": fulltext.source_id,
+        "title": fulltext.title,
+        "kind": fulltext.kind.value,
+        "content": fulltext.content,
+        "url": fulltext.url,
+        "char_count": fulltext.char_count,
+    }

--- a/src/notebooklm/cli/services/source_serializers.py
+++ b/src/notebooklm/cli/services/source_serializers.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...types import Source, SourceFulltext
+    from ...types import Source, SourceFulltext, SourceType
 
 
-def source_kind_value(kind: Any) -> str | None:
+def source_kind_value(kind: SourceType | None) -> str | None:
     """Return the public JSON value for a source kind."""
     return kind.value if kind is not None else None
 

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -88,7 +88,11 @@ from .services.source_research import (
     SourceAddResearchResult,
     execute_source_add_research,
 )
-from .services.source_serializers import source_fulltext_payload, source_summary_payload
+from .services.source_serializers import (
+    source_fulltext_payload,
+    source_kind_value,
+    source_summary_payload,
+)
 from .services.source_wait import (
     SourceWaitNotFound,
     SourceWaitOutcome,
@@ -192,7 +196,7 @@ def _render_source_fulltext_result(
                     "bytes": len(content_bytes),
                     "source_id": fulltext.source_id,
                     "title": fulltext.title,
-                    "kind": fulltext.kind.value,
+                    "kind": source_kind_value(fulltext.kind),
                 }
             )
             return
@@ -959,7 +963,7 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_for
     Use ``--format markdown`` for a rich version with headings/tables/links.
     Text mode truncates at 2000 chars; ``-o FILE`` writes the full content.
     JSON mode emits the full ``SourceFulltext`` payload, or with ``-o`` a
-    ``{path, bytes, source_id, title}`` envelope (content goes to the file
+    ``{path, bytes, source_id, title, kind}`` envelope (content goes to the file
     only, not duplicated to stdout).
     """
     nb_id = require_notebook(notebook_id)

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -153,17 +153,14 @@ def _render_source_get_result(result: SourceGetResult, *, json_output: bool) -> 
         raise AssertionError("unreachable")  # pragma: no cover
 
     if json_output:
-        source_payload = source_summary_payload(src)
-        source_payload.update(
-            {
-                "status": source_status_to_str(src.status),
-                "status_id": src.status,
-                "created_at": (src.created_at.isoformat() if src.created_at else None),
-            }
-        )
         json_output_response(
             {
-                "source": source_payload,
+                "source": {
+                    **source_summary_payload(src),
+                    "status": source_status_to_str(src.status),
+                    "status_id": src.status,
+                    "created_at": (src.created_at.isoformat() if src.created_at else None),
+                },
                 "found": True,
             }
         )

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -18,7 +18,6 @@ below (it is what ``notebooklm source --help`` shows).
 """
 
 import asyncio  # noqa: F401 — re-exported for P1.T2 regression tests that patch source_cmd.asyncio.sleep
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -89,6 +88,7 @@ from .services.source_research import (
     SourceAddResearchResult,
     execute_source_add_research,
 )
+from .services.source_serializers import source_fulltext_payload, source_summary_payload
 from .services.source_wait import (
     SourceWaitNotFound,
     SourceWaitOutcome,
@@ -149,17 +149,17 @@ def _render_source_get_result(result: SourceGetResult, *, json_output: bool) -> 
         raise AssertionError("unreachable")  # pragma: no cover
 
     if json_output:
+        source_payload = source_summary_payload(src)
+        source_payload.update(
+            {
+                "status": source_status_to_str(src.status),
+                "status_id": src.status,
+                "created_at": (src.created_at.isoformat() if src.created_at else None),
+            }
+        )
         json_output_response(
             {
-                "source": {
-                    "id": src.id,
-                    "title": src.title,
-                    "type": str(src.kind),
-                    "url": src.url,
-                    "status": source_status_to_str(src.status),
-                    "status_id": src.status,
-                    "created_at": (src.created_at.isoformat() if src.created_at else None),
-                },
+                "source": source_payload,
                 "found": True,
             }
         )
@@ -192,11 +192,12 @@ def _render_source_fulltext_result(
                     "bytes": len(content_bytes),
                     "source_id": fulltext.source_id,
                     "title": fulltext.title,
+                    "kind": fulltext.kind.value,
                 }
             )
             return
 
-        json_output_response(asdict(fulltext))
+        json_output_response(source_fulltext_payload(fulltext))
         return
 
     if output:

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -93,6 +93,7 @@ GUARDED_PATHS = {
     "cli/services/source_clean.py": SERVICES_ROOT / "source_clean.py",
     "cli/services/source_content.py": SERVICES_ROOT / "source_content.py",
     "cli/services/source_research.py": SERVICES_ROOT / "source_research.py",
+    "cli/services/source_serializers.py": SERVICES_ROOT / "source_serializers.py",
     "cli/services/source_wait.py": SERVICES_ROOT / "source_wait.py",
 }
 
@@ -334,7 +335,7 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
     "cli/services/source_add.py": {
         "path": SERVICES_ROOT / "source_add.py",
         "forbidden_imports": [
-            "source_add.py:359: forbidden relative import: '..rendering'",
+            "source_add.py:360: forbidden relative import: '..rendering'",
         ],
         "pattern_a_violations": [],
         "rationale": (

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -79,6 +79,7 @@ class TestSourceList:
                         id="src_1",
                         title="Test Source",
                         url="https://example.com",
+                        _type_code=5,
                     ),
                 ]
             )
@@ -109,6 +110,7 @@ class TestSourceList:
                 "created_at",
             ]
             assert data["sources"][0]["id"] == "src_1"
+            assert data["sources"][0]["type"] == "web_page"
 
     def test_source_list_limit_caps_rows(self, runner, mock_auth):
         """`source list --limit N` returns at most N data rows."""
@@ -214,6 +216,7 @@ class TestSourceAdd:
                     id="src_new",
                     title="Example",
                     url="https://example.com",
+                    _type_code=5,
                 )
             )
             mock_client_cls.return_value = mock_client
@@ -407,6 +410,7 @@ class TestSourceAdd:
                     id="src_new",
                     title="Example",
                     url="https://example.com",
+                    _type_code=5,
                 )
             )
             mock_client_cls.return_value = mock_client
@@ -422,6 +426,7 @@ class TestSourceAdd:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["source"]["id"] == "src_new"
+            assert data["source"]["type"] == "web_page"
 
     def test_source_add_timeout_flag_threaded_to_client(self, runner, mock_auth):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
@@ -1992,6 +1997,7 @@ class TestSourceFulltext:
                     source_id="src_123",
                     title="Test Source",
                     content="Some content",
+                    _type_code=5,
                     char_count=12,
                     url=None,
                 )
@@ -2010,8 +2016,10 @@ class TestSourceFulltext:
             data = json.loads(result.output)
             assert data["source_id"] == "src_123"
             assert data["title"] == "Test Source"
+            assert data["kind"] == "web_page"
             assert data["content"] == "Some content"
             assert data["char_count"] == 12
+            assert "_type_code" not in data
 
     def test_source_fulltext_format_markdown_propagates(self, runner, mock_auth):
         """`-f markdown` propagates output_format='markdown' to the API."""
@@ -2745,6 +2753,7 @@ class TestSourceJsonOutput:
                     id="src_123",
                     title="My Source",
                     url="https://example.com",
+                    _type_code=5,
                     created_at=datetime(2024, 1, 1, 12, 0),
                 )
             )
@@ -2758,6 +2767,7 @@ class TestSourceJsonOutput:
             assert data["found"] is True
             assert data["source"]["id"] == "src_123"
             assert data["source"]["title"] == "My Source"
+            assert data["source"]["type"] == "web_page"
             assert data["source"]["url"] == "https://example.com"
             assert data["source"]["created_at"] == "2024-01-01T12:00:00"
 
@@ -2907,7 +2917,7 @@ class TestSourceJsonOutput:
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.sources.add_drive = AsyncMock(
-                return_value=Source(id="src_drive", title="My Drive Doc")
+                return_value=Source(id="src_drive", title="My Drive Doc", _type_code=3)
             )
             mock_client_cls.return_value = mock_client
 
@@ -2932,6 +2942,7 @@ class TestSourceJsonOutput:
             assert data["action"] == "add-drive"
             assert data["source"]["id"] == "src_drive"
             assert data["source"]["title"] == "My Drive Doc"
+            assert data["source"]["type"] == "pdf"
             assert data["source"]["drive_file_id"] == "drive_file_xyz"
             assert data["source"]["mime_type"] == "pdf"
             assert data["notebook_id"] == "nb_123"
@@ -3288,6 +3299,7 @@ class TestSourceBundleP1T2:
                     source_id="src_123",
                     title="Big Source",
                     content=body,
+                    _type_code=5,
                     char_count=len(body),
                     url=None,
                 )
@@ -3318,12 +3330,13 @@ class TestSourceBundleP1T2:
             assert data["bytes"] == len(body.encode("utf-8"))
             assert data["source_id"] == "src_123"
             assert data["title"] == "Big Source"
+            assert data["kind"] == "web_page"
             # Full content must not be in the metadata envelope.
             assert "content" not in data
 
     def test_source_fulltext_json_without_output_file_keeps_full_payload(self, runner, mock_auth):
         """Regression guard: when `-o` is OMITTED, `--json` mode still emits the
-        full asdict(SourceFulltext) payload on stdout — unchanged behavior."""
+        full public SourceFulltext payload on stdout."""
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.sources.list = AsyncMock(return_value=[Source(id="src_123", title="Tiny")])
@@ -3332,6 +3345,7 @@ class TestSourceBundleP1T2:
                     source_id="src_123",
                     title="Tiny",
                     content="hello",
+                    _type_code=5,
                     char_count=5,
                     url=None,
                 )
@@ -3345,8 +3359,10 @@ class TestSourceBundleP1T2:
 
             assert result.exit_code == 0, result.output
             data = json.loads(result.output)
+            assert data["kind"] == "web_page"
             assert data["content"] == "hello"
             assert data["char_count"] == 5
+            assert "_type_code" not in data
 
     # ------------------------------------------------------------------
     # Bug 5: source add spinner brackets the awaited upload

--- a/tests/unit/cli/test_source_characterization.py
+++ b/tests/unit/cli/test_source_characterization.py
@@ -111,7 +111,7 @@ class TestSourceAddCharacterization:
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
             client = create_mock_client()
             client.sources.add_url = AsyncMock(
-                return_value=Source(id="src_new", title="T", url="https://x")
+                return_value=Source(id="src_new", title="T", url="https://x", _type_code=5)
             )
             cls.return_value = client
             result = runner.invoke(
@@ -122,6 +122,7 @@ class TestSourceAddCharacterization:
         payload = json.loads(result.output)
         assert payload["source"]["id"] == "src_new"
         assert payload["source"]["title"] == "T"
+        assert payload["source"]["type"] == "web_page"
         assert payload["source"]["url"] == "https://x"
 
 
@@ -151,6 +152,7 @@ class TestSourceListCharacterization:
                         id="src_1",
                         title="One",
                         url=None,
+                        _type_code=5,
                         status=SourceStatus.READY,
                         created_at=datetime(2025, 1, 1, 12, 0, 0),
                     )
@@ -165,6 +167,7 @@ class TestSourceListCharacterization:
         assert payload["count"] == 1
         assert payload["sources"][0]["id"] == "src_1"
         assert payload["sources"][0]["title"] == "One"
+        assert payload["sources"][0]["type"] == "web_page"
 
 
 # ----------------------------------------------------------------------------
@@ -194,6 +197,7 @@ class TestSourceGetCharacterization:
                     id="src_1",
                     title="My Source",
                     url="https://x",
+                    _type_code=5,
                     status=SourceStatus.READY,
                 )
             )
@@ -203,6 +207,7 @@ class TestSourceGetCharacterization:
         payload = json.loads(result.output)
         assert payload["found"] is True
         assert payload["source"]["id"] == "src_1"
+        assert payload["source"]["type"] == "web_page"
         assert payload["source"]["url"] == "https://x"
 
     def test_get_not_found_exits_1_text_mode(self, runner, mock_auth, patched_fetch_tokens):
@@ -395,6 +400,7 @@ class TestSourceFulltextCharacterization:
                     source_id="src_1",
                     title="T",
                     content="hi",
+                    _type_code=5,
                     char_count=2,
                     url=None,
                 )
@@ -404,8 +410,10 @@ class TestSourceFulltextCharacterization:
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["source_id"] == "src_1"
+        assert payload["kind"] == "web_page"
         assert payload["content"] == "hi"
         assert payload["char_count"] == 2
+        assert "_type_code" not in payload
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit/cli/test_source_content_rendering.py
+++ b/tests/unit/cli/test_source_content_rendering.py
@@ -69,6 +69,7 @@ def test_source_fulltext_json_renderer_emits_full_payload(
             source_id="src_1",
             title="Source One",
             content="indexed content",
+            _type_code=5,
             char_count=15,
         )
     )
@@ -80,8 +81,10 @@ def test_source_fulltext_json_renderer_emits_full_payload(
     payload = json.loads(result.output)
     assert payload["source_id"] == "src_1"
     assert payload["title"] == "Source One"
+    assert payload["kind"] == "web_page"
     assert payload["content"] == "indexed content"
     assert payload["char_count"] == 15
+    assert "_type_code" not in payload
 
 
 def test_source_fulltext_json_output_file_writes_content_and_emits_metadata(
@@ -97,6 +100,7 @@ def test_source_fulltext_json_output_file_writes_content_and_emits_metadata(
             source_id="src_1",
             title="Source One",
             content=content,
+            _type_code=5,
             char_count=len(content),
         )
     )
@@ -124,6 +128,7 @@ def test_source_fulltext_json_output_file_writes_content_and_emits_metadata(
         "bytes": len(content.encode("utf-8")),
         "source_id": "src_1",
         "title": "Source One",
+        "kind": "web_page",
     }
 
 


### PR DESCRIPTION
## Summary
- add shared source CLI JSON serializers
- keep source summary outputs on the existing type key while using stable enum values
- make fulltext JSON emit public kind and stop leaking _type_code
- update source CLI and boundary inventory tests

## Tests
- uv run pytest tests/unit/cli/test_source_content_rendering.py tests/unit/cli/test_source_characterization.py tests/unit/cli/test_source.py tests/unit/cli/test_services_boundary.py -q
- uv run ruff check src/notebooklm/cli/source_cmd.py src/notebooklm/cli/services/source_add.py src/notebooklm/cli/services/source_listing.py src/notebooklm/cli/services/source_mutations.py src/notebooklm/cli/services/source_serializers.py tests/unit/cli/test_services_boundary.py tests/unit/cli/test_source.py tests/unit/cli/test_source_characterization.py tests/unit/cli/test_source_content_rendering.py
- uv run mypy src/notebooklm
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Improved error handling and exit codes for source CLI deletions; fixed task ID pinning for source add-research.

* **Enhancements**
  - Centralized JSON serializers so CLI consistently emits user-facing type/kind fields and omits internal metadata.
  - source fulltext now distinguishes metadata-only vs full-content delivery when writing to a file.

* **Documentation**
  - Updated source fulltext help to reflect JSON envelope changes.

* **Tests**
  - Strengthened CLI tests to lock in JSON shapes and command behaviors.

* **Chores**
  - Removed an unused import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->