### PR TITLE
fix(cli): reject stdin source add non-text type

### DIFF
--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -655,9 +655,18 @@ def source_add(
     ``--type text`` to suppress.
     """
     # Unix ``-`` convention: ``source add -`` reads inline text from stdin and
-    # forces the text-source path. Intercepted BEFORE auto-detection so a
-    # single dash never falls into the path-shaped warning.
+    # forces the text-source path. Explicit non-text types are rejected so
+    # intent is not silently overwritten.
     if content == "-":
+        if source_type not in {None, "text"}:
+            message = (
+                "Cannot use '-' (stdin) with --type "
+                f"{source_type}; stdin content can only be added as text."
+            )
+            if json_output:
+                _output_error(message, "VALIDATION_ERROR", json_output, 1)
+                raise AssertionError("unreachable") from None  # pragma: no cover
+            raise click.UsageError(message)
         content = read_stdin_text(source_label="source content")
         source_type = "text"
 

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -3117,6 +3117,73 @@ class TestSourceAddStdinDash:
             assert call.args[1] == "My Title"
             assert call.args[2] == "hello world"
 
+    def test_source_add_dash_with_explicit_text_type_reads_stdin(self, runner, mock_auth):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_text = AsyncMock(
+                return_value=Source(id="src_text", title="Pasted Text")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "add", "-", "--type", "text", "-n", "nb_123"],
+                    input="typed stdin\n",
+                )
+
+            assert result.exit_code == 0, result.output
+            mock_client.sources.add_text.assert_awaited_once()
+            call = mock_client.sources.add_text.call_args
+            assert call.args[2] == "typed stdin"
+
+    @pytest.mark.parametrize("source_type", ["url", "file", "youtube"])
+    def test_source_add_dash_rejects_non_text_type(self, runner, mock_auth, source_type):
+        with (
+            patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls,
+            patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "add", "-", "--type", source_type, "-n", "nb_123"],
+                input="content from stdin\n",
+            )
+
+        assert result.exit_code == 2
+        assert f"Cannot use '-' (stdin) with --type {source_type}" in result.output
+        mock_client_cls.assert_not_called()
+
+    def test_source_add_dash_rejects_non_text_type_json(self, runner, mock_auth):
+        with (
+            patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls,
+            patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "add", "-", "--type", "url", "-n", "nb_123", "--json"],
+                input="content from stdin\n",
+            )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data == {
+            "error": True,
+            "code": "VALIDATION_ERROR",
+            "message": (
+                "Cannot use '-' (stdin) with --type url; stdin content can only be added as text."
+            ),
+        }
+        mock_client_cls.assert_not_called()
+
     def test_source_add_literal_dash_path_unchanged(self, runner, mock_auth):
         """Regression: a normal text argument is not treated as stdin."""
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:


### PR DESCRIPTION
## Summary
- Reject `source add -` when `--type` is explicitly set to `url`, `file`, or `youtube` instead of silently overriding it to text.
- Preserve stdin text ingestion for implicit type detection and explicit `--type text`.
- Add focused CLI regression coverage for text, non-text, and JSON error paths.

Closes #1174

## Test plan
- [x] `uv run pytest tests/unit/cli/test_source.py::TestSourceAddStdinDash -q`
- [x] `uv run pytest tests/unit/cli/test_source.py -q`
- [x] `uv run pytest -q`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Optional: generalize the existing source add-research flag-conflict helper for reuse by this validation path. Deferred because it would broaden this bug fix beyond issue #1174.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `source add` with stdin input. The command now properly rejects incompatible `--type` values (url, file, youtube) when reading from stdin, displaying a clear validation error. Only `--type text` is supported for stdin input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->