### PR TITLE
fix(cli): route agent show errors to stderr

### DIFF
--- a/src/notebooklm/cli/agent_cmd.py
+++ b/src/notebooklm/cli/agent_cmd.py
@@ -4,7 +4,7 @@ import click
 
 from .agent_templates import get_agent_source_content
 from .error_handler import exit_with_code
-from .rendering import console
+from .rendering import console, stderr_console
 
 
 @click.group()
@@ -19,7 +19,7 @@ def show_agent(target: str):
     """Display instructions for Codex or Claude Code."""
     content = get_agent_source_content(target)
     if content is None:
-        console.print(f"[red]Error:[/red] {target} instructions not found in package data.")
+        stderr_console.print(f"[red]Error:[/red] {target} instructions not found in package data.")
         exit_with_code(1)
 
     console.print(content)

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -1,6 +1,7 @@
 """Tests for agent CLI commands."""
 
 import importlib
+import inspect
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,8 @@ agent_templates_module = importlib.import_module("notebooklm.cli.agent_templates
 
 @pytest.fixture
 def runner():
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
     return CliRunner()
 
 

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -39,12 +39,13 @@ class TestAgentShow:
         assert "Claude Skill" in result.output
 
     def test_agent_show_missing_content_returns_error(self, runner):
-        """Test error when bundled agent instructions are missing."""
+        """Test missing bundled instructions report on stderr only."""
         with patch.object(agent_module, "get_agent_source_content", return_value=None):
             result = runner.invoke(cli, ["agent", "show", "codex"])
 
         assert result.exit_code == 1
-        assert "not found" in result.output.lower()
+        assert result.stdout == ""
+        assert "not found" in result.stderr.lower()
 
 
 class TestAgentTemplates:


### PR DESCRIPTION
## Summary
- Route `notebooklm agent show` missing-template diagnostics to `stderr_console`.
- Add a focused CLI regression asserting the not-found path leaves stdout empty and writes the diagnostic to stderr.

Fixes #1175.

## Test plan
- `uv run pytest tests/unit/cli/test_agent.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`
- `uv run pytest`

## Deferred polish findings
- Optional: add success-path `stderr == ""` assertions for `agent show` success cases. Deferred as out of scope for #1175, which only concerns the not-found diagnostic path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for missing agent instructions now appear in the error output stream (stderr) instead of standard output, and the CLI exits with the expected failure code. Tests updated to assert error output and exit behavior, improving reliability of CLI error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->