### PR TITLE
fix(auth): heal an EXPIRED __Secure-1PSIDTS in inline cold-start recovery

### DIFF
--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -35,6 +35,7 @@ import http.cookiejar
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -73,6 +74,54 @@ logger = logging.getLogger("notebooklm.auth")
 _PSIDTS_COOKIE = "__Secure-1PSIDTS"
 
 
+def _psidts_needs_recovery(
+    cookie_names: set[str],
+    cookie_expiry: dict[str, Any],
+    *,
+    now: float | None = None,
+) -> bool:
+    """True when ``__Secure-1PSIDTS`` is absent OR present-but-EXPIRED.
+
+    The recovery precondition originally keyed purely on name presence
+    (``_PSIDTS_COOKIE in cookie_names``), so an idle Chrome session whose
+    PSIDTS row is still on disk but already past its ``expires`` epoch silently
+    skipped the one ``RotateCookies`` POST that would heal it — cold-start then
+    failed hard at the first authed GET.
+
+    Expiry semantics mirror the storage round-trip in
+    :func:`notebooklm._auth.cookies._storage_entry_to_cookie`:
+
+    - ``expires`` of ``None`` or ``-1`` is a *session* cookie (Playwright
+      convention) — never treated as expired, so recovery does NOT fire.
+    - a numeric ``expires`` strictly less than ``now`` (default ``time.time()``)
+      is past its lifetime → treat the cookie as ABSENT so recovery fires.
+    - a numeric ``expires`` at or in the future → cookie is fresh; recovery is
+      skipped (current behavior).
+
+    Args:
+        cookie_names: Set of cookie names present on the source state.
+        cookie_expiry: ``name -> expires`` view over the same entries.
+        now: Injectable wall-clock seconds for deterministic tests; defaults
+            to :func:`time.time` at call time.
+
+    Returns:
+        ``True`` if recovery should proceed (PSIDTS missing or expired),
+        ``False`` if a present, unexpired PSIDTS makes recovery a no-op.
+    """
+    if _PSIDTS_COOKIE not in cookie_names:
+        return True
+    expires = cookie_expiry.get(_PSIDTS_COOKIE)
+    if expires in (None, -1):
+        # Session cookie — no expiry to compare against; treat as present.
+        return False
+    if not isinstance(expires, (int, float)) or isinstance(expires, bool):
+        # Unparseable expiry: fall back to the legacy name-presence behavior
+        # (present → skip) rather than firing a possibly-needless POST.
+        return False
+    reference = time.time() if now is None else now
+    return expires < reference
+
+
 def _resolve_recovery_path(path: Path | str | None) -> Path | None:
     """Resolve the effective file path for recovery, or ``None`` to decline.
 
@@ -100,7 +149,9 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     Pre-conditions (all must hold; otherwise return ``False`` without firing):
 
     1. ``SID`` present in ``storage_path``.
-    2. ``__Secure-1PSIDTS`` absent in ``storage_path``.
+    2. ``__Secure-1PSIDTS`` absent in ``storage_path``, OR present but past its
+       ``expires`` epoch (a ``-1``/``None`` session-cookie expiry counts as
+       present, not expired — see :func:`_psidts_needs_recovery`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``). Google
        rejects ``RotateCookies`` requests that lack these — see
        :func:`notebooklm._auth.cookie_policy._has_valid_secondary_binding`.
@@ -142,12 +193,12 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     state = _read_storage_for_recovery(storage_path)
     if state is None:
         return False
-    cookie_entries, cookie_names = state
+    cookie_entries, cookie_names, cookie_expiry = state
 
     if "SID" not in cookie_names:
         logger.debug("PSIDTS recovery skipped: SID missing — session is truly broken")
         return False
-    if _PSIDTS_COOKIE in cookie_names:
+    if not _psidts_needs_recovery(cookie_names, cookie_expiry):
         return False
     if not _has_valid_secondary_binding(cookie_names):
         logger.debug(
@@ -190,8 +241,8 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         fresh = _read_storage_for_recovery(storage_path)
         if fresh is None:
             return False
-        fresh_entries, fresh_names = fresh
-        if _PSIDTS_COOKIE in fresh_names:
+        fresh_entries, fresh_names, fresh_expiry = fresh
+        if not _psidts_needs_recovery(fresh_names, fresh_expiry):
             logger.debug(
                 "PSIDTS recovery skipped: file healed by another process while waiting for flock"
             )
@@ -209,14 +260,17 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
 
 def _read_storage_for_recovery(
     storage_path: Path,
-) -> tuple[list[dict], set[str]] | None:
+) -> tuple[list[dict], set[str], dict[str, Any]] | None:
     """Load + filter + name-index storage_state for the recovery preconditions.
 
-    Returns ``(cookie_entries, cookie_names)`` on success, or ``None`` on any
-    load/parse failure (caller treats this as "decline recovery"). The narrow
-    exception scope catches the documented raise sites of ``_load_storage_state``
-    (``OSError`` for missing file, ``json.JSONDecodeError`` for malformed JSON)
-    and lets unexpected ``ValueError`` propagate as an implementation bug.
+    Returns ``(cookie_entries, cookie_names, cookie_expiry)`` on success, or
+    ``None`` on any load/parse failure (caller treats this as "decline
+    recovery"). ``cookie_expiry`` is a ``name -> expires`` view over the same
+    entries so the precondition gate can treat a present-but-expired PSIDTS as
+    absent (see :func:`_psidts_needs_recovery`). The narrow exception scope
+    catches the documented raise sites of ``_load_storage_state`` (``OSError``
+    for missing file, ``json.JSONDecodeError`` for malformed JSON) and lets
+    unexpected ``ValueError`` propagate as an implementation bug.
     """
     try:
         storage_state = _load_storage_state(storage_path)
@@ -230,21 +284,28 @@ def _read_storage_for_recovery(
     cookie_names: set[str] = {
         name for entry in cookie_entries if isinstance(name := entry.get("name"), str) and name
     }
-    return cookie_entries, cookie_names
+    cookie_expiry: dict[str, Any] = {
+        name: entry.get("expires")
+        for entry in cookie_entries
+        if isinstance(name := entry.get("name"), str) and name
+    }
+    return cookie_entries, cookie_names, cookie_expiry
 
 
 def _is_psidts_persisted(storage_path: Path) -> bool:
-    """Quick re-read: is ``__Secure-1PSIDTS`` currently in the on-disk file?
+    """Quick re-read: is a fresh ``__Secure-1PSIDTS`` currently on disk?
 
     Used after a held-flock skip to detect when another process has just healed
     the file. Treats any load/parse failure as "not persisted" rather than
-    raising — the caller will retry.
+    raising — the caller will retry. A present-but-expired PSIDTS counts as
+    *not* persisted (mirrors :func:`_psidts_needs_recovery`) so a stale on-disk
+    row doesn't masquerade as a heal.
     """
     state = _read_storage_for_recovery(storage_path)
     if state is None:
         return False
-    _, names = state
-    return _PSIDTS_COOKIE in names
+    _, names, expiry = state
+    return not _psidts_needs_recovery(names, expiry)
 
 
 def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
@@ -381,7 +442,9 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     :func:`_recover_psidts_inline`):
 
     1. ``SID`` present.
-    2. ``__Secure-1PSIDTS`` absent.
+    2. ``__Secure-1PSIDTS`` absent, OR present but past its ``expires`` epoch
+       (a ``-1``/``None`` session-cookie expiry counts as present, not
+       expired — see :func:`_psidts_needs_recovery`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``).
 
     On success, mutates ``rookiepy_cookies`` to append the rotated
@@ -407,11 +470,19 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         and name
         and entry.get("value")
     }
+    cookie_expiry: dict[str, Any] = {
+        name: entry.get("expires")
+        for entry in rookiepy_cookies
+        if isinstance(entry, dict)
+        and isinstance(name := entry.get("name"), str)
+        and name
+        and entry.get("value")
+    }
 
     if "SID" not in cookie_names:
         logger.debug("In-memory PSIDTS recovery skipped: SID missing")
         return False
-    if _PSIDTS_COOKIE in cookie_names:
+    if not _psidts_needs_recovery(cookie_names, cookie_expiry):
         return False
     if not _has_valid_secondary_binding(cookie_names):
         logger.debug(

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -60,6 +60,7 @@ from . import storage as _auth_storage
 # ----------------------------------------------------------------------------
 _has_valid_secondary_binding = _cookie_policy._has_valid_secondary_binding
 _is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
+_auth_domain_priority = _cookie_policy._auth_domain_priority
 _rotation_lock_path = _keepalive._rotation_lock_path
 _file_lock_try_exclusive = _keepalive._file_lock_try_exclusive
 _try_claim_rotation = _keepalive._try_claim_rotation
@@ -120,6 +121,46 @@ def _psidts_needs_recovery(
         return False
     reference = time.time() if now is None else now
     return expires < reference
+
+
+def _index_recovery_cookies(
+    entries: list[dict[str, Any]],
+) -> tuple[set[str], dict[str, Any]]:
+    """Build domain-filtered ``(cookie_names, cookie_expiry)`` views for the gate.
+
+    Only entries on an allowed auth domain (:func:`_is_allowed_auth_domain`)
+    are indexed — this matches the jar-building filter in
+    :func:`_attempt_rotation` / :func:`recover_psidts_in_memory`, so a stray
+    ``__Secure-1PSIDTS`` / ``SID`` on an unrelated domain can't falsely satisfy
+    the precondition and skip the heal.
+
+    When the same name appears on multiple allowed domains, the highest
+    :func:`_auth_domain_priority` tier wins (``.google.com`` > regional > …),
+    mirroring :func:`notebooklm._auth.cookies.flatten_cookie_map`. Tiers are
+    strictly distinct, so the resolved expiry is deterministic regardless of
+    storage_state ordering; within a single tier the first occurrence wins.
+
+    An entry must carry a non-empty ``name`` *and* ``value`` to be indexed: a
+    nameless/valueless cookie can't be meaningfully present on either the
+    file-based or in-memory recovery path.
+    """
+    cookie_names: set[str] = set()
+    cookie_expiry: dict[str, Any] = {}
+    name_priority: dict[str, int] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name or not entry.get("value"):
+            continue
+        if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
+            continue
+        priority = _auth_domain_priority(entry.get("domain", "") or "")
+        if name not in cookie_names or priority > name_priority[name]:
+            cookie_names.add(name)
+            cookie_expiry[name] = entry.get("expires")
+            name_priority[name] = priority
+    return cookie_names, cookie_expiry
 
 
 def _resolve_recovery_path(path: Path | str | None) -> Path | None:
@@ -265,12 +306,15 @@ def _read_storage_for_recovery(
 
     Returns ``(cookie_entries, cookie_names, cookie_expiry)`` on success, or
     ``None`` on any load/parse failure (caller treats this as "decline
-    recovery"). ``cookie_expiry`` is a ``name -> expires`` view over the same
-    entries so the precondition gate can treat a present-but-expired PSIDTS as
-    absent (see :func:`_psidts_needs_recovery`). The narrow exception scope
-    catches the documented raise sites of ``_load_storage_state`` (``OSError``
-    for missing file, ``json.JSONDecodeError`` for malformed JSON) and lets
-    unexpected ``ValueError`` propagate as an implementation bug.
+    recovery"). ``cookie_names`` / ``cookie_expiry`` are domain-filtered,
+    priority-resolved views over the same entries (see
+    :func:`_index_recovery_cookies`) so the precondition gate can treat a
+    present-but-expired PSIDTS as absent (see :func:`_psidts_needs_recovery`).
+    ``cookie_entries`` is the unfiltered list — the jar builder in
+    :func:`_attempt_rotation` applies its own domain filter. The narrow
+    exception scope catches the documented raise sites of ``_load_storage_state``
+    (``OSError`` for missing file, ``json.JSONDecodeError`` for malformed JSON)
+    and lets unexpected ``ValueError`` propagate as an implementation bug.
     """
     try:
         storage_state = _load_storage_state(storage_path)
@@ -281,14 +325,7 @@ def _read_storage_for_recovery(
     if not isinstance(raw_entries, list):
         return None
     cookie_entries: list[dict] = [entry for entry in raw_entries if isinstance(entry, dict)]
-    cookie_names: set[str] = {
-        name for entry in cookie_entries if isinstance(name := entry.get("name"), str) and name
-    }
-    cookie_expiry: dict[str, Any] = {
-        name: entry.get("expires")
-        for entry in cookie_entries
-        if isinstance(name := entry.get("name"), str) and name
-    }
+    cookie_names, cookie_expiry = _index_recovery_cookies(cookie_entries)
     return cookie_entries, cookie_names, cookie_expiry
 
 
@@ -462,22 +499,7 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     Returns ``True`` if the rotation succeeded and the in-memory list now
     contains ``__Secure-1PSIDTS``; ``False`` otherwise.
     """
-    cookie_names: set[str] = {
-        name
-        for entry in rookiepy_cookies
-        if isinstance(entry, dict)
-        and isinstance(name := entry.get("name"), str)
-        and name
-        and entry.get("value")
-    }
-    cookie_expiry: dict[str, Any] = {
-        name: entry.get("expires")
-        for entry in rookiepy_cookies
-        if isinstance(entry, dict)
-        and isinstance(name := entry.get("name"), str)
-        and name
-        and entry.get("value")
-    }
+    cookie_names, cookie_expiry = _index_recovery_cookies(rookiepy_cookies)
 
     if "SID" not in cookie_names:
         logger.debug("In-memory PSIDTS recovery skipped: SID missing")

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from pathlib import Path
 
 import httpx
@@ -142,6 +143,148 @@ class TestRecoveryPreconditions:
         monkeypatch.setattr(psidts_recovery, "_try_claim_rotation", lambda _path: False)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+
+class TestPsidtsExpiryGate:
+    """The precondition gate must treat a present-but-EXPIRED PSIDTS as absent.
+
+    Tier-0 cold-start fix: ``_recover_psidts_inline`` originally keyed purely on
+    name presence, so an idle Chrome session whose ``__Secure-1PSIDTS`` row is
+    still on disk but past its ``expires`` epoch silently skipped the one
+    ``RotateCookies`` POST that would heal it (cold-start then failed at the
+    first authed GET). A ``-1``/``None`` (session-cookie) expiry stays
+    not-expired, matching ``_storage_entry_to_cookie``.
+    """
+
+    _PAST = 1_000_000_000  # 2001-09-09, comfortably in the past
+    _FUTURE = 99_999_999_999  # year 5138, comfortably in the future
+
+    @staticmethod
+    def _with_psidts(*, expires) -> list[dict]:
+        return _RECOVERABLE_COOKIES + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "stale_or_fresh",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": expires,
+            }
+        ]
+
+    # --- direct unit tests of the helper with an injectable ``now`` ---------
+
+    def test_helper_expired_needs_recovery(self):
+        """Present + expires strictly before ``now`` → recovery proceeds."""
+        assert (
+            psidts_recovery._psidts_needs_recovery(
+                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 100.0}, now=200.0
+            )
+            is True
+        )
+
+    def test_helper_fresh_is_skipped(self):
+        """Present + expires at/after ``now`` → recovery is a no-op."""
+        assert (
+            psidts_recovery._psidts_needs_recovery(
+                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 300.0}, now=200.0
+            )
+            is False
+        )
+
+    def test_helper_session_cookie_is_skipped(self):
+        """``expires`` of -1 / None is a session cookie → never expired."""
+        for sentinel in (-1, None):
+            assert (
+                psidts_recovery._psidts_needs_recovery(
+                    {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": sentinel}, now=200.0
+                )
+                is False
+            ), sentinel
+
+    def test_helper_missing_needs_recovery(self):
+        """Absent PSIDTS → recovery proceeds (current behavior, preserved)."""
+        assert psidts_recovery._psidts_needs_recovery(set(), {}, now=200.0) is True
+
+    # --- file-based recovery end-to-end ------------------------------------
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_present_but_expired_fires_recovery(self, tmp_path, httpx_mock: HTTPXMock):
+        """The idle-Chrome case: PSIDTS on disk but expired → POST fires + heals."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, self._with_psidts(expires=self._PAST))
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+
+        rotate_requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        assert len(rotate_requests) == 1
+        saved = json.loads(storage_path.read_text())
+        fresh = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
+        assert fresh["value"] == "fresh_psidts_value"
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_present_and_fresh_skips_recovery(self, tmp_path, httpx_mock: HTTPXMock):
+        """A future-dated PSIDTS is healthy → no POST."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, self._with_psidts(expires=self._FUTURE))
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_present_session_cookie_skips_recovery(self, tmp_path, httpx_mock: HTTPXMock):
+        """A session-cookie (-1) PSIDTS is not expired → no POST (current behavior)."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, self._with_psidts(expires=-1))
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    # --- in-memory twin ----------------------------------------------------
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_in_memory_present_but_expired_fires_recovery(self, httpx_mock: HTTPXMock):
+        now = time.time()
+        cookies = [
+            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
+            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "stale",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": now - 3600,
+            },
+        ]
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+        fresh = [
+            c
+            for c in cookies
+            if c["name"] == "__Secure-1PSIDTS" and c["value"] == "fresh_psidts_value"
+        ]
+        assert len(fresh) == 1
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_in_memory_present_and_fresh_skips_recovery(self, httpx_mock: HTTPXMock):
+        now = time.time()
+        cookies = [
+            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
+            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "fresh_on_disk",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": now + 3600,
+            },
+        ]
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
 
 

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -206,6 +206,61 @@ class TestPsidtsExpiryGate:
         """Absent PSIDTS → recovery proceeds (current behavior, preserved)."""
         assert psidts_recovery._psidts_needs_recovery(set(), {}, now=200.0) is True
 
+    def test_helper_expires_exactly_now_is_skipped(self):
+        """Boundary: ``expires == now`` is fresh (``expires < now`` is strict)."""
+        assert (
+            psidts_recovery._psidts_needs_recovery(
+                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 200.0}, now=200.0
+            )
+            is False
+        )
+
+    # --- domain-filtered / priority-resolved index gate --------------------
+
+    def test_psidts_on_unallowed_domain_does_not_skip_recovery(self):
+        """A PSIDTS on a non-Google domain must NOT satisfy the precondition.
+
+        Otherwise a stray ``__Secure-1PSIDTS`` cookie left by an unrelated site
+        would falsely mark the Google session healthy and skip the heal.
+        """
+        entries = _RECOVERABLE_COOKIES + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "evil",
+                "domain": ".evil.example",
+                "path": "/",
+                "expires": self._FUTURE,
+            }
+        ]
+        names, expiry = psidts_recovery._index_recovery_cookies(entries)
+        assert "__Secure-1PSIDTS" not in names
+        assert psidts_recovery._psidts_needs_recovery(names, expiry) is True
+
+    def test_index_prefers_base_google_domain_for_duplicates(self):
+        """Duplicate names resolve by ``_auth_domain_priority`` (``.google.com`` wins).
+
+        Regardless of list order, the ``.google.com`` PSIDTS expiry must win
+        over a regional-domain duplicate so the gate is order-independent.
+        """
+        fresh_base = {
+            "name": "__Secure-1PSIDTS",
+            "value": "base",
+            "domain": ".google.com",
+            "path": "/",
+            "expires": self._FUTURE,
+        }
+        expired_regional = {
+            "name": "__Secure-1PSIDTS",
+            "value": "regional",
+            "domain": ".google.com.sg",
+            "path": "/",
+            "expires": self._PAST,
+        }
+        for ordering in ([fresh_base, expired_regional], [expired_regional, fresh_base]):
+            names, expiry = psidts_recovery._index_recovery_cookies(_RECOVERABLE_COOKIES + ordering)
+            assert expiry["__Secure-1PSIDTS"] == self._FUTURE, ordering
+            assert psidts_recovery._psidts_needs_recovery(names, expiry) is False, ordering
+
     # --- file-based recovery end-to-end ------------------------------------
 
     @pytest.mark.no_default_keepalive_mock
@@ -286,6 +341,44 @@ class TestPsidtsExpiryGate:
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_in_memory_session_cookie_skips_recovery(self, httpx_mock: HTTPXMock):
+        """A session-cookie (-1) PSIDTS on the in-memory path is not expired → no POST."""
+        cookies = [
+            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
+            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "session",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": -1,
+            },
+        ]
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    # --- flock-held re-read (``_is_psidts_persisted``) ---------------------
+
+    def test_is_psidts_persisted_false_for_expired_on_disk_row(self, tmp_path):
+        """The held-flock re-read must NOT mistake a stale PSIDTS for a heal.
+
+        ``_is_psidts_persisted`` backs the flock-held skip path: a
+        present-but-expired on-disk row counts as *not* persisted, so the
+        caller keeps trying to heal instead of returning a false success.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, self._with_psidts(expires=self._PAST))
+        assert psidts_recovery._is_psidts_persisted(storage_path) is False
+
+    def test_is_psidts_persisted_true_for_fresh_on_disk_row(self, tmp_path):
+        """A future-dated on-disk PSIDTS counts as persisted (heal observed)."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, self._with_psidts(expires=self._FUTURE))
+        assert psidts_recovery._is_psidts_persisted(storage_path) is True
 
 
 class TestRecoveryHappyPath:


### PR DESCRIPTION
## Summary

Inline `__Secure-1PSIDTS` cold-start recovery (`_auth/psidts_recovery.py`) only healed a **missing** PSIDTS — it never healed an **expired-but-present** one. The precondition keyed purely on name presence:

```python
if _PSIDTS_COOKIE in cookie_names:
    return False
```

and expiry was never compared against "now" anywhere in `_auth/`. The common **idle-Chrome** case (PSIDTS row still on disk, but past its `expires` epoch) silently skipped the one `RotateCookies` POST that would heal it, so cold-start failed hard at the first authed GET.

This is the Tier-0 / HIGH "cold-start workers" finding from the v0.6.0 architecture gap review.

## Fix

- New `_psidts_needs_recovery(cookie_names, cookie_expiry, *, now=None)` helper centralizes the decision: returns `True` when PSIDTS is **absent OR present-but-expired**, `False` when present and fresh. A `-1`/`None` expiry is a **session cookie** (Playwright convention) and is treated as *not expired*, mirroring `_storage_entry_to_cookie`'s round-trip semantics. `now` defaults to `time.time()` but is injectable for deterministic tests.
- `_read_storage_for_recovery` now also returns a `name -> expires` view alongside the entries/names tuple.
- The expiry gate is applied at every place name-presence was previously checked:
  - the on-disk precondition (`_recover_psidts_inline`, ~line 150),
  - the post-flock recheck inside the rotation lock,
  - the `_is_psidts_persisted` heal probe (a stale on-disk row no longer masquerades as a heal),
  - the in-memory rookiepy twin (`recover_psidts_in_memory`, ~line 414).

Behavior is otherwise unchanged: missing → recovery proceeds; present+session(-1) → skipped; present+fresh → skipped; the `-1` sentinel handling is preserved.

## Tests

Added `TestPsidtsExpiryGate` covering, for both the file-based and in-memory paths plus direct helper unit tests:

- present + **expired** → recovery proceeds (POST fires, file healed)
- present + **fresh** (future epoch) → skipped, no POST
- present + **session(-1)** → skipped, no POST (current behavior)
- **missing** → proceeds (current behavior)

All 52 tests in `tests/unit/test_auth_psidts_recovery.py` pass (43 original + 9 new). Repo-wide `ruff check`/`ruff format --check`, `mypy src/notebooklm`, and the auth/cookie/recovery unit subset all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication cookie recovery is now expiry-aware: missing or expired cookies trigger rotation, while session cookies and future-dated cookies do not. Both on-disk and in-memory recovery paths re-check expiry before and after acquiring recovery locks and persist refreshed credentials when appropriate.
* **Tests**
  * Added unit and end-to-end tests covering expiry gating, single rotation behavior, domain precedence, and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->