### PR TITLE
fix(auth): stop auth-refresh replay from re-issuing non-idempotent writes

### DIFF
--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -182,7 +182,11 @@ Per-position rationale:
   (each layer has its own guard). Putting them in the other order would
   let an auth-refresh-then-success-then-5xx sequence cause a retry that
   re-triggers the refresh, which the legacy transport loop also guarded
-  against with a per-attempt flag.
+  against with a per-attempt flag. Both layers honor the same
+  `disable_internal_retries` post-resolution bool: a non-idempotent /
+  probe-then-create write is neither retried on 5xx/429 nor replayed
+  after an auth refresh, because a mid-flight 401/403 can land *after*
+  the server committed the write (issue #1157).
 - **AuthRefresh outside ErrorInjection.** Test-injected 401s exercise the
   refresh path realistically — a test that injects a 401 expects the
   refresh middleware to run, not for the injection to short-circuit
@@ -205,7 +209,7 @@ Per-position rationale:
 | Key | Type | Set by | Read by |
 |---|---|---|---|
 | `rpc_method` | `str \| None` | `Session._perform_authed_post` (receives the resolved method-name string from `RpcExecutor._execute_once`, which passes `method.name` — never the `RPCMethod` enum itself; chat-side callers pass `None`) | `MetricsMiddleware`, `TracingMiddleware` |
-| `disable_internal_retries` | `bool` | `Session._perform_authed_post` (receives the post-resolution boolean from `RpcExecutor._execute_once`, which calls `_idempotency.resolve_effective_disable_internal_retries(...)` before invoking the chain) | `RetryMiddleware` |
+| `disable_internal_retries` | `bool` | `Session._perform_authed_post` (receives the post-resolution boolean from `RpcExecutor._execute_once`, which calls `_idempotency.resolve_effective_disable_internal_retries(...)` before invoking the chain) | `RetryMiddleware`, `AuthRefreshMiddleware` (when set, skips the auth-refresh-and-retry replay so a non-idempotent / probe-then-create write is not re-issued after a mid-flight 401/403 — issue #1157) |
 | `build_request` | `BuildRequest` | `Session._perform_authed_post` (stashed before chain entry as the rebuild recipe) | `AuthRefreshMiddleware._rebuild_request_after_refresh`, `Session._authed_post_chain_terminal` (via `_refresh_request_for_current_auth`) |
 | `log_label` | `str` | `Session._perform_authed_post` | `DrainMiddleware`, `RetryMiddleware`, `ErrorInjectionMiddleware`, `AuthRefreshMiddleware`, `TracingMiddleware`, `Session._authed_post_chain_terminal` |
 | `auth_snapshot` | `AuthSnapshot` | `Session._perform_authed_post` (initial snapshot before chain entry); refreshed by `AuthRefreshMiddleware._rebuild_request_after_refresh` after a successful refresh, and replaced by `Session._refresh_request_for_current_auth` at the chain leaf when a freshness check detects auth moved while the request was queued | `Session._refresh_request_for_current_auth` (chain-terminal pre-POST freshness check); pair-mutated with the materialized envelope so middlewares never observe a torn `(snapshot, request)` pair |

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -76,6 +76,7 @@ from ._middleware_context import (
     RPC_CONTEXT_AUTH_REFRESHED,
     RPC_CONTEXT_AUTH_SNAPSHOT,
     RPC_CONTEXT_BUILD_REQUEST,
+    RPC_CONTEXT_DISABLE_INTERNAL_RETRIES,
     RPC_CONTEXT_LOG_LABEL,
 )
 from ._request_types import AuthSnapshot, BuildRequest
@@ -191,11 +192,21 @@ class AuthRefreshMiddleware:
         - No refresh callback configured → propagate any exception unchanged.
         - Exception is not an auth error → propagate.
         - Refresh already done for this logical call → propagate.
+        - ``disable_internal_retries`` is set on the context → propagate.
+          The flag is the post-resolution effective bool produced by
+          :func:`_idempotency.resolve_effective_disable_internal_retries`
+          before chain entry, so a non-idempotent / probe-then-create
+          method is NOT replayed after an auth error (issue #1157). A
+          mid-flight 401/403 can land *after* the server committed the
+          write, so re-POSTing would duplicate the resource / invite /
+          generation. Surfacing the original auth error lets the caller's
+          probe-then-create wrapper disambiguate instead.
         - First ``next_call`` raises something non-``HTTPStatusError`` → propagate.
 
         Refresh-and-retry path:
         1. ``next_call`` raises ``httpx.HTTPStatusError`` AND
-           ``is_auth_error(exc)`` returns True AND no prior refresh.
+           ``is_auth_error(exc)`` returns True AND no prior refresh AND
+           ``disable_internal_retries`` is not set.
         2. Call ``refresh_callable()`` (coalesced single-flight via
            :class:`AuthRefreshCoordinator`).
         3. Mark ``RPC_CONTEXT_AUTH_REFRESHED`` on success.
@@ -217,7 +228,15 @@ class AuthRefreshMiddleware:
                 not self._refresh_callback_enabled()
                 or not self._is_auth_error(exc)
                 or request.context.get(RPC_CONTEXT_AUTH_REFRESHED)
+                or bool(request.context.get(RPC_CONTEXT_DISABLE_INTERNAL_RETRIES, False))
             ):
+                # ``disable_internal_retries`` is the post-resolution
+                # effective bool (see :func:`_idempotency.
+                # resolve_effective_disable_internal_retries`). When set, the
+                # write is non-idempotent / probe-then-create and may have
+                # already committed before the auth error surfaced — replaying
+                # it would duplicate the side effect (issue #1157), so we
+                # propagate the original auth error untouched.
                 raise
 
             self._logger.info(

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -277,8 +277,18 @@ class RpcExecutor:
             return result
         except RPCError as exc:
             elapsed = time.perf_counter() - start
+            # A decoded auth-shaped ``RPCError`` triggers a refresh-and-retry
+            # ONLY when the effective idempotency classification permits a
+            # replay. ``effective_disable_internal_retries`` folds the
+            # registry policy with the caller's intent: for non-idempotent /
+            # probe-then-create methods it is forced True, in which case the
+            # server may have already committed the write before the
+            # auth-shaped error surfaced. Re-POSTing would duplicate the side
+            # effect (issue #1157), so we surface the original error and let
+            # the caller's probe-then-create wrapper disambiguate instead.
             if (
                 not _is_retry
+                and not effective_disable_internal_retries
                 and self._refresh_callback_enabled_provider()
                 and self._is_auth_error(exc)
             ):

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -234,7 +234,9 @@ class TestAutoRefreshIntegration:
         disable flag True. The server may have committed the notebook before
         the 401 surfaced, so ``AuthRefreshMiddleware`` must NOT refresh and
         re-POST — that would duplicate the notebook. The original auth error
-        propagates so the caller's probe-then-create wrapper can disambiguate.
+        propagates so ``NotebooksAPI.create``'s probe-then-create wrapper can
+        disambiguate. Driven through the public ``client.notebooks.create``
+        surface so the regression is pinned end-to-end.
         """
         auth = AuthTokens(
             cookies={"SID": "test"},
@@ -253,22 +255,35 @@ class TestAutoRefreshIntegration:
 
         client._collaborators.auth_coord._refresh_callback = tracking_refresh
 
-        call_count = [0]
+        create_post_count = [0]
 
         async def mock_post(*args, **kwargs):
-            call_count[0] += 1
-            request = httpx.Request("POST", args[0])
+            url = args[0]
+            # ``NotebooksAPI.create`` first lists notebooks to capture a
+            # baseline; that LIST_NOTEBOOKS POST must succeed so only the
+            # CREATE_NOTEBOOK leg exercises the auth-error path.
+            if RPCMethod.LIST_NOTEBOOKS.value in str(url):
+                response = MagicMock()
+                response.text = "list-ok"
+                response.raise_for_status = MagicMock()
+                return response
+            create_post_count[0] += 1
+            request = httpx.Request("POST", url)
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        # Baseline ``list()`` decodes to an empty notebook list; the create's
+        # decode never runs because the POST raises a 401 first.
+        client._seams.decode_response = lambda *a, **kw: []
 
         async with client:
             install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
 
             with pytest.raises(RPCError):
-                await client.rpc_call(RPCMethod.CREATE_NOTEBOOK, ["My Notebook"])
+                await client.notebooks.create("My Notebook")
 
         assert refresh_calls == [], "non-idempotent write must not trigger an auth refresh"
-        assert call_count[0] == 1, "non-idempotent write must POST exactly once (no replay)"
+        assert create_post_count[0] == 1, "CREATE_NOTEBOOK must POST exactly once (no replay)"
 
     @pytest.mark.asyncio
     async def test_rpc_auth_error_does_not_replay_non_idempotent_write(self):
@@ -278,6 +293,7 @@ class TestAutoRefreshIntegration:
         ``RpcExecutor`` must honor the effective disable classification just
         like the HTTP-status leg. ``CREATE_NOTEBOOK`` resolves to disabled
         retries, so the decoded auth error surfaces without a second POST.
+        Driven through the public ``client.notebooks.create`` surface.
         """
         auth = AuthTokens(
             cookies={"SID": "test"},
@@ -296,20 +312,26 @@ class TestAutoRefreshIntegration:
 
         client._collaborators.auth_coord._refresh_callback = tracking_refresh
 
-        post_count = [0]
+        create_post_count = [0]
 
         async def mock_post(*args, **kwargs):
-            post_count[0] += 1
+            if RPCMethod.CREATE_NOTEBOOK.value in str(args[0]):
+                create_post_count[0] += 1
             response = MagicMock()
             response.text = "mock response"
             response.raise_for_status = MagicMock()
             return response
 
-        decode_count = [0]
+        create_decode_count = [0]
 
-        def mock_decode(*args, **kwargs):
-            decode_count[0] += 1
-            raise RPCError("Authentication expired")
+        def mock_decode(raw, rpc_id, *args, **kwargs):
+            # The baseline ``list()`` decodes to an empty list; the create's
+            # decode raises an auth-shaped RPCError to exercise the
+            # decode-time refresh-and-retry leg.
+            if rpc_id == RPCMethod.CREATE_NOTEBOOK.value:
+                create_decode_count[0] += 1
+                raise RPCError("Authentication expired")
+            return []
 
         client._seams.decode_response = mock_decode
 
@@ -317,8 +339,10 @@ class TestAutoRefreshIntegration:
             install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
 
             with pytest.raises(RPCError):
-                await client.rpc_call(RPCMethod.CREATE_NOTEBOOK, ["My Notebook"])
+                await client.notebooks.create("My Notebook")
 
         assert refresh_calls == [], "non-idempotent write must not trigger an auth refresh"
-        assert post_count[0] == 1, "non-idempotent write must POST exactly once (no replay)"
-        assert decode_count[0] == 1, "decode must run once — no retried decode"
+        assert create_post_count[0] == 1, "CREATE_NOTEBOOK must POST exactly once (no replay)"
+        assert create_decode_count[0] == 1, (
+            "CREATE_NOTEBOOK decode must run once — no retried decode"
+        )

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -9,7 +9,7 @@ import pytest
 from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
-from notebooklm.rpc import RPCError
+from notebooklm.rpc import RPCError, RPCMethod
 
 # mock-based refresh-callback wiring tests; no HTTP, no cassette.
 # Opt out of the tier-enforcement hook in tests/integration/conftest.py.
@@ -224,3 +224,101 @@ class TestAutoRefreshIntegration:
 
             assert exc_info.value.__cause__ is not None
             assert "re-authenticate" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_http_auth_error_does_not_replay_non_idempotent_write(self):
+        """A mid-flight 401 on a non-idempotent create is NOT replayed.
+
+        Regression for issue #1157. ``CREATE_NOTEBOOK`` is PROBE_THEN_CREATE,
+        so ``resolve_effective_disable_internal_retries`` forces the effective
+        disable flag True. The server may have committed the notebook before
+        the 401 surfaced, so ``AuthRefreshMiddleware`` must NOT refresh and
+        re-POST — that would duplicate the notebook. The original auth error
+        propagates so the caller's probe-then-create wrapper can disambiguate.
+        """
+        auth = AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="old_csrf",
+            session_id="sid",
+        )
+
+        client = NotebookLMClient(auth)
+        client._composed.chain_host._refresh_retry_delay = 0
+
+        refresh_calls = []
+
+        async def tracking_refresh():
+            refresh_calls.append(True)
+            return client._auth
+
+        client._collaborators.auth_coord._refresh_callback = tracking_refresh
+
+        call_count = [0]
+
+        async def mock_post(*args, **kwargs):
+            call_count[0] += 1
+            request = httpx.Request("POST", args[0])
+            response = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        async with client:
+            install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
+
+            with pytest.raises(RPCError):
+                await client.rpc_call(RPCMethod.CREATE_NOTEBOOK, ["My Notebook"])
+
+        assert refresh_calls == [], "non-idempotent write must not trigger an auth refresh"
+        assert call_count[0] == 1, "non-idempotent write must POST exactly once (no replay)"
+
+    @pytest.mark.asyncio
+    async def test_rpc_auth_error_does_not_replay_non_idempotent_write(self):
+        """A decoded auth-shaped ``RPCError`` is NOT replayed for a create.
+
+        Regression for issue #1157 — the decode-time refresh-and-retry leg in
+        ``RpcExecutor`` must honor the effective disable classification just
+        like the HTTP-status leg. ``CREATE_NOTEBOOK`` resolves to disabled
+        retries, so the decoded auth error surfaces without a second POST.
+        """
+        auth = AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="old_csrf",
+            session_id="sid",
+        )
+
+        client = NotebookLMClient(auth)
+        client._composed.chain_host._refresh_retry_delay = 0
+
+        refresh_calls = []
+
+        async def tracking_refresh():
+            refresh_calls.append(True)
+            return client._auth
+
+        client._collaborators.auth_coord._refresh_callback = tracking_refresh
+
+        post_count = [0]
+
+        async def mock_post(*args, **kwargs):
+            post_count[0] += 1
+            response = MagicMock()
+            response.text = "mock response"
+            response.raise_for_status = MagicMock()
+            return response
+
+        decode_count = [0]
+
+        def mock_decode(*args, **kwargs):
+            decode_count[0] += 1
+            raise RPCError("Authentication expired")
+
+        client._seams.decode_response = mock_decode
+
+        async with client:
+            install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
+
+            with pytest.raises(RPCError):
+                await client.rpc_call(RPCMethod.CREATE_NOTEBOOK, ["My Notebook"])
+
+        assert refresh_calls == [], "non-idempotent write must not trigger an auth refresh"
+        assert post_count[0] == 1, "non-idempotent write must POST exactly once (no replay)"
+        assert decode_count[0] == 1, "decode must run once — no retried decode"

--- a/tests/unit/test_auth_refresh_middleware.py
+++ b/tests/unit/test_auth_refresh_middleware.py
@@ -9,6 +9,10 @@ and ADR-009 §"Chain ordering":
 - **Pass-through when no refresh callback configured.** The
   ``refresh_callback_enabled`` gate matches the legacy
   ``host._refresh_callback is not None`` check.
+- **Pass-through when ``disable_internal_retries`` is set.** A
+  non-idempotent / probe-then-create method (effective disable bool set
+  on the context) is NOT replayed after an auth error — the write may
+  have already committed before the 401/403 surfaced (issue #1157).
 - **Refresh-and-retry on auth error.** First ``next_call`` raises
   ``httpx.HTTPStatusError`` recognized by ``is_auth_error`` → refresh
   callable runs (coalesced single-flight) → optional post-refresh sleep
@@ -214,6 +218,73 @@ async def test_passes_through_on_non_auth_http_error() -> None:
 
     assert excinfo.value is boom
     assert refresh_calls == []
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_disable_internal_retries_set() -> None:
+    """``disable_internal_retries`` on the context suppresses the auth replay.
+
+    Regression for issue #1157: a non-idempotent / probe-then-create method
+    arrives with the post-resolution effective disable bool set on its
+    context. A 401/403 can land *after* the server committed the write, so
+    re-POSTing would duplicate the resource / invite / generation. The
+    middleware must propagate the original auth error instead of refreshing
+    and retrying.
+    """
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(
+            make_request(
+                context={
+                    "log_label": "RPC CREATE_NOTEBOOK",
+                    "disable_internal_retries": True,
+                }
+            )
+        )
+
+    assert excinfo.value is boom
+    assert len(calls) == 1  # initial attempt only — no replay
+    assert refresh_calls == []  # refresh NOT triggered
+
+
+@pytest.mark.asyncio
+async def test_refreshes_when_disable_internal_retries_falsy() -> None:
+    """An explicit falsy ``disable_internal_retries`` still allows the replay.
+
+    Guards the gate against over-triggering: a retry-safe method whose
+    effective disable flag is False must keep the refresh-and-retry path.
+    """
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom, httpx.Response(200, content=b"retry-ok")])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(
+        make_request(
+            context={
+                "log_label": "RPC LIST_NOTEBOOKS",
+                "disable_internal_retries": False,
+            }
+        )
+    )
+
+    assert refresh_calls == [None]
+    assert len(calls) == 2
+    assert response.response.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -328,6 +328,11 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
     async def sleep(seconds: float) -> None:
         sleep_calls.append(seconds)
 
+    # ``LIST_NOTEBOOKS`` is IDEMPOTENT_SET_OP and the caller passes
+    # ``disable_internal_retries=False``, so the effective disable flag is
+    # False and the decode-time auth retry is permitted to fire. The
+    # non-idempotent skip path is covered separately by
+    # ``test_decode_time_auth_retry_skipped_for_non_idempotent_method``.
     result = await _executor(
         owner,
         decode_response=decode,
@@ -339,7 +344,7 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
         "/notebook/abc",
         True,
         False,
-        disable_internal_retries=True,
+        disable_internal_retries=False,
     )
 
     assert result == {"retried": True}
@@ -348,7 +353,7 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
     assert len(is_auth_error_calls) == 1
     assert decode_allow_nulls == [True, True]
     assert len(owner.perform_calls) == 2
-    assert [call["disable_internal_retries"] for call in owner.perform_calls] == [True, True]
+    assert [call["disable_internal_retries"] for call in owner.perform_calls] == [False, False]
 
 
 @pytest.mark.asyncio
@@ -381,6 +386,85 @@ async def test_decode_time_auth_retry_preserves_none_result() -> None:
     assert result is None
     assert owner.refresh_calls == 1
     assert decode_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_skipped_for_non_idempotent_method() -> None:
+    """A non-idempotent create is NOT replayed on a decode-time auth error.
+
+    Regression for issue #1157: ``CREATE_NOTEBOOK`` is PROBE_THEN_CREATE, so
+    ``resolve_effective_disable_internal_retries`` forces the effective
+    disable flag True even though the caller passed False. The server may
+    have already committed the notebook before the auth-shaped ``RPCError``
+    surfaced; re-POSTing would duplicate it. The original error must
+    propagate so the caller's probe-then-create wrapper can disambiguate.
+    """
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    auth_rpc_error = RPCError("authentication expired")
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise auth_rpc_error
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(
+            owner,
+            decode_response=decode,
+            is_auth_error=lambda exc: True,
+        )._execute_once(
+            RPCMethod.CREATE_NOTEBOOK,
+            ["param"],
+            "/",
+            False,
+            False,
+            disable_internal_retries=False,
+        )
+
+    assert raised.value is auth_rpc_error
+    assert owner.refresh_calls == 0
+    # Exactly one POST — the create is never replayed.
+    assert len(owner.perform_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_skipped_when_caller_disables_retries() -> None:
+    """A caller-set ``disable_internal_retries`` also suppresses the replay.
+
+    Even for an otherwise retry-safe method (``LIST_NOTEBOOKS`` is
+    IDEMPOTENT_SET_OP), an explicit ``disable_internal_retries=True`` means
+    the caller has opted out of any internal re-issue. The decode-time auth
+    leg must honor that effective flag rather than blindly re-POST.
+    """
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    auth_rpc_error = RPCError("authentication expired")
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise auth_rpc_error
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(
+            owner,
+            decode_response=decode,
+            is_auth_error=lambda exc: True,
+        )._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+            disable_internal_retries=True,
+        )
+
+    assert raised.value is auth_rpc_error
+    assert owner.refresh_calls == 0
+    assert len(owner.perform_calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

The idempotency `disable_internal_retries` flag is the only duplicate-write guard for non-idempotent / probe-then-create RPCs, but it gated **only** `RetryMiddleware`'s 429/5xx loop. Two separate auth-refresh replay paths re-issued the same mutating POST without ever consulting it:

- `_middleware_auth_refresh.py` — on a 401/403 it refreshed the token and re-invoked `next_call` once, guarded only by `_refresh_callback_enabled` / `_is_auth_error` / `RPC_CONTEXT_AUTH_REFRESHED`. No check of the effective disable-retry flag.
- `_rpc_executor.py` — an auth-flavored `RPCError` in a *decoded* body re-ran the entire `rpc_call` via `try_refresh_and_retry(...)`; the guard did not gate on the idempotency classification (it passed the caller's value through but never checked it).

A non-idempotent create (`CREATE_NOTEBOOK`, `CREATE_ARTIFACT`, `CREATE_NOTE`, `ADD_SOURCE`, `SHARE_NOTEBOOK`, `GENERATE_MIND_MAP`) that reached the server and committed, then saw a 401/403 (token expiring mid-flight, LB hiccup) or an auth-shaped `RPCError`, would be re-POSTed → duplicate resource, duplicate share-invite email, or wasted generation quota.

## Fix

Both replay paths now honor the **effective** `disable_internal_retries` classification (registry policy folded with caller intent):

- `AuthRefreshMiddleware` reads `RPC_CONTEXT_DISABLE_INTERNAL_RETRIES` — the same post-resolution bool `RetryMiddleware` already consumes — and skips the refresh-and-retry when set, propagating the original auth error.
- `RpcExecutor`'s decode-time refresh-and-retry leg gates on the `effective_disable_internal_retries` it already computed via `resolve_effective_disable_internal_retries`, instead of always replaying.

On an auth error for a non-idempotent / probe-then-create method, the replay is skipped and the original error surfaces so the caller's probe-then-create wrapper can disambiguate. The retry-safe path (e.g. `LIST_NOTEBOOKS`, `IDEMPOTENT_SET_OP`) keeps refreshing and retrying as before.

ADR-009's context-key table is updated to record `AuthRefreshMiddleware` as a consumer of `disable_internal_retries`.

## Tests

- `tests/unit/test_auth_refresh_middleware.py` — new `test_passes_through_when_disable_internal_retries_set` (skip on effective-disable) and `test_refreshes_when_disable_internal_retries_falsy` (gate doesn't over-trigger).
- `tests/unit/test_rpc_executor.py` — new `test_decode_time_auth_retry_skipped_for_non_idempotent_method` (registry-forced disable) and `test_decode_time_auth_retry_skipped_when_caller_disables_retries` (caller-set disable); updated the existing collaborator-wiring test to use a retry-safe effective flag.
- `tests/integration/test_auto_refresh.py` — new end-to-end tests for both the HTTP-401 and decoded-`RPCError` legs proving a `CREATE_NOTEBOOK` POSTs exactly once and never refreshes.

All five new/updated tests fail before the fix and pass after. Full suite: `7034 passed, 52 skipped` (one pre-existing CLI login line-wrap assertion failure unrelated to this change — see below). mypy and ruff clean.

## Out of scope (follow-up)

`tests/unit/cli/test_login_multi_account.py::...::test_account_different_existing_profile_account_aborts_without_confirm` fails on clean `main` too: it asserts the contiguous substring `"not overwriting with bob@gmail.com"` but the CLI output wraps across a line break. A terminal-width/line-wrap test brittleness, unrelated to auth-refresh/retry/idempotency.

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified retry behavior: docs now state when internal retries are disabled, auth-refresh and replay are suppressed for non-idempotent probe-then-create writes.

* **Bug Fixes**
  * Non-idempotent write operations are no longer retried or replayed after authentication failures.

* **Tests**
  * Added integration and unit tests ensuring auth failures do not trigger refresh/replay for non-idempotent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->