### PR TITLE
fix(concurrency): give the RPC semaphore the loop-affinity guard/reset its siblings have

### DIFF
--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -6,6 +6,7 @@ import asyncio
 from contextlib import AbstractAsyncContextManager, nullcontext
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from ._loop_affinity import assert_bound_loop
 from ._session_config import DEFAULT_MAX_CONCURRENT_RPCS
 
 _T = TypeVar("_T")
@@ -31,6 +32,15 @@ class ClientComposed:
             raise ValueError(f"max_concurrent_rpcs must be >= 1, got {max_concurrent_rpcs!r}")
         self.max_concurrent_rpcs = max_concurrent_rpcs
         self._rpc_semaphore: asyncio.Semaphore | None = None
+        # Loop-affinity guard for the lazy RPC semaphore. Captured at
+        # ``ClientLifecycle.open()`` time via :meth:`set_bound_loop` (mirroring
+        # the drain ``Condition`` / reqid ``Lock`` / refresh ``Lock`` /
+        # auth-snapshot ``Lock`` sibling primitives) and consulted by
+        # :meth:`get_rpc_semaphore` so a cross-loop call raises an actionable
+        # ``RuntimeError`` rather than reusing an ``asyncio.Semaphore`` bound
+        # to a dead loop. ``None`` is a silent no-op for standalone holders
+        # constructed without an ``open()`` (composition / unit fixtures).
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
         self._transport: SessionTransport | None = None
         self._executor: RpcExecutor | None = None
         self._chain_host: MiddlewareChainHost | None = None
@@ -96,10 +106,51 @@ class ClientComposed:
             raise RuntimeError("ClientComposed._session_collaborators already bound")
         self._session_collaborators = collaborators
 
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the affinity guard.
+
+        Called by :meth:`ClientLifecycle.open` after it captures the running
+        loop, so :meth:`get_rpc_semaphore` can short-circuit cross-loop misuse
+        before reusing the lazily-built :attr:`_rpc_semaphore` (which binds to
+        the loop it was first constructed on). Mirrors the identically-named
+        method on :class:`TransportDrainTracker`, :class:`ReqidCounter`, and
+        :class:`AuthRefreshCoordinator`. Passing ``None`` clears the binding
+        for the next ``open()`` (which will rebind to a fresh loop).
+        """
+        self._bound_loop = loop
+
+    def reset_after_open(self) -> None:
+        """Discard the lazy RPC semaphore so a reopened client rebinds it.
+
+        Called from :meth:`ClientLifecycle.open` (alongside the
+        per-collaborator ``set_bound_loop`` propagation) so a client that was
+        closed and reopened on a *different* event loop builds a fresh
+        ``asyncio.Semaphore`` on the new loop instead of reusing the stale one
+        bound to the old (now-dead) loop. On Python 3.10/3.11 reusing the
+        stale semaphore can raise "bound to a different event loop" or mispark
+        waiters; on 3.12+ the breakage is largely masked, but resetting keeps
+        the behaviour consistent across versions.
+
+        Mirrors :meth:`TransportDrainTracker.reset_after_open`. Deliberately
+        narrow: dropping the reference is enough because the semaphore is
+        reconstructed lazily on the next :meth:`get_rpc_semaphore` call from
+        inside the new loop. ``max_concurrent_rpcs`` is left untouched.
+        """
+        self._rpc_semaphore = None
+
     def get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
-        """Return the lazy per-client RPC semaphore, or a no-op context."""
+        """Return the lazy per-client RPC semaphore, or a no-op context.
+
+        The loop-affinity guard runs BEFORE the lazy ``asyncio.Semaphore``
+        allocation so a cross-loop call (semaphore created under loop A,
+        acquired from loop B) raises ``RuntimeError`` at the call site instead
+        of reusing a primitive bound to the wrong loop. The check is a silent
+        no-op when ``_bound_loop is None`` (standalone holders / unopened
+        composition fixtures), matching the sibling primitives.
+        """
         if self.max_concurrent_rpcs is None:
             return nullcontext()
+        assert_bound_loop(self._bound_loop)
         if self._rpc_semaphore is None:
             self._rpc_semaphore = asyncio.Semaphore(self.max_concurrent_rpcs)
         return self._rpc_semaphore

--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -116,7 +116,17 @@ class ClientComposed:
         method on :class:`TransportDrainTracker`, :class:`ReqidCounter`, and
         :class:`AuthRefreshCoordinator`. Passing ``None`` clears the binding
         for the next ``open()`` (which will rebind to a fresh loop).
+
+        When the loop actually changes, the cached semaphore is discarded here
+        too so this method is self-consistent even if called independently of
+        :meth:`reset_after_open` (e.g. directly in a test or a future caller):
+        a stale semaphore bound to the old loop must never be reused after a
+        rebind. The production ``open()`` path also calls
+        :meth:`reset_after_open` immediately after, so the discard is
+        idempotent there.
         """
+        if loop is not self._bound_loop:
+            self._rpc_semaphore = None
         self._bound_loop = loop
 
     def reset_after_open(self) -> None:

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -84,6 +84,7 @@ from ._session_config import CORE_LOGGER_NAME
 from .auth import AuthTokens
 
 if TYPE_CHECKING:
+    from ._client_composed import ClientComposed
     from ._cookie_persistence import CookiePersistence
     from ._reqid_counter import ReqidCounter
     from ._session_auth import AuthRefreshCoordinator
@@ -278,6 +279,7 @@ class ClientLifecycle:
         auth_coord: AuthRefreshCoordinator,
         reqid: ReqidCounter,
         cookie_persistence: CookiePersistence,
+        composed: ClientComposed,
     ) -> None:
         """Open the HTTP client connection.
 
@@ -321,6 +323,14 @@ class ClientLifecycle:
         drain_tracker.set_bound_loop(self._bound_loop)
         reqid.set_bound_loop(self._bound_loop)
         auth_coord.set_bound_loop(self._bound_loop)
+        # The RPC concurrency semaphore is the fourth loop-bound primitive
+        # propagated here (issue #1169): it was previously the only loop-bound
+        # primitive without an affinity guard or a close→reopen reset, so
+        # reopening on a different loop could reuse a stale
+        # ``asyncio.Semaphore`` and break on Python 3.10/3.11. Propagating the
+        # captured loop lets ``ClientComposed.get_rpc_semaphore`` short-circuit
+        # cross-loop misuse with the shared diagnostic.
+        composed.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
         # admits new transport work again. Wave 1 of plan
         # ``host-protocol-removal`` encapsulated the legacy direct write
@@ -329,6 +339,12 @@ class ClientLifecycle:
         # fields; the method is intentionally narrow (clears ``_draining``
         # only, leaves in-flight counters intact — see its docstring).
         drain_tracker.reset_after_open()
+        # Discard the lazy RPC semaphore so a client reopened on a different
+        # loop rebuilds it on the new loop instead of reusing the stale one
+        # bound to the prior (now-dead) loop (issue #1169). Narrow by design —
+        # the semaphore is reconstructed lazily on the next ``get_rpc_semaphore``
+        # call from inside the new loop; ``max_concurrent_rpcs`` is untouched.
+        composed.reset_after_open()
 
         # Delegate HTTP-client construction and open-time cookie baseline
         # capture to the concrete transport kernel. The lifecycle still owns

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -454,6 +454,7 @@ class NotebookLMClient:
             auth_coord=self._collaborators.auth_coord,
             reqid=self._collaborators.reqid,
             cookie_persistence=self._collaborators.cookie_persistence,
+            composed=self._composed,
         )
         return self
 

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -202,6 +202,83 @@ async def test_same_loop_use_unaffected(
     assert transport.request_count() == 100
 
 
+def test_capped_client_reopen_on_new_loop_rebinds_semaphore(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """Issue #1169: close on loop A, reopen on loop B → RPC semaphore rebinds.
+
+    Pre-fix the RPC concurrency semaphore was the only loop-bound primitive
+    without a close→reopen reset, so a capped client reopened on a different
+    loop reused a stale ``asyncio.Semaphore`` bound to the dead loop — which
+    on Python 3.10/3.11 raised "bound to a different event loop" or misparked
+    waiters when the slot was acquired. Post-fix ``ClientLifecycle.open``
+    calls ``ClientComposed.reset_after_open`` so the semaphore is rebuilt on
+    the new loop and a fan-out still completes (and is still gated by the cap).
+
+    Like the cross-loop test above, this is intentionally NOT ``async def``:
+    we own two ``asyncio.run`` calls explicitly so the open and the reopen
+    happen on two genuinely distinct loop objects.
+    """
+    transport = mock_transport_concurrent
+    transport.set_delay(0.01)
+
+    # Build a capped client once; reuse the instance across two loops.
+    core = build_client_shell_for_tests(auth=_make_auth(), max_concurrent_rpcs=2)
+
+    async def _open_swap_and_close_under_loop_a() -> None:
+        await core.__aenter__()
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        # One dispatch on loop A so the semaphore is actually constructed and
+        # bound to loop A — that is the stale primitive a naive reopen reuses.
+        await core._rpc_executor.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+        await core.close()
+
+    asyncio.run(_open_swap_and_close_under_loop_a())
+    # The reset happens on open(), not close(): the stale semaphore is still
+    # cached here, bound to the now-dead loop A.
+    assert core._composed._rpc_semaphore is not None
+
+    async def _reopen_and_dispatch_under_loop_b() -> None:
+        await core.__aenter__()
+        # reset_after_open() must have discarded the loop-A semaphore so the
+        # next get_rpc_semaphore() rebuilds it on loop B.
+        assert core._composed._rpc_semaphore is None
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        try:
+            # Fan-out on loop B. Pre-fix this would surface the cross-loop
+            # RuntimeError (3.10/3.11) when acquiring the stale slot; post-fix
+            # the semaphore is fresh and bound to loop B, so all calls succeed.
+            results = await asyncio.gather(
+                *[core._rpc_executor.rpc_call(RPCMethod.LIST_NOTEBOOKS, []) for _ in range(8)]
+            )
+        finally:
+            await core.close()
+        assert len(results) == 8
+        assert all(r == [] for r in results)
+        # The cap was still honoured on the rebound semaphore.
+        assert transport.get_peak_inflight() <= 2
+
+    asyncio.run(_reopen_and_dispatch_under_loop_b())
+
+
 async def test_bound_loop_captured_on_open(
     mock_transport_concurrent: ConcurrentMockTransport,
 ) -> None:

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -526,20 +526,76 @@ def test_reset_after_open_discards_lazy_semaphore() -> None:
     asyncio.run(_exercise())
 
 
-def test_set_bound_loop_none_clears_binding() -> None:
-    """``set_bound_loop(None)`` re-arms the silent-no-op path for the next open."""
+def test_set_bound_loop_none_clears_binding_and_discards_semaphore() -> None:
+    """``set_bound_loop(None)`` re-arms the no-op path and drops the stale semaphore."""
 
     async def _exercise() -> None:
         holder = ClientComposed(max_concurrent_rpcs=2)
         holder.set_bound_loop(asyncio.get_running_loop())
-        assert holder._bound_loop is asyncio.get_running_loop()
+        async with holder.get_rpc_semaphore():
+            pass
+        assert holder._rpc_semaphore is not None
+        # Clearing the binding is a loop change (loop -> None), so the cached
+        # semaphore bound to the old loop is discarded for self-consistency.
         holder.set_bound_loop(None)
         assert holder._bound_loop is None
+        assert holder._rpc_semaphore is None
         # With the binding cleared the guard is a no-op again.
         async with holder.get_rpc_semaphore():
             pass
 
     asyncio.run(_exercise())
+
+
+def test_set_bound_loop_same_loop_keeps_cached_semaphore() -> None:
+    """Re-binding to the *same* loop must NOT discard the live semaphore.
+
+    Idempotent ``set_bound_loop`` calls with the unchanged loop are a no-op on
+    the cache — only a genuine loop change invalidates it.
+    """
+
+    async def _exercise() -> None:
+        holder = ClientComposed(max_concurrent_rpcs=2)
+        loop = asyncio.get_running_loop()
+        holder.set_bound_loop(loop)
+        async with holder.get_rpc_semaphore():
+            pass
+        first = holder._rpc_semaphore
+        assert first is not None
+        # Same loop again — the cached semaphore survives.
+        holder.set_bound_loop(loop)
+        assert holder._rpc_semaphore is first
+
+    asyncio.run(_exercise())
+
+
+def test_set_bound_loop_different_loop_discards_stale_semaphore() -> None:
+    """A loop change via ``set_bound_loop`` alone discards the stale semaphore.
+
+    This pins the gemini-flagged self-consistency contract: even without a
+    matching ``reset_after_open`` call, rebinding to a different loop must
+    invalidate the semaphore bound to the previous loop so it is never reused.
+    """
+    holder = ClientComposed(max_concurrent_rpcs=2)
+
+    async def _bind_and_build_under_loop_a() -> None:
+        holder.set_bound_loop(asyncio.get_running_loop())
+        async with holder.get_rpc_semaphore():
+            pass
+
+    asyncio.run(_bind_and_build_under_loop_a())
+    assert holder._rpc_semaphore is not None
+
+    async def _rebind_under_loop_b() -> None:
+        # set_bound_loop to a genuinely different loop must drop the stale
+        # semaphore so the next get_rpc_semaphore() rebuilds on loop B.
+        holder.set_bound_loop(asyncio.get_running_loop())
+        assert holder._rpc_semaphore is None
+        async with holder.get_rpc_semaphore():
+            pass
+        assert holder._rpc_semaphore is not None
+
+    asyncio.run(_rebind_under_loop_b())
 
 
 def test_client_shell_reads_composition_from_client_composed() -> None:

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -409,6 +409,139 @@ def test_client_composed_properties_raise_before_binding(attr_name: str, message
         getattr(holder, attr_name)
 
 
+# ---------------------------------------------------------------------------
+# ClientComposed RPC-semaphore loop-affinity guard / reset (issue #1169)
+# ---------------------------------------------------------------------------
+
+
+def test_get_rpc_semaphore_returns_nullcontext_when_cap_is_none() -> None:
+    """``max_concurrent_rpcs=None`` short-circuits to a no-op context.
+
+    The affinity guard MUST NOT run on the unbounded opt-out path — there is
+    no loop-bound primitive to protect, so even an unset binding is fine.
+    """
+    from contextlib import nullcontext
+
+    holder = ClientComposed(max_concurrent_rpcs=None)
+    # No ``set_bound_loop`` call — the None-cap path never touches the guard.
+    ctx = holder.get_rpc_semaphore()
+    assert isinstance(ctx, type(nullcontext()))
+
+
+def test_get_rpc_semaphore_no_binding_is_silent_noop() -> None:
+    """An unbound holder builds the semaphore without raising.
+
+    Mirrors the sibling primitives: ``assert_bound_loop(None)`` is a silent
+    no-op so standalone holders (composition / unit fixtures) that never ran
+    ``open()`` keep working.
+    """
+
+    async def _exercise() -> None:
+        holder = ClientComposed(max_concurrent_rpcs=2)
+        # ``_bound_loop`` is None — the guard is a no-op and the semaphore is
+        # built lazily on this running loop.
+        async with holder.get_rpc_semaphore():
+            pass
+        assert holder._rpc_semaphore is not None
+
+    asyncio.run(_exercise())
+
+
+def test_get_rpc_semaphore_same_loop_use_unaffected() -> None:
+    """A holder bound to the running loop acquires its semaphore normally."""
+
+    async def _exercise() -> None:
+        holder = ClientComposed(max_concurrent_rpcs=2)
+        holder.set_bound_loop(asyncio.get_running_loop())
+        async with holder.get_rpc_semaphore():
+            pass
+        # Same instance is reused across calls on the same loop.
+        first = holder._rpc_semaphore
+        async with holder.get_rpc_semaphore():
+            pass
+        assert holder._rpc_semaphore is first
+
+    asyncio.run(_exercise())
+
+
+def test_get_rpc_semaphore_cross_loop_raises_actionable_runtime_error() -> None:
+    """A holder bound to loop A raises if its semaphore is acquired on loop B.
+
+    Two independent ``asyncio.run`` calls give two genuinely distinct loops.
+    The guard must fire with the shared loop-affinity diagnostic before the
+    stale ``asyncio.Semaphore`` (bound to the dead loop A) is reused.
+    """
+    holder = ClientComposed(max_concurrent_rpcs=2)
+
+    async def _bind_under_loop_a() -> None:
+        holder.set_bound_loop(asyncio.get_running_loop())
+        # Construct the semaphore on loop A so loop B would reuse a stale one.
+        async with holder.get_rpc_semaphore():
+            pass
+
+    asyncio.run(_bind_under_loop_a())
+    assert holder._rpc_semaphore is not None
+
+    async def _acquire_under_loop_b() -> None:
+        with pytest.raises(RuntimeError, match="bound to a different event loop"):
+            async with holder.get_rpc_semaphore():
+                pass
+        # The actionable second sentence tells users how to fix it.
+        try:
+            async with holder.get_rpc_semaphore():
+                pass
+        except RuntimeError as exc:
+            assert "create a new client in the target loop" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected RuntimeError on cross-loop reuse")
+
+    asyncio.run(_acquire_under_loop_b())
+
+
+def test_reset_after_open_discards_lazy_semaphore() -> None:
+    """``reset_after_open`` drops the cached semaphore so the next call rebuilds.
+
+    This is what lets a client closed on loop A and reopened on loop B build a
+    fresh semaphore bound to loop B rather than reusing the stale one. The cap
+    itself is left untouched.
+    """
+
+    async def _exercise() -> None:
+        holder = ClientComposed(max_concurrent_rpcs=3)
+        holder.set_bound_loop(asyncio.get_running_loop())
+        async with holder.get_rpc_semaphore():
+            pass
+        first = holder._rpc_semaphore
+        assert first is not None
+
+        holder.reset_after_open()
+        assert holder._rpc_semaphore is None
+        assert holder.max_concurrent_rpcs == 3
+
+        async with holder.get_rpc_semaphore():
+            pass
+        assert holder._rpc_semaphore is not None
+        assert holder._rpc_semaphore is not first
+
+    asyncio.run(_exercise())
+
+
+def test_set_bound_loop_none_clears_binding() -> None:
+    """``set_bound_loop(None)`` re-arms the silent-no-op path for the next open."""
+
+    async def _exercise() -> None:
+        holder = ClientComposed(max_concurrent_rpcs=2)
+        holder.set_bound_loop(asyncio.get_running_loop())
+        assert holder._bound_loop is asyncio.get_running_loop()
+        holder.set_bound_loop(None)
+        assert holder._bound_loop is None
+        # With the binding cleared the guard is a no-op again.
+        async with holder.get_rpc_semaphore():
+            pass
+
+    asyncio.run(_exercise())
+
+
 def test_client_shell_reads_composition_from_client_composed() -> None:
     client = build_client_shell_for_tests(_make_auth())
 

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -135,6 +135,14 @@ class _StubHost:
         self._auth_coord.cancel_inflight_refresh = AsyncMock()
         # ``_reqid`` is targeted by ``set_bound_loop`` from open() (P0-2).
         self._reqid = MagicMock()
+        # ``open()`` also propagates the bound loop into the composition
+        # holder and resets the lazy RPC semaphore (issue #1169): it calls
+        # ``composed.set_bound_loop(loop)`` and ``composed.reset_after_open()``
+        # so a client reopened on a different loop rebuilds the semaphore on
+        # the new loop. The ``MagicMock`` default lets both calls land
+        # without configuring side effects; the invocations are asserted by
+        # ``test_open_captures_bound_loop_and_resets_drain``.
+        self._composed = MagicMock()
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
@@ -182,6 +190,7 @@ async def _open(lifecycle: ClientLifecycle, host: _StubHost) -> None:
         auth_coord=host._auth_coord,
         reqid=host._reqid,
         cookie_persistence=host.cookie_persistence,
+        composed=host._composed,
     )
 
 
@@ -251,6 +260,11 @@ async def test_open_captures_bound_loop_and_resets_drain() -> None:
     assert lifecycle._bound_loop is asyncio.get_running_loop()
     assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
     host._drain_tracker.reset_after_open.assert_called_once_with()
+    # Issue #1169: the composition holder is the fourth loop-bound primitive
+    # and must receive the same set_bound_loop / reset_after_open treatment as
+    # the drain tracker so the lazy RPC semaphore rebinds on close→reopen.
+    host._composed.set_bound_loop.assert_called_once_with(asyncio.get_running_loop())
+    host._composed.reset_after_open.assert_called_once_with()
 
     await _close(lifecycle, host)
 


### PR DESCRIPTION
## Root cause

The per-client RPC concurrency semaphore was the **only** loop-bound primitive without an affinity guard or a close→reopen reset.

- `ClientComposed.get_rpc_semaphore()` lazily constructed an `asyncio.Semaphore(...)` once and never reset it; `ClientComposed` had no `set_bound_loop`.
- Every sibling loop-bound primitive — the drain `Condition`, the reqid `Lock`, the refresh `Lock`, and the auth-snapshot `Lock` — receives `set_bound_loop()` in `ClientLifecycle.open()` and is protected by `assert_bound_loop`.

The lifecycle documents close→reopen on a different loop as supported. On Python 3.10/3.11, reusing the stale `asyncio.Semaphore` on the new loop (when `max_concurrent_rpcs` is set) can raise "bound to a different event loop" or mispark waiters. Masked on 3.12+.

## Fix

Mirror the sibling pattern exactly:

- Add `_bound_loop` + `set_bound_loop()` to `ClientComposed`.
- Guard `get_rpc_semaphore()` with `assert_bound_loop(self._bound_loop)` before the lazy build (silent no-op when unbound; skipped entirely on the `max_concurrent_rpcs=None` unbounded path).
- Add `reset_after_open()` (mirroring `TransportDrainTracker.reset_after_open`) that discards the cached semaphore so a reopened client rebuilds it on the new loop; `max_concurrent_rpcs` is left untouched.
- `ClientLifecycle.open()` propagates the captured loop into the holder and resets it alongside the drain tracker; `NotebookLMClient.__aenter__` threads the holder through.

The middleware already calls `composed.get_rpc_semaphore` as a per-invocation factory, so it observes the rebound semaphore after a reset with no further wiring changes.

## Tests

- **Unit** (`test_composition_primitives.py`): `None`-cap stays `nullcontext` (no guard), unbound holder is a silent no-op, same-loop reuse works, cross-loop acquire raises the actionable `RuntimeError`, `reset_after_open` discards the semaphore (cap untouched), `set_bound_loop(None)` re-arms the no-op path.
- **Lifecycle** (`test_session_lifecycle.py`): `open()` calls `composed.set_bound_loop(loop)` and `composed.reset_after_open()`.
- **Integration** (`test_cross_loop_affinity.py`): a capped client closed on loop A and reopened on loop B rebinds the semaphore, a fan-out completes, and the cap is still honoured.

Full suite: 7111 passed, 52 skipped. `mypy` clean, `ruff` clean.

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RPC concurrency handling when a client is closed and reopened on a different event loop—concurrency caps are correctly rebound and no longer become stale.
  * Improved validation and actionable error messages to prevent cross-loop misuse; guidance now directs creating a new client in the target loop.

* **Tests**
  * Added integration test for concurrency caps across event-loop reopenings.
  * Added unit tests covering loop-affinity and semaphore lifecycle behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->