### PR TITLE
refactor(client): move compose helpers and extract client holders

### DIFF
--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -518,8 +518,8 @@ cut of PR 12.9):
 
 The middleware takes a zero-arg async-context-manager factory rather
 than a raw `asyncio.Semaphore`, so production wires
-`SemaphoreMiddleware(self._get_rpc_semaphore)` and the accessor returns
-a `contextlib.nullcontext` when `max_concurrent_rpcs is None` (unbounded
+`ClientComposed.get_rpc_semaphore`. The holder returns a
+`contextlib.nullcontext` when `max_concurrent_rpcs is None` (unbounded
 opt-out) — the `async with` collapses to a no-op for that case.
 
 History: the first cut of PR 12.9 audit-find #1 wrapped the semaphore

--- a/docs/adr/0014-feature-local-runtime-adapters.md
+++ b/docs/adr/0014-feature-local-runtime-adapters.md
@@ -241,11 +241,12 @@ deletes them.
 - ~~`Session.collaborators`, `Session.session_transport`, `Session.rpc_executor`~~
   — three typed accessors per Rule 3 Stage A. **Deleted under Rule 3 Stage B
   by Stage B1 PR 2 of the post-refactoring plan 2026-05-27 (#1089 commit
-  `313bbef1`)** — `compose_session_internals()` in `_session.py` is now the
-  composition root; the three accessor properties and the `_get_rpc_executor`
-  lazy factory all collapsed to direct reads on the returned
-  `ComposedSession`. The previous Task 6.3 AST lint protecting these
-  accessors no longer has live callers to protect.
+  `313bbef1`)** — `compose_session_internals()` became the composition root
+  and later moved to `_session_init.py` during Session-elimination Phase 1;
+  the three accessor properties and the `_get_rpc_executor` lazy factory all
+  collapsed to direct reads on the returned `ComposedSession`. The previous
+  Task 6.3 AST lint protecting these accessors no longer has live callers to
+  protect.
 
 Everything else on `Session` after Wave 5 should be either listed here or
 deleted.
@@ -391,7 +392,8 @@ deferred follow-ups — see [Revision history](#revision-history).
 ### 2026-05-27 — Rule 3 Stage B closure (post-refactoring plan 2026-05-27 Stage B1, #1086 / #1089 / #1091)
 
 Issue #1084 (deferred Rule 3 Stage B) closed. `compose_session_internals()`
-in `_session.py` became the composition root: `Session.__init__` was
+became the composition root and now lives in `_session_init.py`:
+`Session.__init__` was
 narrowed to `(*, collaborators, config, auth)` and the Stage A accessor
 properties (`Session.collaborators`, `Session.session_transport`,
 `Session.rpc_executor`) plus the `_get_rpc_executor` lazy factory were

--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -23,8 +23,8 @@ closed on 2026-05-28 with Waves 0-4. The retained Session surface is now
 the **Inventory** table below in full: the four lifecycle hot-path
 entries (`open` / `close` / `is_open` / `_keepalive_loop`), the
 `__init__` constructor, the `drain` public-API forward, the
-`assert_bound_loop` / `_get_rpc_semaphore` provider-closure capture
-targets, and the Stage B1 composition primitives (`_bind_transport`,
+`assert_bound_loop` provider-closure capture target, and the Stage B1
+composition primitives (`_bind_transport`,
 `_bind_chain_metadata`, `_bind_executor`, `_require_constructed`).
 Stage A accessors (`collaborators` / `session_transport` / `rpc_executor`)
 were deleted in Stage B1 PR 2 of the post-refactoring plan and are
@@ -80,11 +80,10 @@ lint at PR time.
 | `is_open` (property) | lifecycle | retain — public open-state read |
 | `_keepalive_loop` | lifecycle | retain — background task body; introspected by `test_client_keepalive` |
 | `assert_bound_loop` | provider-closure capture target | retain — captured via lambda (`bound_loop_check=lambda: host.assert_bound_loop()`) by `build_session_transport` at [`_session_init.py:395`](../src/notebooklm/_session_init.py); late-bound so a test reassigning `core.assert_bound_loop = mock` still steers the live check |
-| `_get_rpc_semaphore` | provider-closure capture target | retain — passed as `rpc_semaphore_factory=self._get_rpc_semaphore` to `wire_middleware_chain` at [`_session.py:416`](../src/notebooklm/_session.py); has real body (lazy semaphore creation) reading `self._max_concurrent_rpcs` / `self._rpc_semaphore`, not a forward |
 | `_bind_transport` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._transport`. Load-bearing after PR 2 — `Session.__init__` leaves `_transport` at `None` and `compose_session_internals` is the single assignment site. |
 | `_bind_chain_metadata` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for the auxiliary chain artifacts (`_chain_builder` / `_middlewares`). The `_authed_post_chain` slot itself is owned by `MiddlewareChainHost` and assigned exactly once by `compose_session_internals` (`chain_host._authed_post_chain = wired.authed_post_chain`); this binder stores only the auxiliary metadata. Load-bearing — `Session.__init__` leaves the metadata slots at `None` and `compose_session_internals` is the single assignment site. |
 | `_bind_executor` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._rpc_executor`. Load-bearing after PR 2 — the lazy `_get_rpc_executor` factory was deleted; `compose_session_internals` is the single assignment site and the binding is never re-nulled by `close()`. |
-| `_require_constructed` | composition guard | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); fail-fast helper used by `_get_rpc_semaphore` / `open` / `close` to assert the named binding is non-None. Load-bearing — `Session.__init__` leaves the late-bound slots at `None`, and any caller that exercises a Session outside `compose_session_internals` trips the guard. |
+| `_require_constructed` | composition guard | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); fail-fast helper used by `open` / `close` to assert the named binding is non-None. Load-bearing — `Session.__init__` leaves the late-bound slots at `None`, and any caller that exercises a Session outside `compose_session_internals` trips the guard. |
 | `drain` | public API forward | retain — narrow public method (one-line forward to `TransportDrainTracker.drain`). Backs `NotebookLMClient.drain` so the composition root does not dereference the private `_drain_tracker` slot on the session. The Wave 11a deletion row in the **Deleted** section below refers to an earlier compatibility-forward incarnation; this row is the boundary-focused re-introduction (narrow forward, single caller, AST-guarded by `tests/_lint/test_client_composition.py::test_client_does_not_dereference_session_privates`). |
 
 ## Chain-ownership carve-out (closed)
@@ -108,9 +107,10 @@ The two follow-up issues filed per ADR-014 close-out (Wave 6 / Task 6.2):
   `Session` to `NotebookLMClient`; delete `Session.collaborators` /
   `Session.session_transport` / `Session.rpc_executor` accessors. **CLOSED by
   Stage B1 PR 2 of the post-refactoring plan (2026-05-27)** — the composition
-  root moved to `compose_session_internals()` in `_session.py`; the three Stage
-  A accessor properties and the `_get_rpc_executor` lazy factory are listed
-  in the **Deleted** section below.
+  root moved to `compose_session_internals()` (moved from `_session.py` to
+  `_session_init.py` during Session-elimination Phase 1); the three Stage A
+  accessor properties and the `_get_rpc_executor` lazy factory are listed in
+  the **Deleted** section below.
 - **`MiddlewareChainHost` extraction (Rule 4 completion):** extract a
   `MiddlewareChainHost` collaborator owning `_authed_post_chain_terminal` +
   the `_rate_limit_max_retries` / `_server_error_max_retries` /
@@ -130,6 +130,12 @@ compatibility forward that once lived on `Session`; the lint above
 enforces that no Session method exists today without either a
 `retain — <reason>` row in the **Inventory** above or a `deleted in
 Wave 11<sub>` row in one of the cluster sub-sections below.
+
+### Session-elimination Phase 1 — client holders (2026-05-28)
+
+| Method | Category | Disposition |
+|---|---|---|
+| `_get_rpc_semaphore` | provider-closure capture target | deleted in Phase 1 of plan `session-elimination-plan` — the lazy semaphore state moved to `ClientComposed.get_rpc_semaphore`, and `compose_session_internals` now passes that holder method as `rpc_semaphore_factory`. The moved holder preserves the previous `None` opt-out and lazy-once `asyncio.Semaphore` construction while removing `Session._max_concurrent_rpcs` / `Session._rpc_semaphore` ownership. |
 
 ### Wave 11a — drain-and-operation cluster (commit `80a54fda`)
 
@@ -169,11 +175,13 @@ Wave 11<sub>` row in one of the cluster sub-sections below.
 ### Stage B1 PR 2 — composition-root inversion (post-refactoring plan 2026-05-27)
 
 Stage B1 PR 2 inverted the composition root: `compose_session_internals()`
-in `_session.py` now owns the full collaborator-bundle / transport / chain /
-executor construction sequence, and `Session.__init__` was narrowed to
-`(*, collaborators, config, auth)`. The Stage A accessor properties added by
-PR #1069 (Wave 6) and the lazy `_get_rpc_executor` factory all collapse to
-direct reads on the `ComposedSession` returned by the helper.
+owned the full collaborator-bundle / transport / chain / executor construction
+sequence, and `Session.__init__` was narrowed to
+`(*, collaborators, config, auth)`. Session-elimination Phase 1 moved that
+helper from `_session.py` to `_session_init.py` while keeping the same
+composition-root role. The Stage A accessor properties added by PR #1069
+(Wave 6) and the lazy `_get_rpc_executor` factory all collapse to direct reads
+on the `ComposedSession` returned by the helper.
 
 | Method | Category | Disposition |
 |---|---|---|

--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -1,0 +1,48 @@
+"""Client-owned composition holder state."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import AbstractAsyncContextManager, nullcontext
+from typing import TYPE_CHECKING, Any
+
+from ._session_config import DEFAULT_MAX_CONCURRENT_RPCS
+
+if TYPE_CHECKING:
+    from ._rpc_executor import RpcExecutor
+    from ._session_init import SessionCollaborators
+    from ._session_transport import SessionTransport
+
+
+class ClientComposed:
+    """Mutable holder for composition state that is migrating off ``Session``."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
+    ) -> None:
+        if max_concurrent_rpcs is not None and max_concurrent_rpcs < 1:
+            raise ValueError(f"max_concurrent_rpcs must be >= 1, got {max_concurrent_rpcs!r}")
+        self.max_concurrent_rpcs = max_concurrent_rpcs
+        self._rpc_semaphore: asyncio.Semaphore | None = None
+
+        # Phase 2 migration placeholders. Phase 1 still returns the canonical
+        # `ComposedSession` bundle, but it also populates these fields so the
+        # next phase can move reads onto this holder without another state move.
+        self.transport: SessionTransport | None = None
+        self.executor: RpcExecutor | None = None
+        # Avoid a plain `.collaborators` attribute here: the ADR-014 lint
+        # reserves that name for the deleted Stage A Session accessor.
+        self.session_collaborators: SessionCollaborators | None = None
+
+    def get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
+        """Return the lazy per-client RPC semaphore, or a no-op context."""
+        if self.max_concurrent_rpcs is None:
+            return nullcontext()
+        if self._rpc_semaphore is None:
+            self._rpc_semaphore = asyncio.Semaphore(self.max_concurrent_rpcs)
+        return self._rpc_semaphore
+
+
+__all__ = ["ClientComposed"]

--- a/src/notebooklm/_client_seams.py
+++ b/src/notebooklm/_client_seams.py
@@ -1,0 +1,62 @@
+"""Client-level late-rebind seams.
+
+The callable seams in this module are intentionally separate from construction
+seams such as ``async_client_factory``. ``ClientSeams`` owns only callables that
+runtime closures may re-read after construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ClientSeams:
+    """Runtime callables re-read by RPC and middleware closures."""
+
+    decode_response: Callable[..., Any]
+    sleep: Callable[[float], Awaitable[Any]]
+    is_auth_error: Callable[[Exception], bool]
+
+
+def _default_sleep() -> Callable[[float], Awaitable[Any]]:
+    """Resolve sleep through ``notebooklm._session`` for patch compatibility."""
+    from . import _session as session_mod
+
+    return session_mod.asyncio.sleep
+
+
+def _default_decode_response() -> Callable[..., Any]:
+    """Resolve the canonical RPC response decoder."""
+    from .rpc import decode_response
+
+    return decode_response
+
+
+def _default_is_auth_error() -> Callable[[Exception], bool]:
+    """Resolve the canonical auth-error classifier."""
+    from ._session_helpers import is_auth_error
+
+    return is_auth_error
+
+
+def resolve_client_seams(
+    *,
+    sleep: Callable[[float], Awaitable[Any]] | None,
+    is_auth_error: Callable[[Exception], bool] | None,
+    decode_response: Callable[..., Any] | None,
+) -> ClientSeams:
+    """Resolve ``None`` seam defaults into a mutable runtime holder."""
+    return ClientSeams(
+        decode_response=_default_decode_response() if decode_response is None else decode_response,
+        sleep=_default_sleep() if sleep is None else sleep,
+        is_auth_error=_default_is_auth_error() if is_auth_error is None else is_auth_error,
+    )
+
+
+__all__ = [
+    "ClientSeams",
+    "resolve_client_seams",
+]

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -131,9 +131,8 @@ class MiddlewareChainBuilder:
             # ``host._refresh_callback is not None`` gate in the leaf).
             # ``refresh_retry_delay_provider`` is callable for
             # live-binding parity with retry budgets.
-            # ``is_auth_error`` is bound late (see ``_live_is_auth_error``
-            # in ``_session.py``) so test monkeypatches of
-            # ``notebooklm._core.is_auth_error`` reach the chain.
+            # ``is_auth_error`` is supplied as a live-binding callable from
+            # ``ClientSeams`` so test rebinds can still steer the chain.
             # ``auth_snapshot_provider`` gives AuthRefreshMiddleware a
             # fresh post-refresh snapshot so it can replace the
             # populated request envelope before retrying the Kernel.post

--- a/src/notebooklm/_middleware_semaphore.py
+++ b/src/notebooklm/_middleware_semaphore.py
@@ -28,8 +28,8 @@ both contracts in one place:
 
 The semaphore is supplied as a zero-arg async-context-manager factory rather
 than the raw ``asyncio.Semaphore`` so the middleware can be live-bound to
-``Session._get_rpc_semaphore`` — which lazily constructs the semaphore on
-first use (loop affinity) and returns a ``contextlib.nullcontext`` when
+``ClientComposed.get_rpc_semaphore`` — which lazily constructs the semaphore
+on first use (loop affinity) and returns a ``contextlib.nullcontext`` when
 ``max_concurrent_rpcs is None`` (unbounded opt-out). A direct semaphore
 binding would have to be reset on loop reuse and would have a 2-call
 recursive-acquire deadlock risk; the factory closure avoids both.
@@ -69,7 +69,7 @@ class SemaphoreMiddleware:
     - ``semaphore_factory``: zero-arg callable returning an async context
       manager. Called once per chain invocation; the returned context manager
       is entered around ``next_call``. Production wires
-      ``lambda: client_core._get_rpc_semaphore()`` so the live (lazily
+      ``ClientComposed.get_rpc_semaphore`` so the live (lazily
       constructed, loop-bound) semaphore is observed on each call. Tests can
       pass ``lambda: contextlib.nullcontext()`` to disable gating.
 

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -1,49 +1,30 @@
 """Concrete session infrastructure for the NotebookLM API client."""
 
-import asyncio
+from __future__ import annotations
+
+import asyncio  # noqa: F401 - compatibility patch surface for default sleep
 import logging
 import random  # noqa: F401 - tests patch this for _backoff jitter
-from collections.abc import Awaitable, Callable
-from contextlib import AbstractAsyncContextManager, nullcontext
-from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import httpx
+import httpx  # noqa: F401 - compatibility patch surface for AsyncClient defaults
 
-from ._error_injection import _refuse_synthetic_error_outside_test_context
-from ._middleware_chain_host import MiddlewareChainHost
 from ._rpc_executor import RpcExecutor
-from ._session_config import (
-    DEFAULT_CONNECT_TIMEOUT,
-    DEFAULT_KEEPALIVE_MIN_INTERVAL,
-    DEFAULT_MAX_CONCURRENT_RPCS,
-    DEFAULT_MAX_CONCURRENT_UPLOADS,
-    DEFAULT_TIMEOUT,
-)
-from ._session_init import (
-    build_collaborators,
-    build_session_transport,
-    validate_constructor_args,
-    wire_middleware_chain,
-)
-from ._session_lifecycle import CookieRotator, CookieSaver
 from ._session_transport import SessionTransport
 from .auth import (
     AuthTokens,
 )
-from .types import RpcTelemetryEvent
 
 if TYPE_CHECKING:
+    from ._client_seams import ClientSeams
     from ._middleware import Middleware
     from ._middleware_chain import MiddlewareChainBuilder
+    from ._middleware_chain_host import MiddlewareChainHost
     from ._session_init import (
         SessionCollaborators,
         ValidatedSessionConfig,
         WiredMiddleware,
     )
-    from ._session_transport import SessionTransport
-    from .types import ConnectionLimits
 
     # ADR-014 Rule 5 (Wave 4 of session-decoupling): the compile-time
     # ``Session: RpcOwner`` assertion was removed when the ``RpcOwner``
@@ -81,304 +62,6 @@ logger = logging.getLogger(__name__)
 # :meth:`AuthRefreshCoordinator.update_auth_tokens` directly.
 
 
-def _default_decode_response() -> Callable[..., Any]:
-    """Resolve the canonical RPC response decoder used when
-    :class:`Session` is constructed without an explicit
-    ``decode_response=`` kwarg.
-
-    The function is invoked **eagerly** (once per ``Session()`` call)
-    and captures its result immediately. The ``import`` inside the body
-    is deferred so the attribute lookup goes through
-    ``notebooklm.rpc.decode_response`` at construction time — the
-    canonical monkeypatch surface documented in ADR-007. This is NOT
-    a late-binding wrapper — see ``docs/improvement.md`` §4.1 for the
-    contrast with the retired ``_decode_response_late_bound``.
-    """
-    from .rpc import decode_response
-
-    return decode_response
-
-
-def _default_is_auth_error() -> Callable[[Exception], bool]:
-    """Resolve the canonical auth-error classifier used when
-    :class:`Session` is constructed without an explicit
-    ``is_auth_error=`` kwarg.
-
-    The function is invoked **eagerly** (once per ``Session()`` call)
-    and captures its result immediately. The ``import`` inside the body
-    is deferred so the attribute lookup goes through
-    ``notebooklm._session_helpers.is_auth_error`` at construction
-    time — the canonical monkeypatch surface documented in ADR-007.
-    This is NOT a late-binding wrapper — see ``docs/improvement.md``
-    §4.1 for the contrast with the retired ``_live_is_auth_error``.
-    """
-    from ._session_helpers import is_auth_error
-
-    return is_auth_error
-
-
-# ----------------------------------------------------------------------
-# Stage B1 PR 2 — composition root (live)
-# ----------------------------------------------------------------------
-#
-# These helpers (``resolve_seam_defaults`` / :func:`compose_session_internals`
-# / :class:`ComposedSession`) and the ``Session._bind_*`` write-once
-# setters were introduced in Stage B1 PR 1 and made LIVE in PR 2 of the
-# post-refactoring plan (``docs/post-refactoring-plan-2026-05-27.md``).
-#
-# After PR 2, ``Session.__init__`` takes ``(*, collaborators, config,
-# auth)`` and leaves the transport / chain / executor slots at ``None``.
-# :func:`compose_session_internals` is the only path that produces a
-# fully-bound :class:`Session` — it constructs the collaborators bundle,
-# the transport, the wired middleware chain, and the :class:`RpcExecutor`,
-# and drives the write-once binders on the Session. The fail-fast guards
-# on :class:`Session` entry points (``_get_rpc_semaphore`` / ``open`` /
-# ``close``) became load-bearing in PR 2 — they raise actionably if a caller
-# exercises the Session before the composition root has bound the slots.
-#
-# The helper lives in :mod:`notebooklm._session` (not
-# :mod:`notebooklm._session_init`) so seam-default resolution happens
-# against this module's bindings, preserving the documented monkeypatch
-# contract at :mod:`_session_init` lines 19-25.
-
-
-@dataclass(frozen=True)
-class ComposedSession:
-    """Result of :func:`compose_session_internals`.
-
-    Bundles the fully-constructed :class:`Session` with the collaborators
-    and late-bound dependencies that ``NotebookLMClient`` wires feature
-    APIs against. After Stage B1 PR 2, this is the canonical output of
-    the composition root — :class:`NotebookLMClient` consumes it directly
-    and feature adapters draw from ``composed.executor`` /
-    ``composed.transport`` / ``composed.collaborators`` rather than
-    reading back through Session accessors.
-    """
-
-    session: "Session"
-    transport: SessionTransport
-    executor: RpcExecutor
-    collaborators: "SessionCollaborators"
-
-
-def resolve_seam_defaults(
-    *,
-    sleep: Callable[[float], Awaitable[Any]] | None,
-    async_client_factory: Callable[..., httpx.AsyncClient] | None,
-    is_auth_error: Callable[[Exception], bool] | None,
-    decode_response: Callable[..., Any] | None,
-) -> dict[str, Callable[..., Any]]:
-    """Resolve ``None``-default seam callables against this module's bindings.
-
-    Centralizes the ``X if X is not None else <module-attr>`` dance that
-    :class:`Session.__init__` performed inline before Stage B1 PR 2.
-    Resolution happens against the :mod:`notebooklm._session` module's
-    bindings so the documented monkeypatch paths
-    (``notebooklm._session.asyncio.sleep`` /
-    ``notebooklm._session.httpx.AsyncClient`` and the lazy imports inside
-    :func:`_default_decode_response` / :func:`_default_is_auth_error`)
-    keep steering the seams at construction time.
-
-    Called from :func:`compose_session_internals`. After PR 2 this is the
-    single seam-resolution site; ``Session.__init__`` no longer touches
-    the seam defaults.
-    """
-    return {
-        "sleep": asyncio.sleep if sleep is None else sleep,
-        "async_client_factory": (
-            httpx.AsyncClient if async_client_factory is None else async_client_factory
-        ),
-        "is_auth_error": (_default_is_auth_error() if is_auth_error is None else is_auth_error),
-        "decode_response": (
-            _default_decode_response() if decode_response is None else decode_response
-        ),
-    }
-
-
-def compose_session_internals(
-    *,
-    auth: AuthTokens,
-    timeout: float = DEFAULT_TIMEOUT,
-    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
-    refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
-    refresh_retry_delay: float = 0.2,
-    keepalive: float | None = None,
-    keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
-    keepalive_storage_path: Path | None = None,
-    rate_limit_max_retries: int = 3,
-    server_error_max_retries: int = 3,
-    limits: "ConnectionLimits | None" = None,
-    max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
-    max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
-    on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
-    cookie_saver: CookieSaver | None = None,
-    cookie_rotator: CookieRotator | None = None,
-    decode_response: Callable[..., Any] | None = None,
-    sleep: Callable[[float], Awaitable[Any]] | None = None,
-    is_auth_error: Callable[[Exception], bool] | None = None,
-    async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
-) -> ComposedSession:
-    """Single entry point that owns the full Session composition sequence.
-
-    Stage B1 PR 2 made this helper LIVE — :class:`Session.__init__` no
-    longer constructs the collaborator bundle / transport / chain
-    inline; this helper does, and feeds them into a ``Session(*,
-    collaborators=..., config=..., auth=...)`` constructor that just
-    stores references and initialises the late-bound slots to ``None``
-    before the write-once binders fire.
-
-    The kwarg surface mirrors the historical :class:`Session.__init__`
-    kwargs (production NotebookLMClient kwargs ∪ the four seam kwargs
-    ``decode_response`` / ``sleep`` / ``is_auth_error`` /
-    ``async_client_factory``). The seam kwargs are intentionally
-    test-only — they are NOT exposed on ``NotebookLMClient.__init__``,
-    which preserves the public surface. Tests construct Sessions via
-    ``tests/_helpers/session_factory.build_session_for_tests`` (a thin
-    forwarder that accepts the same kwargs and returns the
-    :class:`Session` from a :class:`ComposedSession`).
-
-    The first call inside the body MUST stay
-    :func:`_refuse_synthetic_error_outside_test_context` — that
-    preserves the existing earliest-opportunity refusal pinned by
-    :mod:`tests.unit.concurrency.test_synthetic_error_transport_guard`.
-
-    The lambda closures for the executor wiring
-    (``decode_response`` / ``is_auth_error`` / ``sleep`` /
-    ``timeout_provider`` / ``refresh_callback_enabled_provider`` /
-    ``refresh_retry_delay_provider``) preserve the late-binding contract
-    pinned by
-    :func:`tests.unit.test_init_order.test_session_wires_seam_attributes_for_executor_and_chain`
-    — post-construction ``session._decode_response = rebound`` (and the
-    sibling seam reassignments) continue to take effect inside the live
-    executor because the closures dereference ``session._<attr>`` on
-    every call.
-    """
-    # MUST stay first — preserves the earliest-opportunity refusal that
-    # ``test_synthetic_error_transport_guard`` pins.
-    _refuse_synthetic_error_outside_test_context()
-    resolved = resolve_seam_defaults(
-        sleep=sleep,
-        async_client_factory=async_client_factory,
-        is_auth_error=is_auth_error,
-        decode_response=decode_response,
-    )
-    config = validate_constructor_args(
-        timeout=timeout,
-        connect_timeout=connect_timeout,
-        refresh_retry_delay=refresh_retry_delay,
-        rate_limit_max_retries=rate_limit_max_retries,
-        server_error_max_retries=server_error_max_retries,
-        keepalive=keepalive,
-        keepalive_min_interval=keepalive_min_interval,
-        keepalive_storage_path=keepalive_storage_path,
-        auth_storage_path=auth.storage_path,
-        limits=limits,
-        max_concurrent_uploads=max_concurrent_uploads,
-        max_concurrent_rpcs=max_concurrent_rpcs,
-        decode_response=resolved["decode_response"],
-        sleep=resolved["sleep"],
-        is_auth_error=resolved["is_auth_error"],
-        async_client_factory=resolved["async_client_factory"],
-    )
-    collaborators = build_collaborators(
-        config,
-        auth=auth,
-        refresh_callback=refresh_callback,
-        on_rpc_event=on_rpc_event,
-        cookie_saver=cookie_saver,
-        cookie_rotator=cookie_rotator,
-    )
-    # The :class:`MiddlewareChainHost` owns the retry tunables, the
-    # chain slot, and the chain leaf. It is constructed BEFORE
-    # :class:`Session` because :func:`build_session_transport` and
-    # :func:`wire_middleware_chain` both take it as a direct parameter.
-    chain_host = MiddlewareChainHost(
-        _auth_refresh=collaborators.auth_coord,
-        _rate_limit_max_retries=config.rate_limit_max_retries,
-        _server_error_max_retries=config.server_error_max_retries,
-        _refresh_retry_delay=config.refresh_retry_delay,
-    )
-    session = Session(
-        collaborators=collaborators,
-        config=config,
-        auth=auth,
-        chain_host=chain_host,
-    )
-    transport = build_session_transport(
-        collaborators,
-        host=session,
-        chain_host=chain_host,
-        logger=logger,
-    )
-    session._bind_transport(transport)
-    # Bind the transport on the host as well so the chain leaf
-    # (:meth:`MiddlewareChainHost._authed_post_chain_terminal`) can
-    # forward to it. Both sides are write-once and bound in this same
-    # composition root, so the symmetric bind is safe.
-    chain_host._bind_transport(transport)
-    # The chain leaf wires through ``chain_host._authed_post_chain_terminal``
-    # directly. Tests that need a fake terminal rebind on the host
-    # (``core._chain_host._authed_post_chain_terminal = fake_terminal``);
-    # the chain is rebuilt by the test around that new terminal. The
-    # auth-snapshot lookup passes ``auth=auth`` (the live
-    # :class:`AuthTokens`) directly — the coordinator method takes the
-    # tokens explicitly instead of reaching through a Session-shaped
-    # host (the ``_AuthRefreshHost`` Protocol that re-declared Session's
-    # private slots was deleted).
-    wired = wire_middleware_chain(
-        config,
-        collaborators,
-        chain_host=chain_host,
-        auth=auth,
-        authed_post_chain_terminal=chain_host._authed_post_chain_terminal,
-        rpc_semaphore_factory=session._get_rpc_semaphore,
-    )
-    # The chain slot lives on the host (``chain_host._authed_post_chain``)
-    # and is installed exactly once here. The transport's ``chain_provider``
-    # lambda reads ``chain_host._authed_post_chain`` directly on every
-    # authed POST, so a test that swaps the chain via
-    # ``core._chain_host._authed_post_chain = fake_chain`` continues to
-    # steer the live chain.
-    chain_host._authed_post_chain = wired.authed_post_chain
-    # ``_bind_chain_metadata`` stores only the auxiliary chain artifacts
-    # (``_chain_builder`` / ``_middlewares``) — the chain slot is owned
-    # by the host and assigned above, so this binder has no role in the
-    # canonical install site for ``_authed_post_chain``.
-    session._bind_chain_metadata(wired)
-    # Lambdas preserve the late-binding contract pinned by
-    # ``tests/unit/test_init_order.py``:
-    # post-construction ``session._decode_response = rebound`` /
-    # ``_sleep = …`` / ``_is_auth_error = …`` reassignments continue
-    # to take effect inside the executor because each closure
-    # dereferences ``session._<attr>`` on every call.
-    #
-    # The ``*a, **kw`` forwarding form (instead of capturing the
-    # callable by name) is intentional — it lets test doubles that
-    # rebind ``session._is_auth_error`` / ``session._sleep`` to a
-    # callable with a different signature (e.g. a ``Mock`` with
-    # ``**kwargs``) keep working without the closure dropping
-    # arguments. See gemini-code-assist PR #1086 review, finding 4.
-    executor = RpcExecutor(
-        kernel=collaborators.kernel,
-        transport=transport,
-        auth_refresh=collaborators.auth_coord,
-        metrics=collaborators.metrics,
-        decode_response=lambda *a, **kw: session._decode_response(*a, **kw),
-        is_auth_error=lambda *a, **kw: session._is_auth_error(*a, **kw),
-        sleep=lambda *a, **kw: session._sleep(*a, **kw),
-        timeout_provider=lambda: collaborators.lifecycle._timeout,
-        refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
-        refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
-    )
-    session._bind_executor(executor)
-    return ComposedSession(
-        session=session,
-        transport=transport,
-        executor=executor,
-        collaborators=collaborators,
-    )
-
-
 class Session:
     """Core client infrastructure for HTTP and RPC operations.
 
@@ -392,11 +75,13 @@ class Session:
     ArtifactsAPI, etc.) and should not be used directly.
     """
 
+    _seams: ClientSeams
+
     def __init__(
         self,
         *,
-        collaborators: "SessionCollaborators",
-        config: "ValidatedSessionConfig",
+        collaborators: SessionCollaborators,
+        config: ValidatedSessionConfig,
         auth: AuthTokens,
         chain_host: MiddlewareChainHost,
     ) -> None:
@@ -450,17 +135,7 @@ class Session:
         # are no Session-side aliases or descriptor forwards.
         self._chain_host = chain_host
 
-        # The seam callables ``_decode_response`` / ``_sleep`` /
-        # ``_is_auth_error`` — the executor closures dereference these
-        # via ``session._<attr>`` on every call, so post-construction
-        # reassignment continues to take effect.
         self.auth = auth
-        self._decode_response: Callable[..., Any] = config.decode_response
-        self._sleep: Callable[[float], Awaitable[Any]] = config.sleep
-        self._is_auth_error: Callable[[Exception], bool] = config.is_auth_error
-        self._max_concurrent_rpcs: int | None = config.max_concurrent_rpcs
-        # Lazy-created per-instance — see :meth:`_get_rpc_semaphore`.
-        self._rpc_semaphore: asyncio.Semaphore | None = None
 
         # The collaborator bundle is stored as a private attribute so
         # :class:`NotebookLMClient` can hoist the ``metrics``
@@ -482,10 +157,9 @@ class Session:
 
         # Late-bound storage — these slots stay ``None`` until the
         # composition root in :func:`compose_session_internals` drives
-        # the write-once binders. Entry points (``_get_rpc_semaphore`` /
-        # ``open`` / ``close``) guard against
-        # use-before-bind via :meth:`_require_constructed`. Types
-        # mirror the corresponding :class:`WiredMiddleware` fields so
+        # the write-once binders. Entry points (``open`` / ``close``)
+        # guard against use-before-bind via :meth:`_require_constructed`.
+        # Types mirror the corresponding :class:`WiredMiddleware` fields so
         # downstream readers see precise types rather than ``Any``
         # (claude[bot] review on PR #1089). The ``_authed_post_chain``
         # slot is owned by ``_chain_host``; it is not duplicated here.
@@ -502,35 +176,6 @@ class Session:
         Protocol directly since Wave 2 of the session-decoupling plan.
         """
         self._lifecycle.assert_bound_loop()
-
-    def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
-        """Return the per-instance RPC semaphore (or a null-context).
-
-        When ``max_concurrent_rpcs`` was set to ``None`` at construction
-        time, this returns a :class:`contextlib.nullcontext` so the
-        ``async with`` wrapper inside the chain's ``SemaphoreMiddleware``
-        collapses to a no-op (callers with their own external rate-limiter
-        opted out of the gate). Otherwise it lazily constructs an
-        ``asyncio.Semaphore`` bound to the running loop on first use,
-        mirroring the lazy-init pattern of :attr:`_reqid_lock` /
-        :attr:`_auth_snapshot_lock`.
-
-        The check-then-assign is safe without an outer lock because
-        asyncio is single-threaded: no other coroutine can execute
-        between the ``is None`` check and the assignment unless we
-        ``await`` (and we don't).
-        """
-        # Stage B1 PR 2 fail-fast: this factory is captured by the
-        # chain at construction time and invoked from middleware on
-        # every rpc_call. A pre-composition call indicates the chain
-        # is being exercised before the composition root drove
-        # :meth:`_bind_transport`.
-        self._require_constructed("_transport")
-        if self._max_concurrent_rpcs is None:
-            return nullcontext()
-        if self._rpc_semaphore is None:
-            self._rpc_semaphore = asyncio.Semaphore(self._max_concurrent_rpcs)
-        return self._rpc_semaphore
 
     # ------------------------------------------------------------------
     # Write-once binders + fail-fast guards
@@ -554,7 +199,7 @@ class Session:
     # (and never re-nulled by ``close()`` — see
     # ``_session_lifecycle.py:close`` for the corresponding contract).
 
-    def _bind_transport(self, transport: "SessionTransport") -> None:
+    def _bind_transport(self, transport: SessionTransport) -> None:
         """Write-once setter for :attr:`_transport`.
 
         Raises ``RuntimeError`` on a second bind attempt.
@@ -566,7 +211,7 @@ class Session:
             raise RuntimeError("Session._transport already bound")
         self._transport = transport
 
-    def _bind_chain_metadata(self, wired: "WiredMiddleware") -> None:
+    def _bind_chain_metadata(self, wired: WiredMiddleware) -> None:
         """Write-once setter for the auxiliary chain-metadata artifacts.
 
         The canonical install site for ``_authed_post_chain`` is

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -16,14 +16,11 @@ the ``Kernel.http_client.setter`` and made ``decode_response`` /
 ``sleep`` / ``is_auth_error`` / ``async_client_factory`` the canonical
 injection seams.
 
-**Seam-resolution boundary**: ``None``-default resolution for ``sleep``
-(→ ``asyncio.sleep``) and ``async_client_factory`` (→
-``httpx.AsyncClient``) MUST stay in :mod:`notebooklm._session` so the
-documented monkeypatch paths ``notebooklm._session.asyncio.sleep`` and
-``notebooklm._session.httpx.AsyncClient`` keep steering the seam at
-construction time. The helpers here accept already-resolved seam
-callables; the caller (``Session.__init__``) owns the
-``X if X is not None else <module-attr>`` dance against its own bindings.
+``None``-default resolution for ``sleep`` and ``async_client_factory`` still
+routes through :mod:`notebooklm._session` so the documented monkeypatch paths
+``notebooklm._session.asyncio.sleep`` and
+``notebooklm._session.httpx.AsyncClient`` keep steering construction while
+``_session.py`` remains the compatibility module.
 """
 
 from __future__ import annotations
@@ -37,14 +34,26 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from ._client_composed import ClientComposed
 from ._client_metrics import ClientMetrics
+from ._client_seams import ClientSeams, resolve_client_seams
 from ._cookie_persistence import CookiePersistence
+from ._error_injection import _refuse_synthetic_error_outside_test_context
 from ._kernel import Kernel
 from ._middleware import Middleware, NextCall, build_chain
 from ._middleware_chain import MiddlewareChainBuilder
+from ._middleware_chain_host import MiddlewareChainHost
 from ._reqid_counter import ReqidCounter
+from ._rpc_executor import RpcExecutor
 from ._session_auth import AuthRefreshCoordinator
-from ._session_config import normalize_max_concurrent_uploads
+from ._session_config import (
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_KEEPALIVE_MIN_INTERVAL,
+    DEFAULT_MAX_CONCURRENT_RPCS,
+    DEFAULT_MAX_CONCURRENT_UPLOADS,
+    DEFAULT_TIMEOUT,
+    normalize_max_concurrent_uploads,
+)
 from ._session_helpers import _resolve_keepalive_interval
 from ._session_lifecycle import ClientLifecycle, CookieRotator, CookieSaver
 from ._session_transport import SessionTransport
@@ -56,7 +65,6 @@ if TYPE_CHECKING:
     # :func:`validate_constructor_args` to keep the long-standing
     # defensive guard against the ``types.py`` → session cycle (see the
     # inline comment in the function body).
-    from ._middleware_chain_host import MiddlewareChainHost
     from .types import ConnectionLimits, RpcTelemetryEvent
 
 
@@ -115,6 +123,51 @@ class WiredMiddleware:
     chain_builder: MiddlewareChainBuilder
     middlewares: list[Middleware]
     authed_post_chain: NextCall
+
+
+@dataclass(frozen=True)
+class ComposedSession:
+    """Result of :func:`compose_session_internals`."""
+
+    session: Session
+    transport: SessionTransport
+    executor: RpcExecutor
+    collaborators: SessionCollaborators
+    seams: ClientSeams
+    composed: ClientComposed
+
+
+def _resolve_async_client_factory(
+    async_client_factory: Callable[..., httpx.AsyncClient] | None,
+) -> Callable[..., httpx.AsyncClient]:
+    """Resolve the construction-only async-client seam through ``_session``."""
+    if async_client_factory is not None:
+        return async_client_factory
+
+    from . import _session as session_mod
+
+    return session_mod.httpx.AsyncClient
+
+
+def resolve_seam_defaults(
+    *,
+    sleep: Callable[[float], Awaitable[Any]] | None,
+    async_client_factory: Callable[..., httpx.AsyncClient] | None,
+    is_auth_error: Callable[[Exception], bool] | None,
+    decode_response: Callable[..., Any] | None,
+) -> dict[str, Callable[..., Any]]:
+    """Resolve legacy seam-default shape while keeping ``ClientSeams`` separate."""
+    seams = resolve_client_seams(
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+        decode_response=decode_response,
+    )
+    return {
+        "sleep": seams.sleep,
+        "async_client_factory": _resolve_async_client_factory(async_client_factory),
+        "is_auth_error": seams.is_auth_error,
+        "decode_response": seams.decode_response,
+    }
 
 
 def validate_constructor_args(
@@ -397,13 +450,13 @@ def build_session_transport(
 
 
 def wire_middleware_chain(
-    config: ValidatedSessionConfig,
     collaborators: SessionCollaborators,
     *,
     chain_host: MiddlewareChainHost,
     auth: AuthTokens,
     authed_post_chain_terminal: Callable[..., Awaitable[Any]],
     rpc_semaphore_factory: Callable[[], AbstractAsyncContextManager[Any]],
+    is_auth_error: Callable[[Exception], bool],
 ) -> WiredMiddleware:
     """Construct the :class:`MiddlewareChainBuilder`, build the seven-middleware
     list, and wire the final chain via :func:`build_chain`.
@@ -434,10 +487,10 @@ def wire_middleware_chain(
     Post-construction mutation on ``chain_host._<attr>`` still takes
     effect through the middleware live-binding contract documented in
     :class:`MiddlewareChainBuilder`. The ``rpc_semaphore_factory`` is
-    passed in explicitly so the helper does not need to know that the
-    live semaphore lives on ``Session._get_rpc_semaphore`` — that
-    surface stays on Session because the semaphore is per-loop session
-    state (not chain state).
+    passed in explicitly so the helper does not need to know which holder
+    owns the live semaphore. ``is_auth_error`` is passed as a live-binding
+    callable so rebinding ``ClientSeams.is_auth_error`` after construction
+    still steers the chain.
     """
     # ADR-009 chain construction. PR history, leaf exception shape,
     # and ``RpcRequest.context`` contract live in
@@ -451,7 +504,7 @@ def wire_middleware_chain(
         refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
         refresh_callable=chain_host.await_refresh,
         auth_snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=auth),
-        is_auth_error=config.is_auth_error,
+        is_auth_error=is_auth_error,
         refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
     )
     middlewares: list[Middleware] = chain_builder.build()
@@ -466,12 +519,153 @@ def wire_middleware_chain(
     )
 
 
+def compose_session_internals(
+    *,
+    auth: AuthTokens,
+    timeout: float = DEFAULT_TIMEOUT,
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
+    refresh_retry_delay: float = 0.2,
+    keepalive: float | None = None,
+    keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
+    keepalive_storage_path: Path | None = None,
+    rate_limit_max_retries: int = 3,
+    server_error_max_retries: int = 3,
+    limits: ConnectionLimits | None = None,
+    max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
+    max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
+    on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+    cookie_saver: CookieSaver | None = None,
+    cookie_rotator: CookieRotator | None = None,
+    decode_response: Callable[..., Any] | None = None,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+    is_auth_error: Callable[[Exception], bool] | None = None,
+    async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
+    seams: ClientSeams | None = None,
+    composed: ClientComposed | None = None,
+) -> ComposedSession:
+    """Single entry point that owns the full Session composition sequence."""
+    # MUST stay first — preserves the earliest-opportunity refusal that
+    # ``test_synthetic_error_transport_guard`` pins.
+    _refuse_synthetic_error_outside_test_context()
+
+    seams = seams or resolve_client_seams(
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+        decode_response=decode_response,
+    )
+    if composed is None:
+        composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
+    elif composed.max_concurrent_rpcs != max_concurrent_rpcs:
+        raise ValueError(
+            "composed.max_concurrent_rpcs must match max_concurrent_rpcs "
+            f"(got composed.max_concurrent_rpcs={composed.max_concurrent_rpcs!r}, "
+            f"max_concurrent_rpcs={max_concurrent_rpcs!r})"
+        )
+    async_client_factory = _resolve_async_client_factory(async_client_factory)
+
+    config = validate_constructor_args(
+        timeout=timeout,
+        connect_timeout=connect_timeout,
+        refresh_retry_delay=refresh_retry_delay,
+        rate_limit_max_retries=rate_limit_max_retries,
+        server_error_max_retries=server_error_max_retries,
+        keepalive=keepalive,
+        keepalive_min_interval=keepalive_min_interval,
+        keepalive_storage_path=keepalive_storage_path,
+        auth_storage_path=auth.storage_path,
+        limits=limits,
+        max_concurrent_uploads=max_concurrent_uploads,
+        max_concurrent_rpcs=max_concurrent_rpcs,
+        decode_response=seams.decode_response,
+        sleep=seams.sleep,
+        is_auth_error=seams.is_auth_error,
+        async_client_factory=async_client_factory,
+    )
+    collaborators = build_collaborators(
+        config,
+        auth=auth,
+        refresh_callback=refresh_callback,
+        on_rpc_event=on_rpc_event,
+        cookie_saver=cookie_saver,
+        cookie_rotator=cookie_rotator,
+    )
+    chain_host = MiddlewareChainHost(
+        _auth_refresh=collaborators.auth_coord,
+        _rate_limit_max_retries=config.rate_limit_max_retries,
+        _server_error_max_retries=config.server_error_max_retries,
+        _refresh_retry_delay=config.refresh_retry_delay,
+    )
+
+    from ._session import Session
+
+    session: Session = Session(
+        collaborators=collaborators,
+        config=config,
+        auth=auth,
+        chain_host=chain_host,
+    )
+    session._seams = seams
+
+    from . import _session as session_mod
+
+    transport = build_session_transport(
+        collaborators,
+        host=session,
+        chain_host=chain_host,
+        logger=session_mod.logger,
+    )
+    session._bind_transport(transport)
+    chain_host._bind_transport(transport)
+
+    wired = wire_middleware_chain(
+        collaborators,
+        chain_host=chain_host,
+        auth=auth,
+        authed_post_chain_terminal=chain_host._authed_post_chain_terminal,
+        rpc_semaphore_factory=composed.get_rpc_semaphore,
+        is_auth_error=lambda *a, **kw: seams.is_auth_error(*a, **kw),
+    )
+    chain_host._authed_post_chain = wired.authed_post_chain
+    session._bind_chain_metadata(wired)
+
+    executor = RpcExecutor(
+        kernel=collaborators.kernel,
+        transport=transport,
+        auth_refresh=collaborators.auth_coord,
+        metrics=collaborators.metrics,
+        decode_response=lambda *a, **kw: seams.decode_response(*a, **kw),
+        is_auth_error=lambda *a, **kw: seams.is_auth_error(*a, **kw),
+        sleep=lambda *a, **kw: seams.sleep(*a, **kw),
+        timeout_provider=lambda: collaborators.lifecycle._timeout,
+        refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
+        refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
+    )
+    session._bind_executor(executor)
+
+    composed.transport = transport
+    composed.executor = executor
+    composed.session_collaborators = collaborators
+
+    return ComposedSession(
+        session=session,
+        transport=transport,
+        executor=executor,
+        collaborators=collaborators,
+        seams=seams,
+        composed=composed,
+    )
+
+
 __all__ = [
+    "ComposedSession",
     "SessionCollaborators",
     "ValidatedSessionConfig",
     "WiredMiddleware",
     "build_collaborators",
     "build_session_transport",
+    "compose_session_internals",
+    "resolve_seam_defaults",
     "validate_constructor_args",
     "wire_middleware_chain",
 ]

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -409,7 +409,7 @@ class ClientLifecycle:
 
         Stage B1 PR 2 of the post-refactoring plan removed the
         close-time ``host._rpc_executor = None`` step. The composition
-        root (:func:`notebooklm._session.compose_session_internals`)
+        root (:func:`notebooklm._session_init.compose_session_internals`)
         binds the executor exactly once via
         :meth:`Session._bind_executor` and the binding is preserved
         across ``close()`` → ``open()`` cycles. The executor's

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -39,19 +39,21 @@ if TYPE_CHECKING:
 from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
+from ._client_composed import ClientComposed
+from ._client_seams import resolve_client_seams
 from ._env import get_base_url as get_base_url
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteService
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
-from ._session import compose_session_internals
 from ._session_config import (
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
     DEFAULT_MAX_CONCURRENT_RPCS,
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
+from ._session_init import compose_session_internals
 from ._session_lifecycle import CookieRotator, CookieSaver
 from ._settings import SettingsAPI
 from ._sharing import SharingAPI
@@ -303,6 +305,13 @@ class NotebookLMClient:
         # ``is_auth_error`` / ``async_client_factory``) live on
         # ``compose_session_internals`` and ``build_session_for_tests``
         # only.
+        self._seams = resolve_client_seams(
+            decode_response=None,
+            sleep=None,
+            is_auth_error=None,
+        )
+        self._composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
+
         composed = compose_session_internals(
             auth=auth,
             timeout=timeout,
@@ -322,6 +331,8 @@ class NotebookLMClient:
             # ``_default_cookie_rotator``.
             cookie_saver=cookie_saver,
             cookie_rotator=cookie_rotator,
+            seams=self._seams,
+            composed=self._composed,
         )
         self._session = composed.session
         # Owned reference to the collaborator bundle so

--- a/tests/_helpers/session_factory.py
+++ b/tests/_helpers/session_factory.py
@@ -4,7 +4,7 @@ Stage B1 PR 2 of the post-refactoring plan inverted the composition root —
 :meth:`Session.__init__` no longer takes the full bag of public/seam
 kwargs; it now takes ``(*, collaborators, config, auth)`` and the
 composition sequence lives in
-:func:`notebooklm._session.compose_session_internals`. Tests that
+:func:`notebooklm._session_init.compose_session_internals`. Tests that
 previously called ``Session(auth, …)`` directly migrate to this helper,
 which preserves the full historical kwarg surface (the union of
 ``NotebookLMClient.__init__`` kwargs + the four test-only seam kwargs
@@ -35,7 +35,9 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from notebooklm._session import ComposedSession, Session, compose_session_internals
+from notebooklm._client_composed import ClientComposed
+from notebooklm._client_seams import resolve_client_seams
+from notebooklm._session import Session
 from notebooklm._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -43,6 +45,7 @@ from notebooklm._session_config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
+from notebooklm._session_init import ComposedSession, compose_session_internals
 from notebooklm._session_lifecycle import CookieRotator, CookieSaver
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -80,7 +83,7 @@ def build_session_for_tests(
     Accepts the full historical kwarg surface (``auth`` positional or
     keyword + every other knob ``Session.__init__`` used to accept,
     including the four seam kwargs). Routes through
-    :func:`notebooklm._session.compose_session_internals`, which is the
+    :func:`notebooklm._session_init.compose_session_internals`, which is the
     canonical composition root after Stage B1 PR 2 — so a test calling
     ``build_session_for_tests(auth)`` gets back a fully-composed
     :class:`Session` with ``_transport`` / ``_rpc_executor`` / chain
@@ -93,7 +96,7 @@ def build_session_for_tests(
     :func:`build_composed_session_for_tests` (the same kwarg surface,
     returns the full bundle) — addressed to keep the kwarg-default
     layer this helper applies, rather than reaching directly to
-    :func:`notebooklm._session.compose_session_internals`.
+    :func:`notebooklm._session_init.compose_session_internals`.
     """
     return build_composed_session_for_tests(
         auth=auth,
@@ -149,7 +152,7 @@ def build_composed_session_for_tests(
     :class:`ComposedSession` (``session`` + ``executor`` +
     ``collaborators``), not just the :class:`Session` instance. This
     helper is a thin forwarder to
-    :func:`notebooklm._session.compose_session_internals` that preserves
+    :func:`notebooklm._session_init.compose_session_internals` that preserves
     the documented monkeypatch contract (seam resolution happens against
     ``notebooklm._session``'s module bindings, not this helper's).
 
@@ -158,10 +161,15 @@ def build_composed_session_for_tests(
     helper as the canonical construction site for shell-client test
     fixtures so that the later deletion of ``Session.lifecycle`` (Wave 2)
     is mechanical — no shell-test code has to reach back through
-    ``session.lifecycle`` because the helper hands the four runtime
-    fields (``_auth`` / ``_session`` / ``_collaborators`` /
-    ``_rpc_executor``) to :func:`build_refresh_client_shell` directly.
+    ``session.lifecycle`` because the helper hands the runtime fields to
+    :func:`build_refresh_client_shell` directly.
     """
+    seams = resolve_client_seams(
+        decode_response=decode_response,
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+    )
+    composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
     return compose_session_internals(
         auth=auth,
         timeout=timeout,
@@ -179,10 +187,9 @@ def build_composed_session_for_tests(
         on_rpc_event=on_rpc_event,
         cookie_saver=cookie_saver,
         cookie_rotator=cookie_rotator,
-        decode_response=decode_response,
-        sleep=sleep,
-        is_auth_error=is_auth_error,
         async_client_factory=async_client_factory,
+        seams=seams,
+        composed=composed,
     )
 
 
@@ -191,21 +198,21 @@ def build_refresh_client_shell(composed: ComposedSession) -> NotebookLMClient:
 
     Uses :meth:`NotebookLMClient.__new__` to bypass the heavy
     ``__init__`` side effects (feature-API construction, cross-validation,
-    storage-path canonicalization) while still wiring the four runtime
-    attributes the refresh code path reads off the client.
+    storage-path canonicalization) while still wiring the runtime attributes
+    the refresh code path and holder assertions read off the client.
 
-    The four assignments below MUST stay in lock-step with
+    The assignments below MUST stay in lock-step with
     :meth:`NotebookLMClient.__init__` so test shells and production
     aliases observe the same ``AuthTokens`` instance for the Auth
     Instance Invariant (see
     ``.sisyphus/phases/host-protocol-removal/phase-1.md``):
     ``composed.session.auth`` aliases the same object that flowed into
-    :func:`notebooklm._session.compose_session_internals` and that the
+    :func:`notebooklm._session_init.compose_session_internals` and that the
     snapshot-provider lambdas captured, so setting
     ``client._auth = composed.session.auth`` here mirrors what
     ``self._auth = auth`` sets in production.
 
-    The helper sources its four fields exclusively from
+    The helper sources its runtime fields exclusively from
     :class:`ComposedSession` — there is no read-back through
     ``session.lifecycle`` — so the upcoming Wave 2 deletion of
     ``Session.lifecycle`` does not ripple into shell-test code.
@@ -215,4 +222,6 @@ def build_refresh_client_shell(composed: ComposedSession) -> NotebookLMClient:
     client._auth = composed.session.auth
     client._collaborators = composed.collaborators
     client._rpc_executor = composed.executor
+    client._seams = composed.seams
+    client._composed = composed.composed
     return client

--- a/tests/_lint/test_session_runtime_boundaries.py
+++ b/tests/_lint/test_session_runtime_boundaries.py
@@ -127,10 +127,34 @@ AUTH_COORD_RECEIVER_NAMES: frozenset[str] = frozenset({"auth_coord", "coord"})
 # must be reached through that collaborator's name.
 AUTH_FORWARD_METHOD_NAMES: frozenset[str] = frozenset({"update_auth_tokens", "update_auth_headers"})
 
+MOVED_SESSION_SYMBOL_NAMES: frozenset[str] = frozenset(
+    # Only symbols that used to be reachable through `notebooklm._session`
+    # aliases belong here. Moves between other modules, such as default sleep
+    # resolution moving onto `ClientSeams`, are outside this guard's scope.
+    {
+        "compose_session_internals",
+        "ComposedSession",
+        "resolve_seam_defaults",
+        "_default_decode_response",
+        "_default_is_auth_error",
+    }
+)
+
 
 def _iter_src_files() -> list[Path]:
     """Return every ``.py`` under ``src/notebooklm/``, sorted, excluding caches."""
     return sorted(p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _iter_src_and_test_files() -> list[Path]:
+    """Return every checked ``.py`` file under ``src/notebooklm/`` and ``tests/``."""
+    test_root = REPO_ROOT / "tests"
+    return sorted(
+        p
+        for root in (SRC_ROOT, test_root)
+        for p in root.rglob("*.py")
+        if "__pycache__" not in p.parts
+    )
 
 
 def _find_symbol_appearances(tree: ast.AST, symbol: str) -> list[tuple[int, str]]:
@@ -298,6 +322,56 @@ def _format_receiver_for_diagnostic(receiver: ast.expr) -> str:
     if isinstance(receiver, ast.Attribute):
         return f"...{receiver.attr}"
     return "expression"
+
+
+def _session_module_aliases(tree: ast.AST) -> set[str]:
+    """Return local aliases bound to the ``notebooklm._session`` module."""
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "notebooklm._session" and alias.asname is not None:
+                    aliases.add(alias.asname)
+        elif isinstance(node, ast.ImportFrom):
+            imports_session_from_notebooklm = node.module == "notebooklm"
+            imports_session_from_relative_package = node.module is None and node.level > 0
+            if not (imports_session_from_notebooklm or imports_session_from_relative_package):
+                continue
+            for alias in node.names:
+                if alias.name == "_session":
+                    aliases.add(alias.asname or alias.name)
+    return aliases
+
+
+def _moved_session_symbol_alias_violations(tree: ast.AST, *, rel: str) -> list[str]:
+    """Return uses like ``session_mod.compose_session_internals``."""
+    aliases = _session_module_aliases(tree)
+    if not aliases:
+        return []
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in MOVED_SESSION_SYMBOL_NAMES
+            and isinstance(node.value, ast.Name)
+            and node.value.id in aliases
+        ):
+            violations.append(f"{rel}:{node.lineno} {node.value.id}.{node.attr}")
+    return violations
+
+
+def test_moved_session_symbols_are_not_reached_through_session_module_aliases() -> None:
+    """Moved composition helpers must not be reached through aliased ``_session``."""
+    violations: list[str] = []
+    for path in _iter_src_and_test_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        violations.extend(_moved_session_symbol_alias_violations(tree, rel=rel))
+    assert not violations, (
+        "Composition helpers moved out of notebooklm._session. Import them from "
+        "notebooklm._session_init or notebooklm._client_seams instead. Offenders:\n  "
+        + "\n  ".join(violations)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -720,3 +794,13 @@ def test_format_receiver_for_diagnostic_shapes() -> None:
     assert _format_receiver_for_diagnostic(receivers[0]) == "..._session"
     assert _format_receiver_for_diagnostic(receivers[1]) == "bare"
     assert _format_receiver_for_diagnostic(receivers[2]) == "expression"
+
+
+def test_moved_session_symbol_alias_guard_catches_synthetic_alias() -> None:
+    """Prove aliasing ``notebooklm._session`` cannot hide moved helper access."""
+    tree = ast.parse(
+        "import notebooklm._session as session_mod\nsession_mod.compose_session_internals\n"
+    )
+    assert _moved_session_symbol_alias_violations(tree, rel="synthetic.py") == [
+        "synthetic.py:2 session_mod.compose_session_internals"
+    ]

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -85,12 +85,8 @@ class TestAutoRefreshIntegration:
             response.raise_for_status = MagicMock()
             return response
 
-        # Override the constructor-injected decode-response seam BEFORE the
-        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
-        # stub. The previous ``patch("notebooklm.rpc.decode_response", …)``
-        # idiom relied on the retired module-level late-binding wrapper;
-        # see ``docs/improvement.md`` §4.1.
-        client._session._decode_response = lambda *a, **kw: [[["nb1"], ["Notebook 1"]]]
+        # Override the runtime decode-response seam before the RPC fires.
+        client._seams.decode_response = lambda *a, **kw: [[["nb1"], ["Notebook 1"]]]
 
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
@@ -142,10 +138,8 @@ class TestAutoRefreshIntegration:
                 raise RPCError("Authentication expired")
             return [[["nb1"], ["Notebook 1"]]]
 
-        # Override the constructor-injected decode-response seam BEFORE the
-        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
-        # stub. See ``docs/improvement.md`` §4.1.
-        client._session._decode_response = mock_decode
+        # Override the runtime decode-response seam before the RPC fires.
+        client._seams.decode_response = mock_decode
 
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
@@ -184,10 +178,8 @@ class TestAutoRefreshIntegration:
             response.raise_for_status = MagicMock()
             return response
 
-        # Override the constructor-injected decode-response seam BEFORE the
-        # first RPC fires so the lazily-built ``RpcExecutor`` picks up the
-        # stub. See ``docs/improvement.md`` §4.1.
-        client._session._decode_response = lambda *a, **kw: []
+        # Override the runtime decode-response seam before the RPC fires.
+        client._seams.decode_response = lambda *a, **kw: []
 
         async with client:
             install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -305,9 +305,7 @@ class TestRPCCallAuthRetry:
             mock_post = AsyncMock(return_value=success_response)
             install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
-            # Override the constructor-injected decode-response seam BEFORE
-            # the first RPC fires so the lazily-built ``RpcExecutor`` picks
-            # up the stub. See ``docs/improvement.md`` §4.1.
+            # Override the runtime decode-response seam before the RPC fires.
             decode_responses = iter(
                 [
                     RPCError("authentication expired"),
@@ -321,7 +319,7 @@ class TestRPCCallAuthRetry:
                     raise value
                 return value
 
-            core._decode_response = fake_decode
+            core._seams.decode_response = fake_decode
 
             result = await core._rpc_executor.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -237,11 +237,10 @@ async def test_auth_refresh_middleware_honors_injected_predicate() -> None:
     rewrote this test off the legacy ``_core.is_auth_error`` string-target
     monkeypatch and instead constructs the middleware directly with an
     injected predicate. The
-    production chain seeds ``AuthRefreshMiddleware`` with
-    ``is_auth_error=_live_is_auth_error``; that wiring is
-    covered separately. Here we pin the middleware-level contract:
-    *whatever* predicate is injected drives the refresh-and-retry
-    decision.
+    production chain seeds ``AuthRefreshMiddleware`` with a live-binding
+    ``ClientSeams.is_auth_error`` callable; that wiring is covered
+    separately. Here we pin the middleware-level contract: *whatever*
+    predicate is injected drives the refresh-and-retry decision.
     """
     from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 
@@ -295,17 +294,15 @@ async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
     cover both halves of the contract:
 
     1. ``AuthRefreshMiddleware`` honors its injected predicate.
-    2. ``Session.__init__`` actually wires the middleware with a
-       predicate that recognises real auth errors — currently
-       ``is_auth_error=_live_is_auth_error``, where ``_live_is_auth_error`` resolves
-       :func:`notebooklm._session_helpers.is_auth_error` at call time.
+    2. The composition root actually wires the middleware with a live
+       predicate that recognises real auth errors through
+       ``ClientSeams.is_auth_error``.
 
     Restored in Phase 2 PR 4 after the migration of
     ``test_chain_uses_late_bound_is_auth_error`` (which used
     ``monkeypatch.setattr("notebooklm._core.is_auth_error", lambda exc:
     True)`` to force ANY exception to be treated as an auth error)
-    deleted the only end-to-end check of that wiring. Codex / agy
-    review caught the regression; this test re-adds the coverage
+    deleted the only end-to-end check of that wiring. This test re-adds the coverage
     without depending on the soon-to-be-retired ``_core`` indirection
     by using a real 401 that the canonical predicate already
     recognises.
@@ -328,10 +325,7 @@ async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
         async def fake_post(*args, **kwargs):
             call_count["n"] += 1
             if call_count["n"] == 1:
-                # Real 401 — recognised by ``is_auth_error``, which
-                # ``_live_is_auth_error`` resolves at call time. No
-                # monkeypatch needed: the predicate's natural behavior
-                # drives the refresh path.
+                # Real 401 — recognised by the default ``is_auth_error``.
                 raise _status_error(401)
             return _ok_response()
 

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -4,9 +4,9 @@ Covers the helpers introduced by Stage B1 PR 1 and made live by Stage B1
 PR 2 of the post-refactoring plan
 (``docs/post-refactoring-plan-2026-05-27.md``):
 
-- :class:`notebooklm._session.ComposedSession` dataclass
-- :func:`notebooklm._session.resolve_seam_defaults`
-- :func:`notebooklm._session.compose_session_internals` — the live
+- :class:`notebooklm._session_init.ComposedSession` dataclass
+- :func:`notebooklm._session_init.resolve_seam_defaults`
+- :func:`notebooklm._session_init.compose_session_internals` — the live
   composition root after PR 2
 - ``Session._bind_transport`` / ``_bind_chain_metadata`` / ``_bind_executor``
   write-once setters (now load-bearing — :meth:`Session.__init__` no
@@ -29,14 +29,21 @@ from typing import Any
 import httpx
 import pytest
 
-from _helpers.session_factory import build_session_for_tests
-from notebooklm._session import (
+from _helpers.session_factory import (
+    build_composed_session_for_tests,
+    build_refresh_client_shell,
+    build_session_for_tests,
+)
+from notebooklm._client_composed import ClientComposed
+from notebooklm._client_seams import ClientSeams
+from notebooklm._session import Session
+from notebooklm._session_init import (
     ComposedSession,
-    Session,
     compose_session_internals,
     resolve_seam_defaults,
 )
 from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
 
 
 def _make_auth() -> AuthTokens:
@@ -146,6 +153,64 @@ def test_compose_session_internals_returns_composed_session() -> None:
     # ``_collaborators`` so :class:`NotebookLMClient` can hoist metrics
     # off the bundle without a fresh build).
     assert composed.collaborators is composed.session._collaborators
+    assert isinstance(composed.seams, ClientSeams)
+    assert isinstance(composed.composed, ClientComposed)
+    assert composed.session._seams is composed.seams
+    assert composed.composed.transport is composed.transport
+    assert composed.composed.executor is composed.executor
+    assert composed.composed.session_collaborators is composed.collaborators
+
+
+def test_shell_helpers_carry_client_holders() -> None:
+    """Refresh shell helpers mirror production holder attributes."""
+    composed = build_composed_session_for_tests(auth=_make_auth(), max_concurrent_rpcs=3)
+
+    client = build_refresh_client_shell(composed)
+
+    assert isinstance(client._seams, ClientSeams)
+    assert client._seams is composed.seams
+    assert isinstance(client._composed, ClientComposed)
+    assert client._composed is composed.composed
+    assert client._composed.max_concurrent_rpcs == 3
+
+
+def test_notebooklm_client_initializes_client_holders() -> None:
+    """Production clients own the same holder shape returned by composition."""
+    client = NotebookLMClient(_make_auth(), max_concurrent_rpcs=2)
+
+    assert isinstance(client._seams, ClientSeams)
+    assert isinstance(client._composed, ClientComposed)
+    assert client._session._seams is client._seams
+    assert client._composed.max_concurrent_rpcs == 2
+
+
+def test_invalid_max_concurrent_rpcs_rejected_before_zero_cap_semaphore() -> None:
+    """Production and test construction reject invalid caps before composition use."""
+    auth = _make_auth()
+
+    with pytest.raises(ValueError, match="max_concurrent_rpcs must be >= 1, got 0"):
+        NotebookLMClient(auth, max_concurrent_rpcs=0)
+
+    with pytest.raises(ValueError, match="max_concurrent_rpcs must be >= 1, got 0"):
+        build_session_for_tests(auth, max_concurrent_rpcs=0)
+
+
+def test_prebuilt_client_composed_cap_must_match_constructor_cap() -> None:
+    """A supplied holder cannot silently diverge from validated constructor args."""
+    holder = ClientComposed(max_concurrent_rpcs=5)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"composed\.max_concurrent_rpcs must match max_concurrent_rpcs "
+            r"\(got composed\.max_concurrent_rpcs=5, max_concurrent_rpcs=10\)"
+        ),
+    ):
+        compose_session_internals(
+            auth=_make_auth(),
+            max_concurrent_rpcs=10,
+            composed=holder,
+        )
 
 
 def test_compose_session_internals_refuses_synthetic_error_first(
@@ -172,11 +237,11 @@ def test_compose_session_internals_refuses_synthetic_error_first(
 
 
 def test_compose_session_internals_preserves_late_binding_for_decode_response() -> None:
-    """Post-construction ``session._decode_response = rebound`` MUST still
+    """Post-construction ``session._seams.decode_response = rebound`` MUST still
     steer the executor's decode path.
 
     Pins the lambda-closure contract documented in the plan: the executor
-    is wired with ``decode_response=lambda *a, **kw: session._decode_response(*a, **kw)``
+    is wired with ``decode_response=lambda *a, **kw: seams.decode_response(*a, **kw)``
     so that test reassignments after construction continue to take effect.
     """
     composed = compose_session_internals(auth=_make_auth())
@@ -184,11 +249,11 @@ def test_compose_session_internals_preserves_late_binding_for_decode_response() 
     sentinel: list[Any] = []
 
     def rebound(*args: Any, **kwargs: Any) -> str:
-        """Recording stand-in for ``session._decode_response``."""
+        """Recording stand-in for ``session._seams.decode_response``."""
         sentinel.append(("decoded", args, kwargs))
         return "rebound-result"
 
-    composed.session._decode_response = rebound
+    composed.session._seams.decode_response = rebound
 
     # The executor closure should dispatch through the live attribute,
     # not the value frozen at construction time.
@@ -198,10 +263,10 @@ def test_compose_session_internals_preserves_late_binding_for_decode_response() 
 
 
 def test_compose_session_internals_preserves_late_binding_for_is_auth_error() -> None:
-    """Post-construction ``session._is_auth_error = rebound`` MUST still
+    """Post-construction ``session._seams.is_auth_error = rebound`` MUST still
     steer the executor's classifier.
 
-    Mirror of the ``_decode_response`` test for the auth-error seam.
+    Mirror of the ``decode_response`` test for the auth-error seam.
     """
     composed = compose_session_internals(auth=_make_auth())
 
@@ -209,14 +274,14 @@ def test_compose_session_internals_preserves_late_binding_for_is_auth_error() ->
         """Stand-in classifier — treats KeyError as auth-related."""
         return isinstance(exc, KeyError)
 
-    composed.session._is_auth_error = rebound
+    composed.session._seams.is_auth_error = rebound
 
     assert composed.executor._is_auth_error(KeyError("auth")) is True
     assert composed.executor._is_auth_error(RuntimeError("nope")) is False
 
 
 def test_compose_session_internals_preserves_late_binding_for_sleep() -> None:
-    """Post-construction ``session._sleep = rebound`` MUST still steer the
+    """Post-construction ``session._seams.sleep = rebound`` MUST still steer the
     executor's backoff path.
     """
     composed = compose_session_internals(auth=_make_auth())
@@ -224,10 +289,10 @@ def test_compose_session_internals_preserves_late_binding_for_sleep() -> None:
     calls: list[float] = []
 
     async def rebound(delay: float) -> None:
-        """Recording stand-in for ``session._sleep`` (captures delays)."""
+        """Recording stand-in for ``session._seams.sleep`` (captures delays)."""
         calls.append(delay)
 
-    composed.session._sleep = rebound
+    composed.session._seams.sleep = rebound
 
     asyncio.run(composed.executor._sleep(0.25))
     assert calls == [0.25]
@@ -375,9 +440,9 @@ def test_require_constructed_raises_on_missing_attribute() -> None:
 
 
 def test_entry_point_guards_fire_on_uninitialised_session() -> None:
-    """The fail-fast guards on ``rpc_call`` / ``_get_rpc_semaphore`` /
-    ``open`` / ``close`` raise when the relevant write-once binding is
-    ``None``.
+    """The fail-fast guards on ``open`` / ``close`` and direct
+    ``_require_constructed`` checks raise when the relevant write-once
+    binding is ``None``.
 
     Bypasses :func:`compose_session_internals` (the canonical composition
     root) via ``Session.__new__`` so the guards see a pre-binding
@@ -402,9 +467,6 @@ def test_entry_point_guards_fire_on_uninitialised_session() -> None:
     # exercised whenever any composition primitive probes the slot.
     with pytest.raises(RuntimeError, match="Session not fully constructed: _rpc_executor is None"):
         session._require_constructed("_rpc_executor")
-
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _transport is None"):
-        session._get_rpc_semaphore()
 
     with pytest.raises(RuntimeError, match="Session not fully constructed: _transport is None"):
         asyncio.run(session.open())

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -579,7 +579,7 @@ def test_compose_session_internals_exposes_constructor_di_seams() -> None:
     Stage B1 PR 2 of the post-refactoring plan moved the composition
     root out of ``Session.__init__`` (which now takes
     ``(*, collaborators, config, auth)`` only) into
-    ``notebooklm._session.compose_session_internals``. The seams live
+    ``notebooklm._session_init.compose_session_internals``. The seams live
     on the helper (and on the canonical test builder
     ``build_session_for_tests``), NOT on ``NotebookLMClient.__init__``
     (which preserves the production surface).
@@ -593,7 +593,7 @@ def test_compose_session_internals_exposes_constructor_di_seams() -> None:
     """
     import inspect
 
-    from notebooklm._session import compose_session_internals
+    from notebooklm._session_init import compose_session_internals
 
     sig = inspect.signature(compose_session_internals)
     for name in ("decode_response", "sleep", "is_auth_error", "async_client_factory"):
@@ -634,8 +634,8 @@ def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
     """Constructor-injected seams MUST reach the executor and chain builder.
 
     The ``RpcExecutor`` resolves ``decode_response`` / ``is_auth_error`` /
-    ``sleep`` through closures over ``self._decode_response`` etc., so that
-    legacy tests which rebind ``session._decode_response = stub`` after
+    ``sleep`` through closures over ``ClientSeams`` etc., so that
+    tests which rebind ``session._seams.decode_response = stub`` after
     ``NotebookLMClient.__init__`` (which eagerly builds the executor via
     the ``rpc_executor`` accessor wired into sub-APIs in Wave 7) still take
     effect. This test pins both halves: constructor-injected callables
@@ -665,9 +665,9 @@ def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
         is_auth_error=custom_is_auth_error,
     )
 
-    assert core._decode_response is custom_decode
-    assert core._sleep is custom_sleep
-    assert core._is_auth_error is custom_is_auth_error
+    assert core._seams.decode_response is custom_decode
+    assert core._seams.sleep is custom_sleep
+    assert core._seams.is_auth_error is custom_is_auth_error
 
     executor = core._rpc_executor
     # Constructor-injected callables propagate through the closure.
@@ -678,7 +678,7 @@ def test_session_wires_seam_attributes_for_executor_and_chain() -> None:
     def rebound_decode(*_a, **_kw):
         return ["rebound"]
 
-    core._decode_response = rebound_decode
+    core._seams.decode_response = rebound_decode
     assert executor._decode_response() == ["rebound"]
 
 

--- a/tests/unit/test_lifecycle_executor_reuse.py
+++ b/tests/unit/test_lifecycle_executor_reuse.py
@@ -9,7 +9,7 @@ executor against the new ``httpx.AsyncClient``.
 
 PR 2 deleted both that null line and the lazy factory itself — the
 executor is bound exactly once by the composition root
-(:func:`notebooklm._session.compose_session_internals`) via
+(:func:`notebooklm._session_init.compose_session_internals`) via
 :meth:`Session._bind_executor`, and the same instance survives any
 ``close()`` → ``open()`` cycle. This is safe because the executor's
 transport collaborator (:class:`Kernel`) rebuilds its


### PR DESCRIPTION
## Summary
- move composition helpers and ComposedSession out of `_session.py` into `_session_init.py`
- add client-owned `ClientSeams` and `ClientComposed` holders for runtime seams and RPC semaphore state
- migrate seam patch tests and add a persistent AST guard for moved `_session` helper aliases
- update Session retention and ADR references for the new holder ownership

## Verification
- `uv run pytest tests/unit/test_session_lifecycle.py tests/unit/test_init_order.py tests/unit/test_auth_session.py -q`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/integration -q`
- `uv run pytest tests/_lint -q`
- `uv run mypy src/notebooklm`
- `uv run ruff check src/notebooklm tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and session composition docs/ADRs to reflect the new composition root, seam handling, and wiring changes.

* **Refactor**
  * Reorganized session composition and seam wiring for clearer separation; composition is centralized and internal seams are provided from a per-client holder.

* **Bug Fixes / Behavior**
  * Added validation for per-client RPC concurrency (invalid zero is rejected early). No public API surface was changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->