### PR TITLE
fix(client): cancel in-flight polls before drain wait on close (#1161)

### DIFF
--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -275,8 +275,18 @@ class TransportDrainTracker:
     async def run_drain_hooks(self) -> None:
         """Fire every registered drain hook in registration order.
 
-        Called once from ``ClientLifecycle.close`` after the auth-refresh
-        task has been cancelled and before the HTTP client is shut down.
+        Called from two sites during a graceful ``close(drain=True)``: first
+        from ``NotebookLMClient.close`` *before* the drain wait (so a poll
+        counted in ``operation_scope`` is cancelled-and-settled rather than
+        blocking ``drain()`` — issue #1161), then again from
+        ``ClientLifecycle.close`` after the auth-refresh task has been
+        cancelled and before the HTTP client is shut down. Hooks must
+        therefore tolerate being re-run; the production poll hook
+        (``artifacts.polls``) is a no-op on the second run because
+        already-settled poll tasks are filtered out of
+        ``PollRegistry.active_tasks``. The ``drain=False`` and lifecycle-only
+        paths invoke it just once.
+
         Exceptions in individual hooks are caught and logged via
         ``logger.warning`` (with the registration ``name`` so operators can
         identify the misbehaving feature), then suppressed so a single

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -553,10 +553,36 @@ class NotebookLMClient:
           ``await asyncio.sleep(0)`` or poll to observe it).
 
         There is no path that leaves a live transport behind.
+
+        Drain-hook ordering (issue #1161): feature-owned cancel hooks
+        (e.g. ``artifacts.polls``) run BEFORE the drain wait, not just in
+        the shielded lifecycle close below. In-flight artifact polls wrap
+        themselves in ``TransportDrainTracker.operation_scope`` (see
+        :meth:`notebooklm._artifact_polling.ArtifactPollingService._run_poll_loop_in_scope`),
+        which increments the same in-flight counter ``drain()`` waits on.
+        Without firing the cancel hooks first, ``drain()`` would block on a
+        poll that the cancel hook is supposed to short-circuit — up to the
+        poll's own 300s timeout. Running the hooks first lets ``drain()``
+        observe a cancelled-then-settled count instead of parking on it.
+        The lifecycle close below still re-runs the hooks; that re-run is a
+        cheap no-op because already-settled poll tasks are filtered out of
+        :meth:`notebooklm._polling_registry.PollRegistry.active_tasks`.
         """
         if drain:
             drain_timeout_exc: TimeoutError | None = None
             try:
+                # Issue #1161: fire feature-owned cancel hooks BEFORE the
+                # drain wait so an in-flight poll counted in
+                # ``operation_scope`` is cancelled-and-settled rather than
+                # blocking ``drain()``. The hook runner swallows + logs
+                # per-hook exceptions, so it cannot raise on its own; it is
+                # awaited inside this ``try`` so that a CancelledError
+                # arriving DURING the hook fire still routes through the I12
+                # shielded-close path below (no leaked transport). The
+                # shielded lifecycle close re-runs the hooks idempotently —
+                # already-settled poll tasks are filtered out of
+                # ``PollRegistry.active_tasks`` so the re-run is a no-op.
+                await self._collaborators.drain_tracker.run_drain_hooks()
                 await self.drain(timeout=drain_timeout)
             except TimeoutError as exc:
                 # Drain deadline missed. Hold onto the exception and

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -579,26 +579,12 @@ class NotebookLMClient:
         if drain:
             drain_timeout_exc: TimeoutError | None = None
             try:
-                # Issue #1161: fire feature-owned cancel hooks BEFORE the
-                # drain wait so an in-flight poll counted in
-                # ``operation_scope`` is cancelled-and-settled rather than
-                # blocking ``drain()``.
-                #
-                # Cancellation semantics: ``run_drain_hooks`` awaits its
-                # hooks via ``asyncio.gather(..., return_exceptions=True)``,
-                # so it suppresses (and logs) any *per-hook* exception —
-                # including a hook that raises ``CancelledError`` itself —
-                # and does not re-raise on its own. The ``except
-                # asyncio.CancelledError`` below handles only *caller*
-                # cancellation arriving DURING this await, routing it
-                # through the I12 shielded-close path (no leaked transport).
-                #
-                # Re-run on the lifecycle path: the shielded lifecycle close
-                # re-runs the hooks, but the only production hook
-                # (``artifacts.polls``) is a no-op on the second run because
-                # already-settled poll tasks are filtered out of
-                # ``PollRegistry.active_tasks``. Other future hooks are not
-                # automatically idempotent — register accordingly.
+                # Fire feature-owned cancel hooks BEFORE the drain wait (see
+                # the "Drain-hook ordering" section of the docstring above for
+                # why). Awaited inside this ``try`` so a *caller* CancelledError
+                # arriving during the hook fire still routes through the I12
+                # shielded-close path below; ``run_drain_hooks`` itself never
+                # re-raises (it gathers with ``return_exceptions=True``).
                 await self._collaborators.drain_tracker.run_drain_hooks()
                 await self.drain(timeout=drain_timeout)
             except TimeoutError as exc:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -563,10 +563,18 @@ class NotebookLMClient:
         Without firing the cancel hooks first, ``drain()`` would block on a
         poll that the cancel hook is supposed to short-circuit — up to the
         poll's own 300s timeout. Running the hooks first lets ``drain()``
-        observe a cancelled-then-settled count instead of parking on it.
-        The lifecycle close below still re-runs the hooks; that re-run is a
-        cheap no-op because already-settled poll tasks are filtered out of
+        observe a cancelled-then-settled count instead of parking on it. The
+        lifecycle close below still re-runs the hooks; for the only
+        production hook (``artifacts.polls``) that re-run is a cheap no-op
+        because already-settled poll tasks are filtered out of
         :meth:`notebooklm._polling_registry.PollRegistry.active_tasks`.
+
+        Note: the cancel-hook fire is NOT bounded by ``drain_timeout`` — that
+        deadline budgets the drain *wait*. The production poll-cancel hook
+        settles near-instantly (it cancels its tasks and awaits the
+        cancellation gather), so this is a non-issue in practice; a custom
+        feature hook that blocks indefinitely could still extend shutdown,
+        and such hooks should bound their own work.
         """
         if drain:
             drain_timeout_exc: TimeoutError | None = None
@@ -574,14 +582,23 @@ class NotebookLMClient:
                 # Issue #1161: fire feature-owned cancel hooks BEFORE the
                 # drain wait so an in-flight poll counted in
                 # ``operation_scope`` is cancelled-and-settled rather than
-                # blocking ``drain()``. The hook runner swallows + logs
-                # per-hook exceptions, so it cannot raise on its own; it is
-                # awaited inside this ``try`` so that a CancelledError
-                # arriving DURING the hook fire still routes through the I12
-                # shielded-close path below (no leaked transport). The
-                # shielded lifecycle close re-runs the hooks idempotently —
+                # blocking ``drain()``.
+                #
+                # Cancellation semantics: ``run_drain_hooks`` awaits its
+                # hooks via ``asyncio.gather(..., return_exceptions=True)``,
+                # so it suppresses (and logs) any *per-hook* exception —
+                # including a hook that raises ``CancelledError`` itself —
+                # and does not re-raise on its own. The ``except
+                # asyncio.CancelledError`` below handles only *caller*
+                # cancellation arriving DURING this await, routing it
+                # through the I12 shielded-close path (no leaked transport).
+                #
+                # Re-run on the lifecycle path: the shielded lifecycle close
+                # re-runs the hooks, but the only production hook
+                # (``artifacts.polls``) is a no-op on the second run because
                 # already-settled poll tasks are filtered out of
-                # ``PollRegistry.active_tasks`` so the re-run is a no-op.
+                # ``PollRegistry.active_tasks``. Other future hooks are not
+                # automatically idempotent — register accordingly.
                 await self._collaborators.drain_tracker.run_drain_hooks()
                 await self.drain(timeout=drain_timeout)
             except TimeoutError as exc:

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -227,6 +227,39 @@ async def test_close_drain_cancels_inflight_poll_in_operation_scope() -> None:
     assert core._collaborators.kernel.http_client is None
 
 
+@pytest.mark.asyncio
+async def test_close_fires_drain_hooks_before_drain_wait() -> None:
+    """Issue #1161: ``close(drain=True)`` fires the registered cancel hooks
+    BEFORE awaiting ``drain()`` — the ordering that lets the poll-cancel hook
+    short-circuit a poll counted in the in-flight counter.
+
+    This pins the ordering directly (independent of the operation_scope
+    integration test) so a future refactor that moves the hook fire back
+    after the drain wait fails here.
+    """
+    client = NotebookLMClient(_auth())
+    order: list[str] = []
+
+    async def fake_run_drain_hooks() -> None:
+        order.append("hooks")
+
+    async def fake_drain(timeout: float | None = None) -> None:
+        order.append("drain")
+
+    async def fake_close(**_kwargs: object) -> None:
+        order.append("close")
+
+    client._collaborators.drain_tracker.run_drain_hooks = fake_run_drain_hooks  # type: ignore[method-assign]
+    client._collaborators.drain_tracker.drain = fake_drain  # type: ignore[method-assign]
+    client._collaborators.lifecycle.close = fake_close  # type: ignore[method-assign]
+
+    await client.close()
+
+    assert order == ["hooks", "drain", "close"], (
+        "cancel hooks must fire before the drain wait (issue #1161)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # NotebookLMClient default drain=True (BREAKING)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -201,8 +201,7 @@ async def test_close_drain_cancels_inflight_poll_in_operation_scope() -> None:
                 cancellation_seen.set()
                 raise
 
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[Any] = loop.create_future()
+    future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
     task = asyncio.create_task(parked_poll())
     # Let the task enter ``operation_scope`` so ``_in_flight_posts`` is bumped
     # before close() drains; otherwise the drain wait would trivially pass.
@@ -211,9 +210,13 @@ async def test_close_drain_cancels_inflight_poll_in_operation_scope() -> None:
     registry.register(("nb_1", "task_1"), future, task)
 
     async def cancel_polls() -> None:
-        for poll_task in registry.active_tasks():
+        # Snapshot once before cancelling, matching the production
+        # ``ArtifactPollingService.drain`` pattern (``_artifact_polling.py``).
+        poll_tasks = registry.active_tasks()
+        for poll_task in poll_tasks:
             poll_task.cancel()
-        await asyncio.gather(*registry.active_tasks(), return_exceptions=True)
+        if poll_tasks:
+            await asyncio.gather(*poll_tasks, return_exceptions=True)
 
     tracker.register_drain_hook("artifacts.polls", cancel_polls)
 
@@ -225,6 +228,10 @@ async def test_close_drain_cancels_inflight_poll_in_operation_scope() -> None:
     assert cancellation_seen.is_set()
     assert tracker._in_flight_posts == 0
     assert core._collaborators.kernel.http_client is None
+    # Resolve the registered future so it isn't GC'd un-awaited (the poll task
+    # was cancelled, so mirror that on the shared future).
+    if not future.done():
+        future.cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -165,6 +165,68 @@ async def test_session_close_with_no_polls_is_noop_on_drain_step() -> None:
     assert core._collaborators.kernel.http_client is None
 
 
+@pytest.mark.asyncio
+async def test_close_drain_cancels_inflight_poll_in_operation_scope() -> None:
+    """Issue #1161: ``close(drain=True)`` cancels an in-flight poll counted in
+    ``operation_scope`` instead of blocking on its in-flight counter.
+
+    Reproduces the production wiring: the artifact poll loop runs inside
+    ``TransportDrainTracker.operation_scope`` (incrementing ``_in_flight_posts``)
+    and registers a drain hook that cancels the leader task. Before the fix,
+    ``close()`` awaited ``drain()`` BEFORE the lifecycle ran the cancel hook,
+    so ``drain()`` parked on the in-flight counter until the poll's own timeout
+    (the cancel hook ran too late). The fix fires the cancel hooks before the
+    drain wait so ``drain()`` observes a cancelled-then-settled count.
+
+    A real-time deadline turns a regression into a fast failure rather than a
+    suite hang.
+    """
+    core = build_client_shell_for_tests(_auth())
+    await core.__aenter__()
+
+    tracker = core._collaborators.drain_tracker
+    registry = PollRegistry()
+    cancellation_seen = asyncio.Event()
+    scope_entered = asyncio.Event()
+
+    async def parked_poll() -> None:
+        # Mirror the poll loop: hold an ``operation_scope`` open (bumping the
+        # in-flight counter ``drain()`` waits on) while parked, and unwind via
+        # CancelledError when the drain hook cancels us.
+        async with tracker.operation_scope("artifact wait task_1"):
+            scope_entered.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancellation_seen.set()
+                raise
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[Any] = loop.create_future()
+    task = asyncio.create_task(parked_poll())
+    # Let the task enter ``operation_scope`` so ``_in_flight_posts`` is bumped
+    # before close() drains; otherwise the drain wait would trivially pass.
+    await asyncio.wait_for(scope_entered.wait(), timeout=1.0)
+    assert tracker._in_flight_posts == 1
+    registry.register(("nb_1", "task_1"), future, task)
+
+    async def cancel_polls() -> None:
+        for poll_task in registry.active_tasks():
+            poll_task.cancel()
+        await asyncio.gather(*registry.active_tasks(), return_exceptions=True)
+
+    tracker.register_drain_hook("artifacts.polls", cancel_polls)
+
+    # Default drain=True. Real-time deadline so the pre-fix block (which would
+    # only end at the poll's own timeout) surfaces as a 1s failure.
+    await asyncio.wait_for(core.close(), timeout=1.0)
+
+    assert task.done()
+    assert cancellation_seen.is_set()
+    assert tracker._in_flight_posts == 0
+    assert core._collaborators.kernel.http_client is None
+
+
 # ---------------------------------------------------------------------------
 # NotebookLMClient default drain=True (BREAKING)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`NotebookLMClient.close(drain=True)` awaited `self.drain(timeout=drain_timeout)` **before** the shielded `lifecycle.close()` ran the registered drain hooks (`run_drain_hooks()`).

In-flight artifact polls run their poll loop inside `TransportDrainTracker.operation_scope` (see `_artifact_polling.ArtifactPollingService._run_poll_loop_in_scope`), which increments the same `_in_flight_posts` counter that `drain()` parks on. The cancel hook that is supposed to short-circuit those polls (`artifacts.polls` → `ArtifactPollingService.drain`) was only fired later, inside `lifecycle.close()`.

Result: with the default `drain_timeout=None`, `async with client:` exit (and any `close()`) parked on the in-flight poll until it finished naturally or hit its own 300s timeout — a lifecycle hang. Precondition: a poll in-flight at close time (fire-and-forget / separate-task patterns).

## Fix

Fire the registered drain hooks **before** the drain wait in the `drain=True` branch of `close()`, so `drain()` observes a cancelled-then-settled in-flight count instead of blocking on it.

- The hook fire is awaited inside the existing `try` block, so a `CancelledError` arriving during the hook fire still routes through the I12 shielded-close path (no leaked transport).
- `run_drain_hooks()` swallows + logs per-hook exceptions, so it cannot raise on its own.
- The shielded `lifecycle.close()` still re-runs the hooks; that re-run is a cheap no-op because already-settled poll tasks are filtered out of `PollRegistry.active_tasks`.

## Tests

Adds `test_close_drain_cancels_inflight_poll_in_operation_scope` in `tests/unit/test_session_close.py`. It mirrors the production wiring: a poll task parked inside `operation_scope` (bumping `_in_flight_posts` to 1) with a registered cancel hook, and asserts `close()` completes within a 1s real-time deadline plus the transport is torn down. The test **times out** against the pre-fix code and passes with the fix.

## Verification

- `uv run pytest` — 6995 passed (one pre-existing, unrelated CLI login-output-wrapping failure also present on clean `main`).
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run ruff format` / `ruff check --fix` — clean.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session close with drain now runs feature cleanup hooks before awaiting drain completion, ensuring hooked cancellations are handled and preventing transport leaks during shutdown.

* **Tests**
  * Added unit tests validating that in-flight operations are cancelled promptly during close with drain and that drain hooks run before the drain wait.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->