### PR TITLE
fix(kernel): close AsyncClient if open-time cookie snapshot raises

### DIFF
--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -98,7 +98,15 @@ class Kernel:
             follow_redirects=True,
             limits=limits.to_httpx_limits(),
         )
-        capture_cookie_snapshot(self._http_client.cookies)
+        # If the snapshot raises, __aenter__ has effectively failed, so Python
+        # never calls __aexit__ and the freshly built client would leak its
+        # connection pool. Close it and reset state before re-raising so a
+        # partial open cannot orphan a live client.
+        try:
+            capture_cookie_snapshot(self._http_client.cookies)
+        except BaseException:
+            await self.aclose()
+            raise
 
     async def post(
         self,

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -94,6 +94,39 @@ async def test_open_preserves_explicit_empty_cookie_jar(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_open_closes_client_when_cookie_snapshot_raises() -> None:
+    closed: list[httpx.AsyncClient] = []
+
+    class _TrackingClient(httpx.AsyncClient):
+        async def aclose(self) -> None:
+            closed.append(self)
+            await super().aclose()
+
+    def async_client_factory(**kwargs: object) -> httpx.AsyncClient:
+        return _TrackingClient(**kwargs)  # type: ignore[arg-type]
+
+    kernel = Kernel(async_client_factory=async_client_factory)
+
+    def boom(_: httpx.Cookies) -> None:
+        raise RuntimeError("snapshot failed")
+
+    with pytest.raises(RuntimeError, match="snapshot failed"):
+        await kernel.open(
+            auth=_auth_tokens(),
+            timeout=30.0,
+            connect_timeout=10.0,
+            limits=ConnectionLimits(),
+            capture_cookie_snapshot=boom,
+        )
+
+    # The partially opened client must have been closed and the kernel reset so
+    # it does not leak a live connection pool (issue #1163).
+    assert kernel.http_client is None
+    assert len(closed) == 1
+    assert closed[0].is_closed
+
+
+@pytest.mark.asyncio
 async def test_post_uses_live_http_client_streaming_post() -> None:
     seen_requests: list[httpx.Request] = []
 


### PR DESCRIPTION
## Root cause

`Kernel.open()` builds and assigns the live `httpx.AsyncClient` to `self._http_client` (`src/notebooklm/_kernel.py`) and only then captures the open-time cookie snapshot via the injected `capture_cookie_snapshot` callback (in production, `CookiePersistence.capture_open_snapshot`).

If that snapshot call raises, `open()` propagates the exception with a live, never-closed client. Because `__aenter__` has effectively failed, Python never calls `__aexit__`, so `close()` / `Kernel.aclose()` never run and the client leaks its connection pool — one orphaned client + pool per failed open.

## Fix

Wrap the `capture_cookie_snapshot` call in a `try/except BaseException` that `aclose()`s the freshly built client and resets `_http_client` to `None` before re-raising, so a partial open cannot orphan a live client. `BaseException` is used so that even cancellation/`KeyboardInterrupt` during the snapshot still tears down the pool.

The lifecycle's `_http_client` is a thin property backed by the kernel, so resetting the kernel keeps both views in sync and a subsequent retry of `open()` rebuilds cleanly.

## Tests

Added `test_open_closes_client_when_cookie_snapshot_raises` to `tests/unit/test_kernel.py`, which injects a snapshot callback that raises and asserts the partially built client was closed (`is_closed`) and the kernel was reset (`http_client is None`). Verified this test fails on the pre-fix code and passes after.

Note: an unrelated pre-existing unit test (`tests/unit/cli/test_login_multi_account.py::...aborts_without_confirm`) fails on clean `origin/main` due to terminal-width line wrapping of CLI output; it is out of scope for this issue.

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to ensure HTTP client connections are properly closed and resources are released when initialization errors occur.

* **Tests**
  * Added test coverage to verify proper resource cleanup when initialization fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->