### PR TITLE
docs: enforce bidirectional freshness invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ src/notebooklm/
 │   ├── cookies.py               # Cookie maps + _update_cookie_input
 │   ├── cookie_policy.py         # Domain allowlist and cookie policy
 │   ├── account.py               # Account profile + multi-account switching
-│   ├── session.py               # Auth-session refresh implementation (`RefreshAuthCore` Protocol + `refresh_auth_session()`)
+│   ├── session.py               # Auth-session refresh implementation via `refresh_auth_session()` and explicit collaborators
 │   ├── storage.py               # Profile/state persistence on disk
 │   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
 │   ├── psidts_recovery.py       # Inline PSIDTS recovery for cold-start (issue #865)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,19 +60,25 @@ RPC Layer (rpc/)
 
 2. **Client Runtime Layer** (`src/notebooklm/client.py` + runtime collaborators):
    - `client.py`: `NotebookLMClient` composition root plus public surface
-   - `_client_composed.py`, `_session_init.py`: composition holder and collaborator construction
-   - `_request_types.py`, `_transport_errors.py`, `_streaming_post.py`, `_rpc_executor.py`: request construction, transport errors, streaming HTTP, and RPC dispatch
+   - `_client_composed.py`, `_client_seams.py`, `_session_init.py`: composition holder, injectable seams, and collaborator construction
+   - `_env.py`, `_session_config.py`, `_logging.py`, `_callbacks.py`: environment/config defaults, compatibility logger name, redaction/correlation logging, and callback invocation helpers
+   - `_request_types.py`, `_transport_errors.py`, `_streaming_post.py`, `_session_transport.py`, `_rpc_executor.py`: request construction, transport errors, streaming HTTP, session transport wrapper, and RPC dispatch
    - `_session_auth.py`, `_cookie_persistence.py`: Auth refresh + cookie storage
-   - `_client_metrics.py`, `_transport_drain.py`, `_reqid_counter.py`: Telemetry, drain coordination, request-counter handling
+   - `_client_metrics.py`, `_transport_drain.py`, `_deadline.py`, `_backoff.py`, `_reqid_counter.py`: Telemetry, drain coordination, aggregate deadlines, retry backoff, request-counter handling
    - `_conversation_cache.py`, `_polling_registry.py`: Conversation cache + artifact polling helpers
-   - `_session_config.py`, `_session_helpers.py`, `_error_injection.py`: Module-level constants, helper utilities, synthetic-error transport
+   - `_session_helpers.py`, `_error_injection.py`: Auth-error helpers and synthetic-error transport
    - `_session_lifecycle.py`: Open/close lifecycle (loop-affinity guard + keepalive task)
    - `_session_contracts.py`: Shared session Protocols consumed by feature APIs
+   - `_middleware.py`, `_middleware_context.py`, `_middleware_chain.py`, `_middleware_chain_host.py`, `_middleware_*.py`: HTTP-shaped middleware envelope, context vocabulary, canonical chain builder/host, and chain links
+   - `_idempotency.py`, `_mutating_operations.py`: Mutating-RPC retry taxonomy and legacy probe-then-create recovery metadata
+   - `_atomic_io.py`: Crash-safe JSON writes and locked read-modify-write helpers shared by auth and CLI
 
 3. **Client Layer** (`src/notebooklm/client.py`, `_*.py`):
    - `NotebookLMClient`: Main async client with namespaced APIs
    - `_notebooks.py`, `_sources.py`, `_artifacts.py`, etc.: Domain APIs
    - `_source_*.py`, `_artifact_*.py`: Feature-specific service logic
+   - `_types/`, `_row_adapters.py`: Dataclass implementations and typed views over positional RPC rows
+   - `_research_task_parser.py`, `research.py`: Research task parsing plus public citation/report utilities
 
 4. **CLI Layer** (`src/notebooklm/cli/`):
    - Modular Click commands
@@ -84,24 +90,43 @@ RPC Layer (rpc/)
 |------|---------|
 | `client.py` | Main `NotebookLMClient` class |
 | `_client_composed.py` | Client-owned composition holder for transport, executor, chain host, middleware metadata, and session collaborator bundle. |
+| `_client_seams.py` | Constructor-only injectable seams used by tests and collaborator construction. |
 | `_session_init.py` | Constructor helpers that validate client runtime kwargs, build collaborators, wire middleware, and bind `ClientComposed`. |
 | `_kernel.py` | Concrete `Kernel` transport core (owns `httpx.AsyncClient` + cookie jar) |
-| `_session_config.py` | `DEFAULT_*` knobs and module-level constants |
+| `_session_config.py` | `DEFAULT_*` knobs and module-level constants. `CORE_LOGGER_NAME = "notebooklm._core"` is intentionally preserved as a compatibility logging contract even though the `_core` module was deleted; renaming it silently breaks downstream `caplog`/logger filters. |
+| `_env.py`, `config.py` | Runtime environment defaults and the public config re-export surface |
+| `_logging.py`, `log.py` | Redaction/correlation logging internals and the public logging helper surface |
+| `_callbacks.py` | Sync-or-async callback invocation helper used by telemetry/retry hooks |
 | `_session_helpers.py` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval` |
 | `_error_injection.py` | Synthetic-error env-var resolver + startup guard |
 | `_client_metrics.py` | `ClientMetrics` — `ClientMetricsSnapshot` counters + `on_rpc_event` callback |
 | `_transport_drain.py` | `TransportDrainTracker` — in-flight transport counters + `_TransportOperationToken` |
+| `_deadline.py` | `RuntimeDeadline` helper shared by retry and polling loops so aggregate timeouts clamp sleep consistently |
+| `_backoff.py` | Shared capped exponential-backoff calculation with deterministic test injection |
 | `_reqid_counter.py` | `ReqidCounter` — monotonic `_reqid` for the chat backend |
 | `_session_auth.py` | `AuthRefreshCoordinator` — refresh task + auth-snapshot lock |
 | `_session_lifecycle.py` | `ClientLifecycle` — loop-affinity guard + keepalive task |
+| `_session_transport.py` | Session transport wrapper that drives the middleware chain and typed transport response handling |
 | `_rpc_executor.py` | RPC dispatch executor. Takes its `Kernel`, `SessionTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5). The `RpcOwner` Protocol that previously re-declared Session's private attribute surface was deleted in Wave 4 of session-decoupling (#1068); only the local `DecodeResponse` Protocol remains. |
 | `_request_types.py` | Shared authed POST request construction types: `AuthSnapshot`, `BuildRequest`, `PostBody`, and materialization helpers. |
 | `_transport_errors.py` | Transport exceptions, `Retry-After` parsing, and terminal `Kernel.post` error mapping for retry/auth middleware. |
 | `_streaming_post.py` | Size-capped streaming POST helper used by `Kernel.post`. |
+| `_middleware.py` | HTTP-shaped middleware request/response envelope, chain composition, and middleware Protocol |
+| `_middleware_context.py` | Canonical per-request context-key vocabulary for middleware |
+| `_middleware_chain_host.py` | Mutable owner for the live middleware chain slots and retry-budget tunables |
 | `_conversation_cache.py` | Per-instance LRU conversation cache for `ChatAPI` |
 | `_polling_registry.py` | Pending-poll registry for long-running artifact generations |
 | `_cookie_persistence.py` | Cookie-jar persistence + `__Secure-1PSIDTS` rotation |
 | `_session_contracts.py` | Shared session Protocols consumed by sub-clients |
+| `_idempotency.py` | Mutating-RPC idempotency policy registry and probe-then-retry wrapper; ADR-005 is the taxonomy source |
+| `_mutating_operations.py` | Compatibility view over probe-then-create recovery metadata derived from `_idempotency.py` |
+| `_atomic_io.py`, `io.py` | Atomic JSON write/update internals and public I/O re-export surface for CLI boundary compliance |
+| `exceptions.py` | Public exception hierarchy plus safe diagnostic preview/redaction helpers |
+| `paths.py`, `migration.py` | Profile-aware path resolution and locked migration from the legacy flat layout |
+| `_types/`, `types.py` | Dataclass implementation package and public type/re-export facade |
+| `_row_adapters.py` | Typed adapters over raw positional RPC rows for artifacts, notes, and sources |
+| `artifacts.py`, `research.py`, `utils.py` | Public helper modules for artifact retry, research citation/report utilities, and common async helpers |
+| `_research_task_parser.py` | Internal parser for research task result-type selection |
 | `_notebooks.py` | `client.notebooks` API + source-id resolver |
 | `_sources.py` | `client.sources` API |
 | `_artifacts.py` | `client.artifacts` API |
@@ -123,7 +148,7 @@ RPC Layer (rpc/)
 | `_source_polling.py` | Poll coordination service for active source conversions |
 | `_source_upload.py` | Concurrency-gated upload pipeline for source files |
 | `_notebook_metadata.py` | Metadata protocol schemas for sub-clients |
-| `_url_utils.py` | URL parsing and validation helpers |
+| `_url_utils.py`, `urls.py` | URL parsing/validation internals and the public URL helper facade |
 | `_sharing_manager.py` | Direct sharing management logic |
 | `_version_check.py` | Dynamic client-side version deprecation guard |
 | `_chat_notes.py` | Chat-adjacent note saving workflow adapter |
@@ -144,13 +169,37 @@ RPC Layer (rpc/)
 ```text
 src/notebooklm/
 ├── __init__.py                  # Public exports
+├── __main__.py                  # `python -m notebooklm` entry point
 ├── client.py                    # NotebookLMClient
 ├── auth.py                      # Authentication facade — almost pure re-exports (`enumerate_accounts` exception; ADR-003 flat-re-export goal closed by ADR-014; see file table above)
 ├── types.py                     # Dataclasses
+├── artifacts.py                 # Public artifact-generation retry helpers
+├── config.py                    # Public config facade over _env
+├── exceptions.py                # Public exception hierarchy
+├── io.py                        # Public atomic-I/O facade for CLI boundary compliance
+├── log.py                       # Public logging helper facade
+├── migration.py                 # Legacy flat-layout to profile migration
+├── paths.py                     # Profile-aware path resolution
+├── research.py                  # Public research citation/report helpers
+├── urls.py                      # Public URL helper facade
+├── utils.py                     # Public async utility helpers
+├── _atomic_io.py                # Atomic JSON write/update helpers
+├── _backoff.py                  # Shared retry backoff calculation
+├── _callbacks.py                # Sync/async callback invocation helper
 ├── _client_composed.py          # Client-owned composition holder
+├── _client_seams.py             # Constructor-only injectable seams
+├── _deadline.py                 # RuntimeDeadline helper for aggregate timeouts
+├── _env.py                      # Runtime environment/default endpoint helpers
+├── _idempotency.py              # Mutating-RPC idempotency registry + wrappers
 ├── _kernel.py                   # Concrete Kernel transport core
+├── _logging.py                  # Redaction + correlation logging internals
+├── _loop_affinity.py            # Event-loop affinity guard helper
+├── _mutating_operations.py      # Legacy recovery metadata view over _idempotency
+├── _row_adapters.py             # Typed views over positional RPC rows
 ├── _session_config.py           # DEFAULT_* knobs + module-level constants
 ├── _session_helpers.py          # is_auth_error / AUTH_ERROR_PATTERNS / keepalive helpers
+├── _session_init.py             # Runtime collaborator construction + validation
+├── _session_transport.py        # Middleware-chain transport wrapper
 ├── _error_injection.py          # Synthetic-error env-var resolver + startup guard
 ├── _request_types.py            # AuthSnapshot, BuildRequest, PostBody, request materialization helpers
 ├── _transport_errors.py         # Transport exceptions, Retry-After parsing, Kernel.post error mapping
@@ -184,7 +233,11 @@ src/notebooklm/
 ├── _chat_notes.py               # Note saving workflow adapter
 ├── _chat_protocol.py            # Internal chat types
 ├── _chat_transport.py           # Chat error mapping
+├── _research_task_parser.py     # Research task result-type parser
+├── _middleware.py               # Middleware envelope + Protocol + chain composition primitive
+├── _middleware_context.py       # Middleware context-key vocabulary
 ├── _middleware_chain.py         # Middleware chain builder
+├── _middleware_chain_host.py    # Live middleware chain slots and retry tunables
 ├── _middleware_tracing.py       # Tracing middleware
 ├── _middleware_metrics.py       # Metrics middleware
 ├── _middleware_drain.py         # Drain middleware
@@ -205,6 +258,15 @@ src/notebooklm/
 │   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
 │   ├── psidts_recovery.py       # Inline PSIDTS recovery for cold-start (issue #865)
 │   └── refresh.py               # Token refresh driver (external login cmd, coalesced runs, redaction)
+├── _types/                      # Dataclass implementation package re-exported by types.py
+│   ├── __init__.py
+│   ├── artifacts.py
+│   ├── chat.py
+│   ├── common.py
+│   ├── notebooks.py
+│   ├── notes.py
+│   ├── sharing.py
+│   └── sources.py
 ├── _notebooks.py                # NotebooksAPI
 ├── _sources.py                  # SourcesAPI
 ├── _artifacts.py                # ArtifactsAPI

--- a/docs/adr/0016-auth-identity-and-core-logger-compatibility.md
+++ b/docs/adr/0016-auth-identity-and-core-logger-compatibility.md
@@ -1,0 +1,70 @@
+# ADR-016: Auth Identity and Core Logger Compatibility
+
+## Status
+
+Accepted.
+
+## Context
+
+The session-elimination work moved runtime ownership into
+`NotebookLMClient.__init__`, `ClientComposed`, and direct collaborators. Two
+historical invariants remain load-bearing after that move:
+
+- `NotebookLMClient` and every auth-consuming collaborator must observe the
+  same mutable `AuthTokens` instance. Auth refresh mutates token fields in
+  place, so replacing the object for one consumer would strand the others on
+  stale credentials.
+- The deleted `_core.py` module still has a logging compatibility footprint:
+  downstream tests and user filters match logger name `"notebooklm._core"`.
+  Logger names are strings, not imports, so deleting the module did not make
+  the string safe to rename.
+
+Both rules were previously explained partly in shipped source comments and
+partly in temporary implementation-plan notes. That made future maintenance
+fragile because the source had no stable rationale to cite.
+
+## Decision
+
+**Auth Instance Invariant.** `NotebookLMClient` keeps one authoritative
+`AuthTokens` object at
+`self._auth`, and all collaborators that need auth observe that object rather
+than a copied replacement. Refresh paths update the same object in place.
+
+`CORE_LOGGER_NAME` remains the literal string `"notebooklm._core"` even though
+there is no active `notebooklm._core` compatibility module. Treat the string as
+a public-ish logging contract for filters, `caplog` assertions, and downstream
+diagnostics.
+
+Source comments that need to explain either invariant should cite this ADR
+instead of temporary planning files.
+
+## Consequences
+
+Auth refresh remains identity-sensitive: construction may normalize
+`storage_path` by rebinding the incoming `AuthTokens` before collaborator
+construction, but once `self._auth` is set, runtime collaborators must alias
+that object. Tests that validate auth propagation should assert identity where
+identity is the contract, not only value equality.
+
+Logging refactors must not rename the core logger casually. A future rename
+requires a compatibility plan that preserves or deliberately deprecates filters
+using `"notebooklm._core"`; ordinary module relocation is not enough rationale.
+
+The ADR is intentionally narrow. It does not revive deleted compatibility
+modules, and it does not make `_core` an active import path.
+
+## Alternatives considered
+
+**Let each collaborator own an `AuthTokens` copy.** Rejected because auth
+refresh mutates credentials in place. Copies would make refresh visibility
+depend on which collaborator held which instance, creating stale-cookie and
+stale-CSRF bugs under concurrent use.
+
+**Rename the logger to match the new module layout.** Rejected because the
+logger name has become an observable behavior independent of the deleted
+module. Renaming it would silently disable existing filters and test captures
+without improving runtime isolation.
+
+**Leave the rationale only in source comments.** Rejected because the comments
+need a stable canonical home to cite. The invariant crosses multiple modules
+and should survive future source reshuffles.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ The ADR Index table utilizes four eras of Status notation to reflect the lifecyc
 | [0013](0013-composable-session-capabilities.md)               | Composable Session Capabilities and Feature-Local Runtimes    | Accepted                                                                                                            |
 | [0014](0014-feature-local-runtime-adapters.md)                | Feature-local runtime adapters as Protocol satisfiers         | Accepted (#1082)                                                                                                    |
 | [0015](0015-json-envelope-contract-for-post-parse-click-exceptions.md) | Typed JSON error envelope covers post-parse `ClickException` failures | Accepted                                                                                                            |
+| [0016](0016-auth-identity-and-core-logger-compatibility.md) | Auth identity and core logger compatibility | Accepted                                                                                                            |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,6 +435,20 @@ the executor on direct collaborator dependencies.
 | `_session_init` | [`_session_init.py`](../src/notebooklm/_session_init.py) | Construction-time helpers for `NotebookLMClient`: `validate_constructor_args` (kwarg validation/normalization), `build_collaborators` (the seven collaborators in dependency order: `metrics`, `drain_tracker`, `reqid`, `auth_coord`, `kernel`, `lifecycle`, `cookie_persistence`), `build_session_transport`, `wire_middleware_chain`, and `compose_client_internals`. It binds the runtime graph into `ClientComposed` and returns `ClientInternals(collaborators, executor)`. |
 | `_loop_affinity` | [`_loop_affinity.py`](../src/notebooklm/_loop_affinity.py) | Tiny free-function `assert_bound_loop(bound_loop)` shared by every helper that captures a loop reference at `open()` time (`TransportDrainTracker`, `ReqidCounter`, `AuthRefreshCoordinator`, `ArtifactPollingService`, `ChatAPI`). Enforces ADR-004 without coupling those helpers to the public client. |
 
+### Shipped runtime invariants
+
+[ADR-016](./adr/0016-auth-identity-and-core-logger-compatibility.md)
+pins two compatibility-sensitive details that survive the session-elimination
+work:
+
+- `NotebookLMClient._auth` is the authoritative mutable `AuthTokens`
+  instance. Refresh paths mutate that object in place, and collaborators that
+  observe auth must alias it rather than holding detached copies.
+- `CORE_LOGGER_NAME` intentionally remains the literal
+  `"notebooklm._core"` even though the `_core.py` compatibility module was
+  deleted. Treat it as a logging compatibility contract, not evidence that
+  `notebooklm._core` is an active module.
+
 ## Domain-service collaborators
 
 Beyond the client-owned runtime graph, several feature APIs are implemented via dedicated domain services and helper modules:

--- a/scripts/check_claude_md_freshness.py
+++ b/scripts/check_claude_md_freshness.py
@@ -117,6 +117,13 @@ def _extract_unreasoned_omissions(text: str) -> list[str]:
     return unreasoned
 
 
+def _extract_omission_bullet_path(line: str) -> str | None:
+    match = _OMISSION_PATH_RE.match(line)
+    if match is None:
+        return None
+    return match.group("path").rstrip("/")
+
+
 def _intentional_omissions_section(text: str) -> str:
     section = _section_after_heading(text, _OMISSIONS_HEADING)
     next_heading = re.search(r"^\s*###\s+", section, flags=re.MULTILINE)
@@ -166,9 +173,16 @@ def main(argv: list[str] | None = None) -> int:
     paths = _extract_paths(text)
     omissions = _extract_intentional_omissions(text)
     unreasoned_omissions = _extract_unreasoned_omissions(text)
+    unreasoned_paths = {
+        path for line in unreasoned_omissions if (path := _extract_omission_bullet_path(line))
+    }
     missing = [p for p in paths if not (repo_root / p).exists()]
     top_level_modules = _top_level_notebooklm_modules(repo_root)
-    undocumented = [p for p in top_level_modules if p not in paths and p not in omissions]
+    undocumented = [
+        p
+        for p in top_level_modules
+        if p not in paths and p not in omissions and p not in unreasoned_paths
+    ]
     stale_omissions = [p for p in omissions if not (repo_root / p).exists()]
 
     if missing or undocumented or stale_omissions or unreasoned_omissions:

--- a/scripts/check_claude_md_freshness.py
+++ b/scripts/check_claude_md_freshness.py
@@ -1,22 +1,34 @@
-"""Assert CLAUDE.md repo-structure paths actually exist.
+"""Assert CLAUDE.md repo-structure paths are fresh in both directions.
 
-Prevents silent drift in the hand-maintained file map.
+Prevents silent drift in the hand-maintained file map:
+
+* documented paths must still exist; and
+* direct ``src/notebooklm`` modules/packages must be documented or explicitly
+  omitted with a reason.
 
 Usage:
     python scripts/check_claude_md_freshness.py
     python scripts/check_claude_md_freshness.py --claude-md path/to/CLAUDE.md
 
 Exit codes:
-    0  All listed paths exist.
-    1  One or more paths are missing.
+    0  CLAUDE.md is fresh.
+    1  One or more paths are stale or missing from the map.
     2  Argument error or CLAUDE.md not found.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
+
+_DOCUMENTED_ROOTS = ("src/notebooklm", "tests")
+_OMISSIONS_HEADING = "### Repository Structure Intentional Omissions"
+_OMISSION_BULLET_RE = re.compile(r"^\s*[-*]\s+")
+_IGNORED_PATH_RE = re.compile(
+    r"^\s*[-*]\s+`(?P<path>src/notebooklm/[^`]+)`\s+(?:--|-|:)\s+(?P<reason>.+?)\s*$"
+)
 
 
 def _extract_paths(text: str) -> list[str]:
@@ -65,10 +77,79 @@ def _extract_paths(text: str) -> list[str]:
         stack.append((indent, clean_line))
 
         full_path = "/".join(segment for _, segment in stack)
-        if full_path.startswith(("src/notebooklm", "tests")):
+        if full_path.startswith(_DOCUMENTED_ROOTS):
             paths.append(full_path)
 
     return sorted(set(paths))
+
+
+def _repository_structure_section(text: str) -> str:
+    section = _section_after_heading(text, "### Repository Structure")
+    next_heading = re.search(r"^\s*##\s+", section, flags=re.MULTILINE)
+    if next_heading is not None:
+        section = section[: next_heading.start()]
+    return section
+
+
+def _extract_intentional_omissions(text: str) -> dict[str, str]:
+    """Return intentionally omitted ``src/notebooklm`` paths and their reasons."""
+    omissions: dict[str, str] = {}
+    for line in _intentional_omissions_section(text).splitlines():
+        if "`src/notebooklm/" not in line:
+            continue
+        match = _IGNORED_PATH_RE.match(line)
+        if match is None:
+            continue
+        path = match.group("path").rstrip("/")
+        reason = match.group("reason").strip()
+        if reason:
+            omissions[path] = reason
+    return omissions
+
+
+def _extract_unreasoned_omissions(text: str) -> list[str]:
+    """Return omission bullets that mention a path but do not provide a reason."""
+    unreasoned: list[str] = []
+    for line in _intentional_omissions_section(text).splitlines():
+        if (
+            _OMISSION_BULLET_RE.match(line)
+            and "`src/notebooklm/" in line
+            and _IGNORED_PATH_RE.match(line) is None
+        ):
+            unreasoned.append(line.strip())
+    return unreasoned
+
+
+def _intentional_omissions_section(text: str) -> str:
+    section = _section_after_heading(text, _OMISSIONS_HEADING)
+    next_heading = re.search(r"^\s*###\s+", section, flags=re.MULTILINE)
+    if next_heading is not None:
+        section = section[: next_heading.start()]
+    return section
+
+
+def _section_after_heading(text: str, heading: str) -> str:
+    match = re.search(rf"^\s*{re.escape(heading)}\s*$", text, flags=re.MULTILINE)
+    if match is None:
+        return ""
+    return text[match.end() :]
+
+
+def _top_level_notebooklm_modules(repo_root: Path) -> list[str]:
+    """Return direct ``src/notebooklm`` Python modules and packages."""
+    package_root = repo_root / "src" / "notebooklm"
+    if not package_root.is_dir():
+        return []
+
+    paths: list[str] = []
+    for child in package_root.iterdir():
+        if child.name == "__pycache__":
+            continue
+        if (child.is_file() and child.suffix == ".py") or (
+            child.is_dir() and (child / "__init__.py").is_file()
+        ):
+            paths.append(child.relative_to(repo_root).as_posix())
+    return sorted(paths)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -83,22 +164,39 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     repo_root = Path(args.repo_root).resolve()
-    text = claude.read_text(encoding="utf-8")
-
-    # Only look at the Repository Structure section
-    if "### Repository Structure" in text:
-        text = text.split("### Repository Structure", 1)[1]
-        if "## " in text:
-            text = text.split("## ", 1)[0]
+    text = _repository_structure_section(claude.read_text(encoding="utf-8"))
 
     paths = _extract_paths(text)
+    omissions = _extract_intentional_omissions(text)
+    unreasoned_omissions = _extract_unreasoned_omissions(text)
     missing = [p for p in paths if not (repo_root / p).exists()]
-    if missing:
-        print("Stale CLAUDE.md path references:", file=sys.stderr)
-        for p in missing:
-            print(f"  {p}", file=sys.stderr)
+    top_level_modules = _top_level_notebooklm_modules(repo_root)
+    undocumented = [p for p in top_level_modules if p not in paths and p not in omissions]
+    stale_omissions = [p for p in omissions if not (repo_root / p).exists()]
+
+    if missing or undocumented or stale_omissions or unreasoned_omissions:
+        if missing:
+            print("Stale CLAUDE.md path references:", file=sys.stderr)
+            for p in missing:
+                print(f"  {p}", file=sys.stderr)
+        if undocumented:
+            print("Undocumented top-level src/notebooklm modules/packages:", file=sys.stderr)
+            for p in undocumented:
+                print(f"  {p}", file=sys.stderr)
+        if stale_omissions:
+            print("Stale CLAUDE.md intentional omissions:", file=sys.stderr)
+            for p in stale_omissions:
+                print(f"  {p}", file=sys.stderr)
+        if unreasoned_omissions:
+            print("Intentional omissions without parseable reasons:", file=sys.stderr)
+            for line in unreasoned_omissions:
+                print(f"  {line}", file=sys.stderr)
         return 1
-    print(f"OK: all {len(paths)} CLAUDE.md path references resolve")
+    print(
+        f"OK: {len(paths)} documented paths resolve; "
+        f"{len(top_level_modules)} top-level modules/packages "
+        f"are documented or intentionally omitted"
+    )
     return 0
 
 

--- a/scripts/check_claude_md_freshness.py
+++ b/scripts/check_claude_md_freshness.py
@@ -26,6 +26,7 @@ from pathlib import Path
 _DOCUMENTED_ROOTS = ("src/notebooklm", "tests")
 _OMISSIONS_HEADING = "### Repository Structure Intentional Omissions"
 _OMISSION_BULLET_RE = re.compile(r"^\s*[-*]\s+")
+_OMISSION_PATH_RE = re.compile(r"^\s*[-*]\s+`(?P<path>src/notebooklm/[^`]+)`")
 _IGNORED_PATH_RE = re.compile(
     r"^\s*[-*]\s+`(?P<path>src/notebooklm/[^`]+)`\s+(?:--|-|:)\s+(?P<reason>.+?)\s*$"
 )
@@ -111,11 +112,7 @@ def _extract_unreasoned_omissions(text: str) -> list[str]:
     """Return omission bullets that mention a path but do not provide a reason."""
     unreasoned: list[str] = []
     for line in _intentional_omissions_section(text).splitlines():
-        if (
-            _OMISSION_BULLET_RE.match(line)
-            and "`src/notebooklm/" in line
-            and _IGNORED_PATH_RE.match(line) is None
-        ):
+        if _OMISSION_PATH_RE.match(line) and _IGNORED_PATH_RE.match(line) is None:
             unreasoned.append(line.strip())
     return unreasoned
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -232,19 +232,16 @@ class NotebookLMClient:
         # captures the same (possibly rebound) instance that
         # :func:`compose_client_internals` then propagates into
         # :class:`CookiePersistence`, the snapshot-provider lambdas,
-        # and :class:`SourceUploadPipeline`. The Auth Instance
-        # Invariant (see
-        # ``.sisyphus/phases/host-protocol-removal/phase-1.md``) requires that
-        # every reference across the live object graph alias this exact same
-        # mutable object so :meth:`AuthRefreshCoordinator.update_auth_tokens`
-        # in-place mutations are observed everywhere.
+        # and :class:`SourceUploadPipeline`. ADR-016's Auth Instance
+        # Invariant requires every reference across the live object graph
+        # to alias this exact same mutable object so
+        # :meth:`AuthRefreshCoordinator.update_auth_tokens` in-place
+        # mutations are observed everywhere.
         #
-        # Wave 0 of the host-protocol-removal plan introduced this field;
-        # Wave 2 wired ``refresh_auth()`` to read it; Wave 3 (this PR)
-        # rewired the public ``auth`` property and the
-        # ``SourceUploadPipeline(auth=...)`` constructor argument to back
-        # off this field instead of dereferencing
-        # the former Session-owned auth reference. The client shell helper
+        # ``refresh_auth()``, the public ``auth`` property, and the
+        # ``SourceUploadPipeline(auth=...)`` constructor argument all back
+        # off this field instead of any former Session-owned auth
+        # reference. The client shell helper
         # (``tests/_helpers/client_factory.build_client_shell_for_tests``)
         # mirrors the production attribute shape so tests exercise the
         # same code path as production.
@@ -359,13 +356,10 @@ class NotebookLMClient:
             drain=internals.collaborators.drain_tracker,
             lifecycle=internals.collaborators.lifecycle,
             kernel=internals.collaborators.kernel,
-            # Wave 3 of plan ``host-protocol-removal``: the upload
-            # pipeline now reads the client-owned ``self._auth``
-            # reference set above instead of dereferencing
-            # the former Session-owned auth reference. The Auth Instance
-            # Invariant keeps this aliased across all auth consumers, so
-            # production refresh-time mutation is observed by the
-            # uploader unchanged.
+            # ADR-016's Auth Instance Invariant: the upload pipeline
+            # reads the client-owned ``self._auth`` reference set above
+            # instead of a detached auth copy. Production refresh-time
+            # mutation is therefore observed by the uploader unchanged.
             auth=self._auth,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
@@ -442,12 +436,9 @@ class NotebookLMClient:
     def auth(self) -> AuthTokens:
         """Get the authentication tokens.
 
-        Wave 3 of plan ``host-protocol-removal`` rewired this property
-        to read the client-owned ``self._auth`` reference set in
-        :meth:`__init__`. The Auth Instance Invariant (see
-        ``.sisyphus/phases/host-protocol-removal/phase-1.md``) requires
-        that every reference across the live object graph alias this
-        exact same mutable :class:`AuthTokens` object, so the public
+        ADR-016's Auth Instance Invariant requires every reference across
+        the live object graph to alias the same mutable
+        :class:`AuthTokens` object set in :meth:`__init__`, so the public
         ``client.auth`` identity and behavior are unchanged.
         """
         return self._auth

--- a/tests/unit/test_claude_md_freshness.py
+++ b/tests/unit/test_claude_md_freshness.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from scripts.check_claude_md_freshness import (
     _extract_intentional_omissions,
     _extract_paths,
+    _extract_unreasoned_omissions,
     _repository_structure_section,
     main,
 )
@@ -63,6 +64,19 @@ def test_extract_intentional_omissions_requires_reason():
     assert _extract_intentional_omissions(text) == {
         "src/notebooklm/_compat.py": "Transitional compatibility shim."
     }
+
+
+def test_extract_unreasoned_omissions_ignores_general_notes():
+    text = """
+    ### Repository Structure Intentional Omissions
+
+    - Note: omit `src/notebooklm/_small_helper.py` because it is small.
+    - `src/notebooklm/_missing_reason.py`
+    """
+
+    assert _extract_unreasoned_omissions(text) == [
+        "- `src/notebooklm/_missing_reason.py`"
+    ]
 
 
 def test_repository_structure_heading_must_match_exactly():

--- a/tests/unit/test_claude_md_freshness.py
+++ b/tests/unit/test_claude_md_freshness.py
@@ -6,7 +6,12 @@ import pytest
 # Add project root to sys.path so we can import scripts
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from scripts.check_claude_md_freshness import _extract_paths, main
+from scripts.check_claude_md_freshness import (
+    _extract_intentional_omissions,
+    _extract_paths,
+    _repository_structure_section,
+    main,
+)
 
 pytestmark = pytest.mark.repo_lint
 
@@ -30,9 +35,7 @@ def test_extract_paths():
     assert "src/notebooklm/rpc/types.py" in paths
     assert "src/notebooklm/cli" in paths
     assert "src/notebooklm/cli/helpers.py" in paths
-    # tests/unit/test_cli.py is not in the tree format in this snippet but should work if it matches line.startswith
-    # Wait, my refined extractor only handles tree markers or lines starting with src/notebooklm
-    # I should add tests/ to that as well.
+    assert "tests/unit/test_cli.py" in paths
 
 
 def test_extract_paths_with_tests():
@@ -45,8 +48,38 @@ def test_extract_paths_with_tests():
     paths = _extract_paths(text)
     assert "src/notebooklm" in paths
     assert "src/notebooklm/__init__.py" in paths
-    # assert "tests" in paths # Actually it depends on if it starts with tests/
-    # Let's check my logic.
+    assert "tests" in paths
+    assert "tests/conftest.py" in paths
+
+
+def test_extract_intentional_omissions_requires_reason():
+    text = """
+    ### Repository Structure Intentional Omissions
+
+    - `src/notebooklm/_compat.py` - Transitional compatibility shim.
+    - `src/notebooklm/_missing_reason.py`
+    """
+
+    assert _extract_intentional_omissions(text) == {
+        "src/notebooklm/_compat.py": "Transitional compatibility shim."
+    }
+
+
+def test_repository_structure_heading_must_match_exactly():
+    text = """
+    ### Repository Structure Intentional Omissions
+
+    - `src/notebooklm/not_a_documented_path.py` - This section appears first.
+
+    ### Repository Structure
+
+    src/notebooklm/
+    ├── __init__.py
+    """
+
+    paths = _extract_paths(_repository_structure_section(text))
+    assert "src/notebooklm/__init__.py" in paths
+    assert "src/notebooklm/not_a_documented_path.py" not in paths
 
 
 def test_main_success(tmp_path):
@@ -54,12 +87,24 @@ def test_main_success(tmp_path):
     repo.mkdir()
     (repo / "src/notebooklm").mkdir(parents=True)
     (repo / "src/notebooklm/__init__.py").touch()
+    (repo / "src/notebooklm/client.py").touch()
+    (repo / "src/notebooklm/_small_helper.py").touch()
 
     claude_md = repo / "CLAUDE.md"
     # Explicit utf-8 — the tree-decoration chars `├──` / `│` are outside
     # cp1252 and Windows CI would otherwise crash with UnicodeEncodeError.
     claude_md.write_text(
-        "### Repository Structure\n\nsrc/notebooklm/\n├── __init__.py",
+        """
+        ### Repository Structure
+
+        src/notebooklm/
+        ├── __init__.py
+        ├── client.py
+
+        ### Repository Structure Intentional Omissions
+
+        - `src/notebooklm/_small_helper.py` - Small helper covered by client.py.
+        """,
         encoding="utf-8",
     )
 
@@ -74,6 +119,75 @@ def test_main_failure(tmp_path):
     claude_md = repo / "CLAUDE.md"
     claude_md.write_text(
         "### Repository Structure\n\nsrc/notebooklm/\n├── nonexistent.py",
+        encoding="utf-8",
+    )
+
+    assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 1
+
+
+def test_main_fails_for_undocumented_top_level_module(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src/notebooklm").mkdir(parents=True)
+    (repo / "src/notebooklm/__init__.py").touch()
+    (repo / "src/notebooklm/_new_important_module.py").touch()
+
+    claude_md = repo / "CLAUDE.md"
+    claude_md.write_text(
+        "### Repository Structure\n\nsrc/notebooklm/\n├── __init__.py",
+        encoding="utf-8",
+    )
+
+    assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 1
+
+
+def test_main_allows_intentional_omission_with_reason(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src/notebooklm").mkdir(parents=True)
+    (repo / "src/notebooklm/__init__.py").touch()
+    (repo / "src/notebooklm/_small_helper.py").touch()
+
+    claude_md = repo / "CLAUDE.md"
+    claude_md.write_text(
+        """
+        ### Repository Structure
+
+        src/notebooklm/
+        ├── __init__.py
+
+        ### Repository Structure Intentional Omissions
+
+        These helpers from `src/notebooklm/` are intentionally omitted
+        when a subsystem row already covers them:
+
+        - `src/notebooklm/_small_helper.py` - Small helper covered by the subsystem row.
+        """,
+        encoding="utf-8",
+    )
+
+    assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 0
+
+
+def test_main_fails_for_intentional_omission_without_reason(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src/notebooklm").mkdir(parents=True)
+    (repo / "src/notebooklm/__init__.py").touch()
+    (repo / "src/notebooklm/_small_helper.py").touch()
+
+    claude_md = repo / "CLAUDE.md"
+    claude_md.write_text(
+        """
+        ### Repository Structure
+
+        src/notebooklm/
+        ├── __init__.py
+
+        ### Repository Structure Intentional Omissions
+
+        - `src/notebooklm/_small_helper.py`
+        """,
         encoding="utf-8",
     )
 

--- a/tests/unit/test_claude_md_freshness.py
+++ b/tests/unit/test_claude_md_freshness.py
@@ -74,9 +74,7 @@ def test_extract_unreasoned_omissions_ignores_general_notes():
     - `src/notebooklm/_missing_reason.py`
     """
 
-    assert _extract_unreasoned_omissions(text) == [
-        "- `src/notebooklm/_missing_reason.py`"
-    ]
+    assert _extract_unreasoned_omissions(text) == ["- `src/notebooklm/_missing_reason.py`"]
 
 
 def test_repository_structure_heading_must_match_exactly():
@@ -201,6 +199,30 @@ def test_main_fails_for_intentional_omission_without_reason(tmp_path):
         ### Repository Structure Intentional Omissions
 
         - `src/notebooklm/_small_helper.py`
+        """,
+        encoding="utf-8",
+    )
+
+    assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 1
+
+
+def test_main_fails_for_stale_intentional_omission(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src/notebooklm").mkdir(parents=True)
+    (repo / "src/notebooklm/__init__.py").touch()
+
+    claude_md = repo / "CLAUDE.md"
+    claude_md.write_text(
+        """
+        ### Repository Structure
+
+        src/notebooklm/
+        ├── __init__.py
+
+        ### Repository Structure Intentional Omissions
+
+        - `src/notebooklm/_deleted_helper.py` - Deleted helper retained by mistake.
         """,
         encoding="utf-8",
     )

--- a/tests/unit/test_claude_md_freshness.py
+++ b/tests/unit/test_claude_md_freshness.py
@@ -206,6 +206,34 @@ def test_main_fails_for_intentional_omission_without_reason(tmp_path):
     assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 1
 
 
+def test_main_does_not_double_report_unreasoned_omission(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src/notebooklm").mkdir(parents=True)
+    (repo / "src/notebooklm/__init__.py").touch()
+    (repo / "src/notebooklm/_small_helper.py").touch()
+
+    claude_md = repo / "CLAUDE.md"
+    claude_md.write_text(
+        """
+        ### Repository Structure
+
+        src/notebooklm/
+        ├── __init__.py
+
+        ### Repository Structure Intentional Omissions
+
+        - `src/notebooklm/_small_helper.py`
+        """,
+        encoding="utf-8",
+    )
+
+    assert main(["--claude-md", str(claude_md), "--repo-root", str(repo)]) == 1
+    captured = capsys.readouterr()
+    assert "Intentional omissions without parseable reasons:" in captured.err
+    assert "Undocumented top-level src/notebooklm modules/packages:" not in captured.err
+
+
 def test_main_fails_for_stale_intentional_omission(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- make CLAUDE.md freshness bidirectional for documented paths and direct src/notebooklm modules/packages
- document active runtime/public modules plus ADR-016 for auth identity and core logger compatibility invariants
- replace shipped client.py .sisyphus invariant references with ADR-016

## Test plan
- [x] uv run pytest tests/unit/test_claude_md_freshness.py -q
- [x] uv run python scripts/check_claude_md_freshness.py
- [x] uv run pytest tests/_lint -q
- [x] uv run ruff check scripts/check_claude_md_freshness.py tests/unit/test_claude_md_freshness.py

## Deferred polish findings
None.

Note: execute-task polish did not run agy/Antigravity because this task explicitly forbids invoking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record defining runtime compatibility guarantees for authentication and logging; refreshed repository architecture and module-layout guidance and client usage notes (documentation-only).

* **Chores**
  * Expanded the repository-structure guidance and clarified public entrypoints and type/utility surface descriptions.

* **Tests**
  * Added and expanded unit/integration tests around the documentation freshness checker and repository-structure validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->