### PR TITLE
fix(exceptions): scrub secrets in RPCError.raw_response preview

### DIFF
--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -232,8 +232,10 @@ class RPCError(NotebookLMError):
     Attributes:
         method_id: The RPC method ID (e.g., "abc123") for debugging.
         raw_response: First 80 chars of raw response for debugging
-            (with ``"..."`` suffix if truncated). Set ``NOTEBOOKLM_DEBUG=1`` to
-            preserve the full body.
+            (with ``"..."`` suffix if truncated). Credential-shaped substrings
+            are scrubbed before truncation, so this attribute is safe to splice
+            into ``str()``/``repr()``. Set ``NOTEBOOKLM_DEBUG=1`` to preserve
+            the full body (still scrubbed).
         rpc_code: Google's internal error code if available.
         found_ids: List of RPC IDs found in the response (for debugging).
     """
@@ -298,7 +300,9 @@ class UnknownRPCMethodError(DecodingError):
         found_ids: When raised by the response-level decoder, the list of RPC
             IDs actually present in the response.
         raw_response: First 80 chars of the raw response, when available
-            (``NOTEBOOKLM_DEBUG=1`` preserves the full body).
+            (``NOTEBOOKLM_DEBUG=1`` preserves the full body). The string branch
+            is secret-scrubbed before truncation; non-string payloads are stored
+            as-is on this subclass.
         data_at_failure: Truncated repr (~200 chars) of the data the helper
             was attempting to index into when descent failed.
     """

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -34,14 +34,20 @@ def _truncate_response_preview(raw: str | None) -> str | None:
     Default behavior keeps the preview compact (80 chars + ``"..."`` suffix) so
     error logs and CLI output stay readable. Set ``NOTEBOOKLM_DEBUG=1`` to opt
     into the full untruncated body for deep debugging.
+
+    Credential-shaped substrings (CSRF tokens, session cookies, etc.) are
+    scrubbed *before* truncation in both modes. ``raw_response`` is a public
+    attribute spliced into ``str()``/``repr()`` of RPC errors, so it escapes the
+    logging pipeline's ``RedactingFilter`` and must be sanitized at the source.
     """
     if raw is None:
         return None
+    scrubbed = scrub_secrets(raw)
     if os.environ.get("NOTEBOOKLM_DEBUG") == "1":
-        return raw
-    if len(raw) > 80:
-        return raw[:80] + "..."
-    return raw
+        return scrubbed
+    if len(scrubbed) > 80:
+        return scrubbed[:80] + "..."
+    return scrubbed
 
 
 __all__ = [

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -28,6 +28,15 @@ if TYPE_CHECKING:
 ArtifactStalledPhase = Literal["pending", "in_progress"]
 
 
+_PREVIEW_LIMIT = 80
+# Pre-slice cap for the truncated path: scrub at most this many chars before
+# cutting to ``_PREVIEW_LIMIT``. The 10x window gives a boundary-straddling
+# secret ample room to be neutralized before the 80-char cut (mirrors the
+# two-stage slice in ``AuthExtractionError`` below), while bounding the regex
+# sweep at O(800 chars) instead of O(len(raw)) for multi-MB error bodies.
+_PREVIEW_SCRUB_CAP = _PREVIEW_LIMIT * 10
+
+
 def _truncate_response_preview(raw: str | None) -> str | None:
     """Truncate a raw RPC response preview for safe display in error contexts.
 
@@ -39,14 +48,20 @@ def _truncate_response_preview(raw: str | None) -> str | None:
     scrubbed *before* truncation in both modes. ``raw_response`` is a public
     attribute spliced into ``str()``/``repr()`` of RPC errors, so it escapes the
     logging pipeline's ``RedactingFilter`` and must be sanitized at the source.
+
+    In the default (truncated) path the input is pre-sliced to
+    ``_PREVIEW_SCRUB_CAP`` before scrubbing so a multi-MB error body does not
+    pay for a full regex sweep just to discard all but the first 80 chars. The
+    ``NOTEBOOKLM_DEBUG=1`` path keeps the whole body, so it scrubs the full
+    string.
     """
     if raw is None:
         return None
-    scrubbed = scrub_secrets(raw)
     if os.environ.get("NOTEBOOKLM_DEBUG") == "1":
-        return scrubbed
-    if len(scrubbed) > 80:
-        return scrubbed[:80] + "..."
+        return scrub_secrets(raw)
+    scrubbed = scrub_secrets(raw[:_PREVIEW_SCRUB_CAP])
+    if len(scrubbed) > _PREVIEW_LIMIT:
+        return scrubbed[:_PREVIEW_LIMIT] + "..."
     return scrubbed
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -5,6 +5,7 @@ import pytest
 import notebooklm
 from notebooklm._env import DEFAULT_BASE_URL
 from notebooklm.exceptions import (
+    _PREVIEW_SCRUB_CAP,  # noqa: PLC2701 (test of internal)
     ArtifactDownloadError,
     ArtifactError,
     ArtifactFeatureUnavailableError,
@@ -438,6 +439,43 @@ class TestRPCErrorAttributes:
         assert "***" in e.raw_response
         spliced = RPCError(f"decode failed: {e.raw_response}", raw_response=raw)
         assert secret not in str(spliced)
+
+    def test_rpc_error_scrubs_secret_straddling_truncation_boundary(self, monkeypatch):
+        """A secret straddling the 80-char preview cut is scrubbed, not halved.
+
+        Scrubbing runs on the pre-sliced window *before* the 80-char cut, so a
+        token positioned so that it spans the boundary is neutralized whole — no
+        partial-token suffix can leak into the truncated preview. This is the
+        property the pre-slice (scrub-then-cut) ordering exists to preserve.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        # Pad so the secret suffix straddles the 80-char cut.
+        raw = "x" * 70 + secret
+        e = RPCError("decode failed", raw_response=raw)
+        assert e.raw_response is not None
+        assert e.raw_response.endswith("...")
+        # The secret suffix is gone — only the ``AF1_QpN-`` shape hint (a
+        # deliberate non-secret marker) and a ``*`` redaction stub remain.
+        assert "supersecret" not in e.raw_response
+        assert "csrftoken" not in e.raw_response
+        assert "*" in e.raw_response
+
+    def test_rpc_error_preview_drops_secret_beyond_scrub_cap(self, monkeypatch):
+        """A secret past the pre-slice cap is dropped, never partially leaked.
+
+        The truncated path only scrubs the first ``_PREVIEW_SCRUB_CAP`` chars,
+        but anything beyond the cap is also beyond the 80-char preview, so it is
+        discarded rather than exposed. This guards the perf optimization against
+        ever shrinking the redaction surface that reaches the preview.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        raw = "x" * (_PREVIEW_SCRUB_CAP + 50) + secret
+        e = RPCError("decode failed", raw_response=raw)
+        assert e.raw_response is not None
+        assert secret not in e.raw_response
+        assert e.raw_response == "x" * 80 + "..."
 
     def test_unknown_rpc_method_error_scrubs_secrets_in_raw_response(self, monkeypatch):
         """UnknownRPCMethodError forwards string raw_response through the scrub.

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -397,6 +397,75 @@ class TestRPCErrorAttributes:
         assert e.raw_response.endswith("...")
         assert e.raw_response[:-3] == "x" * 80
 
+    def test_rpc_error_scrubs_secrets_in_raw_response(self, monkeypatch):
+        """raw_response is secret-scrubbed before it can leak.
+
+        ``raw_response`` is a public attribute that escapes the logging
+        pipeline's ``RedactingFilter`` — it is spliced into error ``str``/repr
+        and survives serialization. Credential-shaped substrings must therefore
+        be redacted at the source. The default (truncated) path keeps the scrub
+        *before* the 80-char cut so a secret sitting in the first 80 chars can
+        never survive into the preview.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        raw = f'{{"SNlM0e":"{secret}"}}'
+        # Realistic splice: callers build the message from the (now scrubbed)
+        # raw_response attribute, which is the surface str(exc) exposes.
+        e = RPCError("decode failed", raw_response=raw)
+        assert e.raw_response is not None
+        assert secret not in e.raw_response
+        assert "***" in e.raw_response
+        # A message built from the scrubbed preview stays clean too.
+        spliced = RPCError(f"decode failed: {e.raw_response}", raw_response=raw)
+        assert secret not in str(spliced)
+
+    def test_rpc_error_scrubs_secrets_in_debug_full_body(self, monkeypatch):
+        """NOTEBOOKLM_DEBUG=1 keeps the full body but still scrubs secrets.
+
+        The deep-debug branch returns the untruncated body; it must scrub THEN
+        return so the full-body opt-in does not become a token leak.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "1")
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        raw = f'{{"SNlM0e":"{secret}"}}' + "x" * 1000
+        e = RPCError("decode failed", raw_response=raw)
+        assert e.raw_response is not None
+        # Full body preserved (not truncated) but the token is gone.
+        assert len(e.raw_response) > 80
+        assert not e.raw_response.endswith("...")
+        assert secret not in e.raw_response
+        assert "***" in e.raw_response
+        spliced = RPCError(f"decode failed: {e.raw_response}", raw_response=raw)
+        assert secret not in str(spliced)
+
+    def test_unknown_rpc_method_error_scrubs_secrets_in_raw_response(self, monkeypatch):
+        """UnknownRPCMethodError forwards string raw_response through the scrub.
+
+        It splices structured context into ``str``/``repr`` and exposes the
+        public ``raw_response`` attribute, so the same redaction guarantee must
+        hold for the subclass that carries the string branch.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        raw = f'{{"SNlM0e":"{secret}"}}'
+        e = UnknownRPCMethodError(
+            "schema drift",
+            method_id="abc123",
+            raw_response=raw,
+        )
+        assert isinstance(e.raw_response, str)
+        assert secret not in e.raw_response
+        assert "***" in e.raw_response
+        # str/repr that splice the scrubbed attribute never leak the token.
+        spliced = UnknownRPCMethodError(
+            f"schema drift: {e.raw_response}",
+            method_id="abc123",
+            raw_response=raw,
+        )
+        assert secret not in str(spliced)
+        assert secret not in repr(spliced)
+
     def test_rpc_error_stores_found_ids(self):
         """RPCError stores found_ids list."""
         e = RPCError("Failed", found_ids=["id1", "id2"])


### PR DESCRIPTION
## Summary

`RPCError.raw_response` was truncated but never secret-scrubbed, leaking tokens (`SNlM0e`/`FdrFJe`/cookies) into error strings and logs that bypass the logging `RedactingFilter`.

`exceptions.py` `_truncate_response_preview` only truncated the raw RPC body (80 chars by default, or the **full** body under `NOTEBOOKLM_DEBUG=1`) and never called `scrub_secrets` — even though `scrub_secrets` is already imported at the top of the module and the sibling `AuthExtractionError` already scrubs its own preview.

`raw_response` is a **public attribute** spliced into `UnknownRPCMethodError.__str__`/`__repr__` and exposed via serialization and non-package logging, so it escapes the `log.RedactingFilter`. A token-shaped body therefore leaked through `str(exc)`.

## Fix

- Run `scrub_secrets` on the raw body **before** truncation in the default path, so a secret in the first 80 chars can never survive into the preview.
- In the `NOTEBOOKLM_DEBUG=1` full-body branch, scrub **then** return the full body — the deep-debug opt-in no longer becomes a token leak.

## Tests

Adds three focused tests in `tests/unit/test_exceptions.py` proving the secret is redacted in `.raw_response` and in `str(exc)`:
- `RPCError` default (truncated) mode
- `RPCError` `NOTEBOOKLM_DEBUG=1` full-body mode (asserts body is untruncated AND scrubbed)
- `UnknownRPCMethodError` string `raw_response` branch (str + repr)

## Gap-review finding

Tier-0 security item from the v0.6.0 architecture gap-review: `RPCError.raw_response` truncation path never scrubbed secrets, unlike `AuthExtractionError`. Contained to `src/notebooklm/exceptions.py` + a unit test.

## Gates

- `ruff check` / `ruff format --check`: pass
- `mypy src/notebooklm`: pass (no issues in 186 files)
- `pytest tests/unit/test_exceptions.py` + redaction suites: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented leakage of credential-shaped substrings in error messages: sensitive data is now scrubbed before any preview/truncation. Normal mode returns a short scrubbed preview; debug mode returns the full scrubbed body. Preview handling now bounds the pre-scrub window to avoid partial leaks.

* **Tests**
  * Added tests covering preview and debug scenarios, boundary cases where secrets cross the preview cut, and other error types to ensure redaction and redaction markers appear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->