### PR TITLE
refactor(cli): drain source service boundaries

### DIFF
--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -331,6 +331,7 @@ def artifact_delete(ctx, artifact_id, notebook_id, yes, json_output, client_auth
                 return
 
             if json_output:
+                json_output_response(result.payload)
                 return
 
             resolved_id = result.resolved["artifact_id"]

--- a/src/notebooklm/cli/note_cmd.py
+++ b/src/notebooklm/cli/note_cmd.py
@@ -461,6 +461,7 @@ def note_delete(ctx, note_id, notebook_id, yes, json_output, client_auth):
                 return
 
             if json_output:
+                json_output_response(result.payload)
                 return
 
             resolved_id = result.resolved["note_id"]

--- a/src/notebooklm/cli/services/confirming_mutation.py
+++ b/src/notebooklm/cli/services/confirming_mutation.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, Generic, Literal, TypeVar
 
 from ...client import NotebookLMClient
-from ..rendering import json_output_response
 
 ResolvedT = TypeVar("ResolvedT")
 MutationStatus = Literal["cancelled", "completed"]
@@ -59,8 +58,6 @@ async def run_confirmed_mutation(
 
     await plan.execute(client, resolved)
     payload = plan.serialize_success(resolved)
-    if json_output:
-        json_output_response(payload)
     return MutationResult(
         entity_label=plan.entity_label,
         resolved=resolved,

--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -6,23 +6,17 @@ continues to pass caller-supplied URLs through to NotebookLM unchanged.
 
 from __future__ import annotations
 
-import contextlib
 import ipaddress
 import socket
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import Literal, Protocol
 from urllib.parse import urlsplit
 
 from ...types import Source
 from ...urls import is_youtube_url
 from .source_serializers import source_summary_payload
-
-if TYPE_CHECKING:
-    import click
-
-    from ...client import NotebookLMClient
 
 SourceAddType = Literal["url", "text", "file", "youtube"]
 
@@ -326,7 +320,7 @@ async def add_source(
 
 @dataclass(frozen=True)
 class SourceAddExecutionPlan:
-    """Click-shaped inputs for ``execute_source_add``.
+    """Prepared inputs for ``execute_source_add``.
 
     Distinct from :class:`SourceAddPlan` (which captures the detected source
     type + warnings produced by :func:`build_source_add_plan`). This wraps
@@ -336,43 +330,32 @@ class SourceAddExecutionPlan:
 
     notebook_id: str
     plan: SourceAddPlan
-    json_output: bool
+
+
+@dataclass(frozen=True)
+class SourceAddResult:
+    """Result of adding a source."""
+
+    source: Source
+
+    def payload(self) -> dict[str, object]:
+        """Return the JSON payload for ``source add``."""
+        return {"source": source_summary_payload(self.source)}
 
 
 async def execute_source_add(
-    client: NotebookLMClient,
+    client,
     plan: SourceAddExecutionPlan,
-    *,
-    ctx: click.Context | None = None,
-) -> None:
-    """Run the ``source add`` workflow with spinner + JSON / text rendering.
+) -> SourceAddResult:
+    """Run the ``source add`` workflow and return the added source.
 
-    P1.T2 bug 5: ``rich.console.Console.status`` is a SYNCHRONOUS context
-    manager. The pre-fix shape ``with console.status(...): return _run()``
-    exited the spinner as soon as ``_run()`` returned the coroutine — BEFORE
-    ``with_client`` awaited it — so the spinner was effectively invisible
-    during the actual upload. The ``with`` block here lives inside the
-    awaited coroutine so the spinner spans the real I/O. JSON mode still
-    suppresses the spinner so stdout stays pure JSON.
+    Presentation concerns such as spinners, JSON envelopes, and success
+    messages belong to the command layer. The command wraps this awaitable
+    with the desired status context so the spinner still spans the real I/O.
     """
-    # Local imports keep this service module free of CLI-only top-level deps
-    # so importing it does not pull in click for non-CLI consumers.
-    from ..rendering import cli_print, console, json_output_response
-
-    spinner = (
-        contextlib.nullcontext()
-        if plan.json_output
-        else console.status(f"Adding {plan.plan.detected_type} source...")
+    src = await add_source(
+        client.sources,
+        notebook_id=plan.notebook_id,
+        plan=plan.plan,
     )
-    with spinner:
-        src = await add_source(
-            client.sources,
-            notebook_id=plan.notebook_id,
-            plan=plan.plan,
-        )
-
-    if plan.json_output:
-        json_output_response({"source": source_summary_payload(src)})
-        return
-
-    cli_print(f"[green]Added source:[/green] {src.id}", ctx=ctx)
+    return SourceAddResult(source=src)

--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -11,12 +11,15 @@ import socket
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 from urllib.parse import urlsplit
 
 from ...types import Source
 from ...urls import is_youtube_url
 from .source_serializers import source_summary_payload
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 SourceAddType = Literal["url", "text", "file", "youtube"]
 
@@ -344,7 +347,7 @@ class SourceAddResult:
 
 
 async def execute_source_add(
-    client,
+    client: NotebookLMClient,
     plan: SourceAddExecutionPlan,
 ) -> SourceAddResult:
     """Run the ``source add`` workflow and return the added source.

--- a/src/notebooklm/cli/services/source_add.py
+++ b/src/notebooklm/cli/services/source_add.py
@@ -341,6 +341,7 @@ class SourceAddResult:
 
     source: Source
 
+    @property
     def payload(self) -> dict[str, object]:
         """Return the JSON payload for ``source add``."""
         return {"source": source_summary_payload(self.source)}

--- a/src/notebooklm/cli/services/source_listing.py
+++ b/src/notebooklm/cli/services/source_listing.py
@@ -1,20 +1,20 @@
-"""Service for ``source list`` — fetch + render the source table.
+"""Service for ``source list`` — fetch + prepare the source list payload.
 
 Composes :class:`~notebooklm.cli.services.listing.ListSpec` so the Click
 handler in ``cli/source_cmd.py`` collapses to a one-call wrapper. The
-extracted executor stays a thin facade over the shared listing pipeline —
-all envelope-extras and column logic live here so the handler does not
-need to know how Rich tables or JSON envelopes are assembled.
+extracted executor stays a thin facade over the shared listing pipeline.
+Envelope-extras and column-row data live here, while actual JSON / Rich
+rendering stays in the command layer.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ...types import Source, source_status_to_str
-from ..rendering import get_source_type_display, render_list
-from .listing import ListResult, ListSpec, prepare_list
+from ...types import Source, SourceType, source_status_to_str
+from .listing import ListRender, ListSpec, prepare_list
 from .source_serializers import source_summary_payload
 
 if TYPE_CHECKING:
@@ -29,9 +29,10 @@ class SourceListPlan:
     json_output: bool
     limit: int | None
     no_truncate: bool
+    source_type_display: Callable[[SourceType], str]
 
 
-def _build_spec() -> ListSpec[Source]:
+def _build_spec(source_type_display: Callable[[SourceType], str]) -> ListSpec[Source]:
     """Build the ``ListSpec`` for ``source list``.
 
     Factored out of ``execute_source_list`` so unit tests can introspect
@@ -57,7 +58,7 @@ def _build_spec() -> ListSpec[Source]:
         row=lambda src: [
             src.id,
             src.title or "-",
-            get_source_type_display(src.kind),
+            source_type_display(src.kind),
             src.created_at.strftime("%Y-%m-%d %H:%M") if src.created_at else "-",
             source_status_to_str(src.status),
         ],
@@ -65,10 +66,10 @@ def _build_spec() -> ListSpec[Source]:
     )
 
 
-async def execute_source_list(client: NotebookLMClient, plan: SourceListPlan) -> ListResult[Source]:
-    """Fetch + render the source list per the prepared plan."""
-    spec = _build_spec()
-    render = await prepare_list(
+async def execute_source_list(client: NotebookLMClient, plan: SourceListPlan) -> ListRender[Source]:
+    """Fetch and prepare the source list render payload."""
+    spec = _build_spec(plan.source_type_display)
+    return await prepare_list(
         spec,
         client,
         notebook_id=plan.notebook_id,
@@ -76,8 +77,6 @@ async def execute_source_list(client: NotebookLMClient, plan: SourceListPlan) ->
         json_output=plan.json_output,
         no_truncate=plan.no_truncate,
     )
-    render_list(render)
-    return render.to_list_result()
 
 
 __all__ = ["SourceListPlan", "execute_source_list"]

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -3,29 +3,21 @@
 Each command has its own plan + executor pair. The shared resolver
 helpers (``resolve_source_for_delete``, ``resolve_source_by_exact_title``,
 ``require_yes_in_json``) also live here because they are mutation-specific
-and were previously private helpers on ``cli/source_cmd.py``. The
+and were previously private helpers on ``cli/source_cmd.py``. Typed result
+dataclasses carry presentation payloads back to the command layer. The
 :class:`MutationPlan` pipeline from
 ``cli/services/confirming_mutation.py`` handles the resolve → confirm →
-execute → serialize flow for the destructive paths.
+execute → serialize flow for the destructive paths without printing.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-import click
-
-from ...types import DriveMimeType
-from ..error_handler import output_error
-from ..rendering import (
-    cli_print,
-    cli_status,
-    console,
-    emit_status,
-    json_output_response,
-)
+from ...types import DriveMimeType, Source
 from ..resolve import resolve_source_id, validate_id
 from .confirming_mutation import MutationPlan, run_confirmed_mutation
 from .source_serializers import source_summary_payload
@@ -34,6 +26,151 @@ if TYPE_CHECKING:
     from ...client import NotebookLMClient
 
 DriveMimeChoice = Literal["google-doc", "google-slides", "google-sheets", "pdf"]
+
+
+@dataclass(frozen=True)
+class SourceMutationError(Exception):
+    """Typed source-mutation error for command-layer rendering and exit policy."""
+
+    message: str
+    code: str
+    extra: dict[str, Any] | None = None
+    status_message: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True)
+class SourceIdResolution:
+    """Resolved source-id data plus optional status prose for the command layer."""
+
+    source_id: str
+    status_message: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceDeleteResult:
+    """Outcome of ``source delete``."""
+
+    source_id: str
+    notebook_id: str
+    success: bool
+    status: Literal["completed", "cancelled"]
+    status_message: str | None = None
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "delete",
+            "source_id": self.source_id,
+            "notebook_id": self.notebook_id,
+            "success": self.success,
+            "status": (
+                "cancelled"
+                if self.status == "cancelled"
+                else ("deleted" if self.success else "unknown")
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class SourceDeleteByTitleResult:
+    """Outcome of ``source delete-by-title``."""
+
+    source_id: str
+    title: str
+    notebook_id: str
+    success: bool
+    status: Literal["completed", "cancelled"]
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "delete-by-title",
+            "source_id": self.source_id,
+            "title": self.title,
+            "notebook_id": self.notebook_id,
+            "success": self.success,
+            "status": (
+                "cancelled"
+                if self.status == "cancelled"
+                else ("deleted" if self.success else "unknown")
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class SourceRenameResult:
+    """Outcome of ``source rename``."""
+
+    source: Source
+    notebook_id: str
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "rename",
+            "source_id": self.source.id,
+            "notebook_id": self.notebook_id,
+            "title": self.source.title,
+            "status": "renamed",
+        }
+
+
+@dataclass(frozen=True)
+class SourceRefreshResult:
+    """Outcome of ``source refresh``."""
+
+    source_id: str
+    notebook_id: str
+    result: Source | bool | None
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        if self.result and self.result is not True:
+            return {
+                "action": "refresh",
+                "source_id": self.result.id,
+                "notebook_id": self.notebook_id,
+                "title": self.result.title,
+                "status": "refreshed",
+            }
+        if self.result is True:
+            return {
+                "action": "refresh",
+                "source_id": self.source_id,
+                "notebook_id": self.notebook_id,
+                "status": "refreshed",
+            }
+        return {
+            "action": "refresh",
+            "source_id": self.source_id,
+            "notebook_id": self.notebook_id,
+            "status": "no_result",
+        }
+
+
+@dataclass(frozen=True)
+class SourceAddDriveResult:
+    """Outcome of ``source add-drive``."""
+
+    source: Source
+    notebook_id: str
+    file_id: str
+    mime_type: DriveMimeChoice
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "add-drive",
+            "source": {
+                **source_summary_payload(self.source),
+                "drive_file_id": self.file_id,
+                "mime_type": self.mime_type,
+            },
+            "notebook_id": self.notebook_id,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -65,38 +202,32 @@ def looks_like_full_source_id(source_id: str) -> bool:
 
 async def resolve_source_for_delete(
     client, notebook_id: str, source_id: str, *, json_output: bool = False
-) -> str:
+) -> SourceIdResolution:
     """Resolve a source ID for delete, returning the full source ID string.
 
     Canonical UUIDs take a fast path and skip the live source list
-    lookup. Partial IDs are resolved against the live list. When
-    ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
+    lookup. Partial IDs are resolved against the live list. Successful
+    partial matches return status prose for the command layer to emit.
     """
     source_id = validate_id(source_id, "source")
     if looks_like_full_source_id(source_id):
-        return source_id
+        return SourceIdResolution(source_id=source_id)
 
     sources = await client.sources.list(notebook_id)
     matches = [item for item in sources if item.id.lower().startswith(source_id.lower())]
 
     if len(matches) == 1:
+        status_message = None
         if matches[0].id != source_id:
             title = matches[0].title or "(untitled)"
-            emit_status(
-                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
-                json_output=json_output,
-            )
-        return matches[0].id
+            status_message = f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]"
+        return SourceIdResolution(source_id=matches[0].id, status_message=status_message)
 
     if len(matches) > 1:
-        output_error(
+        raise SourceMutationError(
             build_id_ambiguity_error(source_id, matches),
             "AMBIGUOUS_ID",
-            json_output,
-            1,
         )
-        raise AssertionError("unreachable")  # pragma: no cover
 
     title_matches = [item for item in sources if item.title == source_id]
     if title_matches:
@@ -108,17 +239,13 @@ async def resolve_source_for_delete(
             lines.append(f"  {item.id[:12]}... {item.title}")
         if len(title_matches) > 5:
             lines.append(f"  ... and {len(title_matches) - 5} more")
-        output_error("\n".join(lines), "VALIDATION_ERROR", json_output, 1)
-        raise AssertionError("unreachable")  # pragma: no cover
+        raise SourceMutationError("\n".join(lines), "VALIDATION_ERROR")
 
-    output_error(
+    raise SourceMutationError(
         f"No source found starting with '{source_id}'. "
         "Run 'notebooklm source list' to see available sources.",
         "NOT_FOUND",
-        json_output,
-        1,
     )
-    raise AssertionError("unreachable")  # pragma: no cover
 
 
 async def resolve_source_by_exact_title(
@@ -138,37 +265,37 @@ async def resolve_source_by_exact_title(
             lines.append(f"  {item.id[:12]}... {item.title}")
         if len(matches) > 5:
             lines.append(f"  ... and {len(matches) - 5} more")
-        output_error("\n".join(lines), "AMBIGUOUS_TITLE", json_output, 1)
+        raise SourceMutationError("\n".join(lines), "AMBIGUOUS_TITLE")
 
-    output_error(
+    raise SourceMutationError(
         f"No source found with title '{title}'. "
         "Run 'notebooklm source list' to see available sources.",
         "NOT_FOUND",
-        json_output,
-        1,
     )
-    raise AssertionError("unreachable")  # pragma: no cover
 
 
-def require_yes_in_json(*, action: str, extra: dict[str, Any] | None = None) -> None:
-    """Emit a structured ``CONFIRM_REQUIRED`` error and exit non-zero.
+def require_yes_in_json(
+    *,
+    action: str,
+    extra: dict[str, Any] | None = None,
+    status_message: str | None = None,
+) -> None:
+    """Raise a typed ``CONFIRM_REQUIRED`` error for command-layer handling.
 
     Centralises the JSON-mode confirmation gate used by destructive
     commands (``source delete``, ``source delete-by-title``, ``source
-    clean``). Calling this helper always raises ``SystemExit(1)`` via
-    :func:`output_error` — it never returns normally.
+    clean``). Calling this helper always raises a typed error for the
+    command layer; it never returns normally.
     """
     payload: dict[str, Any] = {"action": action}
     if extra:
         payload.update(extra)
-    output_error(
+    raise SourceMutationError(
         "Pass --yes to confirm destructive operation in --json mode",
-        code="CONFIRM_REQUIRED",
-        json_output=True,
-        exit_code=1,
-        extra=payload,
+        "CONFIRM_REQUIRED",
+        payload,
+        status_message,
     )
-    raise AssertionError("unreachable")  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------
@@ -187,12 +314,15 @@ class SourceDeletePlan:
 
 
 async def execute_source_delete(
-    client: NotebookLMClient, plan: SourceDeletePlan, *, ctx: click.Context | None = None
-) -> None:
+    client: NotebookLMClient,
+    plan: SourceDeletePlan,
+    *,
+    confirmer: Callable[[str], bool],
+) -> SourceDeleteResult:
     """Resolve + confirm + delete a single source by id or partial id."""
 
     async def resolve_delete(client):
-        resolved_id = await resolve_source_for_delete(
+        resolution = await resolve_source_for_delete(
             client, plan.notebook_id, plan.source_id, json_output=plan.json_output
         )
         # P1.T2 bug 1: In --json mode, never prompt — automation cannot
@@ -202,14 +332,16 @@ async def execute_source_delete(
             require_yes_in_json(
                 action="delete",
                 extra={
-                    "source_id": resolved_id,
+                    "source_id": resolution.source_id,
                     "notebook_id": plan.notebook_id,
                 },
+                status_message=resolution.status_message,
             )
         return {
             "notebook_id": plan.notebook_id,
-            "source_id": resolved_id,
+            "source_id": resolution.source_id,
             "success": False,
+            "status_message": resolution.status_message,
         }
 
     async def execute_delete(client, resolved):
@@ -245,17 +377,15 @@ async def execute_source_delete(
         client,
         yes=plan.yes,
         json_output=plan.json_output,
-        confirmer=click.confirm,
+        confirmer=confirmer,
     )
-    if result.status == "cancelled" or plan.json_output:
-        return
-
-    resolved_id = result.resolved["source_id"]
-    success = bool(result.resolved["success"])
-    if success:
-        cli_print(f"[green]Deleted source:[/green] {resolved_id}", ctx=ctx)
-    else:
-        cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
+    return SourceDeleteResult(
+        source_id=result.resolved["source_id"],
+        notebook_id=result.resolved["notebook_id"],
+        success=bool(result.resolved["success"]),
+        status=result.status,
+        status_message=result.resolved.get("status_message"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -277,8 +407,8 @@ async def execute_source_delete_by_title(
     client: NotebookLMClient,
     plan: SourceDeleteByTitlePlan,
     *,
-    ctx: click.Context | None = None,
-) -> None:
+    confirmer: Callable[[str], bool],
+) -> SourceDeleteByTitleResult:
     """Resolve + confirm + delete a source by exact title."""
 
     async def resolve_delete_by_title(client):
@@ -337,17 +467,15 @@ async def execute_source_delete_by_title(
         client,
         yes=plan.yes,
         json_output=plan.json_output,
-        confirmer=click.confirm,
+        confirmer=confirmer,
     )
-    if result.status == "cancelled" or plan.json_output:
-        return
-
-    source_id = result.resolved["source_id"]
-    success = bool(result.resolved["success"])
-    if success:
-        cli_print(f"[green]Deleted source:[/green] {source_id}", ctx=ctx)
-    else:
-        cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
+    return SourceDeleteByTitleResult(
+        source_id=result.resolved["source_id"],
+        title=result.resolved["title"],
+        notebook_id=result.resolved["notebook_id"],
+        success=bool(result.resolved["success"]),
+        status=result.status,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -368,29 +496,13 @@ class SourceRenamePlan:
 async def execute_source_rename(
     client: NotebookLMClient,
     plan: SourceRenamePlan,
-    *,
-    ctx: click.Context | None = None,
-) -> None:
+) -> SourceRenameResult:
     """Resolve + rename a single source."""
     resolved_id = await resolve_source_id(
         client, plan.notebook_id, plan.source_id, json_output=plan.json_output
     )
     src = await client.sources.rename(plan.notebook_id, resolved_id, plan.new_title)
-
-    if plan.json_output:
-        json_output_response(
-            {
-                "action": "rename",
-                "source_id": src.id,
-                "notebook_id": plan.notebook_id,
-                "title": src.title,
-                "status": "renamed",
-            }
-        )
-        return
-
-    cli_print(f"[green]Renamed source:[/green] {src.id}", ctx=ctx)
-    cli_print(f"[bold]New title:[/bold] {src.title}", ctx=ctx)
+    return SourceRenameResult(source=src, notebook_id=plan.notebook_id)
 
 
 # ---------------------------------------------------------------------------
@@ -410,56 +522,14 @@ class SourceRefreshPlan:
 async def execute_source_refresh(
     client: NotebookLMClient,
     plan: SourceRefreshPlan,
-    *,
-    ctx: click.Context | None = None,
-) -> None:
+) -> SourceRefreshResult:
     """Resolve + refresh a URL/Drive source."""
     resolved_id = await resolve_source_id(
         client, plan.notebook_id, plan.source_id, json_output=plan.json_output
     )
 
-    if plan.json_output:
-        src = await client.sources.refresh(plan.notebook_id, resolved_id)
-    else:
-        with cli_status("Refreshing source...", ctx=ctx):
-            src = await client.sources.refresh(plan.notebook_id, resolved_id)
-
-    if plan.json_output:
-        # ``refresh`` may return a Source dataclass, ``True``, or
-        # falsy/None. Surface the same three states in JSON so
-        # automation can branch on ``status`` without scraping text.
-        if src and src is not True:
-            data = {
-                "action": "refresh",
-                "source_id": src.id,
-                "notebook_id": plan.notebook_id,
-                "title": src.title,
-                "status": "refreshed",
-            }
-        elif src is True:
-            data = {
-                "action": "refresh",
-                "source_id": resolved_id,
-                "notebook_id": plan.notebook_id,
-                "status": "refreshed",
-            }
-        else:
-            data = {
-                "action": "refresh",
-                "source_id": resolved_id,
-                "notebook_id": plan.notebook_id,
-                "status": "no_result",
-            }
-        json_output_response(data)
-        return
-
-    if src and src is not True:
-        cli_print(f"[green]Source refreshed:[/green] {src.id}", ctx=ctx)
-        cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
-    elif src is True:
-        cli_print(f"[green]Source refreshed:[/green] {resolved_id}", ctx=ctx)
-    else:
-        cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
+    src = await client.sources.refresh(plan.notebook_id, resolved_id)
+    return SourceRefreshResult(source_id=resolved_id, notebook_id=plan.notebook_id, result=src)
 
 
 # ---------------------------------------------------------------------------
@@ -489,42 +559,32 @@ class SourceAddDrivePlan:
 async def execute_source_add_drive(
     client: NotebookLMClient,
     plan: SourceAddDrivePlan,
-    *,
-    ctx: click.Context | None = None,
-) -> None:
+) -> SourceAddDriveResult:
     """Add a Google Drive document as a source."""
     mime = _DRIVE_MIME_MAP[plan.mime_type]
 
-    if plan.json_output:
-        src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
-    else:
-        with console.status("Adding Drive source..."):
-            src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
-
-    if plan.json_output:
-        json_output_response(
-            {
-                "action": "add-drive",
-                "source": {
-                    **source_summary_payload(src),
-                    "drive_file_id": plan.file_id,
-                    "mime_type": plan.mime_type,
-                },
-                "notebook_id": plan.notebook_id,
-            }
-        )
-        return
-
-    cli_print(f"[green]Added Drive source:[/green] {src.id}", ctx=ctx)
-    cli_print(f"[bold]Title:[/bold] {src.title}", ctx=ctx)
+    src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
+    return SourceAddDriveResult(
+        source=src,
+        notebook_id=plan.notebook_id,
+        file_id=plan.file_id,
+        mime_type=plan.mime_type,
+    )
 
 
 __all__ = [
     "SourceAddDrivePlan",
+    "SourceAddDriveResult",
     "SourceDeleteByTitlePlan",
+    "SourceDeleteByTitleResult",
     "SourceDeletePlan",
+    "SourceDeleteResult",
+    "SourceIdResolution",
+    "SourceMutationError",
     "SourceRefreshPlan",
+    "SourceRefreshResult",
     "SourceRenamePlan",
+    "SourceRenameResult",
     "build_id_ambiguity_error",
     "execute_source_add_drive",
     "execute_source_delete",

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 from ...types import DriveMimeType, Source
 from ..resolve import resolve_source_id, validate_id
@@ -209,11 +209,11 @@ def looks_like_full_source_id(source_id: str) -> bool:
 async def resolve_source_for_delete(
     client: NotebookLMClient, notebook_id: str, source_id: str, *, json_output: bool = False
 ) -> SourceIdResolution:
-    """Resolve a source ID for delete, returning the full source ID string.
+    """Resolve source-id input for delete into a :class:`SourceIdResolution`.
 
     Canonical UUIDs take a fast path and skip the live source list
     lookup. Partial IDs are resolved against the live list. Successful
-    partial matches return status prose for the command layer to emit.
+    partial matches include status prose for the command layer to emit.
     """
     source_id = validate_id(source_id, "source")
     if looks_like_full_source_id(source_id):
@@ -285,7 +285,7 @@ def require_yes_in_json(
     action: str,
     extra: dict[str, Any] | None = None,
     status_message: str | None = None,
-) -> None:
+) -> NoReturn:
     """Raise a typed ``CONFIRM_REQUIRED`` error for command-layer handling.
 
     Centralises the JSON-mode confirmation gate used by destructive

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -28,17 +28,22 @@ if TYPE_CHECKING:
 DriveMimeChoice = Literal["google-doc", "google-slides", "google-sheets", "pdf"]
 
 
-@dataclass(frozen=True)
 class SourceMutationError(Exception):
     """Typed source-mutation error for command-layer rendering and exit policy."""
 
-    message: str
-    code: str
-    extra: dict[str, Any] | None = None
-    status_message: str | None = None
-
-    def __str__(self) -> str:
-        return self.message
+    def __init__(
+        self,
+        message: str,
+        code: str,
+        extra: dict[str, Any] | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        self.message = message
+        self.code = code
+        self.extra = extra
+        self.status_message = status_message
+        metadata = f" (code={code}, extra={extra})" if extra else f" (code={code})"
+        super().__init__(f"{message}{metadata}")
 
 
 @dataclass(frozen=True)
@@ -201,7 +206,7 @@ def looks_like_full_source_id(source_id: str) -> bool:
 
 
 async def resolve_source_for_delete(
-    client, notebook_id: str, source_id: str, *, json_output: bool = False
+    client: NotebookLMClient, notebook_id: str, source_id: str, *, json_output: bool = False
 ) -> SourceIdResolution:
     """Resolve a source ID for delete, returning the full source ID string.
 
@@ -249,8 +254,8 @@ async def resolve_source_for_delete(
 
 
 async def resolve_source_by_exact_title(
-    client, notebook_id: str, title: str, *, json_output: bool = False
-):
+    client: NotebookLMClient, notebook_id: str, title: str, *, json_output: bool = False
+) -> Source:
     """Resolve a source by exact title for the explicit delete-by-title flow."""
     title = validate_id(title, "source title")
     sources = await client.sources.list(notebook_id)

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -88,6 +88,7 @@ class SourceDeleteByTitleResult:
     notebook_id: str
     success: bool
     status: Literal["completed", "cancelled"]
+    status_message: str | None = None
 
     @property
     def payload(self) -> dict[str, Any]:
@@ -558,7 +559,6 @@ class SourceAddDrivePlan:
     file_id: str
     title: str
     mime_type: DriveMimeChoice
-    json_output: bool
 
 
 async def execute_source_add_drive(

--- a/src/notebooklm/cli/share_cmd.py
+++ b/src/notebooklm/cli/share_cmd.py
@@ -377,6 +377,7 @@ def share_remove(ctx, email, notebook_id, yes, json_output, client_auth):
                 return
 
             if json_output:
+                json_output_response(result.payload)
                 return
 
             console.print(f"[green]Removed access for {email}[/green]")

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -42,8 +42,10 @@ from .rendering import (
     console,
     display_report,
     display_research_sources,
+    emit_status,
     get_source_type_display,
     json_output_response,
+    render_list,
 )
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_id
 from .runtime import is_quiet
@@ -74,6 +76,7 @@ from .services.source_mutations import (
     SourceAddDrivePlan,
     SourceDeleteByTitlePlan,
     SourceDeletePlan,
+    SourceMutationError,
     SourceRefreshPlan,
     SourceRenamePlan,
     execute_source_add_drive,
@@ -374,6 +377,70 @@ def _render_source_stale_result(
         exit_with_code(0)
 
 
+def _handle_source_mutation_error(exc: SourceMutationError, *, json_output: bool) -> NoReturn:
+    """Render a typed source-mutation error through the CLI error contract."""
+    if exc.status_message:
+        emit_status(exc.status_message, json_output=json_output)
+    _output_error(
+        exc.message,
+        code=exc.code,
+        json_output=json_output,
+        exit_code=1,
+        extra=exc.extra,
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _render_source_delete_result(result, *, json_output: bool, ctx: click.Context) -> None:
+    status_message = getattr(result, "status_message", None)
+    if status_message:
+        emit_status(status_message, json_output=json_output)
+
+    if json_output:
+        json_output_response(result.payload)
+        return
+
+    if result.status == "cancelled":
+        return
+    if result.success:
+        cli_print(f"[green]Deleted source:[/green] {result.source_id}", ctx=ctx)
+    else:
+        cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
+
+
+def _render_source_rename_result(result, *, json_output: bool, ctx: click.Context) -> None:
+    if json_output:
+        json_output_response(result.payload)
+        return
+
+    cli_print(f"[green]Renamed source:[/green] {result.source.id}", ctx=ctx)
+    cli_print(f"[bold]New title:[/bold] {result.source.title}", ctx=ctx)
+
+
+def _render_source_refresh_result(result, *, json_output: bool, ctx: click.Context) -> None:
+    if json_output:
+        json_output_response(result.payload)
+        return
+
+    refreshed = result.result
+    if refreshed and refreshed is not True:
+        cli_print(f"[green]Source refreshed:[/green] {refreshed.id}", ctx=ctx)
+        cli_print(f"[bold]Title:[/bold] {refreshed.title}", ctx=ctx)
+    elif refreshed is True:
+        cli_print(f"[green]Source refreshed:[/green] {result.source_id}", ctx=ctx)
+    else:
+        cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
+
+
+def _render_source_add_drive_result(result, *, json_output: bool, ctx: click.Context) -> None:
+    if json_output:
+        json_output_response(result.payload)
+        return
+
+    cli_print(f"[green]Added Drive source:[/green] {result.source.id}", ctx=ctx)
+    cli_print(f"[bold]Title:[/bold] {result.source.title}", ctx=ctx)
+
+
 @click.group()
 def source():
     """Source management commands.
@@ -423,8 +490,9 @@ def source_list(ctx, notebook_id, json_output, limit, no_truncate, client_auth):
                 json_output=json_output,
                 limit=limit,
                 no_truncate=no_truncate,
+                source_type_display=get_source_type_display,
             )
-            await execute_source_list(client, plan)
+            render_list(await execute_source_list(client, plan))
 
     return _run()
 
@@ -530,15 +598,15 @@ def source_add(
     async def _run():
         async with NotebookLMClient(client_auth, **client_kwargs) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_add(
-                client,
-                SourceAddExecutionPlan(
-                    notebook_id=nb_id_resolved,
-                    plan=plan,
-                    json_output=json_output,
-                ),
-                ctx=ctx,
-            )
+            execution_plan = SourceAddExecutionPlan(notebook_id=nb_id_resolved, plan=plan)
+            if json_output:
+                result = await execute_source_add(client, execution_plan)
+                json_output_response(result.payload())
+                return
+
+            with cli_status(f"Adding {plan.detected_type} source...", ctx=ctx):
+                result = await execute_source_add(client, execution_plan)
+            cli_print(f"[green]Added source:[/green] {result.source.id}", ctx=ctx)
 
     return _run()
 
@@ -583,16 +651,20 @@ def source_delete(ctx, source_id, notebook_id, yes, json_output, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_delete(
-                client,
-                SourceDeletePlan(
-                    notebook_id=nb_id_resolved,
-                    source_id=source_id,
-                    yes=yes,
-                    json_output=json_output,
-                ),
-                ctx=ctx,
-            )
+            try:
+                result = await execute_source_delete(
+                    client,
+                    SourceDeletePlan(
+                        notebook_id=nb_id_resolved,
+                        source_id=source_id,
+                        yes=yes,
+                        json_output=json_output,
+                    ),
+                    confirmer=click.confirm,
+                )
+            except SourceMutationError as exc:
+                _handle_source_mutation_error(exc, json_output=json_output)
+            _render_source_delete_result(result, json_output=json_output, ctx=ctx)
 
     return _run()
 
@@ -610,16 +682,20 @@ def source_delete_by_title(ctx, title, notebook_id, yes, json_output, client_aut
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_delete_by_title(
-                client,
-                SourceDeleteByTitlePlan(
-                    notebook_id=nb_id_resolved,
-                    title=title,
-                    yes=yes,
-                    json_output=json_output,
-                ),
-                ctx=ctx,
-            )
+            try:
+                result = await execute_source_delete_by_title(
+                    client,
+                    SourceDeleteByTitlePlan(
+                        notebook_id=nb_id_resolved,
+                        title=title,
+                        yes=yes,
+                        json_output=json_output,
+                    ),
+                    confirmer=click.confirm,
+                )
+            except SourceMutationError as exc:
+                _handle_source_mutation_error(exc, json_output=json_output)
+            _render_source_delete_result(result, json_output=json_output, ctx=ctx)
 
     return _run()
 
@@ -637,7 +713,7 @@ def source_rename(ctx, source_id, new_title, notebook_id, json_output, client_au
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_rename(
+            result = await execute_source_rename(
                 client,
                 SourceRenamePlan(
                     notebook_id=nb_id_resolved,
@@ -645,8 +721,8 @@ def source_rename(ctx, source_id, new_title, notebook_id, json_output, client_au
                     new_title=new_title,
                     json_output=json_output,
                 ),
-                ctx=ctx,
             )
+            _render_source_rename_result(result, json_output=json_output, ctx=ctx)
 
     return _run()
 
@@ -663,15 +739,17 @@ def source_refresh(ctx, source_id, notebook_id, json_output, client_auth):
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_refresh(
-                client,
-                SourceRefreshPlan(
-                    notebook_id=nb_id_resolved,
-                    source_id=source_id,
-                    json_output=json_output,
-                ),
-                ctx=ctx,
+            plan = SourceRefreshPlan(
+                notebook_id=nb_id_resolved,
+                source_id=source_id,
+                json_output=json_output,
             )
+            if json_output:
+                result = await execute_source_refresh(client, plan)
+            else:
+                with cli_status("Refreshing source...", ctx=ctx):
+                    result = await execute_source_refresh(client, plan)
+            _render_source_refresh_result(result, json_output=json_output, ctx=ctx)
 
     return _run()
 
@@ -695,17 +773,19 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
     async def _run():
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
-            await execute_source_add_drive(
-                client,
-                SourceAddDrivePlan(
-                    notebook_id=nb_id_resolved,
-                    file_id=file_id,
-                    title=title,
-                    mime_type=mime_type,
-                    json_output=json_output,
-                ),
-                ctx=ctx,
+            plan = SourceAddDrivePlan(
+                notebook_id=nb_id_resolved,
+                file_id=file_id,
+                title=title,
+                mime_type=mime_type,
+                json_output=json_output,
             )
+            if json_output:
+                result = await execute_source_add_drive(client, plan)
+            else:
+                with cli_status("Adding Drive source...", ctx=ctx):
+                    result = await execute_source_add_drive(client, plan)
+            _render_source_add_drive_result(result, json_output=json_output, ctx=ctx)
 
     return _run()
 
@@ -1188,17 +1268,20 @@ def _dispatch_source_clean_result(
 
     if json_output:
         # P1.T2 bug 3: synthesize structured error when --json + no --yes
-        # left candidates uncleaned. ``require_yes_in_json`` raises
-        # ``SystemExit(1)`` via ``output_error`` — it never returns.
+        # left candidates uncleaned. ``require_yes_in_json`` raises a typed
+        # source-mutation error for the command layer — it never returns.
         if result.status == "cancelled" and not yes:
-            require_yes_in_json(
-                action="clean",
-                extra={
-                    "notebook_id": result.notebook_id,
-                    "candidate_count": result.candidate_count,
-                    "candidates": candidate_payload,
-                },
-            )
+            try:
+                require_yes_in_json(
+                    action="clean",
+                    extra={
+                        "notebook_id": result.notebook_id,
+                        "candidate_count": result.candidate_count,
+                        "candidates": candidate_payload,
+                    },
+                )
+            except SourceMutationError as exc:
+                _handle_source_mutation_error(exc, json_output=json_output)
 
         payload: dict[str, Any] = {
             "action": "clean",

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -74,11 +74,16 @@ from .services.source_content import (
 from .services.source_listing import SourceListPlan, execute_source_list
 from .services.source_mutations import (
     SourceAddDrivePlan,
+    SourceAddDriveResult,
     SourceDeleteByTitlePlan,
+    SourceDeleteByTitleResult,
     SourceDeletePlan,
+    SourceDeleteResult,
     SourceMutationError,
     SourceRefreshPlan,
+    SourceRefreshResult,
     SourceRenamePlan,
+    SourceRenameResult,
     execute_source_add_drive,
     execute_source_delete,
     execute_source_delete_by_title,
@@ -391,10 +396,14 @@ def _handle_source_mutation_error(exc: SourceMutationError, *, json_output: bool
     raise AssertionError("unreachable")  # pragma: no cover
 
 
-def _render_source_delete_result(result, *, json_output: bool, ctx: click.Context) -> None:
-    status_message = getattr(result, "status_message", None)
-    if status_message:
-        emit_status(status_message, json_output=json_output)
+def _render_source_delete_result(
+    result: SourceDeleteResult | SourceDeleteByTitleResult,
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
+    if result.status_message:
+        emit_status(result.status_message, json_output=json_output)
 
     if json_output:
         json_output_response(result.payload)
@@ -408,7 +417,12 @@ def _render_source_delete_result(result, *, json_output: bool, ctx: click.Contex
         cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)
 
 
-def _render_source_rename_result(result, *, json_output: bool, ctx: click.Context) -> None:
+def _render_source_rename_result(
+    result: SourceRenameResult,
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
     if json_output:
         json_output_response(result.payload)
         return
@@ -417,7 +431,12 @@ def _render_source_rename_result(result, *, json_output: bool, ctx: click.Contex
     cli_print(f"[bold]New title:[/bold] {result.source.title}", ctx=ctx)
 
 
-def _render_source_refresh_result(result, *, json_output: bool, ctx: click.Context) -> None:
+def _render_source_refresh_result(
+    result: SourceRefreshResult,
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
     if json_output:
         json_output_response(result.payload)
         return
@@ -432,7 +451,12 @@ def _render_source_refresh_result(result, *, json_output: bool, ctx: click.Conte
         cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
 
 
-def _render_source_add_drive_result(result, *, json_output: bool, ctx: click.Context) -> None:
+def _render_source_add_drive_result(
+    result: SourceAddDriveResult,
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
     if json_output:
         json_output_response(result.payload)
         return
@@ -601,7 +625,7 @@ def source_add(
             execution_plan = SourceAddExecutionPlan(notebook_id=nb_id_resolved, plan=plan)
             if json_output:
                 result = await execute_source_add(client, execution_plan)
-                json_output_response(result.payload())
+                json_output_response(result.payload)
                 return
 
             with cli_status(f"Adding {plan.detected_type} source...", ctx=ctx):
@@ -778,7 +802,6 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
                 file_id=file_id,
                 title=title,
                 mime_type=mime_type,
-                json_output=json_output,
             )
             if json_output:
                 result = await execute_source_add_drive(client, plan)

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 import click
+from rich.markup import render as render_markup
 from rich.table import Table
 
 from ..client import NotebookLMClient
@@ -384,14 +385,22 @@ def _render_source_stale_result(
 
 def _handle_source_mutation_error(exc: SourceMutationError, *, json_output: bool) -> NoReturn:
     """Render a typed source-mutation error through the CLI error contract."""
+    extra = dict(exc.extra) if exc.extra else None
+    hint = None
     if exc.status_message:
-        emit_status(exc.status_message, json_output=json_output)
+        plain_status = render_markup(exc.status_message).plain
+        if json_output:
+            extra = extra or {}
+            extra["status_message"] = plain_status
+        else:
+            hint = plain_status
     _output_error(
         exc.message,
         code=exc.code,
         json_output=json_output,
         exit_code=1,
-        extra=exc.extra,
+        extra=extra,
+        hint=hint,
     )
     raise AssertionError("unreachable")  # pragma: no cover
 

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -81,6 +81,7 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 # Click ``BadParameter`` translation and optional-domain warning rendering.
 GUARDED_PATHS = {
     "cli/services/auth_diagnostics.py": SERVICES_ROOT / "auth_diagnostics.py",
+    "cli/services/confirming_mutation.py": SERVICES_ROOT / "confirming_mutation.py",
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
     "cli/services/login/browser_accounts.py": SERVICES_ROOT / "login" / "browser_accounts.py",
     "cli/services/login/cookie_domains.py": SERVICES_ROOT / "login" / "cookie_domains.py",
@@ -94,7 +95,10 @@ GUARDED_PATHS = {
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",
     "cli/services/skill_install.py": SERVICES_ROOT / "skill_install.py",
     "cli/services/source_clean.py": SERVICES_ROOT / "source_clean.py",
+    "cli/services/source_add.py": SERVICES_ROOT / "source_add.py",
     "cli/services/source_content.py": SERVICES_ROOT / "source_content.py",
+    "cli/services/source_listing.py": SERVICES_ROOT / "source_listing.py",
+    "cli/services/source_mutations.py": SERVICES_ROOT / "source_mutations.py",
     "cli/services/source_research.py": SERVICES_ROOT / "source_research.py",
     "cli/services/source_serializers.py": SERVICES_ROOT / "source_serializers.py",
     "cli/services/source_wait.py": SERVICES_ROOT / "source_wait.py",
@@ -154,18 +158,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "Adapter that reads the auth-source override from the live Click "
             "context; the function-level ``import click`` is the only Click "
             "reach-in."
-        ),
-    },
-    "cli/services/confirming_mutation.py": {
-        "path": SERVICES_ROOT / "confirming_mutation.py",
-        "forbidden_imports": [
-            "confirming_mutation.py:10: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "Confirm-prompt helper still pulls ``console`` for echoed "
-            "prompts; rendering reach-in to be inverted via callback "
-            "injection."
         ),
     },
     "cli/services/download.py": {
@@ -310,45 +302,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "Polling helpers still import ``..error_handler`` + "
             "``..rendering`` for status spinners and exit mapping; lift "
             "those callbacks into the command layer."
-        ),
-    },
-    "cli/services/source_add.py": {
-        "path": SERVICES_ROOT / "source_add.py",
-        "forbidden_imports": [
-            "source_add.py:360: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "``source add`` workflow still pulls ``console`` for spinner "
-            "messages; presentation reach-in to be inverted."
-        ),
-    },
-    "cli/services/source_listing.py": {
-        "path": SERVICES_ROOT / "source_listing.py",
-        "forbidden_imports": [
-            "source_listing.py:16: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "Source listing still imports ``..rendering`` for table "
-            "formatting; presentation reach-in to be inverted."
-        ),
-    },
-    "cli/services/source_mutations.py": {
-        "path": SERVICES_ROOT / "source_mutations.py",
-        "forbidden_imports": [
-            "source_mutations.py:18: forbidden top-level import: 'click'",
-            "source_mutations.py:21: forbidden relative import: '..error_handler'",
-            "source_mutations.py:22: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "pattern_b_violations": (
-            "uses click.confirm as the default confirmer for source "
-            "deletion plans; lift to an injected confirmer callback."
-        ),
-        "rationale": (
-            "Source mutation pipeline still owns presentation + Click "
-            "confirmer defaults + exit policy."
         ),
     },
 }

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -38,8 +38,7 @@ from notebooklm.types import Source, SourceFulltext, SourceTimeoutError
 
 
 @pytest.mark.asyncio
-async def test_source_delete_json_without_yes_uses_structured_confirmation_error(
-) -> None:
+async def test_source_delete_json_without_yes_uses_structured_confirmation_error() -> None:
     client = SimpleNamespace(
         sources=SimpleNamespace(
             list=AsyncMock(return_value=[Source(id="src_abcdef", title="Paper")]),

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -19,6 +19,7 @@ from notebooklm.cli.services.source_content import (
 )
 from notebooklm.cli.services.source_mutations import (
     SourceDeletePlan,
+    SourceMutationError,
     SourceRenamePlan,
     execute_source_delete,
     execute_source_rename,
@@ -38,30 +39,7 @@ from notebooklm.types import Source, SourceFulltext, SourceTimeoutError
 
 @pytest.mark.asyncio
 async def test_source_delete_json_without_yes_uses_structured_confirmation_error(
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[dict[str, object]] = []
-
-    def fake_output_error(
-        message: str,
-        code: str,
-        json_output: bool,
-        exit_code: int,
-        *,
-        extra: dict[str, object] | None = None,
-    ) -> None:
-        calls.append(
-            {
-                "message": message,
-                "code": code,
-                "json_output": json_output,
-                "exit_code": exit_code,
-                "extra": extra,
-            }
-        )
-        raise SystemExit(exit_code)
-
-    monkeypatch.setattr(source_mutations, "output_error", fake_output_error)
     client = SimpleNamespace(
         sources=SimpleNamespace(
             list=AsyncMock(return_value=[Source(id="src_abcdef", title="Paper")]),
@@ -75,30 +53,26 @@ async def test_source_delete_json_without_yes_uses_structured_confirmation_error
         json_output=True,
     )
 
-    with pytest.raises(SystemExit) as exc_info:
-        await execute_source_delete(client, plan)
+    with pytest.raises(SourceMutationError) as exc_info:
+        await execute_source_delete(
+            client,
+            plan,
+            confirmer=lambda message: pytest.fail(f"unexpected confirmation: {message}"),
+        )
 
-    assert exc_info.value.code == 1
-    assert calls == [
-        {
-            "message": "Pass --yes to confirm destructive operation in --json mode",
-            "code": "CONFIRM_REQUIRED",
-            "json_output": True,
-            "exit_code": 1,
-            "extra": {
-                "action": "delete",
-                "source_id": "src_abcdef",
-                "notebook_id": "nb_1",
-            },
-        }
-    ]
+    assert exc_info.value.message == "Pass --yes to confirm destructive operation in --json mode"
+    assert exc_info.value.code == "CONFIRM_REQUIRED"
+    assert exc_info.value.extra == {
+        "action": "delete",
+        "source_id": "src_abcdef",
+        "notebook_id": "nb_1",
+    }
+    assert exc_info.value.status_message == "[dim]Matched: src_abcdef... (Paper)[/dim]"
     client.sources.delete.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_source_rename_json_emits_service_payload(monkeypatch: pytest.MonkeyPatch) -> None:
-    payloads: list[dict[str, object]] = []
-    monkeypatch.setattr(source_mutations, "json_output_response", payloads.append)
+async def test_source_rename_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         source_mutations,
         "resolve_source_id",
@@ -108,7 +82,7 @@ async def test_source_rename_json_emits_service_payload(monkeypatch: pytest.Monk
         sources=SimpleNamespace(rename=AsyncMock(return_value=Source(id="src_full", title="New")))
     )
 
-    await execute_source_rename(
+    result = await execute_source_rename(
         client,
         SourceRenamePlan(
             notebook_id="nb_1",
@@ -119,15 +93,13 @@ async def test_source_rename_json_emits_service_payload(monkeypatch: pytest.Monk
     )
 
     client.sources.rename.assert_awaited_once_with("nb_1", "src_full", "New")
-    assert payloads == [
-        {
-            "action": "rename",
-            "source_id": "src_full",
-            "notebook_id": "nb_1",
-            "title": "New",
-            "status": "renamed",
-        }
-    ]
+    assert result.payload == {
+        "action": "rename",
+        "source_id": "src_full",
+        "notebook_id": "nb_1",
+        "title": "New",
+        "status": "renamed",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_confirming_mutation_service.py
+++ b/tests/unit/test_confirming_mutation_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -78,7 +77,7 @@ async def test_yes_skips_confirmation_and_executes_mutation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_json_output_emits_success_payload(capsys: pytest.CaptureFixture[str]) -> None:
+async def test_returns_success_payload() -> None:
     calls: list[tuple[str, Any]] = []
 
     result = await run_confirmed_mutation(
@@ -90,7 +89,7 @@ async def test_json_output_emits_success_payload(capsys: pytest.CaptureFixture[s
     )
 
     assert result.status == "completed"
-    assert json.loads(capsys.readouterr().out) == {"id": "thing_123", "deleted": True}
+    assert result.payload == {"id": "thing_123", "deleted": True}
 
 
 @pytest.mark.asyncio
@@ -107,3 +106,4 @@ async def test_json_output_without_yes_does_not_prompt() -> None:
 
     assert result.status == "completed"
     assert result.resolved.executed is True
+    assert result.payload == {"id": "thing_123", "deleted": True}


### PR DESCRIPTION
## Summary
- Move source add/list/delete/rename/refresh/add-drive presentation and confirmation handling back to `source_cmd.py`.
- Convert cleaned source services and `confirming_mutation` to typed result/error outcomes with injected callbacks instead of Click/Rich runtime imports.
- Update the boundary inventory so cleaned source-related modules move from transitional to guarded.

## Non-source command files touched
- `src/notebooklm/cli/artifact_cmd.py`, `src/notebooklm/cli/note_cmd.py`, and `src/notebooklm/cli/share_cmd.py` each add one mechanical `json_output_response(result.payload)` call. This is required compatibility fallout from making the shared `run_confirmed_mutation` helper return payloads instead of emitting JSON from the service layer. No artifact/generate/download/polling service-boundary cleanup is included.

## Removed boundary rows
- `cli/services/confirming_mutation.py`: removed `confirming_mutation.py:10: forbidden relative import: '..rendering'`
- `cli/services/source_add.py`: removed `source_add.py:360: forbidden relative import: '..rendering'`
- `cli/services/source_listing.py`: removed `source_listing.py:16: forbidden relative import: '..rendering'`
- `cli/services/source_mutations.py`: removed `source_mutations.py:18: forbidden top-level import: 'click'`
- `cli/services/source_mutations.py`: removed `source_mutations.py:21: forbidden relative import: '..error_handler'`
- `cli/services/source_mutations.py`: removed `source_mutations.py:22: forbidden relative import: '..rendering'`
- `cli/services/source_mutations.py`: removed Pattern B rationale for `click.confirm` default confirmer

## Test plan
- [x] `uv run pytest tests/unit/cli/test_services_boundary.py -q`
- [x] `uv run pytest tests/unit/cli -k "source" -q`
- [x] `uv run ruff check src/notebooklm/cli/source_cmd.py src/notebooklm/cli/services tests/unit/cli/test_services_boundary.py`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pytest tests/unit/test_confirming_mutation_service.py tests/unit/test_cli_source_services.py -q`
- [x] `uv run pytest tests/unit/cli/test_artifact.py -k "artifact_delete" -q`
- [x] `uv run pytest tests/unit/cli/test_note.py -k "delete" -q`
- [x] `uv run pytest tests/unit/cli/test_share.py -k "share_remove" -q`

## Deferred polish findings
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commands now emit structured JSON payloads on successful deletes and other mutation actions when using --json.

* **Bug Fixes**
  * Restored missing JSON responses for delete/share/note/artifact flows in JSON mode.

* **Refactor**
  * Reworked CLI service layer to separate presentation from core logic and centralize typed mutation results/errors.

* **Tests**
  * Updated unit tests and boundary classifications to assert structured results and error behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->