### PR TITLE
test(cli): tolerate wrapped login overwrite message

### DIFF
--- a/tests/unit/cli/test_login_multi_account.py
+++ b/tests/unit/cli/test_login_multi_account.py
@@ -305,8 +305,9 @@ class TestLoginMultiAccount:
             )
 
         assert result.exit_code != 0
-        assert "already has auth for alice@example.com" in result.output
-        assert "not overwriting with bob@gmail.com" in result.output
+        output_normalized = " ".join(result.output.split())
+        assert "already has auth for alice@example.com" in output_normalized
+        assert "not overwriting with bob@gmail.com" in output_normalized
         assert _read_account(storage_file) == {
             "authuser": 0,
             "email": "alice@example.com",


### PR DESCRIPTION
## Summary
- Normalize whitespace in the multi-account login overwrite assertion so Click/Rich line wrapping does not fail xdist runs.
- No production code changes.

## Verification
- uv run pytest tests/unit/cli/test_login_multi_account.py::TestLoginMultiAccount::test_account_different_existing_profile_account_aborts_without_confirm -q
- uv run pytest -n auto --dist=worksteal tests/unit/cli/test_login_multi_account.py -q
- uv run ruff check tests/unit/cli/test_login_multi_account.py

## Context
Final integration gate after Phase 5 found the substring split across a newline under xdist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved assertion logic for multi-account login tests to enhance robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->