### PR TITLE
fix: harden validation and refresh follow-up docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ RPC Layer (rpc/)
 | `_mind_map.py` | Specific adapter service representing mind-maps, backed by standard notes |
 | `_artifact_downloads.py` | Asynchronous download coordinator for finished artifacts |
 | `_artifact_formatters.py` | Markdown, HTML, and plain text formatters for artifacts |
-| `_artifact_generation.py` | Extracted artifact generation payload-building service |
+| `_artifact_generation.py` | Artifact generation orchestration/service |
 | `_artifact_payloads.py` | Stable CREATE_ARTIFACT / GENERATE_MIND_MAP request payload builders |
 | `_artifact_listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact_polling.py` | Poll coordination service for artifact generation tasks |
@@ -226,8 +226,8 @@ src/notebooklm/
 ├── _mind_map.py                 # NoteBackedMindMapService
 ├── _artifact_downloads.py       # Artifact download coordinator
 ├── _artifact_formatters.py      # Artifact formatting helpers
-├── _artifact_generation.py      # Artifact generation payload builder
-├── _artifact_payloads.py        # Artifact request payload builders
+├── _artifact_generation.py      # Artifact generation orchestration/service
+├── _artifact_payloads.py        # Stable artifact request payload builders
 ├── _artifact_listing.py         # Artifact listing helper
 ├── _artifact_polling.py         # Artifact polling coordinator
 ├── _source_add.py               # Source addition coordinator

--- a/docs/adr/0005-idempotency-taxonomy.md
+++ b/docs/adr/0005-idempotency-taxonomy.md
@@ -14,6 +14,12 @@ policy and executor token-injection hook. No current `RPCMethod` has a
 verified client-token slot, so keeping the policy made the registry
 advertise a dead retry-safety mechanism.
 
+Amended again on 2026-05-29 after the registry audit was completed:
+the production `IDEMPOTENCY_REGISTRY` now has an explicit entry for
+every active `RPCMethod`. `UNCLASSIFIED` remains only as a hand-built
+placeholder for tests and future development, not as the production
+classification for read-only RPCs.
+
 ## Context
 
 The NotebookLM RPC surface is `batchexecute` over HTTPS, and any mutating call (create, delete, refresh, share, generate, …) is susceptible to a *commit-lost* failure: the server commits the write, then the response is lost in transit. A naive retry produces a duplicate write — a duplicate notebook, a duplicate source, an extra LLM inference, a re-sent invite email — depending on the RPC.
@@ -24,7 +30,7 @@ Five retry-safety profiles cover every verified NotebookLM RPC shape:
 
 | Policy | Meaning | Effect on the inner retry loop |
 |---|---|---|
-| `UNCLASSIFIED` | Placeholder; never classified | Silent, retries enabled (preserves pre-taxonomy behavior) |
+| `UNCLASSIFIED` | Placeholder for hand-built test/future registries; not used by the production registry for active RPCs | Silent, retries enabled (preserves pre-taxonomy behavior) |
 | `PROBE_THEN_CREATE` | Caller owns a probe loop; transport must not blind-retry | Force-disable inner retries |
 | `IDEMPOTENT_SET_OP` | Server applies set semantics (delete / rename) | Retries are safe; left enabled |
 | `AT_LEAST_ONCE_ACCEPTED` | Caller has accepted duplicate-side-effect cost | Retries enabled; rate-limited WARN emitted |
@@ -36,17 +42,17 @@ The audit (`.sisyphus/plans/arch-biggest-problem-audit.md`, disease D3) flagged 
 
 ## Decision
 
-Every `RPCMethod` is registered in `IDEMPOTENCY_REGISTRY` (in `_idempotency.py`) with one of five `IdempotencyPolicy` values, optionally per *operation variant* when the call-site shape differs. The registry is the single source of truth consumed by `RpcExecutor`.
+Every active `RPCMethod` is registered in `IDEMPOTENCY_REGISTRY` (in `_idempotency.py`) with one of five `IdempotencyPolicy` values, optionally per *operation variant* when the call-site shape differs. The registry is the single source of truth consumed by `RpcExecutor`, and the registry-audit tests fail if a new enum member keeps the default placeholder.
 
 The classification rules are:
 
-- **Read-only RPCs** are not classified (the taxonomy applies to mutating RPCs only); the executor's existing retry behavior is correct for them.
+- **Read-only RPCs** classify as `IDEMPOTENT_SET_OP`; replay is explicitly safe because the RPC does not mutate server state.
 - **Mutating RPCs with a stable server-side dedupe key** classify as `IDEMPOTENT_SET_OP` (delete / rename / set-state) — retries are explicitly safe.
 - **Mutating RPCs without a dedupe key but with a probe RPC** classify as `PROBE_THEN_CREATE`; the inner retry loop is force-disabled, and the per-API call site owns a probe-then-create wrapper (see `idempotent_create()` in `_idempotency.py` and the per-API uses in `_notebooks.py`, `_sources.py`).
 - **Mutating RPCs that produce visible side effects (emails, billing, notifications) and that the caller has explicitly opted into** classify as `AT_LEAST_ONCE_ACCEPTED`; retries are enabled but a rate-limited WARN is emitted so operators can observe the trade-off.
 - **Mutating RPCs with no dedupe key and no reliable probe** classify as `NON_IDEMPOTENT_NO_RETRY`; the inner retry loop is force-disabled and the first failure surfaces to the caller for manual disambiguation.
 
-The Wave-2 classifications shipped to date are recorded inline in `_idempotency.py` (with the per-RPC rationale captured at the registration site). Future Wave-2 classifications continue to land in the same module without changes to the executor; the registry is intentionally extensible.
+The completed production classifications are recorded inline in `_idempotency.py` (with the per-RPC rationale captured at the registration site). Future classifications continue to land in the same module without changes to the executor; the registry is intentionally extensible.
 
 The five-policy axis is *closed*. Adding a sixth policy requires updating this ADR and the executor in lock-step.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,15 +247,15 @@ easy to lose during refactors. The taxonomy makes retry safety a
 **property of the call site** (re-derived every time someone touches
 the code).
 
-**The classification.** Mutating RPCs are classified into five
+**The classification.** Every active RPC is classified into one of five
 retry-safety profiles by the `IdempotencyRegistry` in
 [`_idempotency.py`](../src/notebooklm/_idempotency.py):
 
 | Policy | Meaning | Effect on the inner retry loop |
 |--------|---------|--------------------------------|
-| `UNCLASSIFIED` | Placeholder; never classified | Silent, retries enabled (preserves pre-taxonomy behavior) |
+| `UNCLASSIFIED` | Placeholder for hand-built test/future registries; not used by the production registry for active RPCs | Silent, retries enabled (preserves pre-taxonomy behavior) |
 | `PROBE_THEN_CREATE` | Caller owns a probe loop; transport must not blind-retry | Force-disable inner retries |
-| `IDEMPOTENT_SET_OP` | Server applies set semantics (delete / rename) | Retries are safe; left enabled |
+| `IDEMPOTENT_SET_OP` | Replay-safe read-only, delete, rename, or set-state RPC | Retries are safe; left enabled |
 | `AT_LEAST_ONCE_ACCEPTED` | Caller has explicitly accepted duplicate side-effect cost (emails / billing / notifications) | Retries enabled; rate-limited WARN emitted so operators can see the trade-off |
 | `NON_IDEMPOTENT_NO_RETRY` | No dedupe key and no probe; first failure must surface | Force-disable inner retries |
 
@@ -273,6 +273,12 @@ pairs each `PROBE_THEN_CREATE` entry with a `RecoveryKind` —
 `EXECUTABLE` (a probe/recovery wrapper exists) or `DISABLE_ONLY` (with a
 documented reason). A registry-audit test fails if a new
 `PROBE_THEN_CREATE` policy is added without one of those.
+
+The production registry has explicit coverage for every active
+`RPCMethod`, including read-only RPCs. Read-only entries are registered
+as replay-safe `IDEMPOTENT_SET_OP` rows rather than left as
+production-`UNCLASSIFIED`; `UNCLASSIFIED` is retained only as a
+placeholder for tests and future development.
 
 See [ADR-005](./adr/0005-idempotency-taxonomy.md). Side-effect probing
 (`idempotent_create(...)`) is a separate mechanism not owned by the
@@ -425,7 +431,7 @@ the executor on direct collaborator dependencies.
 | `ClientMetrics` | [`_client_metrics.py`](../src/notebooklm/_client_metrics.py) | Per-instance counters (`ClientMetricsSnapshot`) + the `on_rpc_event` user callback. |
 | `ReqidCounter` | [`_reqid_counter.py`](../src/notebooklm/_reqid_counter.py) | Monotonic `_reqid` for the chat backend; lock-protected `next_reqid(...)`. |
 | `CookiePersistence` | [`_cookie_persistence.py`](../src/notebooklm/_cookie_persistence.py) | Cookie-jar persistence + `__Secure-1PSIDTS` rotation. |
-| `IdempotencyRegistry` | [`_idempotency.py`](../src/notebooklm/_idempotency.py) | Policy/classification registry keyed by `(RPCMethod, operation_variant)`. `RpcExecutor._execute_once()` consults it to resolve `effective_disable_internal_retries`. It is part of the RPC dispatch path, not lifecycle state. Side-effect probing (`idempotent_create(...)`) is a separate mechanism not owned by this registry. |
+| `IdempotencyRegistry` | [`_idempotency.py`](../src/notebooklm/_idempotency.py) | Policy/classification registry keyed by `(RPCMethod, operation_variant)`. The production registry explicitly covers every active `RPCMethod`; `UNCLASSIFIED` is retained only as a placeholder for hand-built test/future registries. `RpcExecutor._execute_once()` consults it to resolve `effective_disable_internal_retries`. It is part of the RPC dispatch path, not lifecycle state. Side-effect probing (`idempotent_create(...)`) is a separate mechanism not owned by this registry. |
 | `_request_types` | [`_request_types.py`](../src/notebooklm/_request_types.py) | Owns `AuthSnapshot`, `BuildRequest`, and request materialization shapes shared by RPC, chat, auth refresh, and the chain terminal. |
 | `_transport_errors` | [`_transport_errors.py`](../src/notebooklm/_transport_errors.py) | Owns transport-level exceptions, `Retry-After` parsing, and raw `Kernel.post` error mapping consumed by `RetryMiddleware` and `AuthRefreshMiddleware`. |
 | `_streaming_post` | [`_streaming_post.py`](../src/notebooklm/_streaming_post.py) | Low-level streaming POST helper with the response-size cap used by `Kernel.post`. |

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -13,7 +13,7 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, unquote, urlparse
 
 import httpx
 
@@ -134,8 +134,8 @@ def _load_httpx_cookies(storage_path: Any) -> Any:
 def _is_trusted_download_host(hostname: str | None) -> bool:
     if hostname is None:
         return False
-    hostname = hostname.lower()
-    if "\\" in hostname:
+    hostname = unquote(hostname).lower()
+    if "\\" in hostname or "/" in hostname:
         return False
     return any(
         hostname == domain.lstrip(".") or hostname.endswith(domain)

--- a/src/notebooklm/_artifact_payloads.py
+++ b/src/notebooklm/_artifact_payloads.py
@@ -478,4 +478,11 @@ def _report_config(
             "description": "Custom format",
             "prompt": custom_prompt or "Create a report based on the provided sources.",
         }
-    return _STATIC_REPORT_CONFIGS[report_format]
+    try:
+        return _STATIC_REPORT_CONFIGS[report_format]
+    except KeyError as exc:
+        known_formats = ", ".join(format_.value for format_ in _STATIC_REPORT_CONFIGS)
+        raise ValueError(
+            f"Unsupported report format {report_format!r}; expected one of: "
+            f"{known_formats}, {ReportFormat.CUSTOM.value}"
+        ) from exc

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -765,7 +765,7 @@ _IDEMPOTENT_READ_OR_SET_OP_NOTES: dict[RPCMethod, str] = {
         "set artifact title to a caller-supplied value; replay leaves the same state"
     ),
     RPCMethod.SHARE_ARTIFACT: (
-        "legacy share toggle sets public/private state; replay leaves the same share state"
+        "legacy public share-link state update; replay leaves the same share state"
     ),
     RPCMethod.GET_INTERACTIVE_HTML: (
         "read-only artifact HTML fetch; replay does not mutate artifact state"

--- a/src/notebooklm/_sharing_manager.py
+++ b/src/notebooklm/_sharing_manager.py
@@ -36,7 +36,7 @@ class ShareManager:
     async def share(
         self, notebook_id: str, public: bool = True, artifact_id: str | None = None
     ) -> dict[str, Any]:
-        """Toggle legacy notebook sharing through ``SHARE_ARTIFACT``."""
+        """Set/update legacy public share-link state through ``SHARE_ARTIFACT``."""
         share_options = [1] if public else [0]
         params: list[Any] = [share_options, notebook_id]
         if artifact_id:

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -214,6 +214,11 @@ def _resolve_source_fulltext_output_path(
 ) -> Path:
     """Resolve ``source fulltext -o`` conflicts without silently overwriting."""
     path = Path(output)
+    if path.exists() and path.is_dir():
+        _emit_source_fulltext_flag_conflict(
+            f"Output path is a directory: {path}",
+            json_output=json_output,
+        )
     if force and no_clobber:
         _emit_source_fulltext_flag_conflict(
             "Cannot specify both --force and --no-clobber",

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -31,6 +31,7 @@ class TestAgentShow:
             result = runner.invoke(cli, ["agent", "show", "codex"])
 
         assert result.exit_code == 0
+        assert result.stderr == ""
         assert "Repository Guidelines" in result.output
 
     def test_agent_show_claude_displays_content(self, runner):
@@ -39,6 +40,7 @@ class TestAgentShow:
             result = runner.invoke(cli, ["agent", "show", "claude"])
 
         assert result.exit_code == 0
+        assert result.stderr == ""
         assert "Claude Skill" in result.output
 
     def test_agent_show_missing_content_returns_error(self, runner):

--- a/tests/unit/cli/test_source_content_rendering.py
+++ b/tests/unit/cli/test_source_content_rendering.py
@@ -273,6 +273,63 @@ def test_source_fulltext_json_output_file_no_clobber_rejects_existing_file(
     }
 
 
+def test_source_fulltext_output_rejects_directory_before_fetching(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "fulltext"
+    output_dir.mkdir()
+    client = _client_with_fulltext("content that should not be fetched")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            ["source", "fulltext", "src_1", "-n", "nb_123", "-o", str(output_dir)],
+        )
+
+    assert result.exit_code == 2, result.output
+    assert f"Output path is a directory: {output_dir}" in result.output
+    assert not result.output.strip().startswith("{")
+    client.sources.list.assert_not_awaited()
+    client.sources.get_fulltext.assert_not_awaited()
+
+
+def test_source_fulltext_json_output_rejects_directory_before_fetching(
+    runner: CliRunner,
+    mock_auth,
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "fulltext"
+    output_dir.mkdir()
+    client = _client_with_fulltext("content that should not be fetched")
+
+    with _patched_source_client(client):
+        result = runner.invoke(
+            cli,
+            [
+                "source",
+                "fulltext",
+                "src_1",
+                "-n",
+                "nb_123",
+                "--json",
+                "-o",
+                str(output_dir),
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload == {
+        "error": True,
+        "code": "VALIDATION_ERROR",
+        "message": f"Output path is a directory: {output_dir}",
+    }
+    client.sources.list.assert_not_awaited()
+    client.sources.get_fulltext.assert_not_awaited()
+
+
 def test_source_fulltext_output_file_force_overwrites_existing_file(
     runner: CliRunner,
     mock_auth,

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import re
 import warnings
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, unquote, urlparse
@@ -464,23 +465,37 @@ class TestChatNewConversationLocks:
         assert lock_a is not lock_b
 
     @pytest.mark.asyncio
-    async def test_failed_post_ask_hptbtc_lookup_releases_new_conversation_lock(self, monkeypatch):
-        chat = self._factory()
-        chat._reqid.next_reqid = AsyncMock(side_effect=[100000, 200000])
-        new_conversation_lock = chat._get_new_conversation_lock("nb-1")
+    async def test_failed_post_ask_hptbtc_lookup_releases_new_conversation_lock(self):
+        class HptbtcFailureChatAPI(ChatAPI):
+            def __init__(self, *, lookup_results: list[str | ChatError], **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self._lookup_results = iter(lookup_results)
+                self.lookup_count = 0
 
-        async def fake_chat_aware_authed_post(*args, **kwargs):  # type: ignore[no-untyped-def]
+            async def get_conversation_id(self, notebook_id: str) -> str | None:
+                self.lookup_count += 1
+                result = next(self._lookup_results)
+                if isinstance(result, ChatError):
+                    raise result
+                return result
+
+        async def fake_perform_authed_post(*args: Any, **kwargs: Any) -> httpx.Response:
             return httpx.Response(
                 200,
                 request=httpx.Request("POST", "https://notebooklm.google.com/_/LabsTailwindUi"),
                 content=_make_answer_response_body(),
             )
 
-        get_conversation_id = AsyncMock(
-            side_effect=[ChatError("hPTbtc lookup failed"), "conv-after-failure"]
+        chat = HptbtcFailureChatAPI(
+            rpc=SimpleNamespace(),
+            transport=SimpleNamespace(
+                perform_authed_post=AsyncMock(side_effect=fake_perform_authed_post)
+            ),
+            reqid=SimpleNamespace(next_reqid=AsyncMock(side_effect=[100000, 200000])),
+            loop_guard=SimpleNamespace(assert_bound_loop=lambda: None),
+            lookup_results=[ChatError("hPTbtc lookup failed"), "conv-after-failure"],
         )
-        monkeypatch.setattr("notebooklm._chat.chat_aware_authed_post", fake_chat_aware_authed_post)
-        monkeypatch.setattr(chat, "get_conversation_id", get_conversation_id)
+        new_conversation_lock = chat._get_new_conversation_lock("nb-1")
 
         with pytest.raises(ChatError, match="hPTbtc lookup failed"):
             await chat.ask("nb-1", "first ask", source_ids=["s1"])
@@ -494,7 +509,7 @@ class TestChatNewConversationLocks:
 
         assert result.conversation_id == "conv-after-failure"
         assert result.answer == "Refactor answer is long enough."
-        assert get_conversation_id.await_count == 2
+        assert chat.lookup_count == 2
 
 
 class TestBuildChatRequestFactory:

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -23,6 +23,7 @@ import json
 import re
 import warnings
 from typing import Any
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
@@ -34,6 +35,7 @@ from notebooklm import NotebookLMClient
 from notebooklm._chat import ChatAPI
 from notebooklm._request_types import AuthSnapshot
 from notebooklm.auth import AuthTokens
+from notebooklm.exceptions import ChatError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -436,11 +438,13 @@ class TestChatNewConversationLocks:
     def _factory(self) -> ChatAPI:
         from unittest.mock import MagicMock
 
+        loop_guard = MagicMock()
+        loop_guard.assert_bound_loop = MagicMock()
         return ChatAPI(
             rpc=MagicMock(),
             transport=MagicMock(),
             reqid=MagicMock(),
-            loop_guard=MagicMock(),
+            loop_guard=loop_guard,
         )
 
     def test_same_notebook_reuses_new_conversation_lock(self):
@@ -458,6 +462,39 @@ class TestChatNewConversationLocks:
         lock_b = chat._get_new_conversation_lock("nb-2")
 
         assert lock_a is not lock_b
+
+    @pytest.mark.asyncio
+    async def test_failed_post_ask_hptbtc_lookup_releases_new_conversation_lock(self, monkeypatch):
+        chat = self._factory()
+        chat._reqid.next_reqid = AsyncMock(side_effect=[100000, 200000])
+        new_conversation_lock = chat._get_new_conversation_lock("nb-1")
+
+        async def fake_chat_aware_authed_post(*args, **kwargs):  # type: ignore[no-untyped-def]
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", "https://notebooklm.google.com/_/LabsTailwindUi"),
+                content=_make_answer_response_body(),
+            )
+
+        get_conversation_id = AsyncMock(
+            side_effect=[ChatError("hPTbtc lookup failed"), "conv-after-failure"]
+        )
+        monkeypatch.setattr("notebooklm._chat.chat_aware_authed_post", fake_chat_aware_authed_post)
+        monkeypatch.setattr(chat, "get_conversation_id", get_conversation_id)
+
+        with pytest.raises(ChatError, match="hPTbtc lookup failed"):
+            await chat.ask("nb-1", "first ask", source_ids=["s1"])
+
+        assert not new_conversation_lock.locked()
+
+        result = await asyncio.wait_for(
+            chat.ask("nb-1", "second ask", source_ids=["s1"]),
+            timeout=1.0,
+        )
+
+        assert result.conversation_id == "conv-after-failure"
+        assert result.answer == "Refactor answer is long enough."
+        assert get_conversation_id.await_count == 2
 
 
 class TestBuildChatRequestFactory:

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -233,6 +233,8 @@ async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_p
         "https://attacker.evil\\.google.com/file.mp4",
         "https://attacker.evil%5c.google.com/file.mp4",
         "https://attacker.evil%5C.google.com/file.mp4",
+        "https://attacker.evil%2f.google.com/file.mp4",
+        "https://attacker.evil%2F.google.com/file.mp4",
     ],
 )
 async def test_download_batch_rejects_backslash_hostname_confusion(

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -227,10 +227,19 @@ async def test_untrusted_domain_aggregated_into_failed(mock_artifacts_api, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_download_batch_rejects_backslash_hostname_confusion(mock_artifacts_api, tmp_path):
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://attacker.evil\\.google.com/file.mp4",
+        "https://attacker.evil%5c.google.com/file.mp4",
+        "https://attacker.evil%5C.google.com/file.mp4",
+    ],
+)
+async def test_download_batch_rejects_backslash_hostname_confusion(
+    mock_artifacts_api, tmp_path, url
+):
     """Batch downloads use parsed hostname for the same allowlist guard."""
     api, _ = mock_artifacts_api
-    url = "https://attacker.evil\\.google.com/file.mp4"
 
     with _patched_httpx_client([]) as mock_client:
         result = await api._download_urls_batch([(url, str(tmp_path / "file.mp4"))])

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -144,6 +144,8 @@ class TestDownloadUrlErrorWrapping:
             "https://attacker.evil\\.google.com/file.mp4",
             "https://attacker.evil%5c.google.com/file.mp4",
             "https://attacker.evil%5C.google.com/file.mp4",
+            "https://attacker.evil%2f.google.com/file.mp4",
+            "https://attacker.evil%2F.google.com/file.mp4",
             "https://storage.googleapis.com@attacker.evil/file.mp4",
         ],
     )

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -142,6 +142,8 @@ class TestDownloadUrlErrorWrapping:
         "url",
         [
             "https://attacker.evil\\.google.com/file.mp4",
+            "https://attacker.evil%5c.google.com/file.mp4",
+            "https://attacker.evil%5C.google.com/file.mp4",
             "https://storage.googleapis.com@attacker.evil/file.mp4",
         ],
     )

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -88,6 +88,24 @@ class _FixtureSchemaError(AssertionError):
     handles ``AssertionError`` (e.g. pytest hooks, ``--tb=short``) treats
     it as a structured test failure rather than a generic exception.
     """
+
+
+def test_report_payload_unknown_format_raises_contextual_value_error() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        build_report_artifact_params(
+            "nb_payload",
+            ["src_alpha"],
+            report_format=cast(ReportFormat, "future-report-format"),
+            language="en",
+            custom_prompt=None,
+            extra_instructions=None,
+        )
+
+    message = str(exc_info.value)
+    assert "Unsupported report format" in message
+    assert "future-report-format" in message
+    assert "briefing_doc" in message
+    assert "custom" in message
 
 
 def _fixture_path(method: RPCMethod) -> Path:


### PR DESCRIPTION
## Summary
- Refresh idempotency and artifact-generation docs for the completed registry/payload ownership state.
- Harden source fulltext directory output validation, artifact download host checks, and report-format errors.
- Add focused regressions for hPTbtc lock release, agent stderr cleanliness, directory-output rejection, encoded-host rejection, and unknown report formats.

## Test plan
- `uv run pytest tests/unit/test_chat_ask_invariants.py::TestChatNewConversationLocks tests/unit/cli/test_source_content_rendering.py::test_source_fulltext_output_rejects_directory_before_fetching tests/unit/cli/test_source_content_rendering.py::test_source_fulltext_json_output_rejects_directory_before_fetching tests/unit/cli/test_agent.py::TestAgentShow tests/unit/test_download_url.py::TestDownloadUrlErrorWrapping::test_untrusted_hostname_shapes_rejected_before_streaming tests/unit/test_download_result.py::test_download_batch_rejects_backslash_hostname_confusion tests/unit/test_rpc_golden_payloads.py::test_report_payload_unknown_format_raises_contextual_value_error -q`
- `uv run ruff check src/notebooklm/_sharing_manager.py src/notebooklm/_idempotency.py src/notebooklm/cli/source_cmd.py src/notebooklm/_artifact_downloads.py src/notebooklm/_artifact_payloads.py tests/unit/test_chat_ask_invariants.py tests/unit/cli/test_source_content_rendering.py tests/unit/cli/test_agent.py tests/unit/test_download_url.py tests/unit/test_download_result.py tests/unit/test_rpc_golden_payloads.py`
- `uv run ruff format --check src/notebooklm/_sharing_manager.py src/notebooklm/_idempotency.py src/notebooklm/cli/source_cmd.py src/notebooklm/_artifact_downloads.py src/notebooklm/_artifact_payloads.py tests/unit/test_chat_ask_invariants.py tests/unit/cli/test_source_content_rendering.py tests/unit/cli/test_agent.py tests/unit/test_download_url.py tests/unit/test_download_result.py tests/unit/test_rpc_golden_payloads.py`
- `uv run mypy src/notebooklm`
- `uv run python scripts/check_claude_md_freshness.py`

## Polish notes
- Codex review fixes applied.
- Antigravity review clean.
- Claude external reviewer exceeded the 10-minute polish latency window and was recorded as timed out for the gate; late output was preserved and had no critical/important findings.
- Deferred findings: optional cleanup nits only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened download hostname validation to reject malformed/encoded hostnames.
  * Improved report-format error handling with clearer Unsupported-format errors.
  * source fulltext now rejects directory output paths with clearer validation errors.

* **Documentation**
  * Clarified idempotency taxonomy, registry behavior, and architecture guidance.
  * Updated artifact-generation description and legacy share-link wording.

* **Tests**
  * Expanded tests covering download validation, source CLI directory validation, chat lock behavior, and report-format error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->