### PR TITLE
test(lint): guard session runtime boundaries — close host-protocol-removal

### DIFF
--- a/docs/adr/0014-feature-local-runtime-adapters.md
+++ b/docs/adr/0014-feature-local-runtime-adapters.md
@@ -462,6 +462,30 @@ post-migration table and example code earlier in this ADR document the
 historical Rule 2 satisfier pattern; this revision-history note is the
 authoritative current-state pointer.
 
+### 2026-05-28 — Host-protocol removal (plan `host-protocol-removal`)
+
+Lifecycle / auth refresh no longer consume Session-shaped host
+protocols (host-protocol-removal plan, Waves 1-3, PRs #1131-#1134).
+The `_LifecycleHost` and `RefreshAuthCore` Protocols and the
+`typing.cast(_LifecycleHost, core)` site in `_auth/session.py` were
+deleted in Wave 2 (PR #1133); `refresh_auth_session` now takes the
+five concrete collaborators (`auth`, `kernel`, `auth_coord`,
+`lifecycle`, `cookie_persistence`) as keyword-only arguments and
+`ClientLifecycle.save_cookies` takes the `CookiePersistence`
+collaborator directly. Wave 3 (PR #1134) deleted the Session-level
+auth/lifecycle forwards (`Session.lifecycle`, `Session.update_auth_tokens`,
+`Session.update_auth_headers`) the retired Protocols had backed;
+`NotebookLMClient.auth` now reads `self._auth` directly (set in
+`__init__`) and `SourceUploadPipeline(auth=self._auth)` is wired the
+same way. Wave 4 (PR for this revision) added regression lints under
+`tests/_lint/test_session_runtime_boundaries.py` plus extensions to
+`test_client_composition.py` (the `self._session.<X>` allowlist) and
+`test_session_retention.py` (Wave 3 deletion pin) so neither host
+Protocol nor the deleted Session forwards can quietly come back.
+The auth-refresh path is now fully explicit-collaborator-driven and
+ADR-014 Rule 3 holds end-to-end on the refresh code path as it
+already did on the feature constructors.
+
 ## Related decisions
 
 - Builds on [ADR-013](./0013-composable-session-capabilities.md) (capability

--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -18,6 +18,27 @@ must carry a `retain — <reason>` disposition. No method may be tagged
 `delete in Wave 11` (the cluster deletions have all landed; the
 transitional disposition is gone from the recognised set).
 
+Plan [`host-protocol-removal`](../.sisyphus/phases/host-protocol-removal/phase-1.md)
+closed on 2026-05-28 with Waves 0-4. The retained Session surface is now
+the **Inventory** table below in full: the four lifecycle hot-path
+entries (`open` / `close` / `is_open` / `_keepalive_loop`), the
+`__init__` constructor, the `drain` public-API forward, the
+`assert_bound_loop` / `_get_rpc_semaphore` provider-closure capture
+targets, and the Stage B1 composition primitives (`_bind_transport`,
+`_bind_chain_metadata`, `_bind_executor`, `_require_constructed`).
+Stage A accessors (`collaborators` / `session_transport` / `rpc_executor`)
+were deleted in Stage B1 PR 2 of the post-refactoring plan and are
+recorded in the **Deleted** section below; the chain leaf
+(`_authed_post_chain_terminal`) and the retry-budget tunables live on
+`MiddlewareChainHost` per the [Chain-ownership carve-out](#chain-ownership-carve-out-closed)
+section. Wave 4 of `host-protocol-removal` added regression lints
+([`tests/_lint/test_session_runtime_boundaries.py`](../tests/_lint/test_session_runtime_boundaries.py),
+[`tests/_lint/test_client_composition.py::test_client_self_session_access_is_allowlisted`](../tests/_lint/test_client_composition.py),
+[`tests/_lint/test_session_retention.py::test_wave_3_deletions_stay_out_of_live_inventory`](../tests/_lint/test_session_retention.py))
+that pin the post-Wave-3 surface from both directions so neither the
+`_LifecycleHost` / `RefreshAuthCore` host shape nor the deleted
+auth-forward methods can quietly come back.
+
 ## Categories
 
 | Category | Meaning |

--- a/tests/_lint/test_client_composition.py
+++ b/tests/_lint/test_client_composition.py
@@ -1,9 +1,12 @@
 """ADR-014 Rule 3 enforcement: features take collaborators, not Session.
 
-Three AST guards. The first two were introduced in Wave 13 of the
+Four AST guards. The first two were introduced in Wave 13 of the
 session-decoupling plan (see ``docs/session-decoupling-plan-2026-05-26.md``
 Task 6.3); the third is a follow-up boundary rule that closes out the
-client-side reach-through cleanup.
+client-side reach-through cleanup; the fourth was added in Wave 4 of plan
+[`host-protocol-removal`](../../.sisyphus/phases/host-protocol-removal/phase-1.md)
+to tighten the private-attr rule into a positive allowlist for the few
+``self._session`` attributes the composition root may legitimately read.
 
 1. :func:`test_no_feature_constructed_with_session_at_composition_root`
    parses ``src/notebooklm/client.py`` and fails if any feature-API
@@ -31,13 +34,28 @@ client-side reach-through cleanup.
    shape ``self._session._<name>`` appears anywhere in the module
    (read, write, delete, or augmented assignment). The composition
    root MUST consume ``Session`` through its narrow public surface
-   (e.g. :meth:`Session.drain`, :attr:`Session.auth`, :meth:`Session.open`
-   / :meth:`Session.close`, :attr:`Session.is_open`), never through the
+   (e.g. :meth:`Session.drain`, :meth:`Session.open`,
+   :meth:`Session.close`, :attr:`Session.is_open`), never through the
    underscore-prefixed collaborator slots on ``Session``. The rule is
    boundary-focused: it does not pin line-history-specific reach-through
    call sites and so does not need to be rewritten every time a private
    slot is renamed. New private slots automatically come under the rule
    the moment they get an underscore-prefixed name.
+
+4. :func:`test_client_self_session_access_is_allowlisted` is the
+   stricter sibling of Guard 3 — it walks ``client.py`` and fails if
+   any ``self._session.<X>`` access reads an attribute not in the
+   :data:`SESSION_ALLOWED_ATTRS` set (``open`` / ``close`` / ``drain``
+   / ``is_open``). Wave 3 of plan ``host-protocol-removal`` deleted the
+   transitional ``self._session.lifecycle`` / ``self._session.auth``
+   reads from ``NotebookLMClient`` (the lifecycle is now reached via
+   ``self._collaborators.lifecycle`` and the auth tokens via
+   ``self._auth``). Guard 3 only catches underscore-prefixed slot leaks;
+   this guard ALSO catches public-attribute drift like a future
+   ``self._session.lifecycle`` re-introduction, which Guard 3 would
+   silently allow. The allowlist is intentionally narrow: any
+   ``self._session.<X>`` outside the four lifecycle hot-path
+   accessors must surface here at PR time.
 
 The AST shape is deliberate: a regex over the source would either
 over-match (e.g. ``collaborators`` as a variable name) or under-match
@@ -219,7 +237,7 @@ def test_client_does_not_dereference_session_privates() -> None:
 
     Boundary rule (not line-history-focused): the composition root
     consumes :class:`Session` through narrow public/internal accessors
-    (e.g. :meth:`Session.drain`, :attr:`Session.auth`, :meth:`Session.open`,
+    (e.g. :meth:`Session.drain`, :meth:`Session.open`,
     :meth:`Session.close`, :attr:`Session.is_open`). Any
     ``self._session._<name>`` read, write, delete, or augmented
     assignment reintroduces a private reach-through and fails this
@@ -238,4 +256,112 @@ def test_client_does_not_dereference_session_privates() -> None:
         "self._session — route through a narrow Session accessor "
         "(e.g. Session.drain, Session.open, Session.close, "
         "Session.is_open) instead:\n  " + "\n  ".join(violations)
+    )
+
+
+# Allowlist of ``self._session.<X>`` attribute names that the composition
+# root in ``client.py`` may legitimately read. The four entries are the
+# lifecycle hot-path methods + the ``is_open`` boolean that
+# ``NotebookLMClient`` forwards to its public surface:
+#
+#   - ``open``    — entry point for ``async with NotebookLMClient(...)``
+#   - ``close``   — drain + transport teardown
+#   - ``drain``   — graceful in-flight wait, also exposed publicly
+#   - ``is_open`` — public open-state read
+#
+# Wave 3 of plan ``host-protocol-removal`` deleted the transitional
+# ``self._session.lifecycle`` accessor (the lifecycle collaborator is
+# now reached via ``self._collaborators.lifecycle``) and the
+# ``self._session.auth`` read (the auth tokens are now reached via
+# ``self._auth`` per the Auth Instance Invariant). Wave 4 (this guard)
+# pins the post-Wave-3 surface so neither read can quietly come back.
+#
+# Any addition to this set MUST come with a documented retention reason
+# in ``docs/session-method-retention.md`` and a corresponding row in the
+# Inventory table there. The accompanying lint
+# ``tests/_lint/test_session_retention.py`` AST-parses ``_session.py``
+# and cross-checks the inventory; the two lints together pin the
+# Session surface from both directions (caller-side allowlist here +
+# definer-side inventory there).
+SESSION_ALLOWED_ATTRS: frozenset[str] = frozenset({"open", "close", "drain", "is_open"})
+
+
+def _self_session_attribute_access(node: ast.AST) -> tuple[int, str] | None:
+    """Return ``(lineno, attr)`` if ``node`` is ``self._session.<X>``.
+
+    Mirrors :func:`_is_self_session_private_attribute` but matches the
+    *broader* shape: ANY attribute name (public or private) on
+    ``self._session``, not just the underscore-prefixed ones. Returns
+    the outer Attribute's ``lineno`` and ``attr`` so the caller can
+    filter by allowlist membership and surface a precise diagnostic.
+
+    Dunder attributes (``__class__``, ``__dict__``, etc.) are
+    intentionally excluded — they are Python protocol surface and not
+    project-defined attributes; a ``self._session.__class__`` access is
+    introspection, not a boundary leak. The lint targets only
+    project-owned attribute names.
+
+    The receiver must be exactly the AST shape of ``self._session`` —
+    an :class:`ast.Attribute` whose ``value`` is a bare :class:`ast.Name`
+    ``self`` and whose ``attr`` is ``_session``. Chains like
+    ``other._session.<X>`` are deliberately not flagged here; ``client.py``
+    does not construct alternate references to the session under any
+    other name. This keeps the guard scoped tightly to the composition
+    root's known reach pattern.
+    """
+    if not isinstance(node, ast.Attribute):
+        return None
+    # Exclude Python dunder attributes (``__class__``, ``__dict__``, etc.).
+    if node.attr.startswith("__") and node.attr.endswith("__"):
+        return None
+    inner = node.value
+    if not isinstance(inner, ast.Attribute):
+        return None
+    if inner.attr != "_session":
+        return None
+    if not (isinstance(inner.value, ast.Name) and inner.value.id == "self"):
+        return None
+    return node.lineno, node.attr
+
+
+def test_client_self_session_access_is_allowlisted() -> None:
+    """``self._session.<X>`` in ``client.py`` must be one of the allowed attrs.
+
+    Stricter sibling of :func:`test_client_does_not_dereference_session_privates`:
+    that guard only catches underscore-prefixed slot reads. This one is
+    a positive allowlist — any access ``self._session.<X>`` where ``X``
+    is not in :data:`SESSION_ALLOWED_ATTRS` fails the lint, including
+    public-attribute drift like a future ``self._session.lifecycle``
+    re-introduction.
+
+    Failure mode: Wave 3 of plan ``host-protocol-removal`` deleted
+    ``Session.lifecycle`` and the ``self._session.auth`` read in
+    ``NotebookLMClient``. A future PR that "just adds back
+    ``self._session.lifecycle`` for one read site" would slip past
+    Guard 3 (the attribute is public, not underscore-prefixed) but
+    surfaces here because ``lifecycle`` is not in the allowlist.
+
+    The allowlist is intentionally narrow. Widening it requires
+    cross-updating ``docs/session-method-retention.md`` (which the
+    sibling lint ``test_session_retention.py`` cross-checks) so the
+    retention contract stays synchronised end-to-end.
+    """
+    tree = ast.parse(CLIENT_PATH.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        match = _self_session_attribute_access(node)
+        if match is None:
+            continue
+        lineno, attr = match
+        if attr in SESSION_ALLOWED_ATTRS:
+            continue
+        violations.append(f"line {lineno}: self._session.{attr}")
+    assert not violations, (
+        "client.py may only access self._session.<X> for X in "
+        f"{sorted(SESSION_ALLOWED_ATTRS)!r}. Any other attribute access "
+        "reopens the Session-as-discoverability-hub pattern that ADR-014 "
+        "Rule 3 closed and that Waves 1-3 of plan host-protocol-removal "
+        "narrowed further. Route through the explicit collaborator "
+        "(e.g. self._collaborators.lifecycle for the lifecycle, "
+        "self._auth for the auth tokens) instead:\n  " + "\n  ".join(violations)
     )

--- a/tests/_lint/test_client_composition.py
+++ b/tests/_lint/test_client_composition.py
@@ -71,6 +71,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLIENT_PATH = REPO_ROOT / "src" / "notebooklm" / "client.py"
 SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
@@ -365,3 +367,118 @@ def test_client_self_session_access_is_allowlisted() -> None:
         "(e.g. self._collaborators.lifecycle for the lifecycle, "
         "self._auth for the auth tokens) instead:\n  " + "\n  ".join(violations)
     )
+
+
+# ---------------------------------------------------------------------------
+# Self-coverage for ``_self_session_attribute_access`` — pin the helper's
+# contract before the live production test exercises it. Each case below
+# pairs a synthetic expression with the expected helper return so the
+# documented filtering conditions (receiver shape, dunder exclusion,
+# private/public attr coverage) can be regressed independently of the
+# production scan over ``client.py``. Mirrors the self-coverage pattern
+# every other helper in this suite (see ``test_no_session_compat_bridges.py``
+# and ``test_session_runtime_boundaries.py``) already follows.
+# ---------------------------------------------------------------------------
+
+
+def _single_attribute_node(source: str) -> ast.AST:
+    """Parse ``source`` and return its outermost expression's AST node.
+
+    Centralised so the parametrized cases below don't repeat the
+    ``parse → body[0] → value`` unwrap. ``source`` must be exactly one
+    expression statement; anything else is a test-author error and will
+    surface as an ``IndexError`` or ``AttributeError`` here rather than
+    silently returning the wrong node.
+    """
+    tree = ast.parse(source)
+    expr = tree.body[0]
+    assert isinstance(expr, ast.Expr), (
+        f"Expected single Expr statement, got {type(expr).__name__} for {source!r}"
+    )
+    return expr.value
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_attr"),
+    [
+        # Positive: allowlisted attribute (the helper returns the match;
+        # the allowlist filtering happens at the caller, not here).
+        ("self._session.open", "open"),
+        ("self._session.close", "close"),
+        ("self._session.drain", "drain"),
+        ("self._session.is_open", "is_open"),
+        # Positive: non-allowlisted public attribute — the helper still
+        # surfaces it, the caller filters against ``SESSION_ALLOWED_ATTRS``.
+        # This is the regression vector the live test catches.
+        ("self._session.lifecycle", "lifecycle"),
+        ("self._session.auth", "auth"),
+        # Positive: underscore-prefixed slot — the helper surfaces this
+        # too; the existing ``_is_self_session_private_attribute`` covers
+        # the same shape from a different angle.
+        ("self._session._kernel", "_kernel"),
+    ],
+    ids=[
+        "allowed-open",
+        "allowed-close",
+        "allowed-drain",
+        "allowed-is_open",
+        "forbidden-public-lifecycle",
+        "forbidden-public-auth",
+        "forbidden-private-_kernel",
+    ],
+)
+def test_self_session_attribute_access_matches_canonical_shape(
+    source: str, expected_attr: str
+) -> None:
+    """``self._session.<X>`` for any X (public or private) returns ``(lineno, X)``.
+
+    The helper deliberately does NOT do allowlist filtering — that's
+    the caller's job. Self-coverage here pins the AST-shape contract:
+    the canonical receiver (``self._session``) with any non-dunder
+    attribute name surfaces.
+    """
+    node = _single_attribute_node(source)
+    result = _self_session_attribute_access(node)
+    assert result is not None, f"Expected a match for {source!r}, got None"
+    _lineno, attr = result
+    assert attr == expected_attr
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Receiver is not exactly ``self._session`` — the helper is
+        # scoped to the composition root's canonical reach pattern.
+        # ``other._session.open`` is out of scope (no such alias in
+        # ``client.py``).
+        "other._session.open",
+        # No ``_session`` intermediary — direct attribute access on ``self``
+        # is not what the guard targets.
+        "self.open",
+        # Receiver chain is too deep — ``self.foo._session.open`` does not
+        # match because the immediate inner attribute is not ``_session``
+        # (the parent is ``self.foo``, not ``self``).
+        "self.foo._session.open",
+        # Dunder attribute — Python protocol surface, intentionally excluded.
+        "self._session.__class__",
+        "self._session.__dict__",
+        # Receiver is ``self._session`` but the outer node is the receiver
+        # itself, not an attribute access on it — ``self._session`` standalone
+        # is not a ``self._session.<X>`` chain.
+        "self._session",
+    ],
+    ids=[
+        "other-not-self",
+        "no-_session-intermediary",
+        "chain-too-deep",
+        "dunder-__class__-excluded",
+        "dunder-__dict__-excluded",
+        "receiver-only-no-trailing-attr",
+    ],
+)
+def test_self_session_attribute_access_rejects_non_canonical_shapes(
+    source: str,
+) -> None:
+    """Receiver-shape and dunder exclusions documented in the helper's docstring."""
+    node = _single_attribute_node(source)
+    assert _self_session_attribute_access(node) is None, f"Expected no match for {source!r}"

--- a/tests/_lint/test_session_retention.py
+++ b/tests/_lint/test_session_retention.py
@@ -439,3 +439,71 @@ def test_retention_doc_does_not_list_unknown_methods(
         "section (with the deleting PR's SHA) or remove them:\n"
         + "\n".join(f"  - `{name}`" for name in stale)
     )
+
+
+# ---------------------------------------------------------------------------
+# Wave 4 of plan ``host-protocol-removal`` — pin the Wave 3 deletions.
+# ---------------------------------------------------------------------------
+
+
+# Methods Wave 3 of plan ``host-protocol-removal`` deleted from Session.
+# Each was a one-line forward kept only as a Protocol surface; the
+# Protocol (``RefreshAuthCore``) was retired in Wave 2 and the forwards
+# went with it in Wave 3 (PR #1134). Wave 4 pins the deletions here so a
+# future PR that re-introduces any of them in the live Inventory trips
+# this lint at PR time.
+WAVE_3_DELETED_METHODS: frozenset[str] = frozenset(
+    {"lifecycle", "update_auth_tokens", "update_auth_headers"}
+)
+
+
+def test_wave_3_deletions_stay_out_of_live_inventory(
+    session_methods: list[str],
+    retention_rows: dict[str, str],
+) -> None:
+    """The three Wave 3 deletions must not reappear on Session or in the live Inventory.
+
+    Wave 3 of plan
+    [`host-protocol-removal`](../../.sisyphus/phases/host-protocol-removal/phase-1.md)
+    deleted ``Session.lifecycle`` (the public-API forward returning the
+    ``ClientLifecycle`` collaborator) and the two ``RefreshAuthCore`` Protocol
+    surfaces (``update_auth_tokens`` / ``update_auth_headers``). The
+    Protocol itself was retired in Wave 2 (no surviving caller needed the
+    Session-level delegates after Wave 2 narrowed ``refresh_auth_session``
+    to five explicit kwargs); Wave 3 followed up by deleting the forwards.
+
+    Two assertions, both regression-focused:
+
+    1. None of the three names may be present in the AST-enumerated
+       Session method list. Reappearance means the deletion was reverted;
+       the live caller paths now read ``self._collaborators.lifecycle``
+       (lifecycle), ``self._auth`` (auth tokens), and the coordinator
+       methods directly (``auth_coord.update_auth_*``).
+    2. None of the three names may carry a live row in the **Inventory**
+       table — the rows moved to the Wave-3-specific section under
+       **Deleted** at the bottom of the retention doc. A live row would
+       indicate doc drift even if the method was correctly deleted.
+
+    Failure mode: a future PR that re-adds ``Session.lifecycle`` "for
+    one read site" or revives the ``update_auth_tokens`` forward would
+    surface here under assertion 1; a doc PR that mistakenly resurfaces
+    the deleted row in the live Inventory table would surface under
+    assertion 2.
+    """
+    surviving = sorted(name for name in session_methods if name in WAVE_3_DELETED_METHODS)
+    assert not surviving, (
+        "Wave 3 of plan host-protocol-removal deleted these Session "
+        "methods (PR #1134); reappearance is a regression. The live "
+        "caller paths route through `self._collaborators.lifecycle` "
+        "(for the lifecycle collaborator), `self._auth` (for the auth "
+        "tokens), and `auth_coord.update_auth_*(...)` (for the coordinator "
+        "calls). Offenders:\n  - " + "\n  - ".join(surviving)
+    )
+
+    live_drift = sorted(name for name in retention_rows if name in WAVE_3_DELETED_METHODS)
+    assert not live_drift, (
+        "These Wave 3 deletions resurfaced in the live Inventory table of "
+        f"{RETENTION_DOC.relative_to(REPO_ROOT)}. Their rows belong in the "
+        "Wave-3-specific section under `## Deleted` at the bottom of the "
+        "doc, not in the live Inventory:\n  - " + "\n  - ".join(live_drift)
+    )

--- a/tests/_lint/test_session_runtime_boundaries.py
+++ b/tests/_lint/test_session_runtime_boundaries.py
@@ -9,7 +9,7 @@ auth/lifecycle forwards (``update_auth_tokens`` / ``update_auth_headers``
 adds the AST regression guards that catch any future reintroduction of
 the Session-as-host pattern at PR time.
 
-The five guards in this module are deliberately AST-based — string-vs-name
+The four guards in this module are deliberately AST-based — string-vs-name
 spelling, ``typing.cast`` qualification, and re-imported ``cast`` aliases
 all slip past a regex but not past an :mod:`ast` walk.
 
@@ -27,22 +27,27 @@ all slip past a regex but not past an :mod:`ast` walk.
    Session-as-host coupling Waves 1-3 dismantled.
 
 2. :func:`test_no_cast_to_lifecycle_host_in_src` walks every module
-   under ``src/notebooklm/`` and fails if any :class:`ast.Call` matches
-   ``cast(..., _LifecycleHost)`` in any of four spellings:
+   under ``src/notebooklm/`` and fails if any :class:`ast.Call` to a
+   callable whose name is literally ``cast`` (bare or as a trailing
+   attribute like ``typing.cast``) targets ``_LifecycleHost``:
 
    - ``cast("_LifecycleHost", obj)`` — first-arg string forward ref
    - ``cast(_LifecycleHost, obj)`` — first-arg bare name
    - ``typing.cast("_LifecycleHost", obj)`` / ``typing.cast(_LifecycleHost, obj)`` — qualified
-   - ``c("_LifecycleHost", obj)`` / ``c(_LifecycleHost, obj)`` where
-     ``c = cast`` was re-imported under any name — the walk matches on
-     the second argument's literal, so the callable's spelling does not
-     matter as long as it ends in ``cast`` (the callable shape gate)
-     OR the second argument is itself the bare ``_LifecycleHost`` name.
+
+   Guard 2 keys on BOTH the callable shape (must end in ``cast``) AND
+   the first-arg literal (must spell ``_LifecycleHost``). A truly-aliased
+   ``cast`` import such as ``from typing import cast as c`` followed by
+   ``c("_LifecycleHost", obj)`` is NOT caught by Guard 2 because the
+   callable spelling ``c`` doesn't match. That spelling is handled
+   instead by Guard 1, which surfaces the literal ``"_LifecycleHost"``
+   string regardless of the surrounding call context. The two guards
+   together are alias-spelling invariant.
 
    Failure mode: Wave 2 retired the ``typing.cast(_LifecycleHost, core)``
    call site in ``_auth/session.py``. A naive future "I'll cast it for
-   one line" would slip past Guard 1 only if the import was already
-   present, but would always trip Guard 2.
+   one line using the canonical ``cast`` spelling" trips Guard 2; a
+   "...with an aliased ``cast`` import" trips Guard 1 instead.
 
 3. :func:`test_refresh_auth_core_symbol_does_not_appear_in_src` mirrors
    Guard 1 for ``RefreshAuthCore`` — Wave 2 deleted that Protocol with
@@ -63,11 +68,15 @@ all slip past a regex but not past an :mod:`ast` walk.
    - no Protocol class body that declares a ``_kernel`` attribute, so a
      new host Protocol cannot quietly resurrect the Wave 2 shape
    - no call of the form ``X.update_auth_tokens(...)`` or
-     ``X.update_auth_headers(...)`` where ``X`` is anything other than
-     a coordinator-shaped name (the live caller invokes
-     ``auth_coord.update_auth_tokens(...)`` / ``auth_coord.update_auth_headers(...)``
-     on the explicit kwarg; calling either method on ``core``, ``session``,
-     ``host``, or ``self`` would restore the Session-as-host pattern)
+     ``X.update_auth_headers(...)`` unless the receiver ``X`` is
+     coordinator-shaped — either a bare name in
+     :data:`AUTH_COORD_RECEIVER_NAMES` (``auth_coord``) OR an attribute
+     chain whose terminal segment contains ``coord``/``coordinator``
+     (``self._auth_coord.update_*``, ``client._collaborators.auth_coordinator.update_*``).
+     The live caller invokes ``auth_coord.update_auth_*(...)`` on the
+     explicit kwarg; calling either method on ``core``, ``session``,
+     ``host``, ``self``, or ``self._session`` restores the
+     Session-as-host pattern
    - no ``cast`` to either ``_LifecycleHost`` or ``RefreshAuthCore``
      (this duplicates Guards 1-3 for the one file that historically
      carried both casts; the duplication is intentional belt-and-braces)
@@ -146,12 +155,16 @@ def _find_symbol_appearances(tree: ast.AST, symbol: str) -> list[tuple[int, str]
             hits.append((node.lineno, "Constant"))
         elif isinstance(node, ast.ClassDef) and node.name == symbol:
             hits.append((node.lineno, "ClassDef"))
-        elif isinstance(node, ast.alias) and (node.asname == symbol or node.name == symbol):
-            # ast.alias has no lineno of its own; the enclosing import
-            # node carries it. ``end_lineno`` on ast.alias is populated
-            # in 3.10+, but ``lineno`` is not — fall back to 0 if absent
-            # so the diagnostic still surfaces.
-            hits.append((getattr(node, "lineno", 0), "alias"))
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            # Walk the parent import node rather than ``ast.alias`` itself —
+            # the parent always carries a valid ``lineno`` across all
+            # supported Python versions, whereas ``ast.alias.lineno`` is
+            # populated only from 3.10 onward. Using the parent's
+            # ``lineno`` keeps the diagnostic accurate without a
+            # version-dependent fallback (gemini-code-assist review).
+            for alias in node.names:
+                if alias.name == symbol or alias.asname == symbol:
+                    hits.append((node.lineno, "alias"))
     return hits
 
 
@@ -237,6 +250,54 @@ def _imports_session_class(tree: ast.AST) -> list[int]:
                 if alias.asname == "Session":
                     hits.append(node.lineno)
     return hits
+
+
+def _is_coordinator_receiver(receiver: ast.expr) -> bool:
+    """Return ``True`` if ``receiver`` is a coordinator-shaped access target.
+
+    Two legitimate shapes (Guard 4 sub-check 3):
+
+    1. Bare :class:`ast.Name` whose ``id`` is in
+       :data:`AUTH_COORD_RECEIVER_NAMES` — the canonical live shape in
+       ``refresh_auth_session`` (``auth_coord.update_auth_tokens(...)``).
+    2. :class:`ast.Attribute` whose terminal ``attr`` contains
+       ``coord`` or ``coordinator`` — covers both the private slot
+       (``self._auth_coord``) and any future fully-spelled accessor
+       (``self._collaborators.auth_coordinator``). The match is on the
+       terminal attribute name only, not the upstream chain, so the
+       intent is clear: "the call lands on the coordinator collaborator".
+
+    Anything else (bare-name receivers like ``core`` / ``session`` /
+    ``host`` / ``self``; Attribute chains terminating in
+    non-coordinator segments like ``self._session``; computed
+    receivers like ``[a, b][0]``; Subscripts; etc.) is the regression
+    surface and returns ``False``.
+    """
+    if isinstance(receiver, ast.Name):
+        return receiver.id in AUTH_COORD_RECEIVER_NAMES
+    if isinstance(receiver, ast.Attribute):
+        attr_lower = receiver.attr.lower()
+        return "coord" in attr_lower or "coordinator" in attr_lower
+    return False
+
+
+def _format_receiver_for_diagnostic(receiver: ast.expr) -> str:
+    """Render ``receiver`` as a short human-readable string for failure messages.
+
+    - ``ast.Name`` → its ``id`` (``core``, ``session``, ...).
+    - ``ast.Attribute`` → ``...<terminal_attr>`` (``...session`` for
+      ``self._session``, ``..._kernel`` for ``payload._kernel``). The
+      leading ``...`` signals that the upstream chain is elided so the
+      reader can grep the file by the terminal segment.
+    - Anything else → the literal string ``"expression"`` (we cannot
+      reconstruct an arbitrary AST shape cheaply, and the location
+      lineno is already in the message).
+    """
+    if isinstance(receiver, ast.Name):
+        return receiver.id
+    if isinstance(receiver, ast.Attribute):
+        return f"...{receiver.attr}"
+    return "expression"
 
 
 # ---------------------------------------------------------------------------
@@ -389,13 +450,28 @@ def test_auth_session_module_has_no_host_protocol_residue() -> None:
             )
 
     # Sub-check 3: no ``X.update_auth_tokens(...)`` / ``X.update_auth_headers(...)``
-    # where the receiver is not a coordinator-shaped name. The receiver
-    # may also be an Attribute chain ending in a coordinator name
-    # (``self._auth_coord.update_auth_tokens(...)``), so we check the
-    # *immediate* receiver — for ``a.b.method()`` the receiver is ``a.b``,
-    # for ``a.method()`` the receiver is ``a``. A bare-name receiver is
-    # the regression surface; chain receivers are out of scope (the
-    # live caller uses the kwarg directly, ``auth_coord.update_auth_*``).
+    # unless the receiver is coordinator-shaped. Two receiver shapes
+    # may legitimately reach the coordinator:
+    #
+    #   1. Bare ``Name`` matching :data:`AUTH_COORD_RECEIVER_NAMES`
+    #      (the canonical live shape — ``auth_coord.update_auth_tokens(...)``
+    #      in ``refresh_auth_session``).
+    #   2. ``Attribute`` chain whose terminal ``attr`` is coordinator-shaped
+    #      (``self._auth_coord.update_*``, ``client._collaborators.auth_coord.update_*``).
+    #      "Coordinator-shaped" means the terminal segment contains
+    #      either ``coord`` or ``coordinator`` — covering both the
+    #      private slot name (``_auth_coord``) and a hypothetical
+    #      fully-spelled accessor (``auth_coordinator``).
+    #
+    # Everything else — bare-name receivers like ``core`` / ``session``
+    # / ``host`` / ``self``, and Attribute chains terminating in
+    # non-coordinator segments like ``self._session.update_*`` —
+    # restores the Session-as-host shape Wave 3 deleted and surfaces
+    # here as a violation. The widened receiver coverage closes the
+    # gap that gemini-code-assist flagged: the previous code only
+    # checked ``ast.Name`` receivers and silently passed
+    # ``self._session.update_auth_tokens(...)`` because that receiver
+    # is an ``ast.Attribute``.
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -404,17 +480,15 @@ def test_auth_session_module_has_no_host_protocol_residue() -> None:
         if node.func.attr not in AUTH_FORWARD_METHOD_NAMES:
             continue
         receiver = node.func.value
-        if isinstance(receiver, ast.Name):
-            if receiver.id not in AUTH_COORD_RECEIVER_NAMES:
-                violations.append(
-                    f"_auth/session.py:{node.lineno} calls "
-                    f"`{receiver.id}.{node.func.attr}(...)` — "
-                    f"`{node.func.attr}` now lives on AuthRefreshCoordinator; "
-                    "route through the `auth_coord` kwarg explicitly."
-                )
-        # Attribute-chain receivers (``self._auth_coord.update_*``) are
-        # acceptable — they reach the coordinator through an explicit
-        # collaborator slot rather than a Session-shaped delegate.
+        if _is_coordinator_receiver(receiver):
+            continue
+        receiver_repr = _format_receiver_for_diagnostic(receiver)
+        violations.append(
+            f"_auth/session.py:{node.lineno} calls "
+            f"`{receiver_repr}.{node.func.attr}(...)` — "
+            f"`{node.func.attr}` now lives on AuthRefreshCoordinator; "
+            "route through the `auth_coord` kwarg explicitly."
+        )
 
     # Sub-check 4: no cast to ``_LifecycleHost`` / ``RefreshAuthCore``.
     for node in ast.walk(tree):
@@ -498,8 +572,13 @@ def test_find_symbol_appearances_ignores_unrelated_names() -> None:
         ("cast(_LifecycleHost, x)\n", "_LifecycleHost"),
         # Qualified
         ('typing.cast("_LifecycleHost", x)\n', "_LifecycleHost"),
-        # Aliased cast: still matches because we key on the second-arg literal
-        ('c("_LifecycleHost", x)\n', None),  # bare ``c(...)`` is not a cast call
+        # Aliased callable (``c = cast``) is NOT matched by Guard 2 — the
+        # callable spelling ``c`` doesn't end in ``cast``. Guard 1 catches
+        # the literal ``"_LifecycleHost"`` independently, so the system is
+        # still alias-spelling invariant; ``_cast_target_name`` returns
+        # ``None`` here because ``_is_cast_call`` rejects the callable
+        # shape before the target check runs.
+        ('c("_LifecycleHost", x)\n', None),
         # Sibling Protocol
         ("cast(RefreshAuthCore, x)\n", "RefreshAuthCore"),
     ],
@@ -563,3 +642,81 @@ def test_imports_session_class_catches_both_shapes() -> None:
     # is what the guard is preventing, not the local name choice.
     hits = _imports_session_class(tree)
     assert len(hits) == 3, f"Expected 3 hits, got {hits!r}"
+
+
+@pytest.mark.parametrize(
+    ("source", "is_coordinator"),
+    [
+        # Bare-name receivers that ARE coordinators.
+        ("auth_coord.x", True),
+        ("coord.x", True),
+        # Bare-name receivers that are NOT coordinators (the regression surface).
+        ("core.x", False),
+        ("session.x", False),
+        ("host.x", False),
+        ("self.x", False),
+        # Attribute-chain receivers whose terminal segment IS coordinator-shaped.
+        # The terminal segment is the one immediately before the called method,
+        # so ``self._auth_coord.update_*`` has terminal ``_auth_coord``.
+        ("self._auth_coord.x", True),
+        ("self._collaborators.auth_coordinator.x", True),
+        # Attribute-chain receivers whose terminal segment is NOT coordinator-shaped.
+        # ``self._session.update_*`` was historically the deleted Session-as-host
+        # shape; the previous version of this guard silently passed it.
+        ("self._session.x", False),
+        ("client._collaborators.x", False),  # terminal segment is plain `_collaborators`
+        ("payload.kernel.x", False),
+    ],
+    ids=[
+        "bare-auth-coord",
+        "bare-coord",
+        "bare-core-reject",
+        "bare-session-reject",
+        "bare-host-reject",
+        "bare-self-reject",
+        "chain-self-_auth_coord",
+        "chain-collaborators-auth_coordinator",
+        "chain-self-_session-reject",
+        "chain-collaborators-terminal-only",
+        "chain-payload-kernel-reject",
+    ],
+)
+def test_is_coordinator_receiver_covers_both_shapes(source: str, is_coordinator: bool) -> None:
+    """``_is_coordinator_receiver`` accepts bare coordinator names AND
+    attribute chains whose terminal segment is coordinator-shaped.
+
+    The terminal-segment rule is what closes the gap gemini-code-assist
+    flagged on PR #1135: the previous code only checked bare-name
+    receivers, so ``self._session.update_auth_tokens(...)`` slipped
+    past the guard because its receiver is an ``ast.Attribute`` (the
+    ``self._session`` chain) rather than an ``ast.Name``.
+    """
+    tree = ast.parse(source)
+    # The source above is a single bare attribute expression; the
+    # outermost node is an ``Expr`` wrapping the ``Attribute`` we want.
+    expr = tree.body[0]
+    assert isinstance(expr, ast.Expr)
+    outer = expr.value
+    assert isinstance(outer, ast.Attribute), (
+        f"Expected outer Attribute for {source!r}, got {type(outer).__name__}"
+    )
+    # The receiver of the (would-be) call is ``outer.value`` —
+    # everything up to (but not including) the trailing ``.x``.
+    receiver = outer.value
+    assert _is_coordinator_receiver(receiver) is is_coordinator, (
+        f"For receiver in {source!r}: expected is_coordinator={is_coordinator}, "
+        f"got {_is_coordinator_receiver(receiver)!r}"
+    )
+
+
+def test_format_receiver_for_diagnostic_shapes() -> None:
+    """Diagnostic rendering elides the upstream chain but pins the terminal segment."""
+    tree = ast.parse("self._session.x\nbare.x\n(1 + 2).x\n")
+    receivers = [
+        node.value.value  # type: ignore[union-attr]
+        for node in tree.body
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Attribute)
+    ]
+    assert _format_receiver_for_diagnostic(receivers[0]) == "..._session"
+    assert _format_receiver_for_diagnostic(receivers[1]) == "bare"
+    assert _format_receiver_for_diagnostic(receivers[2]) == "expression"

--- a/tests/_lint/test_session_runtime_boundaries.py
+++ b/tests/_lint/test_session_runtime_boundaries.py
@@ -1,0 +1,565 @@
+"""Meta-lint: regression guards closing plan ``host-protocol-removal``.
+
+Wave 2 of plan ``host-protocol-removal`` deleted the ``_LifecycleHost``
+and ``RefreshAuthCore`` Protocols and rewrote ``refresh_auth_session``
+to take five explicit keyword-only collaborators instead of a
+Session-shaped core. Wave 3 deleted the surviving Session-level
+auth/lifecycle forwards (``update_auth_tokens`` / ``update_auth_headers``
+/ ``lifecycle``) that those Protocols had backed. Wave 4 (this file)
+adds the AST regression guards that catch any future reintroduction of
+the Session-as-host pattern at PR time.
+
+The five guards in this module are deliberately AST-based — string-vs-name
+spelling, ``typing.cast`` qualification, and re-imported ``cast`` aliases
+all slip past a regex but not past an :mod:`ast` walk.
+
+1. :func:`test_lifecycle_host_symbol_does_not_appear_in_src` walks every
+   module under ``src/notebooklm/`` and fails if the bare identifier
+   ``_LifecycleHost`` appears anywhere — as a :class:`ast.Name`, as an
+   :class:`ast.Attribute`, or as a :class:`ast.Constant` string (the
+   forward-reference shape ``cast("_LifecycleHost", ...)``). Reappearance
+   is a regression: Wave 2 deleted the Protocol with #1133 and no
+   surviving code path needs the host shape.
+
+   Failure mode: introducing a typing import like
+   ``from .._session_lifecycle import _LifecycleHost`` or annotating a
+   parameter ``host: "_LifecycleHost"`` would re-establish the
+   Session-as-host coupling Waves 1-3 dismantled.
+
+2. :func:`test_no_cast_to_lifecycle_host_in_src` walks every module
+   under ``src/notebooklm/`` and fails if any :class:`ast.Call` matches
+   ``cast(..., _LifecycleHost)`` in any of four spellings:
+
+   - ``cast("_LifecycleHost", obj)`` — first-arg string forward ref
+   - ``cast(_LifecycleHost, obj)`` — first-arg bare name
+   - ``typing.cast("_LifecycleHost", obj)`` / ``typing.cast(_LifecycleHost, obj)`` — qualified
+   - ``c("_LifecycleHost", obj)`` / ``c(_LifecycleHost, obj)`` where
+     ``c = cast`` was re-imported under any name — the walk matches on
+     the second argument's literal, so the callable's spelling does not
+     matter as long as it ends in ``cast`` (the callable shape gate)
+     OR the second argument is itself the bare ``_LifecycleHost`` name.
+
+   Failure mode: Wave 2 retired the ``typing.cast(_LifecycleHost, core)``
+   call site in ``_auth/session.py``. A naive future "I'll cast it for
+   one line" would slip past Guard 1 only if the import was already
+   present, but would always trip Guard 2.
+
+3. :func:`test_refresh_auth_core_symbol_does_not_appear_in_src` mirrors
+   Guard 1 for ``RefreshAuthCore`` — Wave 2 deleted that Protocol with
+   #1133 and the symbol must stay gone.
+
+   Failure mode: re-declaring ``class RefreshAuthCore(Protocol): ...``
+   anywhere in ``src/notebooklm/`` (most likely in ``_auth/session.py``)
+   would re-establish the Session-shaped argument contract that Wave 2
+   replaced with five explicit kwargs.
+
+4. :func:`test_auth_session_module_has_no_host_protocol_residue` is a
+   focused contract for ``src/notebooklm/_auth/session.py`` — the
+   module Wave 2 rewrote. Four sub-checks, all AST-based:
+
+   - no import of the ``Session`` class (from any module path), so the
+     refresh helper cannot regrow a typing dependency on the concrete
+     lifecycle root
+   - no Protocol class body that declares a ``_kernel`` attribute, so a
+     new host Protocol cannot quietly resurrect the Wave 2 shape
+   - no call of the form ``X.update_auth_tokens(...)`` or
+     ``X.update_auth_headers(...)`` where ``X`` is anything other than
+     a coordinator-shaped name (the live caller invokes
+     ``auth_coord.update_auth_tokens(...)`` / ``auth_coord.update_auth_headers(...)``
+     on the explicit kwarg; calling either method on ``core``, ``session``,
+     ``host``, or ``self`` would restore the Session-as-host pattern)
+   - no ``cast`` to either ``_LifecycleHost`` or ``RefreshAuthCore``
+     (this duplicates Guards 1-3 for the one file that historically
+     carried both casts; the duplication is intentional belt-and-braces)
+
+   Failure mode: a future refactor that "just adds back the Session
+   import for a typing-only annotation" or "re-introduces a cast for
+   one production call site" trips this guard before the PR opens.
+
+The AST shape is deliberate for the same reason Guard 1 / 2 enumerate
+attribute and string forms separately: a regex over the source would
+miss ``cast(_LifecycleHost, ...)`` if the import was renamed
+(``from typing import cast as _cast``) or miss the string form
+(``cast("_LifecycleHost", ...)``) if the file imports were spelled
+differently. The AST walks match on the call shape and the literal
+identifier, so the lint is invariant to import-style or alias choices.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+AUTH_SESSION_PATH = SRC_ROOT / "_auth" / "session.py"
+
+# The two deleted Protocol identifiers. Centralised so future plan
+# closures (or accidental reintroductions) can extend the set in one
+# place. Both were deleted in Wave 2 of plan ``host-protocol-removal``
+# (PR #1133).
+DELETED_HOST_PROTOCOL_NAMES: frozenset[str] = frozenset({"_LifecycleHost", "RefreshAuthCore"})
+
+# Coordinator-shaped receiver names that may legitimately appear on the
+# LHS of ``.update_auth_tokens(...)`` / ``.update_auth_headers(...)`` in
+# the auth-refresh code path. The live caller in
+# ``_auth/session.py::refresh_auth_session`` invokes
+# ``auth_coord.update_auth_tokens(...)`` / ``auth_coord.update_auth_headers(...)``
+# on the explicit ``auth_coord`` kwarg. Names like ``core``, ``host``,
+# ``session``, or ``self`` are the Wave-2-deleted Session-as-host shape
+# and must not reappear.
+AUTH_COORD_RECEIVER_NAMES: frozenset[str] = frozenset({"auth_coord", "coord"})
+
+# The two ``update_auth_*`` method names that historically pinned the
+# ``RefreshAuthCore`` Protocol surface. Wave 3 deleted the Session-level
+# forwards (PR #1134) — they now live on ``AuthRefreshCoordinator`` and
+# must be reached through that collaborator's name.
+AUTH_FORWARD_METHOD_NAMES: frozenset[str] = frozenset({"update_auth_tokens", "update_auth_headers"})
+
+
+def _iter_src_files() -> list[Path]:
+    """Return every ``.py`` under ``src/notebooklm/``, sorted, excluding caches."""
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _find_symbol_appearances(tree: ast.AST, symbol: str) -> list[tuple[int, str]]:
+    """Return ``[(lineno, context), ...]`` for every appearance of ``symbol``.
+
+    Contexts:
+      - ``"Name"`` — bare identifier reference (``_LifecycleHost``)
+      - ``"Attribute"`` — attribute access (``mod._LifecycleHost``)
+      - ``"Constant"`` — string-literal forward reference
+        (``"_LifecycleHost"`` inside annotations / ``cast``)
+      - ``"ClassDef"`` — a class definition by that name
+      - ``"alias"`` — an ``import ... as _LifecycleHost`` or
+        ``from ... import _LifecycleHost`` (the ``alias`` AST node)
+    """
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == symbol:
+            hits.append((node.lineno, "Name"))
+        elif isinstance(node, ast.Attribute) and node.attr == symbol:
+            hits.append((node.lineno, "Attribute"))
+        elif isinstance(node, ast.Constant) and node.value == symbol:
+            hits.append((node.lineno, "Constant"))
+        elif isinstance(node, ast.ClassDef) and node.name == symbol:
+            hits.append((node.lineno, "ClassDef"))
+        elif isinstance(node, ast.alias) and (node.asname == symbol or node.name == symbol):
+            # ast.alias has no lineno of its own; the enclosing import
+            # node carries it. ``end_lineno`` on ast.alias is populated
+            # in 3.10+, but ``lineno`` is not — fall back to 0 if absent
+            # so the diagnostic still surfaces.
+            hits.append((getattr(node, "lineno", 0), "alias"))
+    return hits
+
+
+def _is_cast_call(node: ast.AST) -> bool:
+    """Return True if ``node`` is a :class:`ast.Call` to ``cast`` (any spelling).
+
+    Matches:
+      - ``cast(...)``       (bare name; whether imported as ``cast`` or
+        re-imported under another alias — the name match catches the
+        canonical spelling, and Guard 2 also gates on the second-arg
+        literal so alias rewrites still trip)
+      - ``typing.cast(...)`` / ``t.cast(...)``  (attribute access ending in ``cast``)
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "cast":
+        return True
+    return isinstance(func, ast.Attribute) and func.attr == "cast"
+
+
+def _cast_target_name(call: ast.Call) -> str | None:
+    """Return the target-type identifier if ``call`` is ``cast(<target>, value)``.
+
+    Returns the string content for ``cast("_LifecycleHost", v)``, the
+    ``id`` for ``cast(_LifecycleHost, v)``, or ``None`` for anything
+    else (computed target, missing args, attribute chain, etc.). The
+    runtime contract of ``typing.cast`` requires exactly two positional
+    arguments; we are tolerant of length >= 1 so a malformed cast in
+    new code still surfaces the violation rather than silently skipping.
+    """
+    if not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    if isinstance(first, ast.Name):
+        return first.id
+    return None
+
+
+def _protocol_class_declares_kernel(class_def: ast.ClassDef) -> bool:
+    """Return True if ``class_def`` is a Protocol body that declares ``_kernel``.
+
+    A Protocol body in stub form is a sequence of annotated assignments
+    (``_kernel: Kernel``) or annotated-only statements. We check both
+    the bases for ``Protocol`` membership and the body for a top-level
+    ``_kernel`` annotation. ``runtime_checkable`` decorators do not
+    change the body shape.
+    """
+    base_names: set[str] = set()
+    for base in class_def.bases:
+        if isinstance(base, ast.Name):
+            base_names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            base_names.add(base.attr)
+    if "Protocol" not in base_names:
+        return False
+    for stmt in class_def.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            if stmt.target.id == "_kernel":
+                return True
+    return False
+
+
+def _imports_session_class(tree: ast.AST) -> list[int]:
+    """Return line numbers of any import that brings ``Session`` into scope.
+
+    Catches both ``from notebooklm._session import Session`` and
+    ``import notebooklm._session as ...`` followed by ``Session``
+    reference. We focus on the direct ``Session`` import — the second
+    form would also surface as a ``Session`` Name/Attribute reference,
+    but that's a Guard-2-style concern and out of scope for this guard.
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "Session" or alias.asname == "Session":
+                    hits.append(node.lineno)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname == "Session":
+                    hits.append(node.lineno)
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Guard 1: ``_LifecycleHost`` must not appear in ``src/notebooklm/``.
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_host_symbol_does_not_appear_in_src() -> None:
+    """``_LifecycleHost`` was deleted in Wave 2 (PR #1133); reappearance is a regression.
+
+    Failure mode: a future PR that re-introduces
+    ``from .._session_lifecycle import _LifecycleHost`` or annotates
+    a parameter ``host: "_LifecycleHost"`` would surface here as a
+    ``Name``, ``Attribute``, ``Constant``, ``ClassDef``, or ``alias``
+    violation depending on the exact spelling.
+    """
+    violations: list[str] = []
+    for src in _iter_src_files():
+        rel = src.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        hits = _find_symbol_appearances(tree, "_LifecycleHost")
+        for lineno, ctx in hits:
+            violations.append(f"{rel}:{lineno} ({ctx}) _LifecycleHost")
+    assert not violations, (
+        "_LifecycleHost was deleted in Wave 2 of plan host-protocol-removal "
+        "(PR #1133). Reappearance reintroduces the Session-as-host pattern "
+        "that Wave 2 dismantled — refresh_auth_session now takes five "
+        "explicit keyword-only collaborators (auth, kernel, auth_coord, "
+        "lifecycle, cookie_persistence). Offenders:\n  " + "\n  ".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard 2: no cast to ``_LifecycleHost`` in any spelling.
+# ---------------------------------------------------------------------------
+
+
+def test_no_cast_to_lifecycle_host_in_src() -> None:
+    """``cast(_LifecycleHost, ...)`` in any spelling must not appear in src.
+
+    Spellings caught (per docstring):
+    - ``cast("_LifecycleHost", obj)`` — string forward ref
+    - ``cast(_LifecycleHost, obj)`` — bare name
+    - ``typing.cast("_LifecycleHost", obj)`` — qualified
+    - aliased ``cast`` import (e.g. ``from typing import cast as c``)
+      where the second-arg literal still says ``_LifecycleHost`` (the
+      target match is what trips the guard, not the callable's name)
+
+    Failure mode: Wave 2 retired the ``typing.cast(_LifecycleHost, core)``
+    line in ``_auth/session.py``. Adding it back — or a sibling cast in
+    any other module — would trip this guard.
+    """
+    violations: list[str] = []
+    for src in _iter_src_files():
+        rel = src.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not _is_cast_call(node):
+                continue
+            assert isinstance(node, ast.Call)  # narrowed by _is_cast_call
+            target = _cast_target_name(node)
+            if target == "_LifecycleHost":
+                violations.append(f"{rel}:{node.lineno} cast(..., _LifecycleHost)")
+    assert not violations, (
+        "cast(..., _LifecycleHost) was retired in Wave 2 of plan "
+        "host-protocol-removal (PR #1133). Reintroducing the cast — even "
+        "for a one-line typing accommodation — reopens the Session-as-host "
+        "coupling Waves 1-3 closed. Offenders:\n  " + "\n  ".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard 3: ``RefreshAuthCore`` must not appear in ``src/notebooklm/``.
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_auth_core_symbol_does_not_appear_in_src() -> None:
+    """``RefreshAuthCore`` was deleted in Wave 2 (PR #1133); reappearance is a regression.
+
+    Failure mode: re-declaring ``class RefreshAuthCore(Protocol): ...``
+    in ``src/notebooklm/_auth/session.py`` (or anywhere else under
+    ``src/notebooklm/``) would surface here as a ``ClassDef`` violation;
+    a typing-only ``from ._auth.session import RefreshAuthCore`` would
+    surface as an ``alias`` violation; a string forward reference
+    ``"RefreshAuthCore"`` in an annotation would surface as a
+    ``Constant`` violation.
+    """
+    violations: list[str] = []
+    for src in _iter_src_files():
+        rel = src.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        hits = _find_symbol_appearances(tree, "RefreshAuthCore")
+        for lineno, ctx in hits:
+            violations.append(f"{rel}:{lineno} ({ctx}) RefreshAuthCore")
+    assert not violations, (
+        "RefreshAuthCore was deleted in Wave 2 of plan host-protocol-removal "
+        "(PR #1133). Reappearance restores the Session-shaped argument "
+        "contract that refresh_auth_session(core) once required; the live "
+        "helper takes five explicit collaborators by keyword. Offenders:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard 4: ``_auth/session.py`` must carry no host-Protocol residue.
+# ---------------------------------------------------------------------------
+
+
+def test_auth_session_module_has_no_host_protocol_residue() -> None:
+    """``_auth/session.py`` must remain free of every Wave 2 / Wave 3 residue.
+
+    Four sub-checks (any failure surfaces as a separate violation line):
+
+    1. no import of the ``Session`` class — keeps the refresh helper
+       free of any typing dependency on the lifecycle root
+    2. no Protocol body declaring ``_kernel`` — prevents resurrection of
+       a host-shaped Protocol under a new name
+    3. no call ``X.update_auth_tokens(...)`` / ``X.update_auth_headers(...)``
+       where ``X`` is not a coordinator-shaped name. The live caller
+       routes through ``auth_coord.update_auth_*(...)``; calling either
+       method on ``core`` / ``session`` / ``host`` / ``self`` would
+       restore the deleted Session-as-host shape.
+    4. no cast to ``_LifecycleHost`` or ``RefreshAuthCore`` — duplicates
+       Guards 1-3 for the one file that historically carried both casts;
+       the duplication is belt-and-braces.
+
+    Failure mode: a future PR that "re-adds the Session import for a
+    typing-only annotation" or "re-introduces a cast for one call site"
+    trips this guard before the PR opens.
+    """
+    source = AUTH_SESSION_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    violations: list[str] = []
+
+    # Sub-check 1: no import of ``Session``.
+    for lineno in _imports_session_class(tree):
+        violations.append(
+            f"_auth/session.py:{lineno} imports `Session` — Wave 2 removed "
+            "the Session-shaped core argument; refresh_auth_session takes "
+            "five explicit collaborators."
+        )
+
+    # Sub-check 2: no Protocol class with ``_kernel: ...`` annotation.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and _protocol_class_declares_kernel(node):
+            violations.append(
+                f"_auth/session.py:{node.lineno} declares Protocol `{node.name}` "
+                "with `_kernel` annotation — host-shaped Protocols were "
+                "retired in Wave 2."
+            )
+
+    # Sub-check 3: no ``X.update_auth_tokens(...)`` / ``X.update_auth_headers(...)``
+    # where the receiver is not a coordinator-shaped name. The receiver
+    # may also be an Attribute chain ending in a coordinator name
+    # (``self._auth_coord.update_auth_tokens(...)``), so we check the
+    # *immediate* receiver — for ``a.b.method()`` the receiver is ``a.b``,
+    # for ``a.method()`` the receiver is ``a``. A bare-name receiver is
+    # the regression surface; chain receivers are out of scope (the
+    # live caller uses the kwarg directly, ``auth_coord.update_auth_*``).
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in AUTH_FORWARD_METHOD_NAMES:
+            continue
+        receiver = node.func.value
+        if isinstance(receiver, ast.Name):
+            if receiver.id not in AUTH_COORD_RECEIVER_NAMES:
+                violations.append(
+                    f"_auth/session.py:{node.lineno} calls "
+                    f"`{receiver.id}.{node.func.attr}(...)` — "
+                    f"`{node.func.attr}` now lives on AuthRefreshCoordinator; "
+                    "route through the `auth_coord` kwarg explicitly."
+                )
+        # Attribute-chain receivers (``self._auth_coord.update_*``) are
+        # acceptable — they reach the coordinator through an explicit
+        # collaborator slot rather than a Session-shaped delegate.
+
+    # Sub-check 4: no cast to ``_LifecycleHost`` / ``RefreshAuthCore``.
+    for node in ast.walk(tree):
+        if not _is_cast_call(node):
+            continue
+        assert isinstance(node, ast.Call)  # narrowed by _is_cast_call
+        target = _cast_target_name(node)
+        if target in DELETED_HOST_PROTOCOL_NAMES:
+            violations.append(
+                f"_auth/session.py:{node.lineno} casts to `{target}` — both "
+                "host Protocols were retired in Wave 2 of plan "
+                "host-protocol-removal (PR #1133)."
+            )
+
+    assert not violations, (
+        "_auth/session.py must remain free of Session-as-host residue after "
+        "Waves 2-3 of plan host-protocol-removal. Offenders:\n  " + "\n  ".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-coverage — prove each guard fires on a synthetic regression.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("source", "symbol", "expected_contexts"),
+    [
+        # Bare Name reference
+        ("def f(x: _LifecycleHost) -> None: ...\n", "_LifecycleHost", {"Name"}),
+        # Attribute access
+        ("mod._LifecycleHost\n", "_LifecycleHost", {"Attribute"}),
+        # String forward reference
+        ('x: "_LifecycleHost"\n', "_LifecycleHost", {"Constant"}),
+        # Class definition
+        ("class _LifecycleHost: ...\n", "_LifecycleHost", {"ClassDef"}),
+        # Import alias
+        (
+            "from foo import _LifecycleHost\n",
+            "_LifecycleHost",
+            {"alias"},
+        ),
+        # Mirror for RefreshAuthCore
+        ("class RefreshAuthCore(Protocol): ...\n", "RefreshAuthCore", {"ClassDef"}),
+    ],
+    ids=[
+        "lifecycle-host-name",
+        "lifecycle-host-attribute",
+        "lifecycle-host-string",
+        "lifecycle-host-classdef",
+        "lifecycle-host-import",
+        "refresh-auth-core-classdef",
+    ],
+)
+def test_find_symbol_appearances_catches_each_context(
+    source: str, symbol: str, expected_contexts: set[str]
+) -> None:
+    """``_find_symbol_appearances`` must catch every context the docstring claims."""
+    tree = ast.parse(source)
+    hits = _find_symbol_appearances(tree, symbol)
+    assert hits, f"Expected at least one hit for {symbol!r} in {source!r}"
+    seen_contexts = {ctx for _, ctx in hits}
+    assert expected_contexts.issubset(seen_contexts), (
+        f"Expected contexts {expected_contexts!r} for {source!r}, got {seen_contexts!r}"
+    )
+
+
+def test_find_symbol_appearances_ignores_unrelated_names() -> None:
+    """Unrelated identifiers must not be flagged."""
+    tree = ast.parse("class Other: ...\nfrom foo import Bar\n")
+    assert _find_symbol_appearances(tree, "_LifecycleHost") == []
+    assert _find_symbol_appearances(tree, "RefreshAuthCore") == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_target"),
+    [
+        # String form
+        ('cast("_LifecycleHost", x)\n', "_LifecycleHost"),
+        # Name form
+        ("cast(_LifecycleHost, x)\n", "_LifecycleHost"),
+        # Qualified
+        ('typing.cast("_LifecycleHost", x)\n', "_LifecycleHost"),
+        # Aliased cast: still matches because we key on the second-arg literal
+        ('c("_LifecycleHost", x)\n', None),  # bare ``c(...)`` is not a cast call
+        # Sibling Protocol
+        ("cast(RefreshAuthCore, x)\n", "RefreshAuthCore"),
+    ],
+    ids=[
+        "string-form",
+        "name-form",
+        "qualified-form",
+        "aliased-not-named-cast",
+        "refresh-auth-core",
+    ],
+)
+def test_cast_target_extraction(source: str, expected_target: str | None) -> None:
+    """``_cast_target_name`` resolves first-arg targets across spellings."""
+    tree = ast.parse(source)
+    casts = [
+        _cast_target_name(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_cast_call(node)
+    ]
+    if expected_target is None:
+        assert casts == [], (
+            f"Expected no cast call (callable is not named `cast`) for {source!r}, got {casts!r}"
+        )
+    else:
+        assert expected_target in casts, (
+            f"Expected to find cast target {expected_target!r} in {source!r}, got {casts!r}"
+        )
+
+
+def test_protocol_class_declares_kernel_positive() -> None:
+    """A Protocol body with ``_kernel: T`` must be detected."""
+    tree = ast.parse(
+        "class _HostProto(Protocol):\n    _kernel: object\n    def f(self) -> None: ...\n"
+    )
+    classes = [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
+    assert len(classes) == 1
+    assert _protocol_class_declares_kernel(classes[0])
+
+
+def test_protocol_class_declares_kernel_skips_non_protocol() -> None:
+    """A plain dataclass with ``_kernel`` annotation must NOT trip the guard.
+
+    The Protocol membership gate prevents over-matching on legitimate
+    collaborator dataclasses (e.g. ``ClientLifecycle._kernel: Kernel``).
+    """
+    tree = ast.parse("class Plain:\n    _kernel: object\n")
+    classes = [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
+    assert not _protocol_class_declares_kernel(classes[0])
+
+
+def test_imports_session_class_catches_both_shapes() -> None:
+    """``from foo import Session`` and ``import foo as Session`` both surface."""
+    tree = ast.parse(
+        "from notebooklm._session import Session\n"
+        "import other as Session\n"
+        "from notebooklm._session import Session as S\n"  # aliased rename also surfaces
+    )
+    # All three lines bring some name into scope that resolves to Session.
+    # The third form (``Session as S``) imports the Session class itself
+    # and renames it; we surface that too because the typing dependency
+    # is what the guard is preventing, not the local name choice.
+    hits = _imports_session_class(tree)
+    assert len(hits) == 3, f"Expected 3 hits, got {hits!r}"


### PR DESCRIPTION
## Summary

Close plan [`host-protocol-removal`](../blob/main/.sisyphus/phases/host-protocol-removal/phase-1.md) with regression guards that pin the post-Wave-3 boundary in place from three independent vertices.

- **Wave 0 → #1131** added `self._auth = auth` in `NotebookLMClient.__init__` and the shell helper for refresh tests
- **Wave 1 → #1132** added `TransportDrainTracker.reset_after_open()` + `AuthRefreshCoordinator.cancel_inflight_refresh()`
- **Wave 2 → #1133** (atomic) deleted `_LifecycleHost` + `RefreshAuthCore` Protocols + the `typing.cast(_LifecycleHost, core)` site; rewrote `refresh_auth_session(*, auth, kernel, auth_coord, lifecycle, cookie_persistence)`
- **Wave 3 → #1134** deleted `Session.lifecycle` / `update_auth_tokens` / `update_auth_headers`; `client.auth` reads `self._auth` directly; `SourceUploadPipeline(auth=self._auth)`
- **Wave 4 → this PR** adds the AST regression guards and updates docs

## What this PR adds

**`tests/_lint/test_session_runtime_boundaries.py`** (NEW, AST-based):
- Guard 1: `_LifecycleHost` symbol must not appear in `src/notebooklm/`
- Guard 2: no `cast(_LifecycleHost, ...)` in any of four spellings (string/name/qualified/aliased)
- Guard 3: `RefreshAuthCore` symbol must not appear in `src/notebooklm/`
- Guard 4: `_auth/session.py` may not import `Session`, declare a Protocol with `_kernel`, call `update_auth_*` on a Session-shaped receiver, or cast to either retired Protocol

**`tests/_lint/test_client_composition.py`** (EXTEND):
- New Guard 4 (`test_client_self_session_access_is_allowlisted`): allowlist `self._session.<X>` in `client.py` to `open` / `close` / `drain` / `is_open` only. Stricter than the existing private-attr guard — catches public-attribute drift like a future `self._session.lifecycle` re-introduction.

**`tests/_lint/test_session_retention.py`** (EXTEND):
- New `test_wave_3_deletions_stay_out_of_live_inventory`: pin the three Wave 3 method deletions (`lifecycle` / `update_auth_tokens` / `update_auth_headers`) so they cannot resurface on `Session` or in the live Inventory table.

**Docs:**
- `docs/session-method-retention.md`: add Status paragraph documenting Wave 4 closure and the three new lints
- `docs/adr/0014-feature-local-runtime-adapters.md`: add 2026-05-28 revision note "Lifecycle/auth refresh no longer consume Session-shaped host protocols" with PR refs #1131-#1134

## Triangle of regression guards

| Vertex | Lint | Catches |
|---|---|---|
| Session definition | `test_session_retention.py` | new method on Session w/o doc row; Wave 3 deletions resurfacing |
| Composition root | `test_client_composition.py` Guard 4 | `self._session.<X>` outside the 4-attr allowlist |
| Source-wide symbol scan | `test_session_runtime_boundaries.py` Guards 1-4 | `_LifecycleHost` / `RefreshAuthCore` / cast / Session-shaped receiver |

The three lints together form a triangle: any reintroduction (a) on `Session`, (b) at the composition root, or (c) on the auth helper is caught at a different vertex.

## Test plan

- [x] `uv run ruff format .` — 560 files unchanged
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — no issues found in 178 source files
- [x] `uv run pytest tests/_lint/ -v` — 99 lint tests pass
- [x] `uv run pytest` — 6892 passed / 94 skipped / 2 xfailed in 108s
- [x] All four new guards confirmed to FAIL on synthetic regressions (re-introduced symbol, re-introduced cast, re-declared Protocol, Session-shaped receiver call) so they actually act as regression guards rather than no-ops.

## Deferred polish findings

None. One documented nit (aliased-`cast`-from-typing spelling) is already covered by Guard 1's symbol-appearance scan — if someone aliases `cast` and casts to `_LifecycleHost`, the bare name `_LifecycleHost` still surfaces as an `ast.Name`.

## Constraint compliance

- No `src/notebooklm/**.py` edits (Wave 4 is lints + docs only)
- No new Session methods added
- No Stage-A accessors renamed or deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR and session-retention guidance documenting the finalized session surface and recent runtime protocol changes.

* **Tests**
  * Added repository-wide regression checks and targeted tests to ensure removed host-protocol artifacts stay removed and session lifecycle boundaries remain enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->