### PR TITLE
fix(chat): route streamed-chat parser through safe_index + surface "er" frames

### DIFF
--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -399,9 +399,12 @@ def _raise_chat_error_frame(item: list) -> None:
     frames when the RPC itself failed. The previous parser only inspected
     ``"wrb.fr"`` frames and silently skipped these, so a real server-side
     chat error collapsed into the generic ``ChatResponseParseError`` (or an
-    empty answer). Threading the ``code`` slot through ``safe_index`` keeps
-    the read drift-aware; the embedded code/message is included verbatim so
-    callers see the actual failure instead of a generic parse error.
+    empty answer). The optional ``code`` slot is read with an explicit length
+    guard rather than ``safe_index`` (see the inline comment below): an absent
+    code is normal for a short ``"er"`` frame and must not be treated as schema
+    drift, since the frame is itself the error signal. The embedded code is
+    echoed verbatim so callers see the actual failure instead of a generic
+    parse error.
     """
     # The error code is optional enrichment — its absence must not be treated
     # as schema drift (an ``"er"`` frame is itself the error signal), so read

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -15,15 +15,23 @@ from dataclasses import dataclass, replace
 from typing import Any, Protocol
 from urllib.parse import quote, urlencode
 
-from ._env import get_default_bl, get_default_language
+from ._env import get_default_bl, get_default_language, is_strict_decode_enabled
 from .auth import format_authuser_value
-from .exceptions import ChatError, ChatResponseParseError
+from .exceptions import ChatError, ChatResponseParseError, UnknownRPCMethodError
+from .rpc._safe_index import safe_index
 from .rpc.encoder import nest_source_ids
 from .rpc.types import get_query_url
 from .types import ChatReference
 
 # Deliberate: preserve the pre-extraction chat parser logger namespace.
 logger = logging.getLogger("notebooklm._chat")
+
+# ``safe_index`` source labels for the streamed-chat descents. The streamed
+# chat endpoint (``GenerateFreeFormStreamed``) is not a batchexecute RPC, so
+# there is no obfuscated method ID to thread — descents pass ``method_id=None``
+# and rely on these labels to localize schema drift in raised
+# ``UnknownRPCMethodError`` diagnostics (ADR-011).
+_CHUNK_SOURCE = "_chat_protocol._extract_chunk_with_parseable"
 
 _UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -274,9 +282,22 @@ def _extract_chunk_with_parseable(
 
     parseable = False
     for item in data:
-        if not isinstance(item, list) or len(item) < 3:
+        if not isinstance(item, list) or len(item) < 2:
             continue
-        if item[0] != "wrb.fr":
+
+        # Surface server-side error frames instead of silently skipping them.
+        # The batchexecute stream emits ``["er", rpc_id, code, ...]`` frames
+        # when the RPC itself failed; the old parser only inspected
+        # ``"wrb.fr"`` frames, so a server error collapsed into the generic
+        # "no parseable chunks" / "empty response" failure. ``item[0]`` is a
+        # guaranteed index here (``len(item) >= 2``) so the ``safe_index``
+        # descent is byte-for-byte identical on the happy path and only raises
+        # if the frame tag slot itself drifted out from under us.
+        tag = safe_index(item, 0, method_id=None, source=_CHUNK_SOURCE)
+        if tag == "er":
+            _raise_chat_error_frame(item)
+
+        if tag != "wrb.fr" or len(item) < 3:
             continue
 
         inner_json = item[2]
@@ -307,9 +328,36 @@ def _extract_chunk_with_parseable(
         parseable = True
 
         if isinstance(inner_data, list) and len(inner_data) > 0:
-            first = inner_data[0]
-            if isinstance(first, list) and len(first) > 0:
-                text = first[0]
+            # ``inner_data`` is a *populated* answer record (heartbeats decode
+            # to ``[]`` and are excluded by ``len > 0`` above, so they never
+            # reach this strict descent). Read the answer row through
+            # ``safe_index`` (no-op on the happy path since ``len > 0``); the
+            # descent label localizes any top-level reshape in diagnostics.
+            first = safe_index(inner_data, 0, method_id=None, source=_CHUNK_SOURCE)
+            if not isinstance(first, list):
+                # The populated record's answer row is not a list — a leaf
+                # became a scalar/dict or an inner list became a wrapper. This
+                # is genuine Google-side drift that previously collapsed into a
+                # silent empty answer. Raise the same drift signal
+                # ``safe_index`` uses (``UnknownRPCMethodError`` under strict
+                # mode; soft-mode falls through) so the chat path fails loudly
+                # instead of dropping the answer (ADR-011). ``safe_index``
+                # cannot enforce the list *type* (a ``str`` answer row is still
+                # indexable), so the contract is checked explicitly here.
+                if is_strict_decode_enabled():
+                    raise UnknownRPCMethodError(
+                        f"Streamed chat answer row is not a list (got {type(first).__name__})",
+                        method_id=None,
+                        path=(0,),
+                        source=_CHUNK_SOURCE,
+                        data_at_failure=repr(first)[:200],
+                    )
+                continue
+            if len(first) > 0:
+                # Load-bearing answer-text leaf. On the happy path
+                # ``inner_data[0][0]`` is valid so this is byte-for-byte
+                # identical; under drift it raises rather than dropping text.
+                text = safe_index(inner_data, 0, 0, method_id=None, source=_CHUNK_SOURCE)
                 if not isinstance(text, str) or not text:
                     continue
 
@@ -342,6 +390,29 @@ def _extract_chunk_with_parseable(
         # "API drift" / ``ChatResponseParseError``.
 
     return None, False, refs, None, parseable
+
+
+def _raise_chat_error_frame(item: list) -> None:
+    """Surface a server-side ``"er"`` error frame as a ``ChatError``.
+
+    The streamed batchexecute backend emits ``["er", rpc_id, code, ...]``
+    frames when the RPC itself failed. The previous parser only inspected
+    ``"wrb.fr"`` frames and silently skipped these, so a real server-side
+    chat error collapsed into the generic ``ChatResponseParseError`` (or an
+    empty answer). Threading the ``code`` slot through ``safe_index`` keeps
+    the read drift-aware; the embedded code/message is included verbatim so
+    callers see the actual failure instead of a generic parse error.
+    """
+    # The error code is optional enrichment — its absence must not be treated
+    # as schema drift (an ``"er"`` frame is itself the error signal), so read
+    # the slot with an explicit length guard rather than ``safe_index``.
+    code = item[2] if len(item) > 2 else None
+    detail = f" (code {code!r})" if code is not None else ""
+    raise ChatError(
+        f"Chat request failed: the server returned an error frame{detail}. "
+        "This usually means the request was rejected or the conversation "
+        "could not be served; try again."
+    )
 
 
 def raise_if_rate_limited(error_payload: list) -> None:

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1501,12 +1501,32 @@ class TestExtractAnswerAndRefsFromChunk:
         assert text is None
         assert conv_id is None
 
-    def test_inner_data_first_not_list_is_skipped(self, auth_tokens):
-        """Test that inner_data[0] that is not a list is skipped (line 546)."""
+    def test_inner_data_first_not_list_raises_under_strict_decode(self, auth_tokens):
+        """A populated record whose answer row is not a list is drift.
+
+        Previously this silently returned ``(None, ...)`` (the answer was
+        dropped). Since the strict-decode migration of ``_chat_protocol``
+        (ADR-011) a non-list answer row in a *populated* ``wrb.fr`` record is
+        treated as Google-side wire drift and raises ``UnknownRPCMethodError``
+        under the default strict-decode mode.
+        """
         import json
+
+        from notebooklm.exceptions import UnknownRPCMethodError
 
         client = NotebookLMClient(auth_tokens)
         # inner_data[0] is a string, not a list
+        inner_data = ["not a list"]
+        data = [["wrb.fr", "method_id", json.dumps(inner_data)]]
+        with pytest.raises(UnknownRPCMethodError):
+            client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+
+    def test_inner_data_first_not_list_is_skipped_under_soft_decode(self, auth_tokens, monkeypatch):
+        """Soft-mode preserves the legacy skip-and-degrade contract."""
+        import json
+
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+        client = NotebookLMClient(auth_tokens)
         inner_data = ["not a list"]
         data = [["wrb.fr", "method_id", json.dumps(inner_data)]]
         text, is_answer, refs, conv_id = client.chat._extract_answer_and_refs_from_chunk(

--- a/tests/unit/test_streaming_chat_protocol.py
+++ b/tests/unit/test_streaming_chat_protocol.py
@@ -444,6 +444,78 @@ def test_user_displayable_error_payload_raises_same_chat_error_message() -> None
         raise_if_rate_limited(payload)
 
 
+def _wrb_envelope(inner: Any) -> str:
+    """Length-prefixed single-``wrb.fr``-frame body wrapping ``inner``."""
+    return _length_prefixed(json.dumps([["wrb.fr", None, json.dumps(inner)]]))
+
+
+@pytest.mark.parametrize(
+    "drifted_inner",
+    [
+        ["scalar-answer-row"],  # answer row is a str (indexable but wrong type)
+        [{"answer": "x"}],  # answer row became a dict
+        [42],  # answer row became an int
+        [None],  # answer row became null
+    ],
+)
+def test_drifted_answer_row_raises_under_strict_decode(drifted_inner: Any) -> None:
+    """A populated ``wrb.fr`` record whose answer row is not a list is drift.
+
+    Under the default strict-decode mode this must raise
+    :class:`UnknownRPCMethodError` instead of silently collapsing to an empty
+    answer — that silent collapse was the gap the
+    ``architecture-gap-review`` flagged for ``_chat_protocol`` (ADR-011:38).
+    """
+    from notebooklm.exceptions import UnknownRPCMethodError
+
+    with pytest.raises(UnknownRPCMethodError):
+        parse_streaming_chat_response(_wrb_envelope(drifted_inner))
+
+
+def test_drifted_answer_row_degrades_under_soft_decode(monkeypatch) -> None:
+    """Soft-mode (``NOTEBOOKLM_STRICT_DECODE=0``) preserves the legacy
+    skip-and-return-empty contract for a drifted answer row."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+
+    # The drifted frame is still a *parseable* envelope (inner JSON decoded),
+    # so the parser returns an empty answer rather than raising
+    # ChatResponseParseError.
+    result = parse_streaming_chat_response(_wrb_envelope(["scalar-answer-row"]))
+
+    assert result.answer == ""
+    assert result.references == []
+
+
+def test_empty_answer_row_is_tolerated_as_heartbeat() -> None:
+    """A populated outer wrapping an empty answer row (``[[]]``) is a
+    degenerate/heartbeat record, NOT drift — it returns an empty answer."""
+    result = parse_streaming_chat_response(_wrb_envelope([[]]))
+    assert result.answer == ""
+
+
+def test_error_frame_surfaces_chat_error_with_code() -> None:
+    """An ``"er"`` error frame must surface the embedded server error.
+
+    The previous parser only inspected ``"wrb.fr"`` frames and silently
+    skipped ``"er"`` frames, so a server-side chat error collapsed into the
+    generic empty/parse-failure path. The parser now raises a
+    :class:`ChatError` that echoes the embedded error code.
+    """
+    error_frame = json.dumps([["er", "GenerateFreeFormStreamed", 13, "internal boom"]])
+
+    with pytest.raises(ChatError, match=r"server returned an error frame.*code 13"):
+        parse_streaming_chat_response(_length_prefixed(error_frame))
+
+
+def test_error_frame_without_code_still_surfaces_chat_error() -> None:
+    """A short ``"er"`` frame (no code slot) still raises a ``ChatError``
+    rather than being silently skipped."""
+    error_frame = json.dumps([["er", "GenerateFreeFormStreamed"]])
+
+    with pytest.raises(ChatError, match="server returned an error frame"):
+        parse_streaming_chat_response(_length_prefixed(error_frame))
+
+
 def test_chat_protocol_static_import_guard() -> None:
     forbidden = {
         "notebooklm",


### PR DESCRIPTION
## Summary

The streamed-chat parser in `_chat_protocol.py` (the highest-traffic decode path) hand-rolled positional indexing and did **not** use `safe_index`, so it silently bypassed `NOTEBOOKLM_STRICT_DECODE`. On a Google wire-shape change, a populated `wrb.fr` answer record whose answer row was no longer a list collapsed to an **empty answer** instead of raising drift. It also only inspected `wrb.fr` frames and silently skipped `er` error frames, so a server-side chat error degraded into a generic "empty response" / parse failure.

This is the v0.6.0 architecture gap-review remediation for the **Tier-1 / existential** finding: `_chat_protocol` is explicitly named as unmigrated strict-decode debt in **ADR-011:38** (`docs/adr/0011-schema-validation-policy.md`), alongside `_artifact_downloads` / `_artifact_polling`.

## What changed

**(a) Route the load-bearing answer descents through `safe_index`** (frame tag, answer row, answer-text leaf), threading a `source` label — mirroring how `rpc/decoder.py` consumes `safe_index`.
- The existing `isinstance`/`len` guards already pre-empt out-of-bounds reads, so the **happy path is byte-for-byte unchanged**.
- A *populated* `wrb.fr` record whose answer row is **not a list** is now treated as genuine Google-side drift and raises `UnknownRPCMethodError` under the default strict-decode mode. `safe_index` cannot enforce the list *type* (a `str` answer row is still indexable at `[0]`), so the contract is checked explicitly with the same `is_strict_decode_enabled()` gate `safe_index` uses.
- Soft-mode (`NOTEBOOKLM_STRICT_DECODE=0`) preserves the legacy skip-and-degrade behavior.
- Empty (`[]`) answer rows stay tolerated as degenerate/heartbeat records.

**(b) Detect `er` frames** and surface the embedded error/code as a `ChatError` instead of silently skipping them. The optional code slot is read with a length guard — its absence is not drift, since the `er` frame itself is the error signal.

Per-citation descents (`parse_citations`, `parse_single_citation`, `extract_text_passages`, `collect_texts_from_nested`) keep their tolerant degrade-without-raising contract, which is pinned by existing tests; they are deliberately left for a follow-up (the gap-review explicitly allows migrating the load-bearing answer + citation entry points first).

## Tests

- All existing `tests/unit/test_streaming_chat_protocol.py` cases stay green (citations / scores / ranges / XSSI / empty-raise / `UserDisplayableError`).
- Added: drifted chat envelope raises `UnknownRPCMethodError` under strict-decode (parametrized over scalar / dict / int / null answer rows); soft-mode degrades to empty; `[[]]` heartbeat tolerated; an `er` chat frame surfaces a `ChatError` with the embedded code (and a short `er` frame with no code still raises `ChatError`).
- Updated the one characterization test in `test_chat_characterization.py` that pinned the **old silent-skip** behavior to assert the new strict-raises / soft-skips contract (it characterized exactly the bug being fixed).

## Gates

- `ruff check .` + `ruff format --check .` — pass
- `mypy src/notebooklm --ignore-missing-imports` — pass
- `pytest tests/unit/test_streaming_chat_protocol.py tests/unit/test_chat.py tests/unit/test_chat_characterization.py` — 133 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Chat responses now explicitly surface server-side RPC errors instead of silently failing with empty results.
  * Improved handling of malformed server data with configurable strict and lenient parsing modes.

* **Tests**
  * Added test coverage for error handling and edge-case behavior in chat streaming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->