### PR TITLE
refactor(lifecycle): encapsulate drain and refresh state transitions

### DIFF
--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -339,5 +339,52 @@ class AuthRefreshCoordinator:
 
         await asyncio.shield(refresh_task)
 
+    async def cancel_inflight_refresh(self) -> None:
+        """Cancel any in-flight refresh task during ``ClientLifecycle.close``.
+
+        Mirrors the legacy close block previously inlined in
+        :meth:`ClientLifecycle.close` (Wave 1 of plan ``host-protocol-removal``)
+        so the lifecycle never touches the private ``_refresh_task`` slot
+        on this coordinator:
+
+        - **No-op** when ``_refresh_task is None`` — a freshly-opened client
+          that never triggered an auth refresh has no task to cancel.
+        - **No-op** when ``_refresh_task.done()`` — a refresh wave that
+          already finished must not be re-cancelled (it would be harmless
+          but ``gather(return_exceptions=True)`` would still log noise).
+        - **Cancel** an unfinished task and ``await`` it via
+          ``asyncio.gather(..., return_exceptions=True)`` so the resulting
+          :class:`asyncio.CancelledError` is absorbed and ``close()`` itself
+          stays non-raising in the normal racing case.
+
+        Slot-preservation invariant (CRITICAL — load-bearing): the
+        ``self._refresh_task`` slot is INTENTIONALLY left intact after a
+        cancel. Sibling waiters joined to the same single-flight refresh
+        (see :meth:`await_refresh` and the ``asyncio.shield`` it wraps
+        around the join) read the slot to identify the shared task; clearing
+        it here would break the concurrency invariant pinned by
+        ``tests/unit/test_session_auth.py::test_await_refresh_cancellation_preserves_task_slot``.
+        The slot is replaced only on the NEXT refresh wave once the current
+        task transitions to ``done()`` — never here, never in close.
+
+        Behavior is identical to the pre-Wave-1 inlined block:
+
+            refresh_task = host._auth_coord._refresh_task
+            if refresh_task is not None and not refresh_task.done():
+                refresh_task.cancel()
+                await asyncio.gather(refresh_task, return_exceptions=True)
+
+        Regression coverage:
+        ``tests/unit/concurrency/test_session_close_refresh_race.py`` and
+        the three focused unit tests added with this method in
+        ``tests/unit/test_session_auth.py`` (the two companion
+        ``reset_after_open`` tests for :class:`TransportDrainTracker` live
+        in ``tests/unit/test_session_lifecycle.py``).
+        """
+        refresh_task = self._refresh_task
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+            await asyncio.gather(refresh_task, return_exceptions=True)
+
 
 __all__ = ["AuthRefreshCoordinator"]

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -343,9 +343,13 @@ class ClientLifecycle:
         host._reqid.set_bound_loop(self._bound_loop)
         host._auth_coord.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
-        # admits new transport work again. Direct attribute write mirrors the
-        # legacy ``self._draining = False`` line.
-        host._drain_tracker._draining = False
+        # admits new transport work again. Wave 1 of plan
+        # ``host-protocol-removal`` encapsulated the legacy direct write
+        # ``host._drain_tracker._draining = False`` behind a method on the
+        # tracker so the lifecycle never reaches into private collaborator
+        # fields; the method is intentionally narrow (clears ``_draining``
+        # only, leaves in-flight counters intact — see its docstring).
+        host._drain_tracker.reset_after_open()
 
         # Delegate HTTP-client construction and open-time cookie baseline
         # capture to the concrete transport kernel. The lifecycle still owns
@@ -431,15 +435,16 @@ class ClientLifecycle:
             # racing against close would survive the close path and continue
             # holding the now-torn-down ``httpx.AsyncClient``, surfacing as a
             # confusing httpx error or a "coroutine was never awaited" GC
-            # warning. ``gather(..., return_exceptions=True)`` absorbs the
-            # ``CancelledError`` so close itself stays non-raising. We check
-            # both ``is None`` (no refresh has ever fired) and ``done()`` (a
-            # successful refresh wave already finished) so the cancel is a
-            # true no-op outside the racing case.
-            refresh_task = host._auth_coord._refresh_task
-            if refresh_task is not None and not refresh_task.done():
-                refresh_task.cancel()
-                await asyncio.gather(refresh_task, return_exceptions=True)
+            # warning. Wave 1 of plan ``host-protocol-removal`` encapsulated
+            # the cancel+gather block behind a method on the coordinator so
+            # the lifecycle never reaches into the private ``_refresh_task``
+            # slot; the method preserves both ``is None`` and ``done()``
+            # short-circuits (true no-op outside the racing case) AND the
+            # critical slot-preservation invariant (the ``_refresh_task``
+            # slot is NOT cleared on cancel — sibling waiters joined to the
+            # same single-flight refresh still observe the shared task).
+            # See :meth:`AuthRefreshCoordinator.cancel_inflight_refresh`.
+            await host._auth_coord.cancel_inflight_refresh()
 
             await host._drain_tracker.run_drain_hooks()
 

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -126,6 +126,30 @@ class TransportDrainTracker:
         """
         self._bound_loop = loop
 
+    def reset_after_open(self) -> None:
+        """Clear the drain flag so a reopened client admits new transport work.
+
+        Called from :meth:`ClientLifecycle.open` (immediately after the
+        per-collaborator ``set_bound_loop`` propagation and before the
+        ``Kernel.open`` await) so a previously-drained-then-reopened client
+        admits new top-level operations again. Encapsulates the legacy
+        direct write ``host._drain_tracker._draining = False`` (Wave 1 of
+        plan ``host-protocol-removal``) so the lifecycle never touches the
+        private ``_draining`` field on this collaborator.
+
+        Deliberately narrow: this resets ONLY the ``_draining`` flag. The
+        ``_in_flight_posts`` counter, ``_operation_depths`` map, and lazily
+        bound ``_drain_condition`` are left untouched — clearing those would
+        break the load-bearing in-flight bookkeeping invariants asserted by
+        ``tests/unit/test_observability.py::test_drain_allows_nested_work_inside_accepted_operation``
+        and ``tests/unit/concurrency/test_close_cancellation_leak.py``.
+        Field-level locking is intentionally not used here: the legacy
+        direct write was an unlocked assignment, asyncio is single-threaded,
+        and the assignment is atomic in CPython — adding a condition acquire
+        would only serialise a no-op against in-flight transport begins.
+        """
+        self._draining = False
+
     def get_drain_condition(self) -> asyncio.Condition:
         """Return the per-instance drain ``asyncio.Condition``, creating it lazily.
 

--- a/tests/unit/concurrency/test_session_close_refresh_race.py
+++ b/tests/unit/concurrency/test_session_close_refresh_race.py
@@ -9,21 +9,35 @@ lingering coroutine that pytest's
 "coroutine was never awaited" detector flagged at GC time.
 
 The fix is a small block in :meth:`ClientLifecycle.close` between
-keepalive teardown and ``save_cookies``:
+keepalive teardown and ``save_cookies``. The original inlined block
+(pre-Wave-1 of plan ``host-protocol-removal``) was::
 
     if host._auth_coord._refresh_task and not host._auth_coord._refresh_task.done():
         host._auth_coord._refresh_task.cancel()
         await asyncio.gather(host._auth_coord._refresh_task, return_exceptions=True)
 
-That block:
+Wave 1 of plan ``host-protocol-removal`` encapsulated that block behind
+:meth:`AuthRefreshCoordinator.cancel_inflight_refresh` so the lifecycle
+never reaches into the private ``_refresh_task`` slot. The close path
+now reads as::
+
+    await host._auth_coord.cancel_inflight_refresh()
+
+The encapsulating method preserves every aspect of the original block:
+
 1. Cancels the in-flight refresh task so the shared single-flight refresh
    wave unwinds cleanly.
 2. Awaits the cancellation via ``gather(..., return_exceptions=True)`` so
    ``CancelledError`` does not propagate out of ``close()``.
 3. Sits BEFORE the cookie save / shielded aclose so the refresh callback
    never observes a half-closed transport.
+4. PRESERVES ``self._refresh_task`` after the cancel — sibling waiters
+   joined to the same single-flight refresh still observe the shared task.
 
-These tests exercise both the cancel and the no-cancel-needed paths.
+These tests exercise both the cancel and the no-cancel-needed paths from
+the lifecycle entry point; the focused unit tests of
+:meth:`AuthRefreshCoordinator.cancel_inflight_refresh` itself live in
+``tests/unit/test_session_auth.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -505,3 +505,127 @@ async def test_await_refresh_cancellation_preserves_task_slot() -> None:
     await asyncio.wait_for(waiter_b, EVENT_TIMEOUT_S)
     assert shared_task.done()
     assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# AuthRefreshCoordinator.cancel_inflight_refresh — Wave 1 of
+# host-protocol-removal encapsulated the legacy close-time block
+# (previously read/cancel/gather of ``host._auth_coord._refresh_task``
+# inlined inside ``ClientLifecycle.close``) behind a method on the
+# coordinator. The three tests below pin the three behavioral branches
+# (no task, done task, in-flight task) AND the critical slot-preservation
+# invariant (the cancel path MUST NOT clear ``self._refresh_task``).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_coord_cancel_inflight_refresh_noops_without_task() -> None:
+    """``cancel_inflight_refresh`` is a true no-op when ``_refresh_task is None``.
+
+    A freshly-constructed coordinator (or an open client that never
+    triggered an auth refresh) has ``_refresh_task is None``. Close must
+    invoke ``cancel_inflight_refresh`` unconditionally, so the method has
+    to be safe against the ``None`` slot — calling ``.cancel()`` on ``None``
+    would crash the close path.
+    """
+    coord = AuthRefreshCoordinator()
+    assert coord._refresh_task is None
+
+    # Must not raise.
+    await coord.cancel_inflight_refresh()
+
+    # Slot stays None — the method had nothing to cancel.
+    assert coord._refresh_task is None
+
+
+@pytest.mark.asyncio
+async def test_auth_coord_cancel_inflight_refresh_noops_for_done_task() -> None:
+    """A refresh task that already finished must not be re-cancelled.
+
+    The ``done()`` short-circuit matters because the legacy block guarded
+    both ``is None`` and ``done()`` — a successful refresh wave that ran
+    to completion before ``close()`` arrives stashes the resolved task in
+    the slot. Re-cancelling it would be technically harmless (cancelling
+    a done task is a no-op) but the redundant ``gather(return_exceptions=True)``
+    would still cycle the event loop and potentially log noise on a
+    successful task that was about to be GC'd. The pin also guarantees
+    the slot-preservation contract: the done task stays in the slot.
+    """
+    coord = AuthRefreshCoordinator()
+
+    async def _quick_refresh() -> AuthTokens:
+        return _fresh_auth()
+
+    done_task = asyncio.create_task(_quick_refresh())
+    # Let it complete.
+    await done_task
+    assert done_task.done() and not done_task.cancelled()
+    # Snapshot the result so we can prove the task object was not touched
+    # by ``cancel_inflight_refresh``.
+    pre_result = done_task.result()
+
+    coord._refresh_task = done_task
+
+    await coord.cancel_inflight_refresh()
+
+    assert done_task.done()
+    assert not done_task.cancelled(), (
+        "cancel_inflight_refresh must not call .cancel() on an already-done "
+        "task — the done() short-circuit is load-bearing."
+    )
+    assert done_task.result() is pre_result, "done task's result was disturbed"
+    assert coord._refresh_task is done_task, (
+        "Slot-preservation invariant: cancel_inflight_refresh must not "
+        "clear the _refresh_task slot even on the no-op path."
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_coord_cancel_inflight_refresh_cancels_and_joins_pending_task() -> None:
+    """An in-flight refresh task gets cancelled, joined, and CancelledError absorbed.
+
+    This is the racing-close scenario the method was extracted for: a
+    refresh wave parked on Google's identity surface when ``close()``
+    arrives. The cancel cleans up the runaway task; the
+    ``gather(..., return_exceptions=True)`` absorbs the resulting
+    ``CancelledError`` so the close path itself stays non-raising.
+
+    Slot-preservation invariant (CRITICAL): even after cancelling the
+    in-flight task, ``self._refresh_task`` MUST still reference the same
+    cancelled task object. The next refresh wave is responsible for
+    replacing the slot once the existing task transitions to ``done()``
+    — never this method, never close. This is the same contract pinned by
+    ``test_await_refresh_cancellation_preserves_task_slot`` above, but for
+    the close-driven cancel path rather than waiter-driven cancel.
+    """
+    coord = AuthRefreshCoordinator()
+
+    async def _slow_refresh() -> AuthTokens:
+        await asyncio.sleep(60.0)
+        return _fresh_auth()  # unreachable in this test — cancel fires first.
+
+    slow_task: asyncio.Task[AuthTokens] = asyncio.create_task(_slow_refresh())
+    coord._refresh_task = slow_task
+
+    # Yield so the task actually parks on its sleep.
+    await asyncio.sleep(0)
+    assert not slow_task.done(), "test setup: refresh task should be in-flight"
+
+    # Drive cancel. Must NOT raise — CancelledError is absorbed by
+    # ``gather(return_exceptions=True)``.
+    await coord.cancel_inflight_refresh()
+
+    assert slow_task.done()
+    assert slow_task.cancelled(), (
+        "cancel_inflight_refresh must cancel the in-flight task — without "
+        "the cancel, a slow refresh would survive close() and continue "
+        "holding the now-torn-down http client."
+    )
+    assert coord._refresh_task is slow_task, (
+        "Slot-preservation invariant: cancel_inflight_refresh must NOT "
+        "clear the _refresh_task slot after cancelling the task. Sibling "
+        "waiters joined to the same single-flight refresh read this slot "
+        "to identify the shared task; clearing it here would break the "
+        "concurrency invariant pinned by "
+        "test_await_refresh_cancellation_preserves_task_slot."
+    )

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -53,6 +53,7 @@ from notebooklm._session_lifecycle import (
     _default_cookie_rotator,
     _default_cookie_saver,
 )
+from notebooklm._transport_drain import TransportDrainTracker
 from notebooklm.auth import AuthTokens
 from notebooklm.types import ConnectionLimits
 
@@ -66,10 +67,11 @@ class _StubHost:
     * ``auth`` — a real :class:`AuthTokens` so :meth:`ClientLifecycle.open`
       can read ``cookies`` / ``cookie_jar`` / ``storage_path``.
     * ``_metrics_obj`` / ``_drain_tracker`` / ``_auth_coord`` / ``_reqid`` —
-      ``MagicMock``s; the lifecycle touches
-      ``_drain_tracker._draining = False`` and calls ``set_bound_loop`` on
-      each of the three helpers (drain / reqid / auth_coord) from the
-      open() path so cross-loop misuse can be caught.
+      ``MagicMock``s; the lifecycle calls
+      ``_drain_tracker.reset_after_open()`` (Wave 1 of host-protocol-removal
+      replaced the legacy direct ``_drain_tracker._draining = False`` write)
+      and ``set_bound_loop`` on each of the three helpers (drain / reqid /
+      auth_coord) from the open() path so cross-loop misuse can be caught.
     * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
       coroutine; assertions check it was called with the right args.
     * ``_drain_tracker.run_drain_hooks`` — called by close(); set to an
@@ -93,16 +95,31 @@ class _StubHost:
         )
         self._metrics_obj = MagicMock()
         self._drain_tracker = MagicMock()
-        self._drain_tracker._draining = True  # so we can assert open() resets it
+        # ``open()`` calls ``host._drain_tracker.reset_after_open()`` (Wave 1
+        # of host-protocol-removal — the encapsulated form of the legacy
+        # ``_drain_tracker._draining = False`` write). The ``MagicMock``
+        # default lets the call land without configuring a side effect; the
+        # invocation is asserted by ``test_open_captures_bound_loop_and_resets_drain``.
+        # Seed ``_draining = True`` so a future regression that re-introduces
+        # a direct field read in the lifecycle would still see "drained".
+        self._drain_tracker._draining = True
         # Wave 2 of session-decoupling: drain hooks live on the tracker.
         # ``close()`` calls ``host._drain_tracker.run_drain_hooks()`` so the
         # mock needs an async implementation.
         self._drain_tracker.run_drain_hooks = AsyncMock()
         self._auth_coord = MagicMock()
-        # ``_auth_coord._refresh_task`` is checked by ``close()`` (P0-1).
-        # Default to ``None`` so the cancel branch is skipped; tests that
-        # exercise the in-flight-refresh path overwrite it.
+        # Wave 1 of host-protocol-removal: ``close()`` no longer reads the
+        # private ``_refresh_task`` slot directly — it calls the awaitable
+        # ``cancel_inflight_refresh`` method on the coordinator. Default
+        # ``MagicMock()`` would return a non-awaitable, so the stub needs an
+        # ``AsyncMock`` for that method. The real coordinator handles the
+        # no-op / already-done / in-flight branches internally (covered by
+        # the focused unit tests in ``tests/unit/test_session_auth.py``).
+        # ``_refresh_task`` is kept as ``None`` on the stub for
+        # forward-compatibility with any future test that probes the slot
+        # directly (the lifecycle itself no longer reads it).
         self._auth_coord._refresh_task = None
+        self._auth_coord.cancel_inflight_refresh = AsyncMock()
         # ``_reqid`` is targeted by ``set_bound_loop`` from open() (P0-2).
         self._reqid = MagicMock()
         self.cookie_persistence = MagicMock()
@@ -164,17 +181,34 @@ async def test_open_idempotent_preserves_existing_client() -> None:
 
 @pytest.mark.asyncio
 async def test_open_captures_bound_loop_and_resets_drain() -> None:
-    """``open()`` binds the running loop and clears the host drain flag."""
+    """``open()`` binds the running loop and calls ``reset_after_open`` on the tracker.
+
+    Wave 1 of plan ``host-protocol-removal`` encapsulated the legacy
+    direct write ``host._drain_tracker._draining = False`` behind
+    :meth:`TransportDrainTracker.reset_after_open`. The lifecycle's
+    obligation is now to CALL that method on every ``open()``; the
+    method's own behavior (clearing ``_draining`` while leaving
+    in-flight counters intact) is pinned by the focused unit tests
+    further down in this file.
+
+    Stubs ``host._drain_tracker`` as a ``MagicMock`` so this test
+    captures the call without depending on a real
+    :class:`TransportDrainTracker`. The companion full-stack
+    open-then-close test that exercises a real tracker lives in
+    ``tests/integration/`` (and the AST-guarded lint forbids any
+    lifecycle code from writing to ``_draining`` directly outside the
+    tracker itself, see the acceptance-criteria ``rg`` check in the
+    plan).
+    """
     lifecycle = _make_lifecycle()
     host = _StubHost()
-    assert host._drain_tracker._draining is True
     assert lifecycle._bound_loop is None
 
     await lifecycle.open(host)
 
     assert lifecycle._bound_loop is asyncio.get_running_loop()
     assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
-    assert host._drain_tracker._draining is False
+    host._drain_tracker.reset_after_open.assert_called_once_with()
 
     await lifecycle.close(host)
 
@@ -694,3 +728,92 @@ def test_init_wires_default_seams_when_none_supplied() -> None:
     )
     assert custom_lifecycle._cookie_saver is custom_saver
     assert custom_lifecycle._cookie_rotator is custom_rotator
+
+
+# ---------------------------------------------------------------------------
+# TransportDrainTracker.reset_after_open — Wave 1 of host-protocol-removal
+# encapsulated ``host._drain_tracker._draining = False`` (previously written
+# directly by ``ClientLifecycle.open``) behind a method on the tracker. The
+# method is intentionally narrow: it clears ONLY the ``_draining`` flag and
+# leaves in-flight counters / depth maps untouched. These two tests pin
+# both halves of that contract on the collaborator directly so a regression
+# in the tracker is caught without driving the full lifecycle open() path.
+# ---------------------------------------------------------------------------
+
+
+def test_drain_tracker_reset_after_open_clears_draining_flag() -> None:
+    """``reset_after_open`` flips ``_draining`` from ``True`` back to ``False``.
+
+    Pins the encapsulation of the legacy
+    ``host._drain_tracker._draining = False`` write performed inside
+    ``ClientLifecycle.open``. The behavior is the same — a tracker that was
+    previously drained, then re-opened, admits new top-level work again —
+    just routed through a named method instead of a direct field write.
+    """
+    tracker = TransportDrainTracker()
+    tracker._draining = True
+
+    tracker.reset_after_open()
+
+    assert tracker._draining is False
+
+
+@pytest.mark.asyncio
+async def test_drain_tracker_reset_after_open_does_not_touch_inflight_counts() -> None:
+    """``reset_after_open`` ONLY clears ``_draining`` — every other piece
+    of bookkeeping state is left intact.
+
+    Pins the "intentionally narrow" half of the encapsulation. If a
+    well-meaning maintainer "helpfully" expanded this method to also zero
+    ``_in_flight_posts`` or reset / clear ``_operation_depths``, the
+    load-bearing in-flight invariants asserted by
+    ``tests/unit/test_observability.py::test_drain_allows_nested_work_inside_accepted_operation``
+    and ``tests/unit/concurrency/test_close_cancellation_leak.py`` would
+    break. This regression test catches that expansion at the tracker
+    level so the failure points at the right code rather than surfacing
+    as a confusing in-flight count mismatch elsewhere.
+
+    Seeds an actual operation-depth entry (not just an identity-stable
+    empty map) so a regression that calls
+    ``self._operation_depths.clear()`` — which would preserve map identity
+    but wipe the contents — also fails this test. Async-marked so the
+    seeded task ``asyncio.current_task()`` returns a real task to key the
+    WeakKeyDictionary on.
+    """
+    tracker = TransportDrainTracker()
+    tracker._draining = True
+    # Seed non-default values so the assertions below would fail loudly
+    # if ``reset_after_open`` overwrote them.
+    tracker._in_flight_posts = 3
+    seed_task = asyncio.current_task()
+    assert seed_task is not None, "test runs under @pytest.mark.asyncio"
+    tracker._operation_depths[seed_task] = 2
+    pre_depths_id = id(tracker._operation_depths)
+
+    async def _drain_hook() -> None:
+        return None
+
+    tracker.register_drain_hook("seed_hook", _drain_hook)
+
+    tracker.reset_after_open()
+
+    assert tracker._draining is False, "the one flag this method *does* clear"
+    assert tracker._in_flight_posts == 3, (
+        "reset_after_open must not touch _in_flight_posts — clearing it "
+        "would lose track of in-flight operations and let drain() return "
+        "prematurely on the next close()."
+    )
+    assert id(tracker._operation_depths) == pre_depths_id, (
+        "reset_after_open must preserve the _operation_depths "
+        "WeakKeyDictionary identity — replacing it would orphan per-task "
+        "depth bookkeeping for already-admitted operations."
+    )
+    assert tracker._operation_depths.get(seed_task) == 2, (
+        "reset_after_open must not clear() _operation_depths contents — "
+        "a regression that wiped per-task depths would reject already-"
+        "admitted nested operations after the next open()."
+    )
+    assert "seed_hook" in tracker._drain_hooks, (
+        "reset_after_open must not touch registered drain hooks; feature "
+        "code registers them at construction-time on the tracker."
+    )


### PR DESCRIPTION
## Summary

Move the two direct private-field touches that `ClientLifecycle.open` and `ClientLifecycle.close` performed on its collaborators behind named methods on the collaborators themselves, so the lifecycle never reaches into `TransportDrainTracker._draining` or `AuthRefreshCoordinator._refresh_task`.

- `TransportDrainTracker.reset_after_open()` replaces the `host._drain_tracker._draining = False` write in `open()`. The method is intentionally narrow: it clears ONLY the drain flag and leaves `_in_flight_posts`, `_operation_depths`, `_drain_condition`, and registered drain hooks untouched.
- `AuthRefreshCoordinator.cancel_inflight_refresh()` replaces the read+cancel+gather block in `close()`. It preserves the existing semantics exactly (no-op when None, no-op when done, cancel+`await` with `return_exceptions=True` when in flight) AND preserves the load-bearing slot invariant — `self._refresh_task` is NOT cleared on cancel so sibling waiters joined to the same single-flight refresh still observe the shared task.

Lifecycle method signatures are unchanged in this PR (the host parameter shape still uses `_LifecycleHost`) — narrowing those signatures and deleting `_LifecycleHost` / `RefreshAuthCore` is Wave 2's atomic job.

## Plan reference

This is **Wave 1** of plan `host-protocol-removal`. See [`.sisyphus/phases/host-protocol-removal/phase-1.md`](.sisyphus/phases/host-protocol-removal/phase-1.md) (the Wave 1 section at lines ~509-565 of phase-1.md, plus the risk-matrix entries on "Close/refresh race changes" and "Drain gate reopens incorrectly").

Ships **in parallel with Wave 0** — no file overlap. Wave 0 (`host-protocol-removal/wave-0-shell-helper-and-auth-field`) touches `src/notebooklm/client.py`, `tests/_helpers/session_factory.py`, and `tests/unit/test_concurrency_refresh_race.py`. None of those are touched here.

## Acceptance criteria (from the plan)

- [x] Lifecycle no longer reads or writes `_drain_tracker._draining` or `_auth_coord._refresh_task` directly. Verification: `rg -n '_drain_tracker\._draining|_auth_coord\._refresh_task' src/notebooklm/_session_lifecycle.py` returns one match — a docstring/comment, no live code.
- [x] Existing close/refresh race tests pass: `uv run pytest tests/unit/test_session_lifecycle.py tests/unit/test_session_auth.py tests/unit/concurrency/test_session_close_refresh_race.py tests/unit/test_concurrency_refresh_race.py -q` → 50/50 pass.
- [x] Behavior unchanged before the Wave 2 signature migration — same field-write site in `open`, same cancel+gather semantics in `close`.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` green (178 source files).
- [x] `uv run ruff check src/notebooklm tests` and `uv run ruff format --check .` green.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit tests/integration -q` → 6797 passed, 94 skipped, 2 xfailed.

## New tests (5)

- `test_drain_tracker_reset_after_open_clears_draining_flag`
- `test_drain_tracker_reset_after_open_does_not_touch_inflight_counts` (async — seeds actual `_in_flight_posts`, `_operation_depths[task]`, and registered drain hooks so a regression that calls `.clear()` on the depth map fails)
- `test_auth_coord_cancel_inflight_refresh_noops_without_task`
- `test_auth_coord_cancel_inflight_refresh_noops_for_done_task`
- `test_auth_coord_cancel_inflight_refresh_cancels_and_joins_pending_task` (pins the slot-preservation invariant on the close-driven cancel path)

## Polish

- `/polish` ran with `claude` + `codex` (no `agy` per repo policy 2026-05-27 / 2026-05-28).
- 4 findings consolidated, all applied: 1 IMPORTANT (strengthen depth-map test to seed contents, not just identity) + 3 NIT (docstring fixups).
- 0 deferred findings.

## Deferred polish findings

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal coordination of session lifecycle and authentication refresh cancellation.
  * Enhanced encapsulation of client close and reopen operations for better reliability and cleaner state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->