### PR TITLE
fix(cli): add --json to notebook delete command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -107,6 +107,7 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `create <title> --json` | JSON envelope; with `--use` includes `active_notebook_id` | `notebooklm create "X" --use --json` |
 | `delete -n <id>` | Delete notebook (uses current notebook if `-n` omitted) | `notebooklm delete -n abc123` |
 | `delete -n <id> -y` | Skip confirmation | `notebooklm delete -n abc123 -y` |
+| `delete -n <id> --json` | Emit `{notebook_id, success}` envelope; requires `-y` (refuses to prompt in JSON mode) | `notebooklm delete -n abc123 -y --json` |
 | `rename <title>` | Rename current notebook | `notebooklm rename "New Title"` |
 | `summary` | Get AI summary | `notebooklm summary` |
 | `summary --topics` | Include suggested topics | `notebooklm summary --topics` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -107,7 +107,7 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `create <title> --json` | JSON envelope; with `--use` includes `active_notebook_id` | `notebooklm create "X" --use --json` |
 | `delete -n <id>` | Delete notebook (uses current notebook if `-n` omitted) | `notebooklm delete -n abc123` |
 | `delete -n <id> -y` | Skip confirmation | `notebooklm delete -n abc123 -y` |
-| `delete -n <id> --json` | Emit `{notebook_id, success}` envelope; requires `-y` (refuses to prompt in JSON mode) | `notebooklm delete -n abc123 -y --json` |
+| `delete -n <id> --json` | Emit `{notebook_id, success}` envelope (plus `context_cleared: true` when deleting the active notebook); requires `-y` (refuses to prompt in JSON mode) | `notebooklm delete -n abc123 -y --json` |
 | `rename <title>` | Rename current notebook | `notebooklm rename "New Title"` |
 | `summary` | Get AI summary | `notebooklm summary` |
 | `summary --topics` | Include suggested topics | `notebooklm summary --topics` |

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -16,7 +16,8 @@ import click
 from ..client import NotebookLMClient
 from .auth_runtime import with_client
 from .context import clear_context, get_current_notebook, set_current_notebook
-from .options import list_options, notebook_option
+from .error_handler import _output_error
+from .options import json_option, list_options, notebook_option
 from .rendering import cli_print, console, json_output_response, render_list
 from .resolve import require_notebook, resolve_notebook_id
 from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
@@ -130,8 +131,9 @@ def register_notebook_commands(cli):
     @cli.command("delete")
     @notebook_option
     @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+    @json_option
     @with_client
-    def delete_cmd(ctx, notebook_id, yes, client_auth):
+    def delete_cmd(ctx, notebook_id, yes, json_output, client_auth):
         """Delete a notebook.
 
         Supports partial IDs - 'notebooklm delete -n abc' matches 'abc123...'
@@ -142,7 +144,23 @@ def register_notebook_commands(cli):
             async with NotebookLMClient(client_auth) as client:
 
                 async def resolve_delete(client):
-                    resolved_id = await resolve_notebook_id(client, notebook_id)
+                    resolved_id = await resolve_notebook_id(
+                        client, notebook_id, json_output=json_output
+                    )
+
+                    # In JSON mode, refuse to prompt: ``click.confirm`` writes to
+                    # stdout, which would corrupt the parseable JSON contract callers
+                    # rely on. Require --yes and emit a structured error otherwise.
+                    if json_output and not yes:
+                        _output_error(
+                            "Pass --yes to confirm deletion in --json mode",
+                            code="VALIDATION_ERROR",
+                            json_output=json_output,
+                            exit_code=1,
+                            extra={"notebook_id": resolved_id, "success": False},
+                        )
+                        raise AssertionError("unreachable")  # pragma: no cover
+
                     return {"notebook_id": resolved_id, "success": False}
 
                 async def execute_delete(client, resolved):
@@ -169,7 +187,7 @@ def register_notebook_commands(cli):
                     plan,
                     client,
                     yes=yes,
-                    json_output=False,
+                    json_output=json_output,
                     confirmer=click.confirm,
                 )
                 if result.status == "cancelled":
@@ -177,11 +195,26 @@ def register_notebook_commands(cli):
 
                 resolved_id = result.resolved["notebook_id"]
                 success = bool(result.resolved["success"])
+
+                # Clear context if we deleted the current notebook. Do this
+                # regardless of output mode so JSON callers don't leave a stale
+                # active-notebook pointer behind.
+                if success and get_current_notebook() == resolved_id:
+                    clear_context()
+                    context_cleared = True
+                else:
+                    context_cleared = False
+
+                if json_output:
+                    payload = dict(result.payload)
+                    if context_cleared:
+                        payload["context_cleared"] = True
+                    json_output_response(payload)
+                    return
+
                 if success:
                     cli_print(f"[green]Deleted notebook:[/green] {resolved_id}", ctx=ctx)
-                    # Clear context if we deleted the current notebook
-                    if get_current_notebook() == resolved_id:
-                        clear_context()
+                    if context_cleared:
                         cli_print("[dim]Cleared current notebook context[/dim]", ctx=ctx)
                 else:
                     cli_print("[yellow]Delete may have failed[/yellow]", ctx=ctx)

--- a/tests/fixtures/phase10_cli_contract_baseline.json
+++ b/tests/fixtures/phase10_cli_contract_baseline.json
@@ -1354,6 +1354,24 @@
           "type": {
             "name": "boolean"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Delete a notebook."

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -599,6 +599,109 @@ class TestNotebookDelete:
             assert result.exit_code == 0
             assert "Delete may have failed" in result.output
 
+    def test_notebook_delete_json(self, runner, mock_auth):
+        """--json with --yes emits a parseable success envelope (issue #1167)."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(
+                        id="nb_to_delete",
+                        title="Test Notebook",
+                        created_at=datetime(2024, 1, 1),
+                        is_owner=True,
+                    ),
+                ]
+            )
+            mock_client.notebooks.delete = AsyncMock(return_value=True)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["delete", "-n", "nb_to_delete", "--json", "-y"])
+
+            assert result.exit_code == 0
+            payload = json.loads(result.output)
+            assert payload == {"notebook_id": "nb_to_delete", "success": True}
+            mock_client.notebooks.delete.assert_called_once_with("nb_to_delete")
+
+    def test_notebook_delete_json_requires_yes(self, runner, mock_auth):
+        """--json without --yes refuses to prompt and emits a typed error (issue #1167)."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(
+                        id="nb_to_delete",
+                        title="Test Notebook",
+                        created_at=datetime(2024, 1, 1),
+                        is_owner=True,
+                    ),
+                ]
+            )
+            mock_client.notebooks.delete = AsyncMock(return_value=True)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["delete", "-n", "nb_to_delete", "--json"])
+
+            assert result.exit_code == 1
+            payload = json.loads(result.output)
+            assert payload["error"] is True
+            assert payload["code"] == "VALIDATION_ERROR"
+            assert payload["notebook_id"] == "nb_to_delete"
+            assert payload["success"] is False
+            mock_client.notebooks.delete.assert_not_called()
+
+    def test_notebook_delete_json_clears_context_if_current(self, runner, mock_auth, tmp_path):
+        """--json delete of the current notebook clears context and reports it (issue #1167)."""
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_to_delete"}')
+
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(
+                        id="nb_to_delete",
+                        title="Test Notebook",
+                        created_at=datetime(2024, 1, 1),
+                        is_owner=True,
+                    ),
+                ]
+            )
+            mock_client.notebooks.delete = AsyncMock(return_value=True)
+            mock_client_cls.return_value = mock_client
+
+            with (
+                patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
+                patch(
+                    "notebooklm.cli.notebook_cmd.get_current_notebook", return_value="nb_to_delete"
+                ),
+                patch("notebooklm.cli.notebook_cmd.clear_context") as mock_clear,
+                patch(
+                    "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+                ) as mock_fetch,
+            ):
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["delete", "-n", "nb_to_delete", "--json", "-y"])
+
+            assert result.exit_code == 0
+            payload = json.loads(result.output)
+            assert payload == {
+                "notebook_id": "nb_to_delete",
+                "success": True,
+                "context_cleared": True,
+            }
+            mock_clear.assert_called_once()
+
 
 # =============================================================================
 # NOTEBOOK RENAME TESTS

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -636,6 +636,9 @@ JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
     ("auth", "check"): _AUTH_RATIONALE,
     ("auth", "inspect"): _AUTH_RATIONALE,
     ("configure",): _AUTH_RATIONALE,
+    # top-level notebook `delete` mutation — success path is covered by
+    # tests/unit/cli/test_notebook.py::TestNotebookDelete.
+    ("delete",): _MUTATION_RATIONALE_SUCCESS,
     # download group — success path needs a real artifact + HTTP fetch.
     ("download", "audio"): _DOWNLOAD_RATIONALE_SUCCESS,
     ("download", "cinematic-video"): _DOWNLOAD_RATIONALE_SUCCESS,
@@ -706,6 +709,9 @@ JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
     ("auth", "check"): _AUTH_RATIONALE,
     ("auth", "inspect"): _AUTH_RATIONALE,
     ("configure",): _AUTH_RATIONALE,
+    # top-level notebook `delete` mutation — error path is covered by
+    # tests/unit/cli/test_notebook.py::TestNotebookDelete.
+    ("delete",): _MUTATION_RATIONALE_ERROR,
     # download group — these error paths are covered for audio/video/...; the
     # remaining download_* cases below haven't been added yet.
     ("download", "cinematic-video"): _DOWNLOAD_RATIONALE_ERROR,


### PR DESCRIPTION
## Summary

`notebook delete` was the only delete command — and the only sibling of `list`/`create`/`metadata` — without a `--json` flag. It hardcoded `json_output=False` in its `run_confirmed_mutation` call, so `notebooklm delete -n X --json` crashed with Click exit 2 (`Error: No such option: --json`), leaving the most destructive command with no machine-safe envelope.

## Root cause

`delete_cmd` in `src/notebooklm/cli/notebook_cmd.py` never declared a `--json` option and passed `json_output=False` literally, unlike `note delete`, `artifact delete`, and `source delete`.

## Fix

- Add the shared `@json_option` decorator and thread `json_output` through `resolve_notebook_id` and `run_confirmed_mutation`.
- On success, emit the `{notebook_id, success}` envelope via `json_output_response`, matching the existing `serialize_success` shape.
- In JSON mode, refuse to prompt (an interactive `click.confirm` would corrupt stdout): require `--yes` and otherwise emit a typed `VALIDATION_ERROR` envelope with exit 1 — the same JSON-mode confirmation contract used by `note delete`.
- Context-clearing on deletion of the active notebook now runs in both text and JSON modes; JSON callers see `context_cleared: true` in the payload so they don't leave a stale active-notebook pointer behind.

## Tests

- `test_notebook_delete_json` — `--json -y` emits `{"notebook_id", "success": true}` with exit 0.
- `test_notebook_delete_json_requires_yes` — `--json` without `-y` emits the typed `VALIDATION_ERROR` envelope with exit 1 and does not call delete.
- `test_notebook_delete_json_clears_context_if_current` — deleting the active notebook in JSON mode clears context and reports `context_cleared`.
- Regenerated the phase10 CLI contract baseline (only delta is the new `--json` option on `delete`).
- Documented the flag in `docs/cli-reference.md`.

## Verification

- `uv run pytest` (CLI unit, contract, and notebook integration suites pass; the only failure is the documented pre-existing `test_account_different_existing_profile_account_aborts_without_confirm` terminal-width artifact, unrelated to this change).
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run ruff format` / `ruff check` — clean.

Closes #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to the `delete` command for structured, machine-readable output.
  * JSON mode returns a structured envelope with notebook ID and success, and includes `context_cleared` when the active notebook is removed.
  * Deleting the active notebook now clears its context; JSON mode requires `--yes` and refuses interactive prompts.

* **Documentation**
  * Updated CLI reference for notebook delete JSON behavior.

* **Tests**
  * Added unit tests verifying JSON success/error envelopes and context-clearing behavior; updated JSON purity waivers.

* **Chores**
  * Updated CLI contract/fixture to include `--json`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->