### PR TITLE
fix(sources): fail closed on upload source id parsing

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
 _SOURCE_ID_UUID_PATTERN = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
+_SOURCE_ID_FIELD_NAMES = frozenset({"SOURCE_ID", "source_id", "sourceId"})
+_CONTEXTUAL_SOURCE_ID_FIELD_NAMES = frozenset({"id"})
+_SOURCE_NAME_FIELD_NAMES = frozenset(
+    {"SOURCE_NAME", "source_name", "sourceName", "filename", "fileName", "name", "title"}
+)
+_SOURCE_ID_ENVELOPE_MAX_DEPTH = 8
 
 
 class RpcCallback(Protocol):
@@ -249,41 +255,159 @@ def _retain_background_cancel_task(task: asyncio.Task[None]) -> None:
 def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
     """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
 
-    The historical shape was a strictly position-0 walk: ``[[[[id]]]]``. Issue
-    #474 surfaced cases where that walk lands on ``None`` or on the echoed
-    filename and silently fails. Walk the whole structure instead, prefer a
-    UUID-shaped leaf, and fall back to any other id-shaped string that is
-    plausibly not a status label.
+    Only trusted ADD_SOURCE_FILE shapes are accepted: explicit source-id fields
+    and the legacy singleton list envelope (``[[id]]`` / ``[[[[id]]]]``).
+    Arbitrary nested ids are intentionally ignored so ambiguous responses fall
+    through to the post-register source-list probe.
     """
-    uuid_match: str | None = None
-    fallback: str | None = None
-    # Depth guard for malformed/adversarial payloads. Google's real responses
-    # are shallow, so 50 is generous without risking RecursionError.
-    max_depth = 50
+    field_candidates = _extract_source_id_field_candidates(result, filename)
+    if len(field_candidates) == 1:
+        return field_candidates[0]
+    if len(field_candidates) > 1:
+        return None
+
+    row_candidates = _extract_contextual_source_id_row_candidates(result, filename)
+    if len(row_candidates) == 1:
+        return row_candidates[0]
+    if len(row_candidates) > 1:
+        return None
+
+    return _extract_singleton_source_id_envelope(result, filename)
+
+
+def _extract_source_id_field_candidates(result: Any, filename: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(value: Any) -> None:
+        candidate = _coerce_source_id_candidate(value, filename)
+        if candidate is not None and candidate not in seen:
+            candidates.append(candidate)
+            seen.add(candidate)
+
+    def context_matches(node: dict[Any, Any]) -> bool:
+        names = _source_context_names(node)
+        if not names:
+            return False
+        return any(_coerce_filename_candidate(name) == filename for name in names)
+
+    def context_conflicts(node: dict[Any, Any]) -> bool:
+        names = _source_context_names(node)
+        return bool(names) and not context_matches(node)
 
     def walk(node: Any, depth: int) -> None:
-        nonlocal uuid_match, fallback
-        if uuid_match is not None or depth > max_depth:
+        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
             return
-        if isinstance(node, str):
-            if len(node) > 1000:
-                return
-            candidate = node.strip()
-            if not candidate or candidate == filename:
-                return
-            if _SOURCE_ID_UUID_PATTERN.match(candidate):
-                uuid_match = candidate
-                return
-            if fallback is None and _looks_like_id_string(candidate):
-                fallback = candidate
+        if isinstance(node, dict):
+            mismatched_context = context_conflicts(node)
+            matched_context = context_matches(node)
+            for key, value in node.items():
+                if not isinstance(key, str):
+                    continue
+                if (
+                    (
+                        key in _SOURCE_ID_FIELD_NAMES
+                        and not mismatched_context
+                        and (depth == 0 or matched_context)
+                    )
+                    or (key in _CONTEXTUAL_SOURCE_ID_FIELD_NAMES and matched_context)
+                ):
+                    add_candidate(value)
+            for value in node.values():
+                walk(value, depth + 1)
         elif isinstance(node, list):
             for child in node:
-                if uuid_match is not None:
-                    return
                 walk(child, depth + 1)
 
     walk(result, 0)
-    return uuid_match or fallback
+    return candidates
+
+
+def _extract_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
+    node, depth = _unwrap_singleton_envelope(result)
+    if depth == 0:
+        return None
+
+    return _coerce_source_id_candidate(node, filename)
+
+
+def _extract_contextual_source_id_row_candidates(result: Any, filename: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(value: Any) -> None:
+        candidate = _coerce_source_id_candidate(value, filename)
+        if candidate is not None and candidate not in seen:
+            candidates.append(candidate)
+            seen.add(candidate)
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
+            return
+        if isinstance(node, list):
+            if len(node) >= 2 and _coerce_filename_candidate(node[1]) == filename:
+                add_candidate(node[0])
+            for child in node:
+                walk(child, depth + 1)
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value, depth + 1)
+
+    walk(result, 0)
+    return candidates
+
+
+def _coerce_filename_candidate(value: Any) -> str | None:
+    value, _depth = _unwrap_singleton_envelope(value)
+    if not isinstance(value, str):
+        return None
+    return value.strip()
+
+
+def _coerce_source_id_candidate(value: Any, filename: str) -> str | None:
+    value, _depth = _unwrap_singleton_envelope(value)
+    if not isinstance(value, str):
+        return None
+    if len(value) > 1000:
+        return None
+    candidate = value.strip()
+    if not candidate or candidate == filename:
+        return None
+    if _SOURCE_ID_UUID_PATTERN.match(candidate) or _looks_like_id_string(candidate):
+        return candidate
+    return None
+
+
+def _source_context_names(node: dict[Any, Any]) -> list[Any]:
+    return [
+        value
+        for key, value in node.items()
+        if isinstance(key, str) and key in _SOURCE_NAME_FIELD_NAMES
+    ]
+
+
+def _unwrap_singleton_envelope(value: Any) -> tuple[Any, int]:
+    depth = 0
+    while (
+        isinstance(value, list)
+        and len(value) == 1
+        and depth < _SOURCE_ID_ENVELOPE_MAX_DEPTH
+    ):
+        value = value[0]
+        depth += 1
+    return value, depth
+
+
+def _register_response_shape_label(result: Any) -> str:
+    if isinstance(result, dict):
+        return "object"
+    if isinstance(result, list):
+        return "array"
+    if isinstance(result, str):
+        return "string"
+    if result is None:
+        return "null"
+    return type(result).__name__
 
 
 def _looks_like_id_string(candidate: str) -> bool:
@@ -685,15 +809,35 @@ class SourceUploadPipeline:
 
             source_id = _extract_register_file_source_id(result, filename)
             if source_id:
-                return source_id
+                if baseline_ids is None or source_id not in baseline_ids:
+                    return source_id
+                logger.info(
+                    "register_file_source[%s]: response SOURCE_ID matched a "
+                    "pre-existing source; probing for the newly registered source",
+                    filename,
+                )
 
             # The RPC returned successfully but the response shape did not
-            # contain a parseable SOURCE_ID. Before raising, run the probe
-            # to see if the source landed server-side anyway — the
-            # extraction can fail for schema-drift reasons (#474) while the
-            # create has actually committed. This converts a recoverable
-            # success into the same probe-recovery path that 5xx uses.
-            probed_source_id = await _probe()
+            # contain a trustworthy SOURCE_ID. Before raising, run the
+            # source-list probe to see if the source landed server-side
+            # anyway. This converts recoverable schema drift into the same
+            # probe-recovery path that transport failures use without binding
+            # unrelated ids from the response.
+            try:
+                probed_source_id = await _probe()
+            except SourceAddError:
+                raise
+            except (AuthError, RateLimitError, ServerError, NetworkError) as exc:
+                raise SourceAddError(
+                    filename,
+                    cause=exc,
+                    message=(
+                        f"Cannot confirm registered file source for {filename!r}: "
+                        "the register response did not provide a trustworthy "
+                        f"SOURCE_ID and the source-list probe failed ({type(exc).__name__}). "
+                        "Check the notebook source list before retrying."
+                    ),
+                ) from exc
             if probed_source_id is not None:
                 logger.info(
                     "register_file_source[%s]: response missing SOURCE_ID but "
@@ -702,18 +846,12 @@ class SourceUploadPipeline:
                 )
                 return probed_source_id
 
-            if isinstance(result, str):
-                preview = repr(result[:200])
-                if len(result) > 200:
-                    preview += "..."
-            else:
-                preview = repr(result)
-                if len(preview) > 200:
-                    preview = preview[:200] + "..."
             raise SourceAddError(
                 filename,
                 message=(
-                    f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
+                    f"Failed to get a trustworthy SOURCE_ID from {_register_response_shape_label(result)} "
+                    "registration response, and the source-list probe found no "
+                    "unambiguous new source. Check the notebook source list before retrying."
                 ),
             )
 

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -814,6 +814,9 @@ class SourceUploadPipeline:
             except SourceAddError:
                 raise
             except (AuthError, RateLimitError, ServerError, NetworkError) as exc:
+                # The create RPC already returned successfully, so do not
+                # let idempotent_create treat probe failure here as a
+                # retryable create failure and re-POST the file source.
                 raise SourceAddError(
                     filename,
                     cause=exc,

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -285,22 +285,15 @@ def _extract_source_id_field_candidates(result: Any, filename: str) -> list[str]
             candidates.append(candidate)
             seen.add(candidate)
 
-    def context_matches(node: dict[Any, Any]) -> bool:
-        names = _source_context_names(node)
-        if not names:
-            return False
-        return any(_coerce_filename_candidate(name) == filename for name in names)
-
-    def context_conflicts(node: dict[Any, Any]) -> bool:
-        names = _source_context_names(node)
-        return bool(names) and not context_matches(node)
-
     def walk(node: Any, depth: int) -> None:
         if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
             return
         if isinstance(node, dict):
-            mismatched_context = context_conflicts(node)
-            matched_context = context_matches(node)
+            names = _source_context_names(node)
+            matched_context = bool(names) and any(
+                _coerce_filename_candidate(name) == filename for name in names
+            )
+            mismatched_context = bool(names) and not matched_context
             for key, value in node.items():
                 if not isinstance(key, str):
                     continue

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -335,8 +335,11 @@ def _extract_contextual_source_id_row_candidates(result: Any, filename: str) -> 
         if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
             return
         if isinstance(node, list):
-            if len(node) >= 2 and _coerce_filename_candidate(node[1]) == filename:
-                add_candidate(node[0])
+            if len(node) >= 2:
+                if _coerce_filename_candidate(node[1]) == filename:
+                    add_candidate(node[0])
+                if _coerce_filename_candidate(node[0]) == filename:
+                    add_candidate(node[1])
             for child in node:
                 walk(child, depth + 1)
         elif isinstance(node, dict):

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -305,13 +305,10 @@ def _extract_source_id_field_candidates(result: Any, filename: str) -> list[str]
                 if not isinstance(key, str):
                     continue
                 if (
-                    (
-                        key in _SOURCE_ID_FIELD_NAMES
-                        and not mismatched_context
-                        and (depth == 0 or matched_context)
-                    )
-                    or (key in _CONTEXTUAL_SOURCE_ID_FIELD_NAMES and matched_context)
-                ):
+                    key in _SOURCE_ID_FIELD_NAMES
+                    and not mismatched_context
+                    and (depth == 0 or matched_context)
+                ) or (key in _CONTEXTUAL_SOURCE_ID_FIELD_NAMES and matched_context):
                     add_candidate(value)
             for value in node.values():
                 walk(value, depth + 1)
@@ -388,11 +385,7 @@ def _source_context_names(node: dict[Any, Any]) -> list[Any]:
 
 def _unwrap_singleton_envelope(value: Any) -> tuple[Any, int]:
     depth = 0
-    while (
-        isinstance(value, list)
-        and len(value) == 1
-        and depth < _SOURCE_ID_ENVELOPE_MAX_DEPTH
-    ):
+    while isinstance(value, list) and len(value) == 1 and depth < _SOURCE_ID_ENVELOPE_MAX_DEPTH:
         value = value[0]
         depth += 1
     return value, depth

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -272,6 +272,10 @@ def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
     if len(row_candidates) > 1:
         return None
 
+    prefixed_candidate = _extract_prefixed_singleton_source_id_envelope(result, filename)
+    if prefixed_candidate is not None:
+        return prefixed_candidate
+
     return _extract_singleton_source_id_envelope(result, filename)
 
 
@@ -319,6 +323,13 @@ def _extract_singleton_source_id_envelope(result: Any, filename: str) -> str | N
         return None
 
     return _coerce_source_id_candidate(node, filename)
+
+
+def _extract_prefixed_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
+    if not isinstance(result, list) or len(result) != 2 or result[0] is not None:
+        return None
+
+    return _extract_singleton_source_id_envelope(result[1], filename)
 
 
 def _extract_contextual_source_id_row_candidates(result: Any, filename: str) -> list[str]:
@@ -841,8 +852,9 @@ class SourceUploadPipeline:
             raise SourceAddError(
                 filename,
                 message=(
-                    f"Failed to get a trustworthy SOURCE_ID from {_register_response_shape_label(result)} "
-                    "registration response, and the source-list probe found no "
+                    "Failed to get SOURCE_ID: no trustworthy SOURCE_ID found in "
+                    f"{_register_response_shape_label(result)} registration response, "
+                    "and the source-list probe found no "
                     "unambiguous new source. Check the notebook source list before retrying."
                 ),
             )

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -169,6 +169,7 @@ def test_extract_register_file_source_id_accepts_known_response_shapes() -> None
         _extract_register_file_source_id([[[["report.pdf", ["src_456"], [None]]]]], "report.pdf")
         == "src_456"
     )
+    assert _extract_register_file_source_id([None, [[["src_789"]]]], "report.pdf") == "src_789"
     assert (
         _extract_register_file_source_id({"id": "src_123", "title": "report.pdf"}, "report.pdf")
         == "src_123"

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -18,7 +18,7 @@ from notebooklm._source_upload import (
     _transient_error_types_for_upload,
     _validate_resumable_upload_url,
 )
-from notebooklm.exceptions import ValidationError
+from notebooklm.exceptions import NetworkError, ValidationError
 from notebooklm.rpc import RPCError, RPCMethod
 from notebooklm.types import Source, SourceAddError
 
@@ -150,10 +150,59 @@ def make_pipeline(
     )
 
 
+def test_extract_register_file_source_id_accepts_known_response_shapes() -> None:
+    assert _extract_register_file_source_id([["src_123"]], "report.pdf") == "src_123"
+    assert _extract_register_file_source_id([[[["src_123"]]]], "report.pdf") == "src_123"
+    assert _extract_register_file_source_id({"SOURCE_ID": "src_123"}, "report.pdf") == "src_123"
+    assert (
+        _extract_register_file_source_id(
+            {"source": {"SOURCE_ID": "src_123", "SOURCE_NAME": "report.pdf"}},
+            "report.pdf",
+        )
+        == "src_123"
+    )
+    assert (
+        _extract_register_file_source_id([[[["src_123"], "report.pdf", [None]]]], "report.pdf")
+        == "src_123"
+    )
+    assert (
+        _extract_register_file_source_id({"id": "src_123", "title": "report.pdf"}, "report.pdf")
+        == "src_123"
+    )
+
+
 def test_extract_register_file_source_id_skips_large_string_candidates() -> None:
     long_payload = " " + ("x" * 2000) + " "
 
-    assert _extract_register_file_source_id([long_payload, "src_123"], "report.pdf") == "src_123"
+    assert (
+        _extract_register_file_source_id(
+            {
+                "debug": {"SOURCE_ID": long_payload},
+                "source": {"SOURCE_ID": "src_123", "SOURCE_NAME": "report.pdf"},
+            },
+            "report.pdf",
+        )
+        == "src_123"
+    )
+
+
+def test_extract_register_file_source_id_rejects_ambiguous_nested_ids() -> None:
+    unrelated_uuid = "11111111-2222-3333-4444-555555555555"
+
+    assert (
+        _extract_register_file_source_id(
+            {"debug": [["trace", unrelated_uuid]], "status": "ok"},
+            "report.pdf",
+        )
+        is None
+    )
+    assert (
+        _extract_register_file_source_id(
+            {"debug": {"SOURCE_ID": unrelated_uuid}},
+            "report.pdf",
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -521,10 +570,90 @@ async def test_register_file_source_uses_configured_source_limit_lookup(
 
 
 @pytest.mark.asyncio
-async def test_register_file_source_truncates_large_string_response_preview(
+async def test_register_file_source_ambiguous_response_falls_back_to_probe(
     service: SourceUploadPipeline,
 ) -> None:
-    rpc = RecordingRpc("x" * 5000)
+    unrelated_uuid = "11111111-2222-3333-4444-555555555555"
+    rpc = RecordingRpc({"debug": [["trace", unrelated_uuid]], "status": "ok"})
+    list_sources = AsyncMock(
+        side_effect=[
+            [],
+            [Source(id="src_probe", title="report.pdf")],
+        ]
+    )
+
+    source_id = await service.register_file_source(
+        "nb_123",
+        "report.pdf",
+        rpc_call=rpc,
+        list_sources=list_sources,
+        logger=MagicMock(),
+    )
+
+    assert source_id == "src_probe"
+    assert [call.args for call in list_sources.await_args_list] == [
+        ("nb_123",),
+        ("nb_123",),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_pre_existing_response_id_falls_back_to_probe(
+    service: SourceUploadPipeline,
+) -> None:
+    rpc = RecordingRpc([["src_existing"]])
+    list_sources = AsyncMock(
+        side_effect=[
+            [Source(id="src_existing", title="old.pdf")],
+            [
+                Source(id="src_existing", title="old.pdf"),
+                Source(id="src_new", title="report.pdf"),
+            ],
+        ]
+    )
+
+    source_id = await service.register_file_source(
+        "nb_123",
+        "report.pdf",
+        rpc_call=rpc,
+        list_sources=list_sources,
+        logger=MagicMock(),
+    )
+
+    assert source_id == "src_new"
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_probe_failure_is_typed_and_sanitized(
+    service: SourceUploadPipeline,
+) -> None:
+    unrelated_uuid = "11111111-2222-3333-4444-555555555555"
+    secret = "SECRET_UPLOAD_ID"
+    rpc = RecordingRpc({"debug": [["trace", unrelated_uuid]], "upload": secret})
+    list_sources = AsyncMock(side_effect=[[], NetworkError(f"network leaked {secret}")])
+
+    with pytest.raises(SourceAddError) as exc_info:
+        await service.register_file_source(
+            "nb_123",
+            "report.pdf",
+            rpc_call=rpc,
+            list_sources=list_sources,
+            logger=MagicMock(),
+        )
+
+    message = str(exc_info.value)
+    assert exc_info.value.cause is not None
+    assert "source-list probe failed (NetworkError)" in message
+    assert unrelated_uuid not in message
+    assert secret not in message
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_sanitizes_untrusted_response_error(
+    service: SourceUploadPipeline,
+) -> None:
+    secret = "SECRET_UPLOAD_ID"
+    rpc = RecordingRpc(f"{secret}{'x' * 5000}")
 
     with pytest.raises(SourceAddError) as exc_info:
         await service.register_file_source(
@@ -536,7 +665,8 @@ async def test_register_file_source_truncates_large_string_response_preview(
         )
 
     message = str(exc_info.value)
-    assert "..." in message
+    assert "string registration response" in message
+    assert secret not in message
     assert "x" * 300 not in message
     assert len(message) < 320
 

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -166,6 +166,10 @@ def test_extract_register_file_source_id_accepts_known_response_shapes() -> None
         == "src_123"
     )
     assert (
+        _extract_register_file_source_id([[[["report.pdf", ["src_456"], [None]]]]], "report.pdf")
+        == "src_456"
+    )
+    assert (
         _extract_register_file_source_id({"id": "src_123", "title": "report.pdf"}, "report.pdf")
         == "src_123"
     )

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -412,7 +412,10 @@ class TestRegisterFileSource:
         """The extractor must skip the echoed filename and return the UUID,
         regardless of where the filename sits in the structure (#474).
         """
-        mock_core.rpc_executor.rpc_call.return_value = response
+        mock_core.rpc_executor.rpc_call.side_effect = [
+            [["", []]],
+            response,
+        ]
 
         result = await sources_api._register_file_source("nb_123", filename)
         assert result == expected
@@ -432,16 +435,18 @@ class TestRegisterFileSource:
     async def test_register_file_source_error_message_includes_shape_preview(
         self, sources_api, mock_core
     ):
-        """Future shape drift should surface a structural preview in the error
-        so users can file actionable bug reports (#474).
-        """
+        """Future shape drift should report a sanitized response shape."""
         from notebooklm.exceptions import SourceAddError
 
         # Pure-numeric response — no string leaves → no candidates → raises.
         mock_core.rpc_executor.rpc_call.return_value = [[[1, 2, 3]]]
 
-        with pytest.raises(SourceAddError, match=r"Response shape:.*\[\[\[1, 2, 3\]\]\]"):
+        with pytest.raises(
+            SourceAddError,
+            match="Failed to get SOURCE_ID: no trustworthy SOURCE_ID found in array",
+        ) as exc_info:
             await sources_api._register_file_source("nb_123", "test.pdf")
+        assert "[[[1, 2, 3]]]" not in str(exc_info.value)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status_token", ["OK", "DONE", "true", "null"])


### PR DESCRIPTION
## Summary
- Restrict ADD_SOURCE_FILE source-id extraction to trusted fields, singleton envelopes, and filename-correlated rows.
- Fall back to the existing post-register source-list probe for ambiguous or pre-existing candidates.
- Replace raw response previews with typed, sanitized SourceAddError paths and add focused regression coverage.

## Task
Phase 1 task: p1-source-upload-source-id

## Test plan
- [x] uv run pytest tests/unit/test_source_upload_pipeline.py -q
- [x] uv run pytest tests/integration -k \"source and upload\" -q
- [x] uv run ruff check src/notebooklm/_source_upload.py tests/unit/test_source_upload_pipeline.py

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of uploaded source IDs with shape-aware extraction, ambiguity rejection, and limited nested-envelope tolerance.
  * Registration now always confirms ambiguous or pre-existing response IDs via a verification probe before accepting them.
  * Improved, sanitized error messages that avoid leaking untrusted identifiers or secrets and include response-shape labels.

* **Tests**
  * Expanded unit tests for accepted/rejected response shapes, oversized/ambiguous candidates, probe-fallback behavior, and sanitized error reporting (updated/added tests; one truncation test removed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->