### PR TITLE
fix(cli): exit non-zero when `doctor` checks fail

### DIFF
--- a/src/notebooklm/cli/doctor_cmd.py
+++ b/src/notebooklm/cli/doctor_cmd.py
@@ -17,7 +17,7 @@ from ..paths import (
     get_profile_dir,
     get_storage_path,
 )
-from .error_handler import handle_errors
+from .error_handler import exit_with_code, handle_errors
 from .rendering import console, json_output_response
 
 logger = logging.getLogger(__name__)
@@ -156,6 +156,12 @@ def _run_doctor(fix_issues: bool, *, json_output: bool) -> None:
     if fix_issues:
         fixes_applied = _apply_fixes(checks, home, profile_dir)
 
+    # Determine overall health from the *final* check states (after any fixes
+    # have been applied above). A lingering "fail" means the install is broken,
+    # so exit non-zero — consistent with ``auth check`` and the CLI exit-code
+    # convention — instead of reading as green in CI / ``set -e`` scripts.
+    has_failures = any(c["status"] == "fail" for c in checks.values())
+
     # Output
     if json_output:
         result = {
@@ -166,9 +172,13 @@ def _run_doctor(fix_issues: bool, *, json_output: bool) -> None:
         if fixes_applied:
             result["fixes_applied"] = fixes_applied
         json_output_response(result)
+        if has_failures:
+            exit_with_code(1)
         return
 
     _display_results(profile_name, profile_source, checks, fixes_applied)
+    if has_failures:
+        exit_with_code(1)
 
 
 def _apply_fixes(checks: dict, home, profile_dir) -> list[str]:

--- a/tests/integration/cli_vcr/test_doctor.py
+++ b/tests/integration/cli_vcr/test_doctor.py
@@ -107,16 +107,16 @@ class TestDoctorCommand:
         """Doctor with no ``storage_state.json`` reports auth failure cleanly.
 
         The auth-failure path is the second axis the task acceptance asks
-        for. Even on the failure path the command still exits 0 (it's a
-        diagnostic — ``doctor`` reports failures rather than exiting
-        non-zero) and emits no HTTP requests.
+        for. On the failure path the command exits 1 (issue #1160 — a false
+        ``green`` health check is worse than no check) while still emitting no
+        HTTP requests.
         """
         _make_profile(isolated_home)
         # Deliberately no storage_state.json written.
 
         result = runner.invoke(cli, ["doctor", "--json"])
 
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 1, result.output
         data = json.loads(result.output)
         assert data["checks"]["auth"]["status"] == "fail"
         assert data["checks"]["auth"]["detail"] == "not authenticated"

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -41,9 +41,9 @@ def _storage(cookies: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
     return {"cookies": cookies}
 
 
-def _invoke_json(runner, args: list[str]) -> dict:
+def _invoke_json(runner, args: list[str], *, exit_code: int = 0) -> dict:
     result = runner.invoke(cli, [*args, "doctor", "--json"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == exit_code, result.output
     return json.loads(result.output)
 
 
@@ -78,7 +78,7 @@ def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated
     home = isolated_notebooklm_home
     _write_json(home / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
 
-    data = _invoke_json(runner, ["--storage", str(home / "unused.json")])
+    data = _invoke_json(runner, ["--storage", str(home / "unused.json")], exit_code=1)
 
     assert data["checks"]["migration"] == {
         "status": "fail",
@@ -94,7 +94,7 @@ def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated
 def test_doctor_reports_missing_profile_dir(runner, isolated_notebooklm_home):
     home = isolated_notebooklm_home
 
-    data = _invoke_json(runner, ["--storage", str(home / "unused.json")])
+    data = _invoke_json(runner, ["--storage", str(home / "unused.json")], exit_code=1)
 
     assert data["checks"]["migration"] == {
         "status": "pass",
@@ -111,7 +111,7 @@ def test_doctor_reports_invalid_storage_json(runner, isolated_notebooklm_home):
     profile_dir = _make_profile(isolated_notebooklm_home)
     profile_dir.joinpath("storage_state.json").write_text("{not json", encoding="utf-8")
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["checks"]["auth"]["status"] == "fail"
     assert data["checks"]["auth"]["detail"].startswith("invalid storage file:")
@@ -121,7 +121,7 @@ def test_doctor_reports_invalid_storage_root_shape(runner, isolated_notebooklm_h
     profile_dir = _make_profile(isolated_notebooklm_home)
     _write_json(profile_dir / "storage_state.json", [])
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["checks"]["auth"] == {
         "status": "fail",
@@ -133,7 +133,7 @@ def test_doctor_reports_invalid_storage_cookie_shape(runner, isolated_notebooklm
     profile_dir = _make_profile(isolated_notebooklm_home)
     _write_json(profile_dir / "storage_state.json", {"cookies": {"name": "SID"}})
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["checks"]["auth"] == {
         "status": "fail",
@@ -145,7 +145,7 @@ def test_doctor_reports_cookies_missing_sid(runner, isolated_notebooklm_home):
     profile_dir = _make_profile(isolated_notebooklm_home)
     _write_json(profile_dir / "storage_state.json", _storage([{"name": "HSID", "value": "x"}]))
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["checks"]["auth"] == {"status": "fail", "detail": "SID cookie missing"}
 
@@ -156,7 +156,7 @@ def test_doctor_warns_when_config_default_profile_is_missing(runner, isolated_no
     _write_json(home / "profiles" / "default" / "storage_state.json", _storage([]))
     _write_json(home / "config.json", {"default_profile": "missing"})
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["profile"] == "missing"
     assert data["profile_source"] == "config.json"
@@ -172,7 +172,7 @@ def test_doctor_reports_invalid_config_root_shape(runner, isolated_notebooklm_ho
     _make_profile(home)
     _write_json(home / "config.json", [])
 
-    data = _invoke_json(runner, [])
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert data["checks"]["config"] == {
         "status": "fail",
@@ -185,13 +185,16 @@ def test_doctor_fix_creates_missing_profile_dir(runner, isolated_notebooklm_home
 
     result = runner.invoke(cli, ["doctor", "--fix", "--json"])
 
-    assert result.exit_code == 0, result.output
+    # --fix repairs the profile dir, but no auth was set up so the auth check
+    # is still failing — doctor exits 1 on the lingering failure.
+    assert result.exit_code == 1, result.output
     data = json.loads(result.output)
     profile_dir = home / "profiles" / "default"
     assert profile_dir.is_dir()
     if sys.platform != "win32":
         assert profile_dir.stat().st_mode & 0o777 == 0o700
     assert data["checks"]["profile_dir"] == {"status": "pass", "detail": str(profile_dir)}
+    assert data["checks"]["auth"]["status"] == "fail"
     assert data["fixes_applied"] == [f"Created profile directory: {profile_dir}"]
 
 
@@ -229,7 +232,9 @@ def test_doctor_fix_migrates_legacy_layout(runner, isolated_notebooklm_home):
 def test_doctor_json_output_shape(runner, isolated_notebooklm_home):
     _make_profile(isolated_notebooklm_home)
 
-    data = _invoke_json(runner, [])
+    # No storage_state.json was written, so the auth check fails and doctor
+    # exits 1; the JSON shape contract still holds on the failure path.
+    data = _invoke_json(runner, [], exit_code=1)
 
     assert set(data) == {"profile", "profile_source", "checks"}
     assert set(data["checks"]) == {"migration", "profile_dir", "auth", "config"}
@@ -251,3 +256,54 @@ def test_doctor_json_wraps_unexpected_filesystem_error(runner, isolated_notebook
         "message": "Unexpected error: denied",
     }
     assert result.stderr == ""
+
+
+def test_doctor_text_mode_exits_nonzero_on_failure(runner, isolated_notebooklm_home):
+    """Regression for #1160: text-mode doctor must exit 1 when a check fails.
+
+    Previously the command always exited 0, so a broken install read as green
+    in CI / ``set -e`` scripts. With no profile dir and no auth, both the
+    ``profile_dir`` and ``auth`` checks fail.
+    """
+    result = runner.invoke(cli, ["doctor"])
+
+    assert result.exit_code == 1, result.output
+    # The rendered table still shows the failing rows.
+    assert "fail" in result.output
+
+
+def test_doctor_text_mode_exits_zero_when_all_pass(runner, isolated_notebooklm_home):
+    """A fully healthy profile keeps doctor's text mode at exit 0.
+
+    On Windows the profile_dir permissions check warns rather than passes, but a
+    warning is not a failure, so the command still exits 0.
+    """
+    home = isolated_notebooklm_home
+    profile_dir = _make_profile(home)
+    _write_json(profile_dir / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
+    _write_json(home / "config.json", {"default_profile": "default"})
+
+    result = runner.invoke(cli, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "fail" not in result.output
+
+
+def test_doctor_warn_only_keeps_exit_zero(runner, isolated_notebooklm_home):
+    """A lingering warning (no failures) must not flip the exit code to 1.
+
+    Legacy files alongside a migrated ``profiles/`` directory is a ``warn``
+    (partial migration), not a ``fail`` — doctor should still exit 0.
+    """
+    home = isolated_notebooklm_home
+    profile_dir = _make_profile(home)
+    _write_json(profile_dir / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
+    # Leftover legacy file alongside the profiles/ dir -> migration warn. The
+    # ``--storage`` override suppresses the startup migration that would
+    # otherwise sweep this file into the profile before the checks run.
+    _write_json(home / "context.json", {"current_notebook": "nb_123"})
+
+    data = _invoke_json(runner, ["--storage", str(home / "unused.json")], exit_code=0)
+
+    assert data["checks"]["migration"]["status"] == "warn"
+    assert not any(c["status"] == "fail" for c in data["checks"].values())

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -338,11 +338,10 @@ def _setup_fs_doctor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Lay out a clean profile so ``doctor --json`` reports all-pass.
 
     Mirrors the ``test_doctor_reports_clean_profile_layout`` fixture in
-    tests/unit/cli/test_doctor.py — without those files the doctor command
-    would still exit 0 but emit ``status: "fail"`` entries inside the
-    ``checks`` payload (the JSON document is still well-formed either way,
-    but a clean layout exercises every code branch the success-path sweep
-    cares about).
+    tests/unit/cli/test_doctor.py. A clean layout makes every check pass so the
+    command exits 0 (since #1160 a lingering ``status: "fail"`` exits 1) while
+    still emitting a single well-formed JSON document — which is what this
+    success-path stdout-purity sweep asserts.
     """
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)


### PR DESCRIPTION
## Root cause

`notebooklm doctor` (`src/notebooklm/cli/doctor_cmd.py`) builds check entries with `status: "fail"` (broken auth, incomplete migration, missing profile dir, invalid config) but `_run_doctor` always returns normally. Both the JSON branch (`json_output_response(result); return`) and the text branch (`_display_results(...)`) exited 0 even on failures.

Reproduction from the issue:
```
NOTEBOOKLM_HOME=$(mktemp -d) notebooklm doctor; echo $?   # -> 0, with auth {'status': 'fail'}
```

A health check in CI, a `set -e` script, or a monitoring probe reads the broken install as **green**. By contrast `auth check` already exits 1 on the same condition.

## Fix

Compute overall health from the **final** check states (after any `--fix` repairs have run) and `exit_with_code(1)` when any check still has `status == "fail"`, in **both** the JSON and text branches — consistent with `auth check` and the CLI exit-code convention. The exit happens *after* the payload/table is emitted, so machine-readable output is preserved. Warnings remain non-fatal (exit 0).

## Tests

- Updated the existing failing-check unit/integration cases to assert exit 1 (they previously asserted 0).
- Added regression tests: text-mode doctor exits 1 on failure (the exact issue repro), text-mode exits 0 when all pass, `--fix` that leaves auth failing still exits 1, and a warn-only layout keeps exit 0.

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `doctor` command now properly exits with code 1 when health checks fail and exits with code 0 when all checks pass, in both text and JSON output modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->