### PR TITLE
refactor(cli): drain artifact generation boundaries

### DIFF
--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -19,6 +19,7 @@ from ..types import ExportType
 from .auth_runtime import with_client
 from .error_handler import _output_error, exit_with_code
 from .options import json_option, list_options, notebook_option, wait_polling_options
+from .polling_ui import status_with_elapsed
 from .rendering import (
     cli_name_to_artifact_type,
     cli_print,
@@ -34,7 +35,6 @@ from .resolve import (
 )
 from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, prepare_list
-from .services.polling import status_with_elapsed
 
 
 @click.group()

--- a/src/notebooklm/cli/download_cmd.py
+++ b/src/notebooklm/cli/download_cmd.py
@@ -32,10 +32,10 @@ import click
 from ..client import NotebookLMClient
 from ._download_specs import DOWNLOAD_SPECS, DownloadTypeSpec
 from .auth_runtime import run_client_workflow
-from .error_handler import exit_with_code
+from .error_handler import exit_with_code, output_error
 from .options import _complete_artifacts, alias_command, notebook_option
 from .rendering import console, json_output_response
-from .services.download import build_download_plan, execute_download
+from .services.download import DownloadPlanValidationError, build_download_plan, execute_download
 
 
 @click.group()
@@ -131,7 +131,15 @@ def _run_artifact_download(ctx: click.Context, spec: DownloadTypeSpec, **kwargs:
     key after the workflow completes.
     """
     json_output = bool(kwargs.get("json_output", False))
-    plan = build_download_plan(spec, kwargs, Path.cwd())
+    try:
+        plan = build_download_plan(spec, kwargs, Path.cwd())
+    except DownloadPlanValidationError as exc:
+        if json_output:
+            output_error(exc.message, exc.code, True, 1)
+        raise click.UsageError(exc.message) from exc
+
+    for warning in plan.warnings:
+        click.echo(warning, err=True)
 
     async def body(client: NotebookLMClient) -> dict[str, Any]:
         return await execute_download(

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -13,6 +13,7 @@ import os
 from typing import Any
 
 import click
+from click.core import ParameterSource
 
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
@@ -31,14 +32,20 @@ from .options import (
     wait_option,
     wait_polling_options,
 )
+from .polling_ui import status_with_elapsed
 from .rendering import (
     console,
     json_error_response,
     json_output_response,
 )
 from .resolve import require_notebook
+from .services.artifact_generation import (
+    GenerationOutcome,
+)
 from .services.generate import (
     _INFOGRAPHIC_STYLE_MAP,
+    GenerationExecutionResult,
+    GenerationPlanValidationError,
     build_generation_plan,
     execute_generation,
 )
@@ -129,6 +136,55 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
         console.print(result)
 
 
+def _output_generation_outcome(outcome: GenerationOutcome, json_output: bool) -> None:
+    """Render a generation outcome and apply command-layer exit policy."""
+    if outcome.status in {"failed", "rate_limited"}:
+        message = outcome.error or f"{outcome.artifact_type.title()} generation failed"
+        if outcome.hint is None:
+            output_error(message, outcome.error_code, json_output, outcome.exit_code)
+        else:
+            output_error(
+                message,
+                outcome.error_code,
+                json_output,
+                outcome.exit_code,
+                hint=outcome.hint,
+            )
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    if json_output:
+        if outcome.status == "completed":
+            json_output_response(
+                {"task_id": outcome.task_id, "status": "completed", "url": outcome.url}
+            )
+        else:
+            json_output_response({"task_id": outcome.task_id, "status": "pending"})
+        return
+
+    if outcome.status == "completed":
+        if outcome.url:
+            console.print(f"[green]{outcome.artifact_type.title()} ready:[/green] {outcome.url}")
+        else:
+            console.print(f"[green]{outcome.artifact_type.title()} ready[/green]")
+    else:
+        console.print(f"[yellow]Started:[/yellow] {outcome.task_id or outcome.raw_status}")
+
+
+def _render_generation_result(result: GenerationExecutionResult, json_output: bool) -> None:
+    if result.kind == "mind-map":
+        _output_mind_map_result(result.mind_map, json_output)
+        return
+    if result.generation is None:
+        output_error(
+            f"{result.display_name.title()} generation failed",
+            "GENERATION_FAILED",
+            json_output,
+            1,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    _output_generation_outcome(result.generation, json_output)
+
+
 # Click-handler params that are not part of the service-layer raw_args
 # contract. ``ctx`` carries the parameter-source probe; ``client_auth`` is
 # the AuthTokens injected by ``@with_client``; ``prompt_file`` has already
@@ -152,16 +208,55 @@ def _run_generate(*, kind: str, **handler_locals: Any) -> Any:
     client_auth = handler_locals["client_auth"]
     raw_args = {k: v for k, v in handler_locals.items() if k not in _NON_RAW_ARG_KEYS}
     raw_args["notebook_id"] = require_notebook(raw_args["notebook_id"])
-    plan = build_generation_plan(
-        kind,
-        raw_args,
-        parameter_source=ctx.get_parameter_source,
-        language_resolver=resolve_language,
-    )
+    try:
+        plan = build_generation_plan(
+            kind,
+            raw_args,
+            parameter_explicit=lambda name: (
+                ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+            ),
+            language_resolver=resolve_language,
+        )
+    except GenerationPlanValidationError as exc:
+        output_error(exc.message, exc.code, raw_args["json_output"], 1)
+        raise AssertionError("unreachable") from exc  # pragma: no cover
+
+    if not plan.json_output:
+        for line in plan.warnings:
+            click.echo(line, err=True)
 
     async def _run() -> Any:
         async with NotebookLMClient(client_auth) as client:
-            return await execute_generation(plan, client)
+            result = await execute_generation(
+                plan,
+                client,
+                retry_sink=(
+                    None
+                    if plan.json_output
+                    else lambda event: console.print(
+                        f"[yellow]{plan.display_name.title()} rate limited. "
+                        f"Retrying in {int(event.delay)}s "
+                        f"(attempt {event.next_attempt_number}/{event.total_attempts})...[/yellow]"
+                    )
+                ),
+                wait_context=lambda message, resume_hint: status_with_elapsed(
+                    message,
+                    json_output=plan.json_output,
+                    resume_hint=resume_hint,
+                ),
+                wait_start_sink=(
+                    None
+                    if plan.json_output
+                    else lambda task_id: console.print(
+                        f"[yellow]Generating {plan.display_name}...[/yellow] Task: {task_id}"
+                    )
+                ),
+                mind_map_context=lambda: status_with_elapsed(
+                    "Generating mind map...",
+                    json_output=False,
+                ),
+            )
+            _render_generation_result(result, plan.json_output)
 
     return _run()
 

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -253,7 +253,7 @@ def _run_generate(*, kind: str, **handler_locals: Any) -> Any:
                 ),
                 mind_map_context=lambda: status_with_elapsed(
                     "Generating mind map...",
-                    json_output=False,
+                    json_output=plan.json_output,
                 ),
             )
             _render_generation_result(result, plan.json_output)

--- a/src/notebooklm/cli/polling_ui.py
+++ b/src/notebooklm/cli/polling_ui.py
@@ -18,7 +18,12 @@ async def status_with_elapsed(
     json_output: bool = False,
     resume_hint: str | None = None,
 ) -> AsyncIterator[None]:
-    """Show a transient Rich status spinner with an elapsed-seconds counter."""
+    """Show a transient Rich status spinner with an elapsed-seconds counter.
+
+    The context manager is a no-op in JSON mode so stdout remains parseable. If
+    ``resume_hint`` is provided, ``KeyboardInterrupt`` is converted to the CLI's
+    structured cancellation response; otherwise the interrupt propagates.
+    """
 
     @contextlib.contextmanager
     def _sigint_guard() -> Iterator[None]:

--- a/src/notebooklm/cli/polling_ui.py
+++ b/src/notebooklm/cli/polling_ui.py
@@ -1,0 +1,56 @@
+"""Command-layer UI helpers for long-running polling operations."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import AsyncIterator, Iterator
+
+from .error_handler import emit_cancelled_and_exit
+from .rendering import console
+
+
+@contextlib.asynccontextmanager
+async def status_with_elapsed(
+    message: str,
+    *,
+    json_output: bool = False,
+    resume_hint: str | None = None,
+) -> AsyncIterator[None]:
+    """Show a transient Rich status spinner with an elapsed-seconds counter."""
+
+    @contextlib.contextmanager
+    def _sigint_guard() -> Iterator[None]:
+        try:
+            yield
+        except KeyboardInterrupt:
+            if resume_hint is None:
+                raise
+            emit_cancelled_and_exit(resume_hint, json_output=json_output)
+
+    if json_output:
+        with _sigint_guard():
+            yield
+        return
+
+    start = time.monotonic()
+    with console.status(message) as status:
+
+        async def _ticker() -> None:
+            while True:
+                await asyncio.sleep(1.0)
+                elapsed = int(time.monotonic() - start)
+                status.update(f"{message} [{elapsed}s elapsed]")
+
+        ticker_task = asyncio.create_task(_ticker())
+        try:
+            with _sigint_guard():
+                yield
+        finally:
+            ticker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker_task
+
+
+__all__ = ["status_with_elapsed"]

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -18,13 +18,13 @@ from ..client import NotebookLMClient
 from .auth_runtime import with_client
 from .error_handler import _output_error, exit_with_code
 from .options import notebook_option
+from .polling_ui import status_with_elapsed
 from .rendering import (
     console,
     display_report,
     display_research_sources,
     json_output_response,
 )
-from .polling_ui import status_with_elapsed
 from .resolve import (
     require_notebook,
     resolve_notebook_id,

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -24,11 +24,11 @@ from .rendering import (
     display_research_sources,
     json_output_response,
 )
+from .polling_ui import status_with_elapsed
 from .resolve import (
     require_notebook,
     resolve_notebook_id,
 )
-from .services.polling import status_with_elapsed
 from .services.research import (
     ResearchWaitPlan,
     ResearchWaitResult,

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -1,14 +1,14 @@
 """CLI-internal services for artifact generation commands."""
 
-from collections.abc import Awaitable, Callable
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
 from typing import Any
 
 from ... import artifacts as artifact_retry
 from ...client import NotebookLMClient
 from ...types import GenerationStatus
-from ..error_handler import output_error
-from ..rendering import console, json_output_response
-from .polling import status_with_elapsed
 
 # Retry constants
 RETRY_INITIAL_DELAY = artifact_retry.RATE_LIMIT_RETRY_INITIAL_DELAY
@@ -37,6 +37,24 @@ _TYPICAL_DURATIONS: dict[str, str] = {
 }
 
 
+@dataclass(frozen=True)
+class GenerationOutcome:
+    """Typed result of generation orchestration for command-layer rendering."""
+
+    status: str
+    artifact_type: str
+    task_id: str | None = None
+    url: str | None = None
+    error: str | None = None
+    error_code: str = "GENERATION_FAILED"
+    hint: str | None = None
+    raw_status: Any = None
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.status in {"failed", "rate_limited"} else 0
+
+
 def _format_status_message(artifact_type: str, elapsed: float | None = None) -> str:
     """Build the spinner status line for a long-running generation.
 
@@ -56,7 +74,7 @@ async def generate_with_retry(
     generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
     max_retries: int,
     artifact_type: str,
-    json_output: bool = False,
+    on_retry: Callable[[artifact_retry.RateLimitRetryEvent], None] | None = None,
 ) -> GenerationStatus | None:
     """Generate artifact with retry on rate limit.
 
@@ -67,24 +85,16 @@ async def generate_with_retry(
         generate_fn: Async function that performs the generation.
         max_retries: Maximum number of retries (0 = no retry, just one attempt).
         artifact_type: Display name for progress messages.
-        json_output: Whether to suppress console output.
+        on_retry: Optional command-layer callback for retry notices.
 
     Returns:
         GenerationStatus or None if generation failed.
     """
 
-    def _show_retry(event: artifact_retry.RateLimitRetryEvent) -> None:
-        if not json_output:
-            console.print(
-                f"[yellow]{artifact_type.title()} rate limited. "
-                f"Retrying in {int(event.delay)}s "
-                f"(attempt {event.next_attempt_number}/{event.total_attempts})...[/yellow]"
-            )
-
     return await artifact_retry.with_rate_limit_retry(
         generate_fn,
         max_retries=max_retries,
-        on_retry=_show_retry,
+        on_retry=on_retry,
     )
 
 
@@ -97,13 +107,15 @@ async def handle_generation_result(
     json_output: bool = False,
     timeout: float = 300.0,
     interval: float | None = None,
-) -> GenerationStatus | None:
-    """Handle generation result with optional waiting and output formatting.
+    wait_context: Callable[[str, str], AbstractAsyncContextManager[None]] | None = None,
+    wait_start_sink: Callable[[str], None] | None = None,
+) -> GenerationOutcome:
+    """Handle generation result with optional waiting and typed outcome mapping.
 
     Consolidates common pattern across all generate commands:
     - Check for None/failed result
     - Optionally wait for completion
-    - Output status in JSON or console format
+    - Return a typed outcome for the command layer to render
 
     Args:
         client: The NotebookLM client.
@@ -111,7 +123,8 @@ async def handle_generation_result(
         result: The generation result from artifacts API.
         artifact_type: Display name for the artifact type (e.g., "audio", "video").
         wait: Whether to wait for completion.
-        json_output: Whether to output as JSON.
+        json_output: Deprecated compatibility argument; callers should use
+            ``wait_context`` for presentation policy.
         timeout: Timeout forwarded to ``wait_for_completion``. Callers supply
             per-command defaults; media generators use longer budgets while
             generic artifact waits remain at 300s.
@@ -122,32 +135,28 @@ async def handle_generation_result(
             cadence.
 
     Returns:
-        Final GenerationStatus, or None if generation failed.
+        GenerationOutcome describing the final status.
     """
-    # Both failure branches route through ``output_error`` so the exit code
-    # is non-zero in both text and JSON modes. ``output_error`` always raises
-    # ``SystemExit`` — these calls never return. Runtime failures use
-    # ``output_error`` rather than ``click.ClickException``; the latter is
-    # reserved for input-validation boundaries (CLI argument parsing).
     if not result:
-        output_error(
-            f"{artifact_type.title()} generation failed",
-            "GENERATION_FAILED",
-            json_output,
-            1,
+        return GenerationOutcome(
+            status="failed",
+            artifact_type=artifact_type,
+            error=f"{artifact_type.title()} generation failed",
         )
 
     # Check for rate limiting (result exists but failed due to rate limit)
     if isinstance(result, GenerationStatus) and result.is_rate_limited:
-        output_error(
-            f"{artifact_type.title()} generation rate limited by Google.",
-            "RATE_LIMITED",
-            json_output,
-            1,
+        return GenerationOutcome(
+            status="rate_limited",
+            artifact_type=artifact_type,
+            task_id=result.task_id,
+            error=f"{artifact_type.title()} generation rate limited by Google.",
+            error_code="RATE_LIMITED",
             hint=(
                 "Daily quota may be exceeded. Try again in 1-24 hours, "
                 "or use --retry N to retry automatically."
             ),
+            raw_status=result,
         )
 
     status: Any = result
@@ -155,32 +164,24 @@ async def handle_generation_result(
 
     # Wait for completion if requested
     if wait and task_id:
-        if not json_output:
-            console.print(f"[yellow]Generating {artifact_type}...[/yellow] Task: {task_id}")
+        if wait_start_sink is not None:
+            wait_start_sink(task_id)
         wait_kwargs: dict[str, Any] = {"timeout": timeout}
         if interval is not None:
             wait_kwargs["initial_interval"] = interval
-        # Wrap the blocking poll in a transient spinner so interactive users see
-        # progress feedback during long generations. The status
-        # line includes the artifact kind, a typical-duration hint, and a
-        # live elapsed-seconds counter. No-op under --json.
-        #
-        # The ``resume_hint`` plumbs the canonical M2 cancellation message
-        # (``Cancelled. Resume with: notebooklm artifact poll <task_id>``)
-        # so Ctrl-C during the wait surfaces the resume command instead of
-        # a Python KeyboardInterrupt traceback. See ``cli/error_handler.py``
-        # ``emit_cancelled_and_exit``.
-        async with status_with_elapsed(
+        context = wait_context or _null_wait_context
+        async with context(
             _format_status_message(artifact_type),
-            json_output=json_output,
-            resume_hint=f"notebooklm artifact poll {task_id}",
+            f"notebooklm artifact poll {task_id}",
         ):
             status = await client.artifacts.wait_for_completion(notebook_id, task_id, **wait_kwargs)
 
-    # Output status
-    _output_generation_status(status, artifact_type, json_output)
+    return generation_outcome_from_status(status, artifact_type)
 
-    return status if isinstance(status, GenerationStatus) else None
+
+@contextlib.asynccontextmanager
+async def _null_wait_context(_message: str, _resume_hint: str) -> AsyncIterator[None]:
+    yield
 
 
 def _extract_generation_task_id(result: Any) -> str | None:
@@ -214,43 +215,41 @@ def _extract_task_id(status: Any) -> str | None:
     return None
 
 
-def _output_generation_status(status: Any, artifact_type: str, json_output: bool) -> None:
-    """Output generation status in appropriate format.
-
-    The terminal ``is_failed`` branch routes through ``output_error`` so
-    failures observed after a ``--wait`` produce a non-zero exit in both
-    text and JSON modes.
-    """
+def generation_outcome_from_status(status: Any, artifact_type: str) -> GenerationOutcome:
+    """Map a generation status payload to a command-renderable outcome."""
     is_complete = hasattr(status, "is_complete") and status.is_complete
     is_failed = hasattr(status, "is_failed") and status.is_failed
 
     if is_failed:
-        output_error(
-            getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
-            "GENERATION_FAILED",
-            json_output,
-            1,
+        return GenerationOutcome(
+            status="failed",
+            artifact_type=artifact_type,
+            task_id=_extract_task_id(status),
+            error=getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
+            raw_status=status,
         )
 
-    if json_output:
-        if is_complete:
-            json_output_response(
-                {
-                    "task_id": getattr(status, "task_id", None),
-                    "status": "completed",
-                    "url": getattr(status, "url", None),
-                }
-            )
-        else:
-            task_id = _extract_task_id(status)
-            json_output_response({"task_id": task_id, "status": "pending"})
-    else:
-        if is_complete:
-            url = getattr(status, "url", None)
-            if url:
-                console.print(f"[green]{artifact_type.title()} ready:[/green] {url}")
-            else:
-                console.print(f"[green]{artifact_type.title()} ready[/green]")
-        else:
-            task_id = _extract_task_id(status)
-            console.print(f"[yellow]Started:[/yellow] {task_id or status}")
+    if is_complete:
+        return GenerationOutcome(
+            status="completed",
+            artifact_type=artifact_type,
+            task_id=getattr(status, "task_id", None),
+            url=getattr(status, "url", None),
+            raw_status=status,
+        )
+
+    return GenerationOutcome(
+        status="pending",
+        artifact_type=artifact_type,
+        task_id=_extract_task_id(status),
+        raw_status=status,
+    )
+
+
+__all__ = [
+    "GenerationOutcome",
+    "calculate_backoff_delay",
+    "generate_with_retry",
+    "generation_outcome_from_status",
+    "handle_generation_result",
+]

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -104,7 +104,6 @@ async def handle_generation_result(
     result: Any,
     artifact_type: str,
     wait: bool = False,
-    json_output: bool = False,
     timeout: float = 300.0,
     interval: float | None = None,
     wait_context: Callable[[str, str], AbstractAsyncContextManager[None]] | None = None,
@@ -123,8 +122,6 @@ async def handle_generation_result(
         result: The generation result from artifacts API.
         artifact_type: Display name for the artifact type (e.g., "audio", "video").
         wait: Whether to wait for completion.
-        json_output: Deprecated compatibility argument; callers should use
-            ``wait_context`` for presentation policy.
         timeout: Timeout forwarded to ``wait_for_completion``. Callers supply
             per-command defaults; media generators use longer budgets while
             generic artifact waits remain at 300s.

--- a/src/notebooklm/cli/services/download.py
+++ b/src/notebooklm/cli/services/download.py
@@ -15,12 +15,9 @@ Public API (the three names ADR-008 / phase-3.md P3.T2 requires):
 - :func:`execute_download` — coroutine that performs the actual download.
 
 The split is deliberate: ``build_download_plan`` rejects flag conflicts
-synchronously at the Click decorator boundary, while ``execute_download``
-performs all I/O. Per ADR-015, the conflict-rejection path is dual: under
-``--json`` it emits the typed JSON envelope on stdout via ``output_error``
-and exits 1; in text mode it raises ``click.UsageError`` so Click's parser
-renders standard usage messaging on stderr and exits 2. The Click handler
-wires the two together inside ``run_client_workflow``.
+synchronously with :class:`DownloadPlanValidationError`, while
+``execute_download`` performs all I/O. The Click handler owns the ADR-015
+JSON envelope vs. text ``UsageError`` translation.
 """
 
 from __future__ import annotations
@@ -29,9 +26,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import Any, NoReturn, Protocol
-
-import click
+from typing import Any, Protocol
 
 from ...types import Artifact, ArtifactType
 from ..download_helpers import (
@@ -40,7 +35,6 @@ from ..download_helpers import (
     resolve_partial_artifact_id,
     select_artifact,
 )
-from ..error_handler import output_error
 from ..resolve import require_notebook, resolve_notebook_id
 
 # Format → extension map shared with the runtime extension-override path
@@ -140,6 +134,17 @@ _DownloadFn = Callable[..., Awaitable[str | None]]
 
 
 @dataclass(frozen=True)
+class DownloadPlanValidationError(Exception):
+    """Service-level validation error for command-layer rendering."""
+
+    message: str
+    code: str = "VALIDATION_ERROR"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", (self.message,))
+
+
+@dataclass(frozen=True)
 class DownloadPlan:
     """One validated download invocation.
 
@@ -176,6 +181,7 @@ class DownloadPlan:
     force: bool
     no_clobber: bool
     format_choice: str = ""
+    warnings: tuple[str, ...] = ()
     # Captured at plan-build time so the executor doesn't have to re-derive
     # it; ``Path.cwd()`` at executor time would be wrong if the caller
     # changed directories between ``build_download_plan`` and the awaited
@@ -187,10 +193,9 @@ def _resolve_format_extension(
     spec: DownloadTypeSpec,
     output_path: str | None,
     format_choice: str,
-    warn_sink: Callable[[str], None],
     *,
     download_all: bool = False,
-) -> str:
+) -> tuple[str, tuple[str, ...]]:
     """Compute the effective extension given the spec + user's ``--format``.
 
     Matches the historical wiring exactly:
@@ -202,66 +207,39 @@ def _resolve_format_extension(
       ``output_path``).
     - leaves with no ``--format`` flag → ``spec.extension`` unchanged.
 
-    ``warn_sink`` is the per-call adapter (``click.echo`` with ``err=True``
-    in the live path; configurable for testability). The mismatch warning
-    is suppressed when ``download_all`` is true because the user-supplied
-    path then names a destination *directory* (not a file), so an extension
-    check is meaningless and the warning would be a false positive.
+    A mismatch warning is returned with the extension so the command layer can
+    render it. The warning is suppressed when ``download_all`` is true because
+    the user-supplied path then names a destination *directory* (not a file),
+    so an extension check is meaningless and the warning would be a false positive.
     """
     if not spec.format_choices:
-        return spec.extension
+        return spec.extension, ()
     effective_ext = spec.format_extension_map.get(format_choice, spec.extension)
     # Only warn when the user supplied an output path whose extension doesn't
     # match the chosen --format AND we're in single-file mode (--all uses the
     # path as a directory destination, not a target filename).
     if output_path and not download_all and not output_path.endswith(effective_ext):
-        warn_sink(
-            f"Warning: output path '{output_path}' does not end with "
-            f"'{effective_ext}' but --format {format_choice} was requested."
+        return (
+            effective_ext,
+            (
+                f"Warning: output path '{output_path}' does not end with "
+                f"'{effective_ext}' but --format {format_choice} was requested.",
+            ),
         )
-    return effective_ext
-
-
-def _emit_flag_conflict(message: str, *, json_output: bool) -> NoReturn:
-    """Surface a download flag-conflict via the active CLI error contract.
-
-    Per ADR-015, post-parse flag-combination failures are routed through
-    the typed JSON envelope under ``--json`` (exit ``1``) and via Click's
-    parser-style ``UsageError`` otherwise (exit ``2`` with usage text on
-    stderr). Never returns — both branches raise.
-    """
-    if json_output:
-        # ``output_error`` emits {"error": true, "code": ..., "message": ...}
-        # on stdout and raises SystemExit(1).
-        output_error(message, "VALIDATION_ERROR", True, 1)
-        raise AssertionError("unreachable")  # pragma: no cover
-    raise click.UsageError(message)
+    return effective_ext, ()
 
 
 def build_download_plan(
     config: DownloadTypeSpec,
     args: dict[str, Any],
     cwd: Path | None = None,
-    *,
-    warn_sink: Callable[[str], None] | None = None,
 ) -> DownloadPlan:
     """Validate + assemble a :class:`DownloadPlan` from raw Click args.
 
-    Synchronous: rejects flag conflicts via the canonical CLI error path,
-    routing through the typed JSON envelope under ``--json`` and Click's
-    standard usage path otherwise; resolves the notebook id via the shared
-    ``require_notebook`` helper (no I/O). Does NOT perform the async
-    :func:`resolve_notebook_id` lookup — that runs inside
-    :func:`execute_download`.
-
-    Flag-conflict policy (see ADR-015):
-
-    - Under ``--json``: emit the typed envelope
-      ``{"error": true, "code": "VALIDATION_ERROR", "message": ...}`` on
-      stdout via :func:`output_error` and exit ``1``. The function never
-      returns in this branch.
-    - Under text mode: raise :class:`click.UsageError` so Click's parser
-      renders ``Usage: ... / Error: ...`` on stderr and exits ``2``.
+    Synchronous: rejects flag conflicts with a typed validation exception and
+    resolves the notebook id via the shared ``require_notebook`` helper (no
+    I/O). Does NOT perform the async :func:`resolve_notebook_id` lookup — that
+    runs inside :func:`execute_download`.
 
     Args:
         config: One ``DownloadTypeSpec`` row from the registry.
@@ -273,29 +251,20 @@ def build_download_plan(
             (used for derived-output-path resolution inside the executor).
             ``None`` is fine — the executor falls back to ``Path.cwd()`` at
             call time.
-        warn_sink: Optional callback for the "output path does not end with
-            .ext" warning. Defaults to ``click.echo(..., err=True)``.
-
     Returns:
         Frozen ``DownloadPlan`` ready for :func:`execute_download`.
 
     Raises:
-        click.UsageError: when flag combinations conflict in text mode
-            (i.e. ``args["json_output"]`` is falsy).
-        SystemExit: when flag combinations conflict under ``--json``;
-            :func:`output_error` emits the envelope on stdout and raises
-            ``SystemExit(1)``.
+        DownloadPlanValidationError: when flag combinations conflict. The
+            command layer translates this into Click usage text or the
+            ADR-015 JSON envelope.
     """
-    # Flag conflicts — same checks as the pre-refactor _download_artifacts_generic.
-    # Under --json, route through the typed JSON envelope (ADR-015); otherwise
-    # preserve Click's UsageError path (exit 2 + usage text on stderr).
-    json_output = bool(args.get("json_output", False))
     if args.get("force") and args.get("no_clobber"):
-        _emit_flag_conflict("Cannot specify both --force and --no-clobber", json_output=json_output)
+        raise DownloadPlanValidationError("Cannot specify both --force and --no-clobber")
     if args.get("latest") and args.get("earliest"):
-        _emit_flag_conflict("Cannot specify both --latest and --earliest", json_output=json_output)
+        raise DownloadPlanValidationError("Cannot specify both --latest and --earliest")
     if args.get("download_all") and args.get("artifact_id"):
-        _emit_flag_conflict("Cannot specify both --all and --artifact", json_output=json_output)
+        raise DownloadPlanValidationError("Cannot specify both --all and --artifact")
 
     nb_id = require_notebook(args.get("notebook_id"))
 
@@ -309,12 +278,10 @@ def build_download_plan(
             args.get(config.format_param_name, config.format_default) or config.format_default
         )
 
-    sink = warn_sink if warn_sink is not None else (lambda msg: click.echo(msg, err=True))
-    file_extension = _resolve_format_extension(
+    file_extension, warnings = _resolve_format_extension(
         config,
         output_path=args.get("output_path"),
         format_choice=format_choice,
-        warn_sink=sink,
         download_all=bool(args.get("download_all", False)),
     )
 
@@ -333,6 +300,7 @@ def build_download_plan(
         force=bool(args.get("force", False)),
         no_clobber=bool(args.get("no_clobber", False)),
         format_choice=format_choice,
+        warnings=warnings,
         cwd=cwd if cwd is not None else Path.cwd(),
     )
 

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -870,7 +870,6 @@ async def execute_generation(
         result,
         plan.display_name,
         plan.wait,
-        plan.json_output,
         timeout=plan.timeout,
         interval=plan.interval,
         wait_context=wait_context,

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -16,13 +16,13 @@ shape established by earlier ADR-008 extractions:
   It returns a frozen :class:`GenerationPlan` dataclass.
 * :func:`execute_generation` is the async orchestration: open-client
   scope is the caller's; this function resolves notebook/source IDs,
-  emits queued warnings, dispatches to the right ``client.artifacts.*``
-  method, runs the retry-with-backoff loop via the existing
-  ``services/artifact_generation.py`` core, and handles output / wait.
+  dispatches to the right ``client.artifacts.*`` method, runs the
+  retry-with-backoff loop via the existing ``services/artifact_generation.py``
+  core, and returns a typed result for command-layer rendering.
 
 The Click handlers in ``cli/generate_cmd.py`` shrink to a thin shell:
 build the raw_args dict from Click params, call
-``build_generation_plan(kind, raw_args, parameter_source)``, then call
+``build_generation_plan(kind, raw_args, parameter_explicit)``, then call
 ``execute_generation(plan, client)`` inside an ``async with
 NotebookLMClient(...) as client:`` block.
 
@@ -34,12 +34,11 @@ and is reused as-is; see phase-3.md → P3.T1 must_not_do).
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+import contextlib
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
-
-import click
-from click.core import ParameterSource
 
 from ...types import (
     AudioFormat,
@@ -55,11 +54,10 @@ from ...types import (
     VideoFormat,
     VideoStyle,
 )
-from ..error_handler import output_error
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
-    from ...types import GenerationStatus
+    from .artifact_generation import GenerationOutcome
 
 GenerationKind = Literal[
     "audio",
@@ -255,10 +253,31 @@ class GenerationPlan:
     warnings: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class GenerationPlanValidationError(Exception):
+    """Service-level generation validation error for command-layer rendering."""
+
+    message: str
+    code: str = "VALIDATION_ERROR"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", (self.message,))
+
+
+@dataclass(frozen=True)
+class GenerationExecutionResult:
+    """Typed generation executor result for command-layer rendering."""
+
+    kind: GenerationKind
+    display_name: str
+    generation: GenerationOutcome | None = None
+    mind_map: Any = None
+
+
 def build_generation_plan(
     kind: str,
     raw_args: Mapping[str, Any],
-    parameter_source: Callable[[str], ParameterSource] | None = None,
+    parameter_explicit: Callable[[str], bool] | None = None,
     *,
     language_resolver: Callable[[str | None], str] | None = None,
 ) -> GenerationPlan:
@@ -275,12 +294,10 @@ def build_generation_plan(
             ``language``, ``wait``, ``timeout``, ``interval``,
             ``max_retries``, ``json_output``. Kind-specific keys: see
             internal builders below.
-        parameter_source: Optional callable returning Click's
-            ``ParameterSource`` for a given param name. Used to detect
-            "user did not pass --format / --timeout" cases for the
-            cinematic-video alias. If ``None``, defaults to "every
-            parameter is treated as DEFAULT", which is the right behavior
-            for unit tests that supply args directly.
+        parameter_explicit: Optional callable returning whether a parameter
+            was supplied explicitly by the user. Used to detect "user did
+            not pass --format / --timeout" cases for the cinematic-video
+            alias. If ``None``, defaults to false for every parameter.
         language_resolver: Optional callable that resolves a raw
             ``--language`` value through the env/config/default chain.
             When ``None``, the raw value is passed through unchanged
@@ -292,18 +309,14 @@ def build_generation_plan(
         A frozen :class:`GenerationPlan` ready for :func:`execute_generation`.
 
     Raises:
-        SystemExit: For invalid parameter combinations (cinematic video +
-            ``--style-prompt``, ``--style custom`` without
-            ``--style-prompt``, ``cinematic-video --format <non-cinematic>``).
-            Routed through :func:`cli.error_handler.output_error` per
-            ADR-015: under ``--json`` the typed JSON envelope is emitted on
-            stdout (``code: "VALIDATION_ERROR"``, exit 1); in text mode the
-            same message is written to stderr (exit 1, no usage footer).
+        GenerationPlanValidationError: For invalid parameter combinations
+            (cinematic video + ``--style-prompt``, ``--style custom``
+            without ``--style-prompt``, ``cinematic-video --format
+            <non-cinematic>``). The command layer renders the error through
+            the ADR-015 JSON/text surface.
         ValueError: When ``kind`` is not recognized.
     """
-    source: Callable[[str], ParameterSource] = parameter_source or (
-        lambda _name: ParameterSource.DEFAULT
-    )
+    is_explicit: Callable[[str], bool] = parameter_explicit or (lambda _name: False)
     # Default resolver mirrors the canonical ``"en"`` fallback used by
     # ``cli/generate_cmd.py:resolve_language`` so unit tests that omit a
     # resolver get a stable string back. Production calls (from the Click
@@ -316,7 +329,7 @@ def build_generation_plan(
     builder = _BUILDERS.get(kind)
     if builder is None:
         raise ValueError(f"Unknown generation kind: {kind!r}")
-    return builder(raw_args, source, resolve_language)
+    return builder(raw_args, is_explicit, resolve_language)
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +353,7 @@ def _common(raw_args: Mapping[str, Any]) -> dict[str, Any]:
 
 def _build_audio_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -366,35 +379,28 @@ def _build_audio_plan(
 
 def _build_video_plan_for_kind(
     raw_args: Mapping[str, Any],
-    source: Callable[[str], ParameterSource],
+    source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
     *,
     alias: bool,
 ) -> GenerationPlan:
     """Shared builder for ``video`` and the ``cinematic-video`` alias.
 
-    ``alias=True`` enforces the cinematic-video flag rules: an explicit
-    ``--format <non-cinematic>`` is rejected through ``output_error`` (per
-    ADR-015 the typed JSON envelope covers post-parse validation under
-    ``--json``; text mode writes the same message to stderr and exits 1),
-    the format is coerced to cinematic when not passed, and the timeout
-    defaults to 3600s when the user did not pass ``--timeout``.
+    ``alias=True`` enforces the cinematic-video flag rules. Validation
+    failures are raised as typed service errors for the command layer to
+    render via text or the ADR-015 JSON envelope.
     """
     common = _common(raw_args)
-    json_output = common["json_output"]
     video_format = raw_args.get("video_format", "explainer")
     style = raw_args.get("style", "auto")
     style_prompt_raw = raw_args.get("style_prompt")
 
     if alias:
-        format_explicit = source("video_format") == ParameterSource.COMMANDLINE
+        format_explicit = source("video_format")
         if format_explicit and video_format != "cinematic":
-            output_error(
+            raise GenerationPlanValidationError(
                 "--format must be 'cinematic' for the cinematic-video subcommand "
-                "(use 'generate video --format <other>' for other formats)",
-                "VALIDATION_ERROR",
-                json_output,
-                1,
+                "(use 'generate video --format <other>' for other formats)"
             )
         video_format = "cinematic"
 
@@ -403,29 +409,14 @@ def _build_video_plan_for_kind(
         style_prompt_raw.strip() if isinstance(style_prompt_raw, str) else None
     )
     if is_cinematic and normalized_style_prompt:
-        output_error(
-            "--style-prompt cannot be used with cinematic video",
-            "VALIDATION_ERROR",
-            json_output,
-            1,
-        )
+        raise GenerationPlanValidationError("--style-prompt cannot be used with cinematic video")
     if not is_cinematic and style == "custom" and not normalized_style_prompt:
-        output_error(
-            "--style custom requires --style-prompt",
-            "VALIDATION_ERROR",
-            json_output,
-            1,
-        )
+        raise GenerationPlanValidationError("--style custom requires --style-prompt")
     if not is_cinematic and normalized_style_prompt and style != "custom":
-        output_error(
-            "--style-prompt requires --style custom",
-            "VALIDATION_ERROR",
-            json_output,
-            1,
-        )
+        raise GenerationPlanValidationError("--style-prompt requires --style custom")
 
     timeout_value = common["timeout"]
-    if is_cinematic and source("timeout") != ParameterSource.COMMANDLINE:
+    if is_cinematic and not source("timeout"):
         timeout_value = _CINEMATIC_DEFAULT_TIMEOUT
     language = resolve_language(raw_args.get("language"))
 
@@ -469,7 +460,7 @@ def _build_video_plan_for_kind(
 
 def _build_video_plan(
     raw_args: Mapping[str, Any],
-    source: Callable[[str], ParameterSource],
+    source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     return _build_video_plan_for_kind(raw_args, source, resolve_language, alias=False)
@@ -477,7 +468,7 @@ def _build_video_plan(
 
 def _build_cinematic_video_plan(
     raw_args: Mapping[str, Any],
-    source: Callable[[str], ParameterSource],
+    source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     return _build_video_plan_for_kind(raw_args, source, resolve_language, alias=True)
@@ -485,7 +476,7 @@ def _build_cinematic_video_plan(
 
 def _build_slide_deck_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -510,7 +501,7 @@ def _build_slide_deck_plan(
 
 def _build_revise_slide_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     _resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -536,7 +527,7 @@ def _build_revise_slide_plan(
 
 def _build_quiz_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     _resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -561,7 +552,7 @@ def _build_quiz_plan(
 
 def _build_flashcards_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     _resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -586,7 +577,7 @@ def _build_flashcards_plan(
 
 def _build_infographic_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -612,7 +603,7 @@ def _build_infographic_plan(
 
 def _build_data_table_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -634,7 +625,7 @@ def _build_data_table_plan(
 
 def _build_mind_map_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -656,7 +647,7 @@ def _build_mind_map_plan(
 
 def _build_report_plan(
     raw_args: Mapping[str, Any],
-    _source: Callable[[str], ParameterSource],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
@@ -710,7 +701,7 @@ _BUILDERS: Mapping[
     Callable[
         [
             Mapping[str, Any],
-            Callable[[str], ParameterSource],
+            Callable[[str], bool],
             Callable[[str | None], str],
         ],
         GenerationPlan,
@@ -816,46 +807,24 @@ def _build_call_kwargs(plan: GenerationPlan, *, notebook_id: str, sources: Any) 
     return base
 
 
-def _emit_warnings(plan: GenerationPlan) -> None:
-    """Emit any warnings queued by ``build_generation_plan`` to stderr.
-
-    Plan warnings (e.g. ``--append`` with ``--format custom``) match the
-    pre-extraction ``click.echo(..., err=True)`` semantics. Suppressed in
-    JSON mode so stdout stays parseable AND stderr stays JSON-machine-
-    consumer friendly (the warning text is human prose, not structured).
-    """
-    if plan.json_output or not plan.warnings:
-        return
-    for line in plan.warnings:
-        click.echo(line, err=True)
-
-
 async def execute_generation(
     plan: GenerationPlan,
     client: NotebookLMClient,
-) -> GenerationStatus | None:
+    *,
+    retry_sink: Callable[[Any], None] | None = None,
+    wait_context: Callable[[str, str], AbstractAsyncContextManager[None]] | None = None,
+    wait_start_sink: Callable[[str], None] | None = None,
+    mind_map_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
+) -> GenerationExecutionResult:
     """Drive a single generation request end-to-end.
 
     Caller responsibility: open and close the ``NotebookLMClient`` scope.
-    This function resolves notebook/source IDs, emits queued warnings,
-    dispatches to the matching ``client.artifacts.<method>``, runs the
-    retry-with-backoff loop, then either renders the mind-map result via
-    the legacy text/JSON formatter or hands off to
-    ``handle_generation_result`` (wait + status output + non-zero exit on
-    failure).
-
-    Returns the final :class:`GenerationStatus` (or ``None`` when the
-    underlying call resolved without a status). For ``mind-map`` returns
-    ``None`` — output is rendered inline.
+    This function resolves notebook/source IDs, dispatches to the matching
+    ``client.artifacts.<method>``, runs the retry-with-backoff loop, and
+    returns a typed result for the command layer to render.
     """
-    # Local imports defer heavy CLI-layer wiring (rendering, error_handler)
-    # until execution time and keep the import graph testable.
-    from .. import generate_cmd  # late import: avoids module-load cycles
     from ..resolve import resolve_notebook_id, resolve_source_ids
     from .artifact_generation import generate_with_retry, handle_generation_result
-    from .polling import status_with_elapsed
-
-    _emit_warnings(plan)
 
     nb_id_resolved = await resolve_notebook_id(
         client, plan.notebook_id, json_output=plan.json_output
@@ -877,25 +846,25 @@ async def execute_generation(
         return await api_method(nb_id_resolved, **call_kwargs)
 
     if plan.kind == "mind-map":
-        # Mind-map has a custom output path: no retry loop, optional
-        # spinner, custom formatter. Stay inside the generate_cmd module
-        # for _output_mind_map_result because tests patch it as a
-        # module-level attribute.
         if plan.json_output:
             result = await _generate()
         else:
-            async with status_with_elapsed(
-                "Generating mind map...",
-                json_output=False,
-            ):
+            context = mind_map_context or contextlib.asynccontextmanager(_null_async_context)
+            async with context():
                 result = await _generate()
-        generate_cmd._output_mind_map_result(result, plan.json_output)
-        return None
+        return GenerationExecutionResult(
+            kind=plan.kind,
+            display_name=plan.display_name,
+            mind_map=result,
+        )
 
     result = await generate_with_retry(
-        _generate, plan.max_retries, plan.display_name, plan.json_output
+        _generate,
+        plan.max_retries,
+        plan.display_name,
+        on_retry=retry_sink,
     )
-    return await handle_generation_result(
+    outcome = await handle_generation_result(
         client,
         nb_id_resolved,
         result,
@@ -904,12 +873,25 @@ async def execute_generation(
         plan.json_output,
         timeout=plan.timeout,
         interval=plan.interval,
+        wait_context=wait_context,
+        wait_start_sink=wait_start_sink,
     )
+    return GenerationExecutionResult(
+        kind=plan.kind,
+        display_name=plan.display_name,
+        generation=outcome,
+    )
+
+
+async def _null_async_context() -> AsyncIterator[None]:
+    yield
 
 
 __all__ = [
     "GenerationKind",
+    "GenerationExecutionResult",
     "GenerationPlan",
+    "GenerationPlanValidationError",
     "build_generation_plan",
     "execute_generation",
 ]

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -882,6 +882,7 @@ async def execute_generation(
         generation=outcome,
     )
 
+
 __all__ = [
     "GenerationKind",
     "GenerationExecutionResult",

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -35,7 +35,7 @@ and is reused as-is; see phase-3.md → P3.T1 must_not_do).
 from __future__ import annotations
 
 import contextlib
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import Callable, Mapping
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
@@ -849,7 +849,7 @@ async def execute_generation(
         if plan.json_output:
             result = await _generate()
         else:
-            context = mind_map_context or contextlib.asynccontextmanager(_null_async_context)
+            context = mind_map_context or contextlib.nullcontext
             async with context():
                 result = await _generate()
         return GenerationExecutionResult(
@@ -881,11 +881,6 @@ async def execute_generation(
         display_name=plan.display_name,
         generation=outcome,
     )
-
-
-async def _null_async_context() -> AsyncIterator[None]:
-    yield
-
 
 __all__ = [
     "GenerationKind",

--- a/src/notebooklm/cli/services/polling.py
+++ b/src/notebooklm/cli/services/polling.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
-
-from ..error_handler import emit_cancelled_and_exit
-from ..rendering import console
 
 T = TypeVar("T")
 
@@ -32,55 +28,6 @@ class PollResult(Generic[T]):
     attempts: int
     elapsed: float
     timed_out: bool
-
-
-@contextlib.asynccontextmanager
-async def status_with_elapsed(
-    message: str,
-    *,
-    json_output: bool = False,
-    resume_hint: str | None = None,
-) -> AsyncIterator[None]:
-    """Show a transient Rich status spinner with an elapsed-seconds counter.
-
-    The context manager is a no-op in JSON mode so stdout remains parseable.
-    In text mode it updates the spinner once per second and cancels that
-    ticker when the wrapped block exits. If ``resume_hint`` is provided,
-    ``KeyboardInterrupt`` is converted to the CLI's structured/friendly
-    cancellation response; otherwise the interrupt propagates unchanged.
-    """
-
-    @contextlib.contextmanager
-    def _sigint_guard() -> Iterator[None]:
-        try:
-            yield
-        except KeyboardInterrupt:
-            if resume_hint is None:
-                raise
-            emit_cancelled_and_exit(resume_hint, json_output=json_output)
-
-    if json_output:
-        with _sigint_guard():
-            yield
-        return
-
-    start = time.monotonic()
-    with console.status(message) as status:
-
-        async def _ticker() -> None:
-            while True:
-                await asyncio.sleep(1.0)
-                elapsed = int(time.monotonic() - start)
-                status.update(f"{message} [{elapsed}s elapsed]")
-
-        ticker_task = asyncio.create_task(_ticker())
-        try:
-            with _sigint_guard():
-                yield
-        finally:
-            ticker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await ticker_task
 
 
 async def poll_until(
@@ -119,4 +66,4 @@ async def poll_until(
         await asyncio.sleep(min(interval, timeout - elapsed))
 
 
-__all__ = ["PollResult", "poll_until", "status_with_elapsed"]
+__all__ = ["PollResult", "poll_until"]

--- a/src/notebooklm/cli/services/source_wait.py
+++ b/src/notebooklm/cli/services/source_wait.py
@@ -2,9 +2,8 @@
 
 Owns the dataclass + executor pair so ``cli/source_cmd.py`` stays a thin
 Click handler. The executor wraps the underlying
-``client.sources.wait_until_ready`` call in a transient
-``status_with_elapsed`` spinner (suppressed under JSON) and translates the
-three ``SourceWaitError`` subclasses into a typed
+``client.sources.wait_until_ready`` call in the caller-provided wait context
+and translates the three ``SourceWaitError`` subclasses into a typed
 :class:`SourceWaitOutcome`. The caller renders the outcome and decides the
 exit code.
 
@@ -19,6 +18,9 @@ exit policy, now owned by the caller):
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -28,7 +30,6 @@ from ...types import (
     SourceProcessingError,
     SourceTimeoutError,
 )
-from .polling import status_with_elapsed
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -78,7 +79,12 @@ SourceWaitOutcome = (
 )
 
 
-async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) -> SourceWaitOutcome:
+async def execute_source_wait(
+    client: NotebookLMClient,
+    plan: SourceWaitPlan,
+    *,
+    wait_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
+) -> SourceWaitOutcome:
     """Run the ``source wait`` workflow and return a typed outcome.
 
     The caller is responsible for resolving ``plan.source_id`` to a full
@@ -89,13 +95,8 @@ async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) ->
     only owns the polling loop and exception-to-outcome mapping.
     """
     try:
-        async with status_with_elapsed(
-            f"Waiting for source {plan.source_id} to finish processing...",
-            json_output=plan.json_output,
-            # Parallel hint: ``source wait`` has no separate ``source
-            # poll`` command, so the resume IS re-running the same wait.
-            resume_hint=f"notebooklm source wait {plan.source_id}",
-        ):
+        context = wait_context or contextlib.asynccontextmanager(_null_async_context)
+        async with context():
             source = await client.sources.wait_until_ready(
                 plan.notebook_id,
                 plan.source_id,
@@ -109,6 +110,10 @@ async def execute_source_wait(client: NotebookLMClient, plan: SourceWaitPlan) ->
     except SourceTimeoutError as exc:
         return SourceWaitTimeout(error=exc)
     return SourceWaitReady(source=source)
+
+
+async def _null_async_context() -> AsyncIterator[None]:
+    yield
 
 
 __all__ = [

--- a/src/notebooklm/cli/services/source_wait.py
+++ b/src/notebooklm/cli/services/source_wait.py
@@ -19,7 +19,7 @@ exit policy, now owned by the caller):
 from __future__ import annotations
 
 import contextlib
-from collections.abc import AsyncIterator, Callable
+from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -95,7 +95,7 @@ async def execute_source_wait(
     only owns the polling loop and exception-to-outcome mapping.
     """
     try:
-        context = wait_context or contextlib.asynccontextmanager(_null_async_context)
+        context = wait_context or contextlib.nullcontext
         async with context():
             source = await client.sources.wait_until_ready(
                 plan.notebook_id,
@@ -110,10 +110,6 @@ async def execute_source_wait(
     except SourceTimeoutError as exc:
         return SourceWaitTimeout(error=exc)
     return SourceWaitReady(source=source)
-
-
-async def _null_async_context() -> AsyncIterator[None]:
-    yield
 
 
 __all__ = [

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -37,6 +37,7 @@ from .options import (
     prompt_file_option,
     wait_polling_options,
 )
+from .polling_ui import status_with_elapsed
 from .rendering import (
     cli_print,
     cli_status,
@@ -48,7 +49,6 @@ from .rendering import (
     json_output_response,
     render_list,
 )
-from .polling_ui import status_with_elapsed
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_id
 from .runtime import is_quiet
 from .services import source_add as source_add_service

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -48,6 +48,7 @@ from .rendering import (
     json_output_response,
     render_list,
 )
+from .polling_ui import status_with_elapsed
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_id
 from .runtime import is_quiet
 from .services import source_add as source_add_service
@@ -1213,6 +1214,13 @@ def source_wait(ctx, source_id, notebook_id, timeout, interval, json_output, cli
                     timeout=float(timeout),
                     interval=float(interval),
                     json_output=json_output,
+                ),
+                wait_context=lambda: status_with_elapsed(
+                    f"Waiting for source {resolved_id} to finish processing...",
+                    json_output=json_output,
+                    # Parallel hint: ``source wait`` has no separate ``source
+                    # poll`` command, so the resume IS re-running the same wait.
+                    resume_hint=f"notebooklm source wait {resolved_id}",
                 ),
             )
             _render_source_wait_outcome(outcome, json_output=json_output)

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -439,6 +439,43 @@ class TestDownloadJsonOutputUnicode:
         assert "\\u" not in result.output
 
 
+class TestDownloadWarnings:
+    def test_format_mismatch_warning_is_rendered_by_command_layer(self, runner, mock_auth):
+        """Format-extension warnings carried by the plan are echoed by the Click layer."""
+
+        async def fake_execute_download(*args, **kwargs):
+            return {
+                "operation": "download_single",
+                "artifact": {"title": "Slides", "selection_reason": "latest"},
+                "output_path": "deck.pdf",
+                "status": "downloaded",
+            }
+
+        with (
+            patch("notebooklm.cli.download_cmd.execute_download", fake_execute_download),
+            patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "slide-deck",
+                    "deck.pdf",
+                    "--format",
+                    "pptx",
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0
+        combined = result.output + (result.stderr if result.stderr_bytes else "")
+        assert "does not end with '.pptx'" in combined
+
+
 # =============================================================================
 # COMMAND EXISTENCE TESTS
 # =============================================================================

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -8,13 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from notebooklm.cli.polling_ui import status_with_elapsed
 from notebooklm.cli.services.artifact_generation import (
     RETRY_MAX_DELAY,
+    GenerationOutcome,
     _format_status_message,
     calculate_backoff_delay,
     generate_with_retry,
 )
-from notebooklm.cli.services.polling import status_with_elapsed
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc.types import ReportFormat
 
@@ -26,6 +27,7 @@ from .conftest import create_mock_client
 # the Click Group sitting at the same dotted path.
 generate_module = importlib.import_module("notebooklm.cli.generate_cmd")
 artifact_generation_module = importlib.import_module("notebooklm.cli.services.artifact_generation")
+polling_ui_module = importlib.import_module("notebooklm.cli.polling_ui")
 
 
 @pytest.fixture
@@ -1197,7 +1199,7 @@ class TestGenerateWithRetry:
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await generate_with_retry(
-                generate_fn, max_retries=3, artifact_type="audio", json_output=True
+                generate_fn, max_retries=3, artifact_type="audio"
             )
 
         assert result == success_result
@@ -1216,7 +1218,7 @@ class TestGenerateWithRetry:
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await generate_with_retry(
-                generate_fn, max_retries=2, artifact_type="audio", json_output=True
+                generate_fn, max_retries=2, artifact_type="audio"
             )
 
         assert result == rate_limited
@@ -1233,7 +1235,7 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(return_value=rate_limited)
 
         result = await generate_with_retry(
-            generate_fn, max_retries=0, artifact_type="audio", json_output=True
+            generate_fn, max_retries=0, artifact_type="audio"
         )
 
         assert result == rate_limited
@@ -1251,7 +1253,7 @@ class TestGenerateWithRetry:
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await generate_with_retry(
-                generate_fn, max_retries=3, artifact_type="audio", json_output=True
+                generate_fn, max_retries=3, artifact_type="audio"
             )
 
         # Verify delays: 60s, 120s, 240s (3 retries = 3 sleeps)
@@ -1270,7 +1272,7 @@ class TestGenerateWithRetry:
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await generate_with_retry(
-                generate_fn, max_retries=10, artifact_type="audio", json_output=True
+                generate_fn, max_retries=10, artifact_type="audio"
             )
 
         # Verify no delay exceeds RETRY_MAX_DELAY (300s)
@@ -1513,156 +1515,105 @@ class TestResolveLanguageDirect:
 
 
 # =============================================================================
-# _OUTPUT_GENERATION_STATUS DIRECT TESTS
+# _OUTPUT_GENERATION_OUTCOME DIRECT TESTS
 # =============================================================================
 
 
-class TestOutputGenerationStatusDirect:
-    """Direct tests for _output_generation_status() covering uncovered branches."""
+class TestOutputGenerationOutcomeDirect:
+    """Direct tests for command-layer generation outcome rendering."""
 
     def setup_method(self):
-        self.generate_module = artifact_generation_module
-
-    def _make_status(
-        self, *, is_complete=False, is_failed=False, task_id=None, url=None, error=None
-    ):
-        status = MagicMock()
-        status.is_complete = is_complete
-        status.is_failed = is_failed
-        status.task_id = task_id
-        status.url = url
-        status.error = error
-        return status
+        self.generate_module = generate_module
 
     def test_json_completed_with_url(self):
-        """Lines 200-201, 243: JSON output for completed status with URL."""
-        status = self._make_status(
-            is_complete=True, task_id="task_123", url="https://example.com/audio.mp3"
+        outcome = GenerationOutcome(
+            status="completed",
+            artifact_type="audio",
+            task_id="task_123",
+            url="https://example.com/audio.mp3",
         )
         with patch.object(self.generate_module, "json_output_response") as mock_json:
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
+            self.generate_module._output_generation_outcome(outcome, json_output=True)
         mock_json.assert_called_once_with(
             {"task_id": "task_123", "status": "completed", "url": "https://example.com/audio.mp3"}
         )
 
     def test_json_failed(self):
-        """JSON output for failed status routes through ``output_error``.
-
-        P1.T6: terminal ``is_failed`` no longer fans into separate text/JSON
-        branches — both modes go through ``output_error`` (the public alias
-        of ``error_handler._output_error``) so the exit code is unified at
-        1 across modes.
-        """
-        status = self._make_status(is_failed=True, error="Something went wrong")
+        outcome = GenerationOutcome(status="failed", artifact_type="audio", error="Something went wrong")
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),
         ):
-            # output_error raises SystemExit; in real use the patch
-            # suppresses it but the SystemExit path is part of the
-            # contract — patch a side_effect to mirror the real call.
             mock_err.side_effect = SystemExit(1)
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
+            self.generate_module._output_generation_outcome(outcome, json_output=True)
         mock_err.assert_called_once_with("Something went wrong", "GENERATION_FAILED", True, 1)
 
     def test_json_failed_no_error_message(self):
-        """JSON failed output falls back to default message when error is None.
-
-        Same ``output_error`` routing as ``test_json_failed`` — only the
-        message differs (default fallback when ``status.error`` is None).
-        """
-        status = self._make_status(is_failed=True, error=None)
+        outcome = GenerationOutcome(status="failed", artifact_type="audio")
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),
         ):
             mock_err.side_effect = SystemExit(1)
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
+            self.generate_module._output_generation_outcome(outcome, json_output=True)
         mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", True, 1)
 
     def test_json_pending_with_task_id(self):
-        """Lines 205-207, 257: JSON output for pending status extracts task_id from list."""
-        # Use a list result (lines 205-207: list path in handle_generation_result)
-        # and pending path in _output_generation_status (lines 255-257)
-        status = MagicMock()
-        status.is_complete = False
-        status.is_failed = False
-        status.task_id = "task_456"
+        outcome = GenerationOutcome(status="pending", artifact_type="audio", task_id="task_456")
         with patch.object(self.generate_module, "json_output_response") as mock_json:
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
+            self.generate_module._output_generation_outcome(outcome, json_output=True)
         mock_json.assert_called_once_with({"task_id": "task_456", "status": "pending"})
 
     def test_text_completed_with_url(self):
-        """Line 262: Text output for completed status with URL."""
-        status = self._make_status(
-            is_complete=True, task_id="task_123", url="https://example.com/audio.mp3"
+        outcome = GenerationOutcome(
+            status="completed",
+            artifact_type="audio",
+            task_id="task_123",
+            url="https://example.com/audio.mp3",
         )
         with patch.object(self.generate_module, "console") as mock_console:
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_console.print.assert_called_once_with(
             "[green]Audio ready:[/green] https://example.com/audio.mp3"
         )
 
     def test_text_completed_without_url(self):
-        """Line 264: Text output for completed status without URL."""
-        status = self._make_status(is_complete=True, task_id="task_123", url=None)
+        outcome = GenerationOutcome(status="completed", artifact_type="audio", task_id="task_123")
         with patch.object(self.generate_module, "console") as mock_console:
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_console.print.assert_called_once_with("[green]Audio ready[/green]")
 
     def test_text_failed(self):
-        """Text output for failed status routes through ``output_error``.
-
-        P1.T6: text-mode failures no longer print via Rich + return (which
-        kept exit code 0). They route through ``output_error`` →
-        ``safe_echo(err=True)`` → ``SystemExit(1)`` so text mode now exits
-        non-zero, matching JSON mode.
-        """
-        status = self._make_status(is_failed=True, error="Transcription error")
+        outcome = GenerationOutcome(status="failed", artifact_type="audio", error="Transcription error")
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),
         ):
             mock_err.side_effect = SystemExit(1)
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_err.assert_called_once_with("Transcription error", "GENERATION_FAILED", False, 1)
 
     def test_text_failed_no_error_message(self):
-        """Text failed output falls back to default message when error is None.
-
-        Note: pre-P1.T6 used ``"Unknown error"`` as the text-mode default and
-        ``"Audio generation failed"`` as the JSON-mode default. After
-        unification through ``output_error``, both modes use the same
-        ``"<Title> generation failed"`` fallback.
-        """
-        status = self._make_status(is_failed=True, error=None)
+        outcome = GenerationOutcome(status="failed", artifact_type="audio")
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),
         ):
             mock_err.side_effect = SystemExit(1)
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", False, 1)
 
     def test_text_pending_with_task_id(self):
-        """Line 268: Text output for pending status shows task_id."""
-        status = self._make_status(task_id="task_789")
+        outcome = GenerationOutcome(status="pending", artifact_type="audio", task_id="task_789")
         with patch.object(self.generate_module, "console") as mock_console:
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_console.print.assert_called_once_with("[yellow]Started:[/yellow] task_789")
 
-    def test_text_pending_without_task_id_shows_status(self):
-        """Line 268: Text output for pending status shows status object when no task_id."""
-        status = MagicMock()
-        status.is_complete = False
-        status.is_failed = False
-        # Make _extract_task_id return None by having no task_id attr and not a dict/list
-        del status.task_id
-        with (
-            patch.object(self.generate_module, "_extract_task_id", return_value=None),
-            patch.object(self.generate_module, "console") as mock_console,
-        ):
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
+    def test_text_pending_without_task_id_shows_raw_status(self):
+        raw_status = object()
+        outcome = GenerationOutcome(status="pending", artifact_type="audio", raw_status=raw_status)
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_outcome(outcome, json_output=False)
         mock_console.print.assert_called_once()
         call_args = mock_console.print.call_args[0][0]
         assert "[yellow]Started:[/yellow]" in call_args
@@ -2141,19 +2092,17 @@ class TestGenerateWithRetryConsoleOutput:
         )
         generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
 
-        with (
-            patch.object(artifact_generation_module, "console") as mock_console,
-            patch("asyncio.sleep", new_callable=AsyncMock),
-        ):
+        retry_sink = MagicMock()
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await artifact_generation_module.generate_with_retry(
-                generate_fn, max_retries=1, artifact_type="audio", json_output=False
+                generate_fn,
+                max_retries=1,
+                artifact_type="audio",
+                on_retry=retry_sink,
             )
 
         assert result == success_result
-        # Console should have been called with the retry message
-        mock_console.print.assert_called_once()
-        call_text = mock_console.print.call_args[0][0]
-        assert "rate limited" in call_text.lower() or "Retrying" in call_text
+        retry_sink.assert_called_once()
 
 
 class TestHandleGenerationResultListPathAndWait:
@@ -2307,7 +2256,7 @@ class TestStatusWithElapsed:
         """Under --json the helper must NOT call console.status (stdout stays JSON)."""
 
         async def _exercise() -> None:
-            with patch.object(artifact_generation_module.console, "status") as mock_status:
+            with patch.object(polling_ui_module.console, "status") as mock_status:
                 async with status_with_elapsed("audio", json_output=True):
                     pass
                 assert not mock_status.called, "console.status must not be invoked under --json"
@@ -2421,7 +2370,7 @@ class TestGenerateWaitSigintResumeHint:
         """
 
         async def _exercise() -> None:
-            with patch.object(artifact_generation_module.console, "status") as mock_status:
+            with patch.object(polling_ui_module.console, "status") as mock_status:
                 mock_status.return_value.__enter__ = MagicMock(return_value=MagicMock())
                 mock_status.return_value.__exit__ = MagicMock(return_value=False)
                 with pytest.raises(KeyboardInterrupt):
@@ -2446,8 +2395,8 @@ class TestArtifactGenerationExitCodes:
     failures via ``$?``.
 
     These tests pin the unified contract: every failure path inside
-    ``handle_generation_result`` (and ``_output_generation_status``'s terminal
-    failed branch reached via ``--wait``) routes through ``output_error``,
+    ``handle_generation_result`` (and the command-layer outcome renderer for
+    terminal failures reached via ``--wait``) routes through ``output_error``,
     which exits non-zero and writes the human-readable message to stderr in
     text mode or a structured envelope on stdout in JSON mode.
     """

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -226,7 +226,7 @@ class TestGenerateAudio:
 
         The spinner gives interactive users feedback during the long wait, with
         a transient line naming the artifact kind (and a typical-duration hint).
-        Asserts the wrap by patching `notebooklm.cli.generate_cmd.console.status`
+        Asserts the wrap by patching `notebooklm.cli.polling_ui.console.status`
         and confirming it is invoked exactly once with a message that mentions
         the artifact kind. Does not assert the elapsed-timer ticker — that's a
         rendering detail that relies on a TTY which `CliRunner` doesn't have.
@@ -248,7 +248,7 @@ class TestGenerateAudio:
                 patch(
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
-                patch.object(generate_module.console, "status") as mock_status,
+                patch.object(polling_ui_module.console, "status") as mock_status,
             ):
                 mock_fetch.return_value = ("csrf", "session")
                 # ``console.status`` returns a context manager; emulate one so

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1198,9 +1198,7 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            result = await generate_with_retry(
-                generate_fn, max_retries=3, artifact_type="audio"
-            )
+            result = await generate_with_retry(generate_fn, max_retries=3, artifact_type="audio")
 
         assert result == success_result
         assert generate_fn.call_count == 2
@@ -1217,9 +1215,7 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(return_value=rate_limited)
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await generate_with_retry(
-                generate_fn, max_retries=2, artifact_type="audio"
-            )
+            result = await generate_with_retry(generate_fn, max_retries=2, artifact_type="audio")
 
         assert result == rate_limited
         assert generate_fn.call_count == 3  # initial + 2 retries
@@ -1234,9 +1230,7 @@ class TestGenerateWithRetry:
         )
         generate_fn = AsyncMock(return_value=rate_limited)
 
-        result = await generate_with_retry(
-            generate_fn, max_retries=0, artifact_type="audio"
-        )
+        result = await generate_with_retry(generate_fn, max_retries=0, artifact_type="audio")
 
         assert result == rate_limited
         assert generate_fn.call_count == 1
@@ -1252,9 +1246,7 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(return_value=rate_limited)
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await generate_with_retry(
-                generate_fn, max_retries=3, artifact_type="audio"
-            )
+            await generate_with_retry(generate_fn, max_retries=3, artifact_type="audio")
 
         # Verify delays: 60s, 120s, 240s (3 retries = 3 sleeps)
         delays = [call[0][0] for call in mock_sleep.call_args_list]
@@ -1271,9 +1263,7 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(return_value=rate_limited)
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await generate_with_retry(
-                generate_fn, max_retries=10, artifact_type="audio"
-            )
+            await generate_with_retry(generate_fn, max_retries=10, artifact_type="audio")
 
         # Verify no delay exceeds RETRY_MAX_DELAY (300s)
         delays = [call[0][0] for call in mock_sleep.call_args_list]
@@ -1539,7 +1529,9 @@ class TestOutputGenerationOutcomeDirect:
         )
 
     def test_json_failed(self):
-        outcome = GenerationOutcome(status="failed", artifact_type="audio", error="Something went wrong")
+        outcome = GenerationOutcome(
+            status="failed", artifact_type="audio", error="Something went wrong"
+        )
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),
@@ -1584,7 +1576,9 @@ class TestOutputGenerationOutcomeDirect:
         mock_console.print.assert_called_once_with("[green]Audio ready[/green]")
 
     def test_text_failed(self):
-        outcome = GenerationOutcome(status="failed", artifact_type="audio", error="Transcription error")
+        outcome = GenerationOutcome(
+            status="failed", artifact_type="audio", error="Transcription error"
+        )
         with (
             patch.object(self.generate_module, "output_error") as mock_err,
             pytest.raises(SystemExit),

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -81,7 +81,10 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 # Click ``BadParameter`` translation and optional-domain warning rendering.
 GUARDED_PATHS = {
     "cli/services/auth_diagnostics.py": SERVICES_ROOT / "auth_diagnostics.py",
+    "cli/services/artifact_generation.py": SERVICES_ROOT / "artifact_generation.py",
     "cli/services/confirming_mutation.py": SERVICES_ROOT / "confirming_mutation.py",
+    "cli/services/download.py": SERVICES_ROOT / "download.py",
+    "cli/services/generate.py": SERVICES_ROOT / "generate.py",
     "cli/services/listing.py": SERVICES_ROOT / "listing.py",
     "cli/services/login/browser_accounts.py": SERVICES_ROOT / "login" / "browser_accounts.py",
     "cli/services/login/cookie_domains.py": SERVICES_ROOT / "login" / "cookie_domains.py",
@@ -91,6 +94,7 @@ GUARDED_PATHS = {
     "cli/services/login/outcomes.py": SERVICES_ROOT / "login" / "outcomes.py",
     "cli/services/login/profile_targets.py": SERVICES_ROOT / "login" / "profile_targets.py",
     "cli/services/login/rookiepy_errors.py": SERVICES_ROOT / "login" / "rookiepy_errors.py",
+    "cli/services/polling.py": SERVICES_ROOT / "polling.py",
     "cli/services/research.py": SERVICES_ROOT / "research.py",
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",
     "cli/services/skill_install.py": SERVICES_ROOT / "skill_install.py",
@@ -129,19 +133,6 @@ GUARDED_PATHS = {
 #   ``rationale``             — short note on what migration is in flight or
 #                               why the module is here.
 TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
-    "cli/services/artifact_generation.py": {
-        "path": SERVICES_ROOT / "artifact_generation.py",
-        "forbidden_imports": [
-            "artifact_generation.py:9: forbidden relative import: '..error_handler'",
-            "artifact_generation.py:10: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "Owns rendering imports + ``console.print`` for artifact "
-            "generation progress; exit policy already delegated to the "
-            "command layer."
-        ),
-    },
     "cli/services/auth_source.py": {
         "path": SERVICES_ROOT / "auth_source.py",
         "forbidden_imports": [
@@ -158,46 +149,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "Adapter that reads the auth-source override from the live Click "
             "context; the function-level ``import click`` is the only Click "
             "reach-in."
-        ),
-    },
-    "cli/services/download.py": {
-        "path": SERVICES_ROOT / "download.py",
-        "forbidden_imports": [
-            "download.py:34: forbidden top-level import: 'click'",
-            "download.py:43: forbidden relative import: '..error_handler'",
-        ],
-        "pattern_a_violations": [],
-        "pattern_b_violations": (
-            "raises click.UsageError on flag conflicts (parser-time "
-            "contract), uses output_error for ADR-015 JSON envelopes, "
-            "and uses click.echo for warning sink default."
-        ),
-        "rationale": (
-            "Flag-validation surface raises ``click.UsageError`` and "
-            "emits ADR-015 JSON envelopes from the service layer; it also "
-            "defaults its ``warn_sink`` to ``click.echo``. Lift to "
-            "command-layer validators/output handling."
-        ),
-    },
-    "cli/services/generate.py": {
-        "path": SERVICES_ROOT / "generate.py",
-        "forbidden_imports": [
-            "generate.py:41: forbidden top-level import: 'click'",
-            "generate.py:42: forbidden top-level import: 'click.core'",
-            "generate.py:58: forbidden relative import: '..error_handler'",
-        ],
-        "pattern_a_violations": [],
-        "pattern_b_violations": (
-            "raises click.UsageError on incompatible generation flags, "
-            "uses output_error for ADR-015 JSON envelopes, and "
-            "reads click.core.ParameterSource to distinguish flag-set vs. "
-            "default."
-        ),
-        "rationale": (
-            "Generation flag-validation depends on Click's ParameterSource "
-            "to detect explicit vs. default and currently emits ADR-015 "
-            "JSON envelopes from the service layer. Lift validation/output "
-            "handling to the command layer."
         ),
     },
     "cli/services/login/chromium_accounts.py": {
@@ -289,19 +240,6 @@ TRANSITIONAL_GUARDED_PATHS: dict[str, dict[str, object]] = {
             "shifted in commit e3871dc3 (subprocess-stderr redaction, "
             "PR #1111) but the inventory was not updated in that PR; "
             "refreshed here as a drive-by mechanical fix."
-        ),
-    },
-    "cli/services/polling.py": {
-        "path": SERVICES_ROOT / "polling.py",
-        "forbidden_imports": [
-            "polling.py:12: forbidden relative import: '..error_handler'",
-            "polling.py:13: forbidden relative import: '..rendering'",
-        ],
-        "pattern_a_violations": [],
-        "rationale": (
-            "Polling helpers still import ``..error_handler`` + "
-            "``..rendering`` for status spinners and exit mapping; lift "
-            "those callbacks into the command layer."
         ),
     },
 }

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from notebooklm.cli import source_cmd
-from notebooklm.cli.services import source_mutations, source_research, source_wait
+from notebooklm.cli.services import source_mutations, source_research
 from notebooklm.cli.services.source_content import (
     SourceFulltextPlan,
     SourceGuidePlan,
@@ -582,14 +582,11 @@ async def test_source_add_research_delegates_timeout_budget_to_research_api() ->
 
 
 @pytest.mark.asyncio
-async def test_source_wait_timeout_returns_typed_outcome(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_source_wait_timeout_returns_typed_outcome() -> None:
     @contextlib.asynccontextmanager
     async def fake_status_with_elapsed(*args: object, **kwargs: object) -> AsyncIterator[None]:
         yield
 
-    monkeypatch.setattr(source_wait, "status_with_elapsed", fake_status_with_elapsed)
     timeout_exc = SourceTimeoutError("src_1", 10.0, 2)
     client = SimpleNamespace(
         sources=SimpleNamespace(wait_until_ready=AsyncMock(side_effect=timeout_exc))
@@ -604,6 +601,7 @@ async def test_source_wait_timeout_returns_typed_outcome(
             interval=0.5,
             json_output=True,
         ),
+        wait_context=lambda: fake_status_with_elapsed(),
     )
 
     # Service now returns a typed outcome; presentation + exit code are the

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -11,12 +11,15 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
-import click
 import pytest
 
 from notebooklm.cli._download_specs import DOWNLOAD_SPECS_BY_NAME
 from notebooklm.cli.services import download as download_service
-from notebooklm.cli.services.download import build_download_plan, execute_download
+from notebooklm.cli.services.download import (
+    DownloadPlanValidationError,
+    build_download_plan,
+    execute_download,
+)
 from notebooklm.types import Artifact
 
 
@@ -67,24 +70,24 @@ def resolved_notebook(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_build_download_plan_rejects_force_and_no_clobber() -> None:
     spec = DOWNLOAD_SPECS_BY_NAME["audio"]
 
-    with pytest.raises(click.UsageError, match="Cannot specify both --force and --no-clobber"):
+    with pytest.raises(
+        DownloadPlanValidationError, match="Cannot specify both --force and --no-clobber"
+    ):
         build_download_plan(spec, _args(force=True, no_clobber=True))
 
 
 def test_build_download_plan_applies_registry_format_extension_and_warning() -> None:
     spec = DOWNLOAD_SPECS_BY_NAME["slide-deck"]
-    warnings: list[str] = []
 
     plan = build_download_plan(
         spec,
         _args(output_path="deck.pdf", slide_format="pptx"),
         Path("/workspace"),
-        warn_sink=warnings.append,
     )
 
     assert plan.file_extension == ".pptx"
     assert plan.format_choice == "pptx"
-    assert warnings == [
+    assert list(plan.warnings) == [
         "Warning: output path 'deck.pdf' does not end with '.pptx' but --format pptx was requested."
     ]
 

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -30,10 +30,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from click.core import ParameterSource
 
 from notebooklm.cli.services.generate import (
+    GenerationExecutionResult,
     GenerationPlan,
+    GenerationPlanValidationError,
     build_generation_plan,
     execute_generation,
 )
@@ -57,9 +58,9 @@ from notebooklm.types import (
 # ---------------------------------------------------------------------------
 
 
-def _default_source(_name: str) -> ParameterSource:
-    """Stub that reports every parameter as DEFAULT (= not explicitly passed)."""
-    return ParameterSource.DEFAULT
+def _default_source(_name: str) -> bool:
+    """Stub that reports every parameter as not explicitly passed."""
+    return False
 
 
 def _identity_language(lang: str | None) -> str:
@@ -232,7 +233,7 @@ def test_build_plan_happy_path(
     plan = build_generation_plan(
         kind,
         args,
-        parameter_source=_default_source,
+        parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )
     assert isinstance(plan, GenerationPlan)
@@ -255,34 +256,30 @@ def test_build_plan_unknown_kind_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cinematic_video_rejects_explicit_non_cinematic_format(capsys) -> None:
-    """``cinematic-video --format explainer`` exits 1 through ``output_error``
-    (per ADR-015) when the source reports COMMANDLINE for ``video_format``."""
+def test_cinematic_video_rejects_explicit_non_cinematic_format() -> None:
+    """``cinematic-video --format explainer`` returns a typed validation error."""
 
-    def source(name: str) -> ParameterSource:
-        if name == "video_format":
-            return ParameterSource.COMMANDLINE
-        return ParameterSource.DEFAULT
+    def source(name: str) -> bool:
+        return name == "video_format"
 
     args = _base_args(video_format="explainer", style="auto", style_prompt=None, language="en")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(GenerationPlanValidationError) as exc_info:
         build_generation_plan(
-            "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+            "cinematic-video", args, parameter_explicit=source, language_resolver=_identity_language
         )
-    assert exc_info.value.code == 1
-    captured = capsys.readouterr()
-    assert "--format must be 'cinematic'" in captured.err
+    assert exc_info.value.code == "VALIDATION_ERROR"
+    assert "--format must be 'cinematic'" in exc_info.value.message
 
 
 def test_cinematic_video_explicit_cinematic_format_is_accepted() -> None:
     """``cinematic-video --format cinematic`` (explicit) is fine."""
 
-    def source(name: str) -> ParameterSource:
-        return ParameterSource.COMMANDLINE if name == "video_format" else ParameterSource.DEFAULT
+    def source(name: str) -> bool:
+        return name == "video_format"
 
     args = _base_args(video_format="cinematic", style="auto", style_prompt=None, language="en")
     plan = build_generation_plan(
-        "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+        "cinematic-video", args, parameter_explicit=source, language_resolver=_identity_language
     )
     assert plan.kind == "cinematic-video"
     assert plan.timeout == 3600.0  # default cinematic timeout
@@ -292,15 +289,15 @@ def test_cinematic_video_explicit_timeout_wins_over_default() -> None:
     """When the user passes ``--timeout``, the cinematic 3600s default does
     NOT clobber it."""
 
-    def source(name: str) -> ParameterSource:
+    def source(name: str) -> bool:
         # User passed --timeout explicitly; --format not.
-        return ParameterSource.COMMANDLINE if name == "timeout" else ParameterSource.DEFAULT
+        return name == "timeout"
 
     args = _base_args(
         video_format="explainer", style="auto", style_prompt=None, language="en", timeout=60
     )
     plan = build_generation_plan(
-        "cinematic-video", args, parameter_source=source, language_resolver=_identity_language
+        "cinematic-video", args, parameter_explicit=source, language_resolver=_identity_language
     )
     assert plan.timeout == 60.0  # user override wins
 
@@ -308,14 +305,14 @@ def test_cinematic_video_explicit_timeout_wins_over_default() -> None:
 def test_video_explicit_timeout_wins_over_default() -> None:
     """When the user passes ``--timeout``, the video 1800s default does not clobber it."""
 
-    def source(name: str) -> ParameterSource:
-        return ParameterSource.COMMANDLINE if name == "timeout" else ParameterSource.DEFAULT
+    def source(name: str) -> bool:
+        return name == "timeout"
 
     args = _base_args(
         video_format="explainer", style="auto", style_prompt=None, language="en", timeout=90
     )
     plan = build_generation_plan(
-        "video", args, parameter_source=source, language_resolver=_identity_language
+        "video", args, parameter_explicit=source, language_resolver=_identity_language
     )
     assert plan.timeout == 90.0
 
@@ -327,7 +324,7 @@ def test_video_raw_timeout_is_preserved_when_not_commandline() -> None:
         video_format="explainer", style="auto", style_prompt=None, language="en", timeout=90
     )
     plan = build_generation_plan(
-        "video", args, parameter_source=_default_source, language_resolver=_identity_language
+        "video", args, parameter_explicit=_default_source, language_resolver=_identity_language
     )
     assert plan.timeout == 90.0
 
@@ -337,59 +334,56 @@ def test_video_raw_timeout_is_preserved_when_not_commandline() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_video_cinematic_rejects_style_prompt(capsys) -> None:
-    """Cinematic video + non-empty ``--style-prompt`` exits 1 through
-    ``output_error`` (per ADR-015)."""
+def test_video_cinematic_rejects_style_prompt() -> None:
+    """Cinematic video + non-empty ``--style-prompt`` raises a typed error."""
     args = _base_args(
         video_format="cinematic",
         style="auto",
         style_prompt="foo",
         language="en",
     )
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(GenerationPlanValidationError) as exc_info:
         build_generation_plan(
-            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+            "video", args, parameter_explicit=_default_source, language_resolver=_identity_language
         )
-    assert exc_info.value.code == 1
-    assert "--style-prompt cannot be used" in capsys.readouterr().err
+    assert exc_info.value.code == "VALIDATION_ERROR"
+    assert "--style-prompt cannot be used" in exc_info.value.message
 
 
-def test_video_style_custom_requires_style_prompt(capsys) -> None:
-    """``--style custom`` without ``--style-prompt`` exits 1 through
-    ``output_error`` (per ADR-015)."""
+def test_video_style_custom_requires_style_prompt() -> None:
+    """``--style custom`` without ``--style-prompt`` raises a typed error."""
     args = _base_args(video_format="explainer", style="custom", style_prompt=None, language="en")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(GenerationPlanValidationError) as exc_info:
         build_generation_plan(
-            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+            "video", args, parameter_explicit=_default_source, language_resolver=_identity_language
         )
-    assert exc_info.value.code == 1
-    assert "--style custom requires --style-prompt" in capsys.readouterr().err
+    assert exc_info.value.code == "VALIDATION_ERROR"
+    assert "--style custom requires --style-prompt" in exc_info.value.message
 
 
-def test_video_style_prompt_requires_style_custom(capsys) -> None:
-    """Non-empty ``--style-prompt`` with ``--style != custom`` exits 1 through
-    ``output_error`` (per ADR-015)."""
+def test_video_style_prompt_requires_style_custom() -> None:
+    """Non-empty ``--style-prompt`` with ``--style != custom`` raises a typed error."""
     args = _base_args(
         video_format="explainer", style="anime", style_prompt="hand-drawn", language="en"
     )
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(GenerationPlanValidationError) as exc_info:
         build_generation_plan(
-            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+            "video", args, parameter_explicit=_default_source, language_resolver=_identity_language
         )
-    assert exc_info.value.code == 1
-    assert "--style-prompt requires --style custom" in capsys.readouterr().err
+    assert exc_info.value.code == "VALIDATION_ERROR"
+    assert "--style-prompt requires --style custom" in exc_info.value.message
 
 
-def test_video_style_prompt_strips_whitespace(capsys) -> None:
+def test_video_style_prompt_strips_whitespace() -> None:
     """Whitespace-only ``--style-prompt`` is treated as unset (still triggers
     the ``--style custom`` requirement when style is custom)."""
     args = _base_args(video_format="explainer", style="custom", style_prompt="   ", language="en")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(GenerationPlanValidationError) as exc_info:
         build_generation_plan(
-            "video", args, parameter_source=_default_source, language_resolver=_identity_language
+            "video", args, parameter_explicit=_default_source, language_resolver=_identity_language
         )
-    assert exc_info.value.code == 1
-    assert "--style custom requires --style-prompt" in capsys.readouterr().err
+    assert exc_info.value.code == "VALIDATION_ERROR"
+    assert "--style custom requires --style-prompt" in exc_info.value.message
 
 
 # ---------------------------------------------------------------------------
@@ -405,7 +399,7 @@ def test_report_smart_custom_coercion_on_default_format() -> None:
         append_instructions=None,
     )
     plan = build_generation_plan(
-        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+        "report", args, parameter_explicit=_default_source, language_resolver=_identity_language
     )
     assert plan.params["report_format"] == ReportFormat.CUSTOM
     assert plan.params["custom_prompt"] == "My white paper"
@@ -422,7 +416,7 @@ def test_report_explicit_format_with_description_keeps_format_but_sets_custom_pr
         append_instructions=None,
     )
     plan = build_generation_plan(
-        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+        "report", args, parameter_explicit=_default_source, language_resolver=_identity_language
     )
     assert plan.params["report_format"] == ReportFormat.STUDY_GUIDE
     assert plan.params["custom_prompt"] == "Brief audience: novices"
@@ -438,7 +432,7 @@ def test_report_append_with_custom_format_queues_warning_and_drops_append() -> N
         append_instructions="extra",
     )
     plan = build_generation_plan(
-        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+        "report", args, parameter_explicit=_default_source, language_resolver=_identity_language
     )
     assert plan.params["extra_instructions"] is None
     assert plan.warnings == (
@@ -455,7 +449,7 @@ def test_report_append_with_non_custom_format_passes_through() -> None:
         append_instructions="Target: novices",
     )
     plan = build_generation_plan(
-        "report", args, parameter_source=_default_source, language_resolver=_identity_language
+        "report", args, parameter_explicit=_default_source, language_resolver=_identity_language
     )
     assert plan.params["report_format"] == ReportFormat.STUDY_GUIDE
     assert plan.params["custom_prompt"] is None
@@ -563,7 +557,7 @@ async def test_execute_generation_dispatches_with_expected_kwargs(
     plan = build_generation_plan(
         kind,
         _base_args(**extra),
-        parameter_source=_default_source,
+        parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )
     client = _make_mock_client(method, {"task_id": "tid", "status": "processing"})
@@ -575,17 +569,18 @@ async def test_execute_generation_dispatches_with_expected_kwargs(
     call = api.await_args
     assert call.args == ("nb_123",)
     assert call.kwargs == expected_kwargs
-    # ``execute_generation`` returns ``None`` when the API result is a raw
-    # dict (handle_generation_result short-circuits — no GenerationStatus).
-    assert result is None
+    assert isinstance(result, GenerationExecutionResult)
+    assert result.kind == kind
+    assert result.generation is not None
+    assert result.generation.status == "pending"
+    assert result.generation.task_id == "tid"
 
 
 @pytest.mark.asyncio
-async def test_execute_generation_mind_map_dispatches_and_renders(
+async def test_execute_generation_mind_map_dispatches_and_returns_typed_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Mind-map kind dispatches to ``generate_mind_map`` and renders the
-    result via ``generate_cmd._output_mind_map_result``."""
+    """Mind-map kind dispatches to ``generate_mind_map`` and returns payload for rendering."""
 
     async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
         return nb
@@ -595,20 +590,10 @@ async def test_execute_generation_mind_map_dispatches_and_renders(
 
     monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
     monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
-    captured: dict[str, Any] = {}
-
-    def fake_output(result: Any, json_output: bool) -> None:
-        captured["result"] = result
-        captured["json_output"] = json_output
-
-    import notebooklm.cli.generate_cmd as generate_cmd
-
-    monkeypatch.setattr(generate_cmd, "_output_mind_map_result", fake_output)
-
     plan = build_generation_plan(
         "mind-map",
         _base_args(instructions="summarize", language="en", json_output=True),
-        parameter_source=_default_source,
+        parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )
     mind_map_payload = {"note_id": "n1", "mind_map": {"name": "Root", "children": []}}
@@ -622,16 +607,16 @@ async def test_execute_generation_mind_map_dispatches_and_renders(
         language="en",
         instructions="summarize",
     )
-    assert captured == {"result": mind_map_payload, "json_output": True}
-    assert result is None
+    assert isinstance(result, GenerationExecutionResult)
+    assert result.kind == "mind-map"
+    assert result.mind_map == mind_map_payload
 
 
 @pytest.mark.asyncio
-async def test_execute_generation_emits_warnings_before_api_call(
+async def test_execute_generation_leaves_plan_warnings_for_command_layer(
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Queued plan warnings hit stderr before the API method is called."""
+    """Queued plan warnings stay on the plan while execution remains I/O-free."""
 
     async def fake_resolve_notebook_id(_client, nb, *, json_output=False):
         return nb
@@ -649,7 +634,7 @@ async def test_execute_generation_emits_warnings_before_api_call(
             report_format="custom",
             append_instructions="extra",
         ),
-        parameter_source=_default_source,
+        parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )
     assert plan.warnings  # sanity: plan queued at least one warning
@@ -658,8 +643,6 @@ async def test_execute_generation_emits_warnings_before_api_call(
 
     await execute_generation(plan, client)
 
-    err = capsys.readouterr().err
-    assert "Warning: --append has no effect with --format custom" in err
     client.artifacts.generate_report.assert_awaited_once()
 
 
@@ -684,7 +667,7 @@ async def test_execute_generation_revise_slide_skips_source_resolution(
     plan = build_generation_plan(
         "revise-slide",
         _base_args(description="Move up", artifact_id="art_1", slide_index=3),
-        parameter_source=_default_source,
+        parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )
     client = _make_mock_client("revise_slide", {"task_id": "tid", "status": "processing"})

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -21,7 +21,7 @@ Coverage:
 * ``execute_generation`` mind-map path: dispatches to
   ``generate_mind_map`` and renders via the generate_cmd-level
   ``_output_mind_map_result`` (which the test asserts on).
-* Warning emission to stderr happens BEFORE the API call.
+* Warning emission stays with the command layer; service execution remains I/O-free.
 """
 
 from __future__ import annotations
@@ -615,6 +615,7 @@ async def test_execute_generation_mind_map_dispatches_and_returns_typed_result(
 @pytest.mark.asyncio
 async def test_execute_generation_leaves_plan_warnings_for_command_layer(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Queued plan warnings stay on the plan while execution remains I/O-free."""
 
@@ -644,6 +645,7 @@ async def test_execute_generation_leaves_plan_warnings_for_command_layer(
     await execute_generation(plan, client)
 
     client.artifacts.generate_report.assert_awaited_once()
+    assert capsys.readouterr().err == ""
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_polling_service.py
+++ b/tests/unit/test_polling_service.py
@@ -7,8 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
+from notebooklm.cli import polling_ui
+from notebooklm.cli.polling_ui import status_with_elapsed
 from notebooklm.cli.services import polling
-from notebooklm.cli.services.polling import poll_until, status_with_elapsed
+from notebooklm.cli.services.polling import poll_until
 
 
 @pytest.mark.asyncio
@@ -71,7 +73,7 @@ async def test_status_with_elapsed_json_output_is_no_op() -> None:
     """JSON mode must not start a Rich spinner that could pollute stdout."""
     entered = False
 
-    with patch.object(polling.console, "status") as status:
+    with patch.object(polling_ui.console, "status") as status:
         async with status_with_elapsed("Waiting for work...", json_output=True):
             entered = True
 


### PR DESCRIPTION
## Summary
- Move artifact/generate/download/polling presentation policy out of service modules into command-layer callbacks or typed outcomes.
- Add command-layer `polling_ui.status_with_elapsed` and keep polling service as pure `poll_until` logic.
- Preserve ADR-015 JSON envelopes by translating typed service validation errors in command modules.

## Removed boundary rows
- `cli/services/artifact_generation.py`
- `cli/services/download.py`
- `cli/services/generate.py`
- `cli/services/polling.py`

## Out-of-target files touched
- `src/notebooklm/cli/source_cmd.py`, `src/notebooklm/cli/services/source_wait.py`, and `src/notebooklm/cli/research_cmd.py` are strictly mechanical compatibility updates required by moving the shared `status_with_elapsed` UI helper out of `cli/services/polling.py`; no source/research behavior or semantics were changed.
- `tests/unit/test_cli_source_services.py` and `tests/unit/test_polling_service.py` are matching mechanical test updates for that polling helper relocation.
- `tests/unit/test_download_service.py` and `tests/unit/test_generate_service.py` were updated to assert the new typed service outcomes/validation contracts directly, so broader unit CI does not pin the old service-layer presentation behavior.

## Verification
- `uv run pytest tests/unit/cli/test_services_boundary.py -q`
- `uv run pytest tests/unit/cli -k "artifact or generate or download or polling" -q`
- `uv run pytest tests/unit/cli -k polling -q`
- `uv run pytest tests/unit/test_download_service.py tests/unit/test_generate_service.py tests/unit/test_polling_service.py tests/unit/test_cli_source_services.py -q`
- `uv run ruff check src/notebooklm/cli/artifact_cmd.py src/notebooklm/cli/download_cmd.py src/notebooklm/cli/generate_cmd.py src/notebooklm/cli/services tests/unit/cli/test_services_boundary.py`
- `uv run mypy src/notebooklm`

## Polish / deferred findings
- Claude review findings handled: removed dead generation-status compatibility wrapper/private service import; removed ignored retry parameter; made typed validation exceptions keyword-safe; added download command warning coverage; updated direct service tests to the new contracts.
- Deferred: none.

## Notes
- Rebases from `origin/main` at `3bb5679b7741d716636668b7f309c889075a620a`, which includes Phase 2 merge `a10581127975d7c1e57062a9143012eb25c2419f`.
- Antigravity was not invoked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elapsed-time status spinner for long-running CLI operations.
  * Structured generation outcomes and richer generation result rendering.
  * Download plans now carry format/extension warnings.

* **Bug Fixes**
  * Stronger validation for conflicting download options with explicit validation errors.
  * Generation failure and rate-limit situations surface clearer, structured errors.

* **Tests**
  * Updated and added unit tests covering warnings, validation, retry, and polling behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->