### PR TITLE
fix(auth): harden auth error classification

### DIFF
--- a/src/notebooklm/_session_helpers.py
+++ b/src/notebooklm/_session_helpers.py
@@ -47,6 +47,7 @@ AUTH_ERROR_PATTERNS = (
 
 _AUTH_HTTP_STATUS_CODES = frozenset({400, 401, 403})
 _AUTH_RPC_NUMERIC_CODES = frozenset({401, 403, 16})
+_MAX_RPC_SIGNAL_LENGTH = 256
 _AUTH_RPC_LABEL_CODES = frozenset(
     {
         "AUTHENTICATION_REQUIRED",
@@ -110,6 +111,8 @@ def _coerce_int_code(value: object) -> int | None:
     if isinstance(value, int):
         return int(value)
     if isinstance(value, str):
+        if len(value) > _MAX_RPC_SIGNAL_LENGTH:
+            return None
         stripped = value.strip()
         if stripped.isdigit():
             return int(stripped)
@@ -119,7 +122,10 @@ def _coerce_int_code(value: object) -> int | None:
 def _normalize_code_label(value: object) -> str | None:
     if not isinstance(value, str):
         return None
-    return value.strip().replace("-", "_").replace(" ", "_").upper()
+    if len(value) > _MAX_RPC_SIGNAL_LENGTH:
+        return None
+    normalized = value.strip().replace("-", "_").replace(" ", "_").upper()
+    return normalized if normalized else None
 
 
 def _normalized_message(error: Exception) -> str:

--- a/src/notebooklm/_session_helpers.py
+++ b/src/notebooklm/_session_helpers.py
@@ -35,13 +35,33 @@ from .rpc import (
     ServerError,
 )
 
-# Auth error detection patterns (case-insensitive)
+# Legacy export kept for callers that import the constant directly. Auth
+# classification below no longer uses these as arbitrary RPCError substrings.
 AUTH_ERROR_PATTERNS = (
     "authentication",
     "expired",
     "unauthorized",
     "login",
     "re-authenticate",
+)
+
+_AUTH_HTTP_STATUS_CODES = frozenset({400, 401, 403})
+_AUTH_RPC_NUMERIC_CODES = frozenset({401, 403, 16})
+_AUTH_RPC_LABEL_CODES = frozenset(
+    {
+        "AUTHENTICATION_REQUIRED",
+        "AUTH_EXPIRED",
+        "TOKEN_EXPIRED",
+        "UNAUTHENTICATED",
+        "UNAUTHORIZED",
+    }
+)
+_LEGACY_AUTH_RPC_MESSAGES = frozenset(
+    {
+        "authentication expired",
+        "authentication expired or invalid",
+        "authentication required. run 'notebooklm login' to re-authenticate.",
+    }
 )
 
 
@@ -83,6 +103,57 @@ def resolve_sleep(
     return injected if injected is not None else asyncio.sleep
 
 
+def _coerce_int_code(value: object) -> int | None:
+    """Return an integer status/code value without accepting bools."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _normalize_code_label(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value.strip().replace("-", "_").replace(" ", "_").upper()
+
+
+def _normalized_message(error: Exception) -> str:
+    return " ".join(str(error).split()).casefold()
+
+
+def _rpc_error_has_auth_signal(error: RPCError) -> bool:
+    # Some wrappers attach HTTP-like status metadata to a generic RPCError.
+    # Treat an explicit status_code as authoritative when present.
+    status_code = _coerce_int_code(getattr(error, "status_code", None))
+    if status_code is not None:
+        return status_code in _AUTH_HTTP_STATUS_CODES
+
+    has_explicit_rpc_signal = False
+    for attr_name in ("rpc_code", "code", "status"):
+        value = getattr(error, attr_name, None)
+        numeric_code = _coerce_int_code(value)
+        label_code = _normalize_code_label(value)
+        if numeric_code is not None or label_code is not None:
+            has_explicit_rpc_signal = True
+        if numeric_code in _AUTH_RPC_NUMERIC_CODES:
+            return True
+        if label_code in _AUTH_RPC_LABEL_CODES:
+            return True
+
+    if has_explicit_rpc_signal:
+        return False
+
+    # Backward-compatible fallback for historical auth-service RPCError text.
+    # This is deliberately exact-match only; auth words in arbitrary RPCError
+    # diagnostics are not enough to trigger refresh/re-auth guidance.
+    return _normalized_message(error) in _LEGACY_AUTH_RPC_MESSAGES
+
+
 def is_auth_error(error: Exception) -> bool:
     """Check if an exception indicates an authentication failure.
 
@@ -111,11 +182,9 @@ def is_auth_error(error: Exception) -> bool:
     # (``_is_retry`` in ``rpc_call``) bounds wasted refreshes on legitimate
     # 400s (bad payload) to one extra GET per call.
     if isinstance(error, httpx.HTTPStatusError):
-        return error.response.status_code in (400, 401, 403)
+        return error.response.status_code in _AUTH_HTTP_STATUS_CODES
 
-    # RPCError with auth-related message
     if isinstance(error, RPCError):
-        message = str(error).lower()
-        return any(pattern in message for pattern in AUTH_ERROR_PATTERNS)
+        return _rpc_error_has_auth_signal(error)
 
     return False

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -136,8 +136,20 @@ class TestIsAuthError:
         error = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
         assert is_auth_error(error) is False
 
-    def test_returns_true_for_rpc_error_with_auth_message(self):
-        assert is_auth_error(RPCError("authentication expired")) is True
+    @pytest.mark.parametrize("rpc_code", [401, 403, 16, "UNAUTHENTICATED"])
+    def test_returns_true_for_rpc_error_with_auth_code(self, rpc_code):
+        assert is_auth_error(RPCError("authentication expired", rpc_code=rpc_code)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Unauthorized access to this notebook",
+            "Session expired while rendering an unrelated artifact",
+            "Authentication summary could not be generated",
+        ],
+    )
+    def test_returns_false_for_rpc_error_with_auth_words_but_no_auth_signal(self, message):
+        assert is_auth_error(RPCError(message)) is False
 
     def test_returns_false_for_rpc_error_with_generic_message(self):
         assert is_auth_error(RPCError("some generic error")) is False
@@ -298,7 +310,7 @@ class TestRPCCallAuthRetry:
             # Override the runtime decode-response seam before the RPC fires.
             decode_responses = iter(
                 [
-                    RPCError("authentication expired"),
+                    RPCError("authentication expired", rpc_code=401),
                     ["result_data"],
                 ]
             )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -532,28 +532,48 @@ class TestIsAuthError:
         error = httpx.HTTPStatusError("Server Error", request=request, response=response)
         assert is_auth_error(error) is False
 
-    def test_rpc_error_with_auth_message_is_auth_error(self):
-        """RPCError with 'Authentication' in message should be auth error."""
+    @pytest.mark.parametrize("rpc_code", [401, 403, 16, "UNAUTHENTICATED"])
+    def test_rpc_error_with_explicit_auth_code_is_auth_error(self, rpc_code):
+        """RPCError with an explicit auth status/code should be auth error."""
+
+        error = RPCError("RPC auth service rejected credentials", rpc_code=rpc_code)
+        assert is_auth_error(error) is True
+
+    def test_rpc_error_with_legacy_exact_expired_message_is_auth_error(self):
+        """Known legacy auth-service text still triggers refresh diagnostics."""
 
         error = RPCError("Authentication expired")
         assert is_auth_error(error) is True
 
-    def test_rpc_error_with_expired_message_is_auth_error(self):
-        """RPCError with 'expired' in message should be auth error."""
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Unauthorized access to this notebook",
+            "Session expired while rendering an unrelated artifact",
+            "Please login before retrying this quota-limited action",
+            "Authentication summary could not be generated",
+        ],
+    )
+    def test_rpc_error_with_auth_words_without_signal_is_not_auth_error(self, message):
+        """Auth-related words alone should not trigger auth recovery."""
 
-        error = RPCError("Session expired, please re-login")
-        assert is_auth_error(error) is True
-
-    def test_rpc_error_with_unauthorized_message_is_auth_error(self):
-        """RPCError with 'Unauthorized' in message should be auth error."""
-
-        error = RPCError("Unauthorized access")
-        assert is_auth_error(error) is True
+        error = RPCError(message)
+        assert is_auth_error(error) is False
 
     def test_rpc_error_generic_is_not_auth_error(self):
         """Generic RPCError should NOT be auth error."""
 
         error = RPCError("Rate limit exceeded")
+        assert is_auth_error(error) is False
+
+    @pytest.mark.parametrize("rpc_code", [7, 429, 500, "USER_DISPLAYABLE_ERROR"])
+    def test_rpc_error_with_non_auth_code_is_not_auth_error(self, rpc_code):
+        """Non-auth RPC status/code fields should not trigger auth recovery."""
+
+        error = RPCError(
+            "Authentication required. Run 'notebooklm login' to re-authenticate.",
+            rpc_code=rpc_code,
+        )
         assert is_auth_error(error) is False
 
     def test_auth_error_is_auth_error(self):
@@ -709,7 +729,11 @@ class TestRpcCallAutoRetry:
             decode_call_count[0] += 1
             if decode_call_count[0] == 1:
                 # First decode fails with auth error
-                raise RPCError("Authentication expired", method_id="wXbhsf")
+                raise RPCError(
+                    "Authentication required. Run 'notebooklm login' to re-authenticate.",
+                    method_id="wXbhsf",
+                    rpc_code=401,
+                )
             return ["result"]
 
         core = build_client_shell_for_tests(
@@ -736,6 +760,54 @@ class TestRpcCallAutoRetry:
         assert len(refresh_called) == 1, "refresh_callback should be called once"
         assert decode_call_count[0] == 2, "decode should be called twice (original + retry)"
         assert result == ["result"]
+
+    @pytest.mark.asyncio
+    async def test_no_auth_refresh_on_rpc_error_with_auth_words_without_signal(self):
+        """rpc_call should not refresh on generic RPC text that mentions auth words."""
+        auth = AuthTokens(
+            cookies={"SID": "test", "__Secure-1PSIDTS": "test_1psidts"},
+            csrf_token="csrf",
+            session_id="sid",
+        )
+
+        refresh_called = []
+
+        async def mock_refresh():
+            refresh_called.append(True)
+            return auth
+
+        decode_call_count = [0]
+
+        def mock_decode(*args, **kwargs):
+            decode_call_count[0] += 1
+            raise RPCError(
+                "Unauthorized access to source while generating authentication summary",
+                method_id="wXbhsf",
+            )
+
+        core = build_client_shell_for_tests(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            decode_response=mock_decode,
+        )
+
+        async def mock_post(*args, **kwargs):
+            response = MagicMock()
+            response.text = "mock response"
+            response.raise_for_status = MagicMock()
+            return response
+
+        install_http_client_for_test(core._collaborators.kernel, MagicMock())
+        core._collaborators.kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._collaborators.kernel.get_http_client(), mock_post)
+        core._collaborators.kernel.get_http_client().headers = {"Cookie": "old"}
+
+        with pytest.raises(RPCError, match="Unauthorized access"):
+            await core._rpc_executor.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+        assert refresh_called == []
+        assert decode_call_count[0] == 1
 
     @pytest.mark.asyncio
     async def test_no_retry_without_callback(self):

--- a/tests/unit/test_session_helpers.py
+++ b/tests/unit/test_session_helpers.py
@@ -133,6 +133,14 @@ def test_is_auth_error_prefers_non_auth_rpc_code_over_legacy_message() -> None:
     assert is_auth_error(error) is False
 
 
+@pytest.mark.parametrize("rpc_code", ["", "   ", "9" * 257])
+def test_is_auth_error_ignores_empty_or_large_rpc_code_before_legacy_message(
+    rpc_code: str,
+) -> None:
+    error = RPCError("Authentication expired", rpc_code=rpc_code)
+    assert is_auth_error(error) is True
+
+
 # ---------------------------------------------------------------------------
 # End-to-end late-binding through both middlewares
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_helpers.py
+++ b/tests/unit/test_session_helpers.py
@@ -36,6 +36,7 @@ from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
 from notebooklm._middleware_retry import RetryMiddleware
 from notebooklm._session_helpers import is_auth_error, resolve_sleep
 from notebooklm._transport_errors import TransportServerError
+from notebooklm.rpc import AuthError, RPCError, ServerError
 
 # ---------------------------------------------------------------------------
 # Direct unit tests for resolve_sleep
@@ -73,6 +74,63 @@ def test_resolve_sleep_late_binds_asyncio_sleep(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr("asyncio.sleep", fake)
     assert resolve_sleep(None) is fake
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for is_auth_error
+# ---------------------------------------------------------------------------
+
+
+def test_is_auth_error_accepts_typed_auth_error() -> None:
+    assert is_auth_error(AuthError("Authentication expired")) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403])
+def test_is_auth_error_accepts_auth_http_statuses(status: int) -> None:
+    assert is_auth_error(_auth_error_http(status)) is True
+
+
+@pytest.mark.parametrize("rpc_code", [401, 403, 16, "UNAUTHENTICATED"])
+def test_is_auth_error_accepts_explicit_rpc_auth_codes(rpc_code: int | str) -> None:
+    assert is_auth_error(RPCError("auth service failure", rpc_code=rpc_code)) is True
+
+
+def test_is_auth_error_accepts_explicit_rpc_status_code() -> None:
+    error = RPCError("wrapped auth status")
+    error.status_code = 401
+    assert is_auth_error(error) is True
+
+
+def test_is_auth_error_accepts_explicit_rpc_status_label() -> None:
+    error = RPCError("wrapped auth status")
+    error.status = "UNAUTHENTICATED"
+    assert is_auth_error(error) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Authentication summary failed for a malformed response",
+        "Session expired while processing a non-auth artifact status",
+        "Unauthorized access to this notebook",
+        "Please login before retrying a quota-limited action",
+    ],
+)
+def test_is_auth_error_ignores_auth_words_without_status_or_code(message: str) -> None:
+    assert is_auth_error(RPCError(message)) is False
+
+
+def test_is_auth_error_does_not_promote_server_error_with_auth_code() -> None:
+    error = ServerError("server auth subsystem failed", status_code=500, rpc_code=401)
+    assert is_auth_error(error) is False
+
+
+def test_is_auth_error_prefers_non_auth_rpc_code_over_legacy_message() -> None:
+    error = RPCError(
+        "Authentication required. Run 'notebooklm login' to re-authenticate.",
+        rpc_code=500,
+    )
+    assert is_auth_error(error) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prefer typed auth errors, HTTP auth statuses, and explicit RPC status/code fields in `is_auth_error`
- remove broad RPCError substring matching while preserving a narrow legacy auth-service fallback
- add false-positive coverage so auth-word RPC messages and non-auth codes do not trigger refresh

## Task
Phase 1 task `p1-auth-error-classification` from `.sisyphus/phases/codebase-gaps-remediation-plan/phase-1.md`.

## Test plan
- [x] `uv run pytest tests/unit/test_client.py tests/integration/test_session_integration.py -q`
- [x] `uv run pytest tests/unit -k "auth_error or session_helpers" -q`
- [x] `uv run ruff check src/notebooklm/_session_helpers.py tests/unit/test_client.py tests/integration/test_session_integration.py`
- [x] `uv run ruff check tests/unit/test_session_helpers.py`
- [x] `uv run mypy src/notebooklm`

## Deferred polish findings
none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error detection by relying on structured signals (HTTP status / RPC codes and labels) instead of substring message matching, making retry and refresh behavior more accurate; legacy exact-message allowlist retained for compatibility.

* **Tests**
  * Expanded tests to cover explicit auth signals, precedence rules, negative cases where message text alone should not trigger auth handling, and updated retry scenarios to use explicit auth signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->