### PR TITLE
fix(upload): validate and redact upload urls

### DIFF
--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -91,6 +91,8 @@ _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(\bat=)[^&\s\"'<>]+"), r"\1***"),
     # session-id query param
     (re.compile(r"(\bf\.sid=)[^&\s\"'<>]+"), r"\1***"),
+    # resumable-upload session query param
+    (re.compile(r"(\bupload_id=)[^&\s\"'<>]+", re.IGNORECASE), r"\1***"),
     # OAuth-shaped credentials (refresh / access / authorization code)
     (
         re.compile(
@@ -155,6 +157,7 @@ _DEFAULT_DATEFMT = "%H:%M:%S"
 # Coverage map (pattern -> covering token in this set, all lowercase):
 #   \bat=<csrf>                                          -> "at="
 #   \bf\.sid=<sid>                                       -> "f.sid"
+#   \bupload_id=<resumable upload token>                  -> "upload_id="
 #   (refresh_token|access_token|id_token)= (IGNORECASE)  -> "_token="
 #   \bcode= (IGNORECASE)                                 -> "code="
 #   __Secure-*PAPISID/PSID(TS|CC)?/SAPISID/APISID/SIDCC/HSID/SSID/LSID/SID= -> "sid"
@@ -187,6 +190,7 @@ SECRET_FAST_PATH_TOKENS: tuple[str, ...] = (
     "f.sid",
     "continue=",
     "authuser=",
+    "upload_id=",
     "at=",
     "cookie",
     "authorization",

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -13,7 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import IO, TYPE_CHECKING, Any, Protocol, cast
-from urllib.parse import parse_qsl, urlsplit
+from urllib.parse import SplitResult, parse_qsl, urlsplit
 
 import httpx
 
@@ -89,29 +89,50 @@ module_logger = logging.getLogger("notebooklm").getChild("_sources")
 
 
 def _normalize_upload_path(path: str) -> str:
-    normalized = path or "/"
-    return normalized if normalized.endswith("/") else f"{normalized}/"
+    return (path or "/").rstrip("/") + "/"
+
+
+def _default_port_for_scheme(scheme: str) -> int | None:
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    return None
+
+
+def _redacted_upload_authority(parsed: SplitResult) -> str | None:
+    host = parsed.hostname
+    if host is None:
+        return None
+
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    port = parsed.port
+    port_suffix = f":{port}" if port is not None else ""
+    return f"{host}{port_suffix}"
 
 
 def _redact_upload_url(upload_url: str) -> str:
     """Return a log-safe representation of a resumable upload URL."""
     try:
         parsed = urlsplit(upload_url)
+        authority = _redacted_upload_authority(parsed)
     except ValueError:
         return "[REDACTED_UPLOAD_URL]"
-    if not parsed.scheme or not parsed.netloc:
+    if not parsed.scheme or authority is None:
         return "[REDACTED_UPLOAD_URL]"
     suffix = "?..." if parsed.query else ""
-    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}{suffix}"
+    return f"{parsed.scheme}://{authority}{parsed.path}{suffix}"
 
 
 def _validate_resumable_upload_url(upload_url: str) -> str:
     """Validate that a resumable upload URL targets the configured upload endpoint."""
     try:
         parsed = urlsplit(upload_url)
-        actual_port = parsed.port
+        actual_port = parsed.port or _default_port_for_scheme(parsed.scheme)
         expected = urlsplit(get_upload_url())
-        expected_port = expected.port
+        expected_port = expected.port or _default_port_for_scheme(expected.scheme)
     except ValueError as exc:
         raise ValidationError("Upload URL is not valid") from exc
 
@@ -130,8 +151,8 @@ def _validate_resumable_upload_url(upload_url: str) -> str:
         for key, value in parse_qsl(parsed.query, keep_blank_values=True)
         if key.lower() == "upload_id"
     ]
-    if not any(upload_ids):
-        raise ValidationError("Upload URL must include upload_id")
+    if len(upload_ids) != 1 or not upload_ids[0]:
+        raise ValidationError("Upload URL must include exactly one non-empty upload_id")
 
     return upload_url
 

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import IO, TYPE_CHECKING, Any, Protocol, cast
+from urllib.parse import parse_qsl, urlsplit
 
 import httpx
 
@@ -85,6 +86,54 @@ _TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
 # Preserve the historical ``notebooklm._sources`` log channel after moving
 # upload choreography into this module.
 module_logger = logging.getLogger("notebooklm").getChild("_sources")
+
+
+def _normalize_upload_path(path: str) -> str:
+    normalized = path or "/"
+    return normalized if normalized.endswith("/") else f"{normalized}/"
+
+
+def _redact_upload_url(upload_url: str) -> str:
+    """Return a log-safe representation of a resumable upload URL."""
+    try:
+        parsed = urlsplit(upload_url)
+    except ValueError:
+        return "[REDACTED_UPLOAD_URL]"
+    if not parsed.scheme or not parsed.netloc:
+        return "[REDACTED_UPLOAD_URL]"
+    suffix = "?..." if parsed.query else ""
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}{suffix}"
+
+
+def _validate_resumable_upload_url(upload_url: str) -> str:
+    """Validate that a resumable upload URL targets the configured upload endpoint."""
+    try:
+        parsed = urlsplit(upload_url)
+        actual_port = parsed.port
+        expected = urlsplit(get_upload_url())
+        expected_port = expected.port
+    except ValueError as exc:
+        raise ValidationError("Upload URL is not valid") from exc
+
+    if parsed.scheme != "https":
+        raise ValidationError("Upload URL must use https")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValidationError("Upload URL must not contain credentials")
+    if parsed.hostname is None:
+        raise ValidationError("Upload URL must include a host")
+    if parsed.hostname != expected.hostname or actual_port != expected_port:
+        raise ValidationError("Upload URL host is not trusted")
+    if _normalize_upload_path(parsed.path) != _normalize_upload_path(expected.path):
+        raise ValidationError("Upload URL path is not trusted")
+    upload_ids = [
+        value
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() == "upload_id"
+    ]
+    if not any(upload_ids):
+        raise ValidationError("Upload URL must include upload_id")
+
+    return upload_url
 
 
 async def _build_invalid_argument_source_limit_hint(
@@ -749,7 +798,14 @@ class SourceUploadPipeline:
                     filename, message="Failed to get upload URL from response headers"
                 )
 
-            return upload_url
+            try:
+                return _validate_resumable_upload_url(upload_url)
+            except ValidationError as exc:
+                raise SourceAddError(
+                    filename,
+                    cause=exc,
+                    message=f"Received invalid resumable upload URL from NotebookLM: {exc}",
+                ) from exc
 
     async def upload_file_streaming(
         self,
@@ -767,6 +823,7 @@ class SourceUploadPipeline:
         path_fallback: Path | None = file_obj if isinstance(file_obj, Path) else None
         close_wired = False
         try:
+            upload_url = _validate_resumable_upload_url(upload_url)
             base_url = get_base_url()
             auth_route = self._authuser_header()
             headers = {
@@ -779,7 +836,7 @@ class SourceUploadPipeline:
                 "x-goog-upload-offset": "0",
             }
             diag_name = filename or (path_fallback.name if path_fallback is not None else "<file>")
-            logger.debug("Streaming upload to %s for %s", upload_url, diag_name)
+            logger.debug("Streaming upload to %s for %s", _redact_upload_url(upload_url), diag_name)
             if total_bytes is None and path_fallback is not None:
                 total_bytes = path_fallback.stat().st_size
             progress_total = total_bytes if total_bytes is not None else 0
@@ -882,13 +939,18 @@ class SourceUploadPipeline:
             "x-goog-upload-command": "cancel",
         }
         try:
+            upload_url = _validate_resumable_upload_url(upload_url)
             async with self._client_factory()(
                 timeout=httpx.Timeout(10.0, read=10.0),
                 cookies=self._live_cookies(),
             ) as client:
                 await client.post(upload_url, headers=headers)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("Best-effort Scotty cancel for %s failed: %r", upload_url, exc)
+            logger.debug(
+                "Best-effort Scotty cancel for %s failed: %r",
+                _redact_upload_url(upload_url),
+                exc,
+            )
 
 
 __all__ = [

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -519,13 +519,11 @@ SENSITIVE_PATTERNS: list[tuple[str, str]] = [
     ),
     # Full upload URL that embeds the upload_id token in its query string.
     # Match the whole URL (up to the next quote or whitespace) and collapse
-    # to a stable canonical form so the token never round-trips through a
-    # cassette body. The whole URL — including the ``upload_id=`` substring
-    # — is replaced so the subsequent standalone ``upload_id=`` pattern
-    # cannot re-match this placeholder and produce a non-idempotent rewrite.
+    # to a stable canonical form on NotebookLM's trusted upload endpoint so
+    # cassette replay still passes runtime upload-URL validation.
     (
         r"https://notebooklm\.google\.com/upload/_/\?[^\"\s]*upload_id=[A-Za-z0-9_\-]+",
-        "SCRUBBED_UPLOAD_URL",
+        "https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID",
     ),
     # Standalone upload_id query parameter (anywhere it appears outside the
     # full upload URL above).
@@ -690,12 +688,12 @@ _DETECT_UPLOAD_DRIVE_FIELDS: list[tuple[str, re.Pattern[str]]] = [
     ("Drive file_id (URL)", re.compile(r"/drive/v3/files/([A-Za-z0-9_\-]+)")),
 ]
 
-# Full upload URL is replaced wholesale with ``SCRUBBED_UPLOAD_URL`` rather
-# than per-field, so the detector matches the whole URL form and the leak
-# check is "does it appear at all" (the only legitimate appearance of an
-# upload URL in a cassette is the placeholder itself, which this regex does
-# NOT match — so any match here is a leak).
-_DETECT_UPLOAD_URL = re.compile(r"https://notebooklm\.google\.com/upload/_/\?[^\"\s]*upload_id=")
+# Full upload URL is rewritten to a trusted-host placeholder with a scrubbed
+# upload_id. Any NotebookLM upload URL carrying a non-placeholder upload_id is
+# a leak.
+_DETECT_UPLOAD_URL = re.compile(
+    r"https://notebooklm\.google\.com/upload/_/\?[^\"\s]*upload_id=(?!SCRUBBED_UPLOAD_ID\b)"
+)
 
 # escaped JSON display-name literal detector.
 #
@@ -794,8 +792,8 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
                 leaks.append(f"Leak ({label}): {value!r}")
 
     # --- 5. Full upload URL -----------------------------------------------
-    # The scrubber collapses the entire URL to ``SCRUBBED_UPLOAD_URL``, so any
-    # match of the raw URL form here is by definition a leak.
+    # The scrubber preserves the trusted host/path but rewrites upload_id to
+    # SCRUBBED_UPLOAD_ID, so any match here is by definition a leak.
     for match in _DETECT_UPLOAD_URL.finditer(text):
         leaks.append(f"Leak (upload URL): {match.group(0)!r}")
 

--- a/tests/cassettes/sources_add_file.yaml
+++ b/tests/cassettes/sources_add_file.yaml
@@ -1721,11 +1721,11 @@ interactions:
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Control-URL:
-      - https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
+      - https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-URL:
-      - https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
+      - https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID
     status:
       code: 200
       message: OK
@@ -1761,7 +1761,7 @@ interactions:
       x-goog-upload-offset:
       - '0'
     method: POST
-    uri: https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
+    uri: https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID
   response:
     body:
       string: 'OK: Enqueued blob bytes to spanner queue for processing.'

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -267,7 +267,7 @@ async def test_upload_file_streaming_fd_path_does_not_block_event_loop() -> None
 
         async def _upload() -> None:
             await sources_api._upload_file_streaming(
-                "https://upload.example.com/session",
+                "https://notebooklm.google.com/upload/_/?upload_id=session",
                 file_obj,
                 filename="slow.bin",
             )
@@ -321,7 +321,7 @@ async def test_upload_file_streaming_path_fallback_does_not_block_event_loop(
 
         async def _upload() -> None:
             await sources_api._upload_file_streaming(
-                "https://upload.example.com/session",
+                "https://notebooklm.google.com/upload/_/?upload_id=session",
                 test_file,
             )
 
@@ -384,7 +384,9 @@ async def test_add_file_open_runs_off_loop_thread(
     _core.rpc_executor.rpc_call.return_value = [[[["src_t1"]]]]
 
     mock_start_response = MagicMock()
-    mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com/session"}
+    mock_start_response.headers = {
+        "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+    }
     mock_upload_response = MagicMock()
     mock_upload_response.raise_for_status = MagicMock()
 

--- a/tests/integration/concurrency/test_upload_cancel_dangling_session.py
+++ b/tests/integration/concurrency/test_upload_cancel_dangling_session.py
@@ -50,7 +50,7 @@ from .helpers import with_simulated_cancel
 # of the tier-enforcement hook in tests/integration/conftest.py.
 pytestmark = pytest.mark.allow_no_vcr
 
-UPLOAD_URL = "https://example.test/scotty/upload-session-abc123"
+UPLOAD_URL = "https://notebooklm.google.com/upload/_/?upload_id=upload-session-abc123"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/concurrency/test_upload_timeout_config.py
+++ b/tests/integration/concurrency/test_upload_timeout_config.py
@@ -126,7 +126,7 @@ async def test_custom_upload_timeout_propagates_to_finalize(
         with patch("notebooklm._sources.httpx.AsyncClient", capturing):
             with pytest.raises((httpx.HTTPError, OSError)):
                 await client.sources._upload_file_streaming(
-                    upload_url="https://example.invalid/upload/abc",
+                    upload_url="https://notebooklm.google.com/upload/_/?upload_id=timeout",
                     file_obj=tmp_upload_file,
                 )
 
@@ -148,7 +148,7 @@ async def test_default_upload_timeout_preserves_back_compat_finalize(
         with patch("notebooklm._sources.httpx.AsyncClient", capturing):
             with pytest.raises((httpx.HTTPError, OSError)):
                 await client.sources._upload_file_streaming(
-                    upload_url="https://example.invalid/upload/abc",
+                    upload_url="https://notebooklm.google.com/upload/_/?upload_id=timeout",
                     file_obj=tmp_upload_file,
                 )
 

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -1674,7 +1674,7 @@ class TestAddFileWait:
                     client.sources._uploader,
                     "start_resumable_upload",
                     new_callable=AsyncMock,
-                    return_value="https://upload.example.com/upload_id=abc",
+                    return_value="https://notebooklm.google.com/upload/_/?upload_id=abc",
                 ):
                     with patch.object(
                         client.sources._uploader,

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -496,18 +496,12 @@ def test_upload_id_header_scrubbed() -> None:
 
 
 def test_upload_url_full_scrubbed() -> None:
-    """A full notebooklm upload URL is replaced with the URL placeholder.
-
-    The whole URL collapses to ``SCRUBBED_UPLOAD_URL`` (rather than leaving
-    a half-scrubbed ``upload_id=...`` fragment) so that the standalone
-    ``upload_id=`` pattern below cannot re-match the placeholder — which
-    would otherwise produce a non-idempotent rewrite.
-    """
+    """A full notebooklm upload URL preserves host/path and scrubs the token."""
     url = (
         "https://notebooklm.google.com/upload/_/?authuser=0&upload_id=AJRbA5XZXPNXlxYzAbcdef_-12345"
     )
     scrubbed = scrub_string(url)
-    assert scrubbed == "SCRUBBED_UPLOAD_URL"
+    assert scrubbed == "https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID"
     assert "AJRbA5XZXPNXlx" not in scrubbed
 
 
@@ -636,6 +630,7 @@ def test_is_clean_recognizes_upload_drive_placeholders() -> None:
     for placeholder in [
         "X-GUploader-UploadID: SCRUBBED_UPLOAD_ID",
         "upload_id=SCRUBBED_UPLOAD_ID",
+        "https://notebooklm.google.com/upload/_/?upload_id=SCRUBBED_UPLOAD_ID",
         "SCRUBBED_UPLOAD_URL",
         "SCRUBBED_AONS",
         '{"file_id": "SCRUBBED_DRIVE_FILE_ID"}',

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -155,6 +155,14 @@ def test_formatter_scrubs_fsid_query_param():
     assert "f.sid=***" in out
 
 
+def test_formatter_scrubs_upload_id_query_param():
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record("uploading to https://notebooklm.google.com/upload/_/?upload_id=SECRET_UPLOAD_ID")
+    out = fmt.format(rec)
+    assert "SECRET_UPLOAD_ID" not in out
+    assert "upload_id=***" in out
+
+
 def test_formatter_preserves_non_secret_text():
     fmt = RedactingFormatter(logging.Formatter("%(message)s"))
     rec = _record("RPC LIST_NOTEBOOKS failed for nb_id=abc123 method=LIST in 0.42s")

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -328,7 +328,7 @@ async def test_upload_progress_callback_receives_byte_counts(
             mock_client_cls.return_value = mock_client
 
             await api._upload_file_streaming(
-                "https://upload.example.com/session",
+                "https://notebooklm.google.com/upload/_/?upload_id=session",
                 test_file,
                 on_progress=on_progress,
             )

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -601,3 +601,27 @@ async def test_upload_file_streaming_redacts_upload_url_in_debug_logs(tmp_path) 
     assert any(
         "https://notebooklm.google.com/upload/_/?..." in message for message in debug_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_cancel_upload_session_redacts_credentials_on_validation_failure() -> None:
+    client_factory = MagicMock()
+    runtime = HttpRuntime()
+    service = make_pipeline(kernel=runtime, auth=runtime, async_client_factory=client_factory)
+    logger = MagicMock()
+
+    await service.cancel_upload_session(
+        "https://alice:s3cr3t@notebooklm.google.com/upload/_/?upload_id=SECRET_UPLOAD_ID",
+        "https://notebooklm.google.com",
+        "0",
+        logger=logger,
+    )
+
+    client_factory.assert_not_called()
+    debug_messages = [str(call) for call in logger.debug.call_args_list]
+    assert any(
+        "https://notebooklm.google.com/upload/_/?..." in message for message in debug_messages
+    )
+    assert all("alice" not in message for message in debug_messages)
+    assert all("s3cr3t" not in message for message in debug_messages)
+    assert all("SECRET_UPLOAD_ID" not in message for message in debug_messages)

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -14,6 +14,7 @@ import pytest
 from notebooklm._source_upload import (
     SourceUploadPipeline,
     _extract_register_file_source_id,
+    _redact_upload_url,
     _transient_error_types_for_upload,
     _validate_resumable_upload_url,
 )
@@ -155,10 +156,39 @@ def test_extract_register_file_source_id_skips_large_string_candidates() -> None
     assert _extract_register_file_source_id([long_payload, "src_123"], "report.pdf") == "src_123"
 
 
-def test_validate_resumable_upload_url_accepts_configured_upload_endpoint() -> None:
-    url = "https://notebooklm.google.com/upload/_/?upload_id=session"
-
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://notebooklm.google.com/upload/_/?upload_id=session",
+        "https://notebooklm.google.com:443/upload/_/?upload_id=session",
+        "https://notebooklm.google.com/upload/_//?upload_id=session",
+    ],
+)
+def test_validate_resumable_upload_url_accepts_configured_upload_endpoint(url: str) -> None:
     assert _validate_resumable_upload_url(url) == url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://user:pass@notebooklm.google.com/upload/_/?upload_id=SECRET_UPLOAD_ID",
+            "https://notebooklm.google.com/upload/_/?...",
+        ),
+        (
+            "https://user:pass@[2001:db8::1]:443/upload/_/?upload_id=SECRET_UPLOAD_ID",
+            "https://[2001:db8::1]:443/upload/_/?...",
+        ),
+        ("https://notebooklm.google.com:bad/upload/_/?upload_id=SECRET", "[REDACTED_UPLOAD_URL]"),
+    ],
+)
+def test_redact_upload_url_omits_userinfo_and_query_secrets(url: str, expected: str) -> None:
+    redacted = _redact_upload_url(url)
+
+    assert redacted == expected
+    assert "user" not in redacted
+    assert "pass" not in redacted
+    assert "SECRET" not in redacted
 
 
 @pytest.mark.parametrize(
@@ -167,7 +197,12 @@ def test_validate_resumable_upload_url_accepts_configured_upload_endpoint() -> N
         ("http://notebooklm.google.com/upload/_/?upload_id=session", "must use https"),
         ("https://evil.example/upload/_/?upload_id=session", "host is not trusted"),
         ("https://notebooklm.google.com/other/_/?upload_id=session", "path is not trusted"),
-        ("https://notebooklm.google.com/upload/_/", "must include upload_id"),
+        ("https://notebooklm.google.com/upload/_/", "exactly one non-empty upload_id"),
+        ("https://notebooklm.google.com/upload/_/?upload_id=", "exactly one non-empty upload_id"),
+        (
+            "https://notebooklm.google.com/upload/_/?upload_id=one&upload_id=two",
+            "exactly one non-empty upload_id",
+        ),
     ],
 )
 def test_validate_resumable_upload_url_rejects_untrusted_shapes(url: str, match: str) -> None:

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -15,7 +15,9 @@ from notebooklm._source_upload import (
     SourceUploadPipeline,
     _extract_register_file_source_id,
     _transient_error_types_for_upload,
+    _validate_resumable_upload_url,
 )
+from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import RPCError, RPCMethod
 from notebooklm.types import Source, SourceAddError
 
@@ -153,6 +155,26 @@ def test_extract_register_file_source_id_skips_large_string_candidates() -> None
     assert _extract_register_file_source_id([long_payload, "src_123"], "report.pdf") == "src_123"
 
 
+def test_validate_resumable_upload_url_accepts_configured_upload_endpoint() -> None:
+    url = "https://notebooklm.google.com/upload/_/?upload_id=session"
+
+    assert _validate_resumable_upload_url(url) == url
+
+
+@pytest.mark.parametrize(
+    ("url", "match"),
+    [
+        ("http://notebooklm.google.com/upload/_/?upload_id=session", "must use https"),
+        ("https://evil.example/upload/_/?upload_id=session", "host is not trusted"),
+        ("https://notebooklm.google.com/other/_/?upload_id=session", "path is not trusted"),
+        ("https://notebooklm.google.com/upload/_/", "must include upload_id"),
+    ],
+)
+def test_validate_resumable_upload_url_rejects_untrusted_shapes(url: str, match: str) -> None:
+    with pytest.raises(ValidationError, match=match):
+        _validate_resumable_upload_url(url)
+
+
 @pytest.mark.parametrize(
     ("content_type", "expected"),
     [
@@ -191,10 +213,12 @@ async def test_add_file_uses_pipeline_steps_and_finishes_transport(
     service = make_pipeline(runtime)
 
     register_file_source = AsyncMock(return_value="src_123")
-    start_resumable_upload = AsyncMock(return_value="https://upload.example.com/session")
+    start_resumable_upload = AsyncMock(
+        return_value="https://notebooklm.google.com/upload/_/?upload_id=session"
+    )
 
     async def upload_file_streaming(upload_url, file_obj, **kwargs):
-        assert upload_url == "https://upload.example.com/session"
+        assert upload_url == "https://notebooklm.google.com/upload/_/?upload_id=session"
         assert file_obj.read() == b"hello"
         assert kwargs["filename"] == "report.pdf"
         assert kwargs["total_bytes"] == 5
@@ -250,7 +274,7 @@ async def test_add_file_operation_scope_wraps_sources_semaphore_wait(
     monkeypatch.setattr(
         service,
         "start_resumable_upload",
-        AsyncMock(return_value="https://upload.example.com/session"),
+        AsyncMock(return_value="https://notebooklm.google.com/upload/_/?upload_id=session"),
     )
     monkeypatch.setattr(service, "upload_file_streaming", upload_file_streaming)
     monkeypatch.setattr(service, "wait_until_ready", AsyncMock())
@@ -301,7 +325,7 @@ async def test_add_file_custom_title_waits_for_registration_before_rename(
     monkeypatch.setattr(
         service,
         "start_resumable_upload",
-        AsyncMock(return_value="https://upload.example.com/session"),
+        AsyncMock(return_value="https://notebooklm.google.com/upload/_/?upload_id=session"),
     )
     monkeypatch.setattr(service, "upload_file_streaming", upload_file_streaming)
     monkeypatch.setattr(service, "wait_until_ready", AsyncMock())
@@ -448,7 +472,9 @@ async def test_register_file_source_truncates_large_string_response_preview(
 @pytest.mark.asyncio
 async def test_start_resumable_upload_uses_injected_http_client() -> None:
     response = MagicMock()
-    response.headers = {"x-goog-upload-url": "https://upload.example.com/session"}
+    response.headers = {
+        "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+    }
     response.raise_for_status = MagicMock()
     client = AsyncMock()
     client.post = AsyncMock(return_value=response)
@@ -466,9 +492,77 @@ async def test_start_resumable_upload_uses_injected_http_client() -> None:
         "application/pdf",
     )
 
-    assert upload_url == "https://upload.example.com/session"
+    assert upload_url == "https://notebooklm.google.com/upload/_/?upload_id=session"
     assert client_factory.call_args.kwargs["cookies"] is runtime.cookies
     request = client.post.await_args
     assert request.kwargs["headers"]["x-goog-upload-command"] == "start"
     assert request.kwargs["headers"]["x-goog-upload-header-content-type"] == "application/pdf"
     assert '"SOURCE_ID": "src_123"' in request.kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_start_resumable_upload_rejects_untrusted_upload_header_url() -> None:
+    response = MagicMock()
+    response.headers = {"x-goog-upload-url": "https://evil.example/upload/_/?upload_id=secret"}
+    response.raise_for_status = MagicMock()
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client
+    client_factory = MagicMock(return_value=client_cm)
+    runtime = HttpRuntime()
+    service = make_pipeline(kernel=runtime, auth=runtime, async_client_factory=client_factory)
+
+    with pytest.raises(SourceAddError, match="invalid resumable upload URL"):
+        await service.start_resumable_upload(
+            "nb_123",
+            "report.pdf",
+            12,
+            "src_123",
+            "application/pdf",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_file_streaming_rejects_untrusted_url_before_post(tmp_path) -> None:
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"content")
+    client_factory = MagicMock()
+    runtime = HttpRuntime()
+    service = make_pipeline(kernel=runtime, auth=runtime, async_client_factory=client_factory)
+
+    with pytest.raises(ValidationError, match="host is not trusted"):
+        await service.upload_file_streaming(
+            "https://evil.example/upload/_/?upload_id=secret",
+            file_path,
+        )
+
+    client_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_file_streaming_redacts_upload_url_in_debug_logs(tmp_path) -> None:
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"content")
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client
+    client_factory = MagicMock(return_value=client_cm)
+    runtime = HttpRuntime()
+    service = make_pipeline(kernel=runtime, auth=runtime, async_client_factory=client_factory)
+    logger = MagicMock()
+
+    await service.upload_file_streaming(
+        "https://notebooklm.google.com/upload/_/?upload_id=SECRET_UPLOAD_ID",
+        file_path,
+        logger=logger,
+    )
+
+    debug_messages = [str(call) for call in logger.debug.call_args_list]
+    assert all("SECRET_UPLOAD_ID" not in message for message in debug_messages)
+    assert any(
+        "https://notebooklm.google.com/upload/_/?..." in message for message in debug_messages
+    )

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -567,7 +567,9 @@ class TestStartResumableUpload:
     async def test_start_resumable_upload_success(self, sources_api, mock_core):
         """Test successful upload start."""
         mock_response = MagicMock()
-        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com/session123"}
+        mock_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session123"
+        }
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -580,13 +582,15 @@ class TestStartResumableUpload:
                 "nb_123", "test.pdf", 1024, "src_456", "application/pdf"
             )
 
-        assert result == "https://upload.example.com/session123"
+        assert result == "https://notebooklm.google.com/upload/_/?upload_id=session123"
 
     @pytest.mark.asyncio
     async def test_start_resumable_upload_includes_correct_headers(self, sources_api, mock_core):
         """Test that upload start includes correct headers."""
         mock_response = MagicMock()
-        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -619,7 +623,9 @@ class TestStartResumableUpload:
         mock_core.auth.authuser = 2
         mock_core.auth.account_email = None
         mock_response = MagicMock()
-        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -644,7 +650,9 @@ class TestStartResumableUpload:
         mock_core.auth.authuser = 2
         mock_core.auth.account_email = "user+test@example.com"
         mock_response = MagicMock()
-        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -671,7 +679,9 @@ class TestStartResumableUpload:
         import json
 
         mock_response = MagicMock()
-        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -757,7 +767,7 @@ class TestUploadFileStreaming:
 
             # Should not raise
             await sources_api._upload_file_streaming(
-                "https://upload.example.com/session", test_file
+                "https://notebooklm.google.com/upload/_/?upload_id=session", test_file
             )
 
             mock_client.post.assert_called_once()
@@ -779,7 +789,7 @@ class TestUploadFileStreaming:
             mock_client_cls.return_value = mock_client
 
             await sources_api._upload_file_streaming(
-                "https://upload.example.com/session", test_file
+                "https://notebooklm.google.com/upload/_/?upload_id=session", test_file
             )
 
             call_kwargs = mock_client.post.call_args[1]
@@ -811,7 +821,7 @@ class TestUploadFileStreaming:
             mock_client_cls.return_value = mock_client
 
             await sources_api._upload_file_streaming(
-                "https://upload.example.com/session", test_file
+                "https://notebooklm.google.com/upload/_/?upload_id=session", test_file
             )
 
         assert (
@@ -833,7 +843,7 @@ class TestUploadFileStreaming:
             mock_client_cls.return_value = mock_client
 
             await sources_api._cancel_upload_session(
-                "https://upload.example.com/session",
+                "https://notebooklm.google.com/upload/_/?upload_id=session",
                 "https://notebooklm.google.com",
                 auth_route,
             )
@@ -858,7 +868,9 @@ class TestUploadFileStreaming:
             mock_client.post.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            await sources_api._upload_file_streaming("https://upload.example.com", test_file)
+            await sources_api._upload_file_streaming(
+                "https://notebooklm.google.com/upload/_/?upload_id=session", test_file
+            )
 
             call_kwargs = mock_client.post.call_args[1]
             # Content should be a generator, not bytes
@@ -887,7 +899,9 @@ class TestUploadFileStreaming:
             mock_client_cls.return_value = mock_client
 
             with pytest.raises(httpx.HTTPStatusError):
-                await sources_api._upload_file_streaming("https://upload.example.com", test_file)
+                await sources_api._upload_file_streaming(
+                    "https://notebooklm.google.com/upload/_/?upload_id=session", test_file
+                )
 
 
 # =============================================================================
@@ -910,7 +924,9 @@ class TestAddFile:
 
         # Mock HTTP calls
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com/session"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
 
         mock_upload_response = MagicMock()
 
@@ -945,7 +961,9 @@ class TestAddFile:
         mock_core.rpc_executor.rpc_call.return_value = [[[["src_txt"]]]]
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -972,7 +990,9 @@ class TestAddFile:
         )
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1002,7 +1022,9 @@ class TestAddFile:
         mock_core.rpc_executor.rpc_call.return_value = [[[["src_png"]]]]
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1034,7 +1056,9 @@ class TestAddFile:
         mock_core.rpc_executor.rpc_call.return_value = [[[["src_default"]]]]
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1089,7 +1113,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1151,7 +1177,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1208,7 +1236,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1256,7 +1286,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1291,7 +1323,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1324,7 +1358,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1367,7 +1403,9 @@ class TestAddFile:
         mock_core.rpc_executor.rpc_call.return_value = [[[["src_pdf"]]]]
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1419,7 +1457,9 @@ class TestAddFile:
         )
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1481,7 +1521,9 @@ class TestAddFile:
         )
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1526,7 +1568,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -1577,7 +1621,9 @@ class TestAddFile:
         sources_api._uploader.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 
         mock_start_response = MagicMock()
-        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_start_response.headers = {
+            "x-goog-upload-url": "https://notebooklm.google.com/upload/_/?upload_id=session"
+        }
         mock_upload_response = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:


### PR DESCRIPTION
## Summary
- validate resumable upload URLs before returning them or posting file bytes
- require HTTPS, trusted configured upload host/path, and upload_id
- redact upload_id values in runtime logging
- keep VCR upload replay compatible by preserving the trusted host/path while scrubbing IDs

## Tests
- uv run pytest tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py tests/unit/test_logging.py tests/unit/test_cassette_patterns.py tests/unit/test_observability.py tests/unit/test_env_base_url.py -q
- uv run pytest tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/test_sources_integration.py -q
- uv run ruff check src/notebooklm/_logging.py src/notebooklm/_source_upload.py tests/cassette_patterns.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/test_sources_integration.py tests/unit/test_cassette_patterns.py tests/unit/test_logging.py tests/unit/test_observability.py tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py
- uv run mypy src/notebooklm
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logging now redacts resumable-upload session identifiers (upload_id) to prevent leaking sensitive tokens.

* **Chores**
  * Added validation and sanitation for resumable upload URLs so only trusted, well-formed endpoints are accepted; debug logs now show redacted upload URLs.

* **Tests**
  * Expanded and updated tests and recorded fixtures to cover upload URL validation, redaction, and upload streaming/cancel/finalize behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->