### PR TITLE
refactor(client): finish composed extraction and rename internals builder

### DIFF
--- a/docs/session-method-retention.md
+++ b/docs/session-method-retention.md
@@ -18,26 +18,17 @@ must carry a `retain — <reason>` disposition. No method may be tagged
 `delete in Wave 11` (the cluster deletions have all landed; the
 transitional disposition is gone from the recognised set).
 
-Plan [`host-protocol-removal`](../.sisyphus/phases/host-protocol-removal/phase-1.md)
-closed on 2026-05-28 with Waves 0-4. The retained Session surface is now
-the **Inventory** table below in full: the four lifecycle hot-path
-entries (`open` / `close` / `is_open` / `_keepalive_loop`), the
-`__init__` constructor, the `drain` public-API forward, the
-`assert_bound_loop` provider-closure capture target, and the Stage B1
-composition primitives (`_bind_transport`,
-`_bind_chain_metadata`, `_bind_executor`, `_require_constructed`).
-Stage A accessors (`collaborators` / `session_transport` / `rpc_executor`)
-were deleted in Stage B1 PR 2 of the post-refactoring plan and are
-recorded in the **Deleted** section below; the chain leaf
-(`_authed_post_chain_terminal`) and the retry-budget tunables live on
-`MiddlewareChainHost` per the [Chain-ownership carve-out](#chain-ownership-carve-out-closed)
-section. Wave 4 of `host-protocol-removal` added regression lints
-([`tests/_lint/test_session_runtime_boundaries.py`](../tests/_lint/test_session_runtime_boundaries.py),
-[`tests/_lint/test_client_composition.py::test_client_self_session_access_is_allowlisted`](../tests/_lint/test_client_composition.py),
-[`tests/_lint/test_session_retention.py::test_wave_3_deletions_stay_out_of_live_inventory`](../tests/_lint/test_session_retention.py))
-that pin the post-Wave-3 surface from both directions so neither the
-`_LifecycleHost` / `RefreshAuthCore` host shape nor the deleted
-auth-forward methods can quietly come back.
+Plan [`session-elimination-plan`](../.sisyphus/phases/session-elimination-plan/phase-2.md)
+Phase 2 moved composition runtime state onto `ClientComposed`. The retained
+Session surface is now the **Inventory** table below in full: lifecycle
+hot-path entries (`open` / `close` / `is_open` / `_keepalive_loop`), the
+`__init__` constructor, the `drain` public-API forward, and one-wave
+composition property forwarders (`_transport`, `_rpc_executor`,
+`_chain_builder`, `_middlewares`, `_chain_host`) kept only until Phase 3
+rewrites tests off `build_session_for_tests`. The provider-closure target
+`assert_bound_loop` and the Stage B1 composition primitives
+(`_bind_transport`, `_bind_chain_metadata`, `_bind_executor`,
+`_require_constructed`) are recorded in the **Deleted** section below.
 
 ## Categories
 
@@ -54,6 +45,7 @@ auth-forward methods can quietly come back.
 | `compatibility forward` | One-line forward to a collaborator method; kept only because in-tree callers (mostly tests) reached it via `Session`. Wave 11 (sub-waves 11a, 11b, 11c) deleted every compatibility forward; no row in the live inventory now carries this category. The label is retained in this glossary for the **Deleted** section below and as the disposition lint's vocabulary for any future short-lived forward. |
 | `composition write-once setter` | Stage B1 PR 1 ([post-refactoring plan 2026-05-27](post-refactoring-plan-2026-05-27.md)) primitive: a `_bind_*` method that accepts exactly one bind for a late-bound dependency and raises `RuntimeError` on a second call. Reserved for `compose_session_internals`. DORMANT in PR 1 (Session.__init__ still inline-constructs the transport / chain); becomes the single assignment site in PR 2. |
 | `composition guard` | Stage B1 PR 1 ([post-refactoring plan 2026-05-27](post-refactoring-plan-2026-05-27.md)) primitive: a fail-fast helper that raises `RuntimeError("Session not fully constructed: <attr> is None")` when an entry point runs before the composition root has finished binding required late-bound dependencies. Inert under inline construction (PR 1); load-bearing in PR 2 when the composition root moves into `NotebookLMClient.__init__`. |
+| `composition property forwarder` | Session-elimination Phase 2 temporary property that forwards an old `Session._<slot>` read to `ClientComposed`. Kept only so Phase 3 can rewrite tests separately. |
 
 ## Dispositions
 
@@ -79,12 +71,12 @@ lint at PR time.
 | `close` | lifecycle | retain — drain + transport teardown |
 | `is_open` (property) | lifecycle | retain — public open-state read |
 | `_keepalive_loop` | lifecycle | retain — background task body; introspected by `test_client_keepalive` |
-| `assert_bound_loop` | provider-closure capture target | retain — captured via lambda (`bound_loop_check=lambda: host.assert_bound_loop()`) by `build_session_transport` at [`_session_init.py:395`](../src/notebooklm/_session_init.py); late-bound so a test reassigning `core.assert_bound_loop = mock` still steers the live check |
-| `_bind_transport` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._transport`. Load-bearing after PR 2 — `Session.__init__` leaves `_transport` at `None` and `compose_session_internals` is the single assignment site. |
-| `_bind_chain_metadata` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for the auxiliary chain artifacts (`_chain_builder` / `_middlewares`). The `_authed_post_chain` slot itself is owned by `MiddlewareChainHost` and assigned exactly once by `compose_session_internals` (`chain_host._authed_post_chain = wired.authed_post_chain`); this binder stores only the auxiliary metadata. Load-bearing — `Session.__init__` leaves the metadata slots at `None` and `compose_session_internals` is the single assignment site. |
-| `_bind_executor` | composition write-once setter | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); the write-once binder for `Session._rpc_executor`. Load-bearing after PR 2 — the lazy `_get_rpc_executor` factory was deleted; `compose_session_internals` is the single assignment site and the binding is never re-nulled by `close()`. |
-| `_require_constructed` | composition guard | retain — Stage B1 composition primitive (post-refactoring plan 2026-05-27); fail-fast helper used by `open` / `close` to assert the named binding is non-None. Load-bearing — `Session.__init__` leaves the late-bound slots at `None`, and any caller that exercises a Session outside `compose_session_internals` trips the guard. |
 | `drain` | public API forward | retain — narrow public method (one-line forward to `TransportDrainTracker.drain`). Backs `NotebookLMClient.drain` so the composition root does not dereference the private `_drain_tracker` slot on the session. The Wave 11a deletion row in the **Deleted** section below refers to an earlier compatibility-forward incarnation; this row is the boundary-focused re-introduction (narrow forward, single caller, AST-guarded by `tests/_lint/test_client_composition.py::test_client_does_not_dereference_session_privates`). |
+| `_transport` (property) | composition property forwarder | retain — one-wave Phase 2 forward to `ClientComposed.transport`; Phase 3 rewrites remaining `core._transport` test reads to `client._composed.transport`. |
+| `_rpc_executor` (property) | composition property forwarder | retain — one-wave Phase 2 forward to `ClientComposed.executor`; includes a setter that writes through to the holder so legacy `monkeypatch.setattr(core, "_rpc_executor", fake)` tests keep working until Phase 3 rewrites remaining `core._rpc_executor` / `client._session._rpc_executor` test paths. |
+| `_chain_builder` (property) | composition property forwarder | retain — one-wave Phase 2 forward to `ClientComposed.chain_builder`; Phase 3 rewrites chain metadata tests to the composed holder. |
+| `_middlewares` (property) | composition property forwarder | retain — one-wave Phase 2 forward to `ClientComposed.middlewares`; Phase 3 rewrites middleware list tests to the composed holder. |
+| `_chain_host` (property) | composition property forwarder | retain — one-wave Phase 2 forward to `ClientComposed.chain_host`; Phase 3 rewrites retry/chain-host test patches to `client._composed.chain_host`. |
 
 ## Chain-ownership carve-out (closed)
 
@@ -136,6 +128,16 @@ Wave 11<sub>` row in one of the cluster sub-sections below.
 | Method | Category | Disposition |
 |---|---|---|
 | `_get_rpc_semaphore` | provider-closure capture target | deleted in Phase 1 of plan `session-elimination-plan` — the lazy semaphore state moved to `ClientComposed.get_rpc_semaphore`, and `compose_session_internals` now passes that holder method as `rpc_semaphore_factory`. The moved holder preserves the previous `None` opt-out and lazy-once `asyncio.Semaphore` construction while removing `Session._max_concurrent_rpcs` / `Session._rpc_semaphore` ownership. |
+
+### Session-elimination Phase 2 — client composition owner (2026-05-28)
+
+| Method | Category | Disposition |
+|---|---|---|
+| `assert_bound_loop` | provider-closure capture target | deleted in Phase 2 of plan `session-elimination-plan` — `build_session_transport` now captures `collaborators.lifecycle` and calls `collaborators.lifecycle.assert_bound_loop()` at use time, so the provider no longer needs a Session-level loop-guard forward. |
+| `_bind_transport` | composition write-once setter | deleted in Phase 2 of plan `session-elimination-plan` — write-once transport binding moved to `ClientComposed.bind_transport`; `Session._transport` is now a one-wave property forwarder. |
+| `_bind_chain_metadata` | composition write-once setter | deleted in Phase 2 of plan `session-elimination-plan` — write-once chain-metadata binding moved to `ClientComposed.bind_chain_metadata`; `Session._chain_builder` / `_middlewares` are now one-wave property forwarders. |
+| `_bind_executor` | composition write-once setter | deleted in Phase 2 of plan `session-elimination-plan` — write-once executor binding moved to `ClientComposed.bind_executor`; `Session._rpc_executor` is now a one-wave property forwarder. |
+| `_require_constructed` | composition guard | deleted in Phase 2 of plan `session-elimination-plan` — required-state checks moved to typed `ClientComposed` properties, which raise `RuntimeError("ClientComposed not fully constructed: <attr> is None")` before binding. |
 
 ### Wave 11a — drain-and-operation cluster (commit `80a54fda`)
 

--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import AbstractAsyncContextManager, nullcontext
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ._session_config import DEFAULT_MAX_CONCURRENT_RPCS
 
+_T = TypeVar("_T")
+
 if TYPE_CHECKING:
+    from ._middleware import Middleware
+    from ._middleware_chain import MiddlewareChainBuilder
+    from ._middleware_chain_host import MiddlewareChainHost
     from ._rpc_executor import RpcExecutor
-    from ._session_init import SessionCollaborators
+    from ._session_init import SessionCollaborators, WiredMiddleware
     from ._session_transport import SessionTransport
 
 
@@ -26,15 +31,70 @@ class ClientComposed:
             raise ValueError(f"max_concurrent_rpcs must be >= 1, got {max_concurrent_rpcs!r}")
         self.max_concurrent_rpcs = max_concurrent_rpcs
         self._rpc_semaphore: asyncio.Semaphore | None = None
-
-        # Phase 2 migration placeholders. Phase 1 still returns the canonical
-        # `ComposedSession` bundle, but it also populates these fields so the
-        # next phase can move reads onto this holder without another state move.
-        self.transport: SessionTransport | None = None
-        self.executor: RpcExecutor | None = None
+        self._transport: SessionTransport | None = None
+        self._executor: RpcExecutor | None = None
+        self._chain_host: MiddlewareChainHost | None = None
+        self._chain_builder: MiddlewareChainBuilder | None = None
+        self._middlewares: list[Middleware] | None = None
         # Avoid a plain `.collaborators` attribute here: the ADR-014 lint
         # reserves that name for the deleted Stage A Session accessor.
-        self.session_collaborators: SessionCollaborators | None = None
+        self._session_collaborators: SessionCollaborators | None = None
+
+    @staticmethod
+    def _require_bound(attr_name: str, value: _T | None) -> _T:
+        if value is None:
+            raise RuntimeError(f"ClientComposed not fully constructed: {attr_name} is None")
+        return value
+
+    @property
+    def transport(self) -> SessionTransport:
+        return self._require_bound("_transport", self._transport)
+
+    @property
+    def executor(self) -> RpcExecutor:
+        return self._require_bound("_executor", self._executor)
+
+    @property
+    def chain_host(self) -> MiddlewareChainHost:
+        return self._require_bound("_chain_host", self._chain_host)
+
+    @property
+    def chain_builder(self) -> MiddlewareChainBuilder:
+        return self._require_bound("_chain_builder", self._chain_builder)
+
+    @property
+    def middlewares(self) -> list[Middleware]:
+        return self._require_bound("_middlewares", self._middlewares)
+
+    @property
+    def session_collaborators(self) -> SessionCollaborators:
+        return self._require_bound("_session_collaborators", self._session_collaborators)
+
+    def bind_transport(self, transport: SessionTransport) -> None:
+        if self._transport is not None:
+            raise RuntimeError("ClientComposed._transport already bound")
+        self._transport = transport
+
+    def bind_executor(self, executor: RpcExecutor) -> None:
+        if self._executor is not None:
+            raise RuntimeError("ClientComposed._executor already bound")
+        self._executor = executor
+
+    def bind_chain_host(self, chain_host: MiddlewareChainHost) -> None:
+        if self._chain_host is not None:
+            raise RuntimeError("ClientComposed._chain_host already bound")
+        self._chain_host = chain_host
+
+    def bind_chain_metadata(self, wired: WiredMiddleware) -> None:
+        if self._chain_builder is not None:
+            raise RuntimeError("ClientComposed._chain_metadata already bound")
+        self._chain_builder = wired.chain_builder
+        self._middlewares = wired.middlewares
+
+    def bind_session_collaborators(self, collaborators: SessionCollaborators) -> None:
+        if self._session_collaborators is not None:
+            raise RuntimeError("ClientComposed._session_collaborators already bound")
+        self._session_collaborators = collaborators
 
     def get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
         """Return the lazy per-client RPC semaphore, or a no-op context."""

--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -87,7 +87,7 @@ class ClientComposed:
 
     def bind_chain_metadata(self, wired: WiredMiddleware) -> None:
         if self._chain_builder is not None:
-            raise RuntimeError("ClientComposed._chain_metadata already bound")
+            raise RuntimeError("ClientComposed._chain_builder already bound")
         self._chain_builder = wired.chain_builder
         self._middlewares = wired.middlewares
 

--- a/src/notebooklm/_middleware_chain_host.py
+++ b/src/notebooklm/_middleware_chain_host.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 class MiddlewareChainHost:
     """Owner of the middleware-chain mutable state and chain leaf.
 
-    Constructed by :func:`compose_session_internals` BEFORE
+    Constructed by :func:`compose_client_internals` BEFORE
     :class:`Session`. The transport is bound write-once via
     :meth:`_bind_transport` after :func:`build_session_transport`
     returns — this resolves the host ↔ transport construction cycle
@@ -70,7 +70,7 @@ class MiddlewareChainHost:
         _refresh_retry_delay: Backoff between refresh-retry attempts
             in the auth-refresh middleware. Same live-read contract.
         _authed_post_chain: The wired middleware chain. ``None`` until
-            :func:`compose_session_internals` assigns it directly here.
+            :func:`compose_client_internals` assigns it directly here.
             The transport's ``chain_provider`` lambda reads this
             attribute every authed POST.
         _transport: The :class:`SessionTransport` collaborator. ``None``
@@ -90,7 +90,7 @@ class MiddlewareChainHost:
         """Write-once setter for :attr:`_transport`.
 
         Raises :class:`RuntimeError` on a second bind attempt — the
-        composition root (:func:`compose_session_internals`) is the
+        composition root (:func:`compose_client_internals`) is the
         single legitimate caller, and it fires this once after
         :func:`build_session_transport` returns. The same write-once
         shape on :class:`Session` (:meth:`Session._bind_transport`)

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -9,22 +9,21 @@ from typing import TYPE_CHECKING
 
 import httpx  # noqa: F401 - compatibility patch surface for AsyncClient defaults
 
-from ._rpc_executor import RpcExecutor
-from ._session_transport import SessionTransport
 from .auth import (
     AuthTokens,
 )
 
 if TYPE_CHECKING:
+    from ._client_composed import ClientComposed
     from ._client_seams import ClientSeams
     from ._middleware import Middleware
     from ._middleware_chain import MiddlewareChainBuilder
     from ._middleware_chain_host import MiddlewareChainHost
+    from ._rpc_executor import RpcExecutor
     from ._session_init import (
         SessionCollaborators,
-        ValidatedSessionConfig,
-        WiredMiddleware,
     )
+    from ._session_transport import SessionTransport
 
     # ADR-014 Rule 5 (Wave 4 of session-decoupling): the compile-time
     # ``Session: RpcOwner`` assertion was removed when the ``RpcOwner``
@@ -81,60 +80,36 @@ class Session:
         self,
         *,
         collaborators: SessionCollaborators,
-        config: ValidatedSessionConfig,
         auth: AuthTokens,
-        chain_host: MiddlewareChainHost,
+        composed: ClientComposed,
     ) -> None:
-        """Initialise a Session from a pre-built collaborator bundle.
+        """Initialise the one-wave Session lifecycle forwarder.
 
-        :class:`Session` does not construct the bundle / transport /
-        chain inline — :func:`compose_session_internals` builds all
-        three, then calls this constructor with the validated config +
-        the bundle + the auth tokens. The transport / chain / executor
-        are written into the late-bound slots by the composition root
-        via the :meth:`_bind_transport` / :meth:`_bind_chain_metadata`
-        / :meth:`_bind_executor` write-once setters.
-
-        ``chain_host`` is the :class:`MiddlewareChainHost` constructed
-        by :func:`compose_session_internals` BEFORE this constructor.
-        The host owns the retry tunables, the installed chain slot,
-        and the chain leaf; :class:`Session` keeps a reference to it
-        as ``self._chain_host`` so feature code and tests that need
-        to rebind one of those slots can reach the host directly
-        (``core._chain_host._rate_limit_max_retries = N``,
-        ``core._chain_host._authed_post_chain = fake_chain``,
-        ``core._chain_host._authed_post_chain_terminal = fake_terminal``).
+        :class:`Session` no longer owns composition state. Phase 2 moves
+        transport, executor, chain host, chain builder, and middleware
+        storage to :class:`ClientComposed`; this class keeps temporary
+        property forwarders so tests that still receive a ``Session``
+        can read ``core._transport`` / ``core._rpc_executor`` /
+        ``core._chain_host`` until Phase 3 performs the mass rewrite.
 
         Production callers DO NOT instantiate :class:`Session` directly
-        — :class:`NotebookLMClient` calls
-        :func:`compose_session_internals` from its own ``__init__`` and
-        feature adapters draw from the returned :class:`ComposedSession`.
+        — :class:`NotebookLMClient` constructs it after
+        :func:`compose_client_internals` has fully bound
+        :class:`ClientComposed`.
         Tests use the canonical
         ``tests/_helpers/session_factory.build_session_for_tests``
-        helper, which forwards through the same composition root.
+        helper, which returns the one-wave ``client._session``.
 
         Args:
             collaborators: The :class:`SessionCollaborators` bundle
                 constructed by :func:`build_collaborators` inside
-                :func:`compose_session_internals`.
-            config: The :class:`ValidatedSessionConfig` constructed by
-                :func:`validate_constructor_args` inside
-                :func:`compose_session_internals`.
+                :func:`compose_client_internals`.
             auth: Authentication tokens from browser login.
-            chain_host: The :class:`MiddlewareChainHost` constructed by
-                :func:`compose_session_internals` for this session. The
-                host owns the chain leaf, the chain slot, and the three
-                retry-budget tunables.
+            composed: Client-owned composition holder. It owns the chain
+                host, transport, middleware metadata, executor, and lazy
+                RPC semaphore state.
         """
-        # ``_chain_host`` owns the retry tunables (``_rate_limit_max_retries``,
-        # ``_server_error_max_retries``, ``_refresh_retry_delay``), the
-        # chain slot (``_authed_post_chain``), and the chain leaf
-        # (``_authed_post_chain_terminal``). :func:`compose_session_internals`
-        # constructed the host with the live values BEFORE this Session
-        # was instantiated, and it remains the canonical owner — there
-        # are no Session-side aliases or descriptor forwards.
-        self._chain_host = chain_host
-
+        self._composed = composed
         self.auth = auth
 
         # The collaborator bundle is stored as a private attribute so
@@ -145,7 +120,7 @@ class Session:
         # ``Session.session_transport`` / ``Session.rpc_executor``) that
         # previously exposed the bundle through the Session surface
         # were deleted in this PR — :class:`NotebookLMClient` reads
-        # from the :class:`ComposedSession` it received instead.
+        # from the :class:`ClientInternals` it received instead.
         self._collaborators = collaborators
         self._metrics_obj = collaborators.metrics
         self._drain_tracker = collaborators.drain_tracker
@@ -155,119 +130,29 @@ class Session:
         self._lifecycle = collaborators.lifecycle
         self.cookie_persistence = collaborators.cookie_persistence
 
-        # Late-bound storage — these slots stay ``None`` until the
-        # composition root in :func:`compose_session_internals` drives
-        # the write-once binders. Entry points (``open`` / ``close``)
-        # guard against use-before-bind via :meth:`_require_constructed`.
-        # Types mirror the corresponding :class:`WiredMiddleware` fields so
-        # downstream readers see precise types rather than ``Any``
-        # (claude[bot] review on PR #1089). The ``_authed_post_chain``
-        # slot is owned by ``_chain_host``; it is not duplicated here.
-        self._transport: SessionTransport | None = None
-        self._chain_builder: MiddlewareChainBuilder | None = None
-        self._middlewares: list[Middleware] | None = None
-        self._rpc_executor: RpcExecutor | None = None
+    @property
+    def _transport(self) -> SessionTransport:
+        return self._composed.transport
 
-    def assert_bound_loop(self) -> None:
-        """Raise if this core is used from a loop other than its open-time loop.
+    @property
+    def _rpc_executor(self) -> RpcExecutor:
+        return self._composed.executor
 
-        Forward to :meth:`ClientLifecycle.assert_bound_loop` per ADR-014
-        Rule 1; ``ClientLifecycle`` satisfies the ``LoopGuard`` capability
-        Protocol directly since Wave 2 of the session-decoupling plan.
-        """
-        self._lifecycle.assert_bound_loop()
+    @_rpc_executor.setter
+    def _rpc_executor(self, executor: RpcExecutor) -> None:
+        self._composed._executor = executor
 
-    # ------------------------------------------------------------------
-    # Write-once binders + fail-fast guards
-    # ------------------------------------------------------------------
-    #
-    # The three ``_bind_*`` setters below accept exactly one bind per
-    # attribute. They are reserved for :func:`compose_session_internals`
-    # (the composition root) and are load-bearing — :meth:`Session.__init__`
-    # leaves ``_transport`` / ``_chain_builder`` / ``_middlewares`` /
-    # ``_rpc_executor`` at ``None``, so the composition root is the
-    # single assignment site for each.
-    #
-    # ``_authed_post_chain`` is owned by :class:`MiddlewareChainHost`;
-    # the composition root installs it via
-    # ``chain_host._authed_post_chain = wired.authed_post_chain``. The
-    # binder below stores only the auxiliary chain artifacts
-    # (``_chain_builder`` / ``_middlewares``) so the chain slot has
-    # exactly one assignment site.
-    #
-    # The executor is reachable directly via ``self._rpc_executor``
-    # (and never re-nulled by ``close()`` — see
-    # ``_session_lifecycle.py:close`` for the corresponding contract).
+    @property
+    def _chain_host(self) -> MiddlewareChainHost:
+        return self._composed.chain_host
 
-    def _bind_transport(self, transport: SessionTransport) -> None:
-        """Write-once setter for :attr:`_transport`.
+    @property
+    def _chain_builder(self) -> MiddlewareChainBuilder:
+        return self._composed.chain_builder
 
-        Raises ``RuntimeError`` on a second bind attempt.
-        :func:`compose_session_internals` calls this after
-        :func:`build_session_transport` returns; it is the single
-        assignment site for :attr:`_transport` (Stage B1 PR 2 onwards).
-        """
-        if getattr(self, "_transport", None) is not None:
-            raise RuntimeError("Session._transport already bound")
-        self._transport = transport
-
-    def _bind_chain_metadata(self, wired: WiredMiddleware) -> None:
-        """Write-once setter for the auxiliary chain-metadata artifacts.
-
-        The canonical install site for ``_authed_post_chain`` is
-        ``chain_host._authed_post_chain = wired.authed_post_chain`` in
-        :func:`compose_session_internals`. This binder is left to store
-        only the *auxiliary* artifacts —
-        :class:`MiddlewareChainBuilder` (introspected by builder-level
-        unit tests) and the ``middlewares`` list (introspected by
-        ``test_chain_wiring.test_chain_seeded_with_final_adr_009_ordering``).
-        Raises ``RuntimeError`` on a second bind attempt.
-
-        Tests that need to swap the live chain after construction
-        rebind ``core._chain_host._authed_post_chain = fake_chain`` so
-        the transport's ``chain_provider`` lambda picks up the fake on
-        the next authed POST; this binder does not participate in that
-        post-construction rebind path.
-        """
-        if getattr(self, "_chain_builder", None) is not None:
-            raise RuntimeError("Session._chain_metadata already bound")
-        self._chain_builder = wired.chain_builder
-        self._middlewares = wired.middlewares
-
-    def _bind_executor(self, executor: RpcExecutor) -> None:
-        """Write-once setter for :attr:`_rpc_executor`.
-
-        Stage B1 PR 2 deleted the legacy lazy ``_get_rpc_executor``
-        factory — :func:`compose_session_internals` is the only
-        producer of an :class:`RpcExecutor`, and it drives this binder
-        exactly once during composition. The slot is NOT re-nulled by
-        :meth:`ClientLifecycle.close`; the executor persists across
-        ``close()`` → ``open()`` cycles because the underlying
-        transport collaborator (:class:`Kernel`) rebuilds its
-        ``httpx.AsyncClient`` lazily on each ``open()``.
-        """
-        if getattr(self, "_rpc_executor", None) is not None:
-            raise RuntimeError("Session._rpc_executor already bound")
-        self._rpc_executor = executor
-
-    def _require_constructed(self, attr_name: str) -> None:
-        """Fail-fast guard for :class:`Session` entry points.
-
-        Raises ``RuntimeError("Session not fully constructed: <attr> is
-        None")`` when a required write-once binding is unset. Load-bearing
-        after Stage B1 PR 2: :class:`Session.__init__` leaves the
-        transport / chain / executor slots at ``None`` and only the
-        composition root (:func:`compose_session_internals`) drives the
-        binders, so this guard catches any path that exercises a
-        :class:`Session` outside that root.
-
-        The lookup uses :func:`getattr` with a ``None`` default so the
-        check works during ``__init__`` itself (before the attribute
-        has been assigned for the first time) — that path raises the
-        same actionable message instead of an obscure ``AttributeError``.
-        """
-        if getattr(self, attr_name, None) is None:
-            raise RuntimeError(f"Session not fully constructed: {attr_name} is None")
+    @property
+    def _middlewares(self) -> list[Middleware]:
+        return self._composed.middlewares
 
     async def open(self) -> None:
         """Open the HTTP client connection.
@@ -291,13 +176,6 @@ class Session:
         and passes them through so the lifecycle never reaches back
         through a Session-shaped host.
         """
-        # Stage B1 PR 2 fail-fast: ensure full composition before
-        # lifecycle work. The composition root
-        # (:func:`compose_session_internals`) drives
-        # :meth:`_bind_transport` before returning, so a ``None``
-        # here means the Session was instantiated outside the
-        # composition root and is unusable.
-        self._require_constructed("_transport")
         await self._lifecycle.open(
             auth=self.auth,
             drain_tracker=self._drain_tracker,
@@ -334,8 +212,6 @@ class Session:
         kwargs; this forwarder unpacks its own collaborator aliases
         and passes them through.
         """
-        # Stage B1 PR 2 fail-fast: same guard as :meth:`open`.
-        self._require_constructed("_transport")
         await self._lifecycle.close(
             auth_coord=self._auth_coord,
             drain_tracker=self._drain_tracker,

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -126,15 +126,11 @@ class WiredMiddleware:
 
 
 @dataclass(frozen=True)
-class ComposedSession:
-    """Result of :func:`compose_session_internals`."""
+class ClientInternals:
+    """Result of :func:`compose_client_internals`."""
 
-    session: Session
-    transport: SessionTransport
-    executor: RpcExecutor
     collaborators: SessionCollaborators
-    seams: ClientSeams
-    composed: ClientComposed
+    executor: RpcExecutor
 
 
 def _resolve_async_client_factory(
@@ -389,14 +385,10 @@ def build_collaborators(
     )
 
 
-if TYPE_CHECKING:
-    from ._session import Session
-
-
 def build_session_transport(
     collaborators: SessionCollaborators,
     *,
-    host: Session,
+    auth: AuthTokens,
     chain_host: MiddlewareChainHost,
     logger: logging.Logger,
 ) -> SessionTransport:
@@ -407,26 +399,22 @@ def build_session_transport(
     around ``transport.terminal``. The transport reaches the chain
     through a live-binding ``chain_provider`` closure that reads
     ``chain_host._authed_post_chain`` on every authed POST; that
-    attribute is assigned by :func:`compose_session_internals`
+    attribute is assigned by :func:`compose_client_internals`
     immediately after :func:`wire_middleware_chain` returns. Using a
     provider closure (rather than a frozen reference) preserves the
     pre-extraction behavior where tests reassign
     ``core._chain_host._authed_post_chain = fake_chain`` to install a
     fake chain and expect the next call to honor it.
 
-    The ``snapshot_provider`` closure passes ``host.auth`` (re-read on
-    every call) to :meth:`AuthRefreshCoordinator.snapshot` so the
-    coordinator receives the live :class:`AuthTokens` collaborator
-    directly — the Session-shaped ``_AuthRefreshHost`` Protocol was
-    deleted, and the coordinator routes its lock-wait metric through
-    ``self._metrics`` (supplied at construction). The ``bound_loop_check``
-    lambda re-reads ``host.assert_bound_loop`` on every call rather than
-    freezing the bound method at construction time, so a test that
-    reassigns ``core.assert_bound_loop = mock`` after construction still
-    steers the live check. The lookup goes through ``host.assert_bound_loop``
-    rather than the lifecycle's ``_bound_loop`` directly so a Mock-based
-    Session fixture (which sets ``_lifecycle`` to a MagicMock) still
-    short-circuits the guard.
+    The ``snapshot_provider`` closure passes the client-owned
+    :class:`AuthTokens` collaborator directly to
+    :meth:`AuthRefreshCoordinator.snapshot`; the Session-shaped
+    ``_AuthRefreshHost`` Protocol was deleted, and the coordinator routes
+    its lock-wait metric through ``self._metrics`` (supplied at
+    construction). The ``bound_loop_check`` lambda reads through
+    ``collaborators.lifecycle.assert_bound_loop`` at call time, preserving
+    lifecycle method patchability without retaining a Session-level
+    ``assert_bound_loop`` forward.
 
     The ``chain_host`` parameter lets the chain-slot lookup go through
     the host directly, with no Session-side indirection on the hot
@@ -441,10 +429,10 @@ def build_session_transport(
     """
     return SessionTransport(
         kernel=collaborators.kernel,
-        snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=host.auth),
+        snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=auth),
         chain_provider=lambda: chain_host._authed_post_chain,
         metrics=collaborators.metrics,
-        bound_loop_check=lambda: host.assert_bound_loop(),
+        bound_loop_check=lambda: collaborators.lifecycle.assert_bound_loop(),
         logger=logger,
     )
 
@@ -519,7 +507,7 @@ def wire_middleware_chain(
     )
 
 
-def compose_session_internals(
+def compose_client_internals(
     *,
     auth: AuthTokens,
     timeout: float = DEFAULT_TIMEOUT,
@@ -543,8 +531,8 @@ def compose_session_internals(
     async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
     seams: ClientSeams | None = None,
     composed: ClientComposed | None = None,
-) -> ComposedSession:
-    """Single entry point that owns the full Session composition sequence."""
+) -> ClientInternals:
+    """Single entry point that owns the client composition sequence."""
     # MUST stay first — preserves the earliest-opportunity refusal that
     # ``test_synthetic_error_transport_guard`` pins.
     _refuse_synthetic_error_outside_test_context()
@@ -596,26 +584,18 @@ def compose_session_internals(
         _server_error_max_retries=config.server_error_max_retries,
         _refresh_retry_delay=config.refresh_retry_delay,
     )
-
-    from ._session import Session
-
-    session: Session = Session(
-        collaborators=collaborators,
-        config=config,
-        auth=auth,
-        chain_host=chain_host,
-    )
-    session._seams = seams
+    composed.bind_session_collaborators(collaborators)
+    composed.bind_chain_host(chain_host)
 
     from . import _session as session_mod
 
     transport = build_session_transport(
         collaborators,
-        host=session,
+        auth=auth,
         chain_host=chain_host,
         logger=session_mod.logger,
     )
-    session._bind_transport(transport)
+    composed.bind_transport(transport)
     chain_host._bind_transport(transport)
 
     wired = wire_middleware_chain(
@@ -627,7 +607,7 @@ def compose_session_internals(
         is_auth_error=lambda *a, **kw: seams.is_auth_error(*a, **kw),
     )
     chain_host._authed_post_chain = wired.authed_post_chain
-    session._bind_chain_metadata(wired)
+    composed.bind_chain_metadata(wired)
 
     executor = RpcExecutor(
         kernel=collaborators.kernel,
@@ -641,30 +621,22 @@ def compose_session_internals(
         refresh_callback_enabled_provider=lambda: collaborators.auth_coord.has_refresh_callback,
         refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
     )
-    session._bind_executor(executor)
+    composed.bind_executor(executor)
 
-    composed.transport = transport
-    composed.executor = executor
-    composed.session_collaborators = collaborators
-
-    return ComposedSession(
-        session=session,
-        transport=transport,
-        executor=executor,
+    return ClientInternals(
         collaborators=collaborators,
-        seams=seams,
-        composed=composed,
+        executor=executor,
     )
 
 
 __all__ = [
-    "ComposedSession",
+    "ClientInternals",
     "SessionCollaborators",
     "ValidatedSessionConfig",
     "WiredMiddleware",
     "build_collaborators",
     "build_session_transport",
-    "compose_session_internals",
+    "compose_client_internals",
     "resolve_seam_defaults",
     "validate_constructor_args",
     "wire_middleware_chain",

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -409,7 +409,7 @@ class ClientLifecycle:
 
         Stage B1 PR 2 of the post-refactoring plan removed the
         close-time ``host._rpc_executor = None`` step. The composition
-        root (:func:`notebooklm._session_init.compose_session_internals`)
+        root (:func:`notebooklm._session_init.compose_client_internals`)
         binds the executor exactly once via
         :meth:`Session._bind_executor` and the binding is preserved
         across ``close()`` → ``open()`` cycles. The executor's

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -411,7 +411,7 @@ class ClientLifecycle:
         close-time ``host._rpc_executor = None`` step. The composition
         root (:func:`notebooklm._session_init.compose_client_internals`)
         binds the executor exactly once via
-        :meth:`Session._bind_executor` and the binding is preserved
+        :meth:`notebooklm._client_composed.ClientComposed.bind_executor` and the binding is preserved
         across ``close()`` → ``open()`` cycles. The executor's
         underlying transport collaborator (:class:`Kernel`) rebuilds
         its ``httpx.AsyncClient`` on each :meth:`open`, so the executor

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -411,8 +411,9 @@ class ClientLifecycle:
         close-time ``host._rpc_executor = None`` step. The composition
         root (:func:`notebooklm._session_init.compose_client_internals`)
         binds the executor exactly once via
-        :meth:`notebooklm._client_composed.ClientComposed.bind_executor` and the binding is preserved
-        across ``close()`` → ``open()`` cycles. The executor's
+        :meth:`notebooklm._client_composed.ClientComposed.bind_executor`,
+        and the binding is preserved across ``close()`` → ``open()``
+        cycles. The executor's
         underlying transport collaborator (:class:`Kernel`) rebuilds
         its ``httpx.AsyncClient`` on each :meth:`open`, so the executor
         continues to operate against the fresh transport state without

--- a/src/notebooklm/_session_transport.py
+++ b/src/notebooklm/_session_transport.py
@@ -30,7 +30,7 @@ in ``_session_init.wire_middleware_chain``. Integration tests that
 assign ``client._session._chain_host._refresh_retry_delay = 0`` keep
 steering the live delay.
 
-Construction order in :func:`compose_session_internals`:
+Construction order in :func:`compose_client_internals`:
 :func:`notebooklm._session_init.build_session_transport` constructs the
 transport **before** :func:`wire_middleware_chain`. The wired chain
 leaf is :meth:`MiddlewareChainHost._authed_post_chain_terminal` (a

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -47,13 +47,14 @@ from ._note_service import NoteService
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
+from ._session import Session
 from ._session_config import (
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
     DEFAULT_MAX_CONCURRENT_RPCS,
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
-from ._session_init import compose_session_internals
+from ._session_init import compose_client_internals
 from ._session_lifecycle import CookieRotator, CookieSaver
 from ._settings import SettingsAPI
 from ._sharing import SharingAPI
@@ -230,7 +231,7 @@ class NotebookLMClient:
         # Direct client-owned reference to the authoritative ``AuthTokens``
         # instance. Set AFTER the ``storage_path`` normalization above so it
         # captures the same (possibly rebound) instance that
-        # :func:`compose_session_internals` then propagates into
+        # :func:`compose_client_internals` then propagates into
         # :class:`Session`, :class:`CookiePersistence`, the snapshot-provider
         # lambdas, and :class:`SourceUploadPipeline`. The Auth Instance
         # Invariant (see
@@ -244,10 +245,10 @@ class NotebookLMClient:
         # rewired the public ``auth`` property and the
         # ``SourceUploadPipeline(auth=...)`` constructor argument to back
         # off this field instead of dereferencing
-        # ``self._session.auth``. The shell-client test helper
-        # (``tests/_helpers/session_factory.build_refresh_client_shell``)
-        # mirrors the production attribute shape so refresh-shell tests
-        # exercise the same code path as production.
+        # ``self._session.auth``. The client shell helper
+        # (``tests/_helpers/client_factory.build_client_for_tests``)
+        # mirrors the production attribute shape so tests exercise the
+        # same code path as production.
         self._auth = auth
 
         # Canonicalize the keepalive storage path so different representations
@@ -293,17 +294,15 @@ class NotebookLMClient:
                 )
 
         # Stage B1 PR 2 of the post-refactoring plan inverted the
-        # composition root — :class:`Session` no longer constructs the
-        # collaborator bundle / transport / chain inline; the
-        # :func:`compose_session_internals` helper does, and feeds them
-        # into a ``Session(*, collaborators, config, auth)`` constructor.
-        # Feature adapters below draw from the returned
-        # :class:`ComposedSession` (no Stage A accessor reads).
+        # composition root. Session-elimination Phase 2 finishes the
+        # ownership move: :func:`compose_client_internals` binds
+        # composition state onto ``self._composed`` and returns only the
+        # collaborators + executor that feature adapters need.
         #
         # The public NotebookLMClient kwarg surface is unchanged — the
         # four seam kwargs (``decode_response`` / ``sleep`` /
         # ``is_auth_error`` / ``async_client_factory``) live on
-        # ``compose_session_internals`` and ``build_session_for_tests``
+        # ``compose_client_internals`` and ``build_session_for_tests``
         # only.
         self._seams = resolve_client_seams(
             decode_response=None,
@@ -312,7 +311,7 @@ class NotebookLMClient:
         )
         self._composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
 
-        composed = compose_session_internals(
+        internals = compose_client_internals(
             auth=auth,
             timeout=timeout,
             refresh_callback=self.refresh_auth,
@@ -334,22 +333,27 @@ class NotebookLMClient:
             seams=self._seams,
             composed=self._composed,
         )
-        self._session = composed.session
+        session = Session(
+            collaborators=internals.collaborators,
+            auth=auth,
+            composed=self._composed,
+        )
+        session._seams = self._seams
+        self._session = session
         # Owned reference to the collaborator bundle so
         # :meth:`metrics_snapshot` (and any future
         # NotebookLMClient-side collaborator consumers) read from the
-        # same bundle the Session uses, without going through a Stage A
-        # accessor on the Session.
-        self._collaborators = composed.collaborators
+        # same bundle the Session uses.
+        self._collaborators = internals.collaborators
         # Owned reference to the RPC executor so ``client.rpc_call``
         # dispatches through it directly rather than through a
         # Session-side compatibility wrapper. The executor satisfies the
         # ``RpcCaller`` Protocol and is the same instance the feature
-        # APIs receive (``composed.executor`` is shared with
+        # APIs receive (``internals.executor`` is shared with
         # ``SourcesAPI`` / ``NotebooksAPI`` / ``ArtifactsRuntimeAdapter``
         # / ``ChatAPI`` / etc., so a test that swaps the executor's
         # ``rpc_call`` sees the swap on every feature consumer).
-        self._rpc_executor = composed.executor
+        self._rpc_executor = internals.executor
 
         # ADR-014 Rule 2: the upload pipeline takes its three runtime
         # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
@@ -359,10 +363,10 @@ class NotebookLMClient:
         # the composition root that knows these internals;
         # ``SourcesAPI`` no longer reads them back off the session.
         source_uploader = SourceUploadPipeline(
-            rpc=composed.executor,
-            drain=composed.collaborators.drain_tracker,
-            lifecycle=composed.collaborators.lifecycle,
-            kernel=composed.collaborators.kernel,
+            rpc=internals.executor,
+            drain=internals.collaborators.drain_tracker,
+            lifecycle=internals.collaborators.lifecycle,
+            kernel=internals.collaborators.kernel,
             # Wave 3 of plan ``host-protocol-removal``: the upload
             # pipeline now reads the client-owned ``self._auth``
             # reference set above instead of dereferencing
@@ -373,20 +377,19 @@ class NotebookLMClient:
             auth=self._auth,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
-            record_upload_queue_wait=composed.collaborators.metrics.record_upload_queue_wait,
+            record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
         )
         # ADR-014 Rule 3 Stage B (Stage B1 PR 2 of the post-refactoring
         # plan): simple features take their RpcCaller dependency directly
-        # from the composition root's :attr:`ComposedSession.executor`,
-        # not from a Stage A accessor on :class:`Session` (those
-        # accessors were deleted in PR 2).
+        # from the composition root's executor, not from a Stage A
+        # accessor on :class:`Session` (those accessors were deleted in PR 2).
         self.sources = SourcesAPI(
-            composed.executor,
+            internals.executor,
             uploader=source_uploader,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
         )
-        self.notebooks = NotebooksAPI(composed.executor, sources_api=self.sources)
+        self.notebooks = NotebooksAPI(internals.executor, sources_api=self.sources)
         # Phase 5 wiring per docs/refactor-history.md Migration Plan steps 6-7:
         # the legacy single-service handoff (``MindMapService(self._session)``
         # passed as ``mind_map_service=``) is replaced with the explicit
@@ -394,7 +397,7 @@ class NotebookLMClient:
         # raw row primitives; NoteBackedMindMapService is the mind-map-only
         # adapter the download path uses; the artifact-generation path uses
         # NoteService.create_note directly to persist a generated mind map.
-        note_service = NoteService(composed.executor)
+        note_service = NoteService(internals.executor)
         mind_maps = NoteBackedMindMapService(note_service)
         # ADR-014 Rule 2: the artifacts API takes its three runtime
         # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
@@ -403,9 +406,9 @@ class NotebookLMClient:
         # close-time ``register_drain_hook`` used by the polling
         # service; ``lifecycle`` covers ``assert_bound_loop``.
         self.artifacts = ArtifactsAPI(
-            rpc=composed.executor,
-            drain=composed.collaborators.drain_tracker,
-            lifecycle=composed.collaborators.lifecycle,
+            rpc=internals.executor,
+            drain=internals.collaborators.drain_tracker,
+            lifecycle=internals.collaborators.lifecycle,
             notebooks=self.notebooks,
             mind_maps=mind_maps,
             note_service=note_service,
@@ -419,15 +422,14 @@ class NotebookLMClient:
         #
         # Wave 8 of session-decoupling (ADR-014 Rule 2 Corollary): ChatAPI
         # takes its four direct collaborators (RpcCaller, SessionTransport,
-        # ReqidCounter, LoopGuard) by keyword argument. They are sourced
-        # from the :class:`ComposedSession` returned by the composition
-        # root instead of from Stage A accessors on :class:`Session`
-        # (those accessors were deleted in Stage B1 PR 2).
+        # ReqidCounter, LoopGuard) by keyword argument. The transport is
+        # sourced from ``self._composed``; other runtime fields come from
+        # the :class:`ClientInternals` returned by the composition root.
         self.chat = ChatAPI(
-            rpc=composed.executor,
-            transport=composed.transport,
-            reqid=composed.collaborators.reqid,
-            loop_guard=composed.collaborators.lifecycle,
+            rpc=internals.executor,
+            transport=self._composed.transport,
+            reqid=internals.collaborators.reqid,
+            loop_guard=internals.collaborators.lifecycle,
             notebooks=self.notebooks,
         )
         self.notes = NotesAPI(
@@ -438,11 +440,11 @@ class NotebookLMClient:
         # Pure-RPC features (typed as ``rpc: RpcCaller``). Wave 7 of
         # session-decoupling: pass the ``RpcExecutor`` collaborator
         # directly. Stage B1 PR 2 updated the source from
-        # ``self._session.rpc_executor`` (deleted accessor) to
-        # ``composed.executor``.
-        self.research = ResearchAPI(composed.executor)
-        self.settings = SettingsAPI(composed.executor)
-        self.sharing = SharingAPI(composed.executor)
+        # ``self._session.rpc_executor`` (deleted accessor) to the
+        # composed executor.
+        self.research = ResearchAPI(internals.executor)
+        self.settings = SettingsAPI(internals.executor)
+        self.sharing = SharingAPI(internals.executor)
 
     @property
     def auth(self) -> AuthTokens:
@@ -631,7 +633,7 @@ class NotebookLMClient:
         Stage B1 PR 2 of the post-refactoring plan migrated the read off
         the deleted ``Session.collaborators`` Stage A accessor onto the
         bundle stored by :meth:`__init__` from the composition root's
-        :class:`ComposedSession`.
+        :class:`ClientInternals`.
         """
         return self._collaborators.metrics.snapshot()
 
@@ -794,14 +796,13 @@ class NotebookLMClient:
         ``self._session.<X>`` accessors. The five kwargs mirror the new
         :func:`refresh_auth_session` signature: ``auth`` is the
         client-owned :class:`AuthTokens` instance (the Auth Instance
-        Invariant guarantees this is the same object the composed
+        Invariant guarantees this is the same object the one-wave
         Session also aliases), and the remaining four come from the
         collaborator bundle the composition root produced
-        (:func:`compose_session_internals`). The
-        ``tests/_helpers/session_factory.build_refresh_client_shell``
-        helper wires ``_auth`` and ``_collaborators`` from the composed
-        bundle directly, so test shells observe the same resolution
-        path without going through ``Session``.
+        (:func:`compose_client_internals`). The
+        ``tests/_helpers/client_factory.build_client_for_tests`` helper
+        wires ``_auth`` and ``_collaborators`` from the composed runtime
+        directly, so test shells observe the same resolution path.
 
         Returns:
             Updated AuthTokens.

--- a/tests/_helpers/client_factory.py
+++ b/tests/_helpers/client_factory.py
@@ -1,4 +1,4 @@
-"""Canonical :class:`Session` construction helper for tests."""
+"""Canonical :class:`NotebookLMClient` shell construction helper for tests."""
 
 from __future__ import annotations
 
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from notebooklm._client_composed import ClientComposed
+from notebooklm._client_seams import resolve_client_seams
 from notebooklm._session import Session
 from notebooklm._session_config import (
     DEFAULT_CONNECT_TIMEOUT,
@@ -16,17 +18,17 @@ from notebooklm._session_config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
+from notebooklm._session_init import compose_client_internals
 from notebooklm._session_lifecycle import CookieRotator, CookieSaver
 from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
 from notebooklm.types import RpcTelemetryEvent
-
-from .client_factory import build_client_for_tests
 
 if TYPE_CHECKING:
     from notebooklm.types import ConnectionLimits
 
 
-def build_session_for_tests(
+def build_client_for_tests(
     auth: AuthTokens,
     timeout: float = DEFAULT_TIMEOUT,
     connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
@@ -48,14 +50,21 @@ def build_session_for_tests(
     sleep: Callable[[float], Awaitable[Any]] | None = None,
     is_auth_error: Callable[[Exception], bool] | None = None,
     async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
-) -> Session:
-    """Drop-in replacement for the historical ``Session(auth, ...)`` pattern.
+) -> NotebookLMClient:
+    """Build a minimal client shell with composed runtime attributes populated.
 
-    The client test factory owns composition. This helper keeps its existing
-    signature and return type for one more phase, returning the temporary
-    ``client._session`` forwarder that Phase 3 will remove.
+    The helper preserves the historical test-only seam kwargs without adding
+    them to :class:`NotebookLMClient`'s public constructor. It intentionally
+    does not construct feature API attributes; tests that need the public
+    feature surface should instantiate :class:`NotebookLMClient` directly.
     """
-    return build_client_for_tests(
+    seams = resolve_client_seams(
+        decode_response=decode_response,
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+    )
+    composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
+    internals = compose_client_internals(
         auth=auth,
         timeout=timeout,
         connect_timeout=connect_timeout,
@@ -72,8 +81,23 @@ def build_session_for_tests(
         on_rpc_event=on_rpc_event,
         cookie_saver=cookie_saver,
         cookie_rotator=cookie_rotator,
-        decode_response=decode_response,
-        sleep=sleep,
-        is_auth_error=is_auth_error,
         async_client_factory=async_client_factory,
-    )._session
+        seams=seams,
+        composed=composed,
+    )
+
+    client = NotebookLMClient.__new__(NotebookLMClient)
+    client._auth = auth
+    client._seams = seams
+    client._composed = composed
+    client._collaborators = internals.collaborators
+    client._rpc_executor = internals.executor
+
+    session = Session(
+        collaborators=internals.collaborators,
+        auth=auth,
+        composed=composed,
+    )
+    session._seams = seams
+    client._session = session
+    return client

--- a/tests/unit/test_auth_instance_invariant.py
+++ b/tests/unit/test_auth_instance_invariant.py
@@ -1,0 +1,40 @@
+"""Auth identity invariants for client-owned composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from _helpers.client_factory import build_client_for_tests
+from notebooklm._request_types import AuthSnapshot
+from notebooklm.auth import AuthTokens
+
+
+def _make_auth() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "x", "__Secure-1PSIDTS": "y"},
+        csrf_token="csrf",
+        session_id="sid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_provider_captures_client_auth_by_identity() -> None:
+    """Transport snapshots must pass the identical client-owned auth object."""
+    auth = _make_auth()
+    client = build_client_for_tests(auth)
+    captured: dict[str, AuthTokens] = {}
+
+    async def snapshot(*, auth: AuthTokens) -> AuthSnapshot:
+        captured["auth"] = auth
+        return AuthSnapshot(
+            csrf_token=auth.csrf_token,
+            session_id=auth.session_id,
+            authuser=auth.authuser,
+            account_email=auth.account_email,
+        )
+
+    client._collaborators.auth_coord.snapshot = snapshot  # type: ignore[method-assign]
+
+    await client._composed.transport._snapshot_provider()
+
+    assert captured["auth"] is client._auth

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -1,7 +1,7 @@
 """Integration tests for the authed-post middleware chain.
 
 :func:`notebooklm._middleware.build_chain` is wired by
-:func:`compose_session_internals` against the chain leaf on
+:func:`compose_client_internals` against the chain leaf on
 :class:`MiddlewareChainHost`
 (:meth:`MiddlewareChainHost._authed_post_chain_terminal`), which
 consumes the populated ``RpcRequest.url`` / ``headers`` / ``body``

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -1,23 +1,18 @@
-"""Tests for Stage B1 composition primitives (PR 2 — composition root live).
+"""Tests for client-owned composition primitives.
 
 Covers the helpers introduced by Stage B1 PR 1 and made live by Stage B1
 PR 2 of the post-refactoring plan
 (``docs/post-refactoring-plan-2026-05-27.md``):
 
-- :class:`notebooklm._session_init.ComposedSession` dataclass
+- :class:`notebooklm._session_init.ClientInternals` dataclass
 - :func:`notebooklm._session_init.resolve_seam_defaults`
-- :func:`notebooklm._session_init.compose_session_internals` — the live
-  composition root after PR 2
-- ``Session._bind_transport`` / ``_bind_chain_metadata`` / ``_bind_executor``
-  write-once setters (now load-bearing — :meth:`Session.__init__` no
-  longer inline-sets the slots; :func:`compose_session_internals`
-  drives the binders)
-- ``Session._require_constructed`` fail-fast guard
+- :func:`notebooklm._session_init.compose_client_internals`
+- ``ClientComposed.bind_*`` write-once setters
+- ``ClientComposed`` required-property guards
 
-PR 2 inverted the composition root: :meth:`Session.__init__` now takes
-``(*, collaborators, config, auth)`` and leaves the transport / chain /
-executor slots at ``None``. :func:`compose_session_internals` is the
-only path that produces a fully-bound :class:`Session`.
+Session-elimination Phase 2 leaves :class:`Session` alive as a one-wave
+lifecycle/property forwarder, but all composition runtime state belongs to
+:class:`ClientComposed`.
 """
 
 from __future__ import annotations
@@ -29,17 +24,16 @@ from typing import Any
 import httpx
 import pytest
 
+from _helpers.client_factory import build_client_for_tests
 from _helpers.session_factory import (
-    build_composed_session_for_tests,
-    build_refresh_client_shell,
     build_session_for_tests,
 )
 from notebooklm._client_composed import ClientComposed
 from notebooklm._client_seams import ClientSeams
 from notebooklm._session import Session
 from notebooklm._session_init import (
-    ComposedSession,
-    compose_session_internals,
+    ClientInternals,
+    compose_client_internals,
     resolve_seam_defaults,
 )
 from notebooklm.auth import AuthTokens
@@ -127,51 +121,35 @@ def test_resolve_seam_defaults_passes_through_explicit_callables() -> None:
 
 
 # ---------------------------------------------------------------------------
-# compose_session_internals — live composition root after Stage B1 PR 2
+# compose_client_internals — client-owned composition root
 # ---------------------------------------------------------------------------
 
 
-def test_compose_session_internals_returns_composed_session() -> None:
-    """The helper returns a fully-bundled :class:`ComposedSession`.
+def test_compose_client_internals_returns_client_internals() -> None:
+    """The helper returns collaborators + executor while binding ``ClientComposed``."""
+    holder = ClientComposed()
+    internals = compose_client_internals(auth=_make_auth(), composed=holder)
 
-    PR 2 made the helper load-bearing: :meth:`Session.__init__` no
-    longer constructs collaborators / transport / chain inline, so this
-    bundle is the only path to a usable :class:`Session`.
-    """
-    composed = compose_session_internals(auth=_make_auth())
-
-    assert isinstance(composed, ComposedSession)
-    assert isinstance(composed.session, Session)
-    # The transport in the bundle was constructed by the helper and
-    # passed into ``Session._bind_transport`` — both reads point at the
-    # same instance.
-    assert composed.transport is composed.session._transport
-    # Same shape for the executor — bound via :meth:`_bind_executor`.
-    assert composed.executor is composed.session._rpc_executor
-    # The collaborators bundle is the same instance the helper threaded
-    # into the Session constructor (stored on the Session as
-    # ``_collaborators`` so :class:`NotebookLMClient` can hoist metrics
-    # off the bundle without a fresh build).
-    assert composed.collaborators is composed.session._collaborators
-    assert isinstance(composed.seams, ClientSeams)
-    assert isinstance(composed.composed, ClientComposed)
-    assert composed.session._seams is composed.seams
-    assert composed.composed.transport is composed.transport
-    assert composed.composed.executor is composed.executor
-    assert composed.composed.session_collaborators is composed.collaborators
+    assert isinstance(internals, ClientInternals)
+    assert holder.executor is internals.executor
+    assert holder.session_collaborators is internals.collaborators
+    assert holder.transport is internals.executor._transport
+    assert holder.chain_host._transport is holder.transport
+    assert holder.chain_builder is not None
+    assert len(holder.middlewares) == 7
 
 
 def test_shell_helpers_carry_client_holders() -> None:
-    """Refresh shell helpers mirror production holder attributes."""
-    composed = build_composed_session_for_tests(auth=_make_auth(), max_concurrent_rpcs=3)
-
-    client = build_refresh_client_shell(composed)
+    """Client shell helpers mirror production holder attributes."""
+    client = build_client_for_tests(auth=_make_auth(), max_concurrent_rpcs=3)
 
     assert isinstance(client._seams, ClientSeams)
-    assert client._seams is composed.seams
     assert isinstance(client._composed, ClientComposed)
-    assert client._composed is composed.composed
     assert client._composed.max_concurrent_rpcs == 3
+    assert isinstance(client._session, Session)
+    assert client._session._seams is client._seams
+    assert client._session._rpc_executor is client._rpc_executor
+    assert client._composed.executor is client._rpc_executor
 
 
 def test_notebooklm_client_initializes_client_holders() -> None:
@@ -182,6 +160,8 @@ def test_notebooklm_client_initializes_client_holders() -> None:
     assert isinstance(client._composed, ClientComposed)
     assert client._session._seams is client._seams
     assert client._composed.max_concurrent_rpcs == 2
+    assert client._composed.executor is client._rpc_executor
+    assert client._session._transport is client._composed.transport
 
 
 def test_invalid_max_concurrent_rpcs_rejected_before_zero_cap_semaphore() -> None:
@@ -206,19 +186,19 @@ def test_prebuilt_client_composed_cap_must_match_constructor_cap() -> None:
             r"\(got composed\.max_concurrent_rpcs=5, max_concurrent_rpcs=10\)"
         ),
     ):
-        compose_session_internals(
+        compose_client_internals(
             auth=_make_auth(),
             max_concurrent_rpcs=10,
             composed=holder,
         )
 
 
-def test_compose_session_internals_refuses_synthetic_error_first(
+def test_compose_client_internals_refuses_synthetic_error_first(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """``_refuse_synthetic_error_outside_test_context`` MUST run before any
-    other work in :func:`compose_session_internals`.
+    other work in :func:`compose_client_internals`.
 
     Pins the same contract as
     :mod:`tests.unit.concurrency.test_synthetic_error_transport_guard` —
@@ -233,72 +213,87 @@ def test_compose_session_internals_refuses_synthetic_error_first(
         caplog.at_level(logging.WARNING, logger="notebooklm._core"),
         pytest.raises(RuntimeError, match="NOTEBOOKLM_VCR_RECORD_ERRORS"),
     ):
-        compose_session_internals(auth=_make_auth())
+        compose_client_internals(auth=_make_auth())
 
 
-def test_compose_session_internals_preserves_late_binding_for_decode_response() -> None:
-    """Post-construction ``session._seams.decode_response = rebound`` MUST still
+def test_compose_client_internals_preserves_late_binding_for_decode_response() -> None:
+    """Post-construction ``seams.decode_response = rebound`` MUST still
     steer the executor's decode path.
 
     Pins the lambda-closure contract documented in the plan: the executor
     is wired with ``decode_response=lambda *a, **kw: seams.decode_response(*a, **kw)``
     so that test reassignments after construction continue to take effect.
     """
-    composed = compose_session_internals(auth=_make_auth())
+    seams = ClientSeams(
+        decode_response=lambda *_a, **_kw: None,
+        sleep=asyncio.sleep,
+        is_auth_error=lambda _exc: False,
+    )
+    internals = compose_client_internals(auth=_make_auth(), seams=seams)
 
     sentinel: list[Any] = []
 
     def rebound(*args: Any, **kwargs: Any) -> str:
-        """Recording stand-in for ``session._seams.decode_response``."""
+        """Recording stand-in for ``seams.decode_response``."""
         sentinel.append(("decoded", args, kwargs))
         return "rebound-result"
 
-    composed.session._seams.decode_response = rebound
+    seams.decode_response = rebound
 
     # The executor closure should dispatch through the live attribute,
     # not the value frozen at construction time.
-    result = composed.executor._decode_response("payload", "method-id", allow_null=False)
+    result = internals.executor._decode_response("payload", "method-id", allow_null=False)
     assert result == "rebound-result"
     assert sentinel and sentinel[-1][0] == "decoded"
 
 
-def test_compose_session_internals_preserves_late_binding_for_is_auth_error() -> None:
-    """Post-construction ``session._seams.is_auth_error = rebound`` MUST still
+def test_compose_client_internals_preserves_late_binding_for_is_auth_error() -> None:
+    """Post-construction ``seams.is_auth_error = rebound`` MUST still
     steer the executor's classifier.
 
     Mirror of the ``decode_response`` test for the auth-error seam.
     """
-    composed = compose_session_internals(auth=_make_auth())
+    seams = ClientSeams(
+        decode_response=lambda *_a, **_kw: None,
+        sleep=asyncio.sleep,
+        is_auth_error=lambda _exc: False,
+    )
+    internals = compose_client_internals(auth=_make_auth(), seams=seams)
 
     def rebound(exc: Exception) -> bool:
         """Stand-in classifier — treats KeyError as auth-related."""
         return isinstance(exc, KeyError)
 
-    composed.session._seams.is_auth_error = rebound
+    seams.is_auth_error = rebound
 
-    assert composed.executor._is_auth_error(KeyError("auth")) is True
-    assert composed.executor._is_auth_error(RuntimeError("nope")) is False
+    assert internals.executor._is_auth_error(KeyError("auth")) is True
+    assert internals.executor._is_auth_error(RuntimeError("nope")) is False
 
 
-def test_compose_session_internals_preserves_late_binding_for_sleep() -> None:
-    """Post-construction ``session._seams.sleep = rebound`` MUST still steer the
+def test_compose_client_internals_preserves_late_binding_for_sleep() -> None:
+    """Post-construction ``seams.sleep = rebound`` MUST still steer the
     executor's backoff path.
     """
-    composed = compose_session_internals(auth=_make_auth())
+    seams = ClientSeams(
+        decode_response=lambda *_a, **_kw: None,
+        sleep=asyncio.sleep,
+        is_auth_error=lambda _exc: False,
+    )
+    internals = compose_client_internals(auth=_make_auth(), seams=seams)
 
     calls: list[float] = []
 
     async def rebound(delay: float) -> None:
-        """Recording stand-in for ``session._seams.sleep`` (captures delays)."""
+        """Recording stand-in for ``seams.sleep`` (captures delays)."""
         calls.append(delay)
 
-    composed.session._seams.sleep = rebound
+    seams.sleep = rebound
 
-    asyncio.run(composed.executor._sleep(0.25))
+    asyncio.run(internals.executor._sleep(0.25))
     assert calls == [0.25]
 
 
-def test_compose_session_internals_preserves_late_binding_for_refresh_retry_delay() -> None:
+def test_compose_client_internals_preserves_late_binding_for_refresh_retry_delay() -> None:
     """Post-construction ``chain_host._refresh_retry_delay = X`` MUST be seen
     by the executor's ``refresh_retry_delay_provider`` lambda on the next
     call.
@@ -310,19 +305,20 @@ def test_compose_session_internals_preserves_late_binding_for_refresh_retry_dela
     re-reads the attribute on every invocation, so this is a live binding,
     not a frozen snapshot.
     """
-    composed = compose_session_internals(auth=_make_auth())
+    holder = ClientComposed()
+    internals = compose_client_internals(auth=_make_auth(), composed=holder)
 
-    chain_host = composed.session._chain_host
+    chain_host = holder.chain_host
     # The provider lambda must dereference the *current* attribute on
     # each call — not the value captured at construction time.
     initial = chain_host._refresh_retry_delay
-    assert composed.executor._refresh_retry_delay_provider() == initial
+    assert internals.executor._refresh_retry_delay_provider() == initial
 
     chain_host._refresh_retry_delay = 0.99
-    assert composed.executor._refresh_retry_delay_provider() == 0.99
+    assert internals.executor._refresh_retry_delay_provider() == 0.99
 
 
-def test_compose_session_internals_executor_timeout_provider_reads_lifecycle() -> None:
+def test_compose_client_internals_executor_timeout_provider_reads_lifecycle() -> None:
     """The executor's ``timeout_provider`` reads from the live
     ``ClientLifecycle._timeout`` collaborator attribute.
 
@@ -331,145 +327,100 @@ def test_compose_session_internals_executor_timeout_provider_reads_lifecycle() -
     line 253). A lifecycle-side mutation must surface on the next executor
     call without re-binding.
     """
-    composed = compose_session_internals(auth=_make_auth())
+    internals = compose_client_internals(auth=_make_auth())
 
-    initial = composed.collaborators.lifecycle._timeout
-    assert composed.executor._timeout_provider() == initial
+    initial = internals.collaborators.lifecycle._timeout
+    assert internals.executor._timeout_provider() == initial
 
-    composed.collaborators.lifecycle._timeout = 99.0
-    assert composed.executor._timeout_provider() == 99.0
+    internals.collaborators.lifecycle._timeout = 99.0
+    assert internals.executor._timeout_provider() == 99.0
 
 
 # ---------------------------------------------------------------------------
-# write-once binders — load-bearing after PR 2
+# ClientComposed write-once binders
 # ---------------------------------------------------------------------------
 
 
-def test_bind_executor_raises_on_double_bind() -> None:
-    """:meth:`_bind_executor` accepts exactly one bind.
+def test_client_composed_executor_binder_raises_on_double_bind() -> None:
+    holder = ClientComposed()
+    compose_client_internals(auth=_make_auth(), composed=holder)
 
-    :func:`compose_session_internals` invokes the binder once during
-    composition; calling it a second time on the returned Session must
-    raise.
-    """
-    composed = compose_session_internals(auth=_make_auth())
-
-    with pytest.raises(RuntimeError, match="_rpc_executor already bound"):
-        composed.session._bind_executor(composed.executor)
+    with pytest.raises(RuntimeError, match="_executor already bound"):
+        holder.bind_executor(holder.executor)
 
 
-def test_bind_transport_raises_on_double_bind() -> None:
-    """:meth:`_bind_transport` accepts exactly one bind.
-
-    PR 2 of Stage B1 inverted :meth:`Session.__init__` (the transport
-    slot is now left at ``None`` and the binder is the only assignment
-    site). A second bind attempt after :func:`compose_session_internals`
-    has driven the binder must raise.
-    """
-    composed = compose_session_internals(auth=_make_auth())
+def test_client_composed_transport_binder_raises_on_double_bind() -> None:
+    holder = ClientComposed()
+    compose_client_internals(auth=_make_auth(), composed=holder)
 
     with pytest.raises(RuntimeError, match="_transport already bound"):
-        composed.session._bind_transport(composed.transport)
+        holder.bind_transport(holder.transport)
 
 
-def test_bind_chain_metadata_raises_on_double_bind() -> None:
-    """:meth:`_bind_chain_metadata` accepts exactly one bind.
-
-    Re-driving the binder after composition raises. The binder stores
-    only the auxiliary chain artifacts (``_chain_builder`` /
-    ``_middlewares``); the chain slot itself lives on
-    :class:`MiddlewareChainHost` and is assigned exactly once by the
-    composition root (``chain_host._authed_post_chain =
-    wired.authed_post_chain``).
-    """
-    composed = compose_session_internals(auth=_make_auth())
+def test_client_composed_chain_metadata_binder_raises_on_double_bind() -> None:
+    holder = ClientComposed()
+    compose_client_internals(auth=_make_auth(), composed=holder)
 
     # Build a sentinel ``WiredMiddleware`` carrying the existing values so
     # the rejection comes from the write-once guard, not a missing field.
     from notebooklm._session_init import WiredMiddleware
 
     wired = WiredMiddleware(
-        chain_builder=composed.session._chain_builder,
-        middlewares=composed.session._middlewares,
-        authed_post_chain=composed.session._chain_host._authed_post_chain,
+        chain_builder=holder.chain_builder,
+        middlewares=holder.middlewares,
+        authed_post_chain=holder.chain_host._authed_post_chain,
     )
     with pytest.raises(RuntimeError, match="_chain_metadata already bound"):
-        composed.session._bind_chain_metadata(wired)
+        holder.bind_chain_metadata(wired)
+
+
+def test_client_composed_chain_host_binder_raises_on_double_bind() -> None:
+    holder = ClientComposed()
+    compose_client_internals(auth=_make_auth(), composed=holder)
+
+    with pytest.raises(RuntimeError, match="_chain_host already bound"):
+        holder.bind_chain_host(holder.chain_host)
+
+
+def test_client_composed_session_collaborators_binder_raises_on_double_bind() -> None:
+    holder = ClientComposed()
+    internals = compose_client_internals(auth=_make_auth(), composed=holder)
+
+    with pytest.raises(RuntimeError, match="_session_collaborators already bound"):
+        holder.bind_session_collaborators(internals.collaborators)
 
 
 # ---------------------------------------------------------------------------
-# fail-fast guards
+# ClientComposed required-property guards
 # ---------------------------------------------------------------------------
 
 
-def test_require_constructed_raises_when_attr_is_none() -> None:
-    """The guard raises ``RuntimeError`` with a self-describing message.
+@pytest.mark.parametrize(
+    ("attr_name", "message"),
+    [
+        ("transport", "_transport"),
+        ("executor", "_executor"),
+        ("chain_host", "_chain_host"),
+        ("chain_builder", "_chain_builder"),
+        ("middlewares", "_middlewares"),
+        ("session_collaborators", "_session_collaborators"),
+    ],
+)
+def test_client_composed_properties_raise_before_binding(attr_name: str, message: str) -> None:
+    holder = ClientComposed()
 
-    Constructs a bare ``Session`` via ``__new__`` to bypass the
-    composition root — the resulting instance has all the late-bound
-    slots unset so the guard fires actionably.
-    """
-    session = Session.__new__(Session)
-    session._transport = None  # type: ignore[assignment]
-
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _transport is None"):
-        session._require_constructed("_transport")
-
-
-def test_require_constructed_is_inert_when_attr_is_set() -> None:
-    """The guard returns silently when the binding is set."""
-    session = build_session_for_tests(_make_auth())
-    # ``_transport`` is set by :func:`compose_session_internals` via
-    # :meth:`_bind_transport`.
-    assert session._transport is not None
-    # Should not raise.
-    session._require_constructed("_transport")
+    with pytest.raises(
+        RuntimeError,
+        match=rf"ClientComposed not fully constructed: {message} is None",
+    ):
+        getattr(holder, attr_name)
 
 
-def test_require_constructed_raises_on_missing_attribute() -> None:
-    """The guard also raises for attributes that have never been assigned.
-
-    Uses :func:`getattr` with a ``None`` default so the same actionable
-    message surfaces during ``__init__`` itself, before the attribute
-    has been assigned for the first time.
-    """
+def test_session_composition_properties_forward_to_client_composed() -> None:
     session = build_session_for_tests(_make_auth())
 
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _nonexistent is None"):
-        session._require_constructed("_nonexistent")
-
-
-def test_entry_point_guards_fire_on_uninitialised_session() -> None:
-    """The fail-fast guards on ``open`` / ``close`` and direct
-    ``_require_constructed`` checks raise when the relevant write-once
-    binding is ``None``.
-
-    Bypasses :func:`compose_session_internals` (the canonical composition
-    root) via ``Session.__new__`` so the guards see a pre-binding
-    state — the same state ``__init__`` exits in if the composition
-    root is short-circuited.
-
-    Stage B1 PR 2 of the post-refactoring plan deleted the lazy
-    ``Session._get_rpc_executor`` factory; ``_rpc_executor`` is the slot
-    the composition root binds last and is exercised directly via the
-    :meth:`_require_constructed` guard. The other three entry points
-    continue to probe ``_transport`` because that's the slot the
-    composition root binds first — a pre-transport call indicates
-    a fundamentally unconstructed Session regardless of whether the
-    chain or executor finished wiring.
-    """
-    session = Session.__new__(Session)
-    # No attributes set — guards must treat this as "not constructed".
-    # The guard uses ``getattr(..., None)`` so missing-attribute and
-    # ``None``-bound look the same to the caller.
-
-    # The composition root binds the executor last; the guard is
-    # exercised whenever any composition primitive probes the slot.
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _rpc_executor is None"):
-        session._require_constructed("_rpc_executor")
-
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _transport is None"):
-        asyncio.run(session.open())
-
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _transport is None"):
-        asyncio.run(session.close())
+    assert session._transport is session._composed.transport
+    assert session._rpc_executor is session._composed.executor
+    assert session._chain_host is session._composed.chain_host
+    assert session._chain_builder is session._composed.chain_builder
+    assert session._middlewares is session._composed.middlewares

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -370,7 +370,7 @@ def test_client_composed_chain_metadata_binder_raises_on_double_bind() -> None:
         middlewares=holder.middlewares,
         authed_post_chain=holder.chain_host._authed_post_chain,
     )
-    with pytest.raises(RuntimeError, match="_chain_metadata already bound"):
+    with pytest.raises(RuntimeError, match="_chain_builder already bound"):
         holder.bind_chain_metadata(wired)
 
 

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -68,10 +68,7 @@ import httpx
 import pytest
 
 from _fixtures.kernel_test_helpers import install_http_client_for_test
-from _helpers.session_factory import (
-    build_composed_session_for_tests,
-    build_refresh_client_shell,
-)
+from _helpers.client_factory import build_client_for_tests
 from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 from notebooklm._rpc_executor import RpcExecutor
 from notebooklm._session_auth import AuthRefreshCoordinator
@@ -468,17 +465,16 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
 
     # Build the same auth scaffold the unit conftest's ``make_core`` produces
     # (CSRF_OLD / SID_OLD / old_sid_cookie) so the OLD/NEW marker assertions
-    # below stay valid. Routed through :func:`build_composed_session_for_tests`
-    # (Wave 0 of the host-protocol-removal plan) so we get the full
-    # :class:`ComposedSession` bundle the shell helper needs — instead of
-    # only the :class:`Session` instance ``make_core`` yields.
+    # below stay valid. Routed through :func:`build_client_for_tests` so the
+    # refresh client shell and one-wave Session forwarder share one composed
+    # runtime.
     auth = AuthTokens(
         csrf_token="CSRF_OLD",
         session_id="SID_OLD",
         cookies={"SID": "old_sid_cookie"},
     )
-    composed = build_composed_session_for_tests(auth=auth, refresh_retry_delay=0.0)
-    core = composed.session
+    client = build_client_for_tests(auth=auth, refresh_retry_delay=0.0)
+    core = client._session
     await core.open()
     try:
         # Swap the auto-built http client for one that uses the test
@@ -495,16 +491,6 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
                 timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
             ),
         )
-
-        # ``build_refresh_client_shell`` populates all four runtime
-        # attributes (``_session`` / ``_auth`` / ``_collaborators`` /
-        # ``_rpc_executor``) from the composed bundle so the shell mirrors
-        # production. Pre-Wave-0 this site set only ``client._session = core``,
-        # which left ``client._auth`` unset; that worked because
-        # ``refresh_auth`` reaches through ``self._session.auth``, but it
-        # diverged from production shape and made the later
-        # ``Session.lifecycle`` deletion (Wave 2) require shell rewrites.
-        client = build_refresh_client_shell(composed)
 
         # try/finally ensures the mock-transport handlers are unblocked even
         # if a wait_for times out — otherwise pending tasks dangle in the

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -573,13 +573,12 @@ def test_lifted_core_modules_are_retired() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_compose_session_internals_exposes_constructor_di_seams() -> None:
-    """``compose_session_internals`` MUST expose the four constructor-DI seams.
+def test_compose_client_internals_exposes_constructor_di_seams() -> None:
+    """``compose_client_internals`` MUST expose the four constructor-DI seams.
 
     Stage B1 PR 2 of the post-refactoring plan moved the composition
-    root out of ``Session.__init__`` (which now takes
-    ``(*, collaborators, config, auth)`` only) into
-    ``notebooklm._session_init.compose_session_internals``. The seams live
+    root out of ``Session.__init__`` into
+    ``notebooklm._session_init.compose_client_internals``. The seams live
     on the helper (and on the canonical test builder
     ``build_session_for_tests``), NOT on ``NotebookLMClient.__init__``
     (which preserves the production surface).
@@ -593,12 +592,12 @@ def test_compose_session_internals_exposes_constructor_di_seams() -> None:
     """
     import inspect
 
-    from notebooklm._session_init import compose_session_internals
+    from notebooklm._session_init import compose_client_internals
 
-    sig = inspect.signature(compose_session_internals)
+    sig = inspect.signature(compose_client_internals)
     for name in ("decode_response", "sleep", "is_auth_error", "async_client_factory"):
         assert name in sig.parameters, (
-            f"compose_session_internals must expose constructor-DI kwarg {name!r}"
+            f"compose_client_internals must expose constructor-DI kwarg {name!r}"
         )
         param = sig.parameters[name]
         assert param.kind == inspect.Parameter.KEYWORD_ONLY, (

--- a/tests/unit/test_lifecycle_executor_reuse.py
+++ b/tests/unit/test_lifecycle_executor_reuse.py
@@ -9,9 +9,9 @@ executor against the new ``httpx.AsyncClient``.
 
 PR 2 deleted both that null line and the lazy factory itself — the
 executor is bound exactly once by the composition root
-(:func:`notebooklm._session_init.compose_session_internals`) via
-:meth:`Session._bind_executor`, and the same instance survives any
-``close()`` → ``open()`` cycle. This is safe because the executor's
+(:func:`notebooklm._session_init.compose_client_internals`) via
+:class:`notebooklm._client_composed.ClientComposed`, and the same instance
+survives any ``close()`` → ``open()`` cycle. This is safe because the executor's
 transport collaborator (:class:`Kernel`) rebuilds its
 ``httpx.AsyncClient`` lazily on each :meth:`Kernel.open`, so a stale
 executor reference continues to drive RPCs against a fresh transport.
@@ -22,12 +22,8 @@ This module pins three load-bearing invariants:
    a full ``close()`` → ``open()`` cycle.
 2. The reused executor can still execute an RPC after the cycle (it is
    not bound to a stale transport reference).
-3. The same regression vector that the deleted
-   ``test_close_nulls_rpc_executor`` blocked — a follow-up
-   :meth:`open` quietly missing the executor — surfaces as a clean
-   ``RuntimeError`` if the composition contract is ever broken (the
-   :meth:`_require_constructed` guard fires in the executor binding
-   when ``_rpc_executor`` is ``None``).
+3. The one-wave ``Session._rpc_executor`` property forwards to the
+   client-owned composed executor.
 """
 
 from __future__ import annotations
@@ -142,20 +138,8 @@ async def test_rpc_call_succeeds_after_close_then_open_with_same_executor() -> N
     assert core._rpc_executor is executor
 
 
-def test_require_constructed_raises_when_rpc_executor_is_unbound() -> None:
-    """The :meth:`_require_constructed` guard fires if ``_rpc_executor`` is ``None``.
+def test_session_rpc_executor_forwards_to_client_composed() -> None:
+    """The temporary Session executor seam reads through ``ClientComposed``."""
+    core = build_session_for_tests(_make_auth())
 
-    Tests the contract that catches a regression where the composition
-    root forgets to bind ``_rpc_executor`` (or a close-time null is
-    reintroduced and the next :meth:`open` does not rebind). Bypasses
-    the composition root via ``Session.__new__`` to simulate that
-    broken state.
-    """
-    from notebooklm._session import Session
-
-    session = Session.__new__(Session)
-    # ``_rpc_executor`` is unset on a __new__ instance; the guard uses
-    # ``getattr(..., None)`` so missing-attribute and ``None``-bound look
-    # the same to the caller — both raise the actionable message.
-    with pytest.raises(RuntimeError, match="Session not fully constructed: _rpc_executor is None"):
-        session._require_constructed("_rpc_executor")
+    assert core._rpc_executor is core._composed.executor


### PR DESCRIPTION
## Summary

- move transport/executor/chain composition ownership onto `ClientComposed`
- rename `compose_session_internals`/`ComposedSession` to `compose_client_internals`/`ClientInternals`
- keep `Session` as a one-wave lifecycle/property forwarder and update test helpers/docs for Phase 2

## Verification

- `uv run pytest tests/unit/test_auth_instance_invariant.py tests/unit/test_init_order.py tests/unit/test_composition_primitives.py -q`
- `uv run pytest tests/unit/test_lifecycle_executor_reuse.py -q`
- `uv run pytest tests/_lint/test_client_composition.py tests/_lint/test_session_retention.py -q`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/integration -q`
- `uv run pytest tests/_lint -q`
- `uv run mypy src/notebooklm`
- `uv run ruff check src/notebooklm tests`
- `uv run ruff format --check src/notebooklm tests`
- `uv run python scripts/audit_public_api_compat.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Composition moved to a client-owned holder; sessions now forward composition properties and use lazy, write-once binding with fail-fast access guards.

* **Documentation**
  * Architecture doc updated to reflect Phase‑2 composition ownership, retained/removed surface, and new glossary term for temporary composition forwarders.

* **Tests**
  * Test helpers simplified/centralized; added and updated tests validating late-binding, binder guards, auth identity preservation, and lifecycle/concurrency behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->