### PR TITLE
test: tighten quality ratchets

### DIFF
--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -187,15 +187,6 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # `save_cookies_to_storage`, `_load_storage_state`, `get_storage_path`)
         # — outside the core-injection surface `make_fake_core` covers.
         "tests/unit/test_auth_psidts_recovery.py",
-        # reason: backoff test patches `notebooklm._session_helpers` stdlib
-        # time/sleep seams (asyncio.sleep) — stdlib seam, not core attribute.
-        "tests/unit/test_backoff.py",
-        # reason: Phase-2 PR-5 migrated this file's `asyncio.to_thread` patch
-        # to `notebooklm._session_lifecycle.asyncio.to_thread` (where
-        # `ClientLifecycle.save_cookies` sources it). Still a stdlib-seam
-        # string-target patch into `notebooklm.*` until ADR-007's pattern is
-        # extended to cover stdlib seams.
-        "tests/unit/test_cookie_persistence.py",
         # reason: RPC executor unit test stub-patches `notebooklm._rpc_executor`
         # module-level stdlib seams (asyncio.sleep, time providers) on the
         # executor module itself — below the core-injection seam.
@@ -209,18 +200,9 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # `notebooklm.cli.services.login.firefox_accounts.*` filesystem and
         # database-discovery helpers — CLI-side seam outside `make_fake_core`.
         "tests/unit/test_firefox_containers.py",
-        # reason: P3.T1 generate-extraction service tests patch CLI resolver
-        # functions (`notebooklm.cli.resolve.resolve_notebook_id`,
-        # `resolve_source_ids`) — module-level CLI seams above the
-        # `NotebookLMClient` core.
-        "tests/unit/test_generate_service.py",
         # reason: client __init__ ordering test patches construction helpers to
         # assert wiring order — verifies construction sequencing, not a core method seam.
         "tests/unit/test_init_order.py",
-        # reason: storage migration-lock test patches `notebooklm._auth.storage.*`
-        # filesystem lock helpers — module-level filesystem seam outside
-        # `make_fake_core`.
-        "tests/unit/test_migration_lock.py",
         # reason: public-API shim test asserts forwarding of `notebooklm.<x>`
         # facades; the string-target patches *are* the test subject (shim
         # routing) rather than an incidental implementation detail.
@@ -229,10 +211,6 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # module-level mapping used during request encoding — module-level data
         # seam, not a core attribute.
         "tests/unit/test_rpc_overrides.py",
-        # reason: source symlink test patches `notebooklm.cli.services.source_add.*`
-        # module-level filesystem helpers — CLI-side seam outside the
-        # `make_fake_core` core-injection surface.
-        "tests/unit/test_source_symlink.py",
     }
 )
 

--- a/tests/scripts/check_method_coverage.py
+++ b/tests/scripts/check_method_coverage.py
@@ -35,9 +35,8 @@ The allowlist is intended as a **one-way ratchet**:
 
 * It **must not grow** when a new ``RPCMethod`` member is added — new methods
   must ship with at least one test reference and at least one cassette.
-* It **may shrink** when a maintainer backfills coverage for a grandfathered
-  method; they should delete the entry from :data:`PREEXISTING_GAPS` in the
-  same PR.
+* It **must shrink** when a maintainer backfills coverage for a grandfathered
+  method; stale entries in :data:`PREEXISTING_GAPS` fail the gate.
 
 The script is intentionally a static check (pure text grep on the cassette
 files and on the contents of ``tests/``); it never runs pytest or imports
@@ -101,8 +100,6 @@ PREEXISTING_GAPS: frozenset[str] = frozenset(
         # ``frozenset`` (not ``set``) so the module-level constant cannot be
         # mutated at runtime, matching ``_TEST_REFERENCE_EXCLUDES`` above and
         # reinforcing the "only shrinks" contract structurally.
-        "GET_INTERACTIVE_HTML",  # no test imports the enum or its id 'v9rmvd'
-        "GET_SUGGESTED_REPORTS",  # no cassette body contains id 'ciyUvf'
         "IMPORT_RESEARCH",  # no cassette body contains id 'LBwxtb'
         "REFRESH_SOURCE",  # no cassette body contains id 'FLmJqe'
     }
@@ -233,12 +230,9 @@ def main() -> int:
         print(line)
 
     if unused_allowlist:
-        # Not a hard failure — but call it out loudly so the next PR can
-        # shrink the ratchet. Printed to stderr to keep stdout clean for
-        # parseable failure lines.
         print(
-            "NOTICE: PREEXISTING_GAPS entries now have full coverage and "
-            "should be removed: " + ", ".join(sorted(unused_allowlist)),
+            "STALE: PREEXISTING_GAPS entries now have full coverage and "
+            "must be removed: " + ", ".join(sorted(unused_allowlist)),
             file=sys.stderr,
         )
 
@@ -252,7 +246,7 @@ def main() -> int:
         f"{len(misses)} missing coverage."
     )
 
-    return 1 if misses else 0
+    return 1 if misses or unused_allowlist else 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_backoff.py
+++ b/tests/unit/test_backoff.py
@@ -11,6 +11,7 @@ import random
 
 import pytest
 
+import notebooklm._backoff as backoff_module
 from notebooklm._backoff import compute_backoff_delay
 
 # ---------------------------------------------------------------------------
@@ -83,7 +84,7 @@ def test_jitter_uses_module_random_when_rng_is_none(monkeypatch):
         calls.append((low, high))
         return 0.0
 
-    monkeypatch.setattr("notebooklm._backoff._random.uniform", _fake_uniform)
+    monkeypatch.setattr(backoff_module._random, "uniform", _fake_uniform)
     delay = compute_backoff_delay(2, base=1.0, cap=30.0, jitter_ratio=0.2)
     # raw = 4.0; jitter = 0.0; delay = 4.0
     assert delay == 4.0
@@ -192,7 +193,7 @@ def test_call_site_artifact_polling_matches_legacy_min_powers_of_two():
 
 def test_call_site_transport_matches_legacy_with_zero_jitter(monkeypatch):
     """Pin the transport retry curve with jitter monkeypatched to 0."""
-    monkeypatch.setattr("notebooklm._backoff._random.uniform", lambda a, b: 0.0)
+    monkeypatch.setattr(backoff_module._random, "uniform", lambda a, b: 0.0)
     out = [compute_backoff_delay(n, base=1.0, cap=30.0, jitter_ratio=0.2) for n in range(7)]
     # 1, 2, 4, 8, 16, 30, 30
     assert out == [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0]

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 import notebooklm._cookie_persistence as persistence_module
+import notebooklm._session_lifecycle as lifecycle_module
 from _helpers.client_factory import build_client_shell_for_tests
 from notebooklm._cookie_persistence import CookiePersistence
 from notebooklm.auth import (
@@ -83,7 +84,7 @@ async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thre
         calls.append("to_thread")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("notebooklm._session_lifecycle.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(lifecycle_module.asyncio, "to_thread", fake_to_thread)
     core = build_client_shell_for_tests(
         _auth_tokens(tmp_path / "storage_state.json"), cookie_saver=fake_save
     )

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -31,6 +31,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import notebooklm.cli.resolve as resolve_module
 from notebooklm.cli.services.generate import (
     GenerationExecutionResult,
     GenerationPlan,
@@ -551,8 +552,8 @@ async def test_execute_generation_dispatches_with_expected_kwargs(
     async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
         return tuple(sources)
 
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+    monkeypatch.setattr(resolve_module, "resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr(resolve_module, "resolve_source_ids", fake_resolve_source_ids)
 
     plan = build_generation_plan(
         kind,
@@ -588,8 +589,8 @@ async def test_execute_generation_mind_map_dispatches_and_returns_typed_result(
     async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
         return tuple(sources)
 
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+    monkeypatch.setattr(resolve_module, "resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr(resolve_module, "resolve_source_ids", fake_resolve_source_ids)
     plan = build_generation_plan(
         "mind-map",
         _base_args(instructions="summarize", language="en", json_output=True),
@@ -625,8 +626,8 @@ async def test_execute_generation_leaves_plan_warnings_for_command_layer(
     async def fake_resolve_source_ids(_client, _nb, sources, *, json_output=False):
         return tuple(sources)
 
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+    monkeypatch.setattr(resolve_module, "resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr(resolve_module, "resolve_source_ids", fake_resolve_source_ids)
 
     plan = build_generation_plan(
         "report",
@@ -663,8 +664,8 @@ async def test_execute_generation_revise_slide_skips_source_resolution(
         resolve_calls["sources"] += 1
         return tuple(sources)
 
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_notebook_id", fake_resolve_notebook_id)
-    monkeypatch.setattr("notebooklm.cli.resolve.resolve_source_ids", fake_resolve_source_ids)
+    monkeypatch.setattr(resolve_module, "resolve_notebook_id", fake_resolve_notebook_id)
+    monkeypatch.setattr(resolve_module, "resolve_source_ids", fake_resolve_source_ids)
 
     plan = build_generation_plan(
         "revise-slide",

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -713,7 +713,6 @@ JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
     ("download", "flashcards"): _DOWNLOAD_RATIONALE_ERROR,
     ("download", "quiz"): _DOWNLOAD_RATIONALE_ERROR,
     # generate group — RPC-driven; error envelope covered by integration tests.
-    ("generate", "audio"): _GENERATE_RATIONALE,
     ("generate", "cinematic-video"): _GENERATE_RATIONALE,
     ("generate", "data-table"): _GENERATE_RATIONALE,
     ("generate", "flashcards"): _GENERATE_RATIONALE,
@@ -723,7 +722,6 @@ JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
     ("generate", "report"): _GENERATE_RATIONALE,
     ("generate", "revise-slide"): _GENERATE_RATIONALE,
     ("generate", "slide-deck"): _GENERATE_RATIONALE,
-    ("generate", "video"): _GENERATE_RATIONALE,
     # history / metadata / research-status / status: success-only sweep is the
     # primary contract; error envelope can grow with the suite.
     ("history",): _INTROSPECTION_RATIONALE,
@@ -865,6 +863,8 @@ def test_all_json_commands_have_sweep_entry() -> None:
     # Silent-waiver lint: every waiver entry must carry a non-empty rationale.
     empty_success_rationale = sorted(p for p, r in JSON_SUCCESS_WAIVED.items() if not r.strip())
     empty_error_rationale = sorted(p for p, r in JSON_ERROR_WAIVED.items() if not r.strip())
+    redundant_success_waivers = sorted(p for p in JSON_SUCCESS_WAIVED if p in success_paths)
+    redundant_error_waivers = sorted(p for p in JSON_ERROR_WAIVED if p in error_paths)
 
     report = _build_coverage_report(discovered, success_paths, error_paths)
     # Emit to the captured stdout so ``pytest -s`` surfaces the line; pytest
@@ -900,6 +900,16 @@ def test_all_json_commands_have_sweep_entry() -> None:
     if empty_error_rationale:
         failures.append(
             f"Silent waiver(s) in JSON_ERROR_WAIVED (empty rationale): {empty_error_rationale}"
+        )
+    if redundant_success_waivers:
+        failures.append(
+            "Redundant entries in JSON_SUCCESS_WAIVED (sweep entry now exists): "
+            f"{redundant_success_waivers}"
+        )
+    if redundant_error_waivers:
+        failures.append(
+            "Redundant entries in JSON_ERROR_WAIVED (sweep entry now exists): "
+            f"{redundant_error_waivers}"
         )
     assert not failures, "\n".join(failures) + "\n" + report
 

--- a/tests/unit/test_migration_lock.py
+++ b/tests/unit/test_migration_lock.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 import pytest
 from filelock import FileLock
 
+import notebooklm.migration as migration_module
 from notebooklm.migration import (
     _MIGRATION_LOCK,
     _MIGRATION_MARKER,
@@ -193,7 +194,7 @@ def test_held_lock_surfaces_timeout_error(tmp_path: Path, monkeypatch: pytest.Mo
     holder.acquire()
 
     # Non-blocking acquire exercises the same wrapper branch without a real wait.
-    monkeypatch.setattr("notebooklm.migration._MIGRATION_LOCK_TIMEOUT", 0.0, raising=True)
+    monkeypatch.setattr(migration_module, "_MIGRATION_LOCK_TIMEOUT", 0.0, raising=True)
 
     try:
         with (

--- a/tests/unit/test_source_symlink.py
+++ b/tests/unit/test_source_symlink.py
@@ -30,6 +30,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from notebooklm import paths as paths_module
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Source
 
@@ -62,10 +63,7 @@ def mock_auth(tmp_path: Path, monkeypatch):
     "Missing required cookies: SID, __Secure-1PSIDTS".
     """
     fake_storage = tmp_path / "no_such_storage.json"
-    monkeypatch.setattr(
-        "notebooklm.paths.get_storage_path",
-        lambda profile=None, **_kw: fake_storage,
-    )
+    monkeypatch.setattr(paths_module, "get_storage_path", lambda profile=None, **_kw: fake_storage)
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
         patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,


### PR DESCRIPTION
## Summary
- Remove stale method coverage allowlist rows: GET_INTERACTIVE_HTML, GET_SUGGESTED_REPORTS.
- Make future stale PREEXISTING_GAPS entries fail the method coverage gate.
- Remove forbidden-monkeypatch allowlist rows after migrating object-target patches: tests/unit/test_backoff.py, tests/unit/test_cookie_persistence.py, tests/unit/test_generate_service.py, tests/unit/test_migration_lock.py, tests/unit/test_source_symlink.py.
- Remove redundant JSON error waiver rows: generate audio, generate video, and add a redundant-waiver guard.

## Stacking
Stacked on #1151 (`codebase-gaps/p3-artifact-generate-download-boundaries`) until Wave 4 merges. Do not merge this PR until #1151 has merged, this branch is rebased onto `origin/main`, and the PR is retargeted to `main`.

## Test plan
- [x] uv run python tests/scripts/check_method_coverage.py
- [x] uv run pytest tests/_lint/test_no_forbidden_monkeypatches.py tests/_lint/test_error_handler_allowlist.py -q
- [x] uv run pytest tests/unit/test_json_stdout_purity.py tests/unit/test_json_error_exit.py -q
- [x] uv run ruff check tests/scripts tests/_lint tests/unit
- [x] uv run pytest tests/unit/test_backoff.py tests/unit/test_cookie_persistence.py tests/unit/test_generate_service.py tests/unit/test_migration_lock.py tests/unit/test_source_symlink.py -q

## Deferred polish findings
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened method coverage enforcement by removing grandfathered exceptions; gaps must now shrink, not just remain stable.
  * Enhanced JSON output validation to detect and fail on redundant waivers.

* **Chores**
  * Refactored test infrastructure for improved maintainability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->