### PR TITLE
fix(auth): share one flock file across all storage_state.json mutators

### DIFF
--- a/src/notebooklm/_auth/account.py
+++ b/src/notebooklm/_auth/account.py
@@ -17,6 +17,7 @@ from filelock import FileLock
 from .._atomic_io import atomic_write_json
 from .._env import get_base_url
 from .._url_utils import is_google_auth_redirect
+from .paths import _storage_state_lock_path
 
 logger = logging.getLogger("notebooklm.auth")
 
@@ -395,12 +396,12 @@ def write_account_metadata(storage_path: Path, *, authuser: int, email: str | No
 
     # Acquire a sibling-lock so concurrent callers serialize correctly during
     # the migration window. ``filelock`` reuses the lock file across
-    # invocations; the file is zero-byte and cheap to leave on disk. The dotted
-    # ``.storage_state.json.lock`` name must match ``save_cookies_to_storage``
-    # in ``_auth/storage.py`` so every ``storage_state.json`` mutator serializes
-    # on the *same* lock file (otherwise cookie-save and account-metadata writes
-    # race on different flock files and lose updates).
-    lock_path = storage_path.with_name(f".{storage_path.name}.lock")
+    # invocations; the file is zero-byte and cheap to leave on disk. The lock
+    # path comes from ``_storage_state_lock_path`` so every ``storage_state.json``
+    # mutator (cookie saves in ``_auth/storage.py``, account-metadata writes
+    # here) serializes on the *same* file — otherwise they race on different
+    # flock files and lose updates.
+    lock_path = _storage_state_lock_path(storage_path)
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(lock_path), timeout=10.0):
         # Read-modify-write under the lock to avoid losing concurrent updates.
@@ -464,10 +465,10 @@ def _clear_in_band_account(storage_path: Path) -> None:
     """
     if not storage_path.exists():
         return
-    # Match the dotted ``.storage_state.json.lock`` name used by
-    # ``write_account_metadata`` and ``save_cookies_to_storage`` so every
-    # ``storage_state.json`` mutator serializes on the same lock file.
-    lock_path = storage_path.with_name(f".{storage_path.name}.lock")
+    # Same canonical lock file as ``write_account_metadata`` and
+    # ``save_cookies_to_storage`` so every ``storage_state.json`` mutator
+    # serializes on one flock file.
+    lock_path = _storage_state_lock_path(storage_path)
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with FileLock(str(lock_path), timeout=10.0):

--- a/src/notebooklm/_auth/account.py
+++ b/src/notebooklm/_auth/account.py
@@ -395,8 +395,12 @@ def write_account_metadata(storage_path: Path, *, authuser: int, email: str | No
 
     # Acquire a sibling-lock so concurrent callers serialize correctly during
     # the migration window. ``filelock`` reuses the lock file across
-    # invocations; the file is zero-byte and cheap to leave on disk.
-    lock_path = storage_path.with_suffix(storage_path.suffix + ".lock")
+    # invocations; the file is zero-byte and cheap to leave on disk. The dotted
+    # ``.storage_state.json.lock`` name must match ``save_cookies_to_storage``
+    # in ``_auth/storage.py`` so every ``storage_state.json`` mutator serializes
+    # on the *same* lock file (otherwise cookie-save and account-metadata writes
+    # race on different flock files and lose updates).
+    lock_path = storage_path.with_name(f".{storage_path.name}.lock")
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(lock_path), timeout=10.0):
         # Read-modify-write under the lock to avoid losing concurrent updates.
@@ -460,7 +464,10 @@ def _clear_in_band_account(storage_path: Path) -> None:
     """
     if not storage_path.exists():
         return
-    lock_path = storage_path.with_suffix(storage_path.suffix + ".lock")
+    # Match the dotted ``.storage_state.json.lock`` name used by
+    # ``write_account_metadata`` and ``save_cookies_to_storage`` so every
+    # ``storage_state.json`` mutator serializes on the same lock file.
+    lock_path = storage_path.with_name(f".{storage_path.name}.lock")
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with FileLock(str(lock_path), timeout=10.0):

--- a/src/notebooklm/_auth/paths.py
+++ b/src/notebooklm/_auth/paths.py
@@ -43,6 +43,19 @@ _REFRESH_ATTEMPTED_ENV = "_NOTEBOOKLM_REFRESH_ATTEMPTED"
 NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV = "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE"
 
 
+def _storage_state_lock_path(storage_path: Path) -> Path:
+    """Canonical sibling flock file shared by every ``storage_state.json`` writer.
+
+    ``save_cookies_to_storage`` (cookie writes) and ``write_account_metadata`` /
+    ``_clear_in_band_account`` (account-metadata writes) all mutate the same
+    ``storage_state.json``, so they MUST serialize on the *same* lock file or a
+    read-modify-write from one loses the other's update. Deriving the dotted
+    ``.storage_state.json.lock`` path here keeps that contract enforced by
+    construction instead of by hand-synced string literals in each caller.
+    """
+    return storage_path.with_name(f".{storage_path.name}.lock")
+
+
 def _rotation_lock_path(storage_path: Path | None) -> Path | None:
     """Sibling sentinel used by ``_poke_session`` for cross-process coordination.
 

--- a/src/notebooklm/_auth/paths.py
+++ b/src/notebooklm/_auth/paths.py
@@ -22,8 +22,9 @@ Three categories of names live here:
    :func:`notebooklm.auth._poke_session` / ``_rotate_cookies``. Physically
    adjacent to the keepalive block in ``auth.py`` but conceptually an
    environment-variable name, not a keepalive parameter, so it lives here.
-3. **Path helpers** (:func:`_rotation_lock_path`) that compute sentinel
-   sibling files alongside the user's storage-state path.
+3. **Path helpers** (:func:`_storage_state_lock_path`,
+   :func:`_rotation_lock_path`) that compute sentinel sibling files alongside
+   the user's storage-state path.
 
 The two refresh env vars and the keepalive env var are part of the documented
 public surface of ``notebooklm.auth`` (see :data:`notebooklm.auth.__all__`);

--- a/src/notebooklm/_auth/storage.py
+++ b/src/notebooklm/_auth/storage.py
@@ -19,6 +19,7 @@ import httpx
 from .._atomic_io import atomic_write_json
 from . import cookie_policy as _cookie_policy
 from . import cookies as _auth_cookies
+from .paths import _storage_state_lock_path
 
 logger = logging.getLogger("notebooklm.auth")
 
@@ -377,7 +378,7 @@ def save_cookies_to_storage(
             stacklevel=2,
         )
 
-    lock_path = path.with_name(f".{path.name}.lock")
+    lock_path = _storage_state_lock_path(path)
     with _file_lock_exclusive(lock_path):
         if not path.exists():
             logger.debug("Skipping cookie sync: Storage file not found at %s", path)

--- a/src/notebooklm/_auth/storage.py
+++ b/src/notebooklm/_auth/storage.py
@@ -171,8 +171,16 @@ def _file_lock_exclusive(lock_path: Path) -> Iterator[None]:
     (e.g. a long-running ``NotebookLMClient(keepalive=...)`` worker plus a
     cron-driven ``notebooklm auth refresh``) would otherwise race on the read-
     merge-write cycle and lose updates. The lock is held on a sentinel file
-    sibling to the storage file (``.storage_state.json.lock``), since locking
-    the storage file itself would interfere with the atomic temp-rename below.
+    sibling to the storage file (``.storage_state.json.lock``, derived by
+    :func:`notebooklm._auth.paths._storage_state_lock_path`), since locking the
+    storage file itself would interfere with the atomic temp-rename below.
+
+    ``_auth/account.py`` holds this *same* sentinel via ``filelock.FileLock``
+    when it writes account metadata into ``storage_state.json``. The two
+    mechanisms interoperate because ``filelock.FileLock`` also uses
+    ``fcntl.flock`` on POSIX, so an exclusive hold from either side blocks the
+    other — that cross-mechanism compatibility is what lets cookie saves and
+    account-metadata writes serialize on one file.
 
     The lock is per-process: threads within one process aren't serialized —
     that's the intra-process ``threading.Lock`` in ``Session``. If the

--- a/tests/unit/test_profile_atomic_write.py
+++ b/tests/unit/test_profile_atomic_write.py
@@ -337,10 +337,15 @@ def test_write_preserves_cookies_and_origins(tmp_path: Path) -> None:
 
 
 def _capture_account_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
-    """Record the lock path account.py passes to ``filelock.FileLock``.
+    """Record the ``storage_state.json`` lock path account.py passes to ``FileLock``.
 
     The captured contextmanager is a no-op so the surrounding read-modify-write
-    still completes against the real file.
+    still completes against the real file. ``write_account_metadata`` also calls
+    ``_drop_legacy_account_key``, which locks the sibling ``context.json.lock``;
+    that path is filtered out so it can't clobber the value we assert on. Paths
+    are canonicalized (``.expanduser().resolve()``) because they back
+    cross-process locking, where distinct spellings of the same file must
+    compare equal.
     """
     import contextlib
 
@@ -350,7 +355,9 @@ def _capture_account_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Pat
 
     @contextlib.contextmanager
     def _fake_filelock(path: str, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
-        seen["path"] = Path(path)
+        resolved = Path(path).expanduser().resolve()
+        if "storage_state.json" in resolved.name:
+            seen["path"] = resolved
         yield
 
     monkeypatch.setattr(account_mod, "FileLock", _fake_filelock)
@@ -358,7 +365,11 @@ def _capture_account_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Pat
 
 
 def _capture_storage_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
-    """Record the lock path storage.py passes to ``_file_lock_exclusive``."""
+    """Record the lock path storage.py passes to ``_file_lock_exclusive``.
+
+    Paths are canonicalized to match ``_capture_account_lock_path`` so the two
+    captures compare equal even if their spellings differ.
+    """
     import contextlib
 
     from notebooklm._auth import storage as storage_mod
@@ -367,7 +378,7 @@ def _capture_storage_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Pat
 
     @contextlib.contextmanager
     def _fake_exclusive(lock_path: Path):  # type: ignore[no-untyped-def]
-        seen["path"] = Path(lock_path)
+        seen["path"] = Path(lock_path).expanduser().resolve()
         yield
 
     monkeypatch.setattr(storage_mod, "_file_lock_exclusive", _fake_exclusive)
@@ -413,7 +424,8 @@ def test_storage_state_mutators_share_one_lock_file(
     storage_cookie_lock = storage_seen["path"]
 
     # Canonical name is the dotted, hidden sibling (storage.py contract).
-    expected = storage_path.with_name(f".{storage_path.name}.lock")
+    # Resolve to match the canonicalized captures above.
+    expected = storage_path.with_name(f".{storage_path.name}.lock").expanduser().resolve()
     assert storage_cookie_lock == expected
     assert account_write_lock == expected
     assert account_clear_lock == expected

--- a/tests/unit/test_profile_atomic_write.py
+++ b/tests/unit/test_profile_atomic_write.py
@@ -334,3 +334,88 @@ def test_write_preserves_cookies_and_origins(tmp_path: Path) -> None:
     payload = _read_storage_state(storage_path)
     assert payload["cookies"] == cookies
     assert payload["origins"] == origins
+
+
+def _capture_account_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Record the lock path account.py passes to ``filelock.FileLock``.
+
+    The captured contextmanager is a no-op so the surrounding read-modify-write
+    still completes against the real file.
+    """
+    import contextlib
+
+    from notebooklm._auth import account as account_mod
+
+    seen: dict[str, Path] = {}
+
+    @contextlib.contextmanager
+    def _fake_filelock(path: str, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        seen["path"] = Path(path)
+        yield
+
+    monkeypatch.setattr(account_mod, "FileLock", _fake_filelock)
+    return seen
+
+
+def _capture_storage_lock_path(monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Record the lock path storage.py passes to ``_file_lock_exclusive``."""
+    import contextlib
+
+    from notebooklm._auth import storage as storage_mod
+
+    seen: dict[str, Path] = {}
+
+    @contextlib.contextmanager
+    def _fake_exclusive(lock_path: Path):  # type: ignore[no-untyped-def]
+        seen["path"] = Path(lock_path)
+        yield
+
+    monkeypatch.setattr(storage_mod, "_file_lock_exclusive", _fake_exclusive)
+    return seen
+
+
+def test_storage_state_mutators_share_one_lock_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All ``storage_state.json`` mutators must serialize on the SAME flock file.
+
+    Tier-0 data-loss regression: ``save_cookies_to_storage`` (storage.py) used
+    the dotted ``.storage_state.json.lock`` sibling while ``account.py``'s
+    metadata writers used the non-dotted ``storage_state.json.lock`` — a
+    DIFFERENT file. Cookie-save and account-metadata writes therefore locked on
+    distinct files and could lose updates under concurrency. Assert both paths
+    derive an identical lock filename for the same ``storage_state.json``.
+    """
+    import httpx
+
+    from notebooklm._auth.storage import save_cookies_to_storage
+
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(storage_path, {"cookies": [], "origins": []})
+
+    # account.py: write_account_metadata
+    account_seen = _capture_account_lock_path(monkeypatch)
+    write_account_metadata(storage_path, authuser=1, email="alice@example.com")
+    account_write_lock = account_seen["path"]
+
+    # account.py: _clear_in_band_account (via clear_account_metadata)
+    account_seen.clear()
+    clear_account_metadata(storage_path)
+    account_clear_lock = account_seen["path"]
+
+    # storage.py: save_cookies_to_storage (the canonical cookie-save writer)
+    storage_seen = _capture_storage_lock_path(monkeypatch)
+    save_cookies_to_storage(
+        httpx.Cookies(),
+        path=storage_path,
+        original_snapshot={},
+    )
+    storage_cookie_lock = storage_seen["path"]
+
+    # Canonical name is the dotted, hidden sibling (storage.py contract).
+    expected = storage_path.with_name(f".{storage_path.name}.lock")
+    assert storage_cookie_lock == expected
+    assert account_write_lock == expected
+    assert account_clear_lock == expected
+    # And, transitively, all three agree on the exact same file on disk.
+    assert account_write_lock == account_clear_lock == storage_cookie_lock


### PR DESCRIPTION
## Summary

Tier-0 (HIGH, data-loss) fix from the v0.6.0 architecture gap review.

Cookie-save and account-metadata writes both mutate the same `storage_state.json` under an OS file lock, but they serialized on **different** lock files — a lost-update race.

| Writer | Location | Lock file (before) |
|--------|----------|--------------------|
| `save_cookies_to_storage` | `_auth/storage.py:380` | `.storage_state.json.lock` (dotted, hidden) — canonical |
| `write_account_metadata` | `_auth/account.py:399` | `storage_state.json.lock` (no leading dot) — **divergent** |
| `_clear_in_band_account` | `_auth/account.py:463` | `storage_state.json.lock` (no leading dot) — **divergent** |

Because account.py used `storage_path.with_suffix(storage_path.suffix + ".lock")` while storage.py used `path.with_name(f".{path.name}.lock")`, the two writers acquired **distinct** flock files. A concurrent cookie-save (e.g. a keepalive worker) and an account-metadata write (e.g. `notebooklm login` / `auth refresh`) therefore did not serialize against each other — one writer's read-modify-write could silently clobber the other's commit.

## Fix

Point both `account.py` storage-state writers at the canonical dotted `.storage_state.json.lock` so **every** `storage_state.json` mutator contends on the same lock file.

- The `context.json` lock in `_drop_legacy_account_key` (`account.py:349`, a *different* file) is intentionally left unchanged.
- Verified there are no other `storage_state.json` writers using a divergent lock (the generic `_atomic_io.atomic_update_json` helper is not used by these account paths).

## Test

Adds `test_storage_state_mutators_share_one_lock_file` in `tests/unit/test_profile_atomic_write.py`, which captures the lock path each writer derives and asserts all three (`write_account_metadata`, `_clear_in_band_account`, `save_cookies_to_storage`) resolve to the identical `.storage_state.json.lock`. This test fails on the pre-fix code (`storage_state.json.lock` != `.storage_state.json.lock`).

## Gates

- `ruff check .` + `ruff format --check .`: pass
- `mypy src/notebooklm --ignore-missing-imports`: pass
- `pytest tests/unit/test_profile_atomic_write.py tests/unit/test_auth_account.py`: 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression and helper tests to ensure account metadata and cookie saves synchronize using a single shared lock under concurrent operations.

* **Refactor**
  * Unified the filesystem lock path used by all storage mutators to improve reliability and correctness of concurrent account/cookie writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->