### PR TITLE
fix(cli): protect source fulltext output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **HTML file uploads now fail client-side with a clear validation error** ([#1127](https://github.com/teng-lin/notebooklm-py/issues/1127)). `notebooklm source add ./article.html` and `client.sources.add_file(..., "article.html")` previously reached NotebookLM's upload endpoint as `text/html` and surfaced a cryptic upstream `400 Bad Request`. The upload pipeline now rejects `.html` / `.htm` / `.xhtml` / `.xht` / HTML MIME uploads before registering a source, with guidance to convert the page to `.txt`, `.md`, or `.pdf`.
+- **`notebooklm source fulltext -o FILE` no longer silently overwrites existing files** ([#1173](https://github.com/teng-lin/notebooklm-py/issues/1173)). Existing output paths now auto-rename by default (`FILE` -> `FILE (2)`, etc.); pass `--force` to overwrite intentionally or `--no-clobber` to fail when the path already exists.
 
 ### Removed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -150,7 +150,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID, title | `--mime-type [google-doc\|google-slides\|google-sheets\|pdf]`, `--json` | `source add-drive abc123 "Doc" --mime-type google-slides` |
 | `add-research [query]` | Search query (or `--prompt-file -` for stdin) | `--mode [fast\|deep]`, `--from [web\|drive]`, `--import-all`, `--cited-only`, `--no-wait`, `--timeout`, `--prompt-file PATH` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | `--json` | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install "notebooklm-py[markdown]"` — full extras matrix: [docs/installation.md#optional-extras-matrix](installation.md#optional-extras-matrix)) |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `--force`, `--no-clobber`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install "notebooklm-py[markdown]"` — full extras matrix: [docs/installation.md#optional-extras-matrix](installation.md#optional-extras-matrix)) |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `stale <id>` | Source ID | `--exit-on-stale`, `--json` | `source stale src123` (exit 0 on success; pass `--exit-on-stale` for the back-compat inverted predicate — see [exit codes](cli-exit-codes.md)) |
 | `wait <id>` | Source ID | `--timeout`, `--interval`, `--json` | `source wait src123 --timeout 300 --interval 5` |
@@ -165,6 +165,8 @@ All `source` subcommands also accept `-n/--notebook ID` (resolves via flag > `NO
 `source delete <id>` accepts only full source IDs or unique partial-ID prefixes. To delete by exact source title, use `source delete-by-title "<title>"`.
 
 `source clean` automatically removes duplicate, error, and access-blocked sources; combine with `--dry-run` to preview the candidate set first.
+
+`source fulltext -o FILE` auto-renames an existing output path by default (`FILE` -> `FILE (2)`, etc.) instead of overwriting it. Pass `--force` to overwrite intentionally, or `--no-clobber` to fail if the path exists.
 
 `source stale` reports whether a URL/Drive source needs a refresh. By default it follows the standard CLI exit convention (`0` on success, `1` on error); branch on the JSON `stale`/`fresh` fields (or stdout text) for the freshness verdict. Pass `--exit-on-stale` to opt into the back-compat inverted predicate (`0` = stale, `1` = fresh) for shell idioms like `if notebooklm source stale --exit-on-stale ID; then refresh; fi`.
 

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -185,18 +185,68 @@ def _render_source_get_result(result: SourceGetResult, *, json_output: bool) -> 
         console.print(f"[bold]Created:[/bold] {src.created_at.strftime('%Y-%m-%d %H:%M')}")
 
 
+def _available_output_path(path: Path) -> Path:
+    """Return an available sibling path using the download command's suffix style."""
+    counter = 2
+    base_name = path.stem
+    parent = path.parent
+    ext = path.suffix
+    while path.exists():
+        path = parent / f"{base_name} ({counter}){ext}"
+        counter += 1
+    return path
+
+
+def _emit_source_fulltext_flag_conflict(message: str, *, json_output: bool) -> NoReturn:
+    """Surface a ``source fulltext`` flag conflict via the active CLI error contract."""
+    if json_output:
+        _output_error(message, "VALIDATION_ERROR", json_output, 1)
+        raise AssertionError("unreachable")  # pragma: no cover
+    raise click.UsageError(message)
+
+
+def _resolve_source_fulltext_output_path(
+    output: str,
+    *,
+    force: bool,
+    no_clobber: bool,
+    json_output: bool,
+) -> Path:
+    """Resolve ``source fulltext -o`` conflicts without silently overwriting."""
+    path = Path(output)
+    if force and no_clobber:
+        _emit_source_fulltext_flag_conflict(
+            "Cannot specify both --force and --no-clobber",
+            json_output=json_output,
+        )
+    if not path.exists() or force:
+        return path
+    if no_clobber:
+        suggestion = "Use --force to overwrite or choose a different path"
+        _output_error(
+            f"File exists: {path}",
+            "FILE_EXISTS",
+            json_output,
+            1,
+            extra={"path": str(path), "suggestion": suggestion},
+            hint=suggestion,
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+    return _available_output_path(path)
+
+
 def _render_source_fulltext_result(
     result: SourceFulltextResult,
     *,
     json_output: bool,
-    output: str | None,
+    output: Path | None,
 ) -> None:
     """Render ``source fulltext`` output, including optional file output."""
     fulltext = result.fulltext
     if json_output:
         if output:
             content_bytes = fulltext.content.encode("utf-8")
-            Path(output).write_bytes(content_bytes)
+            output.write_bytes(content_bytes)
             json_output_response(
                 {
                     "path": str(output),
@@ -212,8 +262,13 @@ def _render_source_fulltext_result(
         return
 
     if output:
-        Path(output).write_text(fulltext.content, encoding="utf-8")
-        console.print(f"[green]Saved {fulltext.char_count} chars to {output}[/green]")
+        output.write_text(fulltext.content, encoding="utf-8")
+        console.print(
+            f"Saved {fulltext.char_count} chars to {output}",
+            style="green",
+            markup=False,
+            soft_wrap=True,
+        )
         return
 
     console.print(f"[bold cyan]Source:[/bold cyan] {fulltext.source_id}")
@@ -1058,6 +1113,8 @@ def source_add_research(
 @notebook_option
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.option("--output", "-o", type=click.Path(), help="Write content to file")
+@click.option("--no-clobber", is_flag=True, help="Fail if the output file exists")
+@click.option("--force", is_flag=True, help="Overwrite an existing output file")
 @click.option(
     "--format",
     "-f",
@@ -1067,16 +1124,43 @@ def source_add_research(
     help="Content format: text (default) or markdown",
 )
 @with_client
-def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_format, client_auth):
+def source_fulltext(
+    ctx,
+    source_id,
+    notebook_id,
+    json_output,
+    output,
+    no_clobber,
+    force,
+    output_format,
+    client_auth,
+):
     """Get full content of a source.
 
     Use ``--format markdown`` for a rich version with headings/tables/links.
     Text mode truncates at 2000 chars; ``-o FILE`` writes the full content.
+    Existing output files are auto-renamed unless ``--force`` or
+    ``--no-clobber`` is supplied.
     JSON mode emits the full ``SourceFulltext`` payload, or with ``-o`` a
     ``{path, bytes, source_id, title, kind}`` envelope (content goes to the file
     only, not duplicated to stdout).
     """
     nb_id = require_notebook(notebook_id)
+    if force and no_clobber:
+        _emit_source_fulltext_flag_conflict(
+            "Cannot specify both --force and --no-clobber",
+            json_output=json_output,
+        )
+    output_path = (
+        _resolve_source_fulltext_output_path(
+            output,
+            force=force,
+            no_clobber=no_clobber,
+            json_output=json_output,
+        )
+        if output
+        else None
+    )
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
@@ -1094,7 +1178,11 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_for
             else:
                 with console.status("Fetching fulltext content..."):
                     result = await execute_source_fulltext(client, plan)
-            _render_source_fulltext_result(result, json_output=json_output, output=output)
+            _render_source_fulltext_result(
+                result,
+                json_output=json_output,
+                output=output_path,
+            )
 
     return _run()
 

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -8872,6 +8872,42 @@
           }
         },
         {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Fail if the output file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Overwrite an existing output file",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
           "default": "text",
           "envvar": null,
           "has_custom_shell_complete": false,

--- a/tests/unit/cli/test_source_content_rendering.py
+++ b/tests/unit/cli/test_source_content_rendering.py
@@ -33,6 +33,20 @@ def _client_resolving_source(source_id: str = "src_1", title: str = "Source One"
     return client
 
 
+def _client_with_fulltext(content: str, *, type_code: int | None = None):
+    client = _client_resolving_source()
+    payload = {
+        "source_id": "src_1",
+        "title": "Source One",
+        "content": content,
+        "char_count": len(content),
+    }
+    if type_code is not None:
+        payload["_type_code"] = type_code
+    client.sources.get_fulltext = AsyncMock(return_value=SourceFulltext(**payload))
+    return client
+
+
 @pytest.mark.parametrize("json_output", [False, True])
 def test_source_get_not_found_renderer_exits_one(
     runner: CliRunner,
@@ -130,6 +144,227 @@ def test_source_fulltext_json_output_file_writes_content_and_emits_metadata(
         "title": "Source One",
         "kind": "web_page",
     }
+
+
+def test_source_fulltext_output_file_auto_renames_existing_file(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source [draft].txt"
+    renamed_file = tmp_path / "source [draft] (2).txt"
+    output_file.write_text("existing content", encoding="utf-8")
+    content = "replacement content"
+    client = _client_with_fulltext(content)
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            ["source", "fulltext", "src_1", "-n", "nb_123", "-o", str(output_file)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert output_file.read_text(encoding="utf-8") == "existing content"
+    assert renamed_file.read_text(encoding="utf-8") == content
+    assert f"Saved {len(content)} chars to" in result.output
+    assert str(renamed_file) in result.output
+
+
+def test_source_fulltext_json_output_file_auto_renames_and_emits_actual_path(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    renamed_file = tmp_path / "source (2).txt"
+    output_file.write_text("existing content", encoding="utf-8")
+    content = "replacement content"
+    client = _client_with_fulltext(content, type_code=5)
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "--json",
+                "-o",
+                str(output_file),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert output_file.read_text(encoding="utf-8") == "existing content"
+    assert renamed_file.read_text(encoding="utf-8") == content
+    payload = json.loads(result.output)
+    assert payload["path"] == str(renamed_file)
+    assert payload["bytes"] == len(content.encode("utf-8"))
+
+
+def test_source_fulltext_output_file_no_clobber_rejects_existing_file(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    output_file.write_text("existing content", encoding="utf-8")
+    client = _client_with_fulltext("replacement content")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "-o",
+                str(output_file),
+                "--no-clobber",
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert output_file.read_text(encoding="utf-8") == "existing content"
+    client.sources.get_fulltext.assert_not_awaited()
+    assert f"File exists: {output_file}" in result.output
+    assert "Use --force to overwrite" in result.output
+
+
+def test_source_fulltext_json_output_file_no_clobber_rejects_existing_file(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    output_file.write_text("existing content", encoding="utf-8")
+    client = _client_with_fulltext("replacement content")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "--json",
+                "-o",
+                str(output_file),
+                "--no-clobber",
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert output_file.read_text(encoding="utf-8") == "existing content"
+    client.sources.get_fulltext.assert_not_awaited()
+    payload = json.loads(result.output)
+    assert payload == {
+        "error": True,
+        "code": "FILE_EXISTS",
+        "message": f"File exists: {output_file}",
+        "path": str(output_file),
+        "suggestion": "Use --force to overwrite or choose a different path",
+    }
+
+
+def test_source_fulltext_output_file_force_overwrites_existing_file(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    output_file.write_text("existing content", encoding="utf-8")
+    content = "replacement content"
+    client = _client_with_fulltext(content)
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "-o",
+                str(output_file),
+                "--force",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert output_file.read_text(encoding="utf-8") == content
+    assert not (tmp_path / "source (2).txt").exists()
+
+
+def test_source_fulltext_output_rejects_force_and_no_clobber_json(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    client = _client_with_fulltext("replacement content")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "--json",
+                "-o",
+                str(output_file),
+                "--force",
+                "--no-clobber",
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload == {
+        "error": True,
+        "code": "VALIDATION_ERROR",
+        "message": "Cannot specify both --force and --no-clobber",
+    }
+
+
+def test_source_fulltext_output_rejects_force_and_no_clobber_text(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_file = tmp_path / "source.txt"
+    client = _client_with_fulltext("replacement content")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "-o",
+                str(output_file),
+                "--force",
+                "--no-clobber",
+            ],
+        )
+
+    assert result.exit_code == 2, result.output
+    assert "Cannot specify both --force and --no-clobber" in result.output
+    assert not result.output.strip().startswith("{")
+    client.sources.get_fulltext.assert_not_awaited()
 
 
 def test_source_guide_empty_text_renderer_uses_empty_state(


### PR DESCRIPTION
## Summary
- Prevent `source fulltext -o FILE` from silently overwriting existing files by auto-renaming by default.
- Add `--force` for intentional overwrite and `--no-clobber` for fail-if-exists behavior, with JSON/text error coverage.
- Document the new behavior and update the CLI contract baseline.

Fixes #1173.

## Test plan
- [x] `uv run --frozen --extra dev ruff format --check .`
- [x] `uv run --frozen --extra dev ruff check .`
- [x] `uv run --frozen --extra dev mypy src/notebooklm`
- [x] `uv run --frozen --extra dev pytest tests/unit/cli/test_source_content_rendering.py tests/unit/cli/test_source.py tests/unit/cli/test_phase10_cli_contract.py -q`
- [x] `uv run --frozen --extra dev --extra browser --extra markdown pytest`
- [x] `uv run --frozen --extra dev pre-commit run --all-files`

## Deferred polish findings
- Optional: extract a shared auto-rename helper with the download service if a future command needs the same behavior.
- Optional: reject directory paths at Click parsing for `source fulltext -o`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `source fulltext -o FILE` no longer silently overwrites existing output files; existing paths are auto-renamed by default.

* **New Features**
  * Added `--force` flag to explicitly overwrite existing output files.
  * Added `--no-clobber` flag to fail if the output path already exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->