### PR TITLE
fix(cli): extend audio wait timeout default

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -182,7 +182,7 @@ All generate commands (except the synchronous `mind-map`) accept the same unifor
 - `-s, --source ID` to select specific sources (repeatable)
 - `--json` for machine-readable output (returns `task_id` and `status`)
 - `--wait / --no-wait` to block until completion (default: `--no-wait` — returns immediately with a `task_id`)
-- `--timeout SECONDS` to cap the `--wait` budget (defaults: 300s for audio/quiz/flashcards/slide-deck/infographic/data-table/report/revise-slide, 1800s for video, 3600s for cinematic-video). No-op without `--wait`.
+- `--timeout SECONDS` to cap the `--wait` budget (defaults: 1200s for audio, 1800s for video, 3600s for cinematic-video, and 300s for quiz/flashcards/slide-deck/infographic/data-table/report/revise-slide). No-op without `--wait`.
 - `--interval SECONDS` to tune polling cadence (default: 2). No-op without `--wait`.
 - `--retry N` to automatically retry on rate limits with exponential backoff
 - `--prompt-file PATH` to read the description/query from a file (or `-` for stdin) instead of the command line. Mutually exclusive with the positional argument; useful for long prompts that exceed shell length limits.
@@ -871,7 +871,7 @@ notebooklm generate audio [description] [OPTIONS]
 - `--language LANG` - Output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
 - `-s, --source ID` - Limit to specific source IDs (repeatable, uses all if not specified)
 - `--wait / --no-wait` - Wait for completion (default: `--no-wait`)
-- `--timeout SECONDS` - Maximum seconds to wait (default: 300; no-op without `--wait`)
+- `--timeout SECONDS` - Maximum seconds to wait (default: 1200; no-op without `--wait`)
 - `--interval SECONDS` - Seconds between status checks (default: 2; no-op without `--wait`)
 - `--retry N` - Retry N times with exponential backoff on rate limit
 - `--json` - Output as JSON (returns `task_id` and `status`)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -255,9 +255,9 @@ finish before `timeout`. Both subclass `ArtifactTimeoutError` and built-in
 `status_transitions` so callers can retry, fail soft, or log upstream queueing
 patterns without parsing the message.
 
-The CLI defaults to longer wait budgets for media generation (`video`: 1800s,
-`cinematic-video`: 3600s). In Python, pass the same budget explicitly with
-`wait_for_completion(..., timeout=...)`.
+The CLI defaults to longer wait budgets for media generation (`audio`: 1200s,
+`video`: 1800s, `cinematic-video`: 3600s). In Python, pass the same budget
+explicitly with `wait_for_completion(..., timeout=...)`.
 
 ##### Catching any "not found" across domains
 
@@ -1226,12 +1226,12 @@ from notebooklm import ArtifactTimeoutError
 status = await client.artifacts.generate_audio(nb_id)
 
 try:
-    # Wait with polling. Use a higher timeout for long media jobs such as
-    # video or cinematic-video.
+    # Wait with polling. Use higher timeouts for media jobs:
+    # audio=1200s, video=1800s, cinematic-video=3600s.
     final = await client.artifacts.wait_for_completion(
         nb_id,
         status.task_id,
-        timeout=300,      # Max wait time in seconds
+        timeout=1200,     # Max wait time in seconds
         initial_interval=5  # Initial seconds between polls
     )
 except ArtifactTimeoutError as exc:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -267,9 +267,11 @@ URL is populated.
 **Solution:**
 - Increase the wait budget with `--timeout` or the Python
   `wait_for_completion(..., timeout=...)` argument.
-- For CLI waits, the built-in defaults are 1800s for standard video and
-  3600s for cinematic video; pass a larger `--timeout` if your account's media
-  queue is slower.
+- For `generate <kind> --wait`, the built-in media defaults are 1200s for
+  audio, 1800s for standard video, and 3600s for cinematic video; pass a
+  larger `--timeout` if your account's media queue is slower.
+- `artifact wait` is intentionally generic and still defaults to 300s; when
+  waiting manually on a media task ID, pass the matching media timeout.
 - Catch `ArtifactPendingTimeoutError` to retry queued tasks separately from
   `ArtifactInProgressTimeoutError`, which means the task started but did not
   finish before the timeout.

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -214,7 +214,7 @@ def generate():
 @language_option
 @multi_source_option
 @wait_option
-@wait_polling_options(default_timeout=300, default_interval=2)
+@wait_polling_options(default_timeout=1200, default_interval=2)
 @retry_option
 @json_option
 @with_client

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -156,9 +156,9 @@ def wait_polling_options(
 
     Args:
         default_timeout: Default value for ``--timeout`` in seconds. Each
-            command keeps its own historical default (e.g. ``generate audio``
-            uses 300, ``source wait`` uses 120) so this PR is purely
-            additive — no command changes its existing wait ceiling.
+            command supplies its own wait budget (e.g. ``generate audio``
+            uses 1200, ``source wait`` uses 120); this helper only
+            standardizes the flag wiring and help text.
         default_interval: Default value for ``--interval`` in seconds. Most
             commands use 2 to match the existing ``artifact wait`` default;
             ``source wait`` uses 1 to match its underlying

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -112,7 +112,9 @@ async def handle_generation_result(
         artifact_type: Display name for the artifact type (e.g., "audio", "video").
         wait: Whether to wait for completion.
         json_output: Whether to output as JSON.
-        timeout: Timeout for waiting (default: 300s).
+        timeout: Timeout forwarded to ``wait_for_completion``. Callers supply
+            per-command defaults; media generators use longer budgets while
+            generic artifact waits remain at 300s.
         interval: Polling interval in seconds. ``None`` (default) lets
             ``wait_for_completion`` use its built-in default
             (``initial_interval=2.0``); when supplied, the value is forwarded

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -3712,10 +3712,10 @@
           }
         },
         {
-          "default": 300,
+          "default": 1200,
           "envvar": null,
           "has_custom_shell_complete": false,
-          "help": "Maximum seconds to wait (default: 300)",
+          "help": "Maximum seconds to wait (default: 1200)",
           "is_flag": false,
           "kind": "option",
           "multiple": false,

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -128,6 +128,7 @@ class TestGenerateAudio:
 
             assert result.exit_code == 0
             assert "Audio ready" in result.output or "example.com" in result.output
+            mock_client.artifacts.wait_for_completion.assert_awaited_once()
             kwargs = mock_client.artifacts.wait_for_completion.await_args.kwargs
             assert kwargs.get("timeout") == 1200.0
 

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -128,6 +128,8 @@ class TestGenerateAudio:
 
             assert result.exit_code == 0
             assert "Audio ready" in result.output or "example.com" in result.output
+            kwargs = mock_client.artifacts.wait_for_completion.await_args.kwargs
+            assert kwargs.get("timeout") == 1200.0
 
     def test_generate_audio_with_wait_timeout_interval_forwarded(self, runner, mock_auth):
         """`generate audio --wait --timeout 60 --interval 5` plumbs both into


### PR DESCRIPTION
## Summary
- Increase `notebooklm generate audio --wait` default timeout from 300s to 1200s.
- Update CLI docs, Python API docs, troubleshooting guidance, and CLI contract fixture to match the new audio default.
- Add a unit assertion covering the default timeout passed to `wait_for_completion`.

## Task
`/pr-workflow` for current local changes.

## Test plan
- [x] `uv sync --frozen --extra browser --extra dev --extra markdown`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`
- [x] Re-ran `uv run pytest` and `uv run pre-commit run --all-files` after polish edits

## Polish
- Claude review: fixed stale timeout docstring and updated related service docstring.
- Codex review: no findings.
- Antigravity review: attempted, but the CLI returned a timeout message instead of findings.

## Deferred polish findings
- Optional: reword the top-level CLI timeout-default bullet for scanability; current content is correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference, Python API guides, and troubleshooting docs to reflect new media generation wait-time defaults.

* **Chores**
  * Adjusted default time budgets for media generation: audio 1200s (was 300s), video 1800s, cinematic-video 3600s.

* **Tests**
  * Updated test fixtures and unit tests to verify the updated timeout defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->