### PR TITLE
refactor(payloads): localize artifact and source builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ RPC Layer (rpc/)
 | `_artifact_downloads.py` | Asynchronous download coordinator for finished artifacts |
 | `_artifact_formatters.py` | Markdown, HTML, and plain text formatters for artifacts |
 | `_artifact_generation.py` | Extracted artifact generation payload-building service |
+| `_artifact_payloads.py` | Stable CREATE_ARTIFACT / GENERATE_MIND_MAP request payload builders |
 | `_artifact_listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact_polling.py` | Poll coordination service for artifact generation tasks |
 | `_source_add.py` | Core service layer for adding text, URL, or Google Drive sources |
@@ -150,6 +151,7 @@ RPC Layer (rpc/)
 | `_source_listing.py` | Core service layer for listing notebook sources |
 | `_source_polling.py` | Poll coordination service for active source conversions |
 | `_source_upload.py` | Concurrency-gated upload pipeline for source files |
+| `_source_upload_payloads.py` | Stable source upload registration, rename, and resumable-upload request builders |
 | `_notebook_metadata.py` | Metadata protocol schemas for sub-clients |
 | `_url_utils.py`, `urls.py` | URL parsing/validation internals and the public URL helper facade |
 | `_sharing_manager.py` | Direct sharing management logic |
@@ -225,6 +227,7 @@ src/notebooklm/
 ├── _artifact_downloads.py       # Artifact download coordinator
 ├── _artifact_formatters.py      # Artifact formatting helpers
 ├── _artifact_generation.py      # Artifact generation payload builder
+├── _artifact_payloads.py        # Artifact request payload builders
 ├── _artifact_listing.py         # Artifact listing helper
 ├── _artifact_polling.py         # Artifact polling coordinator
 ├── _source_add.py               # Source addition coordinator
@@ -232,6 +235,7 @@ src/notebooklm/
 ├── _source_listing.py           # Source listing helper
 ├── _source_polling.py           # Source polling coordinator
 ├── _source_upload.py            # Gated source upload service
+├── _source_upload_payloads.py   # Source upload request payload builders
 ├── _notebook_metadata.py        # Metadata protocols
 ├── _url_utils.py                # URL validation helpers
 ├── _sharing_manager.py          # Sharing management logic

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -6,10 +6,23 @@ import json as json_module
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ._artifact_payloads import (
+    build_audio_artifact_params,
+    build_cinematic_video_artifact_params,
+    build_data_table_artifact_params,
+    build_flashcards_artifact_params,
+    build_infographic_artifact_params,
+    build_mind_map_params,
+    build_quiz_artifact_params,
+    build_report_artifact_params,
+    build_revise_slide_params,
+    build_slide_deck_artifact_params,
+    build_suggest_reports_params,
+    build_video_artifact_params,
+)
 from ._env import get_default_language
 from .exceptions import ArtifactFeatureUnavailableError, ValidationError
 from .rpc import (
-    ArtifactTypeCode,
     AudioFormat,
     AudioLength,
     InfographicDetail,
@@ -25,7 +38,6 @@ from .rpc import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
-    nest_source_ids,
     safe_index,
 )
 from .types import GenerationStatus, ReportSuggestion
@@ -67,38 +79,14 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        format_code = (
-            audio_format.value if audio_format is not None else AudioFormat.DEEP_DIVE.value
-        )
-        length_code = audio_length.value if audio_length is not None else AudioLength.DEFAULT.value
-
-        params = [
-            [2],
+        params = build_audio_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.AUDIO.value,
-                source_ids_triple,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        instructions,
-                        length_code,
-                        None,
-                        source_ids_double,
-                        language,
-                        None,
-                        format_code,
-                    ],
-                ],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+            audio_format=audio_format,
+            audio_length=audio_length,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -129,44 +117,15 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        format_code = (
-            video_format.value if video_format is not None else VideoFormat.EXPLAINER.value
-        )
-        style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
-
-        video_config = [
-            source_ids_double,
-            language,
-            instructions,
-            None,
-            format_code,
-            style_code,
-        ]
-        if normalized_style_prompt:
-            video_config.append(normalized_style_prompt)
-
-        params = [
-            [2],
+        params = build_video_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.VIDEO.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    None,
-                    video_config,
-                ],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+            video_format=video_format,
+            video_style=video_style,
+            style_prompt=normalized_style_prompt,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -186,34 +145,12 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        params = [
-            [2],
+        params = build_cinematic_video_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.VIDEO.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    None,
-                    [
-                        source_ids_double,
-                        language,
-                        instructions,
-                        None,
-                        VideoFormat.CINEMATIC.value,
-                    ],
-                ],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -235,74 +172,14 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        format_configs = {
-            ReportFormat.BRIEFING_DOC: {
-                "title": "Briefing Doc",
-                "description": "Key insights and important quotes",
-                "prompt": (
-                    "Create a comprehensive briefing document that includes an "
-                    "Executive Summary, detailed analysis of key themes, important "
-                    "quotes with context, and actionable insights."
-                ),
-            },
-            ReportFormat.STUDY_GUIDE: {
-                "title": "Study Guide",
-                "description": "Short-answer quiz, essay questions, glossary",
-                "prompt": (
-                    "Create a comprehensive study guide that includes key concepts, "
-                    "short-answer practice questions, essay prompts for deeper "
-                    "exploration, and a glossary of important terms."
-                ),
-            },
-            ReportFormat.BLOG_POST: {
-                "title": "Blog Post",
-                "description": "Insightful takeaways in readable article format",
-                "prompt": (
-                    "Write an engaging blog post that presents the key insights "
-                    "in an accessible, reader-friendly format. Include an attention-"
-                    "grabbing introduction, well-organized sections, and a compelling "
-                    "conclusion with takeaways."
-                ),
-            },
-            ReportFormat.CUSTOM: {
-                "title": "Custom Report",
-                "description": "Custom format",
-                "prompt": custom_prompt or "Create a report based on the provided sources.",
-            },
-        }
-
-        config = format_configs[report_format]
-        if extra_instructions and report_format != ReportFormat.CUSTOM:
-            config = {**config, "prompt": f"{config['prompt']}\n\n{extra_instructions}"}
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        params = [
-            [2],
+        params = build_report_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.REPORT.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        config["title"],
-                        config["description"],
-                        None,
-                        source_ids_double,
-                        language,
-                        config["prompt"],
-                        None,
-                        True,
-                    ],
-                ],
-            ],
-        ]
+            source_ids,
+            report_format=report_format,
+            language=language,
+            custom_prompt=custom_prompt,
+            extra_instructions=extra_instructions,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -339,40 +216,13 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
-        difficulty_code = (
-            difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
-        )
-
-        params = [
-            [2],
+        params = build_quiz_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.QUIZ_FLASHCARD.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        2,
-                        None,
-                        instructions,
-                        None,
-                        None,
-                        None,
-                        None,
-                        [quantity_code, difficulty_code],
-                    ],
-                ],
-            ],
-        ]
+            source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -391,39 +241,13 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
-        difficulty_code = (
-            difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
-        )
-
-        params = [
-            [2],
+        params = build_flashcards_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.QUIZ_FLASHCARD.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        1,
-                        None,
-                        instructions,
-                        None,
-                        None,
-                        None,
-                        [difficulty_code, quantity_code],
-                    ],
-                ],
-            ],
-        ]
+            source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -446,36 +270,15 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        orientation_code = (
-            orientation.value if orientation is not None else InfographicOrientation.LANDSCAPE.value
-        )
-        detail_code = (
-            detail_level.value if detail_level is not None else InfographicDetail.STANDARD.value
-        )
-        style_code = style.value if style is not None else InfographicStyle.AUTO_SELECT.value
-
-        params = [
-            [2],
+        params = build_infographic_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.INFOGRAPHIC.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [[instructions, language, None, orientation_code, detail_code, style_code]],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+            orientation=orientation,
+            detail_level=detail_level,
+            style=style,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -497,37 +300,14 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        format_code = (
-            slide_format.value if slide_format is not None else SlideDeckFormat.DETAILED_DECK.value
-        )
-        length_code = (
-            slide_length.value if slide_length is not None else SlideDeckLength.DEFAULT.value
-        )
-
-        params = [
-            [2],
+        params = build_slide_deck_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.SLIDE_DECK.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [[instructions, language, format_code, length_code]],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+            slide_format=slide_format,
+            slide_length=slide_length,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -545,11 +325,7 @@ class ArtifactGenerationService:
         if slide_index < 0:
             raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
 
-        params = [
-            [2],
-            artifact_id,
-            [[[slide_index, prompt]]],
-        ]
+        params = build_revise_slide_params(artifact_id, slide_index, prompt)
         try:
             result = await self._rpc.rpc_call(
                 RPCMethod.REVISE_SLIDE,
@@ -587,33 +363,12 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_triple = nest_source_ids(source_ids, 2)
-
-        params = [
-            [2],
+        params = build_data_table_artifact_params(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.DATA_TABLE.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [None, [instructions, language]],
-            ],
-        ]
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
         return await self.call_generate(
             notebook_id,
             params,
@@ -633,18 +388,11 @@ class ArtifactGenerationService:
         if source_ids is None:
             source_ids = await self._notebooks.get_source_ids(notebook_id)
 
-        source_ids_nested = nest_source_ids(source_ids, 2)
-
-        params = [
-            source_ids_nested,
-            None,
-            None,
-            None,
-            None,
-            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
-            None,
-            [2, None, [1]],
-        ]
+        params = build_mind_map_params(
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
 
         # GENERATE_MIND_MAP is classified PROBE_THEN_CREATE in
         # ``_idempotency.py`` (P0-3). ``operation_variant=None`` is passed
@@ -704,7 +452,7 @@ class ArtifactGenerationService:
         notebook_id: str,
     ) -> list[ReportSuggestion]:
         """Get AI-suggested report formats for a notebook."""
-        params = [[2], notebook_id]
+        params = build_suggest_reports_params(notebook_id)
 
         result = await self._rpc.rpc_call(
             RPCMethod.GET_SUGGESTED_REPORTS,

--- a/src/notebooklm/_artifact_payloads.py
+++ b/src/notebooklm/_artifact_payloads.py
@@ -21,6 +21,37 @@ from .rpc import (
     nest_source_ids,
 )
 
+_STATIC_REPORT_CONFIGS: dict[ReportFormat, dict[str, str]] = {
+    ReportFormat.BRIEFING_DOC: {
+        "title": "Briefing Doc",
+        "description": "Key insights and important quotes",
+        "prompt": (
+            "Create a comprehensive briefing document that includes an "
+            "Executive Summary, detailed analysis of key themes, important "
+            "quotes with context, and actionable insights."
+        ),
+    },
+    ReportFormat.STUDY_GUIDE: {
+        "title": "Study Guide",
+        "description": "Short-answer quiz, essay questions, glossary",
+        "prompt": (
+            "Create a comprehensive study guide that includes key concepts, "
+            "short-answer practice questions, essay prompts for deeper "
+            "exploration, and a glossary of important terms."
+        ),
+    },
+    ReportFormat.BLOG_POST: {
+        "title": "Blog Post",
+        "description": "Insightful takeaways in readable article format",
+        "prompt": (
+            "Write an engaging blog post that presents the key insights "
+            "in an accessible, reader-friendly format. Include an attention-"
+            "grabbing introduction, well-organized sections, and a compelling "
+            "conclusion with takeaways."
+        ),
+    },
+}
+
 
 def build_audio_artifact_params(
     notebook_id: str,
@@ -441,39 +472,10 @@ def _report_config(
     report_format: ReportFormat,
     custom_prompt: str | None,
 ) -> dict[str, str]:
-    format_configs = {
-        ReportFormat.BRIEFING_DOC: {
-            "title": "Briefing Doc",
-            "description": "Key insights and important quotes",
-            "prompt": (
-                "Create a comprehensive briefing document that includes an "
-                "Executive Summary, detailed analysis of key themes, important "
-                "quotes with context, and actionable insights."
-            ),
-        },
-        ReportFormat.STUDY_GUIDE: {
-            "title": "Study Guide",
-            "description": "Short-answer quiz, essay questions, glossary",
-            "prompt": (
-                "Create a comprehensive study guide that includes key concepts, "
-                "short-answer practice questions, essay prompts for deeper "
-                "exploration, and a glossary of important terms."
-            ),
-        },
-        ReportFormat.BLOG_POST: {
-            "title": "Blog Post",
-            "description": "Insightful takeaways in readable article format",
-            "prompt": (
-                "Write an engaging blog post that presents the key insights "
-                "in an accessible, reader-friendly format. Include an attention-"
-                "grabbing introduction, well-organized sections, and a compelling "
-                "conclusion with takeaways."
-            ),
-        },
-        ReportFormat.CUSTOM: {
+    if report_format == ReportFormat.CUSTOM:
+        return {
             "title": "Custom Report",
             "description": "Custom format",
             "prompt": custom_prompt or "Create a report based on the provided sources.",
-        },
-    }
-    return format_configs[report_format]
+        }
+    return _STATIC_REPORT_CONFIGS[report_format]

--- a/src/notebooklm/_artifact_payloads.py
+++ b/src/notebooklm/_artifact_payloads.py
@@ -1,0 +1,479 @@
+"""Artifact generation RPC payload builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .rpc import (
+    ArtifactTypeCode,
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+    nest_source_ids,
+)
+
+
+def build_audio_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+    audio_format: AudioFormat | None,
+    audio_length: AudioLength | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for audio overview generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    source_ids_double = nest_source_ids(source_ids, 1)
+
+    format_code = audio_format.value if audio_format is not None else AudioFormat.DEEP_DIVE.value
+    length_code = audio_length.value if audio_length is not None else AudioLength.DEFAULT.value
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.AUDIO.value,
+            source_ids_triple,
+            None,
+            None,
+            [
+                None,
+                [
+                    instructions,
+                    length_code,
+                    None,
+                    source_ids_double,
+                    language,
+                    None,
+                    format_code,
+                ],
+            ],
+        ],
+    ]
+
+
+def build_video_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+    video_format: VideoFormat | None,
+    video_style: VideoStyle | None,
+    style_prompt: str | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for video overview generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    source_ids_double = nest_source_ids(source_ids, 1)
+
+    format_code = video_format.value if video_format is not None else VideoFormat.EXPLAINER.value
+    style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
+
+    video_config = [
+        source_ids_double,
+        language,
+        instructions,
+        None,
+        format_code,
+        style_code,
+    ]
+    if style_prompt:
+        video_config.append(style_prompt)
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.VIDEO.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            [
+                None,
+                None,
+                video_config,
+            ],
+        ],
+    ]
+
+
+def build_cinematic_video_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for cinematic video generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    source_ids_double = nest_source_ids(source_ids, 1)
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.VIDEO.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            [
+                None,
+                None,
+                [
+                    source_ids_double,
+                    language,
+                    instructions,
+                    None,
+                    VideoFormat.CINEMATIC.value,
+                ],
+            ],
+        ],
+    ]
+
+
+def build_report_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    report_format: ReportFormat,
+    language: str,
+    custom_prompt: str | None,
+    extra_instructions: str | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for report generation."""
+    config = _report_config(report_format, custom_prompt)
+    if extra_instructions and report_format != ReportFormat.CUSTOM:
+        config = {**config, "prompt": f"{config['prompt']}\n\n{extra_instructions}"}
+
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    source_ids_double = nest_source_ids(source_ids, 1)
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.REPORT.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            [
+                None,
+                [
+                    config["title"],
+                    config["description"],
+                    None,
+                    source_ids_double,
+                    language,
+                    config["prompt"],
+                    None,
+                    True,
+                ],
+            ],
+        ],
+    ]
+
+
+def build_quiz_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    instructions: str | None,
+    quantity: QuizQuantity | None,
+    difficulty: QuizDifficulty | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for quiz generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
+    difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.QUIZ_FLASHCARD.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [
+                None,
+                [
+                    2,
+                    None,
+                    instructions,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [quantity_code, difficulty_code],
+                ],
+            ],
+        ],
+    ]
+
+
+def build_flashcards_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    instructions: str | None,
+    quantity: QuizQuantity | None,
+    difficulty: QuizDifficulty | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for flashcard generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
+    difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.QUIZ_FLASHCARD.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [
+                None,
+                [
+                    1,
+                    None,
+                    instructions,
+                    None,
+                    None,
+                    None,
+                    [difficulty_code, quantity_code],
+                ],
+            ],
+        ],
+    ]
+
+
+def build_infographic_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+    orientation: InfographicOrientation | None,
+    detail_level: InfographicDetail | None,
+    style: InfographicStyle | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for infographic generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    orientation_code = (
+        orientation.value if orientation is not None else InfographicOrientation.LANDSCAPE.value
+    )
+    detail_code = (
+        detail_level.value if detail_level is not None else InfographicDetail.STANDARD.value
+    )
+    style_code = style.value if style is not None else InfographicStyle.AUTO_SELECT.value
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.INFOGRAPHIC.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [[instructions, language, None, orientation_code, detail_code, style_code]],
+        ],
+    ]
+
+
+def build_slide_deck_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+    slide_format: SlideDeckFormat | None,
+    slide_length: SlideDeckLength | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for slide deck generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+    format_code = (
+        slide_format.value if slide_format is not None else SlideDeckFormat.DETAILED_DECK.value
+    )
+    length_code = slide_length.value if slide_length is not None else SlideDeckLength.DEFAULT.value
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.SLIDE_DECK.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [[instructions, language, format_code, length_code]],
+        ],
+    ]
+
+
+def build_revise_slide_params(artifact_id: str, slide_index: int, prompt: str) -> list[Any]:
+    """Build ``REVISE_SLIDE`` params for slide revision."""
+    return [
+        [2],
+        artifact_id,
+        [[[slide_index, prompt]]],
+    ]
+
+
+def build_data_table_artifact_params(
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+) -> list[Any]:
+    """Build ``CREATE_ARTIFACT`` params for data table generation."""
+    source_ids_triple = nest_source_ids(source_ids, 2)
+
+    return [
+        [2],
+        notebook_id,
+        [
+            None,
+            None,
+            ArtifactTypeCode.DATA_TABLE.value,
+            source_ids_triple,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [None, [instructions, language]],
+        ],
+    ]
+
+
+def build_mind_map_params(
+    source_ids: list[str],
+    *,
+    language: str,
+    instructions: str | None,
+) -> list[Any]:
+    """Build ``GENERATE_MIND_MAP`` params."""
+    source_ids_nested = nest_source_ids(source_ids, 2)
+
+    return [
+        source_ids_nested,
+        None,
+        None,
+        None,
+        None,
+        ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
+        None,
+        [2, None, [1]],
+    ]
+
+
+def build_suggest_reports_params(notebook_id: str) -> list[Any]:
+    """Build ``GET_SUGGESTED_REPORTS`` params."""
+    return [[2], notebook_id]
+
+
+def _report_config(
+    report_format: ReportFormat,
+    custom_prompt: str | None,
+) -> dict[str, str]:
+    format_configs = {
+        ReportFormat.BRIEFING_DOC: {
+            "title": "Briefing Doc",
+            "description": "Key insights and important quotes",
+            "prompt": (
+                "Create a comprehensive briefing document that includes an "
+                "Executive Summary, detailed analysis of key themes, important "
+                "quotes with context, and actionable insights."
+            ),
+        },
+        ReportFormat.STUDY_GUIDE: {
+            "title": "Study Guide",
+            "description": "Short-answer quiz, essay questions, glossary",
+            "prompt": (
+                "Create a comprehensive study guide that includes key concepts, "
+                "short-answer practice questions, essay prompts for deeper "
+                "exploration, and a glossary of important terms."
+            ),
+        },
+        ReportFormat.BLOG_POST: {
+            "title": "Blog Post",
+            "description": "Insightful takeaways in readable article format",
+            "prompt": (
+                "Write an engaging blog post that presents the key insights "
+                "in an accessible, reader-friendly format. Include an attention-"
+                "grabbing introduction, well-organized sections, and a compelling "
+                "conclusion with takeaways."
+            ),
+        },
+        ReportFormat.CUSTOM: {
+            "title": "Custom Report",
+            "description": "Custom format",
+            "prompt": custom_prompt or "Create a report based on the provided sources.",
+        },
+    }
+    return format_configs[report_format]

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import mimetypes
 import os
@@ -31,6 +30,11 @@ from ._session_contracts import (
 )
 from ._source_listing import SourceLister
 from ._source_polling import SourcePoller
+from ._source_upload_payloads import (
+    build_register_file_source_params,
+    build_rename_source_params,
+    build_resumable_upload_start_request,
+)
 from .auth import authuser_query, format_authuser_value
 from .exceptions import (
     AuthError,
@@ -693,12 +697,7 @@ class SourceUploadPipeline:
         concurrent uploader added one) raises ``SourceAddError`` rather
         than guessing.
         """
-        params = [
-            [[filename]],
-            notebook_id,
-            [2],
-            [1, None, None, None, None, None, None, None, None, None, [1]],
-        ]
+        params = build_register_file_source_params(filename, notebook_id)
         if rpc_call is None:
             rpc_call = self._rpc.rpc_call
         if list_sources is None:
@@ -930,7 +929,7 @@ class SourceUploadPipeline:
     async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source:
         """Rename an uploaded source."""
         module_logger.debug("Renaming source %s to: %s", source_id, new_title)
-        params = [None, [source_id], [[[new_title]]]]
+        params = build_rename_source_params(source_id, new_title)
         result = await self._rpc.rpc_call(
             RPCMethod.UPDATE_SOURCE,
             params,
@@ -948,35 +947,27 @@ class SourceUploadPipeline:
         content_type: str,
     ) -> str:
         """Start a resumable upload session and get the upload URL."""
-        auth_route = self._authuser_header()
-        base_url = get_base_url()
-        url = f"{get_upload_url()}?{self._authuser_query()}"
-
-        headers = {
-            "Accept": "*/*",
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Origin": base_url,
-            "Referer": f"{base_url}/",
-            "x-goog-authuser": auth_route,
-            "x-goog-upload-command": "start",
-            "x-goog-upload-header-content-length": str(file_size),
-            "x-goog-upload-header-content-type": content_type,
-            "x-goog-upload-protocol": "resumable",
-        }
-
-        body = json.dumps(
-            {
-                "PROJECT_ID": notebook_id,
-                "SOURCE_NAME": filename,
-                "SOURCE_ID": source_id,
-            }
+        request = build_resumable_upload_start_request(
+            notebook_id=notebook_id,
+            filename=filename,
+            file_size=file_size,
+            source_id=source_id,
+            content_type=content_type,
+            base_url=get_base_url(),
+            upload_url=get_upload_url(),
+            authuser_query=self._authuser_query(),
+            authuser_header=self._authuser_header(),
         )
 
         async with self._client_factory()(
             timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=60.0)),
             cookies=self._live_cookies(),
         ) as client:
-            response = await client.post(url, headers=headers, content=body)
+            response = await client.post(
+                request.url,
+                headers=request.headers,
+                content=request.body,
+            )
             response.raise_for_status()
 
             upload_url = response.headers.get("x-goog-upload-url")

--- a/src/notebooklm/_source_upload_payloads.py
+++ b/src/notebooklm/_source_upload_payloads.py
@@ -1,0 +1,67 @@
+"""Source upload request payload builders."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResumableUploadStartRequest:
+    """HTTP request fields for starting a Scotty resumable upload."""
+
+    url: str
+    headers: dict[str, str]
+    body: str
+
+
+def build_register_file_source_params(filename: str, notebook_id: str) -> list[Any]:
+    """Build ``ADD_SOURCE_FILE`` params for file source registration."""
+    return [
+        [[filename]],
+        notebook_id,
+        [2],
+        [1, None, None, None, None, None, None, None, None, None, [1]],
+    ]
+
+
+def build_rename_source_params(source_id: str, new_title: str) -> list[Any]:
+    """Build ``UPDATE_SOURCE`` params for source title updates."""
+    return [None, [source_id], [[[new_title]]]]
+
+
+def build_resumable_upload_start_request(
+    *,
+    notebook_id: str,
+    filename: str,
+    file_size: int,
+    source_id: str,
+    content_type: str,
+    base_url: str,
+    upload_url: str,
+    authuser_query: str,
+    authuser_header: str,
+) -> ResumableUploadStartRequest:
+    """Build the HTTP request that starts a resumable upload session."""
+    return ResumableUploadStartRequest(
+        url=f"{upload_url}?{authuser_query}",
+        headers={
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
+            "x-goog-authuser": authuser_header,
+            "x-goog-upload-command": "start",
+            "x-goog-upload-header-content-length": str(file_size),
+            "x-goog-upload-header-content-type": content_type,
+            "x-goog-upload-protocol": "resumable",
+        },
+        body=json.dumps(
+            {
+                "PROJECT_ID": notebook_id,
+                "SOURCE_NAME": filename,
+                "SOURCE_ID": source_id,
+            }
+        ),
+    )

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -32,6 +32,23 @@ from typing import Any
 
 import pytest
 
+from notebooklm._artifact_payloads import (
+    build_audio_artifact_params,
+    build_cinematic_video_artifact_params,
+    build_data_table_artifact_params,
+    build_flashcards_artifact_params,
+    build_infographic_artifact_params,
+    build_mind_map_params,
+    build_quiz_artifact_params,
+    build_report_artifact_params,
+    build_slide_deck_artifact_params,
+    build_video_artifact_params,
+)
+from notebooklm._source_upload_payloads import (
+    build_register_file_source_params,
+    build_rename_source_params,
+    build_resumable_upload_start_request,
+)
 from notebooklm.rpc.decoder import (
     collect_rpc_ids,
     decode_response,
@@ -39,7 +56,21 @@ from notebooklm.rpc.decoder import (
     strip_anti_xssi,
 )
 from notebooklm.rpc.encoder import encode_rpc_request
-from notebooklm.rpc.types import RPCMethod
+from notebooklm.rpc.types import (
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    RPCMethod,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+)
 
 FIXTURE_ROOT: Path = Path(__file__).parents[1] / "fixtures" / "rpc_golden"
 
@@ -157,6 +188,389 @@ def _resolve_mapper(dotted: str, *, method: RPCMethod) -> Any:
 
 
 ALL_METHODS: list[RPCMethod] = list(RPCMethod)
+
+
+def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
+    return [[[method.value, json.dumps(params, separators=(",", ":")), None, "generic"]]]
+
+
+@pytest.mark.parametrize(
+    ("case_name", "params", "expected"),
+    [
+        (
+            "audio_explicit_options",
+            build_audio_artifact_params(
+                "nb_payload",
+                ["src_alpha", "src_beta"],
+                language="es",
+                instructions="Focus on terminology",
+                audio_format=AudioFormat.BRIEF,
+                audio_length=AudioLength.SHORT,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    1,
+                    [[["src_alpha"]], [["src_beta"]]],
+                    None,
+                    None,
+                    [
+                        None,
+                        [
+                            "Focus on terminology",
+                            1,
+                            None,
+                            [["src_alpha"], ["src_beta"]],
+                            "es",
+                            None,
+                            2,
+                        ],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "video_custom_style",
+            build_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="fr",
+                instructions="Summarize visually",
+                video_format=VideoFormat.EXPLAINER,
+                video_style=VideoStyle.CUSTOM,
+                style_prompt="blueprint line art",
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        None,
+                        [
+                            [["src_alpha"]],
+                            "fr",
+                            "Summarize visually",
+                            None,
+                            1,
+                            2,
+                            "blueprint line art",
+                        ],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "cinematic_video",
+            build_cinematic_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="de",
+                instructions=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [None, None, [[["src_alpha"]], "de", None, None, 3]],
+                ],
+            ],
+        ),
+        (
+            "custom_report",
+            build_report_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                report_format=ReportFormat.CUSTOM,
+                language="en",
+                custom_prompt="Compare the claims.",
+                extra_instructions="Ignored for custom reports.",
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    2,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        [
+                            "Custom Report",
+                            "Custom format",
+                            None,
+                            [["src_alpha"]],
+                            "en",
+                            "Compare the claims.",
+                            None,
+                            True,
+                        ],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "quiz_options",
+            build_quiz_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                instructions="Make it practical",
+                quantity=QuizQuantity.FEWER,
+                difficulty=QuizDifficulty.HARD,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    4,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        [2, None, "Make it practical", None, None, None, None, [1, 3]],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "flashcards_options",
+            build_flashcards_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                instructions="Use short prompts",
+                quantity=QuizQuantity.STANDARD,
+                difficulty=QuizDifficulty.EASY,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    4,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        [1, None, "Use short prompts", None, None, None, [1, 2]],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "infographic_visual_options",
+            build_infographic_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="it",
+                instructions="Prioritize the timeline",
+                orientation=InfographicOrientation.PORTRAIT,
+                detail_level=InfographicDetail.DETAILED,
+                style=InfographicStyle.EDITORIAL,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    7,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [["Prioritize the timeline", "it", None, 2, 3, 5]],
+                ],
+            ],
+        ),
+        (
+            "slide_deck_options",
+            build_slide_deck_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="pt",
+                instructions="Board-level summary",
+                slide_format=SlideDeckFormat.PRESENTER_SLIDES,
+                slide_length=SlideDeckLength.SHORT,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    8,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [["Board-level summary", "pt", 2, 2]],
+                ],
+            ],
+        ),
+        (
+            "data_table",
+            build_data_table_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="ja",
+                instructions="Extract product comparisons",
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    9,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [None, ["Extract product comparisons", "ja"]],
+                ],
+            ],
+        ),
+        (
+            "mind_map",
+            build_mind_map_params(
+                ["src_alpha"],
+                language="en",
+                instructions="Cluster by theme",
+            ),
+            [
+                [[["src_alpha"]]],
+                None,
+                None,
+                None,
+                None,
+                ["interactive_mindmap", [["[CONTEXT]", "Cluster by theme"]], "en"],
+                None,
+                [2, None, [1]],
+            ],
+        ),
+    ],
+)
+def test_artifact_payload_builders_match_golden_rpc_envelopes(
+    case_name: str,
+    params: list[Any],
+    expected: list[Any],
+) -> None:
+    method = RPCMethod.GENERATE_MIND_MAP if case_name == "mind_map" else RPCMethod.CREATE_ARTIFACT
+
+    assert params == expected
+    assert encode_rpc_request(method, params) == _expected_rpc_envelope(method, expected)
+
+
+def test_source_upload_rpc_payload_builders_match_golden_envelopes() -> None:
+    register_params = build_register_file_source_params("research.pdf", "nb_payload")
+    rename_params = build_rename_source_params("src_payload", "Renamed source")
+
+    assert register_params == [
+        [["research.pdf"]],
+        "nb_payload",
+        [2],
+        [1, None, None, None, None, None, None, None, None, None, [1]],
+    ]
+    assert encode_rpc_request(RPCMethod.ADD_SOURCE_FILE, register_params) == _expected_rpc_envelope(
+        RPCMethod.ADD_SOURCE_FILE,
+        register_params,
+    )
+    assert rename_params == [None, ["src_payload"], [[["Renamed source"]]]]
+    assert encode_rpc_request(RPCMethod.UPDATE_SOURCE, rename_params) == _expected_rpc_envelope(
+        RPCMethod.UPDATE_SOURCE,
+        rename_params,
+    )
+
+
+def test_resumable_upload_start_request_matches_golden_payload() -> None:
+    request = build_resumable_upload_start_request(
+        notebook_id="nb_payload",
+        filename="research.pdf",
+        file_size=4096,
+        source_id="src_payload",
+        content_type="application/pdf",
+        base_url="https://notebooklm.google.com",
+        upload_url="https://notebooklm.google.com/_/upload",
+        authuser_query="authuser=1",
+        authuser_header="1",
+    )
+
+    assert request.url == "https://notebooklm.google.com/_/upload?authuser=1"
+    assert request.headers == {
+        "Accept": "*/*",
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "Origin": "https://notebooklm.google.com",
+        "Referer": "https://notebooklm.google.com/",
+        "x-goog-authuser": "1",
+        "x-goog-upload-command": "start",
+        "x-goog-upload-header-content-length": "4096",
+        "x-goog-upload-header-content-type": "application/pdf",
+        "x-goog-upload-protocol": "resumable",
+    }
+    assert request.body == (
+        '{"PROJECT_ID": "nb_payload", "SOURCE_NAME": "research.pdf", "SOURCE_ID": "src_payload"}'
+    )
 
 
 def test_every_rpc_method_has_a_fixture() -> None:

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -41,7 +41,9 @@ from notebooklm._artifact_payloads import (
     build_mind_map_params,
     build_quiz_artifact_params,
     build_report_artifact_params,
+    build_revise_slide_params,
     build_slide_deck_artifact_params,
+    build_suggest_reports_params,
     build_video_artifact_params,
 )
 from notebooklm._source_upload_payloads import (
@@ -198,6 +200,33 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
     ("case_name", "params", "expected"),
     [
         (
+            "audio_defaults",
+            build_audio_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions=None,
+                audio_format=None,
+                audio_length=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    1,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    [
+                        None,
+                        [None, 2, None, [["src_alpha"]], "en", None, 1],
+                    ],
+                ],
+            ],
+        ),
+        (
             "audio_explicit_options",
             build_audio_artifact_params(
                 "nb_payload",
@@ -228,6 +257,37 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                             None,
                             2,
                         ],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "video_defaults",
+            build_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions=None,
+                video_format=None,
+                video_style=None,
+                style_prompt=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        None,
+                        [[["src_alpha"]], "en", None, None, 1, 1],
                     ],
                 ],
             ],
@@ -296,6 +356,47 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
             ],
         ),
         (
+            "briefing_report",
+            build_report_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                report_format=ReportFormat.BRIEFING_DOC,
+                language="en",
+                custom_prompt=None,
+                extra_instructions=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    2,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        [
+                            "Briefing Doc",
+                            "Key insights and important quotes",
+                            None,
+                            [["src_alpha"]],
+                            "en",
+                            (
+                                "Create a comprehensive briefing document that includes an "
+                                "Executive Summary, detailed analysis of key themes, important "
+                                "quotes with context, and actionable insights."
+                            ),
+                            None,
+                            True,
+                        ],
+                    ],
+                ],
+            ],
+        ),
+        (
             "custom_report",
             build_report_artifact_params(
                 "nb_payload",
@@ -328,6 +429,35 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                             None,
                             True,
                         ],
+                    ],
+                ],
+            ],
+        ),
+        (
+            "quiz_defaults",
+            build_quiz_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                instructions=None,
+                quantity=None,
+                difficulty=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    4,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        [2, None, None, None, None, None, None, [2, 2]],
                     ],
                 ],
             ],
@@ -391,6 +521,39 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
             ],
         ),
         (
+            "infographic_defaults",
+            build_infographic_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions=None,
+                orientation=None,
+                detail_level=None,
+                style=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    7,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [[None, "en", None, 1, 2, 1]],
+                ],
+            ],
+        ),
+        (
             "infographic_visual_options",
             build_infographic_artifact_params(
                 "nb_payload",
@@ -420,6 +583,40 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                     None,
                     None,
                     [["Prioritize the timeline", "it", None, 2, 3, 5]],
+                ],
+            ],
+        ),
+        (
+            "slide_deck_defaults",
+            build_slide_deck_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions=None,
+                slide_format=None,
+                slide_length=None,
+            ),
+            [
+                [2],
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    8,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    [[None, "en", 1, 1]],
                 ],
             ],
         ),
@@ -520,6 +717,26 @@ def test_artifact_payload_builders_match_golden_rpc_envelopes(
 
     assert params == expected
     assert encode_rpc_request(method, params) == _expected_rpc_envelope(method, expected)
+
+
+def test_revise_slide_payload_builder_matches_golden_envelope() -> None:
+    params = build_revise_slide_params("artifact_payload", 2, "Tighten the summary")
+
+    assert params == [[2], "artifact_payload", [[[2, "Tighten the summary"]]]]
+    assert encode_rpc_request(RPCMethod.REVISE_SLIDE, params) == _expected_rpc_envelope(
+        RPCMethod.REVISE_SLIDE,
+        params,
+    )
+
+
+def test_suggest_reports_payload_builder_matches_golden_envelope() -> None:
+    params = build_suggest_reports_params("nb_payload")
+
+    assert params == [[2], "nb_payload"]
+    assert encode_rpc_request(RPCMethod.GET_SUGGESTED_REPORTS, params) == _expected_rpc_envelope(
+        RPCMethod.GET_SUGGESTED_REPORTS,
+        params,
+    )
 
 
 def test_source_upload_rpc_payload_builders_match_golden_envelopes() -> None:


### PR DESCRIPTION
## Summary
- Extract artifact generation RPC payload builders into `_artifact_payloads.py` and source upload request builders into `_source_upload_payloads.py`.
- Keep artifact/source service behavior unchanged while moving only stable request-shape construction behind focused helpers.
- Add golden payload-builder coverage that checks both helper output and encoded RPC envelopes.

## Task
Phase 5 Wave 2: `p5-payload-locality` from `.sisyphus/phases/codebase-gaps-remediation-plan/phase-5.md`.

## Test plan
- [x] `uv run pytest tests/unit/test_rpc_golden_payloads.py -q`
- [x] `uv run pytest tests/unit -k "artifact or source or upload or golden" -q`
- [x] `uv run ruff check src/notebooklm/_artifact_generation.py src/notebooklm/_source_upload.py tests/unit/test_rpc_golden_payloads.py`
- [x] `uv run ruff check src/notebooklm/_artifact_payloads.py src/notebooklm/_source_upload_payloads.py`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run python scripts/check_claude_md_freshness.py`

## Deferred polish findings
- Optional: update legacy `CLAUDE.md` wording for `_artifact_generation.py` now that raw payload builders live in `_artifact_payloads.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved internal request/parameter construction into dedicated builders for artifact creation and source uploads, standardizing payload assembly across artifact types and upload flows.

* **Tests**
  * Added golden-style tests validating artifact and source-upload payload builders, RPC request envelopes, and resumable-upload start requests.

* **Documentation**
  * Updated repository architecture docs to reflect reorganized client submodules and new payload-builder components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->