### PR TITLE
fix(concurrency): reset the Sources upload semaphore on close→reopen across loops

### DIFF
--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     from ._cookie_persistence import CookiePersistence
     from ._reqid_counter import ReqidCounter
     from ._session_auth import AuthRefreshCoordinator
+    from ._source_upload import SourceUploadPipeline
     from ._transport_drain import TransportDrainTracker
     from .auth import CookieSaveResult
     from .types import ConnectionLimits
@@ -280,6 +281,7 @@ class ClientLifecycle:
         reqid: ReqidCounter,
         cookie_persistence: CookiePersistence,
         composed: ClientComposed,
+        uploader: SourceUploadPipeline,
     ) -> None:
         """Open the HTTP client connection.
 
@@ -331,6 +333,13 @@ class ClientLifecycle:
         # captured loop lets ``ClientComposed.get_rpc_semaphore`` short-circuit
         # cross-loop misuse with the shared diagnostic.
         composed.set_bound_loop(self._bound_loop)
+        # The Sources upload semaphore is the second lazily-built loop-bound
+        # ``asyncio.Semaphore`` with the same close→reopen hazard as the RPC
+        # semaphore above (the bug #1196 fixed for RPC): a client closed on
+        # loop A and reopened on loop B would otherwise reuse a semaphore
+        # bound to the now-dead loop A. Propagating the captured loop lets the
+        # uploader discard the stale semaphore on a loop change.
+        uploader.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
         # admits new transport work again. Wave 1 of plan
         # ``host-protocol-removal`` encapsulated the legacy direct write
@@ -345,6 +354,12 @@ class ClientLifecycle:
         # the semaphore is reconstructed lazily on the next ``get_rpc_semaphore``
         # call from inside the new loop; ``max_concurrent_rpcs`` is untouched.
         composed.reset_after_open()
+        # Same close→reopen reset for the Sources upload semaphore so a
+        # reopened client rebuilds it on the new loop instead of reusing the
+        # stale one bound to the prior (now-dead) loop. Narrow by design — the
+        # semaphore is reconstructed lazily on the next ``get_upload_semaphore``
+        # call from inside the new loop; ``max_concurrent_uploads`` is untouched.
+        uploader.reset_after_open()
 
         # Delegate HTTP-client construction and open-time cookie baseline
         # capture to the concrete transport kernel. The lifecycle still owns

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -490,6 +490,7 @@ class SourceUploadPipeline:
         self._async_client_factory = async_client_factory
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
         self._lister = SourceLister(self._rpc)
         self._poller = SourcePoller()
         self._get_source_limit = get_source_limit
@@ -521,6 +522,52 @@ class SourceUploadPipeline:
         if cookies is None:
             return httpx.Cookies()
         return cast(httpx.Cookies, cookies)
+
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the upload semaphore.
+
+        Called by :meth:`ClientLifecycle.open` after it captures the running
+        loop, mirroring the identically-named method on
+        :class:`notebooklm._client_composed.ClientComposed`,
+        :class:`TransportDrainTracker`, :class:`ReqidCounter`, and
+        :class:`AuthRefreshCoordinator`. Passing ``None`` clears the binding
+        for the next ``open()`` (which rebinds to a fresh loop).
+
+        When the loop actually changes, the cached semaphore is discarded here
+        too so this method is self-consistent even if called independently of
+        :meth:`reset_after_open` (e.g. directly in a test or a future caller):
+        a stale semaphore bound to the old loop must never be reused after a
+        rebind. The production ``open()`` path also calls
+        :meth:`reset_after_open` immediately after, so the discard is
+        idempotent there.
+
+        The cross-loop guard for ``add_file`` is the lifecycle's
+        ``assert_bound_loop`` (already called at the top of :meth:`add_file`);
+        this binding only governs when the lazy semaphore is rebuilt.
+        """
+        if loop is not self._bound_loop:
+            self._upload_semaphore = None
+        self._bound_loop = loop
+
+    def reset_after_open(self) -> None:
+        """Discard the lazy upload semaphore so a reopened client rebinds it.
+
+        Called from :meth:`ClientLifecycle.open` (alongside the
+        per-collaborator ``set_bound_loop`` propagation) so a client that was
+        closed and reopened on a *different* event loop builds a fresh
+        ``asyncio.Semaphore`` on the new loop instead of reusing the stale one
+        bound to the old (now-dead) loop. On Python 3.10/3.11 reusing the
+        stale semaphore can raise "bound to a different event loop" or mispark
+        waiters; on 3.12+ the breakage is largely masked, but resetting keeps
+        the behaviour consistent across versions.
+
+        Mirrors :meth:`notebooklm._client_composed.ClientComposed.reset_after_open`.
+        Deliberately narrow: dropping the reference is enough because the
+        semaphore is reconstructed lazily on the next
+        :meth:`get_upload_semaphore` call from inside the new loop.
+        ``max_concurrent_uploads`` is left untouched.
+        """
+        self._upload_semaphore = None
 
     def get_upload_semaphore(self) -> asyncio.Semaphore:
         """Return the Sources-owned upload semaphore, creating it on first use.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -365,6 +365,15 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
             record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
         )
+        # Hold the uploader as a first-class client attribute so the
+        # open-time loop-affinity reset (issue #1196 upload variant) can
+        # reach it independently of the ``self.sources`` feature surface:
+        # the upload semaphore is a lazily-built loop-bound
+        # ``asyncio.Semaphore`` that must be discarded on close→reopen, the
+        # same as the RPC semaphore. ``__aenter__`` threads this into
+        # ``ClientLifecycle.open`` which calls
+        # ``set_bound_loop`` / ``reset_after_open`` on it.
+        self._source_uploader = source_uploader
         # ADR-014 Rule 3 Stage B (Stage B1 PR 2 of the post-refactoring
         # plan): simple features take their RpcCaller dependency directly
         # from the composition root's executor, not from a Stage A
@@ -455,6 +464,7 @@ class NotebookLMClient:
             reqid=self._collaborators.reqid,
             cookie_persistence=self._collaborators.cookie_persistence,
             composed=self._composed,
+            uploader=self._source_uploader,
         )
         return self
 

--- a/tests/_helpers/client_factory.py
+++ b/tests/_helpers/client_factory.py
@@ -19,6 +19,7 @@ from notebooklm._session_config import (
 )
 from notebooklm._session_init import compose_client_internals
 from notebooklm._session_lifecycle import CookieRotator, CookieSaver
+from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 from notebooklm.types import RpcTelemetryEvent
@@ -91,4 +92,18 @@ def build_client_shell_for_tests(
     client._composed = composed
     client._collaborators = internals.collaborators
     client._rpc_executor = internals.executor
+    # The shell skips feature-API construction, but ``ClientLifecycle.open``
+    # (driven via ``client.__aenter__``) now resets the upload semaphore's
+    # loop binding through ``client._source_uploader`` (issue #1196 upload
+    # variant), so the shell must wire a real uploader the same way
+    # ``NotebookLMClient.__init__`` does.
+    client._source_uploader = SourceUploadPipeline(
+        rpc=internals.executor,
+        drain=internals.collaborators.drain_tracker,
+        lifecycle=internals.collaborators.lifecycle,
+        kernel=internals.collaborators.kernel,
+        auth=auth,
+        max_concurrent_uploads=max_concurrent_uploads,
+        record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
+    )
     return client

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -301,12 +301,37 @@ def test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore(
     Like the RPC-semaphore test above, this is intentionally NOT ``async def``:
     we own two ``asyncio.run`` calls explicitly so the open and the reopen
     happen on two genuinely distinct loop objects.
+
+    The semaphore is capped at 1 and each loop forces a *blocked* second
+    acquire: ``asyncio.Semaphore.acquire`` only consults ``_get_loop()`` (and
+    thus binds the primitive to a loop) on the contended waiter path — the
+    uncontended fast path returns before touching the loop. Mirroring the
+    cap-2 fan-out the RPC test above uses, the contention here makes the
+    cross-loop binding actually exercise the stale-loop hazard pre-fix.
     """
     transport = mock_transport_concurrent
     transport.set_delay(0.0)
 
-    core = build_client_shell_for_tests(auth=_make_auth())
+    core = build_client_shell_for_tests(auth=_make_auth(), max_concurrent_uploads=1)
     uploader = core._source_uploader
+
+    async def _force_contended_acquire(sem: asyncio.Semaphore) -> None:
+        """Drive the blocked-waiter path so ``sem`` binds to the running loop.
+
+        Hold the single slot, start a second ``acquire`` that must block
+        (creating a waiter future via ``_get_loop()`` — the loop-binding
+        step), then release so the waiter proceeds. On a stale cross-loop
+        semaphore this is where 3.10/3.11 raise "bound to a different event
+        loop".
+        """
+        await sem.acquire()
+        waiter = asyncio.ensure_future(sem.acquire())
+        # Yield so the waiter runs far enough to park on the locked semaphore.
+        await asyncio.sleep(0)
+        assert not waiter.done()
+        sem.release()
+        await waiter
+        sem.release()
 
     async def _open_force_semaphore_and_close_under_loop_a() -> None:
         await core.__aenter__()
@@ -321,11 +346,9 @@ def test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore(
             ),
         )
         # Force the upload semaphore to actually be constructed and bound to
-        # loop A — that is the stale primitive a naive reopen reuses. We acquire
-        # it once to prove it works on this loop.
-        sem_a = uploader.get_upload_semaphore()
-        async with sem_a:
-            pass
+        # loop A — that is the stale primitive a naive reopen reuses. The
+        # contended acquire binds it to loop A via the waiter path.
+        await _force_contended_acquire(uploader.get_upload_semaphore())
         await core.close()
 
     asyncio.run(_open_force_semaphore_and_close_under_loop_a())
@@ -349,13 +372,13 @@ def test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore(
             ),
         )
         try:
-            # Acquire the rebuilt semaphore on loop B. Pre-fix this would reuse
-            # the stale loop-A semaphore and (on 3.10/3.11) raise the cross-loop
-            # RuntimeError; post-fix the semaphore is fresh and bound to loop B.
+            # Drive a contended acquire on the rebuilt semaphore under loop B.
+            # Pre-fix this would reuse the stale loop-A semaphore and (on
+            # 3.10/3.11) raise the cross-loop RuntimeError on the waiter path;
+            # post-fix the semaphore is fresh and binds cleanly to loop B.
             sem_b = uploader.get_upload_semaphore()
             assert sem_b is not None
-            async with sem_b:
-                pass
+            await _force_contended_acquire(sem_b)
         finally:
             await core.close()
 

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -279,6 +279,89 @@ def test_capped_client_reopen_on_new_loop_rebinds_semaphore(
     asyncio.run(_reopen_and_dispatch_under_loop_b())
 
 
+def test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """Issue #1196 (upload variant): close on loop A, reopen on loop B → upload semaphore rebinds.
+
+    The Sources upload semaphore (``SourceUploadPipeline._upload_semaphore``)
+    is the second lazily-built loop-bound ``asyncio.Semaphore`` in the client,
+    with the exact close→reopen hazard #1196 fixed for the RPC semaphore: it is
+    bound to whichever loop it was first constructed under, but
+    ``ClientLifecycle.open`` did not reset it, so a client reopened on a
+    *different* loop reused a semaphore bound to the now-dead loop — which on
+    Python 3.10/3.11 raises "bound to a different event loop" or misparks
+    waiters on acquire.
+
+    Post-fix ``ClientLifecycle.open`` calls
+    ``SourceUploadPipeline.set_bound_loop`` + ``reset_after_open`` (mirroring
+    the RPC-semaphore reset above), so the upload semaphore is discarded on a
+    loop change and rebuilt fresh on the new loop.
+
+    Like the RPC-semaphore test above, this is intentionally NOT ``async def``:
+    we own two ``asyncio.run`` calls explicitly so the open and the reopen
+    happen on two genuinely distinct loop objects.
+    """
+    transport = mock_transport_concurrent
+    transport.set_delay(0.0)
+
+    core = build_client_shell_for_tests(auth=_make_auth())
+    uploader = core._source_uploader
+
+    async def _open_force_semaphore_and_close_under_loop_a() -> None:
+        await core.__aenter__()
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        # Force the upload semaphore to actually be constructed and bound to
+        # loop A — that is the stale primitive a naive reopen reuses. We acquire
+        # it once to prove it works on this loop.
+        sem_a = uploader.get_upload_semaphore()
+        async with sem_a:
+            pass
+        await core.close()
+
+    asyncio.run(_open_force_semaphore_and_close_under_loop_a())
+    # The reset happens on open(), not close(): the stale semaphore is still
+    # cached here, bound to the now-dead loop A.
+    assert uploader._upload_semaphore is not None
+
+    async def _reopen_and_use_semaphore_under_loop_b() -> None:
+        await core.__aenter__()
+        # reset_after_open() must have discarded the loop-A semaphore so the
+        # next get_upload_semaphore() rebuilds it on loop B.
+        assert uploader._upload_semaphore is None
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        try:
+            # Acquire the rebuilt semaphore on loop B. Pre-fix this would reuse
+            # the stale loop-A semaphore and (on 3.10/3.11) raise the cross-loop
+            # RuntimeError; post-fix the semaphore is fresh and bound to loop B.
+            sem_b = uploader.get_upload_semaphore()
+            assert sem_b is not None
+            async with sem_b:
+                pass
+        finally:
+            await core.close()
+
+    asyncio.run(_reopen_and_use_semaphore_under_loop_b())
+
+
 async def test_bound_loop_captured_on_open(
     mock_transport_concurrent: ConcurrentMockTransport,
 ) -> None:

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -143,6 +143,15 @@ class _StubHost:
         # without configuring side effects; the invocations are asserted by
         # ``test_open_captures_bound_loop_and_resets_drain``.
         self._composed = MagicMock()
+        # ``open()`` also propagates the bound loop into the Sources upload
+        # pipeline and resets its lazy upload semaphore (issue #1196 upload
+        # variant): it calls ``uploader.set_bound_loop(loop)`` and
+        # ``uploader.reset_after_open()`` so a client reopened on a different
+        # loop rebuilds the upload semaphore on the new loop. The ``MagicMock``
+        # default lets both calls land without configuring side effects; the
+        # invocations are asserted by
+        # ``test_open_captures_bound_loop_and_resets_drain``.
+        self._uploader = MagicMock()
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
@@ -191,6 +200,7 @@ async def _open(lifecycle: ClientLifecycle, host: _StubHost) -> None:
         reqid=host._reqid,
         cookie_persistence=host.cookie_persistence,
         composed=host._composed,
+        uploader=host._uploader,
     )
 
 
@@ -265,6 +275,12 @@ async def test_open_captures_bound_loop_and_resets_drain() -> None:
     # the drain tracker so the lazy RPC semaphore rebinds on close→reopen.
     host._composed.set_bound_loop.assert_called_once_with(asyncio.get_running_loop())
     host._composed.reset_after_open.assert_called_once_with()
+    # Issue #1196 upload variant: the Sources upload pipeline is the second
+    # lazily-built loop-bound semaphore and must receive the same
+    # set_bound_loop / reset_after_open treatment so the upload semaphore
+    # rebinds on close→reopen.
+    host._uploader.set_bound_loop.assert_called_once_with(asyncio.get_running_loop())
+    host._uploader.reset_after_open.assert_called_once_with()
 
     await _close(lifecycle, host)
 

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -292,6 +292,50 @@ async def test_upload_semaphore_is_owned_per_pipeline() -> None:
 
 
 @pytest.mark.asyncio
+async def test_set_bound_loop_discards_semaphore_on_loop_change() -> None:
+    """Issue #1196 upload variant: a loop change must drop the cached semaphore.
+
+    The upload semaphore is bound to whichever loop it was first built under;
+    on a close→reopen onto a different loop the stale semaphore must not be
+    reused (it would raise "bound to a different event loop" on 3.10/3.11).
+    ``set_bound_loop`` discards it whenever the bound loop actually changes,
+    while a repeat of the *same* loop leaves it intact.
+    """
+    pipeline = make_pipeline(max_concurrent_uploads=1)
+    loop_a = asyncio.get_running_loop()
+
+    pipeline.set_bound_loop(loop_a)
+    sem_a = pipeline.get_upload_semaphore()
+    # Re-binding to the same loop must NOT discard the cached semaphore.
+    pipeline.set_bound_loop(loop_a)
+    assert pipeline.get_upload_semaphore() is sem_a
+
+    # A loop change discards the stale semaphore so the next access rebuilds it.
+    other_loop = asyncio.new_event_loop()
+    try:
+        pipeline.set_bound_loop(other_loop)
+        assert pipeline._upload_semaphore is None
+        assert pipeline.get_upload_semaphore() is not sem_a
+    finally:
+        other_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_reset_after_open_drops_semaphore() -> None:
+    """``reset_after_open`` clears the lazy semaphore so a reopen rebuilds it."""
+    pipeline = make_pipeline(max_concurrent_uploads=1)
+    sem = pipeline.get_upload_semaphore()
+    assert pipeline._upload_semaphore is sem
+
+    pipeline.reset_after_open()
+    assert pipeline._upload_semaphore is None
+    # ``max_concurrent_uploads`` is untouched, so the rebuilt semaphore keeps
+    # the same cap and is a fresh object.
+    rebuilt = pipeline.get_upload_semaphore()
+    assert rebuilt is not sem
+
+
+@pytest.mark.asyncio
 async def test_add_file_uses_pipeline_steps_and_finishes_transport(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## Summary

`SourceUploadPipeline._upload_semaphore` (`_source_upload.py`) is a lazily-built loop-bound `asyncio.Semaphore` that binds to whichever event loop first acquires it. `ClientLifecycle.open` reset `drain_tracker` / `reqid` / `auth_coord` / the RPC semaphore (`composed`) on every open, but **never** reset the upload pipeline — so a client closed on loop A and reopened on loop B reused a semaphore bound to the now-dead loop A. On Python 3.10/3.11 that raises `"NotebookLMClient is bound to a different event loop"` or misparks waiters when the slot is acquired. This is the exact close→reopen hazard that **#1196** fixed for the RPC semaphore, left unaddressed for the second lazily-built loop-bound semaphore in the client.

## Gap-review finding

Tier-0, HIGH (concurrency): `SourceUploadPipeline._upload_semaphore` has no loop-affinity reset, so a client closed and reopened on a different event loop reuses a semaphore bound to the dead loop — the same bug #1196 fixed for the RPC semaphore. `ClientLifecycle.open` resets `drain_tracker`/`reqid`/`auth_coord`/`composed` but never the upload pipeline.

## Fix

Mirror the merged #1196 pattern exactly:

- **`_source_upload.py`** — add `set_bound_loop(loop)` (discard `_upload_semaphore` when the bound loop changes) and `reset_after_open()` (drop `_upload_semaphore`) to `SourceUploadPipeline`, identical in shape to `ClientComposed.set_bound_loop` / `reset_after_open`. The semaphore is reconstructed lazily on the next `get_upload_semaphore()` from inside the new loop; `max_concurrent_uploads` is untouched.
- **`client.py`** — hold the uploader as a first-class attribute (`self._source_uploader`) so the open-time reset can reach it independently of the `self.sources` feature surface.
- **`_session_lifecycle.py`** — thread the uploader into `ClientLifecycle.open` and call `uploader.set_bound_loop(self._bound_loop)` + `uploader.reset_after_open()` alongside the existing `composed.*` cascade.

The `add_file` cross-loop guard (`self._lifecycle.assert_bound_loop()`) is unchanged; this fix governs only when the lazy semaphore is rebuilt after a legitimate close→reopen onto a new loop.

## Tests

- `tests/integration/concurrency/test_cross_loop_affinity.py::test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore` — close on loop A (semaphore built + acquired on A), reopen on loop B, assert the stale semaphore was discarded and a fresh one acquires cleanly on B. Mirrors the existing RPC-semaphore reopen test.
- `tests/unit/test_session_lifecycle.py` — asserts `open()` calls `uploader.set_bound_loop(loop)` + `uploader.reset_after_open()`.
- `tests/unit/test_source_upload_pipeline.py` — focused unit tests that `set_bound_loop` discards the semaphore only on a real loop change (same-loop rebind keeps it) and `reset_after_open` drops it.
- `tests/_helpers/client_factory.py` — the shell helper now wires a real `SourceUploadPipeline` so `__aenter__`'s reset has a uploader to drive.

## Gates

- `ruff check .` + `ruff format --check .`: pass
- `mypy src/notebooklm --ignore-missing-imports`: pass (186 files)
- targeted `pytest` (concurrency affinity + lifecycle + source_upload + sources_upload): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent file upload failures when reopening a client in a new runtime/session. Upload state is now reset during client reopen so uploads remain reliable after reconnects.

* **Tests**
  * Added regression and unit tests to ensure uploads continue working correctly across client reopen/restore scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->