### PR TITLE
fix(sources): raise on malformed source-list responses under strict-decode (#1159)

### DIFF
--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from ._env import is_strict_decode_enabled
 from ._row_adapters_sources import SourceRow
 from ._session_contracts import RpcCaller
 from .rpc import RPCError, RPCMethod
@@ -27,7 +28,16 @@ class SourceLister:
         self._rpc = rpc
 
     async def list(self, notebook_id: str, *, strict: bool = False) -> builtins.list[Source]:
-        """List all sources in a notebook."""
+        """List all sources in a notebook.
+
+        A malformed or error-shaped ``GET_NOTEBOOK`` response raises
+        :class:`RPCError` when either ``strict=True`` is passed or
+        ``NOTEBOOKLM_STRICT_DECODE`` is enabled (the default since PR
+        13.9a). This prevents a drifted response from being silently
+        reported as "0 sources" — see issue #1159. Set
+        ``NOTEBOOKLM_STRICT_DECODE=0`` to opt back into the legacy
+        warn-and-return-``[]`` behavior for one release window.
+        """
         params = [notebook_id, None, [2], None, 0]
         notebook = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
@@ -83,6 +93,13 @@ class SourceLister:
             )
 
         sources_list = nb_info[1]
+        if sources_list is None:
+            # A genuinely empty notebook elides the sources slot (``None``
+            # instead of an empty list). This is a valid empty state, NOT a
+            # malformed response, so return ``[]`` without raising even under
+            # strict-decode — issue #1159 reserves the empty list for the
+            # genuinely-empty case (see tests/cassettes/notebook_zero_sources.yaml).
+            return []
         if not isinstance(sources_list, builtins.list):
             return self._handle_malformed_list_response(
                 notebook_id,
@@ -103,11 +120,17 @@ class SourceLister:
         strict: bool,
         error_detail: str = "API response structure changed",
     ) -> None:
+        # Honor the global strict-decode policy (default ON since PR 13.9a)
+        # in addition to the explicit ``strict`` flag, so a drifted or
+        # error-enveloped GET_NOTEBOOK response is surfaced as an error
+        # rather than silently reported as "0 sources" (issue #1159).
+        # ``NOTEBOOKLM_STRICT_DECODE=0`` opts back into the legacy
+        # warn-and-return-``[]`` fallback for one release window.
+        if strict or is_strict_decode_enabled():
+            raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
         # Preserve the historical message prefix so log searches on
         # "SourcesAPI.list:" continue to match after the service extraction.
         logger.warning("SourcesAPI.list: " + message, notebook_id, *log_args)
-        if strict:
-            raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
 
     @staticmethod
     def _parse_source(src: Any) -> Source | None:

--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -120,6 +120,11 @@ class SourceLister:
         strict: bool,
         error_detail: str = "API response structure changed",
     ) -> None:
+        # Always emit the drift WARNING first so log searches and monitoring
+        # on the historical "SourcesAPI.list:" prefix keep firing regardless
+        # of whether we go on to raise — preserving the diagnostic breadcrumb
+        # in strict mode too.
+        logger.warning("SourcesAPI.list: " + message, notebook_id, *log_args)
         # Honor the global strict-decode policy (default ON since PR 13.9a)
         # in addition to the explicit ``strict`` flag, so a drifted or
         # error-enveloped GET_NOTEBOOK response is surfaced as an error
@@ -128,9 +133,6 @@ class SourceLister:
         # warn-and-return-``[]`` fallback for one release window.
         if strict or is_strict_decode_enabled():
             raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
-        # Preserve the historical message prefix so log searches on
-        # "SourcesAPI.list:" continue to match after the service extraction.
-        logger.warning("SourcesAPI.list: " + message, notebook_id, *log_args)
 
     @staticmethod
     def _parse_source(src: Any) -> Source | None:

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -1185,8 +1185,14 @@ class TestListSourcesMalformedResponse:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test list() returns [] when notebook response is empty (lines 71-76)."""
+        """Test list() returns [] when notebook response is empty (lines 71-76).
+
+        Strict-decode (default ON) would raise here; pin soft mode to assert
+        the legacy warn-and-return-[] fallback (issue #1159).
+        """
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [])
         httpx_mock.add_response(content=response.encode())
 
@@ -1201,9 +1207,11 @@ class TestListSourcesMalformedResponse:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test list() returns [] when nb_info is not a list (lines 80-85)."""
         # notebook[0] is a string, not a list - fails isinstance(nb_info, list)
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         response = build_rpc_response(RPCMethod.GET_NOTEBOOK, ["just_a_string"])
         httpx_mock.add_response(content=response.encode())
 
@@ -1218,9 +1226,11 @@ class TestListSourcesMalformedResponse:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test list() returns [] when nb_info list has no index 1 (lines 80-85)."""
         # notebook[0] is a list with only 1 element - len(nb_info) <= 1
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [["just_a_title"]])
         httpx_mock.add_response(content=response.encode())
 
@@ -1235,9 +1245,11 @@ class TestListSourcesMalformedResponse:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test list() returns [] when sources_list is not a list (lines 89-95)."""
         # nb_info[1] is a string - fails isinstance(sources_list, list)
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
         response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook Title", "not_a_list"]])
         httpx_mock.add_response(content=response.encode())
 
@@ -1253,7 +1265,7 @@ class TestListSourcesMalformedResponse:
             ([], "API response structure changed"),
             (["just_a_string"], "API response structure changed"),
             ([["just_a_title"]], "API response structure changed"),
-            ([["Notebook Title", None]], "sources data is NoneType, not list"),
+            ([["Notebook Title", "not_a_list"]], "sources data is str, not list"),
         ],
     )
     async def test_list_sources_strict_raises_for_malformed_response(
@@ -1273,6 +1285,57 @@ class TestListSourcesMalformedResponse:
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(RPCError, match=message):
                 await client.sources.list("nb_123", strict=True)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("rpc_result", "message"),
+        [
+            ([], "API response structure changed"),
+            (["just_a_string"], "API response structure changed"),
+            ([["just_a_title"]], "API response structure changed"),
+            ([["Notebook Title", "not_a_list"]], "sources data is str, not list"),
+        ],
+    )
+    async def test_list_sources_raises_by_default_under_strict_decode(
+        self,
+        rpc_result,
+        message,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Regression for #1159: a malformed source-list response must raise
+        by default (strict-decode ON), not silently report "0 sources".
+        """
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, rpc_result)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(RPCError, match=message):
+                await client.sources.list("nb_123")
+
+    @pytest.mark.asyncio
+    async def test_list_sources_null_slot_is_empty_notebook_under_strict_decode(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A genuinely empty notebook elides the sources slot as ``None``;
+        this is a valid empty state (#1159) and must return ``[]`` even under
+        default strict-decode — never raise.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook Title", None, "nb_123"]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert sources == []
 
 
 class TestListSourcesParsingEdgeCases:

--- a/tests/unit/test_notebook_metadata.py
+++ b/tests/unit/test_notebook_metadata.py
@@ -188,7 +188,9 @@ async def test_default_source_lister_uses_phase8_listing_service() -> None:
 
 @pytest.mark.asyncio
 async def test_default_source_lister_delegates_strict_malformed_handling() -> None:
-    source_lister = create_default_source_lister(RecordingRpc([["Notebook", None]]))
+    # A non-list, non-None sources slot is a genuinely malformed shape (a
+    # ``None`` slot is now the empty-notebook signal — see issue #1159).
+    source_lister = create_default_source_lister(RecordingRpc([["Notebook", "not-a-list"]]))
 
-    with pytest.raises(RPCError, match="sources data is NoneType, not list"):
+    with pytest.raises(RPCError, match="sources data is str, not list"):
         await source_lister.list("nb_123", strict=True)

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -130,6 +130,7 @@ async def test_strict_mode_raises_rpc_error_for_malformed_payloads(
 async def test_malformed_payloads_raise_by_default_under_strict_decode(
     payload: Any,
     message: str,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Regression for issue #1159: with strict-decode at its default (ON), a
@@ -137,9 +138,14 @@ async def test_malformed_payloads_raise_by_default_under_strict_decode(
     # an empty list, even without an explicit ``strict=True``.
     monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
     lister = SourceLister(RecordingRpc(payload))
+    caplog.set_level("WARNING", logger="notebooklm._sources")
 
     with pytest.raises(RPCError, match=message):
         await lister.list("nb_123")
+
+    # The drift WARNING on the historical "SourcesAPI.list:" prefix must still
+    # fire in strict mode so log-based monitoring keeps its breadcrumb.
+    assert "SourcesAPI.list:" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -79,7 +79,12 @@ async def test_malformed_payloads_log_and_return_empty(
     payload: Any,
     message: str,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Strict-decode is the default since PR 13.9a, so the warn-and-return-[]
+    # fallback now requires an explicit opt-out (issue #1159). Pin soft mode
+    # to keep exercising the legacy path.
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
     lister = SourceLister(RecordingRpc(payload))
     caplog.set_level("WARNING", logger="notebooklm._sources")
 
@@ -98,7 +103,7 @@ async def test_malformed_payloads_log_and_return_empty(
         ([], "API response structure changed"),
         (["notebook"], "API response structure changed"),
         ([["Notebook"]], "API response structure changed"),
-        ([["Notebook", None]], "sources data is NoneType, not list"),
+        ([["Notebook", "not-a-list"]], "sources data is str, not list"),
     ],
 )
 async def test_strict_mode_raises_rpc_error_for_malformed_payloads(
@@ -109,6 +114,50 @@ async def test_strict_mode_raises_rpc_error_for_malformed_payloads(
 
     with pytest.raises(RPCError, match=message):
         await lister.list("nb_123", strict=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (None, "API response structure changed"),
+        ([], "API response structure changed"),
+        (["notebook"], "API response structure changed"),
+        ([["Notebook"]], "API response structure changed"),
+        ([["Notebook", "not-a-list"]], "sources data is str, not list"),
+    ],
+)
+async def test_malformed_payloads_raise_by_default_under_strict_decode(
+    payload: Any,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression for issue #1159: with strict-decode at its default (ON), a
+    # malformed/error-shaped response must raise rather than silently return
+    # an empty list, even without an explicit ``strict=True``.
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    lister = SourceLister(RecordingRpc(payload))
+
+    with pytest.raises(RPCError, match=message):
+        await lister.list("nb_123")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strict", [False, True])
+async def test_null_sources_slot_is_empty_notebook_not_malformed(
+    strict: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A genuinely empty notebook elides the sources slot as ``None`` (see
+    # tests/cassettes/notebook_zero_sources.yaml). Per issue #1159 this is a
+    # valid empty state and must return ``[]`` regardless of strict mode,
+    # never raising or warning.
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    lister = SourceLister(
+        RecordingRpc([["Notebook Title", None, "nb_123", "", None, [1, False], None, None, None]])
+    )
+
+    assert await lister.list("nb_123", strict=strict) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

`sources.list()` (and the internal `SourceLister.list`) folded a malformed or error-shaped `GET_NOTEBOOK` response into an empty list whenever the explicit `strict=False` default was used. `_handle_malformed_list_response` only raised when the explicit `strict` flag was set; it ignored `NOTEBOOKLM_STRICT_DECODE` (which defaults to ON since PR 13.9a). The hand-rolled `isinstance` checks therefore never participated in the global strict-decode contract.

As a result, a drifted or error-enveloped response was silently reported as "0 sources" — a sync script could conclude the sources vanished and re-add everything.

## Fix

- Malformed-response detection now raises `RPCError` when either `strict=True` is passed **or** `NOTEBOOKLM_STRICT_DECODE` is enabled (the default). This makes malformed/error responses fail loudly by default, as the issue requested.
- The empty list is reserved for the genuinely-empty case: a fresh notebook elides the sources slot as `None` (verified against `tests/cassettes/notebook_zero_sources.yaml`), which is now treated as a valid empty state and returns `[]` even under strict-decode rather than raising a false positive.
- `NOTEBOOKLM_STRICT_DECODE=0` opts back into the legacy warn-and-return-`[]` fallback for one release window, consistent with the rest of the strict-decode policy.

## Tests

- Unit (`tests/unit/test_source_listing_service.py`): new `test_malformed_payloads_raise_by_default_under_strict_decode` (regression — fails before fix) and `test_null_sources_slot_is_empty_notebook_not_malformed`; existing warn-and-return-`[]` test now pins `NOTEBOOKLM_STRICT_DECODE=0`.
- Integration (`tests/integration/test_sources_integration.py`): new default-strict raising test and a `None`-slot empty-notebook test; existing malformed-shape tests pin soft mode.
- `tests/unit/test_notebook_metadata.py`: strict-delegation test updated to use a genuinely-malformed (non-`None`) sources slot.

All updated/new tests pass; `mypy` and `ruff` are clean.

## Note

A pre-existing, unrelated unit failure exists on clean `main`: `tests/unit/cli/test_login_multi_account.py::TestLoginMultiAccount::test_account_different_existing_profile_account_aborts_without_confirm` (a line-wrapping assertion mismatch in the login CLI output). Out of scope for this issue.

Closes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed notebook source lists now raise `RPCError` by default for better error detection. Disable via `NOTEBOOKLM_STRICT_DECODE=0` environment variable if needed.
  * Genuinely empty notebooks are now properly distinguished from malformed response structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->