### PR TITLE
fix(artifacts): validate download allowlist by hostname

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -13,7 +13,7 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 import httpx
 
@@ -131,11 +131,22 @@ def _load_httpx_cookies(storage_path: Any) -> Any:
     return load_httpx_cookies(path=storage_path)
 
 
-def _is_trusted_download_host(netloc: str) -> bool:
+def _is_trusted_download_host(hostname: str | None) -> bool:
+    if hostname is None:
+        return False
+    hostname = hostname.lower()
+    if "\\" in hostname:
+        return False
     return any(
-        netloc == domain.lstrip(".") or netloc.endswith(domain)
+        hostname == domain.lstrip(".") or hostname.endswith(domain)
         for domain in _TRUSTED_DOWNLOAD_DOMAINS
     )
+
+
+def _download_display_host(parsed: ParseResult) -> str:
+    if parsed.hostname is not None:
+        return parsed.hostname
+    return parsed.netloc.rsplit("@", 1)[-1]
 
 
 class ArtifactDownloadService:
@@ -579,19 +590,20 @@ class ArtifactDownloadService:
             timeout=60.0,
         ) as client:
             for url, output_path in urls_and_paths:
-                parsed_netloc = ""
+                display_host = ""
                 parsed_path = ""
                 try:
                     parsed = urlparse(url)
-                    parsed_netloc = parsed.netloc
+                    display_host = _download_display_host(parsed)
                     parsed_path = parsed.path
                     if parsed.scheme != "https":
                         raise ArtifactDownloadError(
                             "media", details=f"Download URL must use HTTPS: {url[:80]}"
                         )
-                    if not _is_trusted_download_host(parsed.netloc):
+                    if not _is_trusted_download_host(parsed.hostname):
                         raise ArtifactDownloadError(
-                            "media", details=f"Untrusted download domain: {parsed.netloc}"
+                            "media",
+                            details=f"Untrusted download domain: {display_host}",
                         )
 
                     response = await client.get(url)
@@ -600,7 +612,7 @@ class ArtifactDownloadService:
                             "media",
                             details=(
                                 f"Authentication failed (HTTP {response.status_code}) "
-                                f"on {parsed.netloc}{parsed.path}"
+                                f"on {display_host}{parsed.path}"
                             ),
                         )
                     response.raise_for_status()
@@ -617,7 +629,7 @@ class ArtifactDownloadService:
                     result.succeeded.append(output_path)
                     logger.debug(
                         "Downloaded %s%s (%d bytes)",
-                        parsed.netloc,
+                        display_host,
                         parsed.path,
                         len(response.content),
                     )
@@ -637,7 +649,7 @@ class ArtifactDownloadService:
                         reason = e.__class__.__name__
                     logger.warning(
                         "Download failed for %s%s: %s",
-                        parsed_netloc,
+                        display_host,
                         parsed_path,
                         reason,
                     )
@@ -648,11 +660,13 @@ class ArtifactDownloadService:
     async def download_url(self, url: str, output_path: str) -> str:
         """Download a file from URL using streaming with proper cookie handling."""
         parsed = urlparse(url)
+        display_host = _download_display_host(parsed)
         if parsed.scheme != "https":
             raise ArtifactDownloadError("media", details=f"Download URL must use HTTPS: {url[:80]}")
-        if not _is_trusted_download_host(parsed.netloc):
+        if not _is_trusted_download_host(parsed.hostname):
             raise ArtifactDownloadError(
-                "media", details=f"Untrusted download domain: {parsed.netloc}"
+                "media",
+                details=f"Untrusted download domain: {display_host}",
             )
 
         output_file = Path(output_path)
@@ -865,7 +879,7 @@ class ArtifactDownloadService:
                         os.replace(temp_file, output_file)
                         logger.debug(
                             "Downloaded %s%s (%d bytes)",
-                            parsed.netloc,
+                            display_host,
                             parsed.path,
                             total_bytes,
                         )
@@ -875,7 +889,7 @@ class ArtifactDownloadService:
                     raise ArtifactDownloadError(
                         "media",
                         details=(
-                            f"Authentication required for {parsed.netloc}{parsed.path}"
+                            f"Authentication required for {display_host}{parsed.path}"
                             " -- try `notebooklm login`"
                         ),
                         cause=e,
@@ -883,14 +897,14 @@ class ArtifactDownloadService:
                     ) from e
                 raise ArtifactDownloadError(
                     "media",
-                    details=f"HTTP error downloading {parsed.netloc}{parsed.path}",
+                    details=f"HTTP error downloading {display_host}{parsed.path}",
                     cause=e,
                     status_code=e.response.status_code,
                 ) from e
             except httpx.RequestError as e:
                 raise ArtifactDownloadError(
                     "media",
-                    details=f"Network error downloading {parsed.netloc}{parsed.path}",
+                    details=f"Network error downloading {display_host}{parsed.path}",
                     cause=e,
                 ) from e
         except BaseException:

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -227,6 +227,68 @@ async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_download_batch_rejects_backslash_hostname_confusion(mock_artifacts_api, tmp_path):
+    """Batch downloads use parsed hostname for the same allowlist guard."""
+    api, _ = mock_artifacts_api
+    url = "https://attacker.evil\\.google.com/file.mp4"
+
+    with _patched_httpx_client([]) as mock_client:
+        result = await api._download_urls_batch([(url, str(tmp_path / "file.mp4"))])
+
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    failed_url, failed_exc = result.failed[0]
+    assert failed_url == url
+    assert isinstance(failed_exc, ArtifactDownloadError)
+    assert "Untrusted download domain" in str(failed_exc)
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://storage.googleapis.com:443/file.mp4",
+        "https://user:pass@storage.googleapis.com:443/file.mp4",
+    ],
+)
+async def test_download_batch_allows_trusted_hostname_with_userinfo_or_port(
+    mock_artifacts_api, tmp_path, url
+):
+    """Port and userinfo components must not participate in batch host matching."""
+    api, _ = mock_artifacts_api
+    output_path = tmp_path / "file.mp4"
+
+    with _patched_httpx_client([_mock_response(b"payload bytes")]) as mock_client:
+        result = await api._download_urls_batch([(url, str(output_path))])
+
+    assert result.succeeded == [str(output_path)]
+    assert output_path.read_bytes() == b"payload bytes"
+    assert result.failed == []
+    mock_client.get.assert_awaited_once_with(url)
+
+
+@pytest.mark.asyncio
+async def test_download_batch_error_details_redact_userinfo(mock_artifacts_api, tmp_path):
+    """Batch auth errors should report a host without echoing userinfo."""
+    api, _ = mock_artifacts_api
+    url = "https://user:pass@storage.googleapis.com:443/file.mp4"
+    response = _mock_response(b"")
+    response.status_code = 403
+
+    with _patched_httpx_client([response]):
+        result = await api._download_urls_batch([(url, str(tmp_path / "file.mp4"))])
+
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    _, failed_exc = result.failed[0]
+    message = str(failed_exc)
+    assert "Authentication failed (HTTP 403)" in message
+    assert "user:pass" not in message
+    assert "storage.googleapis.com/file.mp4" in message
+
+
+@pytest.mark.asyncio
 async def test_download_warning_log_does_not_leak_url_via_exception_str(
     mock_artifacts_api, tmp_path, caplog
 ):
@@ -261,6 +323,25 @@ async def test_download_warning_log_does_not_leak_url_via_exception_str(
     joined = " ".join(warning_messages)
     assert "LEAKY" not in joined, f"capability token leaked: {joined!r}"
     assert "HTTP 503" in joined
+
+
+@pytest.mark.asyncio
+async def test_download_warning_log_redacts_userinfo(mock_artifacts_api, tmp_path, caplog):
+    """Batch failure logs should use the sanitized host, not the URL netloc."""
+    api, _ = mock_artifacts_api
+    url = "https://user:pass@storage.googleapis.com:443/file.mp4"
+
+    with (
+        _patched_httpx_client([httpx.ConnectError("net down")]),
+        caplog.at_level(logging.WARNING, logger="notebooklm"),
+    ):
+        result = await api._download_urls_batch([(url, str(tmp_path / "file.mp4"))])
+
+    assert len(result.failed) == 1
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    joined = " ".join(warning_messages)
+    assert "user:pass" not in joined
+    assert "storage.googleapis.com/file.mp4" in joined
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -138,6 +138,52 @@ class TestDownloadUrlErrorWrapping:
                 assert f.read() == content
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://attacker.evil\\.google.com/file.mp4",
+            "https://storage.googleapis.com@attacker.evil/file.mp4",
+        ],
+    )
+    async def test_untrusted_hostname_shapes_rejected_before_streaming(
+        self, mock_artifacts_api, tmp_path, url
+    ):
+        """Host allowlist uses parsed hostname, not the display netloc."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+
+        with pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(url, str(output_path))
+
+        assert "Untrusted download domain" in str(exc_info.value)
+        assert "storage.googleapis.com@" not in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://storage.googleapis.com:443/file.mp4",
+            "https://user:pass@storage.googleapis.com:443/file.mp4",
+        ],
+    )
+    async def test_trusted_hostname_with_userinfo_or_port_allowed(
+        self, mock_artifacts_api, tmp_path, url
+    ):
+        """Port and userinfo components must not participate in host matching."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        response = _build_mock_response(content=b"binary media payload")
+        client_patch, cookies_patch = _patch_httpx_client(response)
+
+        with client_patch, cookies_patch:
+            result = await api._download_url(url, str(output_path))
+
+        assert result == str(output_path)
+        assert output_path.read_bytes() == b"binary media payload"
+
+    @pytest.mark.asyncio
     async def test_401_raises_artifact_download_error_with_auth_hint(self, mock_artifacts_api):
         """401 -> ArtifactDownloadError mentioning re-auth, status_code=401."""
         api = mock_artifacts_api
@@ -187,6 +233,42 @@ class TestDownloadUrlErrorWrapping:
             assert "notebooklm login" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            (_make_http_status_error(403), "Authentication required"),
+            (_make_http_status_error(500), "HTTP error downloading"),
+            (httpx.ReadTimeout("read timed out"), "Network error"),
+        ],
+    )
+    async def test_error_details_redact_userinfo(self, mock_artifacts_api, error, expected):
+        """Trusted URLs may contain userinfo, but diagnostics must not echo it."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            if isinstance(error, httpx.HTTPStatusError):
+                response = _build_mock_response(raise_for_status_exc=error)
+                client_patch, cookies_patch = _patch_httpx_client(response)
+            else:
+                client_patch, cookies_patch = _patch_httpx_client(stream_exc=error)
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url(
+                    "https://user:pass@storage.googleapis.com:443/file.mp4",
+                    output_path,
+                )
+
+            message = str(exc_info.value)
+            assert expected in message
+            assert "user:pass" not in message
+            assert "storage.googleapis.com/file.mp4" in message
+
+    @pytest.mark.asyncio
     async def test_500_raises_artifact_download_error_generic_http(self, mock_artifacts_api):
         """500 -> ArtifactDownloadError without auth hint, status_code=500."""
         api = mock_artifacts_api
@@ -206,7 +288,7 @@ class TestDownloadUrlErrorWrapping:
 
             # ``status_code`` rides on the exception attribute, so the
             # message text no longer repeats it. The message uses
-            # ``parsed.netloc + parsed.path`` so capability tokens in query
+            # a sanitized host plus ``parsed.path`` so capability tokens in query
             # params can't leak into log lines.
             assert exc_info.value.status_code == 500
             assert "HTTP error downloading" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- validate artifact download allowlist checks against `parsed.hostname` instead of `parsed.netloc`
- reject backslash-containing hostnames before trusted-domain suffix matching
- add single and batch download regressions for backslash, userinfo, and port URL shapes

## Task
Closes #1172

## Test plan
- [x] `uv run pytest tests/unit/test_download_url.py tests/unit/test_download_result.py -q`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter download URL validation to reject deceptive or untrusted hosts before any network or file activity; error messages now show sanitized host/path and redact credentials.

* **Tests**
  * New unit tests covering allowlist validation, rejection of crafted hostnames, successful trusted downloads, and redaction of sensitive userinfo in errors and logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->