### PR TITLE
fix(sources): reject html file uploads clearly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Exit code semantics` summary section in [`docs/cli-exit-codes.md`](docs/cli-exit-codes.md#exit-code-semantics).** A normative one-line table — `0` = succeeded as documented, `1` = failed or queried target not found, `2` = Click parser-time error — backing the convention every command obeys outside the documented intentional exceptions. Cross-references the existing tables and [ADR-015](docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md).
 - **`NotFoundError` cross-domain umbrella exception.** Catch `NotFoundError` to handle any "resource not found" case across notebooks, sources, and artifacts in one `except` clause — replacing `except (NotebookNotFoundError, SourceNotFoundError, ArtifactNotFoundError):`. `NotebookNotFoundError`, `SourceNotFoundError`, and `ArtifactNotFoundError` all inherit from `NotFoundError`. The umbrella itself is additive; the asymmetric inheritance noted on its original introduction has been resolved in the same release — all three subclasses also mix in `RPCError` (see **Breaking changes** above for the `except`-ordering migration).
 
+### Fixed
+
+- **HTML file uploads now fail client-side with a clear validation error** ([#1127](https://github.com/teng-lin/notebooklm-py/issues/1127)). `notebooklm source add ./article.html` and `client.sources.add_file(..., "article.html")` previously reached NotebookLM's upload endpoint as `text/html` and surfaced a cryptic upstream `400 Bad Request`. The upload pipeline now rejects `.html` / `.htm` / `.xhtml` / `.xht` / HTML MIME uploads before registering a source, with guidance to convert the page to `.txt`, `.md`, or `.pdf`.
+
 ### Removed
 
 - `NotebookLMClient.rpc_call(source_path=...)`, `NotebookLMClient.rpc_call(_is_retry=...)`, `NotebookLMClient.rpc_call(operation_variant=...)` — see Breaking changes above. The corresponding `DeprecationWarning` emitters in `client.py` and the `tests/unit/test_rpc_call_public_surface.py` warning-surface tests were retired in the same change.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -286,6 +286,24 @@ URL is populated.
 
 ### File Upload Issues
 
+#### HTML/XHTML files are rejected before upload
+
+**Cause:** NotebookLM's file-upload endpoint rejects HTML-family uploads, even
+though the web UI may accept pasted rich text.
+
+**Solution:** Convert saved web pages to text, Markdown, or PDF before adding
+them with your preferred extractor:
+
+```bash
+notebooklm source add ./article.txt
+```
+
+You can also pipe extracted text through stdin:
+
+```bash
+python extract_article_text.py ./article.html | notebooklm source add - --type text --title "Article"
+```
+
 #### Text/Markdown files upload but return None
 
 **Cause:** Known issue with native text file uploads.

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -233,6 +233,8 @@ _MEDIA_APPLICATION_CONTENT_TYPES = frozenset(
 )
 _MEDIA_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 _STRICT_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = ()
+_HTML_UPLOAD_SUFFIXES = frozenset({".html", ".htm", ".xhtml", ".xht"})
+_HTML_UPLOAD_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
 
 
 # Audit CC6: single-loop-per-client invariant per ADR-004; not safe for multi-loop fan-out.
@@ -305,15 +307,32 @@ def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
     return guessed or "application/octet-stream"
 
 
+def _normalize_content_type(content_type: str) -> str:
+    return content_type.split(";", 1)[0].strip().lower()
+
+
 def _transient_error_types_for_upload(content_type: str) -> tuple[int | None, ...]:
     """Return source status=ERROR transient policy for this upload."""
-    normalized = content_type.split(";", 1)[0].strip().lower()
+    normalized = _normalize_content_type(content_type)
     if (
         normalized.startswith(_MEDIA_CONTENT_TYPE_PREFIXES)
         or normalized in _MEDIA_APPLICATION_CONTENT_TYPES
     ):
         return _MEDIA_TRANSIENT_ERROR_TYPES
     return _STRICT_TRANSIENT_ERROR_TYPES
+
+
+def _validate_upload_file_supported(file_path: Path, content_type: str) -> None:
+    """Reject local file types known to fail NotebookLM's upload endpoint."""
+    normalized = _normalize_content_type(content_type)
+    if (
+        file_path.suffix.lower() in _HTML_UPLOAD_SUFFIXES
+        or normalized in _HTML_UPLOAD_CONTENT_TYPES
+    ):
+        raise ValidationError(
+            "HTML file uploads are not supported by NotebookLM's upload endpoint: "
+            f"{file_path.name}. Convert the page to .txt, .md, or .pdf first, then retry."
+        )
 
 
 class SourceUploadPipeline:
@@ -400,7 +419,11 @@ class SourceUploadPipeline:
         on_progress: Callable[[int, int], object] | None = None,
         upload_index: int = 0,
     ) -> Source:
-        """Add a file source to a notebook using resumable upload."""
+        """Add a file source to a notebook using resumable upload.
+
+        Raises ``ValidationError`` for HTML-family uploads because
+        NotebookLM's upload endpoint rejects those file extensions.
+        """
         # Audit C1: catch cross-loop add_file *before* touching
         # ``operation_scope`` or lazily allocating the upload semaphore.
         # Both are loop-bound on first use, so a cross-loop call would
@@ -430,6 +453,7 @@ class SourceUploadPipeline:
 
         filename = file_path.name
         content_type = _resolve_upload_content_type(file_path, mime_type)
+        _validate_upload_file_supported(file_path, content_type)
         transient_error_types = _transient_error_types_for_upload(content_type)
         async with self._drain.operation_scope(f"upload:{upload_index}"):
             upload_sem = self.get_upload_semaphore()

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -541,6 +541,12 @@ class SourcesAPI:
             - Markdown: text/markdown
             - EPUB: application/epub+zip
             - Word: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+        Raises:
+            ValidationError: If the path is not a regular file, the title is
+                empty, or the upload is an HTML-family file that NotebookLM's
+                upload endpoint rejects. Convert saved web pages to text,
+                Markdown, or PDF before calling this method.
         """
         wait, wait_timeout = _resolve_legacy_wait_args(
             "SourcesAPI.add_file",

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -283,6 +283,43 @@ async def test_add_file_uses_pipeline_steps_and_finishes_transport(
     )
 
 
+@pytest.mark.parametrize(
+    ("filename", "mime_type"),
+    [
+        ("article.html", None),
+        ("ARTICLE.HTML", None),
+        ("article.htm", None),
+        ("article.xhtml", None),
+        ("article.xht", None),
+        ("article.txt", "text/html"),
+        ("article.txt", "Text/HTML; charset=utf-8"),
+        ("article.xhtml", "application/xhtml+xml"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_file_rejects_html_before_registering_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    filename: str,
+    mime_type: str | None,
+) -> None:
+    file_path = tmp_path / filename
+    file_path.write_text("<html><body><h1>Article</h1></body></html>", encoding="utf-8")
+    service = make_pipeline()
+    register_file_source = AsyncMock(return_value="src_123")
+    start_resumable_upload = AsyncMock()
+
+    monkeypatch.setattr(service, "register_file_source", register_file_source)
+    monkeypatch.setattr(service, "start_resumable_upload", start_resumable_upload)
+    monkeypatch.setattr(service, "upload_file_streaming", AsyncMock())
+
+    with pytest.raises(ValidationError, match="HTML file uploads are not supported"):
+        await service.add_file("nb_123", file_path, mime_type=mime_type)
+
+    register_file_source.assert_not_awaited()
+    start_resumable_upload.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_add_file_operation_scope_wraps_sources_semaphore_wait(
     monkeypatch: pytest.MonkeyPatch, tmp_path


### PR DESCRIPTION
## Summary
- Reject HTML-family file uploads (`.html`, `.htm`, `.xhtml`, `.xht`, and HTML MIME overrides) before registering a NotebookLM source
- Surface a clear `ValidationError` telling users to convert saved pages to `.txt`, `.md`, or `.pdf`
- Document the workaround and add regression coverage for the pre-registration guard

Closes #1127

## Live reproduction
- Confirmed against the live NotebookLM API from unfixed `main`: `.html` upload returns HTTP 400 from `/upload/_/` with body preview `Unsupported file extension for file`
- The temporary live repro notebook was deleted successfully

## Verification
- `uv sync --frozen --extra browser --extra dev --extra markdown`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

## Polish
- Ran simplification pass
- Ran triple review: Codex native, Claude CLI, Antigravity CLI
- Addressed review findings: added XHTML suffix coverage, shared content-type normalization, clarified test scaffolding, and documented the Python API validation contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML/XHTML file uploads are now rejected client-side with validation errors instead of failing server-side.

* **Documentation**
  * Added troubleshooting guide explaining HTML file rejection with workaround solutions (convert to text, Markdown, or PDF).
  * Updated changelog documenting new HTML file validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->