### PR TITLE
fix(notes): thread create note operation variants

### DIFF
--- a/src/notebooklm/_chat_notes.py
+++ b/src/notebooklm/_chat_notes.py
@@ -41,6 +41,8 @@ class SaveChatNoteRpc(Protocol):
         params: list[Any],
         source_path: str = "/",
         allow_null: bool = False,
+        *,
+        operation_variant: str | None = None,
     ) -> Any: ...
 
 
@@ -317,6 +319,7 @@ async def save_chat_answer_as_note(
         RPCMethod.CREATE_NOTE,
         params,
         source_path=f"/notebook/{notebook_id}",
+        operation_variant="saved_from_chat",
     )
 
     # The captured server response wraps the 6-element note in an outer

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -224,6 +224,8 @@ class NoteService:
         notebook_id: str,
         title: str = "New Note",
         content: str = "",
+        *,
+        operation_variant: str = "plain",
     ) -> Note:
         """Create a note row and finalize its content + title.
 
@@ -248,7 +250,7 @@ class NoteService:
             RPCMethod.CREATE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",
-            operation_variant="plain",
+            operation_variant=operation_variant,
         )
 
         note_id: str | None = None

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -248,6 +248,7 @@ class NoteService:
             RPCMethod.CREATE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",
+            operation_variant="plain",
         )
 
         note_id: str | None = None

--- a/tests/unit/test_chat_notes.py
+++ b/tests/unit/test_chat_notes.py
@@ -65,6 +65,7 @@ class TestSaveChatAnswerAsNote:
         assert params[4] == "Title"
         assert params[6] == [2]
         assert rpc.rpc_call.call_args.kwargs["source_path"] == "/notebook/nb-1"
+        assert rpc.rpc_call.call_args.kwargs["operation_variant"] == "saved_from_chat"
 
     @pytest.mark.asyncio
     async def test_parses_wrapped_response_shape(self, rpc: FakeSession) -> None:

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -206,6 +206,22 @@ class TestCrud:
         assert mock_session.rpc_executor.rpc_call.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_create_note_accepts_operation_variant_kwarg(
+        self, service: NoteService, mock_session: FakeSession
+    ) -> None:
+        mock_session.rpc_executor.rpc_call.side_effect = [[["note_123"]], None]
+
+        await service.create_note(
+            "nb_123",
+            title="T",
+            content="body",
+            operation_variant="plain",
+        )
+
+        create_call = mock_session.rpc_executor.rpc_call.await_args_list[0]
+        assert create_call.kwargs["operation_variant"] == "plain"
+
+    @pytest.mark.asyncio
     async def test_update_note_sends_existing_payload(
         self, service: NoteService, mock_session: FakeSession
     ) -> None:

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -182,6 +182,7 @@ class TestCrud:
                 RPCMethod.CREATE_NOTE,
                 ["nb_123", "", [1], None, "Mind Map"],
                 source_path="/notebook/nb_123",
+                operation_variant="plain",
             ),
             call(
                 RPCMethod.UPDATE_NOTE,


### PR DESCRIPTION
## Summary
- Pass `operation_variant="plain"` through plain `CREATE_NOTE` calls.
- Pass `operation_variant="saved_from_chat"` through saved-from-chat `CREATE_NOTE` calls and its protocol seam.
- Assert both variants reach the RPC dispatcher seam in focused unit tests.

Closes #1171

## Test plan
- [x] `uv run pytest tests/unit/test_chat_notes.py tests/unit/test_note_service.py -q`
- [x] `uv run ruff format --check src/notebooklm/_chat_notes.py src/notebooklm/_note_service.py tests/unit/test_chat_notes.py tests/unit/test_note_service.py`
- [x] `uv run ruff check src/notebooklm/_chat_notes.py src/notebooklm/_note_service.py tests/unit/test_chat_notes.py tests/unit/test_note_service.py`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pytest`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Optional: introduce shared constants for `CREATE_NOTE` variant strings. Deferred to match existing `operation_variant` literal convention used by source-add variants.
- Optional: add an extra `SaveChatNoteRpc` protocol synchronization comment. Deferred because the existing protocol docstring already describes the narrow dispatch shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Notes saved from chat conversations are now recorded with source attribution so the system distinguishes chat-saved notes from directly created ones.
  * Note creation now supports specifying a creation variant, with a sensible default retained.

* **Tests**
  * Unit tests updated and expanded to validate the note creation source/variant behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->