### PR TITLE
fix(chat): make conversation cache true LRU with bounded per-conversation turns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ RPC Layer (rpc/)
 | `_middleware.py` | HTTP-shaped middleware request/response envelope, chain composition, and middleware Protocol |
 | `_middleware_context.py` | Canonical per-request context-key vocabulary for middleware |
 | `_middleware_chain_host.py` | Mutable owner for the live middleware chain slots and retry-budget tunables |
-| `_conversation_cache.py` | Per-instance LRU conversation cache for `ChatAPI` |
+| `_conversation_cache.py` | Per-instance true-LRU conversation cache for `ChatAPI` (caps conversation count via `MAX_CONVERSATION_CACHE_SIZE` and per-conversation turns via `MAX_TURNS_PER_CONVERSATION`) |
 | `_polling_registry.py` | Pending-poll registry for long-running artifact generations |
 | `_cookie_persistence.py` | Cookie-jar persistence + `__Secure-1PSIDTS` rotation |
 | `_session_contracts.py` | Shared session Protocols consumed by sub-clients |
@@ -217,7 +217,7 @@ src/notebooklm/
 ├── _client_metrics.py           # Telemetry / metrics seam
 ├── _transport_drain.py          # In-flight transport drain coordinator
 ├── _reqid_counter.py            # Request-counter / request-id helpers
-├── _conversation_cache.py       # Per-instance LRU conversation cache
+├── _conversation_cache.py       # Per-instance true-LRU conversation cache (bounded conversation count + per-conversation turns)
 ├── _polling_registry.py         # Artifact polling helpers
 ├── _cookie_persistence.py       # Cookie-jar persistence + __Secure-1PSIDTS rotation
 ├── _session_lifecycle.py        # Open/close lifecycle seam (loop affinity + keepalive task)

--- a/docs/development.md
+++ b/docs/development.md
@@ -115,7 +115,7 @@ a narrow Protocol surface so it can be unit-tested against a stub:
 | `_request_types.py` | `AuthSnapshot`, `BuildRequest`, request materialization | Shared request construction Interface. |
 | `_transport_errors.py` | transport exceptions, `parse_retry_after`, `raise_mapped_post_error` | Terminal `Kernel.post` error mapping for middleware retry/auth behavior. |
 | `_streaming_post.py` | `stream_post_with_size_cap` | Low-level POST streaming and response-size guard. |
-| `_conversation_cache.py` | `ConversationCache` | Per-instance LRU conversation cache for `ChatAPI` continuity. |
+| `_conversation_cache.py` | `ConversationCache` | Per-instance true-LRU conversation cache for `ChatAPI` continuity. Caps the conversation count (`MAX_CONVERSATION_CACHE_SIZE`) and the turns retained per conversation (`MAX_TURNS_PER_CONVERSATION`). |
 | `_polling_registry.py` | `PollRegistry` | Pending-poll registry shared by long-running artifact generations. |
 | `_cookie_persistence.py` | `CookiePersistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. |
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -684,7 +684,7 @@ compatibility shim was removed in v0.5.0.
 | `_session_helpers` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval`. | Cross-seam pure helpers; behaviour-bearing (and therefore unit-tested). |
 | `_error_injection` | `ERROR_INJECT_ENV_VAR`, `_get_error_injection_mode`, `_refuse_synthetic_error_outside_test_context`. | Env-var resolver + startup guard for the synthetic-error harness. |
 | `_session_auth` | `AuthRefreshCoordinator`: refresh-task lifecycle, refresh lock, `AuthSnapshot` rotation. | Lazy `asyncio.Lock` construction; never instantiated outside a running loop. |
-| `_conversation_cache` | Per-instance LRU `_conversation_cache` for `ChatAPI` continuity. | Pure in-process state; not shared across client instances. |
+| `_conversation_cache` | Per-instance true-LRU `_conversation_cache` for `ChatAPI` continuity; bounds the conversation count and the turns retained per conversation. | Pure in-process state; not shared across client instances. |
 | `_cookie_persistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. | Exposes a `SaveCookiesToStorage` Protocol host. |
 | `_transport_drain` | `TransportDrainTracker`: in-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. | Construction is event-loop-agnostic; the `Condition` is allocated on first use. |
 | `_session_lifecycle` | `ClientLifecycle`: loop-affinity guard, `aclose` plumbing, keepalive task wiring. | Client lifecycle collaborator. |

--- a/src/notebooklm/_conversation_cache.py
+++ b/src/notebooklm/_conversation_cache.py
@@ -1,19 +1,44 @@
-"""Conversation cache collaborator owned by :mod:`notebooklm._chat`."""
+"""Conversation cache collaborator owned by :mod:`notebooklm._chat`.
+
+A per-instance, true-LRU cache of conversation turns. Two caps bound growth:
+
+* ``MAX_CONVERSATION_CACHE_SIZE`` caps the number of distinct conversations.
+  Every access (read or write) marks the touched conversation as most-recently
+  used; when a *new* conversation would exceed the cap the *least*-recently-used
+  conversation is evicted.
+* ``MAX_TURNS_PER_CONVERSATION`` caps the turns retained per conversation. When
+  a conversation exceeds the cap its oldest turns are dropped so the most recent
+  exchanges (the ones follow-up history is built from) always survive.
+
+All mutations are synchronous and contain no ``await`` points, so under
+cooperative asyncio scheduling a mutation runs to completion before any other
+coroutine resumes (see ``tests/unit/test_concurrency_cache_race.py``).
+"""
 
 from __future__ import annotations
 
-__all__ = ["MAX_CONVERSATION_CACHE_SIZE", "ConversationCache"]
+__all__ = [
+    "MAX_CONVERSATION_CACHE_SIZE",
+    "MAX_TURNS_PER_CONVERSATION",
+    "ConversationCache",
+]
 
 from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any
 
-# Maximum number of conversations to cache (FIFO eviction)
+# Maximum number of distinct conversations to cache (LRU eviction).
 MAX_CONVERSATION_CACHE_SIZE = 100
+
+# Maximum number of turns retained per conversation. Generous enough to cover
+# normal multi-turn chats while bounding unbounded growth on a single, very long
+# conversation. When exceeded the oldest turns are dropped first so follow-up
+# history (built from the most recent turns) stays intact.
+MAX_TURNS_PER_CONVERSATION = 1000
 
 
 class ConversationCache:
-    """Synchronous FIFO cache for conversation turns."""
+    """Synchronous true-LRU cache for conversation turns."""
 
     def __init__(
         self,
@@ -33,26 +58,47 @@ class ConversationCache:
         turn_number: int,
         *,
         max_size: int = MAX_CONVERSATION_CACHE_SIZE,
+        max_turns: int = MAX_TURNS_PER_CONVERSATION,
     ) -> None:
-        """Cache a conversation turn, evicting FIFO only for new conversations."""
+        """Cache a conversation turn, applying LRU + per-conversation bounds.
+
+        Touching a conversation (new or existing) marks it most-recently-used.
+        A *new* conversation evicts the least-recently-used entries until the
+        cache is back under ``max_size``. Each conversation's turn list is
+        trimmed to its newest ``max_turns`` entries.
+        """
         is_new_conversation = conversation_id not in self.conversations
 
         if is_new_conversation:
             while len(self.conversations) >= max_size:
                 self.conversations.popitem(last=False)
             self.conversations[conversation_id] = []
+        else:
+            # Existing conversation accessed: promote to most-recently-used.
+            self.conversations.move_to_end(conversation_id)
 
-        self.conversations[conversation_id].append(
+        turns = self.conversations[conversation_id]
+        turns.append(
             {
                 "query": query,
                 "answer": answer,
                 "turn_number": turn_number,
             }
         )
+        # Trim oldest turns once the per-conversation cap is exceeded.
+        if max_turns > 0 and len(turns) > max_turns:
+            del turns[: len(turns) - max_turns]
 
     def get_cached_conversation(self, conversation_id: str) -> list[dict[str, Any]]:
-        """Return cached turns for ``conversation_id`` or an empty list."""
-        return self.conversations.get(conversation_id, [])
+        """Return cached turns for ``conversation_id`` or an empty list.
+
+        Reading a present conversation marks it most-recently-used so it
+        survives eviction ahead of conversations that have not been touched.
+        """
+        if conversation_id in self.conversations:
+            self.conversations.move_to_end(conversation_id)
+            return self.conversations[conversation_id]
+        return []
 
     def clear(self, conversation_id: str | None = None) -> bool:
         """Clear one cached conversation or the whole cache."""

--- a/src/notebooklm/_conversation_cache.py
+++ b/src/notebooklm/_conversation_cache.py
@@ -66,7 +66,15 @@ class ConversationCache:
         A *new* conversation evicts the least-recently-used entries until the
         cache is back under ``max_size``. Each conversation's turn list is
         trimmed to its newest ``max_turns`` entries.
+
+        A non-positive ``max_size`` or ``max_turns`` means "retain nothing":
+        the turn is dropped without mutating the cache. Guarding here also
+        avoids the eviction loop draining the cache and raising ``KeyError``
+        on a ``popitem`` against an empty mapping.
         """
+        if max_size <= 0 or max_turns <= 0:
+            return
+
         is_new_conversation = conversation_id not in self.conversations
 
         if is_new_conversation:
@@ -86,7 +94,7 @@ class ConversationCache:
             }
         )
         # Trim oldest turns once the per-conversation cap is exceeded.
-        if max_turns > 0 and len(turns) > max_turns:
+        if len(turns) > max_turns:
             del turns[: len(turns) - max_turns]
 
     def get_cached_conversation(self, conversation_id: str) -> list[dict[str, Any]]:

--- a/tests/unit/test_conversation_cache.py
+++ b/tests/unit/test_conversation_cache.py
@@ -19,21 +19,49 @@ def test_cache_conversation_turn_appends_turns() -> None:
     ]
 
 
-def test_cache_conversation_turn_fifo_evicts_only_for_new_conversations() -> None:
+def test_cache_conversation_turn_lru_evicts_least_recently_used() -> None:
     cache = ConversationCache()
 
     cache.cache_conversation_turn("conv-1", "q1", "a1", 1, max_size=2)
     cache.cache_conversation_turn("conv-2", "q2", "a2", 1, max_size=2)
+    # Re-touching conv-1 promotes it to most-recently-used, so the next new
+    # conversation evicts conv-2 (the least-recently-used) rather than conv-1.
     cache.cache_conversation_turn("conv-1", "q3", "a3", 2, max_size=2)
     cache.cache_conversation_turn("conv-3", "q4", "a4", 1, max_size=2)
 
-    assert list(cache.conversations) == ["conv-2", "conv-3"]
-    assert cache.get_cached_conversation("conv-2") == [
-        {"query": "q2", "answer": "a2", "turn_number": 1}
+    assert list(cache.conversations) == ["conv-1", "conv-3"]
+    assert cache.get_cached_conversation("conv-1") == [
+        {"query": "q1", "answer": "a1", "turn_number": 1},
+        {"query": "q3", "answer": "a3", "turn_number": 2},
     ]
     assert cache.get_cached_conversation("conv-3") == [
         {"query": "q4", "answer": "a4", "turn_number": 1}
     ]
+
+
+def test_get_cached_conversation_promotes_to_most_recently_used() -> None:
+    cache = ConversationCache()
+
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1, max_size=2)
+    cache.cache_conversation_turn("conv-2", "q2", "a2", 1, max_size=2)
+    # A pure read of conv-1 must mark it most-recently-used so the next new
+    # conversation evicts the untouched conv-2 instead.
+    assert cache.get_cached_conversation("conv-1")
+    cache.cache_conversation_turn("conv-3", "q3", "a3", 1, max_size=2)
+
+    assert list(cache.conversations) == ["conv-1", "conv-3"]
+
+
+def test_per_conversation_turn_cap_evicts_oldest_turns() -> None:
+    cache = ConversationCache()
+
+    for i in range(1, 6):
+        cache.cache_conversation_turn("conv-1", f"q{i}", f"a{i}", i, max_turns=3)
+
+    turns = cache.get_cached_conversation("conv-1")
+    # Only the newest three turns survive; the two oldest were trimmed.
+    assert [turn["turn_number"] for turn in turns] == [3, 4, 5]
+    assert [turn["query"] for turn in turns] == ["q3", "q4", "q5"]
 
 
 def test_get_cached_conversation_returns_empty_list_for_missing_conversation() -> None:

--- a/tests/unit/test_conversation_cache.py
+++ b/tests/unit/test_conversation_cache.py
@@ -64,6 +64,21 @@ def test_per_conversation_turn_cap_evicts_oldest_turns() -> None:
     assert [turn["query"] for turn in turns] == ["q3", "q4", "q5"]
 
 
+def test_cache_conversation_turn_handles_non_positive_bounds() -> None:
+    cache = ConversationCache()
+
+    # A non-positive max_size must not loop forever / KeyError on popitem;
+    # it retains nothing instead.
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1, max_size=0)
+    assert cache.get_cached_conversation("conv-1") == []
+    assert list(cache.conversations) == []
+
+    # A non-positive max_turns likewise caches nothing for that turn.
+    cache.cache_conversation_turn("conv-2", "q1", "a1", 1, max_turns=0)
+    assert cache.get_cached_conversation("conv-2") == []
+    assert list(cache.conversations) == []
+
+
 def test_get_cached_conversation_returns_empty_list_for_missing_conversation() -> None:
     cache = ConversationCache()
 

--- a/tests/unit/test_conversation_cache.py
+++ b/tests/unit/test_conversation_cache.py
@@ -39,6 +39,22 @@ def test_cache_conversation_turn_lru_evicts_least_recently_used() -> None:
     ]
 
 
+def test_cache_conversation_turn_max_size_one_keeps_only_latest() -> None:
+    cache = ConversationCache()
+
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1, max_size=1)
+    assert list(cache.conversations) == ["conv-1"]
+
+    # Each new conversation evicts the sole prior entry; the cache always
+    # holds exactly one conversation.
+    cache.cache_conversation_turn("conv-2", "q2", "a2", 1, max_size=1)
+    assert list(cache.conversations) == ["conv-2"]
+    assert cache.get_cached_conversation("conv-1") == []
+    assert cache.get_cached_conversation("conv-2") == [
+        {"query": "q2", "answer": "a2", "turn_number": 1}
+    ]
+
+
 def test_get_cached_conversation_promotes_to_most_recently_used() -> None:
     cache = ConversationCache()
 

--- a/tests/unit/test_tier_13_all_exports.py
+++ b/tests/unit/test_tier_13_all_exports.py
@@ -47,6 +47,7 @@ EXPECTED_RPC_EXECUTOR_ALL: list[str] = ["DecodeResponse", "RpcExecutor"]
 
 EXPECTED_CONVERSATION_CACHE_ALL: list[str] = [
     "MAX_CONVERSATION_CACHE_SIZE",
+    "MAX_TURNS_PER_CONVERSATION",
     "ConversationCache",
 ]
 


### PR DESCRIPTION
## Summary

`src/notebooklm/_conversation_cache.py` was documented as a "per-instance LRU" cache but actually behaved as **FIFO** with **unbounded** per-conversation turn lists:

- It evicted with `popitem(last=False)` and never promoted a conversation on access, so a frequently-used *old* conversation could be evicted ahead of a *stale* one.
- Each conversation's turn list grew without limit — a single long-lived conversation could accumulate unbounded turns.

This PR makes it a true LRU and bounds per-conversation growth.

## Changes

- **True LRU**: every access (`get_cached_conversation` read path and `cache_conversation_turn` write path) `move_to_end`s the touched conversation, so the most-recently-used conversation survives the `MAX_CONVERSATION_CACHE_SIZE` cap; eviction now drops the least-recently-used entry.
- **Bounded turns**: new `MAX_TURNS_PER_CONVERSATION = 1000` constant; oldest turns are trimmed on append once the cap is exceeded. The default comfortably covers normal multi-turn use, and follow-up history (built from the most recent turns in `_chat.py._build_conversation_history`) stays intact.
- **Docs accuracy**: updated the module docstring/comments (which said "FIFO" internally) and the `CLAUDE.md` / `docs/development.md` / `docs/python-api.md` descriptions so they accurately describe true-LRU + the per-conversation bound.
- **Tests**: LRU keeps a recently-accessed old conversation while evicting a stale one (both write- and read-access paths); per-conversation cap evicts oldest turns. Pinned the new `MAX_TURNS_PER_CONVERSATION` export.

## Verification

- `ruff check` / `ruff format` clean
- `mypy src/notebooklm` clean
- `scripts/check_claude_md_freshness.py` OK
- `pytest -k "conversation or cache or chat"` and full `tests/unit` green

Consumers in `_chat.py` (`get_cached_turns`, `_build_conversation_history`, `cache_size`, `clear_cache`, `cache_turn`) verified correct under LRU + bounded turns.

Fixes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable per-conversation turn limits to optimize cache memory usage

* **Documentation**
  * Clarified that conversation cache now uses true-LRU (Least Recently Used) eviction strategy, ensuring frequently accessed conversations are retained longer

* **Tests**
  * Expanded test coverage for LRU eviction behavior and per-conversation turn limit enforcement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->