### PR TITLE
refactor(session): atomic lifecycle + auth refresh decoupling

### DIFF
--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING
 
 from .._env import get_base_url
 from .._url_utils import is_google_auth_redirect
@@ -13,66 +12,38 @@ from .extraction import extract_wiz_field
 from .tokens import AuthTokens
 
 if TYPE_CHECKING:
+    from .._cookie_persistence import CookiePersistence
     from .._kernel import Kernel
-    from .._session_lifecycle import ClientLifecycle, _LifecycleHost
-
-
-class RefreshAuthCore(Protocol):
-    """Structural core boundary required by auth session refresh.
-
-    Wave 11b of session-decoupling (ADR-014): the live HTTP client is
-    sourced via ``core._kernel.get_http_client()`` instead of a
-    ``core.get_http_client()`` forward on ``Session``. The underscore-
-    prefixed ``_kernel`` slot mirrors the live ``Session._kernel``
-    attribute so structural conformance does not require renaming the
-    Session slot.
-
-    Wave 11c of session-decoupling: the ``save_cookies`` forward on
-    ``Session`` was deleted — :func:`refresh_auth_session` reached the
-    cookie persistence chokepoint through ``core.collaborators.lifecycle``.
-
-    Stage B1 PR 2 of the post-refactoring plan further narrowed this
-    Protocol: the ``collaborators`` property was deleted from
-    :class:`Session` along with the other Stage A accessors, so
-    :func:`refresh_auth_session` now takes ``lifecycle: ClientLifecycle``
-    as an explicit argument supplied by the caller
-    (:meth:`NotebookLMClient.refresh_auth` passes
-    ``self._collaborators.lifecycle``). The Protocol no longer needs a
-    ``collaborators`` field.
-    """
-
-    auth: AuthTokens
-    _kernel: Kernel
-
-    def update_auth_tokens(self, csrf: str, session_id: str) -> Awaitable[None]:
-        """Atomically update auth token scalars."""
-        ...
-
-    def update_auth_headers(self) -> None:
-        """Refresh auth-dependent HTTP state after token mutation."""
-        ...
+    from .._session_auth import AuthRefreshCoordinator
+    from .._session_lifecycle import ClientLifecycle
 
 
 async def refresh_auth_session(
-    core: RefreshAuthCore,
+    *,
+    auth: AuthTokens,
+    kernel: Kernel,
+    auth_coord: AuthRefreshCoordinator,
     lifecycle: ClientLifecycle,
+    cookie_persistence: CookiePersistence,
 ) -> AuthTokens:
     """Refresh NotebookLM auth tokens through the raw homepage session path.
 
-    Stage B1 PR 2 of the post-refactoring plan made ``lifecycle`` an
-    explicit second argument. Previously this function reached the
-    canonical cookie-persistence chokepoint through
-    ``core.collaborators.lifecycle`` (a Stage A accessor on
-    :class:`Session`). PR 2 deleted that accessor — :class:`Session` no
-    longer carries a ``collaborators`` property — so callers now pass
-    ``ClientLifecycle`` directly. The single production caller
-    (:meth:`NotebookLMClient.refresh_auth`) supplies
-    ``self._collaborators.lifecycle``.
+    Wave 2 of plan ``host-protocol-removal`` replaced the legacy
+    Session-shaped core Protocol + ``ClientLifecycle`` argument shape
+    with five explicit keyword-only collaborators. The previous shape
+    required a Session-aliased core that re-declared the underlying
+    private slots (``auth`` / ``_kernel`` / ``update_auth_tokens`` /
+    ``update_auth_headers``) and a separate ``cast`` to satisfy the
+    lifecycle's ``host``-shaped ``save_cookies`` signature; both have
+    been lifted now that every collaborator the refresh path needs is
+    in scope directly. The single production caller
+    (:meth:`NotebookLMClient.refresh_auth`) sources the five
+    collaborators from ``self._auth`` and ``self._collaborators``.
     """
-    http_client = core._kernel.get_http_client()
+    http_client = kernel.get_http_client()
     url = f"{get_base_url()}/"
-    if core.auth.account_email or core.auth.authuser:
-        url = f"{url}?{authuser_query(core.auth.authuser, core.auth.account_email)}"
+    if auth.account_email or auth.authuser:
+        url = f"{url}?{authuser_query(auth.authuser, auth.account_email)}"
     response = await http_client.get(url)
     response.raise_for_status()
 
@@ -93,19 +64,15 @@ async def refresh_auth_session(
 
     # Keep the csrf/session mutation centralized so RPC snapshots cannot
     # observe a torn token pair while refresh is in flight.
-    await core.update_auth_tokens(csrf or "", sid or "")
-    core.update_auth_headers()
+    await auth_coord.update_auth_tokens(auth=auth, csrf=csrf or "", session_id=sid or "")
+    auth_coord.update_auth_headers(auth=auth, kernel=kernel)
     # Persist through ``ClientLifecycle.save_cookies`` so refresh
-    # serializes with keepalive and close saves. The ``host`` argument
-    # of :meth:`ClientLifecycle.save_cookies` is read for its
-    # ``_metrics_obj`` / ``cookie_persistence`` attributes; ``Session``
-    # (the only production caller) satisfies that shape, and unit-test
-    # fakes mirror those attributes via a recording lifecycle. The
-    # ``cast`` is the typing-level acknowledgement that
-    # :class:`RefreshAuthCore` deliberately stays narrow (only declares
-    # what :func:`refresh_auth_session` reads); widening the Protocol
-    # would couple this module to the lifecycle's broader collaborator
-    # surface, which is what Stage B1 PR 2 is moving away from.
-    await lifecycle.save_cookies(cast("_LifecycleHost", core), http_client.cookies)
+    # serializes with keepalive and close saves. The lifecycle's
+    # ``save_cookies`` now takes the :class:`CookiePersistence`
+    # collaborator directly — Wave 2 of plan ``host-protocol-removal``
+    # narrowed the first positional argument from a Session-shaped
+    # ``host`` to the cookie-persistence collaborator the caller already
+    # holds, eliminating the prior ``cast`` to a Protocol-typed host.
+    await lifecycle.save_cookies(cookie_persistence, http_client.cookies)
 
-    return core.auth
+    return auth

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -67,10 +67,16 @@ logger = logging.getLogger(__name__)
 # coordinator method signatures take explicit ``auth`` / ``kernel``
 # collaborators (the Session-shaped ``_AuthRefreshHost`` Protocol was
 # deleted in favor of per-method explicit args).
-# ``Session.update_auth_tokens`` is retained as a delegate
-# because :class:`RefreshAuthCore` in ``_auth/session.py`` is the
-# structural Protocol used by ``refresh_auth_session`` and still
-# requires that method on the core. The AST guards in
+# ``Session.update_auth_tokens`` is retained as a delegate by the
+# retention contract pinned in ``docs/session-method-retention.md`` and
+# ``tests/_lint/test_session_retention.py``. Wave 2 of plan
+# ``host-protocol-removal`` lifted the only remaining production caller
+# (``refresh_auth_session``) off this delegate by giving the auth-session
+# refresh path explicit collaborator kwargs (it now invokes
+# ``auth_coord.update_auth_tokens(auth=..., csrf=..., session_id=...)``
+# directly); the Session delegate body itself is scheduled for deletion
+# in Wave 3 along with ``Session.update_auth_headers`` and the
+# retention-doc rows that pin them. The AST guards in
 # ``tests/unit/test_concurrency_refresh_race.py``
 # (``test_snapshot_acquires_auth_snapshot_lock`` /
 # ``test_update_auth_tokens_has_no_await_inside_mutation_block``)
@@ -637,6 +643,12 @@ class Session:
         intentionally replaces the loop binding; :meth:`close` does not
         unbind so an
         accidental cross-loop call after close still raises actionably.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed
+        :meth:`ClientLifecycle.open` to take explicit collaborator
+        kwargs; this forwarder unpacks its own collaborator aliases
+        and passes them through so the lifecycle never reaches back
+        through a Session-shaped host.
         """
         # Stage B1 PR 2 fail-fast: ensure full composition before
         # lifecycle work. The composition root
@@ -645,7 +657,13 @@ class Session:
         # here means the Session was instantiated outside the
         # composition root and is unusable.
         self._require_constructed("_transport")
-        await self._lifecycle.open(self)
+        await self._lifecycle.open(
+            auth=self.auth,
+            drain_tracker=self._drain_tracker,
+            auth_coord=self._auth_coord,
+            reqid=self._reqid,
+            cookie_persistence=self.cookie_persistence,
+        )
 
     async def close(self) -> None:
         """Close the HTTP client connection.
@@ -669,10 +687,19 @@ class Session:
         ``close()`` → ``open()`` cycles. See
         :mod:`tests.unit.test_lifecycle_executor_reuse` for the
         regression pin.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed
+        :meth:`ClientLifecycle.close` to take explicit collaborator
+        kwargs; this forwarder unpacks its own collaborator aliases
+        and passes them through.
         """
         # Stage B1 PR 2 fail-fast: same guard as :meth:`open`.
         self._require_constructed("_transport")
-        await self._lifecycle.close(self)
+        await self._lifecycle.close(
+            auth_coord=self._auth_coord,
+            drain_tracker=self._drain_tracker,
+            cookie_persistence=self.cookie_persistence,
+        )
 
     async def _keepalive_loop(self, interval: float) -> None:
         """Background loop that periodically pokes the identity surface.
@@ -680,8 +707,16 @@ class Session:
         Thin facade over :meth:`ClientLifecycle._keepalive_loop`. Retained
         as a ``Session`` method so ``test_client_keepalive`` and other
         tests that introspect ``core._keepalive_loop`` continue to resolve.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed
+        :meth:`ClientLifecycle._keepalive_loop` to take an explicit
+        ``cookie_persistence`` kwarg; this forwarder supplies the
+        Session's own collaborator alias.
         """
-        await self._lifecycle._keepalive_loop(self, interval)
+        await self._lifecycle._keepalive_loop(
+            cookie_persistence=self.cookie_persistence,
+            interval=interval,
+        )
 
     @property
     def is_open(self) -> bool:
@@ -741,17 +776,24 @@ class Session:
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
         """Delegate to :meth:`AuthRefreshCoordinator.update_auth_tokens`.
 
-        Retained on Session because the :class:`RefreshAuthCore`
-        Protocol in ``_auth/session.py`` (consumed by
-        :func:`refresh_auth_session`) structurally requires this method
-        on the core. PR 8 collapsed the previously real body into a
-        delegate that forwards through ``self._auth_coord``; PR #4b of
-        the session-refactor arc inlined sibling delegates but kept
-        this one for the Protocol caller. The coordinator now takes
-        ``auth`` explicitly and routes the lock-wait metric through its
-        own ``self._metrics`` (supplied at construction) instead of
-        reaching through a Session-shaped host. The AST guard for the
-        no-await mutation-block invariant lives on
+        Retained on Session by the retention contract pinned in
+        ``docs/session-method-retention.md`` and
+        ``tests/_lint/test_session_retention.py``. Wave 2 of plan
+        ``host-protocol-removal`` lifted the last production caller off
+        this delegate: :func:`refresh_auth_session` now invokes
+        ``auth_coord.update_auth_tokens(auth=..., csrf=...,
+        session_id=...)`` directly through the explicit-collaborator
+        kwargs introduced by that wave. The delegate body is scheduled
+        for deletion in Wave 3 once the retention-doc rows for this
+        method and :meth:`update_auth_headers` are also removed.
+        PR 8 collapsed the previously real body into a delegate that
+        forwards through ``self._auth_coord``; PR #4b of the
+        session-refactor arc inlined sibling delegates but kept this
+        one for the Protocol caller. The coordinator now takes ``auth``
+        explicitly and routes the lock-wait metric through its own
+        ``self._metrics`` (supplied at construction) instead of reaching
+        through a Session-shaped host. The AST guard for the no-await
+        mutation-block invariant lives on
         :meth:`AuthRefreshCoordinator.update_auth_tokens`
         (``test_concurrency_refresh_race.test_update_auth_tokens_has_no_await_inside_mutation_block``).
         """

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -75,7 +75,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -84,7 +84,6 @@ from ._session_config import CORE_LOGGER_NAME
 from .auth import AuthTokens
 
 if TYPE_CHECKING:
-    from ._client_metrics import ClientMetrics
     from ._cookie_persistence import CookiePersistence
     from ._reqid_counter import ReqidCounter
     from ._session_auth import AuthRefreshCoordinator
@@ -166,39 +165,6 @@ async def _default_cookie_rotator(*args: Any, **kwargs: Any) -> None:
 # tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
 # keep matching after the extraction.
 logger = logging.getLogger(CORE_LOGGER_NAME)
-
-
-class _LifecycleHost(Protocol):
-    """Structural host boundary required by :class:`ClientLifecycle`.
-
-    The Protocol pins exactly which collaborators the lifecycle reaches into
-    on the host, so future refactors that move state around ``Session``
-    surface as Protocol violations rather than silent ``AttributeError``s
-    at close-time. ``cookie_persistence`` mirrors today's public attribute
-    name on ``Session``; ``_metrics_obj``, ``_drain_tracker``, and
-    ``_auth_coord`` are helper handles.
-
-    Note: ``_drain_hooks`` was removed from this Protocol in Wave 2 of the
-    session-decoupling plan (ADR-014 Rule 1) — the storage and the
-    ``run_drain_hooks`` firing now live on ``TransportDrainTracker``, so
-    ``close()`` reaches them through ``host._drain_tracker`` instead.
-
-    Stage B1 PR 2 of the post-refactoring plan also removed
-    ``_rpc_executor`` from this Protocol. The lifecycle no longer nulls
-    the executor on :meth:`close` — the executor is bound by the
-    composition root (:func:`notebooklm._session.compose_session_internals`)
-    via :meth:`Session._bind_executor` and survives ``close()`` →
-    ``open()`` cycles. The lifecycle never reads or writes
-    ``_rpc_executor`` after that PR, so the Protocol no longer needs to
-    declare the field.
-    """
-
-    auth: AuthTokens
-    _metrics_obj: ClientMetrics
-    _drain_tracker: TransportDrainTracker
-    _auth_coord: AuthRefreshCoordinator
-    _reqid: ReqidCounter
-    cookie_persistence: CookiePersistence
 
 
 class ClientLifecycle:
@@ -305,7 +271,15 @@ class ClientLifecycle:
     # Open / close
     # ------------------------------------------------------------------
 
-    async def open(self, host: _LifecycleHost) -> None:
+    async def open(
+        self,
+        *,
+        auth: AuthTokens,
+        drain_tracker: TransportDrainTracker,
+        auth_coord: AuthRefreshCoordinator,
+        reqid: ReqidCounter,
+        cookie_persistence: CookiePersistence,
+    ) -> None:
         """Open the HTTP client connection.
 
         Idempotent: if ``_http_client`` is already non-``None`` this is a
@@ -321,6 +295,12 @@ class ClientLifecycle:
         :class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
         for the new substitution point. The httpx transport built here is
         always a real, unwrapped transport.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed this signature
+        from the legacy ``host`` Protocol to explicit
+        keyword-only collaborators so the lifecycle never reaches into
+        ``host.<X>`` attributes; the caller (:meth:`Session.open`) unpacks
+        its own aliases and passes them through.
         """
         if self._http_client is not None:
             return
@@ -339,9 +319,9 @@ class ClientLifecycle:
         # loop through ``Session.bound_loop`` (which reads
         # ``ClientLifecycle.get_bound_loop()``) so no further propagation
         # is needed there.
-        host._drain_tracker.set_bound_loop(self._bound_loop)
-        host._reqid.set_bound_loop(self._bound_loop)
-        host._auth_coord.set_bound_loop(self._bound_loop)
+        drain_tracker.set_bound_loop(self._bound_loop)
+        reqid.set_bound_loop(self._bound_loop)
+        auth_coord.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
         # admits new transport work again. Wave 1 of plan
         # ``host-protocol-removal`` encapsulated the legacy direct write
@@ -349,28 +329,31 @@ class ClientLifecycle:
         # tracker so the lifecycle never reaches into private collaborator
         # fields; the method is intentionally narrow (clears ``_draining``
         # only, leaves in-flight counters intact — see its docstring).
-        host._drain_tracker.reset_after_open()
+        drain_tracker.reset_after_open()
 
         # Delegate HTTP-client construction and open-time cookie baseline
         # capture to the concrete transport kernel. The lifecycle still owns
         # loop binding and open/close ordering.
         await self._kernel.open(
-            auth=host.auth,
+            auth=auth,
             timeout=self._timeout,
             connect_timeout=self._connect_timeout,
             limits=self._limits,
-            capture_cookie_snapshot=host.cookie_persistence.capture_open_snapshot,
+            capture_cookie_snapshot=cookie_persistence.capture_open_snapshot,
         )
 
         # Spawn the keepalive task once the client is ready.
         if self._keepalive_interval is not None:
             self._keepalive_task = asyncio.create_task(
-                self._keepalive_loop(host, self._keepalive_interval)
+                self._keepalive_loop(
+                    cookie_persistence=cookie_persistence,
+                    interval=self._keepalive_interval,
+                )
             )
 
     async def save_cookies(
         self,
-        host: _LifecycleHost,
+        cookie_persistence: CookiePersistence,
         jar: httpx.Cookies,
         path: Path | None = None,
     ) -> None:
@@ -384,15 +367,28 @@ class ClientLifecycle:
         its body so a ``monkeypatch.setattr`` on the canonical seam keeps
         affecting the live save path through the wrapper. Custom callables
         bypass the late-bind hop entirely.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed the first
+        positional argument from the legacy ``host`` Protocol
+        Protocol to the :class:`CookiePersistence` collaborator
+        directly. Callers (lifecycle ``close`` / keepalive loop,
+        :func:`refresh_auth_session`) pass the collaborator they already
+        hold rather than a Session-shaped host wrapper.
         """
-        await host.cookie_persistence.save(
+        await cookie_persistence.save(
             jar,
             path,
             save_cookies_to_storage=self._cookie_saver,
             to_thread=asyncio.to_thread,
         )
 
-    async def close(self, host: _LifecycleHost) -> None:
+    async def close(
+        self,
+        *,
+        auth_coord: AuthRefreshCoordinator,
+        drain_tracker: TransportDrainTracker,
+        cookie_persistence: CookiePersistence,
+    ) -> None:
         """Close the HTTP client connection.
 
         Cancellation safety: the entire close sequence is wrapped in
@@ -421,6 +417,11 @@ class ClientLifecycle:
         its ``httpx.AsyncClient`` on each :meth:`open`, so the executor
         continues to operate against the fresh transport state without
         a fresh executor instance.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed this signature
+        from the legacy ``host`` Protocol to explicit
+        keyword-only collaborators; the caller (:meth:`Session.close`)
+        unpacks its own aliases and passes them through.
         """
         try:
             # Stop the keepalive task before tearing down the HTTP client so
@@ -444,9 +445,9 @@ class ClientLifecycle:
             # slot is NOT cleared on cancel — sibling waiters joined to the
             # same single-flight refresh still observe the shared task).
             # See :meth:`AuthRefreshCoordinator.cancel_inflight_refresh`.
-            await host._auth_coord.cancel_inflight_refresh()
+            await auth_coord.cancel_inflight_refresh()
 
-            await host._drain_tracker.run_drain_hooks()
+            await drain_tracker.run_drain_hooks()
 
             if self._http_client:
                 try:
@@ -455,7 +456,7 @@ class ClientLifecycle:
                     # naturally with any keepalive save still finishing in a
                     # worker thread — close() owns the freshest jar and must
                     # win, not the older snapshot.
-                    await self.save_cookies(host, self._kernel.cookies)
+                    await self.save_cookies(cookie_persistence, self._kernel.cookies)
                 except Exception as e:
                     logger.warning("Failed to sync refreshed cookies during close: %s", e)
         finally:
@@ -473,7 +474,12 @@ class ClientLifecycle:
     # Keepalive
     # ------------------------------------------------------------------
 
-    async def _keepalive_loop(self, host: _LifecycleHost, interval: float) -> None:
+    async def _keepalive_loop(
+        self,
+        *,
+        cookie_persistence: CookiePersistence,
+        interval: float,
+    ) -> None:
         """Background loop that periodically pokes the identity surface.
 
         Sleeps ``interval`` seconds between iterations, then calls
@@ -492,6 +498,13 @@ class ClientLifecycle:
 
         Both classes never propagate; the loop only exits via
         :class:`asyncio.CancelledError` from :meth:`close`.
+
+        Wave 2 of plan ``host-protocol-removal`` narrowed this signature
+        from the legacy ``host`` Protocol to the
+        :class:`CookiePersistence` collaborator (used for the per-iteration
+        cookie save). :meth:`open` spawns the task with the same
+        ``cookie_persistence`` it received, so the loop saves through the
+        same collaborator the open path captured.
         """
         logger.debug("Keepalive task started (interval=%.1fs)", interval)
         # Rotation is delegated to ``self._cookie_rotator`` (Phase 2 PR 3
@@ -530,7 +543,7 @@ class ClientLifecycle:
 
                 try:
                     # save_cookies handles snapshot + lock + off-load.
-                    await self.save_cookies(host, client.cookies)
+                    await self.save_cookies(cookie_persistence, client.cookies)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:  # noqa: BLE001
@@ -548,7 +561,6 @@ __all__ = [
     "ClientLifecycle",
     "CookieRotator",
     "CookieSaver",
-    "_LifecycleHost",
     "_default_cookie_rotator",
     "_default_cookie_saver",
 ]

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -759,26 +759,20 @@ class NotebookLMClient:
         This helps prevent 'Session Expired' errors by obtaining a fresh CSRF
         token (SNlM0e) and session ID (FdrFJe).
 
-        Stage B1 PR 2 of the post-refactoring plan narrowed
-        :class:`RefreshAuthCore` and made ``lifecycle`` an explicit
-        argument; the call site supplies the lifecycle directly rather
-        than letting :func:`refresh_auth_session` reach through a
-        deleted ``Session.collaborators`` Stage A accessor. The
-        lifecycle is sourced from :attr:`Session.lifecycle` — a narrow
-        read-only accessor — rather than from the client's owned
-        ``_collaborators`` bundle so a ``NotebookLMClient`` shell built
-        via ``__new__`` (used in
-        ``tests/unit/test_concurrency_refresh_race.py``, constructed
-        through the
+        Wave 2 of plan ``host-protocol-removal`` rewired this call site
+        onto explicit collaborators sourced from ``self._auth`` and
+        ``self._collaborators``; the call no longer reaches through
+        ``self._session.<X>`` accessors. The five kwargs mirror the new
+        :func:`refresh_auth_session` signature: ``auth`` is the
+        client-owned :class:`AuthTokens` instance (the Auth Instance
+        Invariant guarantees this is the same object the composed
+        Session also aliases), and the remaining four come from the
+        collaborator bundle the composition root produced
+        (:func:`compose_session_internals`). The
         ``tests/_helpers/session_factory.build_refresh_client_shell``
-        helper that wires ``_session`` / ``_auth`` /
-        ``_collaborators`` / ``_rpc_executor`` from the composed
-        bundle) still works: the helper does not call ``__init__``,
-        so ``client._session.lifecycle`` is the resolution path that
-        works without widening the constructor surface. Wave 2 of the
-        host-protocol-removal plan rewires this call site onto
-        ``self._auth`` and an explicit lifecycle collaborator; this
-        docstring will move with the call when that happens.
+        helper wires ``_auth`` and ``_collaborators`` from the composed
+        bundle directly, so test shells observe the same resolution
+        path without going through ``Session``.
 
         Returns:
             Updated AuthTokens.
@@ -786,7 +780,13 @@ class NotebookLMClient:
         Raises:
             ValueError: If token extraction fails (page structure may have changed).
         """
-        return await refresh_auth_session(self._session, self._session.lifecycle)
+        return await refresh_auth_session(
+            auth=self._auth,
+            kernel=self._collaborators.kernel,
+            auth_coord=self._collaborators.auth_coord,
+            lifecycle=self._collaborators.lifecycle,
+            cookie_persistence=self._collaborators.cookie_persistence,
+        )
 
 
 class _FromStorageContext:

--- a/tests/unit/concurrency/test_session_close_refresh_race.py
+++ b/tests/unit/concurrency/test_session_close_refresh_race.py
@@ -67,11 +67,21 @@ def _make_auth() -> AuthTokens:
 
 
 class _StubHost:
-    """Minimal :class:`_LifecycleHost` stand-in for the close path.
+    """Collaborator bundle for the close-path race tests.
 
-    Tests assign ``_auth_coord._refresh_task`` directly when they need to
-    exercise the in-flight-refresh branch; the default of ``None`` matches
-    the post-``__init__``-real-host shape (no refresh has fired yet).
+    Wave 2 of plan ``host-protocol-removal`` narrowed
+    :meth:`ClientLifecycle.close` to take explicit keyword-only
+    collaborators (``auth_coord`` / ``drain_tracker`` /
+    ``cookie_persistence``); this stub remains as a convenience
+    aggregate that each test passes through the module-level
+    :func:`_close` adapter, so the assignment-then-cancel choreography
+    around ``_auth_coord._refresh_task`` stays a single readable
+    statement instead of five-line kwarg unpacking at every call site.
+
+    Tests assign ``_auth_coord._refresh_task`` directly when they need
+    to exercise the in-flight-refresh branch; the default of ``None``
+    matches the post-``__init__``-real-host shape (no refresh has fired
+    yet).
     """
 
     def __init__(self) -> None:
@@ -86,6 +96,21 @@ class _StubHost:
         # ``TransportDrainTracker``; the host no longer carries ``_drain_hooks``.
         # The real tracker constructed above already has its own ``_drain_hooks``.
         self._rpc_executor = None
+
+
+async def _close(lifecycle: ClientLifecycle, host: _StubHost) -> None:
+    """Adapter that forwards a :class:`_StubHost` bundle into the new
+    explicit-kwargs :meth:`ClientLifecycle.close` signature.
+
+    Wave 2 of plan ``host-protocol-removal`` narrowed the close method;
+    this helper keeps the per-test call sites a single line while still
+    exercising the new signature.
+    """
+    await lifecycle.close(
+        auth_coord=host._auth_coord,
+        drain_tracker=host._drain_tracker,
+        cookie_persistence=host.cookie_persistence,
+    )
 
 
 def _make_lifecycle() -> ClientLifecycle:
@@ -147,7 +172,7 @@ async def test_close_cancels_in_flight_refresh_task() -> None:
     assert not slow_task.done(), "test setup: refresh task should be in-flight"
 
     # Drive close. Must NOT raise.
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
     # Yield to let the cancellation propagate. ``gather`` inside ``close``
     # already awaited, so the task should be done by now.
@@ -179,7 +204,7 @@ async def test_close_with_no_refresh_task_is_a_noop_on_that_path() -> None:
     assert host._auth_coord._refresh_task is None
 
     # Must not raise.
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
     assert lifecycle._http_client is None
 
 
@@ -210,7 +235,7 @@ async def test_close_with_completed_refresh_task_does_not_recancel() -> None:
     host._auth_coord._refresh_task = done_task  # type: ignore[assignment]
 
     # Close must not re-cancel a done task.
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
     assert not done_task.cancelled()
     assert done_task.done()

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1146,7 +1146,8 @@ class TestBaselineNotAdvancedOnSaveFailure:
             baseline_before = client._session.cookie_persistence.loaded_cookie_snapshot
             assert client._session._kernel.http_client is not None
             await client._session._lifecycle.save_cookies(
-                client._session, client._session._kernel.get_http_client().cookies
+                client._session.cookie_persistence,
+                client._session._kernel.get_http_client().cookies,
             )
             baseline_after = client._session.cookie_persistence.loaded_cookie_snapshot
 
@@ -1355,11 +1356,11 @@ class TestCASRejectReturnsFalse:
                     cookie["value"] = "sibling"
             _write_storage(storage, cookies)
 
-            await core._lifecycle.save_cookies(core, jar_with("sid1"))
+            await core._lifecycle.save_cookies(core.cookie_persistence, jar_with("sid1"))
             assert _cookie_value(storage, "SID", ".google.com") == "sid1"
             assert _cookie_value(storage, "__Secure-1PSIDTS", ".google.com") == "sibling"
 
-            await core._lifecycle.save_cookies(core, jar_with("sid2"))
+            await core._lifecycle.save_cookies(core.cookie_persistence, jar_with("sid2"))
             assert _cookie_value(storage, "SID", ".google.com") == "sid2", (
                 "The successful SID delta from the partial save must advance "
                 "baseline; otherwise the next SID rotation CAS-rejects against "
@@ -1549,7 +1550,9 @@ class TestCASVariantAware:
             # holds. Run the second save through the real Session plumbing.
             assert core._kernel.http_client is not None
             _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "SIBLING")
-            await core._lifecycle.save_cookies(core, core._kernel.get_http_client().cookies)
+            await core._lifecycle.save_cookies(
+                core.cookie_persistence, core._kernel.get_http_client().cookies
+            )
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "SIBLING", (
                 "Second save must not re-clobber the sibling write — the "
@@ -1566,7 +1569,9 @@ class TestCASVariantAware:
             )
 
             _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "NEXT")
-            await core._lifecycle.save_cookies(core, core._kernel.get_http_client().cookies)
+            await core._lifecycle.save_cookies(
+                core.cookie_persistence, core._kernel.get_http_client().cookies
+            )
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "NEXT", (
                 "After convergence advances the baseline, a later OSID "
@@ -1700,8 +1705,8 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
 
         try:
             await asyncio.gather(
-                core._lifecycle.save_cookies(core, jar_a),
-                core._lifecycle.save_cookies(core, jar_b),
+                core._lifecycle.save_cookies(core.cookie_persistence, jar_a),
+                core._lifecycle.save_cookies(core.cookie_persistence, jar_b),
             )
         finally:
             await core.close()

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -38,11 +38,12 @@ def _auth(**overrides: object) -> AuthTokens:
 class _RecordingKernel:
     """Stub kernel exposing :meth:`get_http_client`.
 
-    Wave 11b of session-decoupling routes ``refresh_auth_session`` through
-    ``core._kernel.get_http_client()`` rather than the deleted
-    ``Session.get_http_client`` forward. Test cores satisfy the new
-    ``RefreshAuthCore`` Protocol by exposing a ``_kernel`` slot with the
-    same one-method shape.
+    Wave 2 of plan ``host-protocol-removal`` narrowed
+    :func:`refresh_auth_session` to take ``kernel`` as an explicit
+    keyword-only argument; this stub mirrors the production
+    :class:`Kernel` shape that satisfies ``kernel.get_http_client()``
+    so tests can drive the refresh path without standing up the full
+    transport stack.
     """
 
     def __init__(self, http_client: httpx.AsyncClient) -> None:
@@ -55,13 +56,12 @@ class _RecordingKernel:
 class _RecordingLifecycle:
     """Lifecycle stub matching the ``ClientLifecycle.save_cookies`` shape.
 
-    Wave 11c of session-decoupling deleted the ``Session.save_cookies``
-    Protocol surface; :func:`refresh_auth_session` now reaches the
-    canonical cookie-persistence chokepoint through
-    ``core.collaborators.lifecycle.save_cookies(core, jar, path)``. The
-    ``host`` (``core``) argument is forwarded as-is — for these unit
-    tests it's the :class:`RecordingRefreshCore` itself, since the real
-    save path is not exercised here.
+    Wave 2 of plan ``host-protocol-removal`` narrowed
+    :meth:`ClientLifecycle.save_cookies` to take the
+    :class:`CookiePersistence` collaborator directly as its first
+    positional argument (was: a Session-shaped ``host``). The recorded
+    ``cookie_persistence`` argument is forwarded as-is — for these unit
+    tests it's the bundle's own ``_RecordingCookiePersistence`` stub.
     """
 
     def __init__(self) -> None:
@@ -70,7 +70,7 @@ class _RecordingLifecycle:
 
     async def save_cookies(
         self,
-        host: Any,
+        cookie_persistence: Any,
         jar: httpx.Cookies,
         path: Path | None = None,
     ) -> None:
@@ -79,50 +79,90 @@ class _RecordingLifecycle:
         self.saved_jars.append(jar)
 
 
+class _RecordingAuthCoord:
+    """Coordinator stub recording ``update_auth_tokens`` /
+    ``update_auth_headers`` calls.
+
+    Wave 2 of plan ``host-protocol-removal`` lifted
+    :func:`refresh_auth_session` off the legacy Session-shaped ``core``
+    Protocol; the function now invokes
+    ``auth_coord.update_auth_tokens(auth=..., csrf=..., session_id=...)``
+    and ``auth_coord.update_auth_headers(auth=..., kernel=...)``
+    directly. The recording stub mirrors those new keyword-only
+    signatures and routes the token mutation through the shared
+    ``AuthTokens`` instance, so post-refresh assertions on
+    ``auth.csrf_token`` / ``.session_id`` still work.
+    """
+
+    def __init__(self, operations: list[str]) -> None:
+        self._operations = operations
+
+    async def update_auth_tokens(self, *, auth: AuthTokens, csrf: str, session_id: str) -> None:
+        self._operations.append("update_auth_tokens")
+        auth.csrf_token = csrf
+        auth.session_id = session_id
+
+    def update_auth_headers(self, *, auth: AuthTokens, kernel: Any) -> None:
+        self._operations.append("update_auth_headers")
+
+
 @dataclass
-class RecordingRefreshCore:
+class RecordingRefreshBundle:
+    """Aggregates the five collaborators :func:`refresh_auth_session`
+    now takes, with a shared operations log so tests can assert
+    end-to-end ordering across the auth-coord and lifecycle stubs.
+
+    Wave 2 of plan ``host-protocol-removal`` decoupled
+    :func:`refresh_auth_session` from a Session-shaped core; this
+    bundle replaces the prior ``RecordingRefreshCore`` shell with a
+    typed collection of the new explicit kwargs.
+    """
+
     auth: AuthTokens
     http_client: httpx.AsyncClient
-    _own_operations: list[str] = field(default_factory=list)
+    operations: list[str] = field(default_factory=list)
     lifecycle: _RecordingLifecycle = field(default_factory=_RecordingLifecycle)
 
     def __post_init__(self) -> None:
-        # Mirror the live ``Session._kernel`` slot — the Wave 11b Protocol
-        # change reaches the live HTTP client via
-        # ``core._kernel.get_http_client()``.
-        self._kernel = _RecordingKernel(self.http_client)
-        # Wire the lifecycle's operations list to share storage with ours so
-        # the legacy ``core.operations`` ordering ([..., "save_cookies"])
-        # still matches without forcing tests to read from two separate
-        # logs. Stage B1 PR 2 of the post-refactoring plan narrowed
-        # :class:`RefreshAuthCore` — the ``collaborators`` property was
-        # dropped along with the deleted ``Session.collaborators`` Stage A
-        # accessor, and :func:`refresh_auth_session` now takes
-        # ``lifecycle`` as an explicit positional argument. Tests pass
-        # ``core.lifecycle`` directly.
-        self.lifecycle.operations = self._own_operations
-
-    @property
-    def operations(self) -> list[str]:
-        """Combined operation log — recordings from this core plus the lifecycle."""
-        return self._own_operations
+        self.kernel = _RecordingKernel(self.http_client)
+        # Share storage so the legacy ordering
+        # (``[..., "save_cookies"]``) still resolves through a single
+        # log without re-aggregating two test-side lists.
+        self.lifecycle.operations = self.operations
+        self.auth_coord = _RecordingAuthCoord(self.operations)
+        # ``refresh_auth_session`` invokes
+        # ``lifecycle.save_cookies(cookie_persistence, jar)`` — the
+        # stub forwards the collaborator unchanged into its operations
+        # log, so a sentinel object is enough here.
+        self.cookie_persistence: Any = object()
 
     @property
     def saved_jars(self) -> list[httpx.Cookies]:
         """Back-compat passthrough so existing assertions still read the recorded jars."""
         return self.lifecycle.saved_jars
 
-    async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
-        self._own_operations.append("update_auth_tokens")
-        self.auth.csrf_token = csrf
-        self.auth.session_id = session_id
-
-    def update_auth_headers(self) -> None:
-        self._own_operations.append("update_auth_headers")
-
 
 def _client(handler: httpx.MockTransport | httpx.AsyncBaseTransport) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=handler, follow_redirects=True)
+
+
+def _invoke(bundle: RecordingRefreshBundle):
+    """Forward a :class:`RecordingRefreshBundle` into the new
+    :func:`refresh_auth_session` kwarg shape.
+
+    Wave 2 of plan ``host-protocol-removal`` made the five
+    collaborators (``auth`` / ``kernel`` / ``auth_coord`` /
+    ``lifecycle`` / ``cookie_persistence``) keyword-only on the
+    refresh entry point; this helper keeps the per-test call sites a
+    single readable expression.
+    """
+    return refresh_auth_session(
+        auth=bundle.auth,
+        kernel=bundle.kernel,  # type: ignore[arg-type]
+        auth_coord=bundle.auth_coord,  # type: ignore[arg-type]
+        lifecycle=bundle.lifecycle,  # type: ignore[arg-type]
+        cookie_persistence=bundle.cookie_persistence,
+    )
 
 
 @pytest.mark.asyncio
@@ -134,16 +174,16 @@ async def test_refresh_auth_session_default_account_uses_bare_base_url() -> None
         return httpx.Response(200, text=REFRESH_HTML, request=request)
 
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(_auth(), http_client)
+        bundle = RecordingRefreshBundle(_auth(), http_client)
 
-        refreshed_auth = await refresh_auth_session(core, core.lifecycle)
+        refreshed_auth = await _invoke(bundle)
 
     assert requests == [httpx.URL("https://notebooklm.google.com/")]
-    assert refreshed_auth is core.auth
+    assert refreshed_auth is bundle.auth
     assert refreshed_auth.csrf_token == "new_csrf_token_123"
     assert refreshed_auth.session_id == "new_session_id_456"
-    assert core.operations == ["update_auth_tokens", "update_auth_headers", "save_cookies"]
-    assert core.saved_jars == [http_client.cookies]
+    assert bundle.operations == ["update_auth_tokens", "update_auth_headers", "save_cookies"]
+    assert bundle.saved_jars == [http_client.cookies]
 
 
 @pytest.mark.asyncio
@@ -156,9 +196,9 @@ async def test_refresh_auth_session_selected_account_uses_account_email_url() ->
 
     auth = _auth(authuser=2, account_email="bob@example.com")
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(auth, http_client)
+        bundle = RecordingRefreshBundle(auth, http_client)
 
-        await refresh_auth_session(core, core.lifecycle)
+        await _invoke(bundle)
 
     assert requests == [httpx.URL("https://notebooklm.google.com/?authuser=bob%40example.com")]
 
@@ -173,9 +213,9 @@ async def test_refresh_auth_session_selected_account_uses_authuser_url() -> None
 
     auth = _auth(authuser=2)
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(auth, http_client)
+        bundle = RecordingRefreshBundle(auth, http_client)
 
-        await refresh_auth_session(core, core.lifecycle)
+        await _invoke(bundle)
 
     assert requests == [httpx.URL("https://notebooklm.google.com/?authuser=2")]
 
@@ -192,12 +232,12 @@ async def test_refresh_auth_session_detects_login_redirect() -> None:
         return httpx.Response(200, text="<html>Please sign in</html>", request=request)
 
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(_auth(), http_client)
+        bundle = RecordingRefreshBundle(_auth(), http_client)
 
         with pytest.raises(ValueError, match="Authentication expired"):
-            await refresh_auth_session(core, core.lifecycle)
+            await _invoke(bundle)
 
-    assert core.operations == []
+    assert bundle.operations == []
 
 
 @pytest.mark.asyncio
@@ -208,16 +248,16 @@ async def test_refresh_auth_session_missing_csrf_wraps_extraction_error() -> Non
         return httpx.Response(200, text=html, request=request)
 
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(_auth(), http_client)
+        bundle = RecordingRefreshBundle(_auth(), http_client)
 
         with pytest.raises(ValueError) as exc_info:
-            await refresh_auth_session(core, core.lifecycle)
+            await _invoke(bundle)
 
     message = str(exc_info.value)
     assert "Failed to extract CSRF token (SNlM0e)." in message
     assert "Preview:" in message
     assert "\n" not in message
-    assert core.operations == []
+    assert bundle.operations == []
 
 
 @pytest.mark.asyncio
@@ -228,16 +268,16 @@ async def test_refresh_auth_session_missing_session_id_wraps_extraction_error() 
         return httpx.Response(200, text=html, request=request)
 
     async with _client(httpx.MockTransport(handler)) as http_client:
-        core = RecordingRefreshCore(_auth(), http_client)
+        bundle = RecordingRefreshBundle(_auth(), http_client)
 
         with pytest.raises(ValueError) as exc_info:
-            await refresh_auth_session(core, core.lifecycle)
+            await _invoke(bundle)
 
     message = str(exc_info.value)
     assert "Failed to extract session ID (FdrFJe)." in message
     assert "Preview:" in message
     assert "\n" not in message
-    assert core.operations == []
+    assert bundle.operations == []
 
 
 @pytest.mark.asyncio
@@ -280,14 +320,19 @@ async def test_refresh_auth_session_persists_through_client_core_save_cookies(
     install_http_client_for_test(core._kernel, http_client)
     core.cookie_persistence.capture_open_snapshot(http_client.cookies)
     try:
-        # The real ``Session`` exposes its lifecycle as the private
-        # ``_lifecycle`` slot — the only attribute on ``Session`` that
-        # carries the :class:`ClientLifecycle`. The
-        # :class:`RecordingRefreshCore` stub above exposes it as
-        # ``lifecycle`` (no underscore) to match the new explicit
-        # argument shape; real Session callers (NotebookLMClient.refresh_auth)
-        # similarly pass ``self._collaborators.lifecycle``.
-        await refresh_auth_session(core, core._lifecycle)
+        # Wave 2 of plan ``host-protocol-removal`` made every dependency
+        # of :func:`refresh_auth_session` an explicit keyword-only
+        # collaborator. Drive the real Session's collaborators through
+        # the new entry point so the persistence path goes through the
+        # production ``ClientLifecycle.save_cookies`` → ``CookiePersistence``
+        # → ``asyncio.to_thread(fake_save_cookies_to_storage)`` plumbing.
+        await refresh_auth_session(
+            auth=core.auth,
+            kernel=core._kernel,
+            auth_coord=core._auth_coord,
+            lifecycle=core._lifecycle,
+            cookie_persistence=core.cookie_persistence,
+        )
     finally:
         await http_client.aclose()
         install_http_client_for_test(core._kernel, None)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -317,7 +317,20 @@ class TestRefreshAuth:
         httpx_mock: HTTPXMock,
         monkeypatch,
     ):
-        """refresh_auth delegates token mutation through Session."""
+        """refresh_auth delegates token mutation through the auth-refresh coordinator.
+
+        Wave 2 of plan ``host-protocol-removal`` rewired
+        :meth:`NotebookLMClient.refresh_auth` to call
+        :func:`refresh_auth_session` with explicit collaborator kwargs
+        — the token-mutation hop now invokes
+        ``auth_coord.update_auth_tokens(auth=..., csrf=..., session_id=...)``
+        directly instead of going through the ``Session.update_auth_tokens``
+        delegate. Tests that want to observe the mutation patch the
+        coordinator method (matching the new keyword-only signature) and
+        read the live ``AuthTokens`` instance via ``client._auth``, which
+        the Auth Instance Invariant keeps aliased with the composed
+        Session's ``auth`` attribute.
+        """
         client = NotebookLMClient(mock_auth)
         html = '"SNlM0e":"new_csrf_token_123" "FdrFJe":"new_session_id_456"'
         httpx_mock.add_response(
@@ -326,12 +339,12 @@ class TestRefreshAuth:
         )
         calls: list[tuple[str, str]] = []
 
-        async def fake_update(csrf: str, session_id: str) -> None:
+        async def fake_update(*, auth, csrf: str, session_id: str) -> None:
             calls.append((csrf, session_id))
-            client._session.auth.csrf_token = csrf
-            client._session.auth.session_id = session_id
+            auth.csrf_token = csrf
+            auth.session_id = session_id
 
-        monkeypatch.setattr(client._session, "update_auth_tokens", fake_update)
+        monkeypatch.setattr(client._collaborators.auth_coord, "update_auth_tokens", fake_update)
 
         async with client:
             refreshed_auth = await client.refresh_auth()
@@ -339,9 +352,9 @@ class TestRefreshAuth:
         assert calls == [("new_csrf_token_123", "new_session_id_456")]
         assert refreshed_auth.csrf_token == "new_csrf_token_123"
         assert refreshed_auth.session_id == "new_session_id_456"
-        assert client._session.auth is refreshed_auth
-        assert client._session.auth.csrf_token == "new_csrf_token_123"
-        assert client._session.auth.session_id == "new_session_id_456"
+        assert client._auth is refreshed_auth
+        assert client._auth.csrf_token == "new_csrf_token_123"
+        assert client._auth.session_id == "new_session_id_456"
 
     @pytest.mark.asyncio
     async def test_refresh_auth_routes_to_account_email(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -491,7 +491,7 @@ class TestSaveCookiesUnification:
         core = build_session_for_tests(auth, cookie_saver=spy)
         core_ref["core"] = core
 
-        await core._lifecycle.save_cookies(core, httpx.Cookies())
+        await core._lifecycle.save_cookies(core.cookie_persistence, httpx.Cookies())
 
         assert lock_held_during_save == [True], (
             "save_cookies must hold _save_lock for the duration of "

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -88,7 +88,7 @@ async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thre
         _auth_tokens(tmp_path / "storage_state.json"), cookie_saver=fake_save
     )
 
-    await core._lifecycle.save_cookies(core, _jar())
+    await core._lifecycle.save_cookies(core.cookie_persistence, _jar())
 
     assert calls == ["to_thread", "save"]
 

--- a/tests/unit/test_save_lock_contract.py
+++ b/tests/unit/test_save_lock_contract.py
@@ -89,7 +89,7 @@ async def test_save_lock_acquired_off_event_loop_thread(
     core = _make_core(tmp_path, cookie_saver=spy)
     core_ref["core"] = core
 
-    await core._lifecycle.save_cookies(core, httpx.Cookies())
+    await core._lifecycle.save_cookies(core.cookie_persistence, httpx.Cookies())
 
     assert observed["lock_held"] is True, (
         "save_cookies must hold _save_lock for the duration of "
@@ -157,7 +157,9 @@ async def test_save_lock_does_not_block_event_loop(
         loop_observations.append(core.cookie_persistence.save_lock.locked())
         release_save.set()
 
-    await asyncio.gather(core._lifecycle.save_cookies(core, httpx.Cookies()), heartbeat())
+    await asyncio.gather(
+        core._lifecycle.save_cookies(core.cookie_persistence, httpx.Cookies()), heartbeat()
+    )
 
     assert loop_observations == [True], (
         "Event loop must remain responsive while _save_lock is held by a "

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -16,11 +16,11 @@ Specifically pinned here:
 * ``_bound_loop`` **mismatch raises ``RuntimeError``** — the cross-loop guard
   in :meth:`SessionTransport.perform_authed_post` reads ``_bound_loop`` through
   the lifecycle and raises actionably when the loops differ.
-* :meth:`ClientLifecycle.save_cookies` **invokes** the host's
-  ``cookie_persistence.save`` collaborator with the right ``jar`` and
-  ``path`` arguments AND with the ``save_cookies_to_storage`` value resolved
-  from ``notebooklm._core`` at call time (so the monkeypatch surface keeps
-  working).
+* :meth:`ClientLifecycle.save_cookies` **invokes** the
+  :class:`CookiePersistence` collaborator's ``save`` method with the right
+  ``jar`` and ``path`` arguments AND with the ``save_cookies_to_storage``
+  value resolved from ``notebooklm._core`` at call time (so the monkeypatch
+  surface keeps working).
 * The httpx ``AsyncClient`` **always uses httpx's default transport** —
   Tier-12 PR 12.6 lifted synthetic-error injection into the chain
   (:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`)
@@ -32,8 +32,13 @@ Specifically pinned here:
   at ``keepalive_min_interval`` so a sub-floor user value gets bumped up.
 
 Tests are intentionally helper-shaped (instantiate :class:`ClientLifecycle`
-directly with a Protocol-conformant stub host) so they cover the lifecycle
-without taking on a ``Session`` dependency.
+directly with a stub collaborator bundle) so they cover the lifecycle
+without taking on a ``Session`` dependency. Wave 2 of plan
+``host-protocol-removal`` narrowed the lifecycle method signatures from
+the legacy Session-shaped ``host`` Protocol to explicit keyword-only
+collaborators; the :class:`_StubHost` fixture now serves purely as a
+convenience bundle, paired with module-level :func:`_open` / :func:`_close`
+adapters that unpack the bundle into the new kwarg shape.
 """
 
 from __future__ import annotations
@@ -59,19 +64,28 @@ from notebooklm.types import ConnectionLimits
 
 
 class _StubHost:
-    """Minimal :class:`_LifecycleHost`-conformant host for unit tests.
+    """Test-side collaborator bundle for :class:`ClientLifecycle` unit tests.
 
-    Mirrors the live ``Session`` shape with simple ``MagicMock`` /
-    ``AsyncMock`` stand-ins for the collaborators the lifecycle reaches into:
+    Wave 2 of plan ``host-protocol-removal`` narrowed the four
+    :class:`ClientLifecycle` methods to take explicit keyword-only
+    collaborators rather than a Session-shaped ``host`` Protocol. This
+    fixture survives as a convenience bundle — it holds the same set of
+    stub collaborators every lifecycle test needs (auth, drain tracker,
+    auth coordinator, reqid counter, cookie persistence) in one place,
+    so each test can do ``lifecycle.open(auth=host.auth,
+    drain_tracker=host._drain_tracker, ...)`` without re-building five
+    mocks at every call site.
+
+    Mirrors the live ``Session`` attribute names for grep continuity:
 
     * ``auth`` — a real :class:`AuthTokens` so :meth:`ClientLifecycle.open`
       can read ``cookies`` / ``cookie_jar`` / ``storage_path``.
-    * ``_metrics_obj`` / ``_drain_tracker`` / ``_auth_coord`` / ``_reqid`` —
-      ``MagicMock``s; the lifecycle calls
-      ``_drain_tracker.reset_after_open()`` (Wave 1 of host-protocol-removal
-      replaced the legacy direct ``_drain_tracker._draining = False`` write)
-      and ``set_bound_loop`` on each of the three helpers (drain / reqid /
-      auth_coord) from the open() path so cross-loop misuse can be caught.
+    * ``_drain_tracker`` / ``_auth_coord`` / ``_reqid`` — ``MagicMock``s;
+      the lifecycle calls ``_drain_tracker.reset_after_open()`` (Wave 1
+      of host-protocol-removal replaced the legacy direct
+      ``_drain_tracker._draining = False`` write) and ``set_bound_loop``
+      on each of the three helpers (drain / reqid / auth_coord) from the
+      open() path so cross-loop misuse can be caught.
     * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
       coroutine; assertions check it was called with the right args.
     * ``_drain_tracker.run_drain_hooks`` — called by close(); set to an
@@ -93,10 +107,9 @@ class _StubHost:
             cookies={"SID": "v1"},
             storage_path=None,
         )
-        self._metrics_obj = MagicMock()
         self._drain_tracker = MagicMock()
-        # ``open()`` calls ``host._drain_tracker.reset_after_open()`` (Wave 1
-        # of host-protocol-removal — the encapsulated form of the legacy
+        # ``open()`` calls ``drain_tracker.reset_after_open()`` (Wave 1 of
+        # host-protocol-removal — the encapsulated form of the legacy
         # ``_drain_tracker._draining = False`` write). The ``MagicMock``
         # default lets the call land without configuring a side effect; the
         # invocation is asserted by ``test_open_captures_bound_loop_and_resets_drain``.
@@ -104,8 +117,8 @@ class _StubHost:
         # a direct field read in the lifecycle would still see "drained".
         self._drain_tracker._draining = True
         # Wave 2 of session-decoupling: drain hooks live on the tracker.
-        # ``close()`` calls ``host._drain_tracker.run_drain_hooks()`` so the
-        # mock needs an async implementation.
+        # ``close()`` calls ``drain_tracker.run_drain_hooks()`` so the mock
+        # needs an async implementation.
         self._drain_tracker.run_drain_hooks = AsyncMock()
         self._auth_coord = MagicMock()
         # Wave 1 of host-protocol-removal: ``close()`` no longer reads the
@@ -128,7 +141,8 @@ class _StubHost:
         # Stage B1 PR 2 dropped the close-time null on ``_rpc_executor``;
         # the slot is left as-set by the composition root. Set a stable
         # sentinel here in case future regression tests want to assert
-        # the value is untouched across an open/close cycle.
+        # the value is untouched across an open/close cycle. The lifecycle
+        # itself no longer reads this slot.
         self._rpc_executor: Any = "RPC_EXECUTOR_SENTINEL"
 
 
@@ -152,6 +166,34 @@ def _make_lifecycle(
     )
 
 
+async def _open(lifecycle: ClientLifecycle, host: _StubHost) -> None:
+    """Adapter that forwards a :class:`_StubHost` bundle into the new
+    explicit-kwargs :meth:`ClientLifecycle.open` signature.
+
+    Wave 2 of plan ``host-protocol-removal`` narrowed the lifecycle to
+    take collaborators by keyword instead of a Session-shaped host. The
+    test fixtures still bundle the collaborators into a stub for
+    convenience; this helper bridges the two shapes so each test stays
+    a single readable line.
+    """
+    await lifecycle.open(
+        auth=host.auth,
+        drain_tracker=host._drain_tracker,
+        auth_coord=host._auth_coord,
+        reqid=host._reqid,
+        cookie_persistence=host.cookie_persistence,
+    )
+
+
+async def _close(lifecycle: ClientLifecycle, host: _StubHost) -> None:
+    """Adapter for :meth:`ClientLifecycle.close` — see :func:`_open`."""
+    await lifecycle.close(
+        auth_coord=host._auth_coord,
+        drain_tracker=host._drain_tracker,
+        cookie_persistence=host.cookie_persistence,
+    )
+
+
 # ---------------------------------------------------------------------------
 # open() — idempotency, bound-loop capture, AsyncClient construction
 # ---------------------------------------------------------------------------
@@ -163,12 +205,12 @@ async def test_open_idempotent_preserves_existing_client() -> None:
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     first_client = lifecycle._http_client
     assert first_client is not None
     assert lifecycle.is_open()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     second_client = lifecycle._http_client
 
     assert second_client is first_client, (
@@ -176,7 +218,7 @@ async def test_open_idempotent_preserves_existing_client() -> None:
         "should preserve the existing AsyncClient instance, not build a fresh one."
     )
 
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
 
 @pytest.mark.asyncio
@@ -204,13 +246,13 @@ async def test_open_captures_bound_loop_and_resets_drain() -> None:
     host = _StubHost()
     assert lifecycle._bound_loop is None
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
 
     assert lifecycle._bound_loop is asyncio.get_running_loop()
     assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
     host._drain_tracker.reset_after_open.assert_called_once_with()
 
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
 
 @pytest.mark.asyncio
@@ -220,9 +262,9 @@ async def test_open_close_open_rebinds_loop() -> None:
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     bound_after_first_open = lifecycle._bound_loop
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
     # close() does NOT clear _bound_loop — the cross-loop guard fires on the
     # next call against a different loop if the user mistakenly hands the
@@ -231,10 +273,10 @@ async def test_open_close_open_rebinds_loop() -> None:
     assert lifecycle.is_open() is False
 
     # Re-open on the same loop. New AsyncClient instance; same bound loop.
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     assert lifecycle._bound_loop is asyncio.get_running_loop()
     assert lifecycle.is_open() is True
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
 
 
 @pytest.mark.asyncio
@@ -247,14 +289,14 @@ async def test_open_captures_cookie_snapshot() -> None:
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     try:
         host.cookie_persistence.capture_open_snapshot.assert_called_once()
         passed_jar = host.cookie_persistence.capture_open_snapshot.call_args.args[0]
         # The jar passed to capture is the AsyncClient's live jar.
         assert passed_jar is lifecycle._http_client.cookies  # type: ignore[union-attr]
     finally:
-        await lifecycle.close(host)
+        await _close(lifecycle, host)
 
 
 # ---------------------------------------------------------------------------
@@ -279,13 +321,13 @@ async def test_open_uses_default_httpx_transport_by_default(
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     try:
         client = lifecycle._http_client
         assert client is not None
         assert isinstance(client._transport, httpx.AsyncHTTPTransport)
     finally:
-        await lifecycle.close(host)
+        await _close(lifecycle, host)
 
 
 @pytest.mark.asyncio
@@ -305,13 +347,13 @@ async def test_open_uses_default_httpx_transport_when_env_var_set(
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     try:
         client = lifecycle._http_client
         assert client is not None
         assert isinstance(client._transport, httpx.AsyncHTTPTransport)
     finally:
-        await lifecycle.close(host)
+        await _close(lifecycle, host)
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +372,7 @@ async def test_close_cancels_keepalive_cleanly() -> None:
     lifecycle = _make_lifecycle(keepalive_interval=0.01)
     host = _StubHost()
 
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     task = lifecycle._keepalive_task
     assert task is not None
     assert not task.done()
@@ -338,7 +380,7 @@ async def test_close_cancels_keepalive_cleanly() -> None:
     # Yield once so the keepalive task actually parks on its sleep.
     await asyncio.sleep(0)
 
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
     assert lifecycle._keepalive_task is None, (
         "close() must null out _keepalive_task after the cancel+gather."
     )
@@ -354,7 +396,7 @@ async def test_close_when_never_opened_is_noop() -> None:
     host = _StubHost()
 
     # No exception, no state churn beyond what's already None/sentinel.
-    await lifecycle.close(host)
+    await _close(lifecycle, host)
     assert lifecycle._http_client is None
     assert lifecycle._keepalive_task is None
 
@@ -391,8 +433,8 @@ async def test_close_runs_drain_hooks_before_transport_teardown() -> None:
 
     lifecycle._kernel.aclose = recording_aclose  # type: ignore[method-assign]
 
-    await lifecycle.open(host)
-    await lifecycle.close(host)
+    await _open(lifecycle, host)
+    await _close(lifecycle, host)
 
     assert events == ["run_drain_hooks", "kernel_aclose"], (
         f"close() must run drain hooks before kernel.aclose(); got {events}"
@@ -435,7 +477,7 @@ async def test_save_cookies_invokes_cookie_persistence(
     jar.set("SID", "v2", domain=".google.com")
     target_path = tmp_path / "storage_state.json"
 
-    await lifecycle.save_cookies(host, jar, target_path)
+    await lifecycle.save_cookies(host.cookie_persistence, jar, target_path)
 
     host.cookie_persistence.save.assert_awaited_once()
     call = host.cookie_persistence.save.call_args
@@ -476,11 +518,11 @@ async def test_bound_loop_get_returns_running_loop_after_open() -> None:
     host = _StubHost()
 
     assert lifecycle.get_bound_loop() is None
-    await lifecycle.open(host)
+    await _open(lifecycle, host)
     try:
         assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
     finally:
-        await lifecycle.close(host)
+        await _close(lifecycle, host)
 
 
 def test_bound_loop_mismatch_via_session_raises_runtime_error() -> None:


### PR DESCRIPTION
## Summary

Wave 2 of plan [`host-protocol-removal/phase-1.md`](.sisyphus/phases/host-protocol-removal/phase-1.md) — the **atomic decoupling PR** that ships the full graph in one PR. An earlier draft tried to split this into two waves; both Codex iter-1 and Claude iter-2 multi-model review flagged it as unsafe to subset (any subset migration leaves at least one caller passing the wrong shape to `save_cookies`).

What ships:

- **`ClientLifecycle.{open,close,_keepalive_loop,save_cookies}` signatures narrow** from a Session-shaped `host: _LifecycleHost` Protocol to explicit keyword-only collaborators (`auth`, `drain_tracker`, `auth_coord`, `reqid`, `cookie_persistence`). `save_cookies` takes `CookiePersistence` as its first positional arg.
- **`_LifecycleHost` Protocol deleted** from `_session_lifecycle.py` (also drops `__all__` entry + unused `ClientMetrics` TYPE_CHECKING import).
- **`Session.open / close / _keepalive_loop` become explicit-collaborator forwarders** that unpack their own aliases into the new kwarg shape.
- **`refresh_auth_session` takes five explicit kwargs** (`auth`, `kernel`, `auth_coord`, `lifecycle`, `cookie_persistence`); `RefreshAuthCore` Protocol + `typing.cast` import + cast call all deleted.
- **`NotebookLMClient.refresh_auth` body** sources the five kwargs from `self._auth` and `self._collaborators` (no `self._session.<X>` reads in the refresh path anymore).

## Atomicity

The graph that forces atomicity: `_auth/session.py:109` previously called `lifecycle.save_cookies(cast("_LifecycleHost", core), ...)`. Both `close()` and `_keepalive_loop()` also call `save_cookies(host, ...)`. `refresh_auth_session(core, lifecycle)` IS the cast site; `client.py:761` passes `self._session` as the core. Any subset migration leaves at least one caller passing the wrong shape. The smallest correct atomic boundary is the full graph.

## Invariants preserved

- **Slot-preservation invariant**: `cancel_inflight_refresh()` (added in Wave 1) is unchanged — the `_refresh_task` slot is still NOT cleared on cancel, so sibling waiters joined to the same single-flight refresh observe the shared task.
- **Auth Instance Invariant**: `self._auth` and `composed.session.auth` continue to alias the exact same `AuthTokens` instance flowed through `compose_session_internals`, so `auth_coord.update_auth_tokens(auth=auth, ...)` in-place mutations propagate everywhere they did before.
- **`Session.update_auth_tokens` / `update_auth_headers` bodies survive this wave** (deletion scheduled for Wave 3 once the retention-doc rows + lint also drop them); they have no production caller after this wave.

## Test migrations (per plan task 11)

- `tests/unit/test_session_lifecycle.py` — `_StubHost` survives as a convenience collaborator bundle; new module-level `_open` / `_close` adapters forward bundles into the new kwarg shape so per-test call sites stay one line.
- `tests/unit/concurrency/test_session_close_refresh_race.py` — same pattern with a local `_close` adapter.
- `tests/unit/test_auth_session.py` — `RecordingRefreshCore` replaced with `RecordingRefreshBundle` + per-test `_invoke` adapter; new `_RecordingAuthCoord` stub matches the keyword-only `update_auth_tokens(*, auth, csrf, session_id)` / `update_auth_headers(*, auth, kernel)` signatures.
- `tests/unit/test_client.py` — `monkeypatch.setattr(client._session, "update_auth_tokens", fake)` migrates to `client._collaborators.auth_coord.update_auth_tokens`; the fake now takes the keyword-only kwargs; `client._session.auth.<field>` mutations + reads migrate to `client._auth.<field>` (Auth Instance Invariant keeps the two aliased).
- `tests/unit/{test_save_lock_contract,test_cookie_persistence,test_client_keepalive,test_auth_cookie_save_race}.py` — `core._lifecycle.save_cookies(core, jar)` → `core._lifecycle.save_cookies(core.cookie_persistence, jar)` (4 files, 6 call sites, mechanical replace).

## Test plan

- [x] `uv run ruff format --check .` clean.
- [x] `uv run ruff check .` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (178 source files).
- [x] `uv run pytest tests/unit -q` green (6190 passed, 50 skipped, 2 xfailed).
- [x] `uv run pytest tests/integration -q` green (649 passed, 2 skipped).
- [x] No source file contains `_LifecycleHost`, `RefreshAuthCore`, or `cast("_LifecycleHost"`.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal authentication and session lifecycle management underwent refactoring to improve code clarity and maintainability. Protocol abstractions were replaced with explicit keyword-only dependency injection, enabling cleaner separation of concerns while preserving all existing functionality and behavior across client authentication and session operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->