### PR TITLE
fix(cli): require yes for artifact delete json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`notebooklm artifact delete <id> --json` now requires `--yes` before deleting** ([#1197](https://github.com/teng-lin/notebooklm-py/issues/1197)). Without `--yes`, the command emits the typed `VALIDATION_ERROR` envelope, includes `"deleted": false`, exits `1`, and leaves the artifact untouched, matching the other destructive delete commands.
 - **HTML file uploads now fail client-side with a clear validation error** ([#1127](https://github.com/teng-lin/notebooklm-py/issues/1127)). `notebooklm source add ./article.html` and `client.sources.add_file(..., "article.html")` previously reached NotebookLM's upload endpoint as `text/html` and surfaced a cryptic upstream `400 Bad Request`. The upload pipeline now rejects `.html` / `.htm` / `.xhtml` / `.xht` / HTML MIME uploads before registering a source, with guidance to convert the page to `.txt`, `.md`, or `.pdf`.
 - **`notebooklm source fulltext -o FILE` no longer silently overwrites existing files** ([#1173](https://github.com/teng-lin/notebooklm-py/issues/1173)). Existing output paths now auto-rename by default (`FILE` -> `FILE (2)`, etc.); pass `--force` to overwrite intentionally or `--no-clobber` to fail when the path already exists.
 

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -293,13 +293,12 @@ race where partial-resolve succeeds but the subsequent `get` returns
 The pre-existing "no partial-ID match" branch (raised by `_resolve_partial_id`
 as a `ClickException`) was already exit `1` and is unchanged.
 
-### `note delete --json` without `--yes`, `note rename` race exit `1` (was `0`) ✅ **Landed**
+### `note`/`artifact delete --json` without `--yes`, `note rename` race exit `1` (was `0`) ✅ **Landed**
 
-Two parallel surgical fixes to `cli/note.py` matching the broader `--json`
-exit-code convention pinned by the prior `get`-on-not-found change. Both
-cases previously emitted a `{"<verb>ed": false, "error": ...}` payload on
-exit `0`, which passed silently in `set -e` / `check_call`-style scripts
-branching on the exit code.
+These surgical fixes match the broader `--json` exit-code convention pinned
+by the prior `get`-on-not-found change. The affected cases previously emitted
+a `{"<verb>ed": false, "error": ...}` payload on exit `0`, which passed
+silently in `set -e` / `check_call`-style scripts branching on the exit code.
 
 `notebooklm note delete <id> --json` without `--yes` cannot prompt (it would
 corrupt the parseable-JSON contract callers depend on), but it must also not
@@ -317,6 +316,12 @@ appear to succeed. The command now emits the standard typed envelope:
 
 on stdout and exits `1`. The text-mode interactive prompt path (no `--json`)
 is unchanged — declining the prompt is still a no-op exit `0`.
+
+`notebooklm artifact delete <id> --json` follows the same destructive-operation
+guard: without `--yes`, it now emits `VALIDATION_ERROR`, includes the resolved
+artifact and notebook IDs plus `"deleted": false`, exits `1`, and does not
+delete the artifact. Passing `--yes` preserves the existing successful JSON
+payload (`{"id": "...", "deleted": true}`).
 
 `notebooklm note rename <id> "new title"` resolves the partial ID and then
 fetches the current note to preserve its content before issuing the update.

--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -278,6 +278,24 @@ def artifact_delete(ctx, artifact_id, notebook_id, yes, json_output, client_auth
                 resolved_id = await resolve_artifact_id(
                     client, nb_id_resolved, artifact_id, json_output=json_output
                 )
+
+                # In JSON mode, refuse to prompt: ``click.confirm`` writes to
+                # stdout, which would corrupt the parseable JSON contract callers
+                # rely on. Require --yes and emit a structured error otherwise.
+                if json_output and not yes:
+                    _output_error(
+                        "Pass --yes to confirm deletion in --json mode",
+                        code="VALIDATION_ERROR",
+                        json_output=json_output,
+                        exit_code=1,
+                        extra={
+                            "id": resolved_id,
+                            "notebook_id": nb_id_resolved,
+                            "deleted": False,
+                        },
+                    )
+                    raise AssertionError("unreachable")  # pragma: no cover
+
                 return {
                     "notebook_id": nb_id_resolved,
                     "artifact_id": resolved_id,

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -589,8 +589,10 @@ class TestArtifactDelete:
             data = json.loads(result.output)
             assert data == {"id": "art_123", "deleted": True}
 
-    def test_artifact_delete_json_without_yes_does_not_prompt(self, runner, mock_auth):
-        """Current JSON contract treats --json as non-interactive execution."""
+    def test_artifact_delete_json_without_yes_emits_structured_error_no_prompt(
+        self, runner, mock_auth
+    ):
+        """`artifact delete --json` without `--yes` refuses instead of deleting."""
         with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.list = AsyncMock(
@@ -613,10 +615,16 @@ class TestArtifactDelete:
                     cli, ["artifact", "delete", "art_123", "-n", "nb_123", "--json"]
                 )
 
-            assert result.exit_code == 0
-            assert json.loads(result.output) == {"id": "art_123", "deleted": True}
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["error"] is True
+            assert data["code"] == "VALIDATION_ERROR"
+            assert "--yes" in data["message"]
+            assert data["id"] == "art_123"
+            assert data["notebook_id"] == "nb_123"
+            assert data["deleted"] is False
             mock_confirm.assert_not_called()
-            mock_client.artifacts.delete.assert_called_once_with("nb_123", "art_123")
+            mock_client.artifacts.delete.assert_not_called()
 
     def test_artifact_delete_mind_map_json_output(self, runner, mock_auth):
         """`artifact delete --json` flags mind-map carve-out in the payload."""


### PR DESCRIPTION
## Summary
- Require `--yes` for `notebooklm artifact delete --json` before performing the destructive delete.
- Return a typed `VALIDATION_ERROR` JSON envelope with `deleted: false` and resolved IDs when confirmation is missing.
- Update CLI exit-code docs and changelog for the automation-facing contract change.

## Fixes
Closes #1197

## Test plan
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest tests/unit/cli/test_artifact.py -q`
- `uv run pytest`
- `uv run pre-commit run --all-files`

## Deferred polish findings
- Consider centralizing JSON-mode confirmation guards in `run_confirmed_mutation` with per-plan blocked payloads.
- Optional: add artifact delete `--json`/no `--yes` coverage for mind-map rows.
- Consider typing `_output_error` as `NoReturn` to remove unreachable `AssertionError` fallthroughs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The `notebooklm artifact delete --json` command now requires the `--yes` flag for deletion confirmation. Omitting `--yes` returns a validation error, exits with code 1, and preserves the artifact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->