### PR TITLE
fix(artifacts): require sustained absence before reporting an artifact 'removed'

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1801,9 +1801,10 @@ class GenerationStatus:
         never fabricated into a terminal *removed* and instead polls through to
         completion (or timeout). Kept *distinct* from ``is_failed``: a *failed*
         artifact still exists in the listing with a terminal FAILED status,
-        whereas a *removed* artifact vanished entirely — usually a daily-quota
-        rejection, possibly a sustained list omission. Branch on this when a
-        delisting and a real terminal failure warrant different handling.
+        whereas a *removed* artifact vanished from the listing and stayed gone —
+        typically a daily-quota rejection, occasionally a longer-lived server-
+        side omission. Branch on this when a delisting and a real terminal
+        failure warrant different handling.
         """
 
     @property

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1795,12 +1795,15 @@ class GenerationStatus:
         """Check if the artifact was delisted by the server.
 
         Set by ``wait_for_completion`` when an artifact disappears from the
-        listing for a sustained run of polls (``max_not_found``). Kept
-        *distinct* from ``is_failed``: a *failed* artifact still exists in the
-        listing with a terminal FAILED status, whereas a *removed* artifact
-        vanished entirely — usually a daily-quota rejection, possibly a
-        transient list omission. Branch on this when a delisting and a real
-        terminal failure warrant different handling.
+        listing for a *sustained* run of polls (``max_not_found``). The absence
+        must be sustained: a transient/flapping omission where the artifact
+        reappears resets the not-found window, so a still-progressing artifact is
+        never fabricated into a terminal *removed* and instead polls through to
+        completion (or timeout). Kept *distinct* from ``is_failed``: a *failed*
+        artifact still exists in the listing with a terminal FAILED status,
+        whereas a *removed* artifact vanished entirely — usually a daily-quota
+        rejection, possibly a sustained list omission. Branch on this when a
+        delisting and a real terminal failure warrant different handling.
         """
 
     @property

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -289,7 +289,6 @@ class ArtifactPollingService:
         deadline = RuntimeDeadline.start(timeout, monotonic=self._resolve_monotonic())
         current_interval = initial_interval
         consecutive_not_found = 0
-        total_not_found = 0
         poll_retry_count = 0
         first_not_found_time: float | None = None
         last_status: str | None = None
@@ -353,37 +352,42 @@ class ArtifactPollingService:
             if status.is_complete or status.is_failed:
                 return status
 
-            # Track the *current* run of consecutive "not found" responses plus
-            # a running total. The API may remove quota-rejected artifacts from
-            # the list entirely instead of setting them to FAILED. A *sustained*
-            # absence is reported with a distinct ``"removed"`` status (see
-            # below) rather than ``"failed"`` so callers can tell a delisted
-            # artifact apart from one the server actually marked terminal-FAILED.
+            # Track the *current* run of consecutive "not found" responses. The
+            # API may remove quota-rejected artifacts from the list entirely
+            # instead of setting them to FAILED. A *sustained* absence is
+            # reported with a distinct ``"removed"`` status (see below) rather
+            # than ``"failed"`` so callers can tell a delisted artifact apart
+            # from one the server actually marked terminal-FAILED.
             #
-            # Both accumulators reset the moment the artifact reappears (see the
+            # The counter resets the moment the artifact reappears (see the
             # ``else`` branch). This is what makes ``"removed"`` mean *stayed
             # absent*: a transient/flapping omission — where the artifact keeps
             # coming back and may still complete — never accumulates toward a
             # spurious terminal ``"removed"`` (issue #1198).
             if status.status == "not_found":
                 consecutive_not_found += 1
-                total_not_found += 1
                 now = deadline.now()
                 if first_not_found_time is None:
                     first_not_found_time = now
                 not_found_elapsed = now - first_not_found_time
 
+                # Two ways to declare a sustained absence terminal:
+                #  - time-gated: enough consecutive misses AND enough wall-clock
+                #    elapsed (avoids a fast burst of polls firing prematurely);
+                #  - window-independent: a long consecutive run (2x the
+                #    threshold) trips removal even when ``min_not_found_window``
+                #    has not yet elapsed.
                 consecutive_trigger = (
                     consecutive_not_found >= max_not_found
                     and not_found_elapsed >= min_not_found_window
                 )
-                total_trigger = total_not_found >= max_not_found * 2
+                window_independent_trigger = consecutive_not_found >= max_not_found * 2
 
-                if consecutive_trigger or total_trigger:
+                if consecutive_trigger or window_independent_trigger:
                     trigger = (
                         f"consecutive={consecutive_not_found}"
                         if consecutive_trigger
-                        else f"total={total_not_found}"
+                        else f"consecutive={consecutive_not_found} (window-independent)"
                     )
                     logger.warning(
                         "Artifact %s disappeared from list (%s not-found polls, "
@@ -413,14 +417,13 @@ class ArtifactPollingService:
                         await maybe_await_callback(on_status_change, removed_status)
                     return removed_status
             else:
-                # The artifact is back in the listing. Reset *all* not-found
-                # tracking — not just the consecutive counter — so removal
-                # requires a single sustained absence run rather than cumulative
-                # absences spread across an otherwise-healthy poll (issue #1198).
-                # An artifact that keeps reappearing is not "removed"; it keeps
-                # polling until it completes or the timeout fires.
+                # The artifact is back in the listing. Reset the not-found
+                # tracking so removal requires a single sustained absence run
+                # rather than cumulative absences spread across an otherwise-
+                # healthy poll (issue #1198). An artifact that keeps reappearing
+                # is not "removed"; it keeps polling until it completes or the
+                # timeout fires.
                 consecutive_not_found = 0
-                total_not_found = 0
                 first_not_found_time = None
 
             if deadline.exceeded():

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -353,12 +353,18 @@ class ArtifactPollingService:
             if status.is_complete or status.is_failed:
                 return status
 
-            # Track consecutive and total "not found" responses. The API may
-            # remove quota-rejected artifacts from the list entirely instead
-            # of setting them to FAILED.  Sustained removal is reported with a
-            # distinct ``"removed"`` status (see below) rather than ``"failed"``
-            # so callers can tell a delisted artifact apart from one the server
-            # actually marked terminal-FAILED.
+            # Track the *current* run of consecutive "not found" responses plus
+            # a running total. The API may remove quota-rejected artifacts from
+            # the list entirely instead of setting them to FAILED. A *sustained*
+            # absence is reported with a distinct ``"removed"`` status (see
+            # below) rather than ``"failed"`` so callers can tell a delisted
+            # artifact apart from one the server actually marked terminal-FAILED.
+            #
+            # Both accumulators reset the moment the artifact reappears (see the
+            # ``else`` branch). This is what makes ``"removed"`` mean *stayed
+            # absent*: a transient/flapping omission — where the artifact keeps
+            # coming back and may still complete — never accumulates toward a
+            # spurious terminal ``"removed"`` (issue #1198).
             if status.status == "not_found":
                 consecutive_not_found += 1
                 total_not_found += 1
@@ -407,7 +413,15 @@ class ArtifactPollingService:
                         await maybe_await_callback(on_status_change, removed_status)
                     return removed_status
             else:
+                # The artifact is back in the listing. Reset *all* not-found
+                # tracking — not just the consecutive counter — so removal
+                # requires a single sustained absence run rather than cumulative
+                # absences spread across an otherwise-healthy poll (issue #1198).
+                # An artifact that keeps reappearing is not "removed"; it keeps
+                # polling until it completes or the timeout fires.
                 consecutive_not_found = 0
+                total_not_found = 0
+                first_not_found_time = None
 
             if deadline.exceeded():
                 raise _artifact_timeout_error(

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -386,10 +386,10 @@ class TestWaitForCompletionQuotaDetection:
         """
         api = _make_api()
         # 7 not-found omissions interleaved with in_progress sightings, then a
-        # genuine completion. With max_not_found=3 the OLD total threshold was 6,
-        # so the pre-fix loop would have returned "removed" at the 6th not-found
-        # (before completing). With the reset, each in_progress wipes the
-        # accumulators, so neither the consecutive nor the total trigger fires.
+        # genuine completion. With max_not_found=3 the OLD cumulative total
+        # threshold was 6, so the pre-fix loop would have returned "removed" at
+        # the 6th not-found (before completing). With the reset, each in_progress
+        # wipes the counter, so no removal trigger ever fires.
         responses = []
         for _ in range(7):
             responses.append(GenerationStatus(task_id="task_abc", status="not_found"))
@@ -417,10 +417,10 @@ class TestWaitForCompletionQuotaDetection:
         """Sustained absence still triggers removal via the total fallback even
         when ``min_not_found_window`` blocks the consecutive trigger.
 
-        Guards the issue #1198 change: resetting accumulators on reappearance
+        Guards the issue #1198 change: resetting the counter on reappearance
         must not weaken detection of a *genuinely* delisted artifact that never
-        comes back. With a large window the consecutive trigger is suppressed,
-        but ``total_not_found`` (which now equals the consecutive run) still
+        comes back. With a large window the time-gated trigger is suppressed,
+        but the window-independent trigger still fires once the consecutive run
         reaches ``max_not_found * 2`` and reports ``"removed"``.
         """
         api = _make_api()

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -373,31 +373,29 @@ class TestWaitForCompletionQuotaDetection:
         assert result.is_removed is True
 
     @pytest.mark.asyncio
-    async def test_flickering_artifact_triggers_total_failure(self):
-        """Oscillating found/not-found (flickering) triggers failure via
-        total_not_found even though consecutive never reaches max_not_found."""
-        api = _make_api()
-        # With max_not_found=3, total threshold is 6.  Alternate to keep
-        # consecutive at most 1, but accumulate 6 total not-founds.
-        responses = []
-        for _ in range(6):
-            responses.append(GenerationStatus(task_id="task_abc", status="not_found"))
-            responses.append(GenerationStatus(task_id="task_abc", status="pending"))
-        # The 6th not_found should trigger total_not_found >= 3*2 = 6
-        # Actually it fires at the not_found before the pending resets consecutive,
-        # so let's just add enough not_founds interleaved.
-        # Sequence: nf, pending, nf, pending, nf, pending, nf, pending, nf, pending, nf
-        # total_not_found hits 6 at the 6th nf (index 10)
-        responses_flickering = []
-        for i in range(12):
-            if i % 2 == 0:
-                responses_flickering.append(
-                    GenerationStatus(task_id="task_abc", status="not_found")
-                )
-            else:
-                responses_flickering.append(GenerationStatus(task_id="task_abc", status="pending"))
+    async def test_transient_omissions_reset_accumulators_and_complete(self):
+        """A flickering artifact that keeps reappearing is NOT declared removed.
 
-        api.poll_status = AsyncMock(side_effect=responses_flickering)
+        Regression for issue #1198: previously ``total_not_found`` accumulated
+        across the whole poll and never reset on reappearance, so an artifact
+        with sporadic brief omissions during an otherwise-healthy generation
+        could trip the total threshold and be fabricated into a terminal
+        ``"removed"`` before it ever completed. Now every reappearance resets
+        the not-found accumulators, so ``"removed"`` requires a *sustained*
+        absence — a flapping artifact polls through to completion instead.
+        """
+        api = _make_api()
+        # 7 not-found omissions interleaved with in_progress sightings, then a
+        # genuine completion. With max_not_found=3 the OLD total threshold was 6,
+        # so the pre-fix loop would have returned "removed" at the 6th not-found
+        # (before completing). With the reset, each in_progress wipes the
+        # accumulators, so neither the consecutive nor the total trigger fires.
+        responses = []
+        for _ in range(7):
+            responses.append(GenerationStatus(task_id="task_abc", status="not_found"))
+            responses.append(GenerationStatus(task_id="task_abc", status="in_progress"))
+        responses.append(GenerationStatus(task_id="task_abc", status="completed"))
+        api.poll_status = AsyncMock(side_effect=responses)
 
         result = await api.wait_for_completion(
             "nb1",
@@ -408,10 +406,41 @@ class TestWaitForCompletionQuotaDetection:
             min_not_found_window=0.0,
         )
 
+        assert result.is_complete is True
+        assert result.is_removed is False
+        # All 15 responses were consumed: the loop never short-circuited to
+        # "removed" despite 7 total not-found polls (> the old total threshold).
+        assert api.poll_status.call_count == 15
+
+    @pytest.mark.asyncio
+    async def test_sustained_not_found_with_blocking_window_still_removed(self):
+        """Sustained absence still triggers removal via the total fallback even
+        when ``min_not_found_window`` blocks the consecutive trigger.
+
+        Guards the issue #1198 change: resetting accumulators on reappearance
+        must not weaken detection of a *genuinely* delisted artifact that never
+        comes back. With a large window the consecutive trigger is suppressed,
+        but ``total_not_found`` (which now equals the consecutive run) still
+        reaches ``max_not_found * 2`` and reports ``"removed"``.
+        """
+        api = _make_api()
+        api.poll_status = AsyncMock(
+            return_value=GenerationStatus(task_id="task_abc", status="not_found")
+        )
+
+        result = await api.wait_for_completion(
+            "nb1",
+            "task_abc",
+            initial_interval=0.01,
+            max_interval=0.01,
+            max_not_found=3,
+            min_not_found_window=9999.0,  # blocks the consecutive trigger
+        )
+
         assert result.is_removed is True
         assert result.is_failed is False
-        assert result.error is not None
-        assert "removed from the list by the server" in result.error
+        # Fires on the total path at max_not_found * 2 = 6 consecutive not-founds.
+        assert api.poll_status.call_count == 6
 
     @pytest.mark.asyncio
     async def test_last_status_set_before_timeout(self):


### PR DESCRIPTION
## Summary

Resolves #1198. The artifact poll loop now requires a **sustained** absence before synthesizing a terminal `"removed"` status: when a polled artifact reappears in the listing, **all** not-found tracking is reset (consecutive counter, running total, and the window start time) — not just the consecutive counter.

## Root cause

In `_run_poll_loop` (`src/notebooklm/_artifact_polling.py`), a "not found" poll incremented both `consecutive_not_found` and `total_not_found`, but the reappearance branch only reset `consecutive_not_found`. `total_not_found` and `first_not_found_time` accumulated across the entire poll session. An artifact with sporadic brief omissions during an otherwise-healthy generation (transient/eventual-consistency blips in the listing) could trip the `total_not_found >= max_not_found * 2` threshold and be reported as terminal `"removed"` **before it ever completed** — a spurious terminal state for an artifact that was still progressing.

## Fix

Reset `consecutive_not_found`, `total_not_found`, and `first_not_found_time` whenever the artifact reappears. `"removed"` now means *stayed absent*:

- **Transient / flapping** delisting (artifact keeps coming back) → never accumulates toward removal; the artifact polls through to completion or times out.
- **Genuine** delisting (artifact never returns) → unchanged: the consecutive trigger (`max_not_found` + `min_not_found_window`) and the window-independent total fallback (`max_not_found * 2`) still fire on a sustained run.

This intentionally refines the heuristic shipped in #1195 (#1168), which is exactly what #1198 was filed to do.

## Tests

`tests/unit/test_quota_failure_detection.py`:
- **Replaced** `test_flickering_artifact_triggers_total_failure` (which asserted the old "flicker → removed" behavior) with `test_transient_omissions_reset_accumulators_and_complete`: 7 not-found omissions interleaved with `in_progress` sightings then a completion — pre-fix this returned `removed` at the 6th not-found; now it completes (all 15 responses consumed, `is_removed is False`).
- **Added** `test_sustained_not_found_with_blocking_window_still_removed`: with `min_not_found_window` blocking the consecutive trigger, a sustained absence still reports `removed` via the total fallback at `max_not_found * 2` — guards that the reset doesn't weaken genuine-delisting detection.
- All other not-found/removed tests (always-not-found → removed, consecutive reset, callback emission, etc.) unchanged and passing.

## Verification

- `uv run pytest` — 7097 passed, 89 skipped
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run ruff format` / `ruff check` — clean

Docs: `docs/python-api.md` `is_removed` docstring updated to state the absence must be sustained (transient reappearance resets the window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact polling to treat brief disappearances as transient; artifacts that reappear are no longer incorrectly marked as "removed". Sustained absences still lead to removal.

* **Documentation**
  * Clarified GenerationStatus.is_removed to distinguish sustained "removed" from terminal "failed" and explain transient omission handling.

* **Tests**
  * Updated and added regression tests to validate transient omissions reset detection and sustained-not-found removal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->