### PR TITLE
fix(runtime): share deadline helper for retries and polling

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -11,6 +11,7 @@ from typing import Any
 from ._artifact_listing import find_artifact_row_by_id
 from ._backoff import compute_backoff_delay
 from ._callbacks import maybe_await_callback
+from ._deadline import Monotonic, RuntimeDeadline, Sleep
 from ._polling_registry import PollRegistry
 from ._row_adapters import ArtifactRow
 from ._session_contracts import LoopGuard, OperationScopeProvider
@@ -53,15 +54,25 @@ class ArtifactPollingService:
         loop_guard: LoopGuard,
         op_scope: OperationScopeProvider,
         poll_registry: PollRegistry | None = None,
+        sleep: Sleep | None = None,
+        monotonic: Monotonic | None = None,
     ) -> None:
         self._loop_guard = loop_guard
         self._op_scope = op_scope
         self._poll_registry = poll_registry if poll_registry is not None else PollRegistry()
+        self._sleep = sleep
+        self._monotonic = monotonic
 
     @property
     def poll_registry(self) -> PollRegistry:
         """Return the feature-owned polling registry."""
         return self._poll_registry
+
+    def _resolve_sleep(self) -> Sleep:
+        return asyncio.sleep if self._sleep is None else self._sleep
+
+    def _resolve_monotonic(self) -> Monotonic:
+        return asyncio.get_running_loop().time if self._monotonic is None else self._monotonic
 
     async def drain(self) -> None:
         """Cancel active leader poll tasks and await polling bookkeeping."""
@@ -275,7 +286,7 @@ class ArtifactPollingService:
         on_status_change: StatusChangeCallback | None,
     ) -> GenerationStatus:
         """The actual polling loop. Driven by the leader's shielded task."""
-        start_time = asyncio.get_running_loop().time()
+        deadline = RuntimeDeadline.start(timeout, monotonic=self._resolve_monotonic())
         current_interval = initial_interval
         consecutive_not_found = 0
         total_not_found = 0
@@ -286,6 +297,14 @@ class ArtifactPollingService:
         status_transitions: list[GenerationStatus] = []
 
         while True:
+            if deadline.expired():
+                raise _artifact_timeout_error(
+                    notebook_id,
+                    task_id,
+                    timeout,
+                    last_status,
+                    status_transitions,
+                )
             try:
                 status = await poll_status(notebook_id, task_id)
             except (NetworkError, RPCTimeoutError, ServerError) as e:
@@ -295,20 +314,18 @@ class ArtifactPollingService:
                 # `timeout` parameter.
                 if poll_retry_count >= POLL_MAX_RETRIES:
                     raise
-                remaining = timeout - (asyncio.get_running_loop().time() - start_time)
-                if remaining <= 0:
+                if deadline.expired():
                     raise
                 poll_retry_count += 1
                 # No jitter here: tests assert exact 2.0/4.0/8.0 sleeps and
                 # the remaining-timeout clamp owns thundering-herd avoidance.
-                backoff = min(
+                backoff = deadline.clamp_sleep(
                     compute_backoff_delay(
                         poll_retry_count,
                         base=1.0,
                         cap=8.0,
                         jitter_ratio=0.0,
-                    ),
-                    remaining,
+                    )
                 )
                 logger.warning(
                     "wait_for_completion: transient %s on poll #%d, retrying in %.1fs",
@@ -316,7 +333,9 @@ class ArtifactPollingService:
                     poll_retry_count,
                     backoff,
                 )
-                await asyncio.sleep(backoff)
+                await self._resolve_sleep()(backoff)
+                if deadline.expired():
+                    raise
                 continue
 
             poll_retry_count = 0  # reset on success
@@ -336,7 +355,7 @@ class ArtifactPollingService:
             if status.status == "not_found":
                 consecutive_not_found += 1
                 total_not_found += 1
-                now = asyncio.get_running_loop().time()
+                now = deadline.now()
                 if first_not_found_time is None:
                     first_not_found_time = now
                 not_found_elapsed = now - first_not_found_time
@@ -376,8 +395,7 @@ class ArtifactPollingService:
             else:
                 consecutive_not_found = 0
 
-            elapsed = asyncio.get_running_loop().time() - start_time
-            if elapsed > timeout:
+            if deadline.exceeded():
                 raise _artifact_timeout_error(
                     notebook_id,
                     task_id,
@@ -386,10 +404,9 @@ class ArtifactPollingService:
                     status_transitions,
                 )
 
-            remaining_time = timeout - elapsed
-            sleep_duration = min(current_interval, remaining_time)
+            sleep_duration = deadline.clamp_sleep(current_interval)
             if sleep_duration > 0:
-                await asyncio.sleep(sleep_duration)
+                await self._resolve_sleep()(sleep_duration)
 
             current_interval = min(current_interval * 2, max_interval)
 

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -297,14 +297,6 @@ class ArtifactPollingService:
         status_transitions: list[GenerationStatus] = []
 
         while True:
-            if deadline.expired():
-                raise _artifact_timeout_error(
-                    notebook_id,
-                    task_id,
-                    timeout,
-                    last_status,
-                    status_transitions,
-                )
             try:
                 status = await poll_status(notebook_id, task_id)
             except (NetworkError, RPCTimeoutError, ServerError) as e:
@@ -315,7 +307,13 @@ class ArtifactPollingService:
                 if poll_retry_count >= POLL_MAX_RETRIES:
                     raise
                 if deadline.expired():
-                    raise
+                    raise _artifact_timeout_error(
+                        notebook_id,
+                        task_id,
+                        timeout,
+                        last_status,
+                        status_transitions,
+                    ) from e
                 poll_retry_count += 1
                 # No jitter here: tests assert exact 2.0/4.0/8.0 sleeps and
                 # the remaining-timeout clamp owns thundering-herd avoidance.
@@ -335,7 +333,13 @@ class ArtifactPollingService:
                 )
                 await self._resolve_sleep()(backoff)
                 if deadline.expired():
-                    raise
+                    raise _artifact_timeout_error(
+                        notebook_id,
+                        task_id,
+                        timeout,
+                        last_status,
+                        status_transitions,
+                    ) from e
                 continue
 
             poll_retry_count = 0  # reset on success
@@ -405,8 +409,16 @@ class ArtifactPollingService:
                 )
 
             sleep_duration = deadline.clamp_sleep(current_interval)
-            if sleep_duration > 0:
+            if sleep_duration > 0.0:
                 await self._resolve_sleep()(sleep_duration)
+            elif current_interval > 0.0:
+                raise _artifact_timeout_error(
+                    notebook_id,
+                    task_id,
+                    timeout,
+                    last_status,
+                    status_transitions,
+                )
 
             current_interval = min(current_interval * 2, max_interval)
 

--- a/src/notebooklm/_deadline.py
+++ b/src/notebooklm/_deadline.py
@@ -1,0 +1,66 @@
+"""Small runtime deadline helper shared by retry and polling loops.
+
+Architecture mapping note: this module owns the narrow internal
+deadline/sleep-clamp primitive used by retry middleware, artifact polling,
+and source polling.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+Monotonic = Callable[[], float]
+Sleep = Callable[[float], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class RuntimeDeadline:
+    """Track an aggregate timeout against a monotonic clock."""
+
+    timeout: float
+    started_at: float
+    monotonic: Monotonic
+
+    @classmethod
+    def start(cls, timeout: float, *, monotonic: Monotonic | None = None) -> RuntimeDeadline:
+        """Capture a monotonic start time for ``timeout`` seconds."""
+        resolved_monotonic = time.monotonic if monotonic is None else monotonic
+        return cls(
+            timeout=float(timeout),
+            started_at=resolved_monotonic(),
+            monotonic=resolved_monotonic,
+        )
+
+    def now(self) -> float:
+        """Return the current monotonic timestamp."""
+        return self.monotonic()
+
+    def elapsed(self) -> float:
+        """Return seconds elapsed since the deadline was started."""
+        return self.now() - self.started_at
+
+    def remaining(self) -> float:
+        """Return non-negative seconds left before the timeout expires."""
+        return max(0.0, self.timeout - self.elapsed())
+
+    def expired(self) -> bool:
+        """Return ``True`` once elapsed time reaches the aggregate timeout."""
+        return self.remaining() <= 0.0
+
+    def exceeded(self) -> bool:
+        """Return ``True`` once elapsed time moves past the aggregate timeout."""
+        return self.elapsed() > self.timeout
+
+    def clamp_sleep(self, requested: float) -> float:
+        """Clamp a requested sleep duration to the remaining timeout budget."""
+        return max(0.0, min(float(requested), self.remaining()))
+
+    def timeout_message(self, operation: str) -> str:
+        """Build a consistent timeout message for diagnostics."""
+        return f"{operation} timed out after {self.timeout:.1f}s"
+
+
+__all__ = ["Monotonic", "RuntimeDeadline", "Sleep"]

--- a/src/notebooklm/_middleware_chain.py
+++ b/src/notebooklm/_middleware_chain.py
@@ -72,6 +72,7 @@ class MiddlewareChainBuilder:
         rpc_semaphore_factory: Callable[[], AbstractAsyncContextManager[Any]],
         rate_limit_max_retries_provider: Callable[[], int],
         server_error_max_retries_provider: Callable[[], int],
+        retry_timeout_provider: Callable[[], float | None],
         refresh_retry_delay_provider: Callable[[], float],
         refresh_callable: Callable[..., Awaitable[Any]],
         auth_snapshot_provider: Callable[[], Awaitable[Any]],
@@ -88,6 +89,7 @@ class MiddlewareChainBuilder:
         self._rpc_semaphore_factory = rpc_semaphore_factory
         self._rate_limit_max_retries_provider = rate_limit_max_retries_provider
         self._server_error_max_retries_provider = server_error_max_retries_provider
+        self._retry_timeout_provider = retry_timeout_provider
         self._refresh_retry_delay_provider = refresh_retry_delay_provider
         self._refresh_callable = refresh_callable
         self._auth_snapshot_provider = auth_snapshot_provider
@@ -118,6 +120,7 @@ class MiddlewareChainBuilder:
             RetryMiddleware(
                 rate_limit_max_retries=self._rate_limit_max_retries_provider,
                 server_error_max_retries=self._server_error_max_retries_provider,
+                retry_timeout=self._retry_timeout_provider,
                 metrics=self._metrics,
             ),
             # AuthRefresh callbacks: ``refresh_callable`` invokes

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -25,10 +25,12 @@ Behavior preservation (vs. pre-PR-12.7):
 - **Same backoff timing** — :func:`_backoff.compute_backoff_delay` is
   invoked with the same ``base=1.0`` / ``cap=30.0`` / ``jitter_ratio=0.2``
   parameters; ``Retry-After`` is honored before falling back to
-  exponential backoff.
-- **Same log lines** — "rate-limited (HTTP 429); sleeping (…); retrying
-  (n/N)" and "server/network error (…); backing off …; retrying (n/N)"
-  match the pre-PR-12.7 message shape so log-grep alerts keep matching.
+  exponential backoff. Sleeps are clamped by the existing client timeout so
+  a retry cannot wait past the logical call's aggregate budget.
+- **Same base log shape** — "rate-limited (HTTP 429); sleeping (…);
+  retrying (n/N)" and "server/network error (…); backing off …; retrying
+  (n/N)" still prefix-match the pre-PR-12.7 shape. Deadline exhaustion emits
+  an additional timeout warning when no retry budget remains.
 - **Same metrics** — ``rpc_rate_limit_retries`` and
   ``rpc_server_error_retries`` are incremented per retry attempt, same as
   the legacy code.
@@ -51,10 +53,12 @@ PR sequence.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from ._backoff import compute_backoff_delay
+from ._deadline import Monotonic, RuntimeDeadline
 from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._middleware_context import RPC_CONTEXT_DISABLE_INTERNAL_RETRIES, RPC_CONTEXT_LOG_LABEL
 from ._session_config import CORE_LOGGER_NAME
@@ -86,6 +90,9 @@ class RetryMiddleware:
     - ``rate_limit_max_retries`` / ``server_error_max_retries``: the same
       budgets exposed by ``Session`` via ``_rate_limit_max_retries`` /
       ``_server_error_max_retries``.
+    - ``retry_timeout``: aggregate retry deadline in seconds. Production wires
+      this to the existing client HTTP timeout so retry sleeps cannot exceed
+      the logical call's timeout budget.
     - ``sleep``: the awaitable sleep function. Defaults to
       :func:`asyncio.sleep`; tests inject a stub to make backoff
       deterministic and to assert on sleep durations.
@@ -104,7 +111,9 @@ class RetryMiddleware:
         *,
         rate_limit_max_retries: int | Callable[[], int],
         server_error_max_retries: int | Callable[[], int],
+        retry_timeout: float | Callable[[], float | None] | None = None,
         sleep: Callable[[float], Awaitable[object]] | None = None,
+        monotonic: Monotonic | None = None,
         logger: logging.Logger | None = None,
         metrics: ClientMetrics | None = None,
     ) -> None:
@@ -123,7 +132,9 @@ class RetryMiddleware:
         # Late-binding rationale lives on ``_session_helpers.resolve_sleep``;
         # see that helper for why we resolve at call time instead of capturing
         # the callable at construction.
+        self._retry_timeout = retry_timeout
         self._sleep = sleep
+        self._monotonic = monotonic
         self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
         self._metrics = metrics
 
@@ -134,6 +145,15 @@ class RetryMiddleware:
     def _resolve_server_error_max(self) -> int:
         v = self._server_error_max
         return v() if callable(v) else v
+
+    def _start_retry_deadline(self) -> RuntimeDeadline | None:
+        v = self._retry_timeout
+        if v is None:
+            return None
+        timeout = v() if callable(v) else v
+        if timeout is None or not math.isfinite(float(timeout)):
+            return None
+        return RuntimeDeadline.start(float(timeout), monotonic=self._monotonic)
 
     async def __call__(
         self,
@@ -158,6 +178,7 @@ class RetryMiddleware:
 
         rate_limit_retries = 0
         server_error_retries = 0
+        retry_deadline = self._start_retry_deadline()
 
         while True:
             try:
@@ -171,6 +192,7 @@ class RetryMiddleware:
                     attempt=rate_limit_retries,
                     log_label=log_label,
                     rate_limit_max=rate_limit_max,
+                    retry_deadline=retry_deadline,
                 )
                 rate_limit_retries += 1
                 if self._metrics is not None:
@@ -185,6 +207,7 @@ class RetryMiddleware:
                     attempt=server_error_retries,
                     log_label=log_label,
                     server_error_max=server_error_max,
+                    retry_deadline=retry_deadline,
                 )
                 server_error_retries += 1
                 if self._metrics is not None:
@@ -198,6 +221,7 @@ class RetryMiddleware:
         attempt: int,
         log_label: str,
         rate_limit_max: int,
+        retry_deadline: RuntimeDeadline | None,
     ) -> None:
         """Honor ``Retry-After`` if present; otherwise exponential backoff.
 
@@ -224,6 +248,13 @@ class RetryMiddleware:
             sleep_seconds = max(_BACKOFF_MIN_SECONDS, backoff)
             sleep_source = f"exp-backoff={sleep_seconds:.1f}s"
 
+        actual_sleep = self._resolve_retry_sleep(
+            retry_deadline=retry_deadline,
+            requested_sleep=sleep_seconds,
+            log_label=log_label,
+            exc=exc,
+        )
+
         self._logger.warning(
             "%s rate-limited (HTTP 429); sleeping (%s) then retrying (%d/%d)",
             log_label,
@@ -231,7 +262,12 @@ class RetryMiddleware:
             attempt + 1,
             rate_limit_max,
         )
-        await resolve_sleep(self._sleep)(sleep_seconds)
+        await resolve_sleep(self._sleep)(actual_sleep)
+        self._raise_if_retry_deadline_expired(
+            retry_deadline=retry_deadline,
+            log_label=log_label,
+            exc=exc,
+        )
 
     async def _wait_for_server_error(
         self,
@@ -240,6 +276,7 @@ class RetryMiddleware:
         attempt: int,
         log_label: str,
         server_error_max: int,
+        retry_deadline: RuntimeDeadline | None,
     ) -> None:
         """Exponential backoff with the same parameters as the legacy loop."""
         backoff = max(
@@ -250,6 +287,12 @@ class RetryMiddleware:
                 cap=_BACKOFF_CAP_SECONDS,
                 jitter_ratio=_BACKOFF_JITTER_RATIO,
             ),
+        )
+        actual_backoff = self._resolve_retry_sleep(
+            retry_deadline=retry_deadline,
+            requested_sleep=backoff,
+            log_label=log_label,
+            exc=exc,
         )
         # ``status_code`` is set on 5xx; the network-error branch sets
         # ``response`` / ``status_code`` to ``None``, so fall back to the
@@ -263,11 +306,43 @@ class RetryMiddleware:
             "%s server/network error (%s); backing off %.1fs then retrying (%d/%d)",
             log_label,
             status_label,
-            backoff,
+            actual_backoff,
             attempt + 1,
             server_error_max,
         )
-        await resolve_sleep(self._sleep)(backoff)
+        await resolve_sleep(self._sleep)(actual_backoff)
+        self._raise_if_retry_deadline_expired(
+            retry_deadline=retry_deadline,
+            log_label=log_label,
+            exc=exc,
+        )
+
+    def _resolve_retry_sleep(
+        self,
+        *,
+        retry_deadline: RuntimeDeadline | None,
+        requested_sleep: float,
+        log_label: str,
+        exc: TransportRateLimited | TransportServerError,
+    ) -> float:
+        if retry_deadline is None:
+            return requested_sleep
+        remaining = retry_deadline.remaining()
+        if remaining <= 0.0 or requested_sleep >= remaining:
+            self._logger.warning("%s", retry_deadline.timeout_message(f"{log_label} retry"))
+            raise exc
+        return retry_deadline.clamp_sleep(requested_sleep)
+
+    def _raise_if_retry_deadline_expired(
+        self,
+        *,
+        retry_deadline: RuntimeDeadline | None,
+        log_label: str,
+        exc: TransportRateLimited | TransportServerError,
+    ) -> None:
+        if retry_deadline is not None and retry_deadline.expired():
+            self._logger.warning("%s", retry_deadline.timeout_message(f"{log_label} retry"))
+            raise exc
 
 
 __all__ = ["RetryMiddleware"]

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -486,6 +486,7 @@ def wire_middleware_chain(
         rpc_semaphore_factory=rpc_semaphore_factory,
         rate_limit_max_retries_provider=lambda: chain_host._rate_limit_max_retries,
         server_error_max_retries_provider=lambda: chain_host._server_error_max_retries,
+        retry_timeout_provider=lambda: collaborators.lifecycle._timeout,
         refresh_retry_delay_provider=lambda: chain_host._refresh_retry_delay,
         refresh_callable=chain_host.await_refresh,
         auth_snapshot_provider=lambda: collaborators.auth_coord.snapshot(auth=auth),

--- a/src/notebooklm/_source_polling.py
+++ b/src/notebooklm/_source_polling.py
@@ -8,6 +8,7 @@ import logging
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any
 
+from ._deadline import RuntimeDeadline
 from .types import Source, SourceNotFoundError, SourceProcessingError, SourceTimeoutError
 
 # Source type codes where status=3 (ERROR) is transient rather than terminal.
@@ -47,7 +48,7 @@ class SourcePoller:
         logger: logging.Logger,
     ) -> Source:
         """Wait for a source to become ready."""
-        start = monotonic()
+        deadline = RuntimeDeadline.start(timeout, monotonic=monotonic)
         interval = initial_interval
         last_status: int | None = None
         transient_errors = (
@@ -56,8 +57,7 @@ class SourcePoller:
 
         while True:
             # Check timeout before each poll.
-            elapsed = monotonic() - start
-            if elapsed >= timeout:
+            if deadline.expired():
                 raise SourceTimeoutError(source_id, timeout, last_status)
 
             source = await get_source(notebook_id, source_id)
@@ -80,11 +80,10 @@ class SourcePoller:
                 )
 
             # Don't sleep longer than remaining time.
-            remaining = timeout - (monotonic() - start)
-            if remaining <= 0:
+            if deadline.expired():
                 raise SourceTimeoutError(source_id, timeout, last_status)
 
-            sleep_time = min(interval, remaining)
+            sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
             interval = min(interval * backoff_factor, max_interval)
 
@@ -104,7 +103,7 @@ class SourcePoller:
         logger: logging.Logger,
     ) -> Source:
         """Wait for a source to be registered server-side."""
-        start = monotonic()
+        deadline = RuntimeDeadline.start(timeout, monotonic=monotonic)
         interval = initial_interval
         last_status: int | None = None
         transient_errors = (
@@ -112,8 +111,7 @@ class SourcePoller:
         )
 
         while True:
-            elapsed = monotonic() - start
-            if elapsed >= timeout:
+            if deadline.expired():
                 raise SourceTimeoutError(source_id, timeout, last_status)
 
             source = await get_source(notebook_id, source_id)
@@ -135,11 +133,10 @@ class SourcePoller:
                     # means the source is registered server-side.
                     return source
 
-            remaining = timeout - (monotonic() - start)
-            if remaining <= 0:
+            if deadline.expired():
                 raise SourceTimeoutError(source_id, timeout, last_status)
 
-            sleep_time = min(interval, remaining)
+            sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
             interval = min(interval * backoff_factor, max_interval)
 

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -7,6 +7,7 @@ import pytest
 from notebooklm._artifact_polling import ArtifactPollingService
 from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
 from notebooklm._polling_registry import PollRegistry
+from notebooklm.exceptions import ArtifactPendingTimeoutError
 from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
 
@@ -142,6 +143,74 @@ async def test_wait_for_completion_retry_success(api):
         # Backoff: 2^1=2, 2^2=4
         mock_sleep.assert_any_call(2.0)
         mock_sleep.assert_any_call(4.0)
+
+
+@pytest.mark.asyncio
+async def test_polling_service_clamps_transient_retry_sleep_to_remaining_timeout() -> None:
+    provider = _FakeTransportProvider()
+    clock = 0.0
+    sleeps: list[float] = []
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    service = ArtifactPollingService(
+        loop_guard=provider,
+        op_scope=provider,
+        poll_registry=provider.poll_registry,
+        sleep=sleep,
+        monotonic=monotonic,
+    )
+    poll_status = AsyncMock(side_effect=NetworkError("transient net"))
+
+    with pytest.raises(NetworkError, match="transient net"):
+        await service.wait_for_completion("nb1", "task1", timeout=1.0, poll_status=poll_status)
+
+    assert poll_status.await_count == 1
+    assert sleeps == [1.0]
+    assert clock == 1.0
+
+
+@pytest.mark.asyncio
+async def test_polling_service_clamps_poll_interval_to_remaining_timeout() -> None:
+    provider = _FakeTransportProvider()
+    clock = 0.0
+    sleeps: list[float] = []
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    service = ArtifactPollingService(
+        loop_guard=provider,
+        op_scope=provider,
+        poll_registry=provider.poll_registry,
+        sleep=sleep,
+        monotonic=monotonic,
+    )
+    poll_status = AsyncMock(return_value=GenerationStatus(task_id="task1", status="pending"))
+
+    with pytest.raises(ArtifactPendingTimeoutError):
+        await service.wait_for_completion(
+            "nb1",
+            "task1",
+            initial_interval=10.0,
+            timeout=1.0,
+            poll_status=poll_status,
+        )
+
+    assert poll_status.await_count == 1
+    assert sleeps == [1.0]
+    assert clock == 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -168,9 +168,11 @@ async def test_polling_service_clamps_transient_retry_sleep_to_remaining_timeout
     )
     poll_status = AsyncMock(side_effect=NetworkError("transient net"))
 
-    with pytest.raises(NetworkError, match="transient net"):
+    with pytest.raises(ArtifactPendingTimeoutError) as exc_info:
         await service.wait_for_completion("nb1", "task1", timeout=1.0, poll_status=poll_status)
 
+    assert isinstance(exc_info.value.__cause__, NetworkError)
+    assert "transient net" in str(exc_info.value.__cause__)
     assert poll_status.await_count == 1
     assert sleeps == [1.0]
     assert clock == 1.0
@@ -208,7 +210,7 @@ async def test_polling_service_clamps_poll_interval_to_remaining_timeout() -> No
             poll_status=poll_status,
         )
 
-    assert poll_status.await_count == 1
+    assert poll_status.await_count == 2
     assert sleeps == [1.0]
     assert clock == 1.0
 

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -1105,6 +1105,9 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
     core = _make_core(server_error_max_retries=8)
     await core.__aenter__()
     try:
+        # This test isolates the exponential schedule itself. Keep the aggregate
+        # retry deadline high enough that it does not stop before the cap repeats.
+        core._collaborators.lifecycle._timeout = 200.0
         sleeps: list[float] = []
 
         async def fake_sleep(seconds: float) -> None:

--- a/tests/unit/test_middleware_chain_builder.py
+++ b/tests/unit/test_middleware_chain_builder.py
@@ -26,6 +26,7 @@ def _builder_kwargs():
         "rpc_semaphore_factory": lambda: nullcontext(),
         "rate_limit_max_retries_provider": lambda: 3,
         "server_error_max_retries_provider": lambda: 3,
+        "retry_timeout_provider": lambda: 30.0,
         "refresh_retry_delay_provider": lambda: 0.0,
         "refresh_callable": lambda: None,
         "auth_snapshot_provider": _snapshot,

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -72,6 +72,39 @@ async def test_rate_limit_retry_success_with_budget(auth_tokens):
 
 
 @pytest.mark.asyncio
+async def test_rate_limit_retry_after_larger_than_client_timeout_does_not_sleep(auth_tokens):
+    """The middleware uses the client timeout as the aggregate retry budget."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.return_value = _build_429("300")
+
+    core = build_client_shell_for_tests(auth_tokens, timeout=0.25, rate_limit_max_retries=2)
+    install_http_client_for_test(core._collaborators.kernel, mock_client)
+    install_post_as_stream(None, mock_client, mock_client.post)
+
+    sleeps: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def _record_sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    with (
+        patch("notebooklm._deadline.time.monotonic", side_effect=monotonic),
+        patch("asyncio.sleep", side_effect=_record_sleep),
+        pytest.raises(RateLimitError),
+    ):
+        await core._rpc_executor.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
+
+    assert mock_client.post.call_count == 1
+    assert sleeps == []
+    assert clock == 0.0
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_retry_exhausted_with_budget(auth_tokens):
     """Budget=2 means: initial + 2 retries = 3 total posts before RateLimitError."""
     mock_client = AsyncMock(spec=httpx.AsyncClient)

--- a/tests/unit/test_retry_after.py
+++ b/tests/unit/test_retry_after.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
+from notebooklm._deadline import RuntimeDeadline
 from notebooklm._transport_errors import MAX_RETRY_AFTER_SECONDS, parse_retry_after
 
 
@@ -35,3 +36,24 @@ def test_parse_retry_after_invalid():
     assert parse_retry_after("   ") is None
     # Partially valid but not what we want
     assert parse_retry_after("2026-05-13") is None
+
+
+def test_runtime_deadline_pins_expired_and_exceeded_boundaries():
+    clock = 10.0
+
+    def monotonic() -> float:
+        return clock
+
+    deadline = RuntimeDeadline.start(1.0, monotonic=monotonic)
+    assert deadline.started_at == 10.0
+    assert deadline.remaining() == 1.0
+    assert deadline.clamp_sleep(5.0) == 1.0
+
+    clock = 11.0
+    assert deadline.remaining() == 0.0
+    assert deadline.expired() is True
+    assert deadline.exceeded() is False
+    assert deadline.timeout_message("retry") == "retry timed out after 1.0s"
+
+    clock = 11.01
+    assert deadline.exceeded() is True

--- a/tests/unit/test_retry_middleware.py
+++ b/tests/unit/test_retry_middleware.py
@@ -181,6 +181,107 @@ async def test_retries_on_429_until_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_429_retry_after_larger_than_remaining_timeout_does_not_sleep() -> None:
+    """A large ``Retry-After`` fails fast when no retry can fit in the deadline."""
+    slept: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        slept.append(seconds)
+        clock += seconds
+
+    first_429 = _rate_limited(retry_after=300)
+    terminal, calls = _scripted_terminal(
+        [
+            first_429,
+            httpx.Response(200, content=b"late-success"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        retry_timeout=1.0,
+        sleep=sleep,
+        monotonic=monotonic,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(TransportRateLimited) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert excinfo.value is first_429
+    assert len(calls) == 1
+    assert slept == []
+    assert clock == 0.0
+
+
+@pytest.mark.asyncio
+async def test_429_does_not_sleep_when_attempt_already_exhausted_retry_timeout() -> None:
+    """Time spent in the failed attempt counts against the aggregate retry timeout."""
+    slept: list[float] = []
+    clock = 0.0
+    first_429 = _rate_limited(retry_after=1)
+    calls: list[RpcRequest] = []
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        nonlocal clock
+        calls.append(request)
+        clock = 1.5
+        raise first_429
+
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        retry_timeout=1.0,
+        sleep=sleep,
+        monotonic=monotonic,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(TransportRateLimited) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert excinfo.value is first_429
+    assert len(calls) == 1
+    assert slept == []
+
+
+@pytest.mark.asyncio
+async def test_429_retry_timeout_none_disables_aggregate_deadline() -> None:
+    """``None`` preserves the historical retry-count-only behavior."""
+    sleep, slept = _recording_sleep()
+    terminal, calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        retry_timeout=lambda: None,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 2
+    assert slept == [1.0]
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_429_without_retry_after_uses_exponential_backoff() -> None:
     """``Retry-After`` absent → exponential backoff with min-floor."""
     sleep, slept = _recording_sleep()
@@ -260,6 +361,45 @@ async def test_retries_on_503_until_success() -> None:
     assert len(slept) == 1
     assert slept[0] >= 0.1
     assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_5xx_backoff_larger_than_remaining_timeout_does_not_sleep() -> None:
+    """5xx backoff uses the same aggregate deadline guard as the 429 path."""
+    slept: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        slept.append(seconds)
+        clock += seconds
+
+    first_503 = _server_error(status=503)
+    terminal, calls = _scripted_terminal(
+        [
+            first_503,
+            httpx.Response(200, content=b"late-success"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        retry_timeout=0.05,
+        sleep=sleep,
+        monotonic=monotonic,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(TransportServerError) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert excinfo.value is first_503
+    assert len(calls) == 1
+    assert slept == []
+    assert clock == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_polling_service.py
+++ b/tests/unit/test_source_polling_service.py
@@ -85,6 +85,42 @@ async def test_wait_until_ready_checks_timeout_after_get(
 
 
 @pytest.mark.asyncio
+async def test_wait_until_ready_clamps_sleep_to_remaining_timeout(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    processing = Source(id="src_1", status=SourceStatus.PROCESSING)
+    get_source = AsyncMock(return_value=processing)
+    sleeps: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    with pytest.raises(SourceTimeoutError) as exc_info:
+        await poller.wait_until_ready(
+            "nb_1",
+            "src_1",
+            timeout=1.0,
+            initial_interval=10.0,
+            get_source=get_source,
+            sleep=sleep,
+            monotonic=monotonic,
+            logger=logger,
+        )
+
+    assert exc_info.value.last_status == SourceStatus.PROCESSING
+    assert get_source.await_count == 1
+    assert sleeps == [1.0]
+    assert clock == 1.0
+
+
+@pytest.mark.asyncio
 async def test_wait_until_ready_raises_source_not_found_when_get_returns_none(
     poller: SourcePoller,
     logger: logging.Logger,
@@ -245,6 +281,41 @@ async def test_wait_until_registered_raises_timeout(
 
     assert exc_info.value.last_status is None
     sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_until_registered_clamps_sleep_to_remaining_timeout(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    get_source = AsyncMock(return_value=None)
+    sleeps: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    with pytest.raises(SourceTimeoutError) as exc_info:
+        await poller.wait_until_registered(
+            "nb_1",
+            "src_1",
+            timeout=1.0,
+            initial_interval=10.0,
+            get_source=get_source,
+            sleep=sleep,
+            monotonic=monotonic,
+            logger=logger,
+        )
+
+    assert exc_info.value.last_status is None
+    assert get_source.await_count == 1
+    assert sleeps == [1.0]
+    assert clock == 1.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `RuntimeDeadline` as the shared internal helper for monotonic deadlines, remaining budget, sleep clamps, and timeout diagnostics.
- Wire retry sleeps to the existing client timeout budget and fail fast when a retry sleep cannot fit before the aggregate deadline.
- Move source/artifact polling sleep clamps onto the shared helper while preserving artifact poll dedupe behavior.

## Task
Phase 2 Wave 1: `p2-runtime-deadline-helper` from `.sisyphus/phases/codebase-gaps-remediation-plan/phase-2.md`.

## Wave 2 Documentation Mapping Note
Document `src/notebooklm/_deadline.py` in the architecture freshness pass as the narrow runtime deadline/sleep-clamp helper shared by retry middleware, artifact polling, and source polling.

## Test plan
- [x] `uv run pytest tests/unit/test_retry_middleware.py tests/unit/test_retry_after.py tests/unit/test_rate_limit_retry.py tests/unit/test_artifact_rate_limit_retry.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_polling_service.py tests/unit/test_source_polling_service.py -q`
- [x] `uv run pytest tests/integration/concurrency/test_artifact_poll_dedupe.py -q`
- [x] `uv run ruff check src/notebooklm/_middleware_retry.py src/notebooklm/_artifact_polling.py src/notebooklm/_source_polling.py`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pytest tests/unit/test_middleware_chain_builder.py -q`

## Deferred polish findings
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeouts now use a unified deadline so sleep/backoff durations are clamped to remaining time, avoiding spurious waits and ensuring retries stop when time is exhausted.
  * Retry behavior preserves original errors when aggregate retry deadlines are hit and provides clearer timeout diagnostics.

* **Tests**
  * Added deterministic tests covering timeout-aware polling and retry scenarios, including rate-limit and backoff edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->