### PR TITLE
fix(artifacts): report delisted artifacts as "removed", not "failed"

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1755,7 +1755,7 @@ Returned by `poll_status`, `wait_for_completion`, and most artifact generation m
 @dataclass
 class GenerationStatus:
     task_id: str                          # Same value as Artifact.id once complete
-    status: str                           # "pending" | "in_progress" | "completed" | "failed" | "not_found"
+    status: str                           # "pending" | "in_progress" | "completed" | "failed" | "not_found" | "removed"
     url: str | None = None                # Populated for media artifacts when status == "completed"
     error: str | None = None
     error_code: str | None = None         # e.g. "USER_DISPLAYABLE_ERROR" for rate limits
@@ -1786,12 +1786,26 @@ class GenerationStatus:
         has either not yet appeared (brief lag after creation) or was
         silently removed server-side (e.g. after a daily-quota rejection).
         ``wait_for_completion`` treats a sustained run of ``not_found``
-        responses as a failure — see its ``max_not_found`` parameter.
+        responses as a *removal* — see its ``max_not_found`` parameter and
+        ``is_removed``.
+        """
+
+    @property
+    def is_removed(self) -> bool:
+        """Check if the artifact was delisted by the server.
+
+        Set by ``wait_for_completion`` when an artifact disappears from the
+        listing for a sustained run of polls (``max_not_found``). Kept
+        *distinct* from ``is_failed``: a *failed* artifact still exists in the
+        listing with a terminal FAILED status, whereas a *removed* artifact
+        vanished entirely — usually a daily-quota rejection, possibly a
+        transient list omission. Branch on this when a delisting and a real
+        terminal failure warrant different handling.
         """
 
     @property
     def is_rate_limited(self) -> bool:
-        """Check if generation failed due to rate limiting."""
+        """Check if generation failed (or was removed) due to rate limiting."""
 ```
 
 **`url` semantics:** `poll_status` populates `url` for media artifact types (audio, video, infographic, slide-deck PDF) as soon as the server reports the asset as ready. Slide decks expose the PDF URL here; for the editable PowerPoint, use `client.artifacts.download_slide_deck(..., output_format="pptx")` instead.

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -355,7 +355,10 @@ class ArtifactPollingService:
 
             # Track consecutive and total "not found" responses. The API may
             # remove quota-rejected artifacts from the list entirely instead
-            # of setting them to FAILED.
+            # of setting them to FAILED.  Sustained removal is reported with a
+            # distinct ``"removed"`` status (see below) rather than ``"failed"``
+            # so callers can tell a delisted artifact apart from one the server
+            # actually marked terminal-FAILED.
             if status.status == "not_found":
                 consecutive_not_found += 1
                 total_not_found += 1
@@ -378,24 +381,31 @@ class ArtifactPollingService:
                     )
                     logger.warning(
                         "Artifact %s disappeared from list (%s not-found polls, "
-                        "%s) — treating as failed",
+                        "%s) — treating as removed",
                         task_id,
                         trigger,
                         f"elapsed={not_found_elapsed:.1f}s",
                     )
-                    failed_status = GenerationStatus(
+                    # Report removal with a distinct ``"removed"`` status, not
+                    # ``"failed"``. The artifact vanished from the listing
+                    # (commonly a daily-quota rejection, possibly a transient
+                    # omission) — that is not the same as the server marking it
+                    # terminal-FAILED, and conflating the two would mask a real
+                    # failure or fabricate one. The error text is retained so
+                    # exception-free callers still get an actionable message.
+                    removed_status = GenerationStatus(
                         task_id=task_id,
-                        status="failed",
+                        status="removed",
                         error=(
-                            "Generation failed: artifact was removed by the server. "
-                            "This may indicate a daily quota/rate limit was exceeded, "
-                            "an invalid notebook ID, or a transient API issue. "
-                            "Try again later."
+                            "Generation incomplete: artifact was removed from the "
+                            "list by the server. This may indicate a daily "
+                            "quota/rate limit was exceeded, an invalid notebook "
+                            "ID, or a transient API issue. Try again later."
                         ),
                     )
-                    if on_status_change is not None and last_emitted_status != "failed":
-                        await maybe_await_callback(on_status_change, failed_status)
-                    return failed_status
+                    if on_status_change is not None and last_emitted_status != "removed":
+                        await maybe_await_callback(on_status_change, removed_status)
+                    return removed_status
             else:
                 consecutive_not_found = 0
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -673,11 +673,14 @@ class ArtifactsAPI:
             poll_interval: Deprecated. Use initial_interval instead. Scheduled
                 for removal in v0.6.0.
             max_not_found: Consecutive "not found" polls before treating
-                the task as failed.  When the API removes an artifact
+                the task as *removed*.  When the API removes an artifact
                 from the list (e.g. after a daily-quota rejection), the
-                poller would otherwise spin until *timeout*.  Defaults
-                to 5 to tolerate brief replication lag and slow networks.
-                (Leader only.)
+                poller would otherwise spin until *timeout*.  The returned
+                status is ``"removed"`` (see :attr:`GenerationStatus.is_removed`),
+                kept distinct from ``"failed"`` so a delisted artifact is not
+                conflated with one the server actually marked terminal-FAILED.
+                Defaults to 5 to tolerate brief replication lag and slow
+                networks. (Leader only.)
             min_not_found_window: Minimum seconds that must have elapsed
                 since the *first* not-found response before a consecutive
                 run triggers failure.  This avoids false positives on

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -319,7 +319,7 @@ class GenerationStatus:
     """
 
     task_id: str  # Same as artifact_id - used for polling and becomes Artifact.id
-    status: str  # "pending", "in_progress", "completed", "failed", "not_found"
+    status: str  # "pending", "in_progress", "completed", "failed", "not_found", "removed"
     url: str | None = None
     error: str | None = None
     error_code: str | None = None  # e.g., "USER_DISPLAYABLE_ERROR" for rate limits
@@ -357,18 +357,38 @@ class GenerationStatus:
         daily-quota rejection).
 
         ``wait_for_completion`` treats a sustained run of ``not_found``
-        responses as a failure — see its ``max_not_found`` parameter.
+        responses as a *removal* — see its ``max_not_found`` parameter and
+        :attr:`is_removed`.
         """
         return self.status == "not_found"
+
+    @property
+    def is_removed(self) -> bool:
+        """Check if the artifact was delisted by the server.
+
+        This status is set by ``wait_for_completion()`` when an artifact
+        disappears from the listing for a sustained run of polls (see its
+        ``max_not_found`` parameter). It is deliberately *distinct* from
+        :attr:`is_failed`: a ``failed`` artifact still exists in the listing
+        with a terminal FAILED status, whereas a ``removed`` artifact vanished
+        from the listing entirely — typically after a daily-quota rejection,
+        but possibly a transient list omission. Conflating the two would mask
+        a genuine terminal failure as a transient hiccup, or vice versa, so
+        callers that need to react differently can branch on this property.
+        """
+        return self.status == "removed"
 
     @property
     def is_rate_limited(self) -> bool:
         """Check if generation failed due to rate limiting or quota exceeded.
 
         Returns True when the API rejected the request, typically due to
-        too many requests or quota exhaustion.
+        too many requests or quota exhaustion. A ``removed`` status (the
+        artifact was delisted, often after a quota rejection) is treated the
+        same as a ``failed`` status here so that rate-limit retry policies
+        keep working when the server silently drops the artifact.
         """
-        if not self.is_failed:
+        if not (self.is_failed or self.is_removed):
             return False
 
         # Prefer structured error code when available

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -216,8 +216,12 @@ def generation_outcome_from_status(status: Any, artifact_type: str) -> Generatio
     """Map a generation status payload to a command-renderable outcome."""
     is_complete = hasattr(status, "is_complete") and status.is_complete
     is_failed = hasattr(status, "is_failed") and status.is_failed
+    # A ``removed`` status (artifact delisted by the server) is distinct from
+    # ``failed`` at the API layer, but the CLI surfaces both as a non-zero-exit
+    # error since neither produced a usable artifact.
+    is_removed = hasattr(status, "is_removed") and status.is_removed
 
-    if is_failed:
+    if is_failed or is_removed:
         return GenerationOutcome(
             status="failed",
             artifact_type=artifact_type,

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -117,6 +117,7 @@ class TestGenerateAudio:
             completed_status = MagicMock()
             completed_status.is_complete = True
             completed_status.is_failed = False
+            completed_status.is_removed = False
             completed_status.url = "https://example.com/audio.mp3"
             completed_status.artifact_id = "audio_123"
             mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
@@ -151,6 +152,7 @@ class TestGenerateAudio:
             completed_status = MagicMock()
             completed_status.is_complete = True
             completed_status.is_failed = False
+            completed_status.is_removed = False
             completed_status.url = "https://example.com/audio.mp3"
             completed_status.task_id = "audio_xyz"
             mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
@@ -239,6 +241,7 @@ class TestGenerateAudio:
             completed_status = MagicMock()
             completed_status.is_complete = True
             completed_status.is_failed = False
+            completed_status.is_removed = False
             completed_status.url = "https://example.com/audio.mp3"
             completed_status.task_id = "audio_xyz"
             mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -200,8 +200,13 @@ class TestWaitForCompletionQuotaDetection:
     """wait_for_completion fails fast when artifact disappears from list."""
 
     @pytest.mark.asyncio
-    async def test_consecutive_not_found_raises_failed(self):
-        """After max_not_found consecutive not-found polls, returns failed."""
+    async def test_consecutive_not_found_returns_removed(self):
+        """After max_not_found consecutive not-found polls, returns removed.
+
+        Regression for issue #1168: a delisted artifact is reported with a
+        distinct ``"removed"`` status, *not* ``"failed"``, so callers do not
+        conflate a transient list omission with a genuine terminal failure.
+        """
         api = _make_api()
         # Always return not_found
         api.poll_status = AsyncMock(
@@ -217,7 +222,10 @@ class TestWaitForCompletionQuotaDetection:
             min_not_found_window=0.0,
         )
 
-        assert result.is_failed is True
+        assert result.is_removed is True
+        # A removal is NOT a terminal FAILED artifact — see issue #1168.
+        assert result.is_failed is False
+        assert result.status == "removed"
         assert result.error is not None
         assert "quota" in result.error.lower() or "limit" in result.error.lower()
 
@@ -270,7 +278,7 @@ class TestWaitForCompletionQuotaDetection:
         )
         elapsed = time.monotonic() - start
 
-        assert result.is_failed is True
+        assert result.is_removed is True
         # Should complete well before the 60s timeout
         assert elapsed < 5.0, f"Expected fast failure, took {elapsed:.2f}s"
 
@@ -291,7 +299,34 @@ class TestWaitForCompletionQuotaDetection:
         )
 
         assert result.is_failed is True
+        # A genuine terminal FAILED artifact must NOT be reported as removed
+        # (issue #1168: the two states must stay disjoint).
+        assert result.is_removed is False
         assert result.error == "Some server error"
+
+    @pytest.mark.asyncio
+    async def test_removed_status_invokes_status_change_callback(self):
+        """on_status_change fires once with the synthesized removed status."""
+        api = _make_api()
+        api.poll_status = AsyncMock(
+            return_value=GenerationStatus(task_id="task_abc", status="not_found")
+        )
+        observed: list[str] = []
+
+        result = await api.wait_for_completion(
+            "nb1",
+            "task_abc",
+            initial_interval=0.01,
+            max_interval=0.01,
+            max_not_found=3,
+            min_not_found_window=0.0,
+            on_status_change=lambda status: observed.append(status.status),
+        )
+
+        assert result.is_removed is True
+        # The terminal "removed" status is the last status emitted, exactly once.
+        assert observed[-1] == "removed"
+        assert observed.count("removed") == 1
 
     @pytest.mark.asyncio
     async def test_timeout_includes_last_status(self):
@@ -335,7 +370,7 @@ class TestWaitForCompletionQuotaDetection:
 
         # Should have polled exactly 5 times (default max_not_found=5)
         assert call_count == 5
-        assert result.is_failed is True
+        assert result.is_removed is True
 
     @pytest.mark.asyncio
     async def test_flickering_artifact_triggers_total_failure(self):
@@ -373,9 +408,10 @@ class TestWaitForCompletionQuotaDetection:
             min_not_found_window=0.0,
         )
 
-        assert result.is_failed is True
+        assert result.is_removed is True
+        assert result.is_failed is False
         assert result.error is not None
-        assert "removed by the server" in result.error
+        assert "removed from the list by the server" in result.error
 
     @pytest.mark.asyncio
     async def test_last_status_set_before_timeout(self):
@@ -475,6 +511,49 @@ class TestGenerationStatusIsNotFound:
         assert status.is_failed is False
         assert status.is_complete is False
         assert status.is_pending is False
+
+
+# ---------------------------------------------------------------------------
+# GenerationStatus.is_removed property (issue #1168)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerationStatusIsRemoved:
+    """is_removed identifies a delisted artifact, distinct from failed."""
+
+    def test_is_removed_true_for_removed_status(self):
+        status = GenerationStatus(task_id="x", status="removed")
+        assert status.is_removed is True
+
+    def test_removed_is_not_failed(self):
+        """A removed artifact is not a terminal FAILED artifact."""
+        status = GenerationStatus(task_id="x", status="removed")
+        assert status.is_failed is False
+        assert status.is_complete is False
+        assert status.is_pending is False
+        assert status.is_not_found is False
+
+    def test_failed_is_not_removed(self):
+        """A terminal FAILED artifact is not reported as removed."""
+        status = GenerationStatus(task_id="x", status="failed")
+        assert status.is_removed is False
+
+    def test_other_statuses_are_not_removed(self):
+        for value in ("pending", "in_progress", "completed", "not_found"):
+            assert GenerationStatus(task_id="x", status=value).is_removed is False
+
+    def test_removed_with_quota_error_is_rate_limited(self):
+        """A removal carrying quota wording stays rate-limit-retryable."""
+        status = GenerationStatus(
+            task_id="x",
+            status="removed",
+            error="artifact was removed; daily quota/rate limit was exceeded",
+        )
+        assert status.is_rate_limited is True
+
+    def test_removed_without_quota_wording_is_not_rate_limited(self):
+        status = GenerationStatus(task_id="x", status="removed", error="just gone")
+        assert status.is_rate_limited is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1168.

When an artifact stops appearing in the listing, the poll loop in `_artifact_polling.py` synthesized a terminal `GenerationStatus(status="failed")`. This **conflated** two genuinely-distinct conditions:

- a **delisted** artifact — vanished from the listing entirely, commonly after a daily-quota rejection but possibly a transient list omission, and
- a **genuinely failed** artifact — still present in the listing with a server-set terminal `FAILED` status code.

Callers that branch on `status` (or `.is_failed`) could no longer tell the two apart, and the masking the issue flags (a still-running / transiently-omitted generation reported as a hard failure) was silent.

## Fix

Introduce a distinct `"removed"` status, keeping it disjoint from `"failed"`:

- `GenerationStatus` gains an `is_removed` property; the new status value is documented alongside the existing ones. `is_failed` stays `False` for `"removed"` (and `is_removed` is `False` for a real `"failed"`), so the two states never collide.
- The poll loop returns `status="removed"` instead of fabricating `"failed"`. It keeps the actionable error text and the **fast-fail** behavior that motivated the original not-found heuristic (issue #239) — the loop still does not spin to `timeout`.
- `is_rate_limited` continues to treat a quota-worded removal as retryable, so the existing `with_rate_limit_retry` policy keeps working when the server silently drops the artifact.
- The CLI (`generation_outcome_from_status`) maps `"removed"` to the same non-zero-exit error outcome it already produced for the synthesized failure, so user-facing CLI behavior is unchanged; automation reading the JSON `status` now sees the more accurate `"removed"`.

## Tests

- `tests/unit/test_quota_failure_detection.py`: updated the delisting assertions from `is_failed` to `is_removed`/`is_failed is False`; added a `TestGenerationStatusIsRemoved` class and an `on_status_change` callback test for the terminal `"removed"` emission. The genuine-`failed` path test now also asserts `is_removed is False`.
- `tests/unit/cli/test_generate.py`: the `--wait` `MagicMock` fixtures now set `is_removed = False` (a MagicMock attribute is otherwise truthy).

`uv run pytest`, `uv run mypy src/notebooklm --ignore-missing-imports`, and `ruff format`/`check` all pass (the unrelated, pre-existing `test_login_multi_account` terminal-width artifact aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)