### PR TITLE
fix(idempotency): complete RPC registry classifications

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -15,14 +15,13 @@ This module hosts two cooperating pieces:
    *effective* ``disable_internal_retries`` value (and, for
    ``CLIENT_TOKEN_DEDUPE`` policies, inject a fresh client-token into
    request params before encoding). The registry is a single source of
-   truth that future RPCs can be classified against without touching the
-   executor.
+   truth for every ``RPCMethod`` without touching the executor.
 
-   This foundation is intentionally **behavior-neutral**: every method
-   defaults to :attr:`IdempotencyPolicy.UNCLASSIFIED`, which is silent
-   and reproduces today's retry behavior. The Wave-2 classification
-   arc (see ADR-005, ``docs/adr/0005-idempotency-taxonomy.md``)
-   replaces these placeholders RPC-by-RPC.
+   The production registry is complete: every active ``RPCMethod`` has
+   an explicit default classification, with variant rows for wire shapes
+   like ``ADD_SOURCE`` and ``CREATE_NOTE`` where retry safety differs by
+   call site. ``UNCLASSIFIED`` remains available only as a hand-built
+   registry placeholder for tests and future development.
 
 Per-API probes used by :func:`idempotent_create` are caller-supplied
 because there is no universal probe key (notebooks: title +
@@ -163,22 +162,19 @@ async def idempotent_create(
 
 
 # ============================================================================
-# Mutating-RPC idempotency registry (B1 foundation — P0-3 + P1-2)
+# RPC idempotency registry
 # ============================================================================
 #
 # The registry is the single source of truth for "how should this RPC behave
-# under retry?" It is consulted by ``RpcExecutor`` at five sites to compute
-# the *effective* ``disable_internal_retries`` value, and (for
-# ``CLIENT_TOKEN_DEDUPE`` policies) to inject a fresh client-token into
-# request params before encoding.
+# under retry?" It is consulted by ``RpcExecutor`` to compute the *effective*
+# ``disable_internal_retries`` value, and (for ``CLIENT_TOKEN_DEDUPE`` policies)
+# to inject a fresh client-token into request params before encoding.
 #
-# IMPORTANT — behavior-neutral foundation:
-#   This module is a foundation only. Every ``RPCMethod`` default-populates
-#   to ``IdempotencyPolicy.UNCLASSIFIED`` with the Wave-2 placeholder note.
-#   UNCLASSIFIED is silent (no log emission, no behavior change) and
-#   resolves to ``effective_disable_internal_retries=False`` so today's
-#   retries continue to fire identically. Wave 2 will classify individual
-#   RPCs without changing the executor.
+# IMPORTANT — complete production registry:
+#   The module-level registry seeds missing methods with UNCLASSIFIED only as a
+#   future-drift sentinel, then overwrites every current ``RPCMethod`` with an
+#   explicit policy below. Unit tests fail if a new enum member keeps the
+#   placeholder.
 
 
 class IdempotencyPolicy(str, Enum):
@@ -193,10 +189,11 @@ class IdempotencyPolicy(str, Enum):
 
     * **Safe to retry inside the transport**:
       :attr:`UNCLASSIFIED` (placeholder — preserves today's retries),
-      :attr:`IDEMPOTENT_SET_OP` (rename / delete — server is the
-      idempotence anchor), :attr:`CLIENT_TOKEN_DEDUPE` (server
-      deduplicates by injected token), :attr:`AT_LEAST_ONCE_ACCEPTED`
-      (caller has accepted at-least-once semantics; WARN logged).
+      :attr:`IDEMPOTENT_SET_OP` (read-only, rename / delete / set-state
+      operations where replay leaves the same server state),
+      :attr:`CLIENT_TOKEN_DEDUPE` (server deduplicates by injected
+      token), :attr:`AT_LEAST_ONCE_ACCEPTED` (caller has accepted
+      at-least-once semantics; WARN logged).
 
     * **NOT safe to retry inside the transport**:
       :attr:`PROBE_THEN_CREATE` (callers own the probe loop; transport
@@ -233,8 +230,8 @@ _POLICIES_THAT_FORCE_DISABLE: frozenset[IdempotencyPolicy] = frozenset(
 
 # ProbeKeyFn signature: takes the encoded ``params`` list and returns an
 # opaque, hashable probe key the caller can use to identify "is this the
-# write I issued?" Currently informational — Wave 2 plumbs it into the
-# create-probe state machines. ``None`` is the no-probe sentinel.
+# write I issued?" Currently informational; future probe-loop work may plumb it
+# into create-probe state machines. ``None`` is the no-probe sentinel.
 ProbeKeyFn = Callable[[list[Any]], Any]
 
 
@@ -246,8 +243,8 @@ class IdempotencyEntry:
         policy: Classification for the ``(RPCMethod, operation_variant)``
             row this entry describes.
         probe_key_fn: Optional probe-key extractor for PROBE_THEN_CREATE
-            entries. ``None`` for policies that don't probe. Wave 2 wires
-            this into the per-API probe loops.
+            entries. ``None`` for policies that don't probe. Future work may
+            wire this into the per-API probe loops.
         client_token_field: For CLIENT_TOKEN_DEDUPE entries, the slot
             in the params payload that receives the auto-injected
             ``uuid4().hex`` token. ``str`` keys are used when the RPC
@@ -256,7 +253,7 @@ class IdempotencyEntry:
             batchexecute encoder consumes. ``None`` for other policies.
         notes: Free-form human-readable note. UNCLASSIFIED entries
             registered without an explicit ``notes`` value receive the
-            placeholder marker that flags them for Wave 2 classification;
+            placeholder marker that flags them for explicit classification;
             all other policies default to an empty string.
     """
 
@@ -266,7 +263,7 @@ class IdempotencyEntry:
     notes: str = ""
 
 
-_UNCLASSIFIED_PLACEHOLDER_NOTE = "placeholder — Wave 2 must classify"
+_UNCLASSIFIED_PLACEHOLDER_NOTE = "placeholder — must classify"
 
 
 class IdempotencyRegistry:
@@ -284,9 +281,9 @@ class IdempotencyRegistry:
     * ``get_entry(method, operation_variant=v)`` when ``method`` has
       explicit variant entries but ``v`` is not among them → raises
       :class:`~notebooklm.exceptions.IdempotencyVariantError`. The
-      explicit variant table signals "Wave 2 has classified this method
-      by variant" — an unknown variant is almost certainly a caller typo
-      or API drift, not safe to mask via silent fallback.
+      explicit variant table signals "this method is classified by variant" —
+      an unknown variant is almost certainly a caller typo or API drift, not
+      safe to mask via silent fallback.
 
     Thread/loop-safety: the registry is populated at import time and is
     intended to be effectively immutable in production. Tests may
@@ -313,13 +310,13 @@ class IdempotencyRegistry:
     ) -> None:
         """Register (or overwrite) the entry for ``(method, variant)``.
 
-        Wave 2 will call this once per method/variant at module import.
+        Production code calls this once per method/variant at module import.
         Tests may call it ad-hoc on a fresh :class:`IdempotencyRegistry`
         instance to exercise specific policies.
 
         Effective notes default: when ``policy == UNCLASSIFIED`` and the
         caller did not pass ``notes=...``, the placeholder marker
-        ``"placeholder — Wave 2 must classify"`` is used. Any other
+        ``"placeholder — must classify"`` is used. Any other
         policy defaults to ``""``.
         """
         if notes is None:
@@ -388,41 +385,38 @@ class IdempotencyRegistry:
         return iter(snapshot)
 
     def _seed_defaults(self) -> None:
-        """Populate every :class:`~notebooklm.rpc.RPCMethod` with the
-        UNCLASSIFIED placeholder at ``variant=None``.
+        """Populate missing :class:`~notebooklm.rpc.RPCMethod` defaults with
+        the UNCLASSIFIED placeholder.
 
-        Called once at module import to guarantee the registry is a
-        total function over ``RPCMethod``. Wave 2 will replace these
-        placeholders one at a time as it classifies each RPC.
+        Called once at module import to guarantee the registry is a total
+        function over ``RPCMethod``. The production registrations below
+        replace every current placeholder; guard tests fail if future enum
+        members are added without an explicit classification.
         """
         for method in RPCMethod:
-            # ``setdefault`` would lose the placeholder note if a future
-            # caller pre-registers a non-default entry. Use explicit
-            # absence check so we never overwrite a real Wave 2 entry.
+            # ``setdefault`` would lose the placeholder note if a future caller
+            # pre-registers a non-default entry. Use explicit absence check so
+            # we never overwrite a real classification.
             if method not in self._entries or None not in self._entries[method]:
                 self.register(method, IdempotencyPolicy.UNCLASSIFIED)
 
 
-# Module-level production registry. Wave 2 classifies individual RPCs in
-# two passes:
+# Module-level production registry. Classifications are registered in two
+# passes:
 #
-#   * Some entries (research/notes from b-research-notes, sources/
-#     ADD_SOURCE variants from b-sources) are registered *before* the
-#     default-fill seeding pass so ``_seed_defaults`` skips them (it only
-#     populates ``(method, None)`` entries that are absent). Variant
-#     entries (``variant != None``) sit alongside the ``None`` default;
-#     the seeder leaves them alone.
-#   * Other entries (delete/refresh/share from b-generation) are
-#     registered *after* the seeding pass and overwrite the
-#     UNCLASSIFIED placeholders that the seeder populated.
+#   * Some entries are registered *before* the default-fill seeding pass so
+#     ``_seed_defaults`` skips them. Variant entries (``variant != None``) sit
+#     alongside the ``None`` default; the seeder leaves them alone.
+#   * The remaining entries are registered *after* the seeding pass and
+#     overwrite any UNCLASSIFIED placeholders that the seeder populated.
 #
 # Both orderings yield the same final registry shape; the difference is
-# stylistic. Future Wave-2 classifications may use either approach.
+# stylistic. Future classifications may use either approach.
 IDEMPOTENCY_REGISTRY = IdempotencyRegistry()
 
 
 # ----------------------------------------------------------------------------
-# Wave 2 classifications — P0-3 (b-research-notes)
+# Active classifications — research and notes
 # ----------------------------------------------------------------------------
 #
 # Three RPCs in the research + notes family are ``NON_IDEMPOTENT_NO_RETRY``.
@@ -517,14 +511,15 @@ IDEMPOTENCY_REGISTRY.register(
     notes=_CREATE_NOTE_NOT_IDEMPOTENT_NOTE,
 )
 
-# Default-fill every remaining method with the UNCLASSIFIED placeholder.
+# Default-fill every remaining method with an UNCLASSIFIED placeholder. The
+# explicit registrations below must replace every placeholder before tests pass.
 # Methods classified above are skipped by the absence check inside
 # ``_seed_defaults``.
 IDEMPOTENCY_REGISTRY._seed_defaults()
 
 
 # ---------------------------------------------------------------------------
-# Wave 2 classifications
+# Active classifications — artifact and generation create patterns
 # ---------------------------------------------------------------------------
 #
 # CREATE_ARTIFACT (P0-3) — mutating create. Params are nested positional
@@ -587,15 +582,14 @@ IDEMPOTENCY_REGISTRY.register(
         "forces the inner retry loop off so a 5xx after server-side "
         "generation does not trigger a fresh LLM inference whose result "
         "may diverge from the first (lost) response. The persisted-note "
-        "side of the mind-map chain (CREATE_NOTE / UPDATE_NOTE in "
-        "NoteService.create_note) remains UNCLASSIFIED and is the subject "
-        "of a follow-up classification task."
+        "side of the mind-map chain is classified separately: CREATE_NOTE "
+        "is NON_IDEMPOTENT_NO_RETRY and UPDATE_NOTE is an idempotent set op."
     ),
 )
 
 
 # ----------------------------------------------------------------------------
-# Wave 2 classifications (P0-3 side-effects + P1-2 notebooks)
+# Active classifications — side effects and notebooks
 # ----------------------------------------------------------------------------
 #
 # These entries replace the UNCLASSIFIED placeholders for mutating RPCs whose
@@ -677,7 +671,7 @@ IDEMPOTENCY_REGISTRY.register(
 
 
 # ----------------------------------------------------------------------------
-# Wave 2 classifications — ADD_SOURCE + ADD_SOURCE_FILE (P0-3, P1-2)
+# Active classifications — ADD_SOURCE + ADD_SOURCE_FILE
 # ----------------------------------------------------------------------------
 #
 # ADD_SOURCE is variant-shaped: the call site distinguishes ``"url"`` (web /
@@ -704,10 +698,22 @@ IDEMPOTENCY_REGISTRY.register(
 # matches (>1 new source with the same filename) raise rather than guess.
 # PROBE_THEN_CREATE.
 #
-# These four entries flip the executor onto the probe-then-create path
-# via ``resolve_effective_disable_internal_retries`` — the per-API call
-# sites in ``_source_add.py`` / ``_source_upload.py`` own the probe loop.
+# These entries force-disable blind transport retries via
+# ``resolve_effective_disable_internal_retries``. The per-API call sites in
+# ``_source_add.py`` / ``_source_upload.py`` own the executable probe loop for
+# the URL, Drive, and file variants.
 
+_RAW_ADD_SOURCE_NOT_IDEMPOTENT_NOTE = (
+    "raw ADD_SOURCE without an operation_variant has no proven dedupe/probe "
+    "key. Public call sites must pass 'url', 'drive', or 'text'; direct "
+    "rpc_call users get first-failure surfacing rather than blind retry"
+)
+
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.ADD_SOURCE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=_RAW_ADD_SOURCE_NOT_IDEMPOTENT_NOTE,
+)
 IDEMPOTENCY_REGISTRY.register(
     RPCMethod.ADD_SOURCE,
     IdempotencyPolicy.PROBE_THEN_CREATE,
@@ -738,15 +744,116 @@ IDEMPOTENCY_REGISTRY.register(
 
 
 # ----------------------------------------------------------------------------
+# Complete coverage — read-only / idempotent set-state RPCs
+# ----------------------------------------------------------------------------
+#
+# ``IDEMPOTENT_SET_OP`` is the retry-safe bucket for operations where replay
+# cannot create an additional server resource. This includes side-effect-free
+# reads and "set this state to X" mutations; both preserve the public retry
+# default because transport retries remain enabled.
+
+_IDEMPOTENT_READ_OR_SET_OP_NOTES: dict[RPCMethod, str] = {
+    RPCMethod.LIST_NOTEBOOKS: "read-only list; replay does not mutate notebook state",
+    RPCMethod.GET_NOTEBOOK: "read-only notebook fetch; replay does not mutate notebook state",
+    RPCMethod.RENAME_NOTEBOOK: (
+        "set notebook title/settings to caller-supplied values; replay leaves the same state"
+    ),
+    RPCMethod.GET_SOURCE: "read-only source content fetch; replay does not mutate source state",
+    RPCMethod.CHECK_SOURCE_FRESHNESS: (
+        "read-only freshness check; replay does not start a refresh job"
+    ),
+    RPCMethod.UPDATE_SOURCE: (
+        "set source metadata/title to caller-supplied values; replay leaves the same state"
+    ),
+    RPCMethod.SUMMARIZE: (
+        "response-only notebook summary generation; no persisted resource is created by replay"
+    ),
+    RPCMethod.GET_SOURCE_GUIDE: (
+        "response-only source guide fetch/generation; no persisted resource is created by replay"
+    ),
+    RPCMethod.GET_SUGGESTED_REPORTS: (
+        "response-only report suggestion generation; no persisted resource is created by replay"
+    ),
+    RPCMethod.LIST_ARTIFACTS: "read-only artifact list; replay does not mutate artifact state",
+    RPCMethod.RENAME_ARTIFACT: (
+        "set artifact title to a caller-supplied value; replay leaves the same state"
+    ),
+    RPCMethod.SHARE_ARTIFACT: (
+        "legacy share toggle sets public/private state; replay leaves the same share state"
+    ),
+    RPCMethod.GET_INTERACTIVE_HTML: (
+        "read-only artifact HTML fetch; replay does not mutate artifact state"
+    ),
+    RPCMethod.POLL_RESEARCH: "read-only research task poll; replay does not start a task",
+    RPCMethod.GET_NOTES_AND_MIND_MAPS: (
+        "read-only notes/mind-maps list; replay does not mutate note state"
+    ),
+    RPCMethod.UPDATE_NOTE: (
+        "set note content/title to caller-supplied values; replay leaves the same state"
+    ),
+    RPCMethod.DELETE_NOTE: "server-side note delete is idempotent (set-op semantics)",
+    RPCMethod.GET_LAST_CONVERSATION_ID: (
+        "read-only conversation id fetch; replay does not mutate chat state"
+    ),
+    RPCMethod.GET_CONVERSATION_TURNS: (
+        "read-only conversation history fetch; replay does not mutate chat state"
+    ),
+    RPCMethod.DELETE_CONVERSATION: (
+        "server-side conversation delete is idempotent (set-op semantics)"
+    ),
+    RPCMethod.GET_SHARE_STATUS: "read-only share status fetch; replay does not mutate ACL state",
+    RPCMethod.REMOVE_RECENTLY_VIEWED: (
+        "remove notebook from recents is idempotent; replay leaves it absent"
+    ),
+    RPCMethod.GET_USER_SETTINGS: "read-only settings fetch; replay does not mutate settings",
+    RPCMethod.SET_USER_SETTINGS: (
+        "set user settings to caller-supplied values; replay leaves the same state"
+    ),
+    RPCMethod.GET_USER_TIER: "read-only account tier fetch; replay does not mutate account state",
+}
+
+for _method, _notes in _IDEMPOTENT_READ_OR_SET_OP_NOTES.items():
+    IDEMPOTENCY_REGISTRY.register(
+        _method,
+        IdempotencyPolicy.IDEMPOTENT_SET_OP,
+        notes=_notes,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Complete coverage — non-idempotent methods with no reliable probe/token
+# ----------------------------------------------------------------------------
+
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.EXPORT_ARTIFACT,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=(
+        "exports create an external Docs/Sheets artifact and return its URL; "
+        "there is no client-token slot or reliable post-failure probe to bind "
+        "a commit-lost export to this call"
+    ),
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.REVISE_SLIDE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=(
+        "slide revision starts a prompt-driven generation/update with no "
+        "client-token slot or probe; a blind retry may create a second, "
+        "divergent revision"
+    ),
+)
+
+
+# ----------------------------------------------------------------------------
 # AT_LEAST_ONCE_ACCEPTED rate-limited WARN logger
 # ----------------------------------------------------------------------------
 #
 # Per-method timestamp ledger so the WARN log fires at most once per
 # ``_AT_LEAST_ONCE_LOG_INTERVAL`` seconds per ``(method, variant)``. This
-# keeps the foundation behavior-neutral under load: even if Wave 2
-# classifies several hot-path RPCs as AT_LEAST_ONCE_ACCEPTED, callers
-# won't drown in WARN spam. The choice of 30s mirrors the cadence of
-# similar advisory-log throttles elsewhere in the codebase.
+# keeps the registry behavior manageable under load: even if several hot-path
+# RPCs are AT_LEAST_ONCE_ACCEPTED, callers won't drown in WARN spam. The choice
+# of 30s mirrors the cadence of similar advisory-log throttles elsewhere in the
+# codebase.
 _AT_LEAST_ONCE_LOG_INTERVAL: float = 30.0
 # Audit CC6: single-loop-per-client invariant per ADR-004; not safe for multi-loop fan-out.
 _at_least_once_last_logged: dict[tuple[RPCMethod, str | None], float] = {}
@@ -797,7 +904,8 @@ def resolve_effective_disable_internal_retries(
        remain enabled.
     4. All other policies (UNCLASSIFIED, IDEMPOTENT_SET_OP,
        CLIENT_TOKEN_DEDUPE) → returns ``caller_disable_internal_retries``
-       unchanged. UNCLASSIFIED is silent (no log emission).
+       unchanged. UNCLASSIFIED is silent (no log emission) and should appear
+       only in hand-built test registries, not in the production registry.
 
     Raises :class:`~notebooklm.exceptions.IdempotencyVariantError` for
     unknown variants on methods with explicit variant tables.
@@ -842,8 +950,8 @@ def maybe_inject_client_token(
       when ``0 <= index < len(params)`` and the existing slot is falsy
       (``None``, empty string). If the index is out of range the
       function logs a warning and returns without raising — this is a
-      foundation safety guard so a mis-registered entry doesn't crash a
-      live RPC; Wave 2 owns the per-method registration audit.
+      safety guard so a mis-registered entry doesn't crash a live RPC;
+      registry guard tests own the per-method registration audit.
 
     No-op for policies other than ``CLIENT_TOKEN_DEDUPE``, for entries
     without a ``client_token_field``, for entries where the slot already
@@ -877,9 +985,9 @@ def maybe_inject_client_token(
         # caller passed a dict / scalar. No-op.
         return
     if not (0 <= field_key < len(params)):
-        # Out-of-range index — likely a Wave 2 mis-registration. Don't
-        # crash a live RPC; log once and let the caller surface it via
-        # logs rather than via exception.
+        # Out-of-range index — likely a registry mis-registration. Don't crash
+        # a live RPC; log once and let the caller surface it via logs rather
+        # than via exception.
         logger.warning(
             "CLIENT_TOKEN_DEDUPE for RPC %s has out-of-range "
             "client_token_field=%d for params of length %d; skipping injection",

--- a/src/notebooklm/_mutating_operations.py
+++ b/src/notebooklm/_mutating_operations.py
@@ -1,4 +1,11 @@
-"""Audit inventory for mutating operations that suppress blind retries."""
+"""Compatibility shim for probe-then-create recovery metadata.
+
+The active retry taxonomy lives in :mod:`notebooklm._idempotency`. This
+module intentionally derives its keys from ``IDEMPOTENCY_REGISTRY`` so it
+cannot become a second source of truth for which RPCs suppress blind
+transport retries. The only data retained here is the legacy recovery
+label used by existing tests and private importers.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +13,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 
+from ._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyEntry, IdempotencyPolicy
 from .rpc.types import RPCMethod
 
 
@@ -26,54 +34,40 @@ class MutatingOperationPolicy:
     disable_only_reason: str = ""
 
 
+_EXECUTABLE_RECOVERY_KEYS: frozenset[tuple[RPCMethod, str | None]] = frozenset(
+    {
+        (RPCMethod.CREATE_NOTEBOOK, None),
+        (RPCMethod.ADD_SOURCE, "url"),
+        (RPCMethod.ADD_SOURCE, "drive"),
+        (RPCMethod.ADD_SOURCE_FILE, None),
+    }
+)
+
+
+def _build_policy(
+    method: RPCMethod,
+    variant: str | None,
+    entry: IdempotencyEntry,
+) -> MutatingOperationPolicy:
+    key = (method, variant)
+    if key in _EXECUTABLE_RECOVERY_KEYS:
+        return MutatingOperationPolicy(
+            method=method,
+            variant=variant,
+            recovery=RecoveryKind.EXECUTABLE,
+        )
+    return MutatingOperationPolicy(
+        method=method,
+        variant=variant,
+        recovery=RecoveryKind.DISABLE_ONLY,
+        disable_only_reason=entry.notes,
+    )
+
+
 MUTATING_OPERATION_POLICIES: dict[tuple[RPCMethod, str | None], MutatingOperationPolicy] = {
-    (RPCMethod.CREATE_NOTEBOOK, None): MutatingOperationPolicy(
-        method=RPCMethod.CREATE_NOTEBOOK,
-        variant=None,
-        recovery=RecoveryKind.EXECUTABLE,
-    ),
-    (RPCMethod.ADD_SOURCE, "url"): MutatingOperationPolicy(
-        method=RPCMethod.ADD_SOURCE,
-        variant="url",
-        recovery=RecoveryKind.EXECUTABLE,
-    ),
-    (RPCMethod.ADD_SOURCE, "drive"): MutatingOperationPolicy(
-        method=RPCMethod.ADD_SOURCE,
-        variant="drive",
-        recovery=RecoveryKind.EXECUTABLE,
-    ),
-    (RPCMethod.ADD_SOURCE_FILE, None): MutatingOperationPolicy(
-        method=RPCMethod.ADD_SOURCE_FILE,
-        variant=None,
-        recovery=RecoveryKind.EXECUTABLE,
-    ),
-    (RPCMethod.CREATE_ARTIFACT, None): MutatingOperationPolicy(
-        method=RPCMethod.CREATE_ARTIFACT,
-        variant=None,
-        recovery=RecoveryKind.DISABLE_ONLY,
-        disable_only_reason=(
-            "artifact generation disables blind retries today; list-based "
-            "probe recovery is not implemented yet"
-        ),
-    ),
-    (RPCMethod.GENERATE_MIND_MAP, None): MutatingOperationPolicy(
-        method=RPCMethod.GENERATE_MIND_MAP,
-        variant=None,
-        recovery=RecoveryKind.DISABLE_ONLY,
-        disable_only_reason=(
-            "mind-map generation disables blind retries today; no executable "
-            "probe wrapper binds a lost generation response to a later result"
-        ),
-    ),
-    (RPCMethod.SHARE_NOTEBOOK, None): MutatingOperationPolicy(
-        method=RPCMethod.SHARE_NOTEBOOK,
-        variant=None,
-        recovery=RecoveryKind.DISABLE_ONLY,
-        disable_only_reason=(
-            "sharing disables blind retries today; GET_SHARE_STATUS-based "
-            "probe recovery is not implemented yet"
-        ),
-    ),
+    (method, variant): _build_policy(method, variant, entry)
+    for method, variant, entry in IDEMPOTENCY_REGISTRY.iter_entries()
+    if entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
 }
 
 

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -114,9 +114,8 @@ class RpcExecutor:
 
         The ``operation_variant`` kwarg (default ``None``) routes through
         the :class:`IdempotencyRegistry` lookup in :meth:`_execute_once` so the
-        executor can pick a method-variant-specific policy. Currently
-        every method default-resolves to ``UNCLASSIFIED`` (silent + no
-        behavior change); Wave 2 will populate variant entries.
+        executor can pick a method-variant-specific policy for wire shapes
+        such as ``ADD_SOURCE`` and ``CREATE_NOTE``.
         """
         # Pre-open guard — preserves the historical ``RuntimeError`` surface by
         # routing through ``Kernel.get_http_client()`` (which raises the same
@@ -182,10 +181,9 @@ class RpcExecutor:
         # Consult the idempotency registry. The registry is the single
         # source of truth for "how should this RPC behave under retry?";
         # the caller's explicit ``disable_internal_retries=True`` always
-        # wins (caller intent > policy). For UNCLASSIFIED entries (the
-        # B1-foundation default for every method), the effective value
-        # equals the caller's value and no log is emitted — today's
-        # retries fire identically.
+        # wins (caller intent > policy). Read-only and idempotent set-state
+        # entries keep the caller's value unchanged, so existing retry
+        # defaults remain intact for retry-safe RPCs.
         #
         # The registry call also raises ``IdempotencyVariantError`` if
         # the caller passed an unknown ``operation_variant`` to a method
@@ -200,7 +198,7 @@ class RpcExecutor:
         # For CLIENT_TOKEN_DEDUPE policies, inject a fresh ``uuid4().hex``
         # into the registry-named param field UNLESS the caller already
         # populated it. No-op for every other policy, so this is a
-        # zero-cost call for the UNCLASSIFIED-everywhere B1 default.
+        # zero-cost call for every non-token policy.
         maybe_inject_client_token(
             IDEMPOTENCY_REGISTRY,
             method,

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -395,8 +395,8 @@ async def test_notebooks_create_probe_propagates_network_error(
         return httpx.Response(404, text="unexpected")
 
     # Skip backoff sleeps so the test doesn't pay the inner-retry wall time
-    # on the probe's LIST_NOTEBOOKS retries (LIST_NOTEBOOKS is UNCLASSIFIED
-    # so the transport still retries 5xx/network errors there).
+    # on the probe's LIST_NOTEBOOKS retries (LIST_NOTEBOOKS is explicitly
+    # retry-safe, so the transport still retries 5xx/network errors there).
     async def _no_sleep(_seconds: float) -> None:
         return None
 
@@ -411,7 +411,7 @@ async def test_notebooks_create_probe_propagates_network_error(
         await client._collaborators.kernel.get_http_client().aclose()
 
     # Sanity check: the probe was actually attempted and the create fired
-    # once before the probe failed. LIST_NOTEBOOKS is UNCLASSIFIED so the
+    # once before the probe failed. LIST_NOTEBOOKS is retry-safe so the
     # inner transport retry loop fires for the probe — we don't pin a
     # precise count, only that the probe path was entered (>1 list call).
     assert list_call_count >= 2, (

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -1,14 +1,11 @@
-"""Tests for the mutating-RPC idempotency registry foundation.
+"""Tests for the RPC idempotency registry.
 
-This is the B1 foundation (P0-3 + P1-2): a 6-policy classification layer
-with operation variants that the ``RpcExecutor`` consults to compute
+The registry is a 6-policy classification layer with operation variants
+that the ``RpcExecutor`` consults to compute
 ``effective_disable_internal_retries`` and optional client-token injection.
-
-Behavioral classifications for individual RPCs are intentionally deferred
-to Wave 2 — every method default-populates to
-:attr:`~notebooklm._idempotency.IdempotencyPolicy.UNCLASSIFIED` and the
-executor MUST stay silent + reproduce today's retry behavior for those
-entries (regression-protect the "no behavioral drift" acceptance).
+The production registry must explicitly classify every ``RPCMethod``; the
+``UNCLASSIFIED`` policy is retained only as a placeholder for hand-built
+test registries and future-drift detection.
 """
 
 from __future__ import annotations
@@ -31,31 +28,106 @@ from notebooklm.exceptions import IdempotencyVariantError
 from notebooklm.rpc import RPCMethod
 
 # ---------------------------------------------------------------------------
-# Coverage: every RPCMethod has a (method, None) entry
+# Coverage: every RPCMethod has an explicit production classification
 # ---------------------------------------------------------------------------
 
 
-def test_registry_covers_every_rpc_method_at_variant_none() -> None:
-    """Every RPCMethod MUST have a (method, None) entry — the default fallback.
-
-    Wave 2 will classify each method individually. Until then, every method
-    resolves to UNCLASSIFIED with the placeholder note so the registry is
-    a total function over ``RPCMethod``.
-    """
+def test_registry_classifies_every_rpc_method_at_variant_none() -> None:
+    """Every RPCMethod MUST have an explicit ``(method, None)`` entry."""
     for method in RPCMethod:
         entry = IDEMPOTENCY_REGISTRY.get_entry(method)
         assert entry is not None, f"{method.name} has no (method, None) registry entry"
         assert isinstance(entry, IdempotencyEntry)
         assert isinstance(entry.policy, IdempotencyPolicy)
+        assert entry.policy is not IdempotencyPolicy.UNCLASSIFIED, (
+            f"{method.name} kept the UNCLASSIFIED placeholder; add an explicit "
+            "idempotency classification"
+        )
+        assert entry.notes.strip(), f"{method.name} classification must document its rationale"
 
 
-def test_registry_defaults_to_unclassified_placeholder() -> None:
-    """Default placeholder MUST be UNCLASSIFIED with the Wave 2 marker note."""
-    # Pick a stable method that Wave 2 hasn't classified yet.
-    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.LIST_NOTEBOOKS)
-    assert entry.policy is IdempotencyPolicy.UNCLASSIFIED
-    assert "placeholder" in entry.notes.lower()
-    assert "wave 2" in entry.notes.lower()
+def test_registry_has_no_unclassified_production_entries() -> None:
+    """Guard against future ``RPCMethod`` additions without classification."""
+    unclassified = [
+        f"{method.name}:{variant or '<default>'}"
+        for method, variant, entry in IDEMPOTENCY_REGISTRY.iter_entries()
+        if entry.policy is IdempotencyPolicy.UNCLASSIFIED
+    ]
+
+    assert unclassified == []
+
+
+def test_retry_disabled_entries_are_intentional_and_documented() -> None:
+    """Non-retryable methods are pinned so cleanup cannot make them retryable."""
+    expected = {
+        (RPCMethod.CREATE_NOTEBOOK, None): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.ADD_SOURCE, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.ADD_SOURCE, "url"): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.ADD_SOURCE, "drive"): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.ADD_SOURCE, "text"): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.ADD_SOURCE_FILE, None): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.CREATE_ARTIFACT, None): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.EXPORT_ARTIFACT, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.REVISE_SLIDE, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.START_FAST_RESEARCH, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.START_DEEP_RESEARCH, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.IMPORT_RESEARCH, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.GENERATE_MIND_MAP, None): IdempotencyPolicy.PROBE_THEN_CREATE,
+        (RPCMethod.CREATE_NOTE, None): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.CREATE_NOTE, "plain"): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.CREATE_NOTE, "saved_from_chat"): IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        (RPCMethod.SHARE_NOTEBOOK, None): IdempotencyPolicy.PROBE_THEN_CREATE,
+    }
+    actual = {
+        (method, variant): entry.policy
+        for method, variant, entry in IDEMPOTENCY_REGISTRY.iter_entries()
+        if entry.policy
+        in {
+            IdempotencyPolicy.PROBE_THEN_CREATE,
+            IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        }
+    }
+
+    assert actual == expected
+    for method, variant in expected:
+        entry = IDEMPOTENCY_REGISTRY.get_entry(method, operation_variant=variant)
+        assert entry.notes.strip()
+        assert (
+            resolve_effective_disable_internal_retries(
+                IDEMPOTENCY_REGISTRY,
+                method,
+                caller_disable_internal_retries=False,
+                operation_variant=variant,
+            )
+            is True
+        )
+
+
+def test_non_idempotent_no_retry_entries_document_dedupe_gap() -> None:
+    """Hard no-retry methods must explain why blind retry cannot be safe."""
+    expected_terms = {
+        (RPCMethod.ADD_SOURCE, None): ("operation_variant", "blind retry"),
+        (RPCMethod.ADD_SOURCE, "text"): ("no reliable dedupe key",),
+        (RPCMethod.EXPORT_ARTIFACT, None): ("external docs/sheets", "no client-token"),
+        (RPCMethod.REVISE_SLIDE, None): ("no client-token", "blind retry"),
+        (RPCMethod.START_FAST_RESEARCH, None): ("ambiguous", "same query"),
+        (RPCMethod.START_DEEP_RESEARCH, None): ("ambiguous", "same query"),
+        (RPCMethod.IMPORT_RESEARCH, None): ("cannot bind", "same urls"),
+        (RPCMethod.CREATE_NOTE, None): ("no client-token", "no client-visible note_id"),
+        (RPCMethod.CREATE_NOTE, "plain"): ("no client-token", "no client-visible note_id"),
+        (RPCMethod.CREATE_NOTE, "saved_from_chat"): (
+            "no client-token",
+            "no client-visible note_id",
+        ),
+    }
+
+    for (method, variant), terms in expected_terms.items():
+        entry = IDEMPOTENCY_REGISTRY.get_entry(method, operation_variant=variant)
+
+        assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+        lower_notes = entry.notes.lower()
+        for term in terms:
+            assert term in lower_notes
 
 
 # ---------------------------------------------------------------------------
@@ -133,8 +205,8 @@ def test_unknown_variant_with_explicit_variant_entries_raises() -> None:
 
 def test_unknown_variant_with_no_variant_entries_falls_back_quietly() -> None:
     """A method with ONLY the ``(method, None)`` entry MUST tolerate any
-    variant name (silent fallback). This keeps the foundation behavior-neutral
-    until Wave 2 adds variant tables."""
+    variant name (silent fallback). This keeps methods without variant tables
+    backward-compatible."""
     registry = IdempotencyRegistry()
     registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
 
@@ -238,9 +310,10 @@ def test_safe_policies_leave_caller_false_untouched(
 def test_unclassified_emits_no_log_lines_across_1000_calls(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """UNCLASSIFIED MUST be 100% silent — the foundation cannot spam logs
-    while Wave 2 hasn't classified the bulk of the registry. 1000 calls
-    is enough to catch any per-call WARN/INFO leak."""
+    """UNCLASSIFIED MUST be 100% silent in hand-built placeholder registries.
+
+    1000 calls is enough to catch any per-call WARN/INFO leak.
+    """
     registry = IdempotencyRegistry()
     registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
 
@@ -494,7 +567,7 @@ def test_client_token_dedupe_is_noop_for_other_policies() -> None:
 
 
 # ---------------------------------------------------------------------------
-# RpcExecutor consultation: behavioral equivalence with default registry
+# RpcExecutor consultation: behavioral equivalence with active registry
 # ---------------------------------------------------------------------------
 
 
@@ -571,10 +644,12 @@ def _build_rpc_executor() -> Any:
 async def test_default_registry_preserves_today_behavior(
     _build_rpc_executor: Any,
 ) -> None:
-    """Behavioral equivalence: with the production registry's default
-    UNCLASSIFIED policy for every method, an unspecified
-    ``disable_internal_retries`` MUST resolve to False — exactly today's
-    behavior. No drift."""
+    """Behavioral equivalence: retry-safe classifications keep retries enabled.
+
+    ``LIST_NOTEBOOKS`` is explicitly classified as a retry-safe read. An
+    unspecified ``disable_internal_retries`` MUST still resolve to False —
+    exactly the public default.
+    """
     executor, _unused, captured = _build_rpc_executor
 
     await executor._execute_once(
@@ -619,8 +694,8 @@ async def test_operation_variant_kwarg_threads_through_executor(
     _build_rpc_executor: Any,
 ) -> None:
     """``operation_variant`` MUST be accepted as a kwarg on
-    ``RpcExecutor._execute_once()`` without breaking the call. Wave 2 will wire
-    behavioral effects; this PR only adds the seam."""
+    ``RpcExecutor._execute_once()`` without breaking fallback for methods
+    without explicit variant tables."""
     executor, _unused, captured = _build_rpc_executor
 
     # Should not raise — kwarg is accepted everywhere.

--- a/tests/unit/test_mutating_operations.py
+++ b/tests/unit/test_mutating_operations.py
@@ -1,4 +1,4 @@
-"""Audit tests for mutating operation recovery inventory."""
+"""Audit tests for the mutating operation compatibility shim."""
 
 from __future__ import annotations
 
@@ -23,7 +23,8 @@ def _probe_then_create_registry_keys() -> set[tuple[RPCMethod, str | None]]:
     }
 
 
-def test_every_probe_then_create_entry_has_mutating_operation_policy() -> None:
+def test_mutating_operation_shim_does_not_add_policy_data() -> None:
+    """The shim must derive retry-policy membership from the active registry."""
     assert set(MUTATING_OPERATION_POLICIES) == _probe_then_create_registry_keys()
 
 


### PR DESCRIPTION
## Summary
- classify every active `RPCMethod` in `IDEMPOTENCY_REGISTRY` and remove production `UNCLASSIFIED` placeholders
- preserve ADD_SOURCE/CREATE_NOTE variant behavior while making raw/no-probe mutating paths explicitly no-retry
- reduce `_mutating_operations.py` to a registry-derived compatibility shim and add guard tests for future enum drift

## Task
Phase 1 task `p1-idempotency-registry` from `.sisyphus/phases/codebase-gaps-remediation-plan/phase-1.md`.

## Test plan
- [x] `uv run pytest tests/unit/test_idempotency_registry.py tests/integration/test_side_effects_idempotency.py tests/integration/concurrency/test_idempotency_create.py -q`
- [x] `uv run pytest tests/unit/test_mutating_operations.py -q`
- [x] `uv run ruff check src/notebooklm/_idempotency.py tests/unit/test_idempotency_registry.py`
- [x] `uv run ruff check src/notebooklm/_mutating_operations.py src/notebooklm/_rpc_executor.py tests/unit/test_mutating_operations.py tests/integration/test_side_effects_idempotency.py`
- [x] `uv run mypy src/notebooklm`

## Deferred polish findings
- ADR/docs still describe read-only RPCs as unclassified; deferred because this task's target files are code/tests.
- `_sharing_manager.py` uses legacy "toggle" wording for set-state `SHARE_ARTIFACT`; deferred because the file is outside this task's target scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to validate operation policy consistency and robustness.

* **Refactor**
  * Reorganized internal policy management for improved system consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->