### PR TITLE
fix(rpc): count malformed chunk payload records

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -185,7 +185,8 @@ def parse_chunked_response(response: str) -> list[Any]:
         List of parsed JSON chunks
 
     Raises:
-        RPCError: If more than 10% of response records are malformed, indicating API issues.
+        RPCError: If more than 10% of attempted payload records are malformed,
+            indicating API issues.
 
     Note:
         Malformed chunks are skipped with a warning logged. A byte-count line
@@ -195,15 +196,20 @@ def parse_chunked_response(response: str) -> list[Any]:
         preserve Google's original byte count and live Google responses use a
         different unit (likely UTF-16 code units) than ``len(s.encode("utf-8"))``.
         A JSONDecodeError on the payload still emits a WARNING on the
-        subsequent parse-failure path. If the malformed-record rate exceeds
-        10%, raises RPCError as this likely indicates API changes.
+        subsequent parse-failure path. If the malformed-payload rate exceeds
+        10%, raises RPCError as this likely indicates API changes. Framing and
+        mixed payload/framing corruption keep their own strict guards without
+        letting byte-count records dilute the payload-specific threshold.
     """
     if not response or not response.strip():
         return []
 
     chunks = []
-    skipped_count = 0
-    total_records = 0
+    malformed_payload_records = 0
+    payload_records = 0
+    malformed_framing_records = 0
+    framing_records = 0
+    response_records = 0
     lines = [line.removesuffix("\r") for line in response.strip().split("\n")]
 
     i = 0
@@ -218,16 +224,18 @@ def parse_chunked_response(response: str) -> list[Any]:
         # Try to parse as byte count
         try:
             byte_count = int(line)
-            total_records += 1
+            framing_records += 1
+            response_records += 1
             i += 1
 
             # Next line should be JSON payload
             if i >= len(lines):
-                skipped_count += 1
+                malformed_framing_records += 1
                 logger.warning("Skipping byte-count line %d without payload", i)
                 continue
 
             json_str = lines[i]
+            payload_records += 1
             actual_byte_count = len(json_str.encode("utf-8"))
             if actual_byte_count != byte_count:
                 # DEBUG (not WARNING): live multi-chunk responses trip this on
@@ -246,7 +254,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                 chunks.append(chunk)
             except json.JSONDecodeError as e:
                 # Skip malformed chunks but warn
-                skipped_count += 1
+                malformed_payload_records += 1
                 logger.warning(
                     "Skipping malformed chunk at line %d: %s. Preview: %s",
                     i + 1,
@@ -256,13 +264,14 @@ def parse_chunked_response(response: str) -> list[Any]:
             i += 1
         except ValueError:
             # Not a byte count, try to parse as JSON directly
-            total_records += 1
+            payload_records += 1
+            response_records += 1
             try:
                 chunk = json.loads(line)
                 chunks.append(chunk)
             except json.JSONDecodeError as e:
                 # Skip non-JSON lines but warn
-                skipped_count += 1
+                malformed_payload_records += 1
                 logger.warning(
                     "Skipping non-JSON line at %d: %s. Preview: %s",
                     i + 1,
@@ -271,21 +280,53 @@ def parse_chunked_response(response: str) -> list[Any]:
                 )
             i += 1
 
+    payload_error_rate = malformed_payload_records / payload_records if payload_records else 0
+    framing_error_rate = malformed_framing_records / framing_records if framing_records else 0
+    malformed_records = malformed_payload_records + malformed_framing_records
+    response_error_rate = malformed_records / response_records if response_records else 0
+
     # Fail if error rate is too high (indicates API problems)
-    if skipped_count > 0:
-        error_rate = skipped_count / total_records if total_records else 0
-        if error_rate > 0.1:  # More than 10% malformed
-            raise RPCError(
-                f"Response parsing failed: {skipped_count} of {total_records} response records "
-                f"malformed. "
-                f"This may indicate API changes or data corruption.",
-                raw_response=response,
-            )
-        # Non-critical but warn user results may be incomplete
+    if payload_error_rate > 0.1:  # More than 10% malformed
+        raise RPCError(
+            f"Response parsing failed: {malformed_payload_records} of "
+            f"{payload_records} payload records "
+            f"malformed. "
+            f"This may indicate API changes or data corruption.",
+            raw_response=response,
+        )
+
+    if framing_error_rate > 0.1:  # More than 10% malformed
+        raise RPCError(
+            f"Response parsing failed: {malformed_framing_records} of "
+            f"{framing_records} framing records malformed. "
+            f"This may indicate API changes or data corruption.",
+            raw_response=response,
+        )
+
+    # Preserve the legacy aggregate strictness after payload/framing-specific
+    # checks so mixed corruption does not become more permissive.
+    if response_error_rate > 0.1:  # More than 10% malformed
+        raise RPCError(
+            f"Response parsing failed: {malformed_records} of "
+            f"{response_records} response records malformed. "
+            f"This may indicate API changes or data corruption.",
+            raw_response=response,
+        )
+
+    if malformed_payload_records > 0:
         logger.warning(
-            "Parsed response but skipped %d malformed chunks (%d%%). Results may be incomplete.",
-            skipped_count,
-            int(error_rate * 100),
+            "Parsed response but skipped %d malformed payload chunks (%d%%). "
+            "Results may be incomplete.",
+            malformed_payload_records,
+            int(payload_error_rate * 100),
+        )
+
+    if malformed_framing_records > 0:
+        logger.warning(
+            "Parsed response but skipped %d malformed framing records (%d%%). "
+            "Results may be incomplete.",
+            malformed_framing_records,
+            int(framing_error_rate * 100),
         )
 
     return chunks

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -103,8 +103,8 @@ class TestParseChunkedResponse:
 
     def test_ignores_malformed_chunks(self):
         """Test malformed chunks are ignored when below 10% threshold."""
-        # Add 10 valid chunk records and 1 malformed record, keeping the record-based
-        # error rate below the 10% threshold.
+        # Add 10 valid payload records and 1 malformed payload record, keeping
+        # the payload error rate below the 10% threshold.
         valid_chunks = [json.dumps([f"valid{i}"]) for i in range(10)]
         valid_parts = "\n".join([f"{len(c)}\n{c}" for c in valid_chunks])
         response = f"{valid_parts}\n99\nnot-json\n"
@@ -149,6 +149,11 @@ class TestParseChunkedResponse:
         assert chunks == [[f"valid{i}"] for i in range(10)]
         assert "without payload" in caplog.text
 
+    def test_trailing_byte_count_above_framing_threshold_raises(self):
+        """A framing-only response fails strict decoding."""
+        with pytest.raises(RPCError, match="1 of 1 framing records"):
+            parse_chunked_response("42\n")
+
     def test_skips_payload_split_across_lines_below_threshold(self):
         """A payload split across lines is treated as truncated malformed input."""
         valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(20))
@@ -169,21 +174,32 @@ class TestParseChunkedResponse:
 
         assert chunks == [[f"valid{i}"] for i in range(20)]
 
-    def test_error_rate_exactly_ten_percent_is_tolerated(self):
-        """The malformed-record threshold is exclusive: exactly 10% does not raise."""
-        valid_lines = "\n".join(json.dumps([f"valid{i}"]) for i in range(9))
-        response = f"{valid_lines}\nnot-json\n"
+    def test_payload_error_rate_exactly_ten_percent_is_tolerated(self):
+        """The payload threshold is exclusive: exactly 10% does not raise."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(9))
+        response = f"{valid_parts}\n99\nnot-json\n"
 
         chunks = parse_chunked_response(response)
 
         assert chunks == [[f"valid{i}"] for i in range(9)]
 
-    def test_error_rate_just_above_ten_percent_raises(self):
-        """The parser raises once malformed records exceed 10%."""
-        valid_lines = "\n".join(json.dumps([f"valid{i}"]) for i in range(8))
-        response = f"{valid_lines}\nnot-json\n"
+    def test_byte_count_frames_do_not_dilute_malformed_payload_rate(self):
+        """The parser raises when payload errors exceed 10%, excluding byte-count frames."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(8))
+        response = f"{valid_parts}\n99\nnot-json\n"
 
-        with pytest.raises(RPCError, match="Response parsing failed"):
+        with pytest.raises(RPCError) as exc_info:
+            parse_chunked_response(response)
+
+        assert "1 of 9 payload records malformed" in str(exc_info.value)
+        assert "18 response records" not in str(exc_info.value)
+
+    def test_mixed_payload_and_framing_errors_preserve_strict_threshold(self):
+        """Separate payload/framing rates must not loosen mixed malformed streams."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
+        response = f"{valid_parts}\n99\nnot-json\n42\n"
+
+        with pytest.raises(RPCError, match="2 of 12 response records"):
             parse_chunked_response(response)
 
 


### PR DESCRIPTION
## Summary
- split chunked decoder malformed accounting into payload, framing, and aggregate strict guards
- threshold malformed payloads against attempted payload records so byte-count frames cannot dilute the failure rate
- add chunked threshold regressions for exact threshold, payload-above-threshold, framing-only failure, and mixed corruption

## Task
Phase 1 task `p1-rpc-decoder-denominator` from `.sisyphus/phases/codebase-gaps-remediation-plan/phase-1.md`.

## Test plan
- [x] `uv run pytest tests/unit/test_decoder.py -q`
- [x] `uv run pytest tests/unit/test_rpc_golden_payloads.py -q`
- [x] `uv run ruff check src/notebooklm/rpc/decoder.py tests/unit/test_decoder.py`
- [x] `uv run mypy src/notebooklm/rpc`

## Deferred polish findings
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise detection of malformed response parts by tracking payload vs framing errors separately.
  * Stricter enforcement of error-rate thresholds (per-type and combined), with clearer warnings when limits are exceeded.
* **Tests**
  * Added and adjusted tests to cover per-type thresholds, mixed-error scenarios, and regression cases for strict decoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->