### PR TITLE
fix(decoder): harden RPC drift detection in extract/parse + golden suite

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -38,9 +38,42 @@ __all__ = [
     "extract_rpc_result",
     "decode_response",
     "safe_index",
+    "byte_count_mismatch_total",
+    "reset_byte_count_mismatch_total",
 ]
 
 logger = logging.getLogger(__name__)
+
+# Number of times ``parse_chunked_response`` has observed a declared byte-count
+# that did not match the UTF-8 byte length of the following payload. The
+# tolerant parse is *not* affected (mismatches are expected on live multi-chunk
+# streams; see ``parse_chunked_response``'s Note: block), but a monotonically
+# rising counter is the cheapest drift signal: a sudden jump means Google
+# changed the framing unit or the proxy stopped preserving counts. Read-only
+# for callers; reset only via ``reset_byte_count_mismatch_total`` (tests).
+_BYTE_COUNT_MISMATCH_TOTAL = 0
+
+# Emit at most one byte-count-mismatch WARNING per this many observed
+# mismatches so a live multi-chunk response cannot flood CI logs while a real
+# drift event still surfaces above DEBUG. The first mismatch of a process
+# always warns (1 % interval == 0).
+_BYTE_COUNT_MISMATCH_WARN_INTERVAL = 500
+
+
+def byte_count_mismatch_total() -> int:
+    """Return the process-wide byte-count-mismatch counter.
+
+    Exposed for drift dashboards / telemetry probes that want to alert on a
+    sudden rise without re-parsing logs. The value only ever increases within
+    a process; ``reset_byte_count_mismatch_total`` exists for test isolation.
+    """
+    return _BYTE_COUNT_MISMATCH_TOTAL
+
+
+def reset_byte_count_mismatch_total() -> None:
+    """Reset the byte-count-mismatch counter (test isolation only)."""
+    global _BYTE_COUNT_MISMATCH_TOTAL
+    _BYTE_COUNT_MISMATCH_TOTAL = 0
 
 
 class RPCErrorCode(IntEnum):
@@ -195,12 +228,19 @@ def parse_chunked_response(response: str) -> list[Any]:
         valid JSON, because recorded and proxy-transformed streams may not
         preserve Google's original byte count and live Google responses use a
         different unit (likely UTF-16 code units) than ``len(s.encode("utf-8"))``.
+        Each mismatch also increments the process-wide
+        ``byte_count_mismatch_total`` counter and emits a rate-limited WARNING
+        (one per ``_BYTE_COUNT_MISMATCH_WARN_INTERVAL`` mismatches) so a real
+        framing-unit change is a visible drift signal without the tolerant
+        parse changing or per-chunk DEBUG noise flooding CI logs.
         A JSONDecodeError on the payload still emits a WARNING on the
         subsequent parse-failure path. If the malformed-payload rate exceeds
         10%, raises RPCError as this likely indicates API changes. Framing and
         mixed payload/framing corruption keep their own strict guards without
         letting byte-count records dilute the payload-specific threshold.
     """
+    global _BYTE_COUNT_MISMATCH_TOTAL
+
     if not response or not response.strip():
         return []
 
@@ -248,6 +288,22 @@ def parse_chunked_response(response: str) -> list[Any]:
                     actual_byte_count,
                     _truncate_response_preview(json_str),
                 )
+                # Surface the mismatch as a drift signal WITHOUT changing the
+                # tolerant parse: bump a process-wide counter (telemetry probes
+                # alert on a sudden rise) and emit a rate-limited WARNING so a
+                # real framing-unit change rises above the per-chunk DEBUG noise
+                # without flooding CI logs on every live multi-chunk response.
+                _BYTE_COUNT_MISMATCH_TOTAL += 1
+                if _BYTE_COUNT_MISMATCH_TOTAL % _BYTE_COUNT_MISMATCH_WARN_INTERVAL == 1:
+                    logger.warning(
+                        "Byte-count mismatch in chunked response (declared %d, "
+                        "actual %d bytes); tolerated. Total mismatches this "
+                        "process: %d — a sudden rise may indicate the "
+                        "batchexecute framing unit changed.",
+                        byte_count,
+                        actual_byte_count,
+                        _BYTE_COUNT_MISMATCH_TOTAL,
+                    )
 
             try:
                 chunk = json.loads(json_str)
@@ -476,9 +532,28 @@ def _user_displayable_error_message(error_info: Any) -> str:
     return f"{message} Upstream status code {code} ({label})."
 
 
+_SENTINEL_NO_RESULT = object()
+
+
 def extract_rpc_result(chunks: list[Any], rpc_id: str) -> Any:
-    """Extract result data for a specific RPC ID from chunks."""
+    """Extract result data for a specific RPC ID from chunks.
+
+    In ``rt=c`` streamed mode the backend can emit more than one ``wrb.fr``
+    frame for a single ``rpc_id`` (e.g. a null placeholder frame followed by
+    the final populated frame). We iterate every frame and return the result
+    of the **last non-null** ``wrb.fr`` frame for ``rpc_id`` so the placeholder
+    does not shadow the real payload. ``er`` frames and embedded
+    ``UserDisplayableError`` markers still raise immediately — those are
+    terminal signals, not placeholders to be superseded.
+
+    For single-frame responses (every existing golden fixture) the first and
+    last usable frame are identical, so behaviour is unchanged.
+    """
     source = "decoder.extract_rpc_result"
+    # Track the last usable result so a later populated frame wins over an
+    # earlier null placeholder. ``_SENTINEL_NO_RESULT`` distinguishes "no
+    # wrb.fr frame seen yet" from "the last frame genuinely carried null".
+    last_result: Any = _SENTINEL_NO_RESULT
     for chunk in chunks:
         if not isinstance(chunk, list):
             continue
@@ -535,12 +610,22 @@ def extract_rpc_result(chunks: list[Any], rpc_id: str) -> Any:
 
                 if isinstance(result_data, str):
                     try:
-                        return json.loads(result_data)
+                        parsed: Any = json.loads(result_data)
                     except json.JSONDecodeError:
-                        return result_data
-                return result_data
+                        parsed = result_data
+                else:
+                    parsed = result_data
 
-    return None
+                # Prefer a later populated frame over an earlier null
+                # placeholder; only let a null frame overwrite a previous
+                # usable result when nothing better followed (it won't, since
+                # we never downgrade a non-null result back to null).
+                if parsed is not None or last_result is _SENTINEL_NO_RESULT:
+                    last_result = parsed
+
+    if last_result is _SENTINEL_NO_RESULT:
+        return None
+    return last_result
 
 
 def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) -> Any:

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -55,8 +55,9 @@ _BYTE_COUNT_MISMATCH_TOTAL = 0
 
 # Emit at most one byte-count-mismatch WARNING per this many observed
 # mismatches so a live multi-chunk response cannot flood CI logs while a real
-# drift event still surfaces above DEBUG. The first mismatch of a process
-# always warns (1 % interval == 0).
+# drift event still surfaces above DEBUG. The counter is post-incremented
+# before the modulo test, so the first mismatch of a process always warns
+# (1 % interval == 1) and subsequent warnings land at interval + 1.
 _BYTE_COUNT_MISMATCH_WARN_INTERVAL = 500
 
 

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+import threading
 from enum import IntEnum
 from typing import Any
 
@@ -53,6 +54,15 @@ logger = logging.getLogger(__name__)
 # for callers; reset only via ``reset_byte_count_mismatch_total`` (tests).
 _BYTE_COUNT_MISMATCH_TOTAL = 0
 
+# Guards every read/increment/reset of ``_BYTE_COUNT_MISMATCH_TOTAL``. The
+# counter is mutated from ``parse_chunked_response``, which can run on worker
+# threads (``run_in_executor`` / ``ThreadPoolExecutor``) or from several
+# per-thread ``NotebookLMClient`` instances at once. ``x += 1`` is a
+# read-modify-write over multiple bytecodes, so the GIL does not make it
+# atomic — without this lock increments could be lost and the "warn every N"
+# cadence could fire on a stale count.
+_BYTE_COUNT_MISMATCH_LOCK = threading.Lock()
+
 # Emit at most one byte-count-mismatch WARNING per this many observed
 # mismatches so a live multi-chunk response cannot flood CI logs while a real
 # drift event still surfaces above DEBUG. The counter is post-incremented
@@ -68,13 +78,15 @@ def byte_count_mismatch_total() -> int:
     sudden rise without re-parsing logs. The value only ever increases within
     a process; ``reset_byte_count_mismatch_total`` exists for test isolation.
     """
-    return _BYTE_COUNT_MISMATCH_TOTAL
+    with _BYTE_COUNT_MISMATCH_LOCK:
+        return _BYTE_COUNT_MISMATCH_TOTAL
 
 
 def reset_byte_count_mismatch_total() -> None:
     """Reset the byte-count-mismatch counter (test isolation only)."""
     global _BYTE_COUNT_MISMATCH_TOTAL
-    _BYTE_COUNT_MISMATCH_TOTAL = 0
+    with _BYTE_COUNT_MISMATCH_LOCK:
+        _BYTE_COUNT_MISMATCH_TOTAL = 0
 
 
 class RPCErrorCode(IntEnum):
@@ -294,8 +306,12 @@ def parse_chunked_response(response: str) -> list[Any]:
                 # alert on a sudden rise) and emit a rate-limited WARNING so a
                 # real framing-unit change rises above the per-chunk DEBUG noise
                 # without flooding CI logs on every live multi-chunk response.
-                _BYTE_COUNT_MISMATCH_TOTAL += 1
-                if _BYTE_COUNT_MISMATCH_TOTAL % _BYTE_COUNT_MISMATCH_WARN_INTERVAL == 1:
+                # Snapshot the count under the lock so the modulo decision and
+                # the logged total are consistent even under concurrent parses.
+                with _BYTE_COUNT_MISMATCH_LOCK:
+                    _BYTE_COUNT_MISMATCH_TOTAL += 1
+                    mismatch_total = _BYTE_COUNT_MISMATCH_TOTAL
+                if mismatch_total % _BYTE_COUNT_MISMATCH_WARN_INTERVAL == 1:
                     logger.warning(
                         "Byte-count mismatch in chunked response (declared %d, "
                         "actual %d bytes); tolerated. Total mismatches this "
@@ -303,7 +319,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                         "batchexecute framing unit changed.",
                         byte_count,
                         actual_byte_count,
-                        _BYTE_COUNT_MISMATCH_TOTAL,
+                        mismatch_total,
                     )
 
             try:

--- a/tests/fixtures/rpc_golden/ADD_SOURCE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE.json
@@ -48,5 +48,97 @@
         "SCRUBBED_SRC_NEW_001"
       ]
     ]
-  }
+  },
+  "drift_cases": [
+    {
+      "name": "error_frame",
+      "description": "An 'er' frame for this method id raises RPCError.",
+      "chunks": [
+        [
+          [
+            "er",
+            "izAoDd",
+            "Source rejected",
+            null,
+            null
+          ]
+        ]
+      ],
+      "expected_exception": "RPCError",
+      "expected_message_substring": "Source rejected"
+    },
+    {
+      "name": "not_found_status_code",
+      "description": "Null result with bare NOT_FOUND (5) status at index 5 raises ClientError, not auth.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "izAoDd",
+            null,
+            null,
+            null,
+            [
+              5
+            ],
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "ClientError",
+      "expected_message_substring": "Not found"
+    },
+    {
+      "name": "method_id_drift",
+      "description": "Response names a different id, signalling a wire-id change.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "ZZdrift",
+            "[[\"SCRUBBED_SRC_NEW_001\"]]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "UnknownRPCMethodError",
+      "expected_message_substring": "may have changed"
+    },
+    {
+      "name": "multi_frame_placeholder_then_final",
+      "description": "rt=c streamed null placeholder followed by the populated frame; the final frame wins.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "izAoDd",
+            null,
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ],
+        [
+          [
+            "wrb.fr",
+            "izAoDd",
+            "[[\"SCRUBBED_SRC_NEW_001\"]]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_decoded": [
+        [
+          "SCRUBBED_SRC_NEW_001"
+        ]
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/CREATE_ARTIFACT.json
+++ b/tests/fixtures/rpc_golden/CREATE_ARTIFACT.json
@@ -39,5 +39,102 @@
     "expected_decoded": [
       "SCRUBBED_ARTIFACT_001"
     ]
-  }
+  },
+  "drift_cases": [
+    {
+      "name": "error_frame",
+      "description": "An 'er' frame for this method id raises RPCError.",
+      "chunks": [
+        [
+          [
+            "er",
+            "R7cb6c",
+            "Artifact generation rejected",
+            null,
+            null
+          ]
+        ]
+      ],
+      "expected_exception": "RPCError",
+      "expected_message_substring": "Artifact generation rejected"
+    },
+    {
+      "name": "user_displayable_rate_limit",
+      "description": "Embedded UserDisplayableError at index 5 raises RateLimitError.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "R7cb6c",
+            null,
+            null,
+            null,
+            [
+              8,
+              null,
+              [
+                [
+                  "UserDisplayableError",
+                  []
+                ]
+              ]
+            ],
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "RateLimitError",
+      "expected_message_substring": "rate limit"
+    },
+    {
+      "name": "method_id_drift",
+      "description": "Response names a different id, signalling a wire-id change.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "ZZdrift",
+            "[\"SCRUBBED_ARTIFACT_001\"]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "UnknownRPCMethodError",
+      "expected_message_substring": "may have changed"
+    },
+    {
+      "name": "multi_frame_placeholder_then_final",
+      "description": "rt=c streamed null placeholder followed by the populated frame; the final frame wins.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "R7cb6c",
+            null,
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ],
+        [
+          [
+            "wrb.fr",
+            "R7cb6c",
+            "[\"SCRUBBED_ARTIFACT_001\"]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_decoded": [
+        "SCRUBBED_ARTIFACT_001"
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
+++ b/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
@@ -59,5 +59,105 @@
         ]
       ]
     ]
-  }
+  },
+  "drift_cases": [
+    {
+      "name": "error_frame",
+      "description": "An 'er' frame for this method id raises RPCError.",
+      "chunks": [
+        [
+          [
+            "er",
+            "wXbhsf",
+            "Authentication failed",
+            null,
+            null
+          ]
+        ]
+      ],
+      "expected_exception": "RPCError",
+      "expected_message_substring": "Authentication failed"
+    },
+    {
+      "name": "permission_denied_status_code",
+      "description": "Null result with bare PERMISSION_DENIED (7) status raises ClientError, not auth.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "wXbhsf",
+            null,
+            null,
+            null,
+            [
+              7
+            ],
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "ClientError",
+      "expected_message_substring": "Permission denied"
+    },
+    {
+      "name": "method_id_drift",
+      "description": "Response names a different id, signalling a wire-id change.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "ZZdrift",
+            "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0]]]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "UnknownRPCMethodError",
+      "expected_message_substring": "may have changed"
+    },
+    {
+      "name": "multi_frame_placeholder_then_final",
+      "description": "rt=c streamed null placeholder followed by the populated frame; the final frame wins.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "wXbhsf",
+            null,
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ],
+        [
+          [
+            "wrb.fr",
+            "wXbhsf",
+            "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0]]]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_decoded": [
+        [
+          [
+            "SCRUBBED_NB_001",
+            "Scrubbed Notebook One",
+            null,
+            null,
+            null,
+            null,
+            0
+          ]
+        ]
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/README.md
+++ b/tests/fixtures/rpc_golden/README.md
@@ -38,7 +38,23 @@ ID changes without renaming the file.
   },
 
   "mapper": "notebooklm._research_task_parser:parse_research_task_models",
-  "mapper_expected": [/* the public-dict shape (or list thereof) produced by the mapper */]
+  "mapper_expected": [/* the public-dict shape (or list thereof) produced by the mapper */],
+
+  "drift_cases": [
+    {
+      "name": "error_frame",
+      "description": "One sentence describing the drift scenario.",
+      "chunks": [/* synthetic chunks for this scenario */],
+      "allow_null": false,
+      "expected_exception": "RPCError",
+      "expected_message_substring": "..."
+    },
+    {
+      "name": "multi_frame_placeholder_then_final",
+      "chunks": [/* null placeholder frame, then populated frame */],
+      "expected_decoded": /* the python payload decode_response must return */
+    }
+  ]
 }
 ```
 
@@ -48,6 +64,24 @@ whose payload is consumed by inline feature-level extraction
 mapper is imported via `module.path:attribute` form and applied to
 `expected_decoded`; the returned value (or its `to_public_dict()` form for
 dataclasses) is compared against `mapper_expected`.
+
+`drift_cases` is **optional** — present only on the drift-prone methods
+(`CREATE_ARTIFACT`, `ADD_SOURCE`, `START_FAST_RESEARCH`, `LIST_NOTEBOOKS`)
+that pin the decoder's *error-path* behaviour in addition to the happy path.
+Each case rebuilds the chunked wire response from its own `chunks` and feeds
+it to `decode_response`. A case must declare **exactly one** of:
+
+- `expected_exception` — the exact decoder exception class name
+  (`RPCError`, `ClientError`, `RateLimitError`, or `UnknownRPCMethodError`),
+  optionally narrowed by a case-insensitive `expected_message_substring`.
+  Covers `er` frames, embedded `UserDisplayableError` rate limits, bare
+  gRPC NOT_FOUND/PERMISSION_DENIED status codes, and method-id drift.
+- `expected_decoded` — the payload `decode_response` must return when the
+  response carries multiple frames for one id (e.g. a `rt=c` null
+  placeholder followed by the populated final frame). Pins the
+  "prefer the last non-null `wrb.fr` frame" contract.
+
+`allow_null` defaults to `false` per case.
 
 ## Scrubbing rules
 

--- a/tests/fixtures/rpc_golden/START_FAST_RESEARCH.json
+++ b/tests/fixtures/rpc_golden/START_FAST_RESEARCH.json
@@ -37,5 +37,102 @@
     "expected_decoded": [
       "SCRUBBED_RESEARCH_001"
     ]
-  }
+  },
+  "drift_cases": [
+    {
+      "name": "error_frame_numeric_code",
+      "description": "An 'er' frame with a numeric code raises RPCError.",
+      "chunks": [
+        [
+          [
+            "er",
+            "Ljjv0c",
+            429,
+            null,
+            null
+          ]
+        ]
+      ],
+      "expected_exception": "RPCError",
+      "expected_message_substring": "rate limit"
+    },
+    {
+      "name": "user_displayable_rate_limit",
+      "description": "Embedded UserDisplayableError at index 5 raises RateLimitError.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "Ljjv0c",
+            null,
+            null,
+            null,
+            [
+              8,
+              null,
+              [
+                [
+                  "UserDisplayableError",
+                  []
+                ]
+              ]
+            ],
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "RateLimitError",
+      "expected_message_substring": "rate limit"
+    },
+    {
+      "name": "method_id_drift",
+      "description": "Response names a different id, signalling a wire-id change.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "ZZdrift",
+            "[\"SCRUBBED_RESEARCH_001\"]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_exception": "UnknownRPCMethodError",
+      "expected_message_substring": "may have changed"
+    },
+    {
+      "name": "multi_frame_placeholder_then_final",
+      "description": "rt=c streamed null placeholder followed by the populated frame; the final frame wins.",
+      "chunks": [
+        [
+          [
+            "wrb.fr",
+            "Ljjv0c",
+            null,
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ],
+        [
+          [
+            "wrb.fr",
+            "Ljjv0c",
+            "[\"SCRUBBED_RESEARCH_001\"]",
+            null,
+            null,
+            null,
+            "generic"
+          ]
+        ]
+      ],
+      "expected_decoded": [
+        "SCRUBBED_RESEARCH_001"
+      ]
+    }
+  ]
 }

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -13,11 +13,13 @@ from notebooklm.rpc.decoder import (
     RPCError,
     RPCErrorCode,
     UnknownRPCMethodError,
+    byte_count_mismatch_total,
     collect_rpc_ids,
     decode_response,
     extract_rpc_result,
     get_error_message_for_code,
     parse_chunked_response,
+    reset_byte_count_mismatch_total,
     strip_anti_xssi,
 )
 from notebooklm.rpc.types import RPCMethod
@@ -139,6 +141,80 @@ class TestParseChunkedResponse:
         assert mismatch_records[0].levelno == logging.DEBUG
         assert "payload is" in mismatch_records[0].message
 
+    def test_byte_count_mismatch_bumps_counter_and_warns_first_time(self, caplog):
+        """A byte-count mismatch is a drift signal: counter + one WARNING.
+
+        The tolerant parse is unchanged (valid JSON payloads are still
+        returned), but each mismatch increments the process-wide counter and
+        the first mismatch of the process emits a rate-limited WARNING so a
+        real framing-unit change rises above the per-chunk DEBUG noise.
+        """
+        reset_byte_count_mismatch_total()
+        try:
+            payload = json.dumps(["wrong-size"])
+            response = f"{len(payload) + 1}\n{payload}\n"
+
+            assert byte_count_mismatch_total() == 0
+            with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
+                chunks = parse_chunked_response(response)
+
+            # Tolerant parse preserved: valid JSON still returned.
+            assert chunks == [["wrong-size"]]
+            assert byte_count_mismatch_total() == 1
+
+            warnings = [
+                r
+                for r in caplog.records
+                if r.name == "notebooklm.rpc.decoder"
+                and r.levelno == logging.WARNING
+                and "Byte-count mismatch" in r.message
+            ]
+            assert len(warnings) == 1
+            assert "framing unit changed" in warnings[0].message
+        finally:
+            reset_byte_count_mismatch_total()
+
+    def test_byte_count_mismatch_warning_is_rate_limited(self, caplog):
+        """Repeated mismatches keep counting but do not flood WARNING logs."""
+        reset_byte_count_mismatch_total()
+        try:
+            payload = json.dumps(["wrong-size"])
+            record = f"{len(payload) + 1}\n{payload}"
+            # 50 mismatching records well under the WARN interval (500).
+            response = "\n".join(record for _ in range(50)) + "\n"
+
+            with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
+                chunks = parse_chunked_response(response)
+
+            assert chunks == [["wrong-size"]] * 50
+            assert byte_count_mismatch_total() == 50
+            warnings = [
+                r
+                for r in caplog.records
+                if r.name == "notebooklm.rpc.decoder"
+                and r.levelno == logging.WARNING
+                and "Byte-count mismatch" in r.message
+            ]
+            # Only the first mismatch of the process warns; the rest are
+            # counted silently (still DEBUG-logged).
+            assert len(warnings) == 1
+        finally:
+            reset_byte_count_mismatch_total()
+
+    def test_matching_byte_count_does_not_bump_counter(self):
+        """A correct byte count is not a mismatch and must not bump the counter."""
+        reset_byte_count_mismatch_total()
+        try:
+            payload = json.dumps(["right-size"])
+            response = f"{len(payload.encode('utf-8'))}\n{payload}\n"
+
+            chunks = parse_chunked_response(response)
+
+            assert chunks == [["right-size"]]
+            assert byte_count_mismatch_total() == 0
+        finally:
+            reset_byte_count_mismatch_total()
+
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):
         """A trailing byte-count line without a payload is malformed and skipped."""
         valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
@@ -244,6 +320,51 @@ class TestExtractRPCResult:
         result = extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
         assert result == "plain string result"
 
+    def test_prefers_last_non_null_frame_for_same_id(self):
+        """rt=c emits a null placeholder then the populated frame; the last wins.
+
+        Multiple ``wrb.fr`` frames for one RPC ID are legal in streamed
+        ``rt=c`` mode. The decoder must skip past an earlier null placeholder
+        and return the final populated payload instead of the first match.
+        """
+        placeholder = ["wrb.fr", RPCMethod.LIST_NOTEBOOKS.value, None, None, None, None]
+        final = [
+            "wrb.fr",
+            RPCMethod.LIST_NOTEBOOKS.value,
+            json.dumps([["final-notebook"]]),
+            None,
+            None,
+            None,
+        ]
+        # Frames may arrive in separate chunks or grouped — cover both.
+        chunks = [[placeholder], [final]]
+
+        result = extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+        assert result == [["final-notebook"]]
+
+    def test_does_not_downgrade_populated_frame_to_later_null(self):
+        """A trailing null frame must not clobber an earlier populated result."""
+        final = [
+            "wrb.fr",
+            RPCMethod.LIST_NOTEBOOKS.value,
+            json.dumps([["real-data"]]),
+            None,
+            None,
+            None,
+        ]
+        trailing_null = ["wrb.fr", RPCMethod.LIST_NOTEBOOKS.value, None, None, None, None]
+        chunks = [[final], [trailing_null]]
+
+        result = extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+        assert result == [["real-data"]]
+
+    def test_single_null_frame_still_returns_none(self):
+        """A lone null frame returns None exactly as before (first==last)."""
+        chunks = [["wrb.fr", RPCMethod.LIST_NOTEBOOKS.value, None, None, None, None]]
+
+        result = extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+        assert result is None
+
     def test_raises_on_error_chunk(self):
         """Test raises RPCError for error chunks."""
         chunks = [
@@ -251,6 +372,15 @@ class TestExtractRPCResult:
         ]
 
         with pytest.raises(RPCError, match="Some error message"):
+            extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+
+    def test_error_frame_after_null_placeholder_still_raises(self):
+        """An 'er' frame following a null placeholder is terminal and raises."""
+        placeholder = ["wrb.fr", RPCMethod.LIST_NOTEBOOKS.value, None, None, None, None]
+        error = ["er", RPCMethod.LIST_NOTEBOOKS.value, "Terminal failure", None, None]
+        chunks = [[placeholder], [error]]
+
+        with pytest.raises(RPCError, match="Terminal failure"):
             extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
 
     def test_handles_numeric_error_code(self):

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -215,6 +215,40 @@ class TestParseChunkedResponse:
         finally:
             reset_byte_count_mismatch_total()
 
+    def test_concurrent_mismatches_do_not_lose_increments(self):
+        """The counter is lock-guarded, so concurrent parses must not race.
+
+        ``x += 1`` on a module global is a non-atomic read-modify-write in
+        CPython, so without the lock concurrent ``parse_chunked_response``
+        calls (worker threads / multiple per-thread clients) could lose
+        increments. Drive many threads at one mismatch each and assert the
+        total equals the number of parses exactly.
+        """
+        import threading
+
+        reset_byte_count_mismatch_total()
+        try:
+            payload = json.dumps(["wrong-size"])
+            response = f"{len(payload) + 1}\n{payload}\n"
+            threads = 16
+            per_thread = 50
+            barrier = threading.Barrier(threads)
+
+            def worker() -> None:
+                barrier.wait()
+                for _ in range(per_thread):
+                    parse_chunked_response(response)
+
+            workers = [threading.Thread(target=worker) for _ in range(threads)]
+            for t in workers:
+                t.start()
+            for t in workers:
+                t.join()
+
+            assert byte_count_mismatch_total() == threads * per_thread
+        finally:
+            reset_byte_count_mismatch_total()
+
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):
         """A trailing byte-count line without a payload is malformed and skipped."""
         valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -51,6 +51,12 @@ from notebooklm._source_upload_payloads import (
     build_rename_source_params,
     build_resumable_upload_start_request,
 )
+from notebooklm.exceptions import (
+    ClientError,
+    RateLimitError,
+    RPCError,
+    UnknownRPCMethodError,
+)
 from notebooklm.rpc.decoder import (
     collect_rpc_ids,
     decode_response,
@@ -1059,4 +1065,124 @@ def test_mapper_output_shape_when_documented(method: RPCMethod) -> None:
         f"Mapper {mapper_ref!r} for {method.name} returned a shape that "
         f"does not match the fixture's mapper_expected.\n"
         f"Got: {mapped_repr!r}\nExpected: {expected!r}"
+    )
+
+
+# Drift-case exception names a fixture may declare, mapped to the concrete
+# decoder exception class. Restricting the allowed names keeps a fixture from
+# silently asserting against a typo'd / non-existent exception.
+_DRIFT_EXCEPTION_TYPES: dict[str, type[RPCError]] = {
+    "RPCError": RPCError,
+    "ClientError": ClientError,
+    "RateLimitError": RateLimitError,
+    "UnknownRPCMethodError": UnknownRPCMethodError,
+}
+
+# Methods whose fixtures are expected to carry a ``drift_cases`` block. These
+# are the drift-prone methods called out in the gap review: artifact creation,
+# source attach, a research start, and the notebook list. The guard below fails
+# loudly if any of them loses its drift coverage.
+_DRIFT_COVERED_METHODS: tuple[RPCMethod, ...] = (
+    RPCMethod.CREATE_ARTIFACT,
+    RPCMethod.ADD_SOURCE,
+    RPCMethod.START_FAST_RESEARCH,
+    RPCMethod.LIST_NOTEBOOKS,
+)
+
+
+def _collect_drift_cases() -> list[tuple[str, RPCMethod, dict[str, Any]]]:
+    """Flatten every fixture's ``drift_cases`` into parametrize tuples.
+
+    Returns ``(case_id, method, case)`` triples so each drift scenario is an
+    individually addressable test row.
+    """
+    collected: list[tuple[str, RPCMethod, dict[str, Any]]] = []
+    for method in ALL_METHODS:
+        fixture = _load_fixture(method)
+        for case in fixture.get("drift_cases", []):
+            name = case.get("name", "unnamed")
+            collected.append((f"{method.name}-{name}", method, case))
+    return collected
+
+
+_DRIFT_CASES = _collect_drift_cases()
+
+
+def test_drift_prone_methods_have_drift_cases() -> None:
+    """The drift-prone methods must each ship a non-empty ``drift_cases`` block.
+
+    This is the load-bearing guard for the error-path coverage: if a future
+    edit drops the ``drift_cases`` from one of these fixtures, the suite fails
+    loudly rather than silently losing the decoder's error-path goldens.
+    """
+    missing = []
+    for method in _DRIFT_COVERED_METHODS:
+        fixture = _load_fixture(method)
+        cases = fixture.get("drift_cases")
+        if not isinstance(cases, list) or not cases:
+            missing.append(method.name)
+    assert not missing, (
+        f"Drift-prone methods missing a non-empty 'drift_cases' block: "
+        f"{missing}. Restore the decoder error-path goldens for each."
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "case"),
+    [(method, case) for _, method, case in _DRIFT_CASES],
+    ids=[case_id for case_id, _, _ in _DRIFT_CASES],
+)
+def test_decoder_drift_case_behaviour(method: RPCMethod, case: dict[str, Any]) -> None:
+    """Each drift case asserts the decoder's exact error / multi-frame result.
+
+    A case declares **exactly one** of ``expected_exception`` (the decoder
+    must raise that class) or ``expected_decoded`` (the decoder must return
+    that payload — used for multi-frame placeholder-then-final responses).
+    """
+    chunks = case["chunks"]
+    allow_null = case.get("allow_null", False)
+    raw_response = _build_wire_response(chunks)
+
+    has_exception = "expected_exception" in case
+    has_decoded = "expected_decoded" in case
+    if has_exception == has_decoded:
+        raise _FixtureSchemaError(
+            f"Drift case {case.get('name')!r} for RPCMethod.{method.name} must "
+            f"declare exactly one of 'expected_exception' / 'expected_decoded' "
+            f"(file: {_fixture_path(method)})."
+        )
+
+    if has_exception:
+        exc_name = case["expected_exception"]
+        if exc_name not in _DRIFT_EXCEPTION_TYPES:
+            raise _FixtureSchemaError(
+                f"Drift case {case.get('name')!r} for RPCMethod.{method.name} "
+                f"declares unknown expected_exception {exc_name!r}; allowed: "
+                f"{sorted(_DRIFT_EXCEPTION_TYPES)} (file: {_fixture_path(method)})."
+            )
+        exc_type = _DRIFT_EXCEPTION_TYPES[exc_name]
+        with pytest.raises(exc_type) as exc_info:
+            decode_response(raw_response, method.value, allow_null=allow_null)
+        # Assert the EXACT class, not just an IS-A match: ClientError /
+        # RateLimitError / UnknownRPCMethodError all subclass RPCError, so a
+        # bare ``pytest.raises(RPCError)`` would not catch a regression that
+        # raised the wrong (broader/narrower) subtype.
+        assert type(exc_info.value) is exc_type, (
+            f"Drift case {case['name']!r} for {method.name} expected exactly "
+            f"{exc_name}, got {type(exc_info.value).__name__}."
+        )
+        substring = case.get("expected_message_substring")
+        if substring is not None:
+            assert substring.lower() in str(exc_info.value).lower(), (
+                f"Drift case {case['name']!r} for {method.name}: message "
+                f"{str(exc_info.value)!r} does not contain {substring!r}."
+            )
+        return
+
+    expected = case["expected_decoded"]
+    decoded = decode_response(raw_response, method.value, allow_null=allow_null)
+    assert decoded == expected, (
+        f"Drift case {case['name']!r} for {method.name} returned a payload "
+        f"that does not match expected_decoded.\n"
+        f"Got: {decoded!r}\nExpected: {expected!r}"
     )

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -1098,7 +1098,14 @@ def _collect_drift_cases() -> list[tuple[str, RPCMethod, dict[str, Any]]]:
     """
     collected: list[tuple[str, RPCMethod, dict[str, Any]]] = []
     for method in ALL_METHODS:
-        fixture = _load_fixture(method)
+        # Runs at import/collection time, so a missing or malformed fixture must
+        # not abort collection here — the dedicated guard tests
+        # (test_every_rpc_method_has_a_fixture / the schema checks) own those
+        # failures and emit far clearer messages than a collection-time crash.
+        try:
+            fixture = _load_fixture(method)
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
         for case in fixture.get("drift_cases", []):
             name = case.get("name", "unnamed")
             collected.append((f"{method.name}-{name}", method, case))


### PR DESCRIPTION
## Summary

Three cohesive drift-detection fixes in `src/notebooklm/rpc/decoder.py`, surfaced by the v0.6.0 architecture gap review (Tier-1 drift-detection finding: the decoder + golden suite under-cover the error/streamed paths that signal Google changed a wire shape or method ID).

### (A) `extract_rpc_result`: prefer the LAST non-null `wrb.fr` frame
Previously the function returned the result of the **first** matching `wrb.fr` frame for the RPC id. In `rt=c` streamed mode the backend can emit a **null placeholder** frame followed by the **populated final** frame for a single id — returning the first match silently dropped the real payload. It now iterates every frame and keeps the last usable (non-null) result, while still:
- raising immediately on `er` frames (terminal, even after a placeholder),
- raising `RateLimitError` on embedded `UserDisplayableError` markers,
- never downgrading a populated result back to a later null.

For every existing single-frame golden fixture `first == last`, so behaviour is unchanged.

### (B) `parse_chunked_response`: surface byte-count mismatch as a drift signal
A declared byte-count that mismatches `len(payload)` was silently downgraded to DEBUG. It is now also a signal **without changing the tolerant parse**:
- a process-wide `byte_count_mismatch_total()` counter (telemetry/drift probes can alert on a sudden rise),
- a rate-limited WARNING (one per `_BYTE_COUNT_MISMATCH_WARN_INTERVAL` mismatches) so a real framing-unit change rises above the per-chunk DEBUG noise without flooding CI logs.

The mismatch is still tolerated (valid JSON payloads are returned) — existing tolerance tests stay green. `reset_byte_count_mismatch_total()` is added for test isolation.

### (C) Golden suite drift coverage
The `tests/fixtures/rpc_golden/*.json` fixtures + `test_rpc_golden_payloads.py` previously pinned only happy-path single-frame responses. Extended the fixture schema with an optional `drift_cases` block (documented in the directory README) and added a parametrized test that asserts the decoder raises the **exact** exception (`RPCError` / `ClientError` / `RateLimitError` / `UnknownRPCMethodError`) or returns the right multi-frame payload for representative envelopes — `er` frames, embedded `UserDisplayableError` rate limits, bare gRPC NOT_FOUND/PERMISSION_DENIED status codes, method-id drift, and placeholder-then-final multi-frame streams — across the drift-prone methods: **CREATE_ARTIFACT, ADD_SOURCE, START_FAST_RESEARCH, LIST_NOTEBOOKS**. A guard fails loudly if any of those loses its drift coverage.

## Tests
- New `extract_rpc_result` multi-frame / non-downgrade / terminal-error tests in `test_decoder.py`.
- New byte-count counter + rate-limited-WARNING + matching-count-no-bump tests in `test_decoder.py`.
- 16 new parametrized drift-case rows + a coverage guard in `test_rpc_golden_payloads.py`.

## Gates
- `ruff check .` + `ruff format --check .`: pass
- `mypy src/notebooklm --ignore-missing-imports`: pass
- targeted `pytest` (decoder + golden + strict-decode) and full `tests/unit`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process-wide telemetry for response framing mismatches and an exposed reset for the mismatch counter.

* **Bug Fixes**
  * Improved multi-frame streaming handling so the final populated frame wins and null placeholders don't overwrite results.
  * Treat framing byte-count drift as a visible warning (rate-limited) while preserving tolerant parsing.

* **Tests**
  * Expanded tests and fixtures covering drift/error scenarios and concurrent parsing.

* **Documentation**
  * Updated fixture README to document drift-case schema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->