### PR TITLE
refactor(cli): move cookie domain parsing to command layer

### DIFF
--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -49,8 +49,8 @@ ALLOWED_CLICK_EXCEPTION_SITES: list[tuple[str, int, str]] = [
     ("src/notebooklm/cli/profile_cmd.py", 279, "profile rename source validation"),
     ("src/notebooklm/cli/profile_cmd.py", 281, "profile rename destination validation"),
     ("src/notebooklm/cli/resolve.py", 58, "entity ID argument validation"),
-    ("src/notebooklm/cli/session_cmd.py", 160, "login profile-name validation translation"),
     ("src/notebooklm/cli/session_cmd.py", 161, "login profile-name validation translation"),
+    ("src/notebooklm/cli/session_cmd.py", 162, "login profile-name validation translation"),
 ]
 
 # Raw ``raise SystemExit`` should live in this module. If a future path truly

--- a/src/notebooklm/cli/services/login/cookie_domains.py
+++ b/src/notebooklm/cli/services/login/cookie_domains.py
@@ -5,37 +5,31 @@ imports). Owns:
 
 - :data:`_INCLUDE_DOMAINS_ALL` — sentinel label for "include every optional
   sibling-product domain".
-- :func:`_parse_include_domains` — Click value parser.
-- :func:`_warn_missing_optional_domains` — migration warning.
+- :func:`_parse_include_domains` — pure label parser.
+- :func:`_warn_missing_optional_domains` — migration-warning message builder.
 - :func:`_resolve_optional_cookie_domains` — label → domain-set resolver.
 - :func:`_build_google_cookie_domains` — final domain list builder.
-
-ADR-015 Pattern B waiver: ``_parse_include_domains`` raises
-``click.BadParameter`` from a Click ``callback=`` hook (parser-time, not
-service-layer policy). ADR-015 explicitly preserves parser-time
-``click.BadParameter`` behaviour, so this module's ``import click`` is a
-permanent transitional entry in
-``tests/unit/cli/test_services_boundary.py`` unless the callback
-architecture is restructured separately.
 """
 
 from __future__ import annotations
 
 import logging
-
-import click
+from collections.abc import Callable
 
 from ....auth import (
     GOOGLE_REGIONAL_CCTLDS,
     OPTIONAL_COOKIE_DOMAINS_BY_LABEL,
     REQUIRED_COOKIE_DOMAINS,
 )
-from ...rendering import console
 
 logger = logging.getLogger(__name__)
 
 
 _INCLUDE_DOMAINS_ALL = "all"
+
+
+class IncludeDomainsParseError(ValueError):
+    """Raised when ``--include-domains`` contains an unknown label."""
 
 
 def _parse_include_domains(values: tuple[str, ...]) -> set[str]:
@@ -46,7 +40,7 @@ def _parse_include_domains(values: tuple[str, ...]) -> set[str]:
     commas is tolerated. Empty fragments are dropped.
 
     Raises:
-        click.BadParameter: if any label is not one of
+        IncludeDomainsParseError: if any label is not one of
             :data:`notebooklm.auth.OPTIONAL_COOKIE_DOMAINS_BY_LABEL` keys
             (or the literal ``"all"``).
     """
@@ -63,33 +57,42 @@ def _parse_include_domains(values: tuple[str, ...]) -> set[str]:
     bad = labels - valid
     if bad:
         supported = ", ".join(sorted(valid))
-        raise click.BadParameter(
+        raise IncludeDomainsParseError(
             f"unknown --include-domains label(s): {', '.join(sorted(bad))}. Supported: {supported}."
         )
     return labels
 
 
-def _warn_missing_optional_domains(include_domains: set[str]) -> None:
-    """Emit a migration warning when the default minimum-cookies set is used.
+def _warn_missing_optional_domains(
+    include_domains: set[str],
+    *,
+    warn: Callable[[str], None] | None = None,
+) -> str | None:
+    """Build or emit the migration warning for the minimum-cookies default.
 
     The cookie-domain split narrows the default extraction set to
     :data:`REQUIRED_COOKIE_DOMAINS`. Users upgrading from the prior
     behavior need a heads-up that YouTube / Docs / myaccount / Mail
-    cookies are no longer scraped at login. Telling them how to opt back
-    in is the entire point of the warning.
+    cookies are no longer scraped at login.
+
+    ``warn`` is injected by the command layer for interactive CLI runs so
+    this service module does not import presentation helpers.
     """
     if include_domains:
-        return
+        return None
     supported = ", ".join(sorted(OPTIONAL_COOKIE_DOMAINS_BY_LABEL))
-    console.print(
+    message = (
         "[dim]Note: sibling-product cookies not included by default. "
         f"Pass --include-domains=<{supported}> (or =all) to extract them.[/dim]"
     )
+    if warn is not None:
+        warn(message)
     logger.info(
         "Login extracting REQUIRED_COOKIE_DOMAINS only (cookie-domain split default). "
         "Pass --include-domains=%s (or =all) to include sibling cookies.",
         supported,
     )
+    return message
 
 
 def _resolve_optional_cookie_domains(labels: set[str]) -> frozenset[str]:
@@ -98,8 +101,8 @@ def _resolve_optional_cookie_domains(labels: set[str]) -> frozenset[str]:
     Contract: ``labels`` must be the output of
     :func:`_parse_include_domains`, which validates that every label is in
     :data:`OPTIONAL_COOKIE_DOMAINS_BY_LABEL` (or the literal ``"all"``).
-    Callers are expected to surface the ``click.BadParameter`` from the
-    parser before we ever reach this function; the dict lookup below is
+    Callers are expected to surface parser errors before we ever reach
+    this function; the dict lookup below is
     therefore unguarded by design.
     """
     if not labels:

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -85,13 +85,14 @@ from .services.login import (
     _login_all_accounts_from_browser,
     _login_browser_cookies_single,
     _login_with_browser_cookies,  # noqa: F401 — patch surface only
-    _parse_include_domains,
     _refresh_from_browser_cookies,
     _resolve_optional_cookie_domains,  # noqa: F401 — patch surface only
     _select_account,  # noqa: F401 — patch surface only
     _sync_server_language_to_config,
-    _warn_missing_optional_domains,
     _write_extracted_cookies,  # noqa: F401 — patch surface only
+)
+from .services.login import (
+    cookie_domains as _cookie_domains,
 )
 from .services.login.exceptions import LoginConfigurationError
 from .services.login.outcomes import BrowserCookieOutcome, NetworkFailure
@@ -191,6 +192,19 @@ def _run_playwright_login(
         include_domains=include_domains,
     )
     run_playwright_login(plan)
+
+
+def _parse_include_domains(values: tuple[str, ...]) -> set[str]:
+    """Command-layer Click wrapper for the service ``--include-domains`` parser."""
+    try:
+        return _cookie_domains._parse_include_domains(values)
+    except _cookie_domains.IncludeDomainsParseError as exc:
+        raise click.BadParameter(str(exc)) from None
+
+
+def _warn_missing_optional_domains(include_domains: set[str]) -> None:
+    """Render the cookie-domain migration warning from the command layer."""
+    _cookie_domains._warn_missing_optional_domains(include_domains, warn=console.print)
 
 
 def _use_notebook_table() -> Table:

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -77,10 +77,13 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 # ``run_async``). The current boundary scanner intentionally does not flag
 # those imports; their important invariant is zero Pattern A pairs until the
 # remaining seams are inverted into caller-provided callbacks.
+# Login ``cookie_domains.py`` is pure service code: the command layer hosts
+# Click ``BadParameter`` translation and optional-domain warning rendering.
 GUARDED_PATHS = {
     "cli/services/auth_diagnostics.py": SERVICES_ROOT / "auth_diagnostics.py",
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
     "cli/services/login/browser_accounts.py": SERVICES_ROOT / "login" / "browser_accounts.py",
+    "cli/services/login/cookie_domains.py": SERVICES_ROOT / "login" / "cookie_domains.py",
     "cli/services/login/cookie_jar.py": SERVICES_ROOT / "login" / "cookie_jar.py",
     "cli/services/login/cookie_writes.py": SERVICES_ROOT / "login" / "cookie_writes.py",
     "cli/services/login/exceptions.py": SERVICES_ROOT / "login" / "exceptions.py",
@@ -229,29 +232,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "of catching ``SystemExit``."
         ),
     },
-    "cli/services/login/cookie_domains.py": {
-        "path": SERVICES_ROOT / "login" / "cookie_domains.py",
-        "forbidden_imports": [
-            "cookie_domains.py:26: forbidden top-level import: 'click'",
-        ],
-        "pattern_a_violations": [],
-        "pattern_b_violations": (
-            "raises click.BadParameter from a Click callback= hook "
-            "(parser-time, explicitly allowed by ADR-015). Permanent "
-            "transitional entry: the Click parameter-callback contract "
-            "requires this exception type, so the module's ``import click`` "
-            "stays put unless the callback architecture is restructured "
-            "to host the parser elsewhere."
-        ),
-        "rationale": (
-            "Permanent waiver — Click's ``callback=`` API on the "
-            "``--include-domains`` flag requires ``raise click.BadParameter``. "
-            "ADR-015 explicitly preserves parser-time ``ClickException`` "
-            "behaviour, so this stays a transitional entry indefinitely "
-            "(no `forbidden_imports`/`pattern_b_violations` removal "
-            "planned without a separate callback-architecture refactor)."
-        ),
-    },
     "cli/services/login/firefox_accounts.py": {
         "path": SERVICES_ROOT / "login" / "firefox_accounts.py",
         "forbidden_imports": [],
@@ -373,12 +353,8 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
     },
 }
 
-# Modules with a documented, indefinite exception. Empty by default — the
-# Pattern B parser-time exception for cookie_domains.py lives in
-# ``TRANSITIONAL_GUARDED_PATHS`` because the lift is still planned (Click
-# parameter-callback contract is the documented exception, but the module
-# could host its callback elsewhere in a future refactor). Adding to this
-# dict requires a documented architecture exception.
+# Modules with a documented, indefinite exception. Empty by default; adding
+# to this dict requires a documented architecture exception.
 #
 # Entry schema (when populated):
 #   ``path``      — ``pathlib.Path`` to the module.


### PR DESCRIPTION
## Summary
- move `--include-domains` Click error translation out of `cli/services/login/cookie_domains.py` and into `session_cmd.py`
- inject optional-domain warning rendering from the command layer so the cookie-domain service no longer imports CLI rendering
- move `cli/services/login/cookie_domains.py` from `TRANSITIONAL_GUARDED_PATHS` to `GUARDED_PATHS`

## Removed boundary rows
- `cli/services/login/cookie_domains.py`

## Test plan
- [x] `uv run pytest tests/unit/cli/test_services_boundary.py -q`
- [x] `uv run pytest tests/unit/cli -k "login or auth or profile" -q`
- [x] `uv run ruff check src/notebooklm/cli tests/unit/cli/test_services_boundary.py`
- [x] `uv run mypy src/notebooklm`

## Deferred polish findings
none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized domain parsing and warning logic to separate CLI presentation from core parsing.

* **CLI**
  * Command-layer now handles presentation of include-domain argument errors and warning messages.

* **Tests**
  * Updated boundary/enforcement tests to reflect the module's new layering status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->