### PR TITLE
fix(rpc): raise on method-ID drift and anti-bot walls under allow_null

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -590,7 +590,13 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
             e.raw_response = _truncate_response_preview(response_preview)
         raise
 
-    if result is None and not allow_null:
+    if result is None:
+        # An *absent* RPC ID is categorically different from a *present-but-null*
+        # result. The drift detector — the strongest signal that Google changed a
+        # method ID or served an anti-bot/redirect wall instead of real RPC data —
+        # must fire even when ``allow_null=True``; ``allow_null`` only sanctions a
+        # ``wrb.fr`` frame that genuinely carried a null payload, not a response
+        # that never contained the requested ID at all.
         if found_ids and rpc_id not in found_ids:
             # Method ID likely changed - provide actionable error
             raise UnknownRPCMethodError(
@@ -602,48 +608,55 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
                 raw_response=response_preview,
             )
 
-        if rpc_id in found_ids:
-            # RPC ID was found but extract_rpc_result returned None
-            # This means wrb.fr had null result_data without UserDisplayableError.
-            # Enrich the message if the server attached a bare status code at
-            # index 5 (issues #114 / #294 showed GET_NOTEBOOK returning [5]).
-            status = _find_wrb_status(chunks, rpc_id)
-            if status is not None:
-                code, label = status
-                message = f"RPC {rpc_id} returned null result with status code {code} ({label})."
-                # Route NOT_FOUND (5) / PERMISSION_DENIED (7) through ClientError
-                # so _core.is_auth_error does not misclassify them as auth
-                # failures and trigger a spurious token-refresh retry. The
-                # account-routing hint is only relevant for these two codes —
-                # other codes (e.g. INTERNAL 13) get a plain message.
-                if code in (5, 7):
-                    raise ClientError(
-                        message + _ACCOUNT_MISMATCH_HINT,
-                        method_id=rpc_id,
-                        rpc_code=code,
-                        found_ids=found_ids,
-                        raw_response=response_preview,
-                    )
-                raise RPCError(
-                    message,
+        if not found_ids:
+            # No RPC data found at all — the response carried no recognizable RPC
+            # frames (e.g. an anti-bot/redirect HTML page). This is never a benign
+            # null, so raise regardless of ``allow_null``.
+            raise RPCError(
+                f"No result found for RPC ID: {rpc_id} "
+                f"(response contained no RPC data — {len(chunks)} chunks parsed)",
+                method_id=rpc_id,
+                raw_response=response_preview,
+            )
+
+        # ``rpc_id`` is present in ``found_ids`` but ``extract_rpc_result`` returned
+        # None — the requested frame carried a genuinely null payload. Honor
+        # ``allow_null`` here and return None for callers that opt in.
+        if allow_null:
+            return None
+
+        # RPC ID was found but extract_rpc_result returned None.
+        # This means wrb.fr had null result_data without UserDisplayableError.
+        # Enrich the message if the server attached a bare status code at
+        # index 5 (issues #114 / #294 showed GET_NOTEBOOK returning [5]).
+        status = _find_wrb_status(chunks, rpc_id)
+        if status is not None:
+            code, label = status
+            message = f"RPC {rpc_id} returned null result with status code {code} ({label})."
+            # Route NOT_FOUND (5) / PERMISSION_DENIED (7) through ClientError
+            # so _core.is_auth_error does not misclassify them as auth
+            # failures and trigger a spurious token-refresh retry. The
+            # account-routing hint is only relevant for these two codes —
+            # other codes (e.g. INTERNAL 13) get a plain message.
+            if code in (5, 7):
+                raise ClientError(
+                    message + _ACCOUNT_MISMATCH_HINT,
                     method_id=rpc_id,
                     rpc_code=code,
                     found_ids=found_ids,
                     raw_response=response_preview,
                 )
             raise RPCError(
-                f"RPC {rpc_id} returned null result data "
-                f"(possible server error or parameter mismatch)",
+                message,
                 method_id=rpc_id,
+                rpc_code=code,
                 found_ids=found_ids,
                 raw_response=response_preview,
             )
-
-        # No RPC data found at all (found_ids is empty; non-empty cases handled above)
         raise RPCError(
-            f"No result found for RPC ID: {rpc_id} "
-            f"(response contained no RPC data — {len(chunks)} chunks parsed)",
+            f"RPC {rpc_id} returned null result data (possible server error or parameter mismatch)",
             method_id=rpc_id,
+            found_ids=found_ids,
             raw_response=response_preview,
         )
 

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -630,6 +630,10 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
         # Enrich the message if the server attached a bare status code at
         # index 5 (issues #114 / #294 showed GET_NOTEBOOK returning [5]).
         status = _find_wrb_status(chunks, rpc_id)
+        # The base ``RPCError.__str__`` does not surface ``found_ids``, so embed
+        # it in the message text too — otherwise the strongest debugging signal
+        # is silently dropped from plain logs and tracebacks for these branches.
+        found_ids_suffix = f" Found IDs: {found_ids}."
         if status is not None:
             code, label = status
             message = f"RPC {rpc_id} returned null result with status code {code} ({label})."
@@ -640,21 +644,22 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
             # other codes (e.g. INTERNAL 13) get a plain message.
             if code in (5, 7):
                 raise ClientError(
-                    message + _ACCOUNT_MISMATCH_HINT,
+                    message + found_ids_suffix + _ACCOUNT_MISMATCH_HINT,
                     method_id=rpc_id,
                     rpc_code=code,
                     found_ids=found_ids,
                     raw_response=response_preview,
                 )
             raise RPCError(
-                message,
+                message + found_ids_suffix,
                 method_id=rpc_id,
                 rpc_code=code,
                 found_ids=found_ids,
                 raw_response=response_preview,
             )
         raise RPCError(
-            f"RPC {rpc_id} returned null result data (possible server error or parameter mismatch)",
+            f"RPC {rpc_id} returned null result data "
+            f"(possible server error or parameter mismatch).{found_ids_suffix}",
             method_id=rpc_id,
             found_ids=found_ids,
             raw_response=response_preview,

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -720,6 +720,20 @@ class TestNullResultStatusCodeEnrichment:
             result = decode_response(self._build_raw([code]), self.RPC_ID, allow_null=True)
             assert result is None, f"allow_null=True leaked for code {code}"
 
+    def test_enriched_messages_surface_found_ids(self):
+        """found_ids must appear in the message text, not just the attribute.
+
+        The base RPCError.__str__ does not append found_ids, so embedding it in
+        the message keeps the strongest drift/debug signal visible in plain logs
+        and tracebacks across all three null-result enrichment branches.
+        """
+        for error_info in ([5], [13], [99]):
+            with pytest.raises(RPCError) as exc_info:
+                decode_response(self._build_raw(error_info), self.RPC_ID)
+            message = str(exc_info.value)
+            assert "Found IDs:" in message
+            assert self.RPC_ID in message
+
     def test_boolean_error_info_is_not_treated_as_status_code(self):
         """[true] must not be accepted as code 1 — bool is a subclass of int.
 

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -840,6 +840,62 @@ class TestUnknownRPCMethodErrorRouting:
         assert len(err.raw_response) <= 83
 
 
+class TestAllowNullDoesNotMaskDrift:
+    """Issue #1158: ``allow_null=True`` must not swallow method-ID drift or
+    anti-bot/redirect walls as a benign ``None``.
+
+    ``allow_null`` only sanctions a ``wrb.fr`` frame that genuinely carried a
+    null payload (the requested ``rpc_id`` *is* present). An *absent* RPC ID
+    (drift) or a body with no RPC frames at all (anti-bot wall) is categorically
+    different and must still raise, even for opt-in callers.
+    """
+
+    def test_allow_null_still_raises_on_method_id_drift(self):
+        """Requested ID missing but another ID present → UnknownRPCMethodError,
+        even with allow_null=True."""
+        requested = "OldMethodId"
+        actual = "NewMethodId"
+        inner = json.dumps([])
+        chunk = json.dumps(["wrb.fr", actual, inner, None, None])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            decode_response(raw, requested, allow_null=True)
+        err = exc_info.value
+        assert err.method_id == requested
+        assert err.found_ids == [actual]
+        assert "may have changed" in str(err)
+
+    def test_allow_null_still_raises_when_no_rpc_data(self):
+        """Empty/anti-bot body with no RPC frames → RPCError, even with
+        allow_null=True."""
+        raw = ")]}'\n"
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, "AnyId", allow_null=True)
+        assert "response contained no RPC data" in str(exc_info.value)
+        assert not isinstance(exc_info.value, UnknownRPCMethodError)
+
+    def test_allow_null_still_raises_on_non_rpc_json_body(self):
+        """A parseable but non-RPC JSON body (e.g. a redirect/error page) yields
+        no found_ids → RPCError, even with allow_null=True."""
+        chunk = json.dumps({"redirect": "https://accounts.google.com/"})
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, RPCMethod.CREATE_ARTIFACT.value, allow_null=True)
+        assert "response contained no RPC data" in str(exc_info.value)
+        assert not isinstance(exc_info.value, UnknownRPCMethodError)
+
+    def test_allow_null_returns_none_for_present_but_null_frame(self):
+        """Regression guard: when the requested ID IS present with a null
+        payload, allow_null=True still returns None (the legitimate use case)."""
+        rpc_id = RPCMethod.CREATE_ARTIFACT.value
+        chunk = json.dumps(["wrb.fr", rpc_id, None, None, None])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+        result = decode_response(raw, rpc_id, allow_null=True)
+        assert result is None
+
+
 class TestMalformedChunkResilience:
     """safe_index hot-path traversal must tolerate malformed chunks.
 


### PR DESCRIPTION
## Root cause

`decode_response` gated its **entire** null-handling block — including the
`found_ids` method-ID drift detector and the "no RPC data at all" branch —
behind a single `result is None and not allow_null` condition
(`src/notebooklm/rpc/decoder.py`).

As a result, any caller passing `allow_null=True` (`CREATE_ARTIFACT`,
`GENERATE_MIND_MAP`, `DELETE_SOURCE`, `GET_SUGGESTED_REPORTS`, and the other
fire-and-forget / optional-content callers) silently received `None` whenever
Google drifted a method ID or served an anti-bot/redirect page. The strongest
drift signal in the decoder (`found_ids and rpc_id not in found_ids`) never
fired for those callers. For `CREATE_ARTIFACT` the `None` collapsed into a
`GenerationStatus(status="failed")`, masking a wall as an ordinary failure while
the write may already have committed.

## Fix

Split the `result is None` cases by what `found_ids` tells us — an *absent* RPC
ID is categorically different from a *present-but-null* result:

- **RPC ID absent but other IDs present** (method-ID drift) → `UnknownRPCMethodError`, **always**, even under `allow_null`.
- **No RPC frames at all** (anti-bot/redirect wall) → `RPCError`, **always**, even under `allow_null`.
- **Requested RPC ID present with a genuinely null payload** → this is the only case `allow_null` is meant to sanction; it still returns `None` for opt-in callers.

This is a behavior-preserving change for the legitimate `allow_null` use case
(fire-and-forget mutations and optional content that return null `wrb.fr`
frames) and only adds a hard error for the drift / wall cases that were
previously swallowed.

## Tests

Added `TestAllowNullDoesNotMaskDrift` in `tests/unit/test_decoder.py`:
- drift under `allow_null=True` → raises `UnknownRPCMethodError`
- empty/no-RPC-data body under `allow_null=True` → raises `RPCError`
- non-RPC JSON body (redirect/error page) under `allow_null=True` → raises `RPCError`
- regression guard: present-but-null frame under `allow_null=True` → still returns `None`

The three new "raises" tests fail against the unfixed decoder and pass after the
fix; the regression guard passes both ways. Full unit + integration suite green;
`mypy` clean.

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Decoder now distinguishes absent RPC frames from present-but-null payloads; permissive null handling applies only to the latter.
  * Missing RPC IDs and responses with no RPC data properly raise errors instead of being masked as null.
  * Error messages now surface found IDs and route/status hints for specific status codes to improve diagnostics.
  * Added unit tests covering these behaviors and regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->