### PR TITLE
fix(logging): redact bare SNlM0e/FdrFJe/csrf token values

### DIFF
--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -83,38 +83,62 @@ def correlation_id(req_id: str | None = None) -> Iterator[str]:
         reset_request_id(token)
 
 
+# WIZ_global_data CSRF (SNlM0e) and session-id (FdrFJe) markers. These appear
+# in HTML/JSON responses (``"SNlM0e":"AF1_QpN-..."``), in query / form bodies
+# (``SNlM0e=...``), and in diagnostic prose (``SNlM0e value is AF1_QpN-...``).
+# The marker name (and any quoting) is preserved; only the value is redacted.
+# Split into three shape-specific patterns so each value class is anchored
+# precisely and the capture groups are directly testable:
+#   - QUOTED: ``"marker":"value"`` / ``'marker':'value'`` (JSON / inline JS).
+#     Group 2 captures the verbatim run from the key's closing quote through
+#     the value's opening quote (``"\s*:\s*"``) so it is reproduced exactly in
+#     the replacement; group 3 is the value's quote char, back-referenced as
+#     the closing quote. The value uses the escape-aware idiom
+#     ``(?:[^"'\\]|\\.)*`` (mirroring the VCR cassette sanitizer in
+#     ``tests/cassette_patterns.py``) so a JSON ``\"`` inside the value does
+#     not terminate the match early and leak the tail. ``\s*`` around the
+#     colon tolerates pretty-printed JSON.
+#   - HTML_ESCAPED: ``&quot;marker&quot;:&quot;value&quot;`` (script block
+#     rendered inside an HTML attribute). Terminates on the literal
+#     ``&quot;``, so embedded entities (``&amp;``) survive into the redaction.
+#   - UNQUOTED: ``marker=value`` / ``marker: value`` / ``marker value is value``
+#     (query, form, or diagnostic prose). The value class excludes trailing
+#     punctuation / brackets (``.?!)]}>``) so benign sentence punctuation and
+#     enclosing parens are NOT swallowed into the redacted run.
+# Each marker is its own alternation so capture group 1 is always the full
+# marker name; ``\b`` left-anchors so it is not matched mid-identifier.
+_CSRF_MARKER_QUOTED = re.compile(r"(\b(?:SNlM0e|FdrFJe))([\"']?\s*:\s*)([\"'])(?:[^\"'\\]|\\.)*\3")
+_CSRF_MARKER_HTML_ESCAPED = re.compile(
+    r"(\b(?:SNlM0e|FdrFJe))((?:&quot;)?\s*:\s*)(&quot;)(?:(?!&quot;).)*&quot;"
+)
+_CSRF_MARKER_UNQUOTED = re.compile(
+    r"(\b(?:SNlM0e|FdrFJe))(\s*(?:value\s+is|[:=])\s*)[^\s\"'<>&;,.?!)\]}]+"
+)
+
+# Bare Google CSRF tokens. The CSRF value (``SNlM0e`` / the ``at=`` body param)
+# is always emitted with the ``AF1_QpN-`` family prefix, so a standalone token
+# is redacted even with no surrounding marker. The prefix is preserved as a
+# shape hint; the secret suffix is dropped.
+_CSRF_BARE_TOKEN = re.compile(r"(AF1_QpN-)[A-Za-z0-9_-]+")
+
+
 # Patterns are immutable. Adding a new pattern requires a unit test.
 # Order matters: longer / more-specific cookie names first within the cookie
 # group so `SID` doesn't shadow `SAPISID`. Patterns are applied in sequence.
 _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # CSRF / form-body auth tokens (Google batchexecute)
     (re.compile(r"(\bat=)[^&\s\"'<>]+"), r"\1***"),
-    # WIZ_global_data CSRF (SNlM0e) and session-id (FdrFJe) markers. These
-    # appear in HTML/JSON responses (``"SNlM0e":"AF1_QpN-..."``), in query /
-    # form bodies (``SNlM0e=...``), and in diagnostic prose
-    # (``SNlM0e value is AF1_QpN-...``). The marker name itself is kept; the
-    # following token-shaped value is redacted. The separator class spans
-    # the JSON colon, ``=``, and a prose run (``"value is"`` / whitespace),
-    # then the value runs until the next quote/whitespace/JSON delimiter.
-    # The marker is matched as its own alternation so the captured ``\1``
-    # group always reflects the full marker name. ``\b`` left-anchors the
-    # marker so it is not matched mid-identifier.
-    (
-        re.compile(
-            r"(\b(?:SNlM0e|FdrFJe))"
-            r"((?:&quot;)?[\"']?\s*(?:value\s+is|[:=])\s*(?:&quot;)?[\"']?)"
-            r"[^\s\"'<>&;,}]+"
-        ),
-        r"\1\2***",
-    ),
+    # WIZ_global_data CSRF / session-id markers (see the pattern docs above).
+    # The quoted / HTML-escaped variants run before the unquoted one so the
+    # quote-aware value classes win on JSON-shaped input.
+    (_CSRF_MARKER_QUOTED, r"\1\2\3***\3"),
+    (_CSRF_MARKER_HTML_ESCAPED, r"\1\2\3***&quot;"),
+    (_CSRF_MARKER_UNQUOTED, r"\1\2***"),
     # ``csrf=<value>`` form parameter (the CSRF token shows up canonically as
     # ``at=<csrf>``, but a ``csrf=`` alias must not leak the value either).
     (re.compile(r"(\bcsrf=)[^&\s\"'<>]+", re.IGNORECASE), r"\1***"),
-    # Bare Google CSRF tokens. The CSRF value (``SNlM0e`` / the ``at=`` body
-    # param) is always emitted with the ``AF1_QpN-`` family prefix, so a
-    # standalone token is redacted even with no surrounding marker. The
-    # prefix is preserved as a shape hint; the secret suffix is dropped.
-    (re.compile(r"(AF1_QpN-)[A-Za-z0-9_-]+"), r"\1***"),
+    # Bare Google CSRF tokens (see the pattern docs above).
+    (_CSRF_BARE_TOKEN, r"\1***"),
     # session-id query param
     (re.compile(r"(\bf\.sid=)[^&\s\"'<>]+"), r"\1***"),
     # resumable-upload session query param

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -89,6 +89,32 @@ def correlation_id(req_id: str | None = None) -> Iterator[str]:
 _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # CSRF / form-body auth tokens (Google batchexecute)
     (re.compile(r"(\bat=)[^&\s\"'<>]+"), r"\1***"),
+    # WIZ_global_data CSRF (SNlM0e) and session-id (FdrFJe) markers. These
+    # appear in HTML/JSON responses (``"SNlM0e":"AF1_QpN-..."``), in query /
+    # form bodies (``SNlM0e=...``), and in diagnostic prose
+    # (``SNlM0e value is AF1_QpN-...``). The marker name itself is kept; the
+    # following token-shaped value is redacted. The separator class spans
+    # the JSON colon, ``=``, and a prose run (``"value is"`` / whitespace),
+    # then the value runs until the next quote/whitespace/JSON delimiter.
+    # The marker is matched as its own alternation so the captured ``\1``
+    # group always reflects the full marker name. ``\b`` left-anchors the
+    # marker so it is not matched mid-identifier.
+    (
+        re.compile(
+            r"(\b(?:SNlM0e|FdrFJe))"
+            r"((?:&quot;)?[\"']?\s*(?:value\s+is|[:=])\s*(?:&quot;)?[\"']?)"
+            r"[^\s\"'<>&;,}]+"
+        ),
+        r"\1\2***",
+    ),
+    # ``csrf=<value>`` form parameter (the CSRF token shows up canonically as
+    # ``at=<csrf>``, but a ``csrf=`` alias must not leak the value either).
+    (re.compile(r"(\bcsrf=)[^&\s\"'<>]+", re.IGNORECASE), r"\1***"),
+    # Bare Google CSRF tokens. The CSRF value (``SNlM0e`` / the ``at=`` body
+    # param) is always emitted with the ``AF1_QpN-`` family prefix, so a
+    # standalone token is redacted even with no surrounding marker. The
+    # prefix is preserved as a shape hint; the secret suffix is dropped.
+    (re.compile(r"(AF1_QpN-)[A-Za-z0-9_-]+"), r"\1***"),
     # session-id query param
     (re.compile(r"(\bf\.sid=)[^&\s\"'<>]+"), r"\1***"),
     # resumable-upload session query param
@@ -156,6 +182,9 @@ _DEFAULT_DATEFMT = "%H:%M:%S"
 #
 # Coverage map (pattern -> covering token in this set, all lowercase):
 #   \bat=<csrf>                                          -> "at="
+#   \b(SNlM0e|FdrFJe)<sep><value>                         -> "snlm0e" / "fdrfje"
+#   \bcsrf=<csrf> (IGNORECASE)                           -> "csrf"
+#   AF1_QpN-<bare csrf token>                            -> "af1_qpn-"
 #   \bf\.sid=<sid>                                       -> "f.sid"
 #   \bupload_id=<resumable upload token>                  -> "upload_id="
 #   (refresh_token|access_token|id_token)= (IGNORECASE)  -> "_token="
@@ -178,15 +207,24 @@ _DEFAULT_DATEFMT = "%H:%M:%S"
 #   - "continue=" and "authuser=" are NOT in ``_REDACT_PATTERNS``. Including
 #     them is harmless: they only INCREASE the regex-sweep rate, never the
 #     redaction surface, and they hedge against future audit additions.
-#   - "csrf" is not in any pattern verbatim (the CSRF token shows up as
-#     ``at=<csrf>``), but is kept as a defensive token in case future log
-#     call sites emit ``CSRF=`` style markers.
+#   - "csrf" covers the ``csrf=<value>`` form alias. The canonical CSRF
+#     token shows up as ``at=<csrf>`` (covered by "at="); the standalone
+#     ``AF1_QpN-`` token shape is covered by "af1_qpn-".
+#   - "snlm0e" / "fdrfje" cover the WIZ_global_data CSRF / session-id markers
+#     in their JSON, query, and prose shapes. They are lowercased to match
+#     the lowercased input even though the marker regex is case-sensitive
+#     (the markers are canonical mixed-case identifiers); the lowercase
+#     substring still triggers the sweep, which is harmless if the regex
+#     then misses.
 #   - "sapisid" is redundant given "sid", but kept as documentation that we
 #     deliberately cover that cookie family.
 SECRET_FAST_PATH_TOKENS: tuple[str, ...] = (
     "sid",
     "sapisid",
     "csrf",
+    "snlm0e",
+    "fdrfje",
+    "af1_qpn-",
     "f.sid",
     "continue=",
     "authuser=",

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -204,6 +204,66 @@ def test_formatter_scrubs_set_cookie_response_header():
     assert "Set-Cookie: ***" in out
 
 
+def test_formatter_scrubs_bare_csrf_and_session_markers():
+    """Bare ``SNlM0e`` / ``FdrFJe`` markers must be redacted in every shape
+    they appear in — JSON (``"SNlM0e":"AF1_QpN-..."``), query/form
+    (``FdrFJe=...``), HTML-escaped (``&quot;...&quot;``), and diagnostic prose
+    (``SNlM0e value is AF1_QpN-...``).
+
+    Pre-fix the redactor only matched the canonical wire shapes (``at=``,
+    ``f.sid=``, cookies); a third-party logger or exception text emitting a
+    bare ``SNlM0e``/``FdrFJe`` value — or the ``csrf=`` alias — leaked a
+    credential-equivalent token (the CSRF token authorizes all RPC mutations).
+    See issue #1165.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    cases = [
+        # marker, full input, secret value that must NOT survive
+        ("SNlM0e", "SNlM0e value is AF1_QpN-PROSE_SECRET reported", "AF1_QpN-PROSE_SECRET"),
+        ("FdrFJe", "session FdrFJe=1234567890123456 in url", "1234567890123456"),
+        ("csrf", "form body csrf=AF1_QpN-CSRF_ALIAS&hl=en", "AF1_QpN-CSRF_ALIAS"),
+        ("SNlM0e", 'wiz data {"SNlM0e":"AF1_QpN-JSON_SECRET"}', "AF1_QpN-JSON_SECRET"),
+        ("SNlM0e", "single {'SNlM0e':'AF1_QpN-SQ_SECRET'}", "AF1_QpN-SQ_SECRET"),
+        (
+            "FdrFJe",
+            "escaped {&quot;FdrFJe&quot;:&quot;9988776655&quot;}",
+            "9988776655",
+        ),
+    ]
+    for marker, text, secret in cases:
+        rec = _record(text)
+        out = fmt.format(rec)
+        assert secret not in out, f"{secret!r} leaked from {text!r}: got {out!r}"
+        # The marker name itself is preserved (only the value is redacted).
+        assert marker in out, f"marker {marker!r} stripped from {text!r}: got {out!r}"
+        assert "***" in out, f"no redaction placeholder in {out!r}"
+
+
+def test_formatter_scrubs_bare_af1_qpn_csrf_token():
+    """A standalone Google CSRF token (``AF1_QpN-...`` family) is redacted even
+    with no surrounding marker — the prefix is the credential's stable shape.
+
+    The ``AF1_QpN-`` prefix is preserved as a diagnostic shape hint; the secret
+    suffix is dropped. Regression for issue #1165 (defense-in-depth)."""
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record("rejected token AF1_QpN-LOOSE_SECRET_SUFFIX seen on the wire")
+    out = fmt.format(rec)
+    assert "LOOSE_SECRET_SUFFIX" not in out
+    assert "AF1_QpN-***" in out
+
+
+def test_formatter_marker_redaction_preserves_benign_at_suffix_fields():
+    """The CSRF/session markers must not over-redact benign fields. Fields
+    whose names merely *contain* ``sid`` / ``at`` as substrings (``rate=``,
+    ``coordinate=``, ``valid=``) keep their values — only the anchored markers
+    redact. Guards against an overbroad #1165 fix."""
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record("metrics rate=10 coordinate=5 valid=true latency_ms=420")
+    out = fmt.format(rec)
+    for keep in ("rate=10", "coordinate=5", "valid=true", "latency_ms=420"):
+        assert keep in out, f"benign field {keep!r} over-redacted: {out!r}"
+
+
 def test_formatter_scrubs_psidts_in_non_header_shapes():
     """Standalone ``__Secure-[13]PSIDTS=<value>`` tokens must be redacted in
     every HTTP-shaped form they appear in (refresh-cmd stdout/stderr,
@@ -686,6 +746,10 @@ def test_fast_path_tokens_cover_every_redaction_pattern():
     # token (case-insensitively) AND get rewritten by scrub_secrets.
     samples = [
         ("at=", "posted body at=SECRET_X&hl=en"),
+        ("snlm0e", 'wiz data "SNlM0e":"AF1_QpN-SECRET_X"'),
+        ("fdrfje", "session FdrFJe=SECRET_SID_X"),
+        ("csrf", "form csrf=AF1_QpN-SECRET_X"),
+        ("af1_qpn-", "bare token AF1_QpN-SECRET_X in prose"),
         ("f.sid", "url ?f.sid=ABC_DEF"),
         ("_token=", "oauth body refresh_token=RT&access_token=AT&id_token=IT"),
         ("code=", "oauth callback code=AUTH_X"),

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -238,6 +238,58 @@ def test_formatter_scrubs_bare_csrf_and_session_markers():
         assert marker in out, f"marker {marker!r} stripped from {text!r}: got {out!r}"
         assert "***" in out, f"no redaction placeholder in {out!r}"
 
+    # Surrounding punctuation / quotes / brackets must be preserved exactly —
+    # only the value is replaced. (gemini-code-assist: guard against the
+    # unquoted value class swallowing trailing sentence punctuation or the
+    # enclosing parens / JSON quotes.)
+    exact = [
+        ("SNlM0e value is AF1_QpN-PROSE_SECRET.", "SNlM0e value is ***."),
+        ("(FdrFJe=1234567890123456)", "(FdrFJe=***)"),
+        ('{"SNlM0e":"AF1_QpN-JSON_SECRET"}', '{"SNlM0e":"***"}'),
+        ("{'SNlM0e':'AF1_QpN-SQ_SECRET'}", "{'SNlM0e':'***'}"),
+        (
+            "{&quot;FdrFJe&quot;:&quot;9988776655&quot;}",
+            "{&quot;FdrFJe&quot;:&quot;***&quot;}",
+        ),
+    ]
+    for text, expected in exact:
+        rec = _record(text)
+        assert fmt.format(rec) == expected, f"unexpected redaction of {text!r}"
+
+
+def test_csrf_marker_regex_capture_groups():
+    """Directly pin the compiled marker patterns' capture groups so a future
+    edit can't silently shift what gets captured (and therefore reproduced
+    verbatim) vs. redacted. A string-shape assertion alone can't distinguish
+    "captured the right span" from "coincidental prefix preservation."
+    (gemini-code-assist suggestion.)
+    """
+    from notebooklm._logging import (
+        _CSRF_MARKER_HTML_ESCAPED,
+        _CSRF_MARKER_QUOTED,
+        _CSRF_MARKER_UNQUOTED,
+    )
+
+    m = _CSRF_MARKER_QUOTED.search('{"SNlM0e":"AF1_QpN-JSON_SECRET"}')
+    assert m is not None
+    assert m.group(1) == "SNlM0e"
+    assert m.group(2) == '":'  # key-closing quote through the colon
+    assert m.group(3) == '"'  # value quote, back-referenced as the closer
+    assert "AF1_QpN-JSON_SECRET" in m.group(0)
+
+    m = _CSRF_MARKER_UNQUOTED.search("FdrFJe value is AF1_QpN-PROSE_SECRET.")
+    assert m is not None
+    assert m.group(1) == "FdrFJe"
+    assert m.group(2) == " value is "
+    # The trailing period is NOT part of the match (value class excludes it).
+    assert m.group(0).endswith("AF1_QpN-PROSE_SECRET")
+
+    m = _CSRF_MARKER_HTML_ESCAPED.search("{&quot;SNlM0e&quot;:&quot;sekret&quot;}")
+    assert m is not None
+    assert m.group(1) == "SNlM0e"
+    assert m.group(2) == "&quot;:"
+    assert m.group(3) == "&quot;"
+
 
 def test_formatter_scrubs_bare_af1_qpn_csrf_token():
     """A standalone Google CSRF token (``AF1_QpN-...`` family) is redacted even
@@ -253,14 +305,28 @@ def test_formatter_scrubs_bare_af1_qpn_csrf_token():
 
 
 def test_formatter_marker_redaction_preserves_benign_at_suffix_fields():
-    """The CSRF/session markers must not over-redact benign fields. Fields
-    whose names merely *contain* ``sid`` / ``at`` as substrings (``rate=``,
-    ``coordinate=``, ``valid=``) keep their values — only the anchored markers
-    redact. Guards against an overbroad #1165 fix."""
+    """The CSRF/session markers must not over-redact benign fields.
+
+    ``csrf_protected``/``nb_sid`` contain fast-path token substrings (``csrf``,
+    ``sid``) so the gate opens and the regex sweep genuinely runs — proving the
+    anchored markers don't redact fields that merely *contain* a token
+    substring (and that the cookie / ``csrf=`` patterns don't fire on a
+    ``csrf_protected=`` prefix). Guards against an overbroad #1165 fix.
+    (coderabbitai: the original input had no fast-path token and so was
+    short-circuited before any pattern ran.)"""
     fmt = RedactingFormatter(logging.Formatter("%(message)s"))
-    rec = _record("metrics rate=10 coordinate=5 valid=true latency_ms=420")
+    rec = _record(
+        "metrics rate=10 coordinate=5 valid=true latency_ms=420 csrf_protected=yes nb_sid=keepme"
+    )
     out = fmt.format(rec)
-    for keep in ("rate=10", "coordinate=5", "valid=true", "latency_ms=420"):
+    for keep in (
+        "rate=10",
+        "coordinate=5",
+        "valid=true",
+        "latency_ms=420",
+        "csrf_protected=yes",
+        "nb_sid=keepme",
+    ):
         assert keep in out, f"benign field {keep!r} over-redacted: {out!r}"
 
 


### PR DESCRIPTION
## Summary

`scrub_secrets()` (the package's documented redaction safety net) only matched specific wire shapes — `at=`, `f.sid=`, `upload_id=`, OAuth `name=value`, Google session cookies, `Cookie:`/`Set-Cookie:`, and `Authorization: Bearer`. Bare WIZ_global_data CSRF (`SNlM0e`) and session-id (`FdrFJe`) markers, the `csrf=` form alias, and a standalone `AF1_QpN-` CSRF token all passed through **unredacted**, and the fast-path gate skipped the regex sweep entirely for messages containing only these tokens.

Because the CSRF token authorizes every RPC mutation, any future log line or third-party logger (the exact case `scrub_secrets` exists to backstop) emitting one of these shapes would leak a credential-equivalent value.

## Root cause

`_REDACT_PATTERNS` in `src/notebooklm/_logging.py` had no anchor for the `SNlM0e`/`FdrFJe` markers, the `csrf=` alias, or the bare `AF1_QpN-` CSRF token prefix, and `SECRET_FAST_PATH_TOKENS` lacked the corresponding gate substrings.

## Fix

Added four redaction patterns:
- `SNlM0e` / `FdrFJe` markers across JSON (`"SNlM0e":"..."`), single-quoted, HTML-escaped (`&quot;...&quot;`), query/form (`SNlM0e=...`), and diagnostic-prose (`SNlM0e value is ...`) shapes — the marker name is preserved, the value becomes `***`.
- `csrf=<value>` form alias (case-insensitive).
- Bare `AF1_QpN-<token>` CSRF prefix — the prefix is kept as a diagnostic shape hint, the secret suffix dropped.

Added matching fast-path tokens (`snlm0e`, `fdrfje`, `af1_qpn-`; `csrf` was already present) plus the coverage-map documentation, and extended the load-bearing fast-path invariant test so the gate cannot silently skip these shapes.

## Tests

- New regression tests fail before the fix and pass after (verified by stashing the source change).
- A guard test pins that benign fields (`rate=`, `coordinate=`, `valid=`) are **not** over-redacted by the new marker patterns.
- Full suite green (the single unrelated `test_account_different_existing_profile_account_aborts_without_confirm` failure is the documented pre-existing terminal-width artifact on clean main).

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential and sensitive token redaction to cover additional CSRF and session markers across multiple data formats (JSON structures, form parameters, and plain text), improving protection against accidental credential leakage in logs and diagnostic output.

* **Tests**
  * Added comprehensive unit tests to verify enhanced credential redaction patterns work correctly across various data formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->