### PR TITLE
fix(notes): raise when CREATE_NOTE returns no usable note id

### DIFF
--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -678,18 +678,20 @@ class ArtifactGenerationService:
                 if isinstance(mind_map_data, dict) and "name" in mind_map_data:
                     title = mind_map_data["name"]
 
+                # ``NoteService.create_note`` raises ``RPCError`` when the
+                # server omits a usable row id (issue #1162); on success it
+                # always returns a ``Note`` with a non-empty id. The
+                # ``note.id or None`` below is therefore defensive only —
+                # it preserves the public dict contract ("note_id is None
+                # means persistence failed") for any future degenerate
+                # shape, but the empty-id case now surfaces as an error
+                # rather than a silent ``{"note_id": None}``. The original
+                # ``if note`` dead-code guard was removed in PR #873.
                 note = await self._note_service.create_note(
                     notebook_id,
                     title=title,
                     content=mind_map_json,
                 )
-                # ``NoteService.create_note`` always returns a ``Note``
-                # instance — even when the server omits the row id it
-                # returns ``Note(id="", ...)``. The dataclass is always
-                # truthy, so guarding on ``if note`` was dead code. Map
-                # the empty-string ID to ``None`` so the public dict
-                # contract ("note_id is None means persistence failed")
-                # is honored. Surfaced by claude[bot] review on PR #873.
                 note_id = note.id or None
 
                 return {

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -28,6 +28,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from ._row_adapters_notes import NoteRow
+from .exceptions import RPCError
 from .rpc.types import RPCMethod
 from .types import Note
 
@@ -257,57 +258,67 @@ class NoteService:
             elif isinstance(result[0], str):
                 note_id = result[0]
 
-        if note_id:
-            # Shield the UPDATE_NOTE finalize from outer cancellation:
-            # CREATE_NOTE has already persisted a row server-side; without
-            # the shield, a cancel arriving between CREATE_NOTE and
-            # UPDATE_NOTE completion leaves an orphan row with no
-            # title/content.
-            #
-            # ``update_task`` is a freestanding ``asyncio.Task`` (not a
-            # bare coroutine) so the cancel-time cleanup branch can await
-            # it before issuing the best-effort DELETE_NOTE. If we instead
-            # fired DELETE_NOTE in parallel with the still-running
-            # shielded UPDATE_NOTE (the pattern coderabbit flagged on PR
-            # #875), delete could complete first and update could then
-            # write to an already-soft-deleted row — observable as an
-            # inconsistent row state on the server side and a swallowed
-            # exception in the cleanup task.
-            update_task = asyncio.create_task(
-                self.update_note(notebook_id, note_id, content, title)
+        if not note_id:
+            # CREATE_NOTE returned a payload we cannot extract a note id
+            # from. Returning ``Note(id="")`` would be a success-shaped
+            # lie: the title/content were never finalized via UPDATE_NOTE,
+            # and any later operation keyed on the empty id misbehaves.
+            # Raise instead, matching the sibling create paths
+            # (``_source_add`` / ``notebooks.create``) which surface an
+            # error rather than fabricate a degenerate resource.
+            raise RPCError(
+                "CREATE_NOTE returned no usable note id; the note was not created",
+                method_id=RPCMethod.CREATE_NOTE.value,
             )
-            try:
-                await asyncio.shield(update_task)
-            except asyncio.CancelledError:
-                # Ordered fire-and-forget cleanup: first wait for the
-                # shielded UPDATE_NOTE to finish (success OR error),
-                # THEN issue the best-effort DELETE_NOTE. The re-raise
-                # MUST NOT await the wrapper task. Strong-ref via
-                # ``_cleanup_tasks`` so the loop's weak-ref Task storage
-                # cannot GC the wrapper mid-flight (RUF006); the
-                # done-callback discards on completion so the set stays
-                # bounded.
-                async def _finalize_then_cleanup() -> None:
-                    try:
-                        try:
-                            await update_task
-                        except Exception:  # noqa: BLE001 — log and proceed to delete
-                            logger.debug(
-                                "Shielded UPDATE_NOTE failed before cleanup for note %s in notebook %s",
-                                note_id,
-                                notebook_id,
-                                exc_info=True,
-                            )
-                    finally:
-                        await self._delete_note_best_effort(notebook_id, note_id)
 
-                cleanup_task = asyncio.create_task(_finalize_then_cleanup())
-                _cleanup_tasks.add(cleanup_task)
-                cleanup_task.add_done_callback(_cleanup_tasks.discard)
-                raise
+        # Shield the UPDATE_NOTE finalize from outer cancellation:
+        # CREATE_NOTE has already persisted a row server-side; without
+        # the shield, a cancel arriving between CREATE_NOTE and
+        # UPDATE_NOTE completion leaves an orphan row with no
+        # title/content.
+        #
+        # ``update_task`` is a freestanding ``asyncio.Task`` (not a
+        # bare coroutine) so the cancel-time cleanup branch can await
+        # it before issuing the best-effort DELETE_NOTE. If we instead
+        # fired DELETE_NOTE in parallel with the still-running
+        # shielded UPDATE_NOTE (the pattern coderabbit flagged on PR
+        # #875), delete could complete first and update could then
+        # write to an already-soft-deleted row — observable as an
+        # inconsistent row state on the server side and a swallowed
+        # exception in the cleanup task.
+        update_task = asyncio.create_task(self.update_note(notebook_id, note_id, content, title))
+        try:
+            await asyncio.shield(update_task)
+        except asyncio.CancelledError:
+            # Ordered fire-and-forget cleanup: first wait for the
+            # shielded UPDATE_NOTE to finish (success OR error),
+            # THEN issue the best-effort DELETE_NOTE. The re-raise
+            # MUST NOT await the wrapper task. Strong-ref via
+            # ``_cleanup_tasks`` so the loop's weak-ref Task storage
+            # cannot GC the wrapper mid-flight (RUF006); the
+            # done-callback discards on completion so the set stays
+            # bounded.
+            async def _finalize_then_cleanup() -> None:
+                try:
+                    try:
+                        await update_task
+                    except Exception:  # noqa: BLE001 — log and proceed to delete
+                        logger.debug(
+                            "Shielded UPDATE_NOTE failed before cleanup for note %s in notebook %s",
+                            note_id,
+                            notebook_id,
+                            exc_info=True,
+                        )
+                finally:
+                    await self._delete_note_best_effort(notebook_id, note_id)
+
+            cleanup_task = asyncio.create_task(_finalize_then_cleanup())
+            _cleanup_tasks.add(cleanup_task)
+            cleanup_task.add_done_callback(_cleanup_tasks.discard)
+            raise
 
         return Note(
-            id=note_id or "",
+            id=note_id,
             notebook_id=notebook_id,
             title=title,
             content=content,

--- a/tests/integration/test_notes_integration.py
+++ b/tests/integration/test_notes_integration.py
@@ -10,6 +10,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
+from notebooklm.exceptions import RPCError
 from notebooklm.rpc import RPCMethod
 
 pytestmark = pytest.mark.allow_no_vcr
@@ -165,6 +166,29 @@ class TestNotesAPI:
         requests = httpx_mock.get_requests()
         assert RPCMethod.CREATE_NOTE in str(requests[0].url)
         assert RPCMethod.UPDATE_NOTE in str(requests[1].url)
+
+    @pytest.mark.asyncio
+    async def test_create_note_raises_when_id_unparseable(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A CREATE_NOTE payload with no extractable id must raise, not
+        return a success-shaped ``Note(id="")`` (issue #1162)."""
+        # ``[[]]`` parses but yields no note id (empty inner row).
+        create_response = build_rpc_response(RPCMethod.CREATE_NOTE, [[]])
+        httpx_mock.add_response(content=create_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(RPCError, match="no usable note id"):
+                await client.notes.create("nb_123", "My Title", "My Content")
+
+        # The finalize UPDATE_NOTE must never have been attempted: bailing
+        # before UPDATE_NOTE is what prevents the degenerate empty-id note.
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+        assert RPCMethod.CREATE_NOTE in str(requests[0].url)
 
     @pytest.mark.asyncio
     async def test_update_note(

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -22,6 +22,7 @@ import pytest
 
 from _fixtures.fake_core import FakeSession, make_fake_core
 from notebooklm._note_service import NoteRowKind, NoteService
+from notebooklm.exceptions import RPCError
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import Note
 
@@ -192,15 +193,17 @@ class TestCrud:
         ]
 
     @pytest.mark.asyncio
-    async def test_create_note_returns_empty_id_when_server_omits_id(
+    async def test_create_note_raises_when_server_omits_id(
         self, service: NoteService, mock_session: FakeSession
     ) -> None:
         mock_session.rpc_executor.rpc_call.return_value = None
 
-        note = await service.create_note("nb_123", title="T", content="body")
+        # An unparseable CREATE_NOTE payload must surface as an error
+        # rather than a success-shaped ``Note(id="")`` (issue #1162).
+        with pytest.raises(RPCError, match="no usable note id"):
+            await service.create_note("nb_123", title="T", content="body")
 
-        assert note.id == ""
-        # Only CREATE_NOTE should fire; the UPDATE_NOTE skip avoids
+        # Only CREATE_NOTE should fire; bailing before UPDATE_NOTE avoids
         # poisoning a non-existent row.
         assert mock_session.rpc_executor.rpc_call.await_count == 1
 

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -7,6 +7,7 @@ import pytest
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
 from notebooklm._notes import NotesAPI
+from notebooklm.exceptions import RPCError
 from notebooklm.types import Note
 
 
@@ -501,24 +502,25 @@ class TestCreateNote:
         assert result.id == "new_note_456"
 
     @pytest.mark.asyncio
-    async def test_create_with_null_result(self, notes_api, mock_core):
-        """Test create() when RPC returns None."""
+    async def test_create_raises_when_null_result(self, notes_api, mock_core):
+        """create() must raise when RPC returns None (issue #1162).
+
+        A ``None`` payload carries no note id, so finalizing the note is
+        impossible. Returning ``Note(id="")`` would be a success-shaped
+        lie; the create-contract requires surfacing the failure instead.
+        """
         mock_core.rpc_executor.rpc_call.return_value = None
 
-        result = await notes_api.create("nb_123", "Title", "Content")
-
-        assert result.id == ""
-        assert result.title == "Title"
-        assert result.content == "Content"
+        with pytest.raises(RPCError, match="no usable note id"):
+            await notes_api.create("nb_123", "Title", "Content")
 
     @pytest.mark.asyncio
-    async def test_create_with_empty_result(self, notes_api, mock_core):
-        """Test create() when RPC returns empty list."""
+    async def test_create_raises_when_empty_result(self, notes_api, mock_core):
+        """create() must raise when RPC returns an empty list (issue #1162)."""
         mock_core.rpc_executor.rpc_call.return_value = []
 
-        result = await notes_api.create("nb_123", "Title", "Content")
-
-        assert result.id == ""
+        with pytest.raises(RPCError, match="no usable note id"):
+            await notes_api.create("nb_123", "Title", "Content")
 
     @pytest.mark.asyncio
     async def test_create_calls_update_after_create(self, notes_api, mock_core):
@@ -534,13 +536,20 @@ class TestCreateNote:
         assert mock_core.rpc_executor.rpc_call.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_create_skips_update_when_no_id(self, notes_api, mock_core):
-        """Test that create() skips update when no note_id returned."""
+    async def test_create_does_not_update_when_no_id(self, notes_api, mock_core):
+        """create() must bail before UPDATE_NOTE when no id is returned.
+
+        It now raises (issue #1162) rather than silently returning an
+        empty-id note, but the invariant that the finalize UPDATE_NOTE is
+        never attempted without a note id still holds — only the single
+        CREATE_NOTE RPC is issued before the error surfaces.
+        """
         mock_core.rpc_executor.rpc_call.return_value = None
 
-        await notes_api.create("nb_123", "Title", "Content")
+        with pytest.raises(RPCError, match="no usable note id"):
+            await notes_api.create("nb_123", "Title", "Content")
 
-        # Should only have 1 RPC call (CREATE_NOTE)
+        # Should only have 1 RPC call (CREATE_NOTE); no UPDATE_NOTE finalize.
         assert mock_core.rpc_executor.rpc_call.call_count == 1
 
 


### PR DESCRIPTION
## Root cause

`NoteService.create_note` (`src/notebooklm/_note_service.py`) parsed the
`CREATE_NOTE` response to extract a note id, then ran the `UPDATE_NOTE`
finalize inside an `if note_id:` block. When the id could **not** be
extracted, that block was skipped and the method fell through to
`return Note(id=note_id or "", ...)`.

The caller therefore received a `Note` that *looked* created and carried
the requested title/content, but:

- the title/content were never finalized server-side (no `UPDATE_NOTE`),
- the note has an empty id, so any later operation keyed on it misbehaves,
- **no error was raised** — a create-contract violation.

Sibling create paths (`_source_add`, `notebooks.create`) already raise on
a degenerate/empty payload instead of fabricating a resource.

## Fix

Raise `RPCError` when the note id cannot be extracted, matching the other
create paths. The successful path now always returns a `Note` with a
non-empty id (the `or ""` fallback is gone).

Also updated the now-stale `_artifact_generation` mind-map comment, which
documented the old "returns `Note(id="")`" behavior — `create_note` now
raises there too rather than silently degrading to `{"note_id": None}`.

## Tests

- `tests/integration/test_notes_integration.py`: new
  `test_create_note_raises_when_id_unparseable` exercising the public
  `client.notes.create` API — asserts `RPCError` is raised and that the
  finalize `UPDATE_NOTE` is never issued (only the single `CREATE_NOTE`
  POST fires).
- `tests/unit/test_notes_unit.py` and `tests/unit/test_note_service.py`:
  the three tests that asserted the old empty-id contract now assert the
  raise behavior (they previously encoded the exact bug).

All pass; the only failing test locally
(`test_login_multi_account` text-wrapping assertion) is a pre-existing,
terminal-width-dependent failure unrelated to this change (confirmed on
clean `main`).

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note creation error handling and reliability. The system now properly raises an error when the server fails to return a valid note identifier during creation, preventing incomplete notes from being saved. This ensures better error visibility and maintains data consistency across your notebooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->