### PR TITLE
test(client): add composed shell helper for refresh tests + set self._auth

### DIFF
--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -225,6 +225,28 @@ class NotebookLMClient:
         if storage_path is not None and auth.storage_path != storage_path:
             auth = dataclasses.replace(auth, storage_path=storage_path)
 
+        # Direct client-owned reference to the authoritative ``AuthTokens``
+        # instance. Set AFTER the ``storage_path`` normalization above so it
+        # captures the same (possibly rebound) instance that
+        # :func:`compose_session_internals` then propagates into
+        # :class:`Session`, :class:`CookiePersistence`, the snapshot-provider
+        # lambdas, and :class:`SourceUploadPipeline`. The Auth Instance
+        # Invariant (see
+        # ``.sisyphus/phases/host-protocol-removal/phase-1.md``) requires that
+        # every reference across the live object graph alias this exact same
+        # mutable object so :meth:`AuthRefreshCoordinator.update_auth_tokens`
+        # in-place mutations are observed everywhere.
+        #
+        # Wave 0 of the host-protocol-removal plan only SETS this field; no
+        # production read site exists yet. Wave 2 wires ``refresh_auth()`` to
+        # read it; Wave 3 updates the public ``auth`` property to back off
+        # this field instead of the ``self._session.auth`` reach-through.
+        # The field is set today so the shell-client test helper
+        # (``tests/_helpers/session_factory.build_refresh_client_shell``) can
+        # mirror the production attribute shape from PR 1 onward, keeping
+        # test shells and production aligned across the intermediate PRs.
+        self._auth = auth
+
         # Canonicalize the keepalive storage path so different representations
         # of the same physical file (relative vs absolute, ``~`` shorthand,
         # symlink components) hash to the same key in the in-process rotation

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -768,11 +768,17 @@ class NotebookLMClient:
         read-only accessor — rather than from the client's owned
         ``_collaborators`` bundle so a ``NotebookLMClient`` shell built
         via ``__new__`` (used in
-        ``tests/unit/test_concurrency_refresh_race.py``) still works:
-        the test sets ``client._session`` directly and never calls
-        ``__init__``, so ``client._session.lifecycle`` is the only
-        resolution path that works without widening the constructor
-        surface.
+        ``tests/unit/test_concurrency_refresh_race.py``, constructed
+        through the
+        ``tests/_helpers/session_factory.build_refresh_client_shell``
+        helper that wires ``_session`` / ``_auth`` /
+        ``_collaborators`` / ``_rpc_executor`` from the composed
+        bundle) still works: the helper does not call ``__init__``,
+        so ``client._session.lifecycle`` is the resolution path that
+        works without widening the constructor surface. Wave 2 of the
+        host-protocol-removal plan rewires this call site onto
+        ``self._auth`` and an explicit lifecycle collaborator; this
+        docstring will move with the call when that happens.
 
         Returns:
             Updated AuthTokens.

--- a/tests/_helpers/session_factory.py
+++ b/tests/_helpers/session_factory.py
@@ -89,8 +89,11 @@ def build_session_for_tests(
     The composition extras (``transport`` / ``executor`` /
     ``collaborators``) are not returned here because the vast majority
     of call sites only need the :class:`Session` instance; tests that
-    want the full :class:`ComposedSession` tuple call
-    :func:`compose_session_internals` directly.
+    want the full :class:`ComposedSession` bundle call
+    :func:`build_composed_session_for_tests` (the same kwarg surface,
+    returns the full bundle) — addressed to keep the kwarg-default
+    layer this helper applies, rather than reaching directly to
+    :func:`notebooklm._session.compose_session_internals`.
     """
     return build_composed_session_for_tests(
         auth=auth,

--- a/tests/_helpers/session_factory.py
+++ b/tests/_helpers/session_factory.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from notebooklm._session import Session, compose_session_internals
+from notebooklm._session import ComposedSession, Session, compose_session_internals
 from notebooklm._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -45,6 +45,7 @@ from notebooklm._session_config import (
 )
 from notebooklm._session_lifecycle import CookieRotator, CookieSaver
 from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
 from notebooklm.types import RpcTelemetryEvent
 
 if TYPE_CHECKING:
@@ -91,7 +92,74 @@ def build_session_for_tests(
     want the full :class:`ComposedSession` tuple call
     :func:`compose_session_internals` directly.
     """
-    composed = compose_session_internals(
+    return build_composed_session_for_tests(
+        auth=auth,
+        timeout=timeout,
+        connect_timeout=connect_timeout,
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=refresh_retry_delay,
+        keepalive=keepalive,
+        keepalive_min_interval=keepalive_min_interval,
+        keepalive_storage_path=keepalive_storage_path,
+        rate_limit_max_retries=rate_limit_max_retries,
+        server_error_max_retries=server_error_max_retries,
+        limits=limits,
+        max_concurrent_uploads=max_concurrent_uploads,
+        max_concurrent_rpcs=max_concurrent_rpcs,
+        on_rpc_event=on_rpc_event,
+        cookie_saver=cookie_saver,
+        cookie_rotator=cookie_rotator,
+        decode_response=decode_response,
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+        async_client_factory=async_client_factory,
+    ).session
+
+
+def build_composed_session_for_tests(
+    auth: AuthTokens,
+    timeout: float = DEFAULT_TIMEOUT,
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
+    refresh_retry_delay: float = 0.2,
+    keepalive: float | None = None,
+    keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
+    keepalive_storage_path: Path | None = None,
+    rate_limit_max_retries: int = 3,
+    server_error_max_retries: int = 3,
+    limits: ConnectionLimits | None = None,
+    max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
+    max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
+    on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+    cookie_saver: CookieSaver | None = None,
+    cookie_rotator: CookieRotator | None = None,
+    *,
+    decode_response: Callable[..., Any] | None = None,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+    is_auth_error: Callable[[Exception], bool] | None = None,
+    async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
+) -> ComposedSession:
+    """Same kwarg surface as :func:`build_session_for_tests` but returns the full bundle.
+
+    Tests that need to construct a ``NotebookLMClient``-shaped shell via
+    :func:`build_refresh_client_shell` need access to the full
+    :class:`ComposedSession` (``session`` + ``executor`` +
+    ``collaborators``), not just the :class:`Session` instance. This
+    helper is a thin forwarder to
+    :func:`notebooklm._session.compose_session_internals` that preserves
+    the documented monkeypatch contract (seam resolution happens against
+    ``notebooklm._session``'s module bindings, not this helper's).
+
+    Wave 0 of the host-protocol-removal plan (see
+    ``.sisyphus/phases/host-protocol-removal/phase-1.md``) introduced this
+    helper as the canonical construction site for shell-client test
+    fixtures so that the later deletion of ``Session.lifecycle`` (Wave 2)
+    is mechanical — no shell-test code has to reach back through
+    ``session.lifecycle`` because the helper hands the four runtime
+    fields (``_auth`` / ``_session`` / ``_collaborators`` /
+    ``_rpc_executor``) to :func:`build_refresh_client_shell` directly.
+    """
+    return compose_session_internals(
         auth=auth,
         timeout=timeout,
         connect_timeout=connect_timeout,
@@ -113,4 +181,35 @@ def build_session_for_tests(
         is_auth_error=is_auth_error,
         async_client_factory=async_client_factory,
     )
-    return composed.session
+
+
+def build_refresh_client_shell(composed: ComposedSession) -> NotebookLMClient:
+    """Build a minimal :class:`NotebookLMClient` shell for refresh-path tests.
+
+    Uses :meth:`NotebookLMClient.__new__` to bypass the heavy
+    ``__init__`` side effects (feature-API construction, cross-validation,
+    storage-path canonicalization) while still wiring the four runtime
+    attributes the refresh code path reads off the client.
+
+    The four assignments below MUST stay in lock-step with
+    :meth:`NotebookLMClient.__init__` so test shells and production
+    aliases observe the same ``AuthTokens`` instance for the Auth
+    Instance Invariant (see
+    ``.sisyphus/phases/host-protocol-removal/phase-1.md``):
+    ``composed.session.auth`` aliases the same object that flowed into
+    :func:`notebooklm._session.compose_session_internals` and that the
+    snapshot-provider lambdas captured, so setting
+    ``client._auth = composed.session.auth`` here mirrors what
+    ``self._auth = auth`` sets in production.
+
+    The helper sources its four fields exclusively from
+    :class:`ComposedSession` — there is no read-back through
+    ``session.lifecycle`` — so the upcoming Wave 2 deletion of
+    ``Session.lifecycle`` does not ripple into shell-test code.
+    """
+    client = NotebookLMClient.__new__(NotebookLMClient)
+    client._session = composed.session
+    client._auth = composed.session.auth
+    client._collaborators = composed.collaborators
+    client._rpc_executor = composed.executor
+    return client

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -60,29 +60,24 @@ from __future__ import annotations
 import ast
 import asyncio
 import contextlib
-import importlib.util
 import inspect
 import json
 import textwrap
-from pathlib import Path
 
 import httpx
 import pytest
 
+from _fixtures.kernel_test_helpers import install_http_client_for_test
+from _helpers.session_factory import (
+    build_composed_session_for_tests,
+    build_refresh_client_shell,
+)
 from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 from notebooklm._rpc_executor import RpcExecutor
 from notebooklm._session_auth import AuthRefreshCoordinator
 from notebooklm._session_transport import SessionTransport
+from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
-
-_UNIT_CONFTEST_SPEC = importlib.util.spec_from_file_location(
-    "unit_conftest_make_core",
-    Path(__file__).resolve().parent / "conftest.py",
-)
-assert _UNIT_CONFTEST_SPEC is not None and _UNIT_CONFTEST_SPEC.loader is not None
-_unit_conftest = importlib.util.module_from_spec(_UNIT_CONFTEST_SPEC)
-_UNIT_CONFTEST_SPEC.loader.exec_module(_unit_conftest)
-make_core = _unit_conftest.make_core
 
 # Test-side deadline for any single asyncio.Event in the race scaffolding.
 # Generous enough not to flake on slow CI, tight enough that a regression
@@ -471,13 +466,45 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
 
     transport = httpx.MockTransport(handler)
 
-    async with make_core(transport=transport) as core:
-        # NotebookLMClient.__new__ skips __init__ side effects — we only need a
-        # shell whose .auth property routes to our test core.
-        from notebooklm.client import NotebookLMClient
+    # Build the same auth scaffold the unit conftest's ``make_core`` produces
+    # (CSRF_OLD / SID_OLD / old_sid_cookie) so the OLD/NEW marker assertions
+    # below stay valid. Routed through :func:`build_composed_session_for_tests`
+    # (Wave 0 of the host-protocol-removal plan) so we get the full
+    # :class:`ComposedSession` bundle the shell helper needs — instead of
+    # only the :class:`Session` instance ``make_core`` yields.
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "old_sid_cookie"},
+    )
+    composed = build_composed_session_for_tests(auth=auth, refresh_retry_delay=0.0)
+    core = composed.session
+    await core.open()
+    try:
+        # Swap the auto-built http client for one that uses the test
+        # transport so we can observe the real ``httpx.Request`` (cookie
+        # merge, headers, body, URL). Mirrors the ``make_core`` post-open
+        # transport-install dance verbatim.
+        prior_cookies = core._kernel.get_http_client().cookies
+        await core._kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
 
-        client = NotebookLMClient.__new__(NotebookLMClient)
-        client._session = core
+        # ``build_refresh_client_shell`` populates all four runtime
+        # attributes (``_session`` / ``_auth`` / ``_collaborators`` /
+        # ``_rpc_executor``) from the composed bundle so the shell mirrors
+        # production. Pre-Wave-0 this site set only ``client._session = core``,
+        # which left ``client._auth`` unset; that worked because
+        # ``refresh_auth`` reaches through ``self._session.auth``, but it
+        # diverged from production shape and made the later
+        # ``Session.lifecycle`` deletion (Wave 2) require shell rewrites.
+        client = build_refresh_client_shell(composed)
 
         # try/finally ensures the mock-transport handlers are unblocked even
         # if a wait_for times out — otherwise pending tasks dangle in the
@@ -516,15 +543,17 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
             for t in pending:
                 t.cancel()
             # Bounded join so cancelled tasks actually settle before the
-            # ``async with make_core(...)`` block exits. Narrow to
-            # ``(CancelledError, Exception)`` so KeyboardInterrupt / SystemExit
-            # during the test still propagate.
+            # outer ``core.close()`` runs. Narrow to ``(CancelledError,
+            # Exception)`` so KeyboardInterrupt / SystemExit during the
+            # test still propagate.
             if pending:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await asyncio.wait_for(
                         asyncio.gather(*pending, return_exceptions=True),
                         EVENT_TIMEOUT_S,
                     )
+    finally:
+        await core.close()
 
     assert len(captured_post) == 1, (
         f"Expected exactly one POST on the wire, got {len(captured_post)}: {captured_post!r}"


### PR DESCRIPTION
## Summary

Wave 0 of the host-protocol-removal plan (`.sisyphus/phases/host-protocol-removal/phase-1.md`). Three files, 173 insertions:

- **`src/notebooklm/client.py`** (+22): adds `self._auth = auth` in `NotebookLMClient.__init__`, placed AFTER the `storage_path`-normalization `dataclasses.replace` so it aliases the same instance that flows into `compose_session_internals`. Unread by production at the end of this PR — Wave 2 will wire `refresh_auth()` to read it; Wave 3 updates the public `auth` property.
- **`tests/_helpers/session_factory.py`** (+105): adds `build_composed_session_for_tests` (returns the full `ComposedSession` bundle) and `build_refresh_client_shell` (constructs a `NotebookLMClient` shell via `__new__`, wiring all four runtime attributes `_session` / `_auth` / `_collaborators` / `_rpc_executor` off `ComposedSession`). Existing `build_session_for_tests` now delegates to `build_composed_session_for_tests` (no behavior change for current callers).
- **`tests/unit/test_concurrency_refresh_race.py`** (+69 net): migrates the rpc-vs-refresh race test off the `make_core(transport=...)` shim onto the new helper pair, plus `install_http_client_for_test` for the transport-install dance. No behavior change.

## Auth Instance Invariant note

Every reference across the live `NotebookLMClient` object graph must alias one shared mutable `AuthTokens` instance so `AuthRefreshCoordinator.update_auth_tokens` in-place mutations propagate everywhere. `self._auth` is set AFTER the `storage_path` rebind so it captures the same (possibly rebound) instance that flows into `compose_session_internals` (and therefore into `Session.auth`, `CookiePersistence`, the snapshot-provider lambdas at `_session_init.py:391` and `_session_init.py:453`, and `SourceUploadPipeline._auth` once that migrates in a later wave).

`self._auth` is unread by production at the end of this PR. It is set today only so the shell-client test helper (`tests/_helpers/session_factory.build_refresh_client_shell`) can mirror the production attribute shape from PR 1 onward, keeping test shells and production aligned across the intermediate PRs.

## Why a shell helper now (motivation)

The next wave deletes `Session.lifecycle`. Without this helper, every `NotebookLMClient.__new__` shell test that wires `client._session = core` would then have to be rewritten to reach around the deleted accessor. With this helper, shell tests source all four runtime fields directly from `ComposedSession` — the later `Session.lifecycle` deletion becomes mechanical with no shell-test ripple.

## Reference-discovery dump (Wave 0 baseline)

Reviewers can spot-check that every reference below is either migrated by this PR or intentionally retained for later waves.

### Protocol / cast surface

```
$ rg -n "_LifecycleHost|RefreshAuthCore|cast\(.*_LifecycleHost" src tests docs
src/notebooklm/_auth/session.py:17:    from .._session_lifecycle import ClientLifecycle, _LifecycleHost
src/notebooklm/_auth/session.py:20:class RefreshAuthCore(Protocol):
src/notebooklm/_auth/session.py:57:    core: RefreshAuthCore,
src/notebooklm/_auth/session.py:105:    # :class:`RefreshAuthCore` deliberately stays narrow (only declares
src/notebooklm/_auth/session.py:109:    await lifecycle.save_cookies(cast("_LifecycleHost", core), http_client.cookies)
src/notebooklm/_session_lifecycle.py:171:class _LifecycleHost(Protocol):
src/notebooklm/_session_lifecycle.py:308:    async def open(self, host: _LifecycleHost) -> None:
src/notebooklm/_session_lifecycle.py:369:        host: _LifecycleHost,
src/notebooklm/_session_lifecycle.py:391:    async def close(self, host: _LifecycleHost) -> None:
src/notebooklm/_session_lifecycle.py:471:    async def _keepalive_loop(self, host: _LifecycleHost, interval: float) -> None:
src/notebooklm/_session_lifecycle.py:546:    "_LifecycleHost",
src/notebooklm/_session.py:71:# because :class:`RefreshAuthCore` in ``_auth/session.py`` is the
src/notebooklm/_session.py:744:        Retained on Session because the :class:`RefreshAuthCore`
src/notebooklm/client.py:763:        :class:`RefreshAuthCore` and made ``lifecycle`` an explicit
tests/unit/test_auth_session.py:44:    ``RefreshAuthCore`` Protocol by exposing a ``_kernel`` slot with the
tests/unit/test_auth_session.py:98:        # :class:`RefreshAuthCore` — the ``collaborators`` property was
tests/unit/test_session_compat_delegates.py:20:    External Protocol surface (``RefreshAuthCore`` in ``_auth/session.py``)
tests/unit/test_session_lifecycle.py:61:    """Minimal :class:`_LifecycleHost`-conformant host for unit tests.
tests/unit/concurrency/test_session_close_refresh_race.py:56:    """Minimal :class:`_LifecycleHost` stand-in for the close path.
tests/_lint/test_session_retention.py:209:        "Session.update_auth_tokens is the RefreshAuthCore Protocol surface and "
tests/_lint/test_session_retention.py:284:        "| `update_auth_tokens` | RefreshAuthCore Protocol surface | retain — pinned |\n"
tests/_lint/test_session_retention.py:377:        "lazy collaborator factory | RefreshAuthCore Protocol surface | "
tests/_lint/test_client_composition.py:95:# operates on the ``RefreshAuthCore`` Protocol that explicitly declares
tests/_lint/test_client_composition.py:102:# accessors entirely, ``RefreshAuthCore`` will be reshaped to take the
docs/session-method-retention.md: <4 retention-table rows describing RefreshAuthCore Protocol surface>
docs/session-decoupling-plan-2026-05-26.md: <historical plan notes>
docs/architecture.md:425/477: <architecture index entries>
```

### `refresh_auth_session` callers / `self._session.lifecycle` reach-throughs

```
$ rg -n "refresh_auth_session\(|self\._session\.lifecycle" src tests docs
src/notebooklm/_auth/session.py:56:async def refresh_auth_session(
src/notebooklm/client.py:783:        return await refresh_auth_session(self._session, self._session.lifecycle)
tests/unit/test_auth_session.py:139:        refreshed_auth = await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:161:        await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:178:        await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:198:            await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:214:            await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:234:            await refresh_auth_session(core, core.lifecycle)
tests/unit/test_auth_session.py:290:        await refresh_auth_session(core, core._lifecycle)
docs/session-method-retention.md: <retention table rows>
docs/architecture.md:477: <index entry>
```

### Session auth/coord/kernel/lifecycle reach-throughs

```
$ rg -n "self\._session\.(auth|lifecycle|_lifecycle|_auth_coord|_kernel|_drain_tracker|_reqid|cookie_persistence)" src tests
src/notebooklm/_session.py:696:        ``self._session._drain_tracker`` (a private collaborator slot)
src/notebooklm/_session.py:713:        ``self._session._lifecycle`` (a private collaborator slot).
src/notebooklm/_session.py:714:        The previous ``self._session._lifecycle`` reach-through was
src/notebooklm/client.py:243:        # this field instead of the ``self._session.auth`` reach-through.   <-- NEW in this PR (docstring)
src/notebooklm/client.py:354:            auth=self._session.auth,
src/notebooklm/client.py:431:        return self._session.auth
src/notebooklm/client.py:783:        return await refresh_auth_session(self._session, self._session.lifecycle)
tests/unit/test_concurrency_refresh_race.py:504:        # ``refresh_auth`` reaches through ``self._session.auth``, but it   <-- NEW in this PR (comment)
tests/unit/test_client_keepalive.py:352:        ``self._session.auth.storage_path`` directly, not the keepalive-specific
```

### Direct callers of `Session.update_auth_*` (will die in a later wave)

```
$ rg -n "\.update_auth_headers\(|\.update_auth_tokens\(" tests src docs
src/notebooklm/_session.py:739:        self._auth_coord.update_auth_headers(auth=self.auth, kernel=self._kernel)
src/notebooklm/_session.py:758:        await self._auth_coord.update_auth_tokens(auth=self.auth, csrf=csrf, session_id=session_id)
src/notebooklm/_auth/session.py:96:    await core.update_auth_tokens(csrf or "", sid or "")
src/notebooklm/_auth/session.py:97:    core.update_auth_headers()
tests/unit/test_init_order.py:1137:        return self._core.update_auth_tokens(csrf, sid)
tests/unit/test_session_auth.py:174/210/281/314/323/356: <coord-direct calls in coord unit tests>
tests/integration/test_error_paths_vcr.py:225:            client._session.update_auth_headers()
tests/integration/test_auth_refresh_vcr.py:152:            client._session.update_auth_headers()
tests/integration/test_auto_refresh.py:61/113:            client._session.update_auth_headers()
tests/integration/test_session_integration.py:477/499/535:            core.update_auth_headers()
docs/session-method-retention.md: <retention rows>
docs/architecture.md:425: <index entry>
```

### `SourceUploadPipeline` auth wiring (must migrate in a later wave at `client.py:332`)

```
$ rg -n "SourceUploadPipeline\(|_source_upload\." src tests
src/notebooklm/client.py:349:        source_uploader = SourceUploadPipeline(
src/notebooklm/_sources.py:44-46: <attribute re-exports>
src/notebooklm/_middleware_drain.py:32: <docstring mention>
src/notebooklm/_session_contracts.py:21: <docstring mention>
src/notebooklm/_idempotency.py:709: <docstring mention>
tests/unit/test_source_upload_pipeline.py:141: <test construction>
tests/unit/test_env_base_url.py:106: <test construction>
tests/unit/test_sources_upload.py:92: <test construction>
tests/unit/test_observability.py:299: <test construction>
tests/unit/concurrency/test_loop_affinity_guard.py:257: <test construction>
tests/_fixtures/fake_core.py:11: <fixture mention>
tests/integration/test_sources_idempotency.py:4: <docstring mention>
tests/integration/test_sources_integration.py:31: <docstring mention>
tests/integration/concurrency/test_upload_blocks_loop.py:129: <test construction>
tests/_lint/test_no_legacy_rpc_callable_aliases.py:10: <lint reference>
```

### Compat-delegate inventory (list of methods the lint inspects)

```
$ rg -n "_DELEGATE_METHODS" tests
tests/unit/test_session_compat_delegates.py:51:_DELEGATE_METHODS = [
tests/unit/test_session_compat_delegates.py:93:@pytest.mark.parametrize("name", _DELEGATE_METHODS)
tests/unit/test_session_compat_delegates.py:121:@pytest.mark.parametrize("name", _DELEGATE_METHODS)
```

### `NotebookLMClient.__new__` shell tests

```
$ rg -n "NotebookLMClient\.__new__|client\._session\s*=" tests src
src/notebooklm/_session.py:717:        constructs a shell client via ``NotebookLMClient.__new__`` and
tests/_helpers/session_factory.py:189: <new helper docstring>
tests/_helpers/session_factory.py:210:    client = NotebookLMClient.__new__(NotebookLMClient)   <-- the canonical shell construction site
tests/_helpers/session_factory.py:211:    client._session = composed.session                    <-- migrated to helper in this PR
tests/unit/test_concurrency_refresh_race.py:502: <new docstring referencing pre-Wave-0 shape>
```

The only `NotebookLMClient.__new__` site outside the new helper is the comment-level reference in `test_concurrency_refresh_race.py` — the actual `__new__` call was moved into `build_refresh_client_shell` by this PR.

## Acceptance criteria (per Wave 0 spec)

- [x] Targeted baseline is green:
      `tests/unit/test_session_lifecycle.py tests/unit/test_auth_session.py tests/unit/concurrency/test_session_close_refresh_race.py tests/unit/test_concurrency_refresh_race.py tests/_lint/test_client_composition.py tests/_lint/test_session_retention.py` -> 58 passed
- [x] `ruff format --check`, `ruff check`, `mypy src/notebooklm` clean
- [x] `NotebookLMClient.__new__` shell tests no longer rely on only `client._session = core` (now use `build_refresh_client_shell`)
- [x] `NotebookLMClient.__init__` sets `self._auth = auth`; field is unread in production at end of PR
- [x] No other production code changes in this wave

## Test plan

- [x] Targeted unit + lint suites green inside the worktree
- [ ] CI green on the PR (full suite)
- [ ] `claude[bot]` review acknowledged + any threads resolved
- [ ] `coderabbitai` review acknowledged + any threads resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token refresh handling during concurrent operations to prevent corruption of in-flight requests and ensure a stable auth snapshot across simultaneous activity.
  * Clarified refresh lifecycle behavior so token updates are consistently visible to components that rely on the client’s auth state.

* **Chores**
  * Enhanced test infrastructure with new helpers and updated test scaffolding to better simulate and validate concurrency and refresh scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->