### PR TITLE
fix(auth): release refresh lock if lock-wait metric raises

### DIFF
--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -324,9 +324,15 @@ class AuthRefreshCoordinator:
         lock = self.get_refresh_lock()
         wait_start = time.perf_counter()
         await lock.acquire()
-        if self._metrics is not None:
-            self._metrics.record_lock_wait(time.perf_counter() - wait_start)
         try:
+            # ``record_lock_wait`` lives INSIDE the ``try`` so a metric-side
+            # exception (e.g. a misconfigured spy in tests, or a runtime bug
+            # in :class:`ClientMetrics`) cannot leave the refresh lock held —
+            # the ``finally`` releases unconditionally. Mirrors the same
+            # hardening on :meth:`update_auth_tokens`; the call is synchronous
+            # so no await runs between acquiring and releasing the lock.
+            if self._metrics is not None:
+                self._metrics.record_lock_wait(time.perf_counter() - wait_start)
             if self._refresh_task is not None and not self._refresh_task.done():
                 refresh_task = self._refresh_task
                 logger.debug("Joining existing refresh task")

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -327,6 +327,52 @@ async def test_update_auth_tokens_releases_lock_when_metric_raises(
     assert auth.session_id == "W"
 
 
+@pytest.mark.asyncio
+async def test_await_refresh_releases_lock_when_metric_raises() -> None:
+    """A metric-side exception must NOT leave the refresh lock held.
+
+    Companion to ``test_update_auth_tokens_releases_lock_when_metric_raises``
+    but for the single-flight refresh lock. Pins that ``record_lock_wait``
+    lives inside the ``try`` block guarded by ``finally: lock.release()``;
+    without that guard a buggy metrics implementation (or a test spy that
+    raises) would silently hang every subsequent ``await_refresh`` caller on
+    the leaked lock.
+    """
+    call_count = 0
+
+    async def cb() -> AuthTokens:
+        nonlocal call_count
+        call_count += 1
+        return AuthTokens(
+            csrf_token=f"R{call_count}",
+            session_id="S",
+            cookies={"SID": f"sid{call_count}"},
+        )
+
+    metrics = _ExplodingMetrics()
+    coord = AuthRefreshCoordinator(
+        refresh_callback=cb,
+        metrics=cast(ClientMetrics, metrics),
+    )
+
+    with pytest.raises(RuntimeError, match="metrics blew up"):
+        await coord.await_refresh()
+
+    # The refresh task is never created when the metric raises before
+    # task-creation runs, so a leaked lock would not be masked by a joined
+    # task — the second ``await_refresh`` must acquire the lock itself.
+    assert coord._refresh_task is None
+
+    # The lock must be released even though the metric write raised. Wrap in
+    # ``wait_for`` so a leaked lock surfaces as a fast failure rather than
+    # hanging the suite.
+    metrics2 = _RecordingMetrics()
+    coord._metrics = cast(ClientMetrics, metrics2)
+    await asyncio.wait_for(coord.await_refresh(), timeout=EVENT_TIMEOUT_S)
+    assert call_count == 1
+    assert len(metrics2.lock_waits) == 1
+
+
 # ---------------------------------------------------------------------------
 # update_auth_headers — syncs auth.cookie_jar from get_http_client().cookies
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`AuthRefreshCoordinator.await_refresh` recorded the lock-wait metric *between* `lock.acquire()` and the `try:` block:

```python
await lock.acquire()
if self._metrics is not None:
    self._metrics.record_lock_wait(...)   # OUTSIDE the try
try:
    ...
finally:
    lock.release()
```

If `record_lock_wait` raised — a misconfigured metrics spy in tests, or any future `ClientMetrics` bug — the lock was acquired and never released. Every subsequent `await_refresh` then deadlocks on `lock.acquire()`.

The sibling `update_auth_tokens` in the same file was already hardened against exactly this (its metric call lives inside the `try`), with a comment explaining why; `await_refresh` was missed.

## Fix

Move the `record_lock_wait` call inside the `try` guarded by `finally: lock.release()`, mirroring `update_auth_tokens`. The call is synchronous, so no await runs between acquiring and releasing the lock (preserving the single-flight task-creation invariant).

## Test

Added `test_await_refresh_releases_lock_when_metric_raises`, a companion to the existing `test_update_auth_tokens_releases_lock_when_metric_raises`. It uses the `_ExplodingMetrics` spy to make `record_lock_wait` raise, asserts the error propagates, then asserts a follow-up `await_refresh` acquires the lock without hanging (wrapped in `asyncio.wait_for` so a leaked lock surfaces as a fast failure). Verified the test fails (TimeoutError) on the unpatched code and passes with the fix.

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session refresh reliability by ensuring proper lock release during metric recording failures.

* **Tests**
  * Added test coverage for metric recording failures during session refresh operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->