### PR TITLE
fix(idempotency): remove unused client token dedupe policy

### DIFF
--- a/docs/adr/0005-idempotency-taxonomy.md
+++ b/docs/adr/0005-idempotency-taxonomy.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-Accepted (retroactive). Documents the six-policy classification shipped in tier-9 (B1 foundation + Wave-2 classifications across `b-research-notes`, `b-generation`, `b-sources`, and `b-side-effects`). This ADR is the canonical home for the rationale that previously lived in the now-gitignored tier-9 plan; the registry code in `src/notebooklm/_idempotency.py` references this ADR as ADR-005.
+Accepted (retroactive). Originally documented the six-policy
+classification shipped in tier-9 (B1 foundation + Wave-2 classifications
+across `b-research-notes`, `b-generation`, `b-sources`, and
+`b-side-effects`). This ADR is the canonical home for the rationale that
+previously lived in the now-gitignored tier-9 plan; the registry code in
+`src/notebooklm/_idempotency.py` references this ADR as ADR-005.
+
+Amended on 2026-05-29 to remove the unregistered `CLIENT_TOKEN_DEDUPE`
+policy and executor token-injection hook. No current `RPCMethod` has a
+verified client-token slot, so keeping the policy made the registry
+advertise a dead retry-safety mechanism.
 
 ## Context
 
@@ -10,37 +20,35 @@ The NotebookLM RPC surface is `batchexecute` over HTTPS, and any mutating call (
 
 The transport retry layer runs an inner retry loop for transient 5xx / 429 / network-error failures. That loop is *correct* for read-only RPCs and dangerous for mutating ones. Before the taxonomy existed, the only mitigation was a per-call-site decision (`disable_internal_retries=True`) that did not document *why* an RPC was retry-unsafe, so the decision was easy to lose during refactors.
 
-Six retry-safety profiles cover every realistic NotebookLM RPC shape:
+Five retry-safety profiles cover every verified NotebookLM RPC shape:
 
 | Policy | Meaning | Effect on the inner retry loop |
 |---|---|---|
 | `UNCLASSIFIED` | Placeholder; never classified | Silent, retries enabled (preserves pre-taxonomy behavior) |
 | `PROBE_THEN_CREATE` | Caller owns a probe loop; transport must not blind-retry | Force-disable inner retries |
 | `IDEMPOTENT_SET_OP` | Server applies set semantics (delete / rename) | Retries are safe; left enabled |
-| `CLIENT_TOKEN_DEDUPE` | Server dedupes on an injected token | Retries are safe; client-token injected before encoding |
 | `AT_LEAST_ONCE_ACCEPTED` | Caller has accepted duplicate-side-effect cost | Retries enabled; rate-limited WARN emitted |
 | `NON_IDEMPOTENT_NO_RETRY` | No dedupe key, no probe; first failure must surface | Force-disable inner retries |
 
-The taxonomy and the production registry (`IDEMPOTENCY_REGISTRY` in `_idempotency.py`) are consulted by `RpcExecutor` to compute the effective `disable_internal_retries` value and to inject a client-token for `CLIENT_TOKEN_DEDUPE` entries. Variants (e.g. `ADD_SOURCE` `"url"` vs `"text"` vs `"drive"`) carry their own classifications when the wire-shape differs by call-site.
+The taxonomy and the production registry (`IDEMPOTENCY_REGISTRY` in `_idempotency.py`) are consulted by `RpcExecutor` to compute the effective `disable_internal_retries` value. Variants (e.g. `ADD_SOURCE` `"url"` vs `"text"` vs `"drive"`) carry their own classifications when the wire-shape differs by call-site.
 
 The audit (`.sisyphus/plans/arch-biggest-problem-audit.md`, disease D3) flagged ten references to "Wave 2" in `_idempotency.py` whose design rationale lived only in the gitignored `.sisyphus/plans/tier-9-p0-p1.md`. This ADR is the public home for that rationale; the in-code references now point here.
 
 ## Decision
 
-Every `RPCMethod` is registered in `IDEMPOTENCY_REGISTRY` (in `_idempotency.py`) with one of six `IdempotencyPolicy` values, optionally per *operation variant* when the call-site shape differs. The registry is the single source of truth consumed by `RpcExecutor`.
+Every `RPCMethod` is registered in `IDEMPOTENCY_REGISTRY` (in `_idempotency.py`) with one of five `IdempotencyPolicy` values, optionally per *operation variant* when the call-site shape differs. The registry is the single source of truth consumed by `RpcExecutor`.
 
 The classification rules are:
 
 - **Read-only RPCs** are not classified (the taxonomy applies to mutating RPCs only); the executor's existing retry behavior is correct for them.
 - **Mutating RPCs with a stable server-side dedupe key** classify as `IDEMPOTENT_SET_OP` (delete / rename / set-state) — retries are explicitly safe.
-- **Mutating RPCs with a client-injectable token slot** classify as `CLIENT_TOKEN_DEDUPE`; the registry records the param-slot index (or dict key) and the executor injects a fresh `uuid4().hex` before encoding when the slot is empty.
 - **Mutating RPCs without a dedupe key but with a probe RPC** classify as `PROBE_THEN_CREATE`; the inner retry loop is force-disabled, and the per-API call site owns a probe-then-create wrapper (see `idempotent_create()` in `_idempotency.py` and the per-API uses in `_notebooks.py`, `_sources.py`).
 - **Mutating RPCs that produce visible side effects (emails, billing, notifications) and that the caller has explicitly opted into** classify as `AT_LEAST_ONCE_ACCEPTED`; retries are enabled but a rate-limited WARN is emitted so operators can observe the trade-off.
 - **Mutating RPCs with no dedupe key and no reliable probe** classify as `NON_IDEMPOTENT_NO_RETRY`; the inner retry loop is force-disabled and the first failure surfaces to the caller for manual disambiguation.
 
 The Wave-2 classifications shipped to date are recorded inline in `_idempotency.py` (with the per-RPC rationale captured at the registration site). Future Wave-2 classifications continue to land in the same module without changes to the executor; the registry is intentionally extensible.
 
-The six-policy axis is *closed*. Adding a seventh policy requires updating this ADR and the executor in lock-step.
+The five-policy axis is *closed*. Adding a sixth policy requires updating this ADR and the executor in lock-step.
 
 ## Consequences
 
@@ -48,8 +56,7 @@ The six-policy axis is *closed*. Adding a seventh policy requires updating this 
 
 - Retry safety is now a *property of the RPC*, not a property of the call site. New call sites inherit the safe behavior without re-deriving it.
 - The executor's retry logic is small and local; the policy decisions live in the registry where they can be reviewed in isolation.
-- The taxonomy is small enough (six policies) that a reviewer can hold it in mind during a code review. A seventh policy would push past that threshold and is rejected by design.
-- The `CLIENT_TOKEN_DEDUPE` injection is automatic and behavior-neutral when callers do not provide a token, which matters for the test path: tests that construct params manually don't have to special-case the token slot.
+- The taxonomy is small enough (five policies) that a reviewer can hold it in mind during a code review. A sixth policy would push past that threshold and is rejected by design.
 
 **Unwanted:**
 
@@ -63,6 +70,6 @@ The six-policy axis is *closed*. Adding a seventh policy requires updating this 
 - **Per-call-site `disable_internal_retries=True` flags, no registry.** Rejected. That is the pre-taxonomy state and the audit measured the cost: every refactor risks dropping a flag, and the rationale for "why is this RPC retry-unsafe" lives nowhere. The registry centralises both the decision and the justification (`notes=...` per entry).
 - **Per-call annotation on the RPC method ID enum (e.g. `RPCMethod.CREATE_NOTEBOOK.policy`).** Rejected. The RPC enum is the source of truth for *method IDs* and is structured to track Google's wire surface. Coupling it to retry semantics would mix transport policy with protocol identity, and the RPC enum is the kind of file that needs to remain mechanically updatable when Google changes a method ID.
 - **No taxonomy; rely on `httpx`'s built-in retry policy.** Rejected. `httpx` retries are not aware of *which* RPCs are commit-safe to retry. A blind transport-level retry of `CREATE_NOTE` produces a duplicate note; a blind retry of `DELETE_NOTEBOOK` is safe. The transport cannot know which is which; the taxonomy is necessarily a layer above the transport.
-- **More than six policies.** Rejected. The audit derived the six-policy axis by enumerating realistic NotebookLM call-site shapes; every shape the codebase has met to date fits one of the six. Adding a policy without a real call-site need would balloon the cognitive surface for reviewers without a corresponding gain.
-- **Fewer than six policies (collapse `IDEMPOTENT_SET_OP` + `CLIENT_TOKEN_DEDUPE`).** Rejected. The two are wire-different: `IDEMPOTENT_SET_OP` requires nothing from the caller; `CLIENT_TOKEN_DEDUPE` requires the executor to inject a token before encoding. Collapsing them would force every caller of a token-dedupe RPC to inject manually, which is exactly the failure mode the registry is designed to prevent.
+- **More than five policies.** Rejected. The audit derived the active policy axis by enumerating verified NotebookLM call-site shapes; every shape the codebase has met to date fits one of the five. Adding a policy without a real call-site need would balloon the cognitive surface for reviewers without a corresponding gain.
+- **Keep a speculative `CLIENT_TOKEN_DEDUPE` policy.** Rejected. The executor previously had token-injection machinery, but no production registry entry used it and no current RPC has a verified client-token slot. A future verified token-dedupe RPC can reintroduce the policy together with the method registration and focused tests.
 - **Per-call idempotency annotation as a decorator on the API method.** Rejected. The registry-based approach lets `RpcExecutor` consult the policy without per-call-site bookkeeping, and it survives refactors that move call sites between modules. A decorator approach would have to be re-applied on every move.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Most public methods (`client.notebooks.list()`, `client.sources.rename()`,
                                  v
 +----------------------------------------------------------------+
 | RpcExecutor._execute_once(...)                                 |
-|   - idempotency policy / client-token injection                |
+|   - idempotency policy resolution                              |
 |   - method-id resolution, request encoding, URL/body builder   |
 +----------------------------------------------------------------+
                                  |
@@ -247,7 +247,7 @@ easy to lose during refactors. The taxonomy makes retry safety a
 **property of the call site** (re-derived every time someone touches
 the code).
 
-**The classification.** Mutating RPCs are classified into six
+**The classification.** Mutating RPCs are classified into five
 retry-safety profiles by the `IdempotencyRegistry` in
 [`_idempotency.py`](../src/notebooklm/_idempotency.py):
 
@@ -256,18 +256,16 @@ retry-safety profiles by the `IdempotencyRegistry` in
 | `UNCLASSIFIED` | Placeholder; never classified | Silent, retries enabled (preserves pre-taxonomy behavior) |
 | `PROBE_THEN_CREATE` | Caller owns a probe loop; transport must not blind-retry | Force-disable inner retries |
 | `IDEMPOTENT_SET_OP` | Server applies set semantics (delete / rename) | Retries are safe; left enabled |
-| `CLIENT_TOKEN_DEDUPE` | Server dedupes on an injected token slot | Retries are safe; client-token injected before encoding |
 | `AT_LEAST_ONCE_ACCEPTED` | Caller has explicitly accepted duplicate side-effect cost (emails / billing / notifications) | Retries enabled; rate-limited WARN emitted so operators can see the trade-off |
 | `NON_IDEMPOTENT_NO_RETRY` | No dedupe key and no probe; first failure must surface | Force-disable inner retries |
 
-The axis is *closed*. A seventh policy would need an ADR update and an
-executor change in lockstep — the six-policy cap is intentional so a
+The axis is *closed*. A sixth policy would need an ADR update and an
+executor change in lockstep — the five-policy cap is intentional so a
 reviewer can hold the whole taxonomy in mind during a code review.
 
 `RpcExecutor._execute_once` consults the registry once per call to
-resolve the effective `disable_internal_retries` and to inject client
-tokens. The caller's explicit `disable_internal_retries=True` always
-wins over the registry default.
+resolve the effective `disable_internal_retries`. The caller's explicit
+`disable_internal_retries=True` always wins over the registry default.
 
 The audit inventory in
 [`_mutating_operations.py`](../src/notebooklm/_mutating_operations.py)
@@ -427,7 +425,7 @@ the executor on direct collaborator dependencies.
 | `ClientMetrics` | [`_client_metrics.py`](../src/notebooklm/_client_metrics.py) | Per-instance counters (`ClientMetricsSnapshot`) + the `on_rpc_event` user callback. |
 | `ReqidCounter` | [`_reqid_counter.py`](../src/notebooklm/_reqid_counter.py) | Monotonic `_reqid` for the chat backend; lock-protected `next_reqid(...)`. |
 | `CookiePersistence` | [`_cookie_persistence.py`](../src/notebooklm/_cookie_persistence.py) | Cookie-jar persistence + `__Secure-1PSIDTS` rotation. |
-| `IdempotencyRegistry` | [`_idempotency.py`](../src/notebooklm/_idempotency.py) | Policy/classification registry keyed by `(RPCMethod, operation_variant)`. `RpcExecutor._execute_once()` consults it to resolve `effective_disable_internal_retries` and to inject client tokens for `CLIENT_TOKEN_DEDUPE` methods (most entries are currently `UNCLASSIFIED`, a behaviour-neutral default). It is part of the RPC dispatch path, not lifecycle state. Side-effect probing (`idempotent_create(...)`) is a separate mechanism not owned by this registry. |
+| `IdempotencyRegistry` | [`_idempotency.py`](../src/notebooklm/_idempotency.py) | Policy/classification registry keyed by `(RPCMethod, operation_variant)`. `RpcExecutor._execute_once()` consults it to resolve `effective_disable_internal_retries`. It is part of the RPC dispatch path, not lifecycle state. Side-effect probing (`idempotent_create(...)`) is a separate mechanism not owned by this registry. |
 | `_request_types` | [`_request_types.py`](../src/notebooklm/_request_types.py) | Owns `AuthSnapshot`, `BuildRequest`, and request materialization shapes shared by RPC, chat, auth refresh, and the chain terminal. |
 | `_transport_errors` | [`_transport_errors.py`](../src/notebooklm/_transport_errors.py) | Owns transport-level exceptions, `Retry-After` parsing, and raw `Kernel.post` error mapping consumed by `RetryMiddleware` and `AuthRefreshMiddleware`. |
 | `_streaming_post` | [`_streaming_post.py`](../src/notebooklm/_streaming_post.py) | Low-level streaming POST helper with the response-size cap used by `Kernel.post`. |

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -10,12 +10,11 @@ This module hosts two cooperating pieces:
    wrapper inverts the direction: run with internal-retries disabled,
    then probe for a server-side commit before re-issuing.
 
-2. :class:`IdempotencyRegistry` — the 6-policy classification layer that
+2. :class:`IdempotencyRegistry` — the 5-policy classification layer that
    :class:`~notebooklm._rpc_executor.RpcExecutor` consults to compute the
-   *effective* ``disable_internal_retries`` value (and, for
-   ``CLIENT_TOKEN_DEDUPE`` policies, inject a fresh client-token into
-   request params before encoding). The registry is a single source of
-   truth for every ``RPCMethod`` without touching the executor.
+   *effective* ``disable_internal_retries`` value. The registry is a
+   single source of truth for every ``RPCMethod`` without touching the
+   executor.
 
    The production registry is complete: every active ``RPCMethod`` has
    an explicit default classification, with variant rows for wire shapes
@@ -30,16 +29,15 @@ baseline-diff; sources: url-match; ``add_text``: no probe possible — see
 
 This module is private (``_idempotency.py``); call sites live in the
 domain APIs (``_notebooks.py``, ``_sources.py``) and the RPC executor
-(``_rpc_executor.py``). The canonical home for the taxonomy itself, the
-six-policy axis, and the per-RPC classification rationale is
-ADR-005 (``docs/adr/0005-idempotency-taxonomy.md``).
+(``_rpc_executor.py``). The canonical home for the taxonomy itself and
+the per-RPC classification rationale is ADR-005
+(``docs/adr/0005-idempotency-taxonomy.md``).
 """
 
 from __future__ import annotations
 
 import logging
 import time
-import uuid
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
@@ -167,8 +165,7 @@ async def idempotent_create(
 #
 # The registry is the single source of truth for "how should this RPC behave
 # under retry?" It is consulted by ``RpcExecutor`` to compute the *effective*
-# ``disable_internal_retries`` value, and (for ``CLIENT_TOKEN_DEDUPE`` policies)
-# to inject a fresh client-token into request params before encoding.
+# ``disable_internal_retries`` value before request encoding.
 #
 # IMPORTANT — complete production registry:
 #   The module-level registry seeds missing methods with UNCLASSIFIED only as a
@@ -180,7 +177,7 @@ async def idempotent_create(
 class IdempotencyPolicy(str, Enum):
     """Classification axis for mutating-RPC retry safety.
 
-    Six policies — no more, no fewer. The axis was sized to cover all
+    Five policies — no more, no fewer. The axis was sized to cover all
     realistic NotebookLM RPC shapes without inventing per-method special
     cases. See ADR-005 (``docs/adr/0005-idempotency-taxonomy.md``) for
     the derivation and the per-policy rationale.
@@ -191,9 +188,8 @@ class IdempotencyPolicy(str, Enum):
       :attr:`UNCLASSIFIED` (placeholder — preserves today's retries),
       :attr:`IDEMPOTENT_SET_OP` (read-only, rename / delete / set-state
       operations where replay leaves the same server state),
-      :attr:`CLIENT_TOKEN_DEDUPE` (server deduplicates by injected
-      token), :attr:`AT_LEAST_ONCE_ACCEPTED` (caller has accepted
-      at-least-once semantics; WARN logged).
+      :attr:`AT_LEAST_ONCE_ACCEPTED` (caller has accepted at-least-once
+      semantics; WARN logged).
 
     * **NOT safe to retry inside the transport**:
       :attr:`PROBE_THEN_CREATE` (callers own the probe loop; transport
@@ -209,7 +205,6 @@ class IdempotencyPolicy(str, Enum):
     UNCLASSIFIED = "unclassified"
     PROBE_THEN_CREATE = "probe_then_create"
     IDEMPOTENT_SET_OP = "idempotent_set_op"
-    CLIENT_TOKEN_DEDUPE = "client_token_dedupe"
     AT_LEAST_ONCE_ACCEPTED = "at_least_once_accepted"
     NON_IDEMPOTENT_NO_RETRY = "non_idempotent_no_retry"
 
@@ -245,12 +240,6 @@ class IdempotencyEntry:
         probe_key_fn: Optional probe-key extractor for PROBE_THEN_CREATE
             entries. ``None`` for policies that don't probe. Future work may
             wire this into the per-API probe loops.
-        client_token_field: For CLIENT_TOKEN_DEDUPE entries, the slot
-            in the params payload that receives the auto-injected
-            ``uuid4().hex`` token. ``str`` keys are used when the RPC
-            params are a dict; ``int`` keys are used to inject into a
-            positional slot inside the list-shaped params that the
-            batchexecute encoder consumes. ``None`` for other policies.
         notes: Free-form human-readable note. UNCLASSIFIED entries
             registered without an explicit ``notes`` value receive the
             placeholder marker that flags them for explicit classification;
@@ -259,7 +248,6 @@ class IdempotencyEntry:
 
     policy: IdempotencyPolicy
     probe_key_fn: ProbeKeyFn | None = None
-    client_token_field: str | int | None = None
     notes: str = ""
 
 
@@ -305,7 +293,6 @@ class IdempotencyRegistry:
         *,
         variant: str | None = None,
         probe_key_fn: ProbeKeyFn | None = None,
-        client_token_field: str | int | None = None,
         notes: str | None = None,
     ) -> None:
         """Register (or overwrite) the entry for ``(method, variant)``.
@@ -326,7 +313,6 @@ class IdempotencyRegistry:
         entry = IdempotencyEntry(
             policy=policy,
             probe_key_fn=probe_key_fn,
-            client_token_field=client_token_field,
             notes=notes,
         )
         self._entries.setdefault(method, {})[variant] = entry
@@ -530,7 +516,7 @@ IDEMPOTENCY_REGISTRY._seed_defaults()
 # caller-supplied client-token slot. The server allocates the artifact_id
 # in the response (``ArtifactGenerationService.parse_generation_result``
 # reads ``result[0][0]`` — see ``_artifact_generation.py``), so a
-# CLIENT_TOKEN_DEDUPE classification is impossible.
+# token-dedupe strategy is impossible.
 #
 # PROBE_THEN_CREATE forces ``effective_disable_internal_retries=True``,
 # which suppresses ``_perform_authed_post``'s inner retry loop. Without
@@ -558,7 +544,7 @@ IDEMPOTENCY_REGISTRY.register(
 # slot is structural (sources, content config, language, mode triple). The
 # response carries the mind-map JSON directly (line 614-622 reads
 # ``result[0][0]``) — there is no task_id to probe with after the fact, so
-# CLIENT_TOKEN_DEDUPE is impossible here too.
+# token-dedupe is impossible here too.
 #
 # Note: ``GENERATE_MIND_MAP`` itself does NOT persist the note server-side
 # (see ``tests/integration/test_mind_map_chain_vcr.py`` header). The actual
@@ -902,10 +888,10 @@ def resolve_effective_disable_internal_retries(
        emits a rate-limited WARN and returns ``caller_disable_internal_retries``
        unchanged. Caller has accepted at-least-once semantics; retries
        remain enabled.
-    4. All other policies (UNCLASSIFIED, IDEMPOTENT_SET_OP,
-       CLIENT_TOKEN_DEDUPE) → returns ``caller_disable_internal_retries``
-       unchanged. UNCLASSIFIED is silent (no log emission) and should appear
-       only in hand-built test registries, not in the production registry.
+    4. All other policies (UNCLASSIFIED, IDEMPOTENT_SET_OP) → returns
+       ``caller_disable_internal_retries`` unchanged. UNCLASSIFIED is
+       silent (no log emission) and should appear only in hand-built
+       test registries, not in the production registry.
 
     Raises :class:`~notebooklm.exceptions.IdempotencyVariantError` for
     unknown variants on methods with explicit variant tables.
@@ -923,83 +909,9 @@ def resolve_effective_disable_internal_retries(
         _maybe_log_at_least_once(method, operation_variant)
         return caller_disable_internal_retries
 
-    # UNCLASSIFIED / IDEMPOTENT_SET_OP / CLIENT_TOKEN_DEDUPE: silent,
-    # caller value passes through unchanged.
+    # UNCLASSIFIED / IDEMPOTENT_SET_OP: silent, caller value passes
+    # through unchanged.
     return caller_disable_internal_retries
-
-
-def maybe_inject_client_token(
-    registry: IdempotencyRegistry,
-    method: RPCMethod,
-    params: Any,
-    *,
-    operation_variant: str | None,
-) -> None:
-    """Inject a fresh ``uuid4().hex`` client-token for CLIENT_TOKEN_DEDUPE
-    methods, when (and only when) the caller did not already populate the
-    token slot.
-
-    ``params`` is mutated in place. Two shapes are supported, matching
-    the two shapes that ``RpcExecutor._execute_once`` is asked to encode:
-
-    * ``dict``-shaped params with a ``str`` ``client_token_field`` key:
-      ``params[field_name] = uuid4().hex`` if the key is absent or maps
-      to a falsy value.
-    * ``list``-shaped params (the batchexecute-typical shape) with an
-      ``int`` ``client_token_field`` index: ``params[index] = uuid4().hex``
-      when ``0 <= index < len(params)`` and the existing slot is falsy
-      (``None``, empty string). If the index is out of range the
-      function logs a warning and returns without raising — this is a
-      safety guard so a mis-registered entry doesn't crash a live RPC;
-      registry guard tests own the per-method registration audit.
-
-    No-op for policies other than ``CLIENT_TOKEN_DEDUPE``, for entries
-    without a ``client_token_field``, for entries where the slot already
-    holds a non-falsy value (caller-provided token wins), and for params
-    whose shape doesn't match the field type (``int`` field on a non-list
-    or ``str`` field on a non-dict). Raises
-    :class:`~notebooklm.exceptions.IdempotencyVariantError` for unknown
-    variants on methods with explicit variant tables.
-    """
-    entry = registry.get_entry(method, operation_variant=operation_variant)
-    if entry.policy is not IdempotencyPolicy.CLIENT_TOKEN_DEDUPE:
-        return
-    field_key = entry.client_token_field
-    if field_key is None:
-        return
-
-    if isinstance(field_key, str):
-        if not isinstance(params, dict):
-            # Shape mismatch — registry registered a dict-style field
-            # but caller passed a list. No-op rather than crash.
-            return
-        if params.get(field_key):
-            # Caller-provided token wins.
-            return
-        params[field_key] = uuid.uuid4().hex
-        return
-
-    # Positional injection into list params (batchexecute typical shape).
-    if not isinstance(params, list):
-        # Shape mismatch — registry registered a positional slot but
-        # caller passed a dict / scalar. No-op.
-        return
-    if not (0 <= field_key < len(params)):
-        # Out-of-range index — likely a registry mis-registration. Don't crash
-        # a live RPC; log once and let the caller surface it via logs rather
-        # than via exception.
-        logger.warning(
-            "CLIENT_TOKEN_DEDUPE for RPC %s has out-of-range "
-            "client_token_field=%d for params of length %d; skipping injection",
-            method.name,
-            field_key,
-            len(params),
-        )
-        return
-    if params[field_key]:
-        # Caller-provided token (or other truthy value) wins.
-        return
-    params[field_key] = uuid.uuid4().hex
 
 
 __all__ = [
@@ -1010,5 +922,4 @@ __all__ = [
     "IDEMPOTENCY_REGISTRY",
     "ProbeKeyFn",
     "resolve_effective_disable_internal_retries",
-    "maybe_inject_client_token",
 ]

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -16,7 +16,6 @@ import httpx
 from ._env import get_default_language
 from ._idempotency import (
     IDEMPOTENCY_REGISTRY,
-    maybe_inject_client_token,
     resolve_effective_disable_internal_retries,
 )
 from ._logging import get_request_id, reset_request_id, set_request_id
@@ -192,17 +191,6 @@ class RpcExecutor:
             IDEMPOTENCY_REGISTRY,
             method,
             caller_disable_internal_retries=disable_internal_retries,
-            operation_variant=operation_variant,
-        )
-
-        # For CLIENT_TOKEN_DEDUPE policies, inject a fresh ``uuid4().hex``
-        # into the registry-named param field UNLESS the caller already
-        # populated it. No-op for every other policy, so this is a
-        # zero-cost call for every non-token policy.
-        maybe_inject_client_token(
-            IDEMPOTENCY_REGISTRY,
-            method,
-            params,
             operation_variant=operation_variant,
         )
 

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -162,14 +162,10 @@ class TestRegistryClassification:
     def test_create_artifact_classified_as_probe_then_create(self) -> None:
         entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.CREATE_ARTIFACT)
         assert entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
-        # CREATE_ARTIFACT params carry no caller-supplied token slot, so
-        # client_token_field MUST remain unset.
-        assert entry.client_token_field is None
 
     def test_generate_mind_map_classified_as_probe_then_create(self) -> None:
         entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.GENERATE_MIND_MAP)
         assert entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
-        assert entry.client_token_field is None
 
     def test_create_artifact_variant_none_explicit(self) -> None:
         """Passing ``operation_variant=None`` (the b1 plumbed call-site

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -1,11 +1,11 @@
 """Tests for the RPC idempotency registry.
 
-The registry is a 6-policy classification layer with operation variants
+The registry is a 5-policy classification layer with operation variants
 that the ``RpcExecutor`` consults to compute
-``effective_disable_internal_retries`` and optional client-token injection.
-The production registry must explicitly classify every ``RPCMethod``; the
-``UNCLASSIFIED`` policy is retained only as a placeholder for hand-built
-test registries and future-drift detection.
+``effective_disable_internal_retries``. The production registry must
+explicitly classify every ``RPCMethod``; the ``UNCLASSIFIED`` policy is
+retained only as a placeholder for hand-built test registries and
+future-drift detection.
 """
 
 from __future__ import annotations
@@ -131,17 +131,16 @@ def test_non_idempotent_no_retry_entries_document_dedupe_gap() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 6-policy enum
+# 5-policy enum
 # ---------------------------------------------------------------------------
 
 
-def test_idempotency_policy_has_all_six_values() -> None:
-    """The classification axis is 6-way; nothing else."""
+def test_idempotency_policy_has_all_five_values() -> None:
+    """The classification axis is 5-way; nothing else."""
     expected = {
         "UNCLASSIFIED",
         "PROBE_THEN_CREATE",
         "IDEMPOTENT_SET_OP",
-        "CLIENT_TOKEN_DEDUPE",
         "AT_LEAST_ONCE_ACCEPTED",
         "NON_IDEMPOTENT_NO_RETRY",
     }
@@ -281,7 +280,6 @@ def test_non_idempotent_no_retry_disables_internal_retries() -> None:
     [
         IdempotencyPolicy.UNCLASSIFIED,
         IdempotencyPolicy.IDEMPOTENT_SET_OP,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
         IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED,
     ],
 )
@@ -372,198 +370,6 @@ def test_at_least_once_accepted_rate_limits_warn_log(
         "calls; expected ≤2 (rate-limited)"
     )
     assert len(warn_records) >= 1, "AT_LEAST_ONCE_ACCEPTED emitted 0 WARN lines; expected ≥1"
-
-
-# ---------------------------------------------------------------------------
-# CLIENT_TOKEN_DEDUPE: token injection
-# ---------------------------------------------------------------------------
-
-
-def test_client_token_dedupe_injects_uuid_when_field_missing() -> None:
-    """CLIENT_TOKEN_DEDUPE policy MUST inject a fresh ``uuid4().hex`` token
-    into the field named by ``IdempotencyEntry.client_token_field`` when the
-    caller did NOT pre-populate it."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field="client_token",
-    )
-
-    params: dict[str, Any] = {"foo": "bar"}
-    maybe_inject_client_token(
-        registry,
-        RPCMethod.LIST_NOTEBOOKS,
-        params,
-        operation_variant=None,
-    )
-
-    assert "client_token" in params
-    token = params["client_token"]
-    assert isinstance(token, str)
-    assert len(token) == 32  # uuid4().hex is 32 hex chars
-    assert int(token, 16) >= 0  # parseable as hex
-
-
-def test_client_token_dedupe_respects_caller_provided_token() -> None:
-    """If the caller already pre-populated the client-token field, the
-    registry MUST NOT overwrite it. Caller intent wins."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field="client_token",
-    )
-
-    params: dict[str, Any] = {"client_token": "caller-provided-token"}
-    maybe_inject_client_token(
-        registry,
-        RPCMethod.LIST_NOTEBOOKS,
-        params,
-        operation_variant=None,
-    )
-
-    assert params["client_token"] == "caller-provided-token"
-
-
-def test_client_token_dedupe_positional_injection_into_list_params() -> None:
-    """When ``client_token_field`` is an int, the registry MUST inject into
-    the list-shaped params at that index (batchexecute typical shape)."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field=2,  # positional slot
-    )
-
-    params: list[Any] = ["notebook_id", "title", None, "extra"]
-    maybe_inject_client_token(
-        registry,
-        RPCMethod.LIST_NOTEBOOKS,
-        params,
-        operation_variant=None,
-    )
-
-    token = params[2]
-    assert isinstance(token, str)
-    assert len(token) == 32
-    # Surrounding slots untouched
-    assert params[0] == "notebook_id"
-    assert params[1] == "title"
-    assert params[3] == "extra"
-
-
-def test_client_token_dedupe_positional_respects_caller_value() -> None:
-    """Caller-populated positional client-token MUST NOT be overwritten."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field=2,
-    )
-
-    params: list[Any] = ["nb", "t", "caller-token", "extra"]
-    maybe_inject_client_token(
-        registry,
-        RPCMethod.LIST_NOTEBOOKS,
-        params,
-        operation_variant=None,
-    )
-
-    assert params[2] == "caller-token"
-
-
-def test_client_token_dedupe_positional_out_of_range_warns_and_noops(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Out-of-range positional index MUST log a warning and no-op
-    (foundation safety guard — don't crash a live RPC over registry drift)."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field=99,  # out of range
-    )
-
-    params: list[Any] = ["only", "two"]
-    with caplog.at_level(logging.WARNING, logger="notebooklm._idempotency"):
-        maybe_inject_client_token(
-            registry,
-            RPCMethod.LIST_NOTEBOOKS,
-            params,
-            operation_variant=None,
-        )
-
-    # Params unchanged
-    assert params == ["only", "two"]
-    # Warning emitted
-    warn_records = [
-        r
-        for r in caplog.records
-        if r.name.startswith("notebooklm._idempotency") and r.levelno >= logging.WARNING
-    ]
-    assert len(warn_records) == 1
-    assert "out-of-range" in warn_records[0].message
-
-
-def test_client_token_dedupe_field_shape_mismatch_noops() -> None:
-    """A ``str`` ``client_token_field`` with list-shaped params (or an
-    ``int`` field with dict-shaped params) MUST no-op rather than crash."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    # str field, list params → no-op
-    registry = IdempotencyRegistry()
-    registry.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field="client_token",
-    )
-    list_params: list[Any] = ["a", "b"]
-    maybe_inject_client_token(
-        registry, RPCMethod.LIST_NOTEBOOKS, list_params, operation_variant=None
-    )
-    assert list_params == ["a", "b"]
-
-    # int field, dict params → no-op
-    registry2 = IdempotencyRegistry()
-    registry2.register(
-        RPCMethod.LIST_NOTEBOOKS,
-        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
-        client_token_field=0,
-    )
-    dict_params: dict[str, Any] = {"foo": "bar"}
-    maybe_inject_client_token(
-        registry2, RPCMethod.LIST_NOTEBOOKS, dict_params, operation_variant=None
-    )
-    assert dict_params == {"foo": "bar"}
-
-
-def test_client_token_dedupe_is_noop_for_other_policies() -> None:
-    """Token injection MUST be skipped for non-CLIENT_TOKEN_DEDUPE policies."""
-    from notebooklm._idempotency import maybe_inject_client_token
-
-    registry = IdempotencyRegistry()
-    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
-
-    params: dict[str, Any] = {"foo": "bar"}
-    maybe_inject_client_token(
-        registry,
-        RPCMethod.LIST_NOTEBOOKS,
-        params,
-        operation_variant=None,
-    )
-
-    assert "client_token" not in params
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove the unregistered `CLIENT_TOKEN_DEDUPE` policy and executor token-injection hook.
- Update idempotency registry tests and artifact-generation assertions for the active five-policy taxonomy.
- Amend ADR-005 and architecture docs so they no longer advertise token injection as a live mechanism.

Closes #1170

## Test plan
- [x] `uv run pytest tests/unit/test_idempotency_registry.py tests/integration/test_artifact_generation_idempotency.py -q`
- [x] `uv run ruff check src/notebooklm/_idempotency.py src/notebooklm/_rpc_executor.py tests/unit/test_idempotency_registry.py tests/integration/test_artifact_generation_idempotency.py`
- [x] `uv run ruff format --check src/notebooklm/_idempotency.py src/notebooklm/_rpc_executor.py tests/unit/test_idempotency_registry.py tests/integration/test_artifact_generation_idempotency.py`
- [x] `uv run pytest tests/unit -q`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q`
- [x] post-polish/rebase: `uv run pytest tests/unit/test_idempotency_registry.py tests/integration/test_artifact_generation_idempotency.py -q`
- [x] post-polish/rebase: `uv run ruff check .`

## Deferred polish findings
- Optional changelog note deferred: this removes private dead code with no runtime behavior change; the existing historical changelog entry remains the record of what shipped in that older release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated idempotency policy taxonomy from 6 to 5 policies in architecture documentation and design records.

* **Refactor**
  * Removed the `CLIENT_TOKEN_DEDUPE` policy and associated client token injection mechanism.
  * Simplified idempotency registry to focus on retry-safety resolution.
  * Updated tests to reflect the reduced policy set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->