### PR TITLE
docs(config): clarify sessionless config vocabulary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -446,8 +446,11 @@ work:
   observe auth must alias it rather than holding detached copies.
 - `CORE_LOGGER_NAME` intentionally remains the literal
   `"notebooklm._core"` even though the `_core.py` compatibility module was
-  deleted. Treat it as a logging compatibility contract, not evidence that
-  `notebooklm._core` is an active module.
+  deleted. Runtime code keeps using this logger key through
+  `CORE_LOGGER_NAME` for downstream log filters and `caplog` selectors.
+  Treat it as a logging compatibility contract, not evidence that
+  `notebooklm._core` is an active module or that a concrete `Session` owner
+  remains in the runtime graph.
 
 ## Domain-service collaborators
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 **Status:** Active
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-29
 
 This guide covers storage locations, environment settings, and configuration options for `notebooklm-py`.
 
@@ -142,6 +142,19 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress stderr deprecation notices for deprecated CLI flags | - |
 | `NOTEBOOKLM_VCR_RECORD_ERRORS` | Synthetic-error injection mode for VCR test cassettes (`429`, `5xx`, `expired_csrf`) | - |
+
+### Public config API vs internal resolvers
+
+`src/notebooklm/_env.py` owns internal environment/default resolution for
+runtime behavior. It reads process environment variables and contains internal
+defaults such as `DEFAULT_BL` for the chat streaming build label.
+
+`notebooklm.config` is the stable public import surface. It intentionally
+re-exports only the supported endpoint/language helpers:
+`DEFAULT_BASE_URL`, `PERSONAL_BASE_HOST`, `ENTERPRISE_BASE_HOST`,
+`get_base_url`, `get_base_host`, and `get_default_language`. Existing imports
+from `notebooklm.config` remain supported; internal-only `_env` names should
+not be imported by downstream code.
 
 ### Env vars and precedence
 
@@ -573,6 +586,11 @@ notebooklm list 2>&1 | cat
 ```bash
 NOTEBOOKLM_DEBUG_RPC=1 notebooklm list
 ```
+
+Runtime transport and middleware logs still use the historical
+`notebooklm._core` logger key via `CORE_LOGGER_NAME`. That name is a
+compatibility logging contract for existing filters and tests; it does not
+mean the deleted `_core.py` module or a concrete `Session` owner still exists.
 
 ### Check Authentication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,8 +151,8 @@ defaults such as `DEFAULT_BL` for the chat streaming build label.
 
 `notebooklm.config` is the stable public import surface. It intentionally
 re-exports only the supported endpoint/language helpers:
-`DEFAULT_BASE_URL`, `PERSONAL_BASE_HOST`, `ENTERPRISE_BASE_HOST`,
-`get_base_url`, `get_base_host`, and `get_default_language`. Existing imports
+`DEFAULT_BASE_URL`, `ENTERPRISE_BASE_HOST`, `get_base_host`, `get_base_url`,
+`get_default_language`, and `PERSONAL_BASE_HOST`. Existing imports
 from `notebooklm.config` remain supported; internal-only `_env` names should
 not be imported by downstream code.
 
@@ -586,6 +586,8 @@ notebooklm list 2>&1 | cat
 ```bash
 NOTEBOOKLM_DEBUG_RPC=1 notebooklm list
 ```
+
+### Logger namespace compatibility
 
 Runtime transport and middleware logs still use the historical
 `notebooklm._core` logger key via `CORE_LOGGER_NAME`. That name is a

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -1,8 +1,12 @@
-"""Runtime environment helpers for NotebookLM endpoints and defaults.
+"""Internal environment/default resolvers for NotebookLM runtime behavior.
 
 Centralises lookup of environment variables that influence the live behavior
 of the client. Keeping these here avoids scattering ``os.environ.get`` calls
 across the codebase and gives each override a single, documented entry point.
+
+This is an implementation module. Public configuration imports stay on
+``notebooklm.config``, which deliberately re-exports only the supported subset
+of endpoint/language helpers from here.
 """
 
 from __future__ import annotations

--- a/src/notebooklm/_session_config.py
+++ b/src/notebooklm/_session_config.py
@@ -1,4 +1,4 @@
-"""Module-level constants for the NotebookLM session client.
+"""Module-level constants for the NotebookLM client runtime.
 
 Holds the ``DEFAULT_*`` knobs that historically lived in the
 ``notebooklm._core`` preamble (the compatibility shim was removed in
@@ -22,7 +22,7 @@ __all__ = [
     "normalize_max_concurrent_uploads",
 ]
 
-# Single source of truth for the logger name every session /
+# Single source of truth for the logger name every client-runtime /
 # middleware seam pins. Tests that filter logs via
 # ``caplog.at_level(..., logger=CORE_LOGGER_NAME)`` (or, more commonly,
 # the literal string) match this name. PR 12.9 audit fix: was previously
@@ -34,7 +34,8 @@ __all__ = [
 # logging key even though the ``_core`` compatibility shim was deleted in
 # v0.5.0 — the logger is keyed by string, not module, and renaming would
 # silently break every ``caplog.at_level("notebooklm._core", ...)`` site
-# downstream. Treat this string as a public-ish logging contract.
+# downstream. Treat this string as a compatibility logging contract; it is
+# not evidence that a concrete ``_core`` module or ``Session`` owner exists.
 CORE_LOGGER_NAME = "notebooklm._core"
 
 # Default HTTP timeouts in seconds

--- a/src/notebooklm/_session_init.py
+++ b/src/notebooklm/_session_init.py
@@ -1,13 +1,14 @@
 """Construction-time helpers for the NotebookLM client composition root.
 
-Mechanical decomposition of the former concrete session constructor
+Mechanical decomposition of the former monolithic client-runtime constructor
 (``docs/improvement.md`` §3.1) into three concerns:
 :func:`validate_constructor_args` (kwarg validation + normalization),
 :func:`build_collaborators` (the seven collaborators in dependency order),
 and :func:`wire_middleware_chain` (the seven-middleware ADR-009 chain).
 Behavior is bit-for-bit identical to the pre-extraction constructor;
-dependency-ordering and seam-resolution comments are preserved verbatim
-inside the helpers so future readers see *why* the order matters.
+dependency-ordering and seam-resolution comments are preserved where still
+applicable inside the helpers so future readers see *why* the order matters
+without looking for a concrete ``Session`` owner.
 
 Builds on the constructor-DI work in #1027 (``36dcc634`` —
 "refactor(session): constructor DI for late-bound test seams; drop
@@ -61,8 +62,8 @@ from .auth import AuthTokens
 if TYPE_CHECKING:
     # Runtime import of ``ConnectionLimits`` is deferred to
     # :func:`validate_constructor_args` to keep the long-standing
-    # defensive guard against the ``types.py`` → session cycle (see the
-    # inline comment in the function body).
+    # defensive guard against the historical ``types.py`` -> runtime
+    # construction cycle (see the inline comment in the function body).
     from .types import ConnectionLimits, RpcTelemetryEvent
 
 # Preserve the historical logger namespace while avoiding a raw deleted-module
@@ -80,7 +81,7 @@ class ValidatedSessionConfig:
     to the minimum-interval floor), or a seam callable resolved through
     the canonical module-attribute lookup that ``None`` defaults trigger
     (where applicable — see the module docstring for which seams are
-    resolved here vs. in ``Session.__init__``).
+    resolved here vs. in the public client constructor).
     """
 
     timeout: float
@@ -104,9 +105,9 @@ class SessionCollaborators:
     :func:`build_collaborators`.
 
     The construction order inside ``build_collaborators`` mirrors the
-    pre-extraction ``Session.__init__`` exactly (see the inline comments
-    there for the rationale); this container exists only to give
-    ``__init__`` a single hand-off shape after the construction phase.
+    pre-extraction runtime constructor exactly (see the inline comments
+    there for the rationale); this container exists only to give the
+    client constructor a single hand-off shape after the construction phase.
     """
 
     metrics: ClientMetrics
@@ -205,9 +206,9 @@ def validate_constructor_args(
     if limits is not None:
         _resolved_limits = limits
     else:
-        # Lazy import — defensive guard against the ``types.py`` →
-        # session cycle (preserved from the pre-extraction
-        # ``Session.__init__`` comment "Lazy import to break the
+        # Lazy import — defensive guard against the historical
+        # ``types.py`` -> runtime-construction cycle (preserved from
+        # the pre-extraction comment "Lazy import to break the
         # types.py -> _core.py cycle").
         from .types import ConnectionLimits
 
@@ -221,7 +222,8 @@ def validate_constructor_args(
     # Fail-fast validation for ``max_concurrent_uploads``. The value is
     # NOT propagated into :class:`ValidatedSessionConfig` because the
     # actual upload semaphore state is owned by
-    # ``SourceUploadPipeline`` (not ``Session``); this call exists
+    # ``SourceUploadPipeline`` (not the client-runtime composition
+    # helpers); this call exists
     # solely for the ``ValueError``-raising side effect on the
     # constructor's behalf — same shape as the inline check it
     # replaced.
@@ -234,7 +236,7 @@ def validate_constructor_args(
     # so helper GET/POSTs outside the RPC pipeline still have pool
     # headroom. Cross-validation with ``limits.max_connections`` is
     # enforced one layer up at ``NotebookLMClient.__init__`` because
-    # ``Session`` synthesizes its own ``ConnectionLimits()`` when
+    # this helper synthesizes its own ``ConnectionLimits()`` when
     # ``limits=None``, masking the relationship at this layer.
     resolved_max_concurrent_rpcs: int | None
     if max_concurrent_rpcs is None:
@@ -279,7 +281,7 @@ def build_collaborators(
 ) -> SessionCollaborators:
     """Construct the seven extracted collaborators in dependency order.
 
-    The order mirrors the pre-extraction ``Session.__init__`` exactly so
+    The order mirrors the pre-extraction runtime constructor exactly so
     the load-bearing inter-collaborator wiring stays obvious to future
     readers: metrics is built first because it absorbs the optional
     ``on_rpc_event`` callback AND because the lock-wait metric callback
@@ -457,12 +459,12 @@ def wire_middleware_chain(
     * ``auth`` — the live :class:`AuthTokens` collaborator passed
       explicitly to :meth:`AuthRefreshCoordinator.snapshot` on every
       call. The provider lambda captures this object by reference; the
-      capture is safe because production never reassigns
-      ``Session.auth`` after construction (the only mutation path is
-      in-place scalar updates via
+      capture is safe because production never reassigns the
+      client-owned ``AuthTokens`` object after construction (the only
+      mutation path is in-place scalar updates via
       :meth:`AuthRefreshCoordinator.update_auth_tokens`, which mutate
       the captured instance directly). This replaced the previous
-      ``auth_snapshot_host: _AuthRefreshHost`` (= Session) parameter
+      ``auth_snapshot_host: _AuthRefreshHost`` host-shaped parameter
       when the ``_AuthRefreshHost`` Protocol was deleted in favor of
       per-method explicit collaborators; the coordinator routes its
       lock-wait metric through its own ``self._metrics`` (supplied at

--- a/src/notebooklm/config.py
+++ b/src/notebooklm/config.py
@@ -1,4 +1,9 @@
-"""Public runtime configuration surface (re-exports from internal _env)."""
+"""Public runtime configuration surface.
+
+This module is the stable import surface for configuration helpers. The
+resolution logic lives in :mod:`notebooklm._env`; only the names re-exported
+here are public API.
+"""
 
 from ._env import (
     DEFAULT_BASE_URL,


### PR DESCRIPTION
## Summary
- Clarifies `_session_init.py` and `_session_config.py` comments/docstrings so maintainers are not sent looking for a concrete `Session` owner.
- Documents the split between internal environment/default resolution in `_env.py` and the stable public re-export surface in `config.py` / `notebooklm.config`.
- Makes logger naming compatibility explicit in code comments and docs: `CORE_LOGGER_NAME = "notebooklm._core"` is preserved as a logging contract.

## Preservation notes
- Public config imports from `notebooklm.config` are unchanged; the re-export list and import behavior are preserved.
- Logger compatibility is preserved; this PR does not rename the `notebooklm._core` logger category.
- This PR is wording/docs only and does not start Phase 4 Wave 2 typing work.

## Test plan
- [x] `uv run pytest tests/unit -k "config or session_init or session_config" -q`
- [x] `uv run pytest tests/_lint -q`
- [x] `uv run ruff check src/notebooklm/_session_init.py src/notebooklm/_session_config.py src/notebooklm/_env.py src/notebooklm/config.py`
- [x] `uv run mypy src/notebooklm`

## Deferred polish findings
None.

## Notes
Pre-PR polish ran without the agy/Antigravity lens because this task explicitly prohibits invoking agy/Antigravity tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced public configuration API docs and clarified boundaries between public and internal surfaces.
  * Clarified runtime logging compatibility contracts used by transport/middleware.
  * Refined module-level docstrings to improve clarity on configuration resolution and runtime initialization.
  * Updated metadata with current "Last Updated" date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->