### PR TITLE
test: raise coverage on low-coverage login/CLI helper modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ fail_under = 90
 # rationale in the commit message.
 [tool.notebooklm.per_file_coverage_floors]
 "src/notebooklm/__main__.py" = 0
-"src/notebooklm/cli/_firefox_containers.py" = 75
+"src/notebooklm/cli/_firefox_containers.py" = 95
 "src/notebooklm/cli/doctor_cmd.py" = 63
 "src/notebooklm/cli/profile_cmd.py" = 74
 "src/notebooklm/cli/session_cmd.py" = 83

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -77,3 +77,45 @@ class TestAgentTemplates:
 
         assert content is not None
         assert "NotebookLM Automation" in content
+
+    def test_codex_reads_repo_root_agents_when_present(self, tmp_path):
+        """Codex prefers the repo-root AGENTS.md when running from a checkout."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("# Repository Guidelines\nlocal", encoding="utf-8")
+        with patch.object(agent_templates_module, "REPO_ROOT_AGENTS", agents_file):
+            content = agent_templates_module.get_agent_source_content("codex")
+
+        assert content == "# Repository Guidelines\nlocal"
+
+    def test_unknown_target_returns_none(self, tmp_path):
+        """An unsupported agent name yields ``None`` (no template file)."""
+        # Point the repo-root probes at non-existent paths so the lookup
+        # falls through to the ``AGENT_TEMPLATE_FILES`` map, which has no
+        # entry for an unknown target.
+        with (
+            patch.object(agent_templates_module, "REPO_ROOT_AGENTS", tmp_path / "AGENTS.md"),
+            patch.object(agent_templates_module, "REPO_ROOT_CLAUDE_SKILL", tmp_path / "SKILL.md"),
+        ):
+            assert agent_templates_module.get_agent_source_content("gpt-9000") is None
+
+    def test_read_package_data_returns_file_contents(self, tmp_path):
+        """``_read_package_data`` reads a bundled template file.
+
+        The packaged ``notebooklm/data/`` directory only exists in built
+        wheels, not in a source checkout, so point ``resources.files`` at a
+        temp tree that mirrors the bundled layout to exercise the read.
+        """
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "BUNDLED.md").write_text("bundled body", encoding="utf-8")
+
+        with patch.object(agent_templates_module.resources, "files", return_value=tmp_path):
+            content = agent_templates_module._read_package_data("BUNDLED.md")
+
+        assert content == "bundled body"
+
+    def test_read_package_data_missing_file_returns_none(self, tmp_path):
+        """A missing packaged file is swallowed and reported as ``None``."""
+        # data/ dir exists but the requested file does not -> FileNotFoundError.
+        (tmp_path / "data").mkdir()
+        with patch.object(agent_templates_module.resources, "files", return_value=tmp_path):
+            assert agent_templates_module._read_package_data("does-not-exist.md") is None

--- a/tests/unit/cli/test_cookie_jar_enumerate.py
+++ b/tests/unit/cli/test_cookie_jar_enumerate.py
@@ -1,0 +1,193 @@
+"""Unit tests for ``_enumerate_one_jar`` failure-outcome branches.
+
+``_enumerate_one_jar`` probes one rookiepy cookie set against
+``?authuser=N`` and returns either a list of :class:`Account` records or a
+:class:`BrowserCookieOutcome` subclass on failure. The CLI-level fan-out
+tests exercise the happy paths and the quiet network branch; these direct
+unit tests pin the remaining validation-failure and stale-cookie outcome
+shapes (both quiet and loud).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from notebooklm.cli.services.login import cookie_jar
+from notebooklm.cli.services.login.outcomes import (
+    CookieValidationFailure,
+    NetworkFailure,
+    StaleCookies,
+)
+
+
+class _FakeAccount:
+    def __init__(self, authuser, email, is_default):
+        self.authuser = authuser
+        self.email = email
+        self.is_default = is_default
+
+
+def _patch_auth_internals(*, run_async_side_effect=None, run_async_return=None):
+    """Patch the function-local ``notebooklm.auth`` imports + ``run_async``.
+
+    ``_enumerate_one_jar`` imports ``build_cookie_jar`` /
+    ``extract_cookies_with_domains`` / ``enumerate_accounts`` from
+    ``notebooklm.auth`` at call time and drives the probe through
+    ``cookie_jar.run_async``. Stub them so no real network or cookie
+    machinery runs.
+    """
+    # ``enumerate_accounts`` is async, so ``patch(...)`` would auto-create an
+    # ``AsyncMock`` whose call returns an un-awaited coroutine (``run_async``
+    # is stubbed and never awaits it). Use an explicit sync ``MagicMock`` so
+    # ``enumerate_accounts(jar)`` returns a plain sentinel instead.
+    patches = [
+        patch("notebooklm.auth.extract_cookies_with_domains", return_value={}),
+        patch("notebooklm.auth.build_cookie_jar", return_value=object()),
+        patch("notebooklm.auth.enumerate_accounts", MagicMock(return_value=object())),
+    ]
+    if run_async_side_effect is not None:
+        patches.append(patch.object(cookie_jar, "run_async", side_effect=run_async_side_effect))
+    else:
+        patches.append(patch.object(cookie_jar, "run_async", return_value=run_async_return))
+    return patches
+
+
+class TestValidationFailure:
+    def test_quiet_returns_collapsed_validation_failure(self):
+        with patch.object(
+            cookie_jar,
+            "validate_with_recovery",
+            return_value=({"cookies": []}, ValueError("missing SID")),
+        ):
+            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=True)
+
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "COOKIE_VALIDATION_FAILED"
+        # Quiet mode collapses to the single-line message naming the browser.
+        assert "chrome" in out.message
+        assert "\n" not in out.message
+
+    def test_loud_returns_validation_failure_with_hint(self):
+        with patch.object(
+            cookie_jar,
+            "validate_with_recovery",
+            return_value=({"cookies": []}, ValueError("missing SID")),
+        ):
+            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=False)
+
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "COOKIE_VALIDATION_FAILED"
+        # Loud mode includes the underlying error and a multi-line hint body.
+        assert "missing SID" in out.message
+        assert "No valid Google authentication cookies" in out.message
+
+
+class TestStaleCookies:
+    def test_quiet_returns_collapsed_stale_outcome(self):
+        patches = _patch_auth_internals(run_async_side_effect=ValueError("rejected"))
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=True)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert isinstance(out, StaleCookies)
+        assert out.code == "STALE_COOKIES"
+        assert "firefox" in out.message
+        assert "too stale" in out.message
+
+    def test_loud_returns_detailed_stale_outcome(self):
+        patches = _patch_auth_internals(run_async_side_effect=ValueError("rejected"))
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=False)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert isinstance(out, StaleCookies)
+        assert out.code == "STALE_COOKIES"
+        assert "Account discovery failed" in out.message
+        assert "notebooklm login" in out.message
+
+
+class TestNetworkFailure:
+    def test_quiet_reraises_network_error(self):
+        patches = _patch_auth_internals(run_async_side_effect=httpx.ConnectError("no route"))
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                with pytest.raises(httpx.RequestError):
+                    cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=True)
+            finally:
+                for p in patches:
+                    p.stop()
+
+    def test_loud_returns_network_failure_outcome(self):
+        patches = _patch_auth_internals(run_async_side_effect=httpx.ConnectError("no route"))
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=False)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert isinstance(out, NetworkFailure)
+        assert out.code == "NETWORK_ERROR"
+
+
+class TestSuccessPath:
+    def test_legacy_single_jar_returns_accounts_unchanged(self):
+        accounts = [_FakeAccount(0, "a@gmail.com", True)]
+        patches = _patch_auth_internals(run_async_return=accounts)
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert out == accounts
+
+    def test_fanout_tags_accounts_with_browser_profile(self):
+        accounts = [_FakeAccount(0, "a@gmail.com", True)]
+        patches = _patch_auth_internals(run_async_return=accounts)
+        # Account is constructed inside the function from notebooklm.auth, so
+        # leave the real class in place here (only the probe is stubbed).
+        with patch.object(
+            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        ):
+            for p in patches:
+                p.start()
+            try:
+                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", "Profile 1")
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert len(out) == 1
+        assert out[0].browser_profile == "Profile 1"
+        assert out[0].email == "a@gmail.com"

--- a/tests/unit/cli/test_cookie_jar_enumerate.py
+++ b/tests/unit/cli/test_cookie_jar_enumerate.py
@@ -10,6 +10,7 @@ shapes (both quiet and loud).
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -30,38 +31,41 @@ class _FakeAccount:
         self.is_default = is_default
 
 
-def _patch_auth_internals(*, run_async_side_effect=None, run_async_return=None):
-    """Patch the function-local ``notebooklm.auth`` imports + ``run_async``.
+@contextmanager
+def _enumerate_env(*, validate_return, run_async_side_effect=None, run_async_return=None):
+    """Patch the collaborators ``_enumerate_one_jar`` reaches at call time.
 
-    ``_enumerate_one_jar`` imports ``build_cookie_jar`` /
-    ``extract_cookies_with_domains`` / ``enumerate_accounts`` from
-    ``notebooklm.auth`` at call time and drives the probe through
-    ``cookie_jar.run_async``. Stub them so no real network or cookie
-    machinery runs.
+    ``validate_with_recovery`` and ``run_async`` are module-level imports in
+    ``cookie_jar`` (patched via ``patch.object``); ``build_cookie_jar`` /
+    ``extract_cookies_with_domains`` / ``enumerate_accounts`` are *function-local*
+    ``from ....auth import ...`` lookups, so they're patched on ``notebooklm.auth``.
+    ``enumerate_accounts`` is async, so an auto-specced ``patch`` would hand back
+    an un-awaited coroutine (``run_async`` is stubbed and never awaits it); an
+    explicit sync ``MagicMock`` returns a plain sentinel instead.
     """
-    # ``enumerate_accounts`` is async, so ``patch(...)`` would auto-create an
-    # ``AsyncMock`` whose call returns an un-awaited coroutine (``run_async``
-    # is stubbed and never awaits it). Use an explicit sync ``MagicMock`` so
-    # ``enumerate_accounts(jar)`` returns a plain sentinel instead.
-    patches = [
-        patch("notebooklm.auth.extract_cookies_with_domains", return_value={}),
-        patch("notebooklm.auth.build_cookie_jar", return_value=object()),
-        patch("notebooklm.auth.enumerate_accounts", MagicMock(return_value=object())),
-    ]
-    if run_async_side_effect is not None:
-        patches.append(patch.object(cookie_jar, "run_async", side_effect=run_async_side_effect))
-    else:
-        patches.append(patch.object(cookie_jar, "run_async", return_value=run_async_return))
-    return patches
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(cookie_jar, "validate_with_recovery", return_value=validate_return)
+        )
+        stack.enter_context(patch("notebooklm.auth.extract_cookies_with_domains", return_value={}))
+        stack.enter_context(patch("notebooklm.auth.build_cookie_jar", return_value=object()))
+        stack.enter_context(
+            patch("notebooklm.auth.enumerate_accounts", MagicMock(return_value=object()))
+        )
+        if run_async_side_effect is not None:
+            stack.enter_context(
+                patch.object(cookie_jar, "run_async", side_effect=run_async_side_effect)
+            )
+        else:
+            stack.enter_context(
+                patch.object(cookie_jar, "run_async", return_value=run_async_return)
+            )
+        yield
 
 
 class TestValidationFailure:
     def test_quiet_returns_collapsed_validation_failure(self):
-        with patch.object(
-            cookie_jar,
-            "validate_with_recovery",
-            return_value=({"cookies": []}, ValueError("missing SID")),
-        ):
+        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))):
             out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=True)
 
         assert isinstance(out, CookieValidationFailure)
@@ -71,11 +75,7 @@ class TestValidationFailure:
         assert "\n" not in out.message
 
     def test_loud_returns_validation_failure_with_hint(self):
-        with patch.object(
-            cookie_jar,
-            "validate_with_recovery",
-            return_value=({"cookies": []}, ValueError("missing SID")),
-        ):
+        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))):
             out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=False)
 
         assert isinstance(out, CookieValidationFailure)
@@ -87,17 +87,11 @@ class TestValidationFailure:
 
 class TestStaleCookies:
     def test_quiet_returns_collapsed_stale_outcome(self):
-        patches = _patch_auth_internals(run_async_side_effect=ValueError("rejected"))
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        with _enumerate_env(
+            validate_return=({"cookies": [1]}, None),
+            run_async_side_effect=ValueError("rejected"),
         ):
-            for p in patches:
-                p.start()
-            try:
-                out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=True)
-            finally:
-                for p in patches:
-                    p.stop()
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=True)
 
         assert isinstance(out, StaleCookies)
         assert out.code == "STALE_COOKIES"
@@ -105,17 +99,11 @@ class TestStaleCookies:
         assert "too stale" in out.message
 
     def test_loud_returns_detailed_stale_outcome(self):
-        patches = _patch_auth_internals(run_async_side_effect=ValueError("rejected"))
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        with _enumerate_env(
+            validate_return=({"cookies": [1]}, None),
+            run_async_side_effect=ValueError("rejected"),
         ):
-            for p in patches:
-                p.start()
-            try:
-                out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=False)
-            finally:
-                for p in patches:
-                    p.stop()
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=False)
 
         assert isinstance(out, StaleCookies)
         assert out.code == "STALE_COOKIES"
@@ -125,31 +113,21 @@ class TestStaleCookies:
 
 class TestNetworkFailure:
     def test_quiet_reraises_network_error(self):
-        patches = _patch_auth_internals(run_async_side_effect=httpx.ConnectError("no route"))
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        with (
+            _enumerate_env(
+                validate_return=({"cookies": [1]}, None),
+                run_async_side_effect=httpx.ConnectError("no route"),
+            ),
+            pytest.raises(httpx.RequestError),
         ):
-            for p in patches:
-                p.start()
-            try:
-                with pytest.raises(httpx.RequestError):
-                    cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=True)
-            finally:
-                for p in patches:
-                    p.stop()
+            cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=True)
 
     def test_loud_returns_network_failure_outcome(self):
-        patches = _patch_auth_internals(run_async_side_effect=httpx.ConnectError("no route"))
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
+        with _enumerate_env(
+            validate_return=({"cookies": [1]}, None),
+            run_async_side_effect=httpx.ConnectError("no route"),
         ):
-            for p in patches:
-                p.start()
-            try:
-                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=False)
-            finally:
-                for p in patches:
-                    p.stop()
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=False)
 
         assert isinstance(out, NetworkFailure)
         assert out.code == "NETWORK_ERROR"
@@ -158,35 +136,17 @@ class TestNetworkFailure:
 class TestSuccessPath:
     def test_legacy_single_jar_returns_accounts_unchanged(self):
         accounts = [_FakeAccount(0, "a@gmail.com", True)]
-        patches = _patch_auth_internals(run_async_return=accounts)
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
-        ):
-            for p in patches:
-                p.start()
-            try:
-                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None)
-            finally:
-                for p in patches:
-                    p.stop()
+        with _enumerate_env(validate_return=({"cookies": [1]}, None), run_async_return=accounts):
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None)
 
         assert out == accounts
 
     def test_fanout_tags_accounts_with_browser_profile(self):
-        accounts = [_FakeAccount(0, "a@gmail.com", True)]
-        patches = _patch_auth_internals(run_async_return=accounts)
-        # Account is constructed inside the function from notebooklm.auth, so
+        # Account is reconstructed inside the function from notebooklm.auth, so
         # leave the real class in place here (only the probe is stubbed).
-        with patch.object(
-            cookie_jar, "validate_with_recovery", return_value=({"cookies": [1]}, None)
-        ):
-            for p in patches:
-                p.start()
-            try:
-                out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", "Profile 1")
-            finally:
-                for p in patches:
-                    p.stop()
+        accounts = [_FakeAccount(0, "a@gmail.com", True)]
+        with _enumerate_env(validate_return=({"cookies": [1]}, None), run_async_return=accounts):
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", "Profile 1")
 
         assert len(out) == 1
         assert out[0].browser_profile == "Profile 1"

--- a/tests/unit/cli/test_cookie_writes.py
+++ b/tests/unit/cli/test_cookie_writes.py
@@ -1,0 +1,254 @@
+"""Unit tests for the cookie-write + account-selection helpers.
+
+Covers the failure-outcome and nonfatal-warning branches of
+``_select_account``, ``_select_refresh_account``, and
+``_write_extracted_cookies`` that the CLI-level flows don't otherwise
+exercise directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from notebooklm.cli.services.login import cookie_writes
+from notebooklm.cli.services.login.outcomes import CookieValidationFailure
+
+
+def test_emit_warning_prints_through_console():
+    """``_emit_warning`` renders the message via the rendering console."""
+    with patch("notebooklm.cli.rendering.console") as console:
+        cookie_writes._emit_warning("[yellow]heads up[/yellow]")
+    console.print.assert_called_once_with("[yellow]heads up[/yellow]")
+
+
+class _Acct:
+    def __init__(self, authuser, email, is_default):
+        self.authuser = authuser
+        self.email = email
+        self.is_default = is_default
+
+
+# ---------------------------------------------------------------------------
+# _select_account
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAccount:
+    def test_no_accounts_returns_failure(self):
+        out = cookie_writes._select_account([], account_email=None)
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "NO_ACCOUNTS_FOUND"
+
+    def test_email_match_returns_account(self):
+        acct = _Acct(0, "Match@Gmail.com", True)
+        out = cookie_writes._select_account([acct], account_email="match@gmail.com")
+        assert out is acct
+
+    def test_email_not_found_returns_failure_listing_available(self):
+        acct = _Acct(0, "other@gmail.com", True)
+        out = cookie_writes._select_account([acct], account_email="missing@gmail.com")
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "ACCOUNT_NOT_FOUND"
+        assert "other@gmail.com" in out.message
+
+    def test_default_account_returned_without_email(self):
+        first = _Acct(0, "a@gmail.com", False)
+        default = _Acct(1, "b@gmail.com", True)
+        out = cookie_writes._select_account([first, default], account_email=None)
+        assert out is default
+
+    def test_no_default_marker_warns_and_returns_first(self):
+        first = _Acct(0, "a@gmail.com", False)
+        second = _Acct(1, "b@gmail.com", False)
+        with patch.object(cookie_writes, "_emit_warning") as emit:
+            out = cookie_writes._select_account([first, second], account_email=None)
+        assert out is first
+        emit.assert_called_once()
+        assert "did not mark a default" in emit.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# _select_refresh_account
+# ---------------------------------------------------------------------------
+
+
+class TestSelectRefreshAccount:
+    def test_no_accounts_returns_failure(self):
+        out = cookie_writes._select_refresh_account([], {}, "chrome")
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "NO_ACCOUNTS_FOUND"
+        assert "chrome" in out.message
+
+    def test_email_match_wins(self):
+        acct = _Acct(0, "user@gmail.com", True)
+        out = cookie_writes._select_refresh_account([acct], {"email": "user@gmail.com"}, "chrome")
+        assert out is acct
+
+    def test_email_present_but_missing_returns_failure(self):
+        acct = _Acct(0, "other@gmail.com", True)
+        out = cookie_writes._select_refresh_account([acct], {"email": "user@gmail.com"}, "chrome")
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "PROFILE_ACCOUNT_MISSING"
+        assert "other@gmail.com" in out.message
+
+    def test_authuser_match_when_no_email(self):
+        acct = _Acct(3, "x@gmail.com", False)
+        out = cookie_writes._select_refresh_account([acct], {"authuser": 3}, "chrome")
+        assert out is acct
+
+    def test_authuser_stale_returns_failure(self):
+        acct = _Acct(0, "x@gmail.com", True)
+        out = cookie_writes._select_refresh_account([acct], {"authuser": 9}, "chrome")
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "PROFILE_ACCOUNT_MISSING"
+        assert "old account route" in out.message
+
+    def test_no_metadata_falls_back_to_default(self):
+        first = _Acct(0, "a@gmail.com", False)
+        default = _Acct(1, "b@gmail.com", True)
+        out = cookie_writes._select_refresh_account([first, default], {}, "chrome")
+        assert out is default
+
+    def test_no_metadata_no_default_falls_back_to_first(self):
+        first = _Acct(0, "a@gmail.com", False)
+        second = _Acct(1, "b@gmail.com", False)
+        out = cookie_writes._select_refresh_account([first, second], {}, "chrome")
+        assert out is first
+
+
+# ---------------------------------------------------------------------------
+# _write_extracted_cookies
+# ---------------------------------------------------------------------------
+
+
+def _ok_storage():
+    return {"cookies": [{"name": "SID", "value": "x"}]}
+
+
+class TestWriteExtractedCookies:
+    def test_validation_failure_returns_outcome(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with patch.object(
+            cookie_writes,
+            "validate_with_recovery",
+            return_value=({"cookies": []}, ValueError("missing SID")),
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [], storage_path=storage_path, profile=None, authuser=0, email="a@gmail.com"
+            )
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "COOKIE_VALIDATION_FAILED"
+        assert "missing SID" in out.message
+
+    def test_disk_write_failure_returns_outcome(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with (
+            patch.object(
+                cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
+            ),
+            patch.object(cookie_writes, "atomic_write_json", side_effect=OSError("disk full")),
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [{"name": "SID"}],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
+            )
+        assert isinstance(out, CookieValidationFailure)
+        assert out.code == "STORAGE_WRITE_FAILED"
+        assert "disk full" in out.message
+
+    def test_metadata_write_failure_is_nonfatal(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with (
+            patch.object(
+                cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
+            ),
+            patch.object(cookie_writes, "atomic_write_json"),
+            patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
+            patch("notebooklm.cli.runtime.run_async"),
+            patch("notebooklm.auth.write_account_metadata", side_effect=OSError("ro fs")),
+            patch.object(cookie_writes, "_emit_warning") as emit,
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [{"name": "SID"}],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
+            )
+        # Cookies were written; metadata failure only warns.
+        assert out is None
+        assert any("metadata write failed" in c.args[0] for c in emit.call_args_list)
+
+    def test_verification_value_error_warns(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with (
+            patch.object(
+                cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
+            ),
+            patch.object(cookie_writes, "atomic_write_json"),
+            patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
+            patch("notebooklm.cli.runtime.run_async", side_effect=ValueError("bad token")),
+            patch("notebooklm.auth.write_account_metadata"),
+            patch.object(cookie_writes, "_emit_warning") as emit,
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [{"name": "SID"}],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
+            )
+        assert out is None
+        assert any("failed verification" in c.args[0] for c in emit.call_args_list)
+
+    def test_verification_network_error_warns(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with (
+            patch.object(
+                cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
+            ),
+            patch.object(cookie_writes, "atomic_write_json"),
+            patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
+            patch(
+                "notebooklm.cli.runtime.run_async",
+                side_effect=httpx.ConnectError("offline"),
+            ),
+            patch("notebooklm.auth.write_account_metadata"),
+            patch.object(cookie_writes, "_emit_warning") as emit,
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [{"name": "SID"}],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
+            )
+        assert out is None
+        assert any("could not verify" in c.args[0] for c in emit.call_args_list)
+
+    def test_happy_path_returns_none(self, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        with (
+            patch.object(
+                cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
+            ),
+            patch.object(cookie_writes, "atomic_write_json"),
+            patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
+            patch("notebooklm.cli.runtime.run_async"),
+            patch("notebooklm.auth.write_account_metadata"),
+            patch.object(cookie_writes, "_emit_warning") as emit,
+        ):
+            out = cookie_writes._write_extracted_cookies(
+                [{"name": "SID"}],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
+            )
+        assert out is None
+        emit.assert_not_called()

--- a/tests/unit/cli/test_firefox_accounts.py
+++ b/tests/unit/cli/test_firefox_accounts.py
@@ -1,0 +1,118 @@
+"""Unit tests for the Firefox-family cookie helper error branches.
+
+``_read_firefox_container_cookies`` maps every extractor failure to a
+friendly message + ``exit_with_code(1)`` (raised as ``SystemExit``). These
+tests pin the three terminal error handlers and the early return in
+``_maybe_warn_firefox_containers_in_use`` when no profile is found.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notebooklm.cli.services.login import firefox_accounts
+
+
+def _fake_containers_module(profile_path, *, extract_side_effect=None):
+    """Build a stand-in for the ``_firefox_containers`` module."""
+    mod = MagicMock()
+    mod.find_firefox_profile_path.return_value = profile_path
+    mod.resolve_container_id.return_value = "none"
+    if extract_side_effect is not None:
+        mod.extract_firefox_container_cookies.side_effect = extract_side_effect
+    return mod
+
+
+class TestReadFirefoxContainerCookiesErrors:
+    def test_file_not_found_exits(self, tmp_path):
+        mod = _fake_containers_module(
+            tmp_path, extract_side_effect=FileNotFoundError("no cookies.sqlite")
+        )
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console") as console,
+            pytest.raises(SystemExit) as exc,
+        ):
+            firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+        assert exc.value.code == 1
+        assert any("no cookies.sqlite" in str(c) for c in console.print.call_args_list)
+
+    def test_oserror_routes_through_rookiepy_handler(self, tmp_path):
+        mod = _fake_containers_module(tmp_path, extract_side_effect=OSError("database is locked"))
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console") as console,
+            pytest.raises(SystemExit) as exc,
+        ):
+            firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+        assert exc.value.code == 1
+        # The locked-DB message from _handle_rookiepy_error is surfaced.
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        assert "database is locked" in printed
+
+    def test_runtime_error_routes_through_rookiepy_handler(self, tmp_path):
+        mod = _fake_containers_module(
+            tmp_path, extract_side_effect=RuntimeError("totally unexpected")
+        )
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console"),
+            pytest.raises(SystemExit) as exc,
+        ):
+            firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+        assert exc.value.code == 1
+
+    def test_sqlite_database_error_exits(self, tmp_path):
+        mod = _fake_containers_module(
+            tmp_path, extract_side_effect=sqlite3.DatabaseError("malformed db")
+        )
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console") as console,
+            pytest.raises(SystemExit) as exc,
+        ):
+            firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+        assert exc.value.code == 1
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        assert "malformed db" in printed
+
+    def test_success_returns_cookies(self, tmp_path):
+        mod = _fake_containers_module(tmp_path)
+        mod.extract_firefox_container_cookies.return_value = [{"name": "SID"}]
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console"),
+            patch.object(
+                firefox_accounts, "_build_google_cookie_domains", return_value=[".google.com"]
+            ),
+        ):
+            cookies = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+        assert cookies == [{"name": "SID"}]
+
+
+class TestMaybeWarnFirefoxContainersInUse:
+    def test_no_profile_returns_silently(self):
+        mod = MagicMock()
+        mod.find_firefox_profile_path.return_value = None
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console") as console,
+        ):
+            firefox_accounts._maybe_warn_firefox_containers_in_use()
+        mod.has_container_cookies_in_use.assert_not_called()
+        console.print.assert_not_called()
+
+    def test_warns_when_container_cookies_in_use(self, tmp_path):
+        mod = MagicMock()
+        mod.find_firefox_profile_path.return_value = tmp_path
+        mod.has_container_cookies_in_use.return_value = True
+        with (
+            patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
+            patch.object(firefox_accounts, "console") as console,
+        ):
+            firefox_accounts._maybe_warn_firefox_containers_in_use()
+        console.print.assert_called_once()
+        assert "Multi-Account Container" in console.print.call_args[0][0]

--- a/tests/unit/cli/test_rookiepy_errors.py
+++ b/tests/unit/cli/test_rookiepy_errors.py
@@ -1,0 +1,58 @@
+"""Unit tests for the friendly rookiepy error message formatter.
+
+``_handle_rookiepy_error`` is a pure helper: it classifies a rookiepy
+``OSError``/``RuntimeError`` into one of four user-facing message shapes
+(locked DB, permission denied, decryption failure, generic) and returns
+Rich-markup text. These tests pin each classification branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm.cli.services.login.rookiepy_errors import _handle_rookiepy_error
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    ["database is locked", "could not acquire LOCK on profile"],
+)
+def test_locked_database_branch(error_text):
+    msg = _handle_rookiepy_error(RuntimeError(error_text), "chrome")
+    assert "browser database is locked" in msg
+    assert "Close your browser" in msg
+    assert "chrome" in msg
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    ["Permission denied", "access is denied to profile"],
+)
+def test_permission_denied_branch(error_text):
+    msg = _handle_rookiepy_error(OSError(error_text), "brave")
+    assert "Permission denied reading brave cookies" in msg
+    assert "grant Terminal/Python access" in msg
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    ["keychain entry unavailable", "failed to decrypt value"],
+)
+def test_decryption_branch(error_text):
+    msg = _handle_rookiepy_error(RuntimeError(error_text), "edge")
+    assert "Could not decrypt edge cookies" in msg
+    assert "Keychain access" in msg
+
+
+def test_generic_branch_includes_original_message():
+    err = RuntimeError("some totally unexpected failure")
+    msg = _handle_rookiepy_error(err, "firefox")
+    assert "Failed to read cookies from firefox" in msg
+    assert "some totally unexpected failure" in msg
+
+
+def test_classification_is_case_insensitive():
+    # "LOCK" upper-cased still routes to the locked-database branch because
+    # the helper lower-cases the message before matching.
+    msg = _handle_rookiepy_error(RuntimeError("DATABASE IS LOCKED"), "chrome")
+    assert "browser database is locked" in msg

--- a/tests/unit/test_check_coverage_thresholds.py
+++ b/tests/unit/test_check_coverage_thresholds.py
@@ -241,7 +241,7 @@ def test_per_file_real_baselines_pass_against_repo_pyproject(tmp_path, capsys, s
             # Match the floors checked in — every path at exactly its floor
             # should pass (>= comparison).
             "src/notebooklm/__main__.py": 0.0,
-            "src/notebooklm/cli/_firefox_containers.py": 75.0,
+            "src/notebooklm/cli/_firefox_containers.py": 95.0,
             "src/notebooklm/cli/doctor_cmd.py": 63.0,
             "src/notebooklm/cli/profile_cmd.py": 74.0,
             "src/notebooklm/cli/session_cmd.py": 83.0,

--- a/tests/unit/test_firefox_containers.py
+++ b/tests/unit/test_firefox_containers.py
@@ -19,7 +19,17 @@ from typing import Any
 
 import pytest
 
+from notebooklm.cli import _firefox_containers
 from notebooklm.cli._firefox_containers import (
+    _copy_sqlite_for_read,
+    _domain_matches_any,
+    _firefox_db_uses_millisecond_expiry,
+    _firefox_root_dirs,
+    _identity_display_name,
+    _l10n_label_name,
+    _load_identities,
+    _resolve_profile_path,
+    _row_to_rookiepy_dict,
     extract_firefox_container_cookies,
     find_firefox_profile_path,
     has_container_cookies_in_use,
@@ -578,3 +588,294 @@ class TestFindFirefoxProfilePath:
         except configparser.Error:  # pragma: no cover — defensive
             pytest.fail("malformed profiles.ini should not raise to caller")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _firefox_root_dirs — platform-specific candidate lists
+# ---------------------------------------------------------------------------
+
+
+class TestFirefoxRootDirs:
+    """The default root-dir resolver is monkeypatched out elsewhere, so probe
+    each platform branch directly here."""
+
+    def test_macos_returns_application_support(self, monkeypatch):
+        monkeypatch.setattr(_firefox_containers.sys, "platform", "darwin")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/Users/me")))
+        roots = _firefox_root_dirs()
+        assert roots == [Path("/Users/me/Library/Application Support/Firefox")]
+
+    def test_windows_uses_appdata_and_localappdata(self, monkeypatch):
+        monkeypatch.setattr(_firefox_containers.sys, "platform", "win32")
+        monkeypatch.setenv("APPDATA", r"C:\Users\me\AppData\Roaming")
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\me\AppData\Local")
+        roots = _firefox_root_dirs()
+        # The roaming-AppData candidate (no "Packages" segment) and the
+        # Microsoft Store LocalCache candidate (under "Packages") must each
+        # appear. "Packages not in" uniquely pins the APPDATA candidate, since
+        # the LOCALAPPDATA path also contains a "Roaming" segment.
+        assert any("Mozilla" in str(r) and "Packages" not in str(r) for r in roots)
+        assert any("Packages" in str(r) for r in roots)
+
+    def test_windows_without_env_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(_firefox_containers.sys, "platform", "win32")
+        monkeypatch.delenv("APPDATA", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        assert _firefox_root_dirs() == []
+
+    def test_linux_includes_xdg_and_snap_locations(self, monkeypatch):
+        monkeypatch.setattr(_firefox_containers.sys, "platform", "linux")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/home/me")))
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/home/me/.config")
+        roots = _firefox_root_dirs()
+        assert Path("/home/me/.config/mozilla/firefox") in roots
+        assert Path("/home/me/.mozilla/firefox") in roots
+        assert any("snap" in str(r) for r in roots)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_profile_path + find_firefox_profile_path edge branches
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProfilePath:
+    def test_absolute_path_returned_verbatim(self, tmp_path):
+        abs_path = tmp_path / "absolute.default"
+        result = _resolve_profile_path(tmp_path, str(abs_path), is_relative=False)
+        assert result == abs_path
+
+    def test_relative_path_joined_to_root(self, tmp_path):
+        result = _resolve_profile_path(tmp_path, "Profiles/rel.default", is_relative=True)
+        assert result == (tmp_path / "Profiles" / "rel.default").resolve()
+
+
+class TestFindFirefoxProfilePathEdges:
+    def _write_profiles_ini(self, root: Path, content: str) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "profiles.ini").write_text(content, encoding="utf-8")
+
+    def test_skips_nonexistent_root_then_finds_next(self, tmp_path, monkeypatch):
+        missing = tmp_path / "missing"
+        root = tmp_path / "Firefox"
+        profile = root / "Profiles" / "xyz.default"
+        profile.mkdir(parents=True)
+        (profile / "cookies.sqlite").touch()
+        self._write_profiles_ini(
+            root, "[Profile0]\nName=only\nIsRelative=1\nPath=Profiles/xyz.default\n"
+        )
+        monkeypatch.setattr(_firefox_containers, "_firefox_root_dirs", lambda: [missing, root])
+        assert find_firefox_profile_path() == profile.resolve()
+
+    def test_skips_root_without_profiles_ini_then_finds_next(self, tmp_path, monkeypatch):
+        # An existing root dir that has no profiles.ini must be skipped (not
+        # raise) before we fall through to the next, valid root.
+        empty_root = tmp_path / "EmptyFirefox"
+        empty_root.mkdir()
+        root = tmp_path / "Firefox"
+        profile = root / "Profiles" / "xyz.default"
+        profile.mkdir(parents=True)
+        (profile / "cookies.sqlite").touch()
+        self._write_profiles_ini(
+            root, "[Profile0]\nName=only\nIsRelative=1\nPath=Profiles/xyz.default\n"
+        )
+        monkeypatch.setattr(_firefox_containers, "_firefox_root_dirs", lambda: [empty_root, root])
+        assert find_firefox_profile_path() == profile.resolve()
+
+    def test_legacy_default_with_absolute_path(self, tmp_path, monkeypatch):
+        root = tmp_path / "Firefox"
+        profile = tmp_path / "elsewhere" / "abs.default"
+        profile.mkdir(parents=True)
+        # IsRelative=0 + an absolute Path exercises the non-relative branch.
+        self._write_profiles_ini(
+            root,
+            f"[Profile0]\nName=def\nIsRelative=0\nPath={profile}\nDefault=1\n",
+        )
+        monkeypatch.setattr(_firefox_containers, "_firefox_root_dirs", lambda: [root])
+        assert find_firefox_profile_path() == profile
+
+    def test_non_profile_sections_skipped_in_all_loops(self, tmp_path, monkeypatch):
+        root = tmp_path / "Firefox"
+        profile = root / "Profiles" / "found.default"
+        profile.mkdir(parents=True)
+        (profile / "cookies.sqlite").touch()
+        # [General] is neither Install nor Profile; both the Default=1 loop and
+        # the best-effort loop must skip it. A Profile section without a Path is
+        # also skipped before we reach the one that has cookies.sqlite.
+        self._write_profiles_ini(
+            root,
+            "[General]\nStartWithLastProfile=1\n\n"
+            "[Profile0]\nName=nopath\nIsRelative=1\n\n"
+            "[Profile1]\nName=found\nIsRelative=1\nPath=Profiles/found.default\n",
+        )
+        monkeypatch.setattr(_firefox_containers, "_firefox_root_dirs", lambda: [root])
+        assert find_firefox_profile_path() == profile.resolve()
+
+
+# ---------------------------------------------------------------------------
+# l10n + identity display-name helpers
+# ---------------------------------------------------------------------------
+
+
+class TestL10nAndIdentityHelpers:
+    def test_l10n_label_none_for_empty(self):
+        assert _l10n_label_name(None) is None
+        assert _l10n_label_name("") is None
+
+    def test_l10n_label_none_for_non_matching_id(self):
+        # Present but not a userContext<Name>.label form -> None.
+        assert _l10n_label_name("someOther.thing") is None
+
+    def test_l10n_label_extracts_name(self):
+        assert _l10n_label_name("userContextWork.label") == "Work"
+
+    def test_identity_display_name_prefers_name(self):
+        assert _identity_display_name({"name": "Custom"}) == "Custom"
+
+    def test_identity_display_name_falls_back_to_l10n(self):
+        # No usable name -> derive from l10nID.
+        assert _identity_display_name({"l10nID": "userContextPersonal.label"}) == "Personal"
+
+    def test_unknown_name_lists_builtin_labels(self, tmp_path):
+        # Built-in identities only carry l10nID; the error listing must derive
+        # display names through _identity_display_name's l10n fallback.
+        _make_containers_json(tmp_path / "containers.json")  # built-ins only
+        with pytest.raises(ValueError) as exc:
+            resolve_container_id(tmp_path, "Nonexistent")
+        msg = str(exc.value)
+        assert "Personal" in msg
+        assert "Work" in msg
+
+
+class TestLoadIdentities:
+    def test_identities_not_a_list_returns_empty(self, tmp_path):
+        # Valid JSON, but "identities" is the wrong shape.
+        (tmp_path / "containers.json").write_text(
+            json.dumps({"identities": {"not": "a list"}}), encoding="utf-8"
+        )
+        assert _load_identities(tmp_path) == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _load_identities(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# _copy_sqlite_for_read — WAL/SHM sidecar handling
+# ---------------------------------------------------------------------------
+
+
+class TestCopySqliteForRead:
+    def test_copies_wal_and_shm_sidecars(self, tmp_path):
+        source = tmp_path / "cookies.sqlite"
+        source.write_bytes(b"main-db")
+        (tmp_path / "cookies.sqlite-wal").write_bytes(b"wal-data")
+        (tmp_path / "cookies.sqlite-shm").write_bytes(b"shm-data")
+        dest_dir = tmp_path / "copy"
+        dest_dir.mkdir()
+
+        dest = _copy_sqlite_for_read(source, dest_dir)
+
+        assert dest.read_bytes() == b"main-db"
+        assert (dest_dir / "cookies.sqlite-wal").read_bytes() == b"wal-data"
+        assert (dest_dir / "cookies.sqlite-shm").read_bytes() == b"shm-data"
+
+
+# ---------------------------------------------------------------------------
+# _firefox_db_uses_millisecond_expiry — defensive cursor branches
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, *, raise_error=False, row=("0",)):
+        self._raise = raise_error
+        self._row = row
+
+    def execute(self, *_args, **_kwargs):
+        if self._raise:
+            raise sqlite3.DatabaseError("pragma blew up")
+        return self
+
+    def fetchone(self):
+        return self._row
+
+
+class TestMillisecondExpiryDetection:
+    def test_database_error_returns_false(self):
+        assert _firefox_db_uses_millisecond_expiry(_FakeCursor(raise_error=True)) is False
+
+    def test_no_row_returns_false(self):
+        assert _firefox_db_uses_millisecond_expiry(_FakeCursor(row=None)) is False
+
+    def test_non_integer_user_version_returns_false(self):
+        assert _firefox_db_uses_millisecond_expiry(_FakeCursor(row=("notanint",))) is False
+
+    def test_schema_16_returns_true(self):
+        assert _firefox_db_uses_millisecond_expiry(_FakeCursor(row=(16,))) is True
+
+    def test_schema_below_16_returns_false(self):
+        assert _firefox_db_uses_millisecond_expiry(_FakeCursor(row=(15,))) is False
+
+
+# ---------------------------------------------------------------------------
+# _row_to_rookiepy_dict — non-numeric millisecond expiry
+# ---------------------------------------------------------------------------
+
+
+class TestRowToRookiepyDict:
+    def test_non_numeric_expiry_in_ms_left_unchanged(self):
+        # expiry is a str while expiry_in_ms is True -> the // 1000 raises
+        # TypeError and the value is left as-is (best effort).
+        row = (".google.com", "SID", "v", "/", "not-a-number", 1, 0, 0)
+        result = _row_to_rookiepy_dict(row, expiry_in_ms=True)
+        assert result["expires"] == "not-a-number"
+
+    def test_numeric_expiry_in_ms_divided(self):
+        row = (".google.com", "SID", "v", "/", 9_999_999_999_000, 1, 0, 0)
+        result = _row_to_rookiepy_dict(row, expiry_in_ms=True)
+        assert result["expires"] == 9_999_999_999
+
+    def test_none_values_get_defaults(self):
+        row = (None, None, None, None, None, 0, 0, None)
+        result = _row_to_rookiepy_dict(row, expiry_in_ms=False)
+        assert result["domain"] == ""
+        assert result["value"] == ""
+        assert result["path"] == "/"
+        assert result["secure"] is False
+
+
+# ---------------------------------------------------------------------------
+# _domain_matches_any — full branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestDomainMatchesAny:
+    def test_empty_host_is_false(self):
+        assert _domain_matches_any("", [".google.com"]) is False
+
+    def test_empty_needle_skipped(self):
+        # An empty needle is skipped; the next (matching) needle still wins.
+        assert _domain_matches_any("mail.google.com", ["", ".google.com"]) is True
+
+    def test_dotted_suffix_match(self):
+        assert _domain_matches_any("mail.google.com", [".google.com"]) is True
+
+    def test_dotted_base_exact_match(self):
+        assert _domain_matches_any("google.com", [".google.com"]) is True
+
+    def test_exact_non_dotted_match(self):
+        assert _domain_matches_any("google.com", ["google.com"]) is True
+
+    def test_no_match_returns_false(self):
+        assert _domain_matches_any("evil.com", [".google.com", "example.com"]) is False
+
+
+# ---------------------------------------------------------------------------
+# has_container_cookies_in_use — malformed DB swallowed
+# ---------------------------------------------------------------------------
+
+
+class TestHasContainerCookiesInUseErrors:
+    def test_malformed_database_returns_false(self, tmp_path):
+        # A non-sqlite file passes the is_file() gate but errors on SELECT.
+        bogus = tmp_path / "cookies.sqlite"
+        bogus.write_bytes(b"this is definitely not a sqlite database")
+        assert has_container_cookies_in_use(tmp_path) is False

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -154,3 +154,30 @@ class TestContainsGoogleAuthRedirect:
         <a href="https://google.com">Google</a>
         """
         assert contains_google_auth_redirect(html) is False
+
+
+class TestUrlParsingExceptionPaths:
+    """Cover the defensive ``except`` branches in the URL parsers.
+
+    ``urlparse(...).hostname`` raises ``ValueError`` for malformed inputs
+    such as an unterminated IPv6 literal. Both validators must swallow that
+    and report a non-match rather than propagating the exception.
+    """
+
+    # ``http://[::1`` has an unterminated IPv6 host; ``.hostname`` raises
+    # ``ValueError: Invalid IPv6 URL`` in CPython's urllib.
+    MALFORMED_IPV6 = "http://[::1"
+
+    def test_is_youtube_url_swallows_parse_error(self):
+        assert is_youtube_url(self.MALFORMED_IPV6) is False
+
+    def test_is_google_auth_redirect_swallows_parse_error(self):
+        assert is_google_auth_redirect(self.MALFORMED_IPV6) is False
+
+    def test_contains_google_auth_redirect_swallows_parse_error(self):
+        # The malformed URL is extracted by the regex (it stops at the
+        # space, leaving the unterminated ``http://[::1``), then routed
+        # through ``is_google_auth_redirect`` where the ValueError is
+        # swallowed.
+        text = f"redirecting to {self.MALFORMED_IPV6} signin"
+        assert contains_google_auth_redirect(text) is False

--- a/tests/unit/test_version_check.py
+++ b/tests/unit/test_version_check.py
@@ -31,3 +31,23 @@ def test_version_check_passes_on_supported_python():
 
     # Should not raise on current Python (>= 3.10)
     check_python_version()
+
+
+def test_version_check_in_process_exits_on_old_python(monkeypatch):
+    """In-process variant so coverage records the ``sys.exit`` branch.
+
+    The subprocess test above proves the user-facing message, but runs in a
+    child interpreter where coverage isn't tracked. Patch ``version_info``
+    in-process and assert the ``SystemExit`` carries the expected guidance.
+    """
+    import pytest
+
+    from notebooklm import _version_check
+
+    monkeypatch.setattr(_version_check.sys, "version_info", (3, 9, 5))
+    with pytest.raises(SystemExit) as exc_info:
+        _version_check.check_python_version()
+
+    message = str(exc_info.value)
+    assert "requires Python 3.10 or later" in message
+    assert "3.9.5" in message


### PR DESCRIPTION
## Summary

Adds focused unit tests for the lowest-coverage modules surfaced by the project coverage report, lifting each from below the per-file/project floor to ~100%. Total project coverage rises **94.4% → 95.1%** with no source changes (test-only, plus one coverage-floor bump).

### Modules covered

| Module | Before | After |
|--------|-------:|------:|
| `_url_utils.py` | 78% | 100% |
| `_version_check.py` | 71% | 100% |
| `cli/agent_templates.py` | 69% | 100% |
| `cli/services/login/rookiepy_errors.py` | 38% | 100% |
| `cli/services/login/cookie_jar.py` | 84% | 100% |
| `cli/services/login/cookie_writes.py` | 70% | 99% |
| `cli/services/login/firefox_accounts.py` | 78% | 100% |
| `cli/_firefox_containers.py` | 77% | 97% |

### What the new tests exercise

- **`_url_utils`** — the defensive `urlparse(...).hostname` `ValueError` fallbacks (unterminated IPv6 literal) in all three validators.
- **`_version_check`** — an in-process variant so coverage records the `sys.exit` branch (the existing test ran in a subprocess).
- **`agent_templates`** — the repo-root-AGENTS branch, unknown-target `None`, and the `_read_package_data` read/missing paths (mocked `resources.files` since `notebooklm/data/` only exists in built wheels).
- **`rookiepy_errors`** — all four message-classification branches (locked DB, permission, decryption, generic) + case-insensitivity.
- **`cookie_jar._enumerate_one_jar`** — quiet/loud validation-failure, stale-cookie, and network-failure outcome shapes plus the success/fan-out tagging paths.
- **`cookie_writes`** — `_select_account` / `_select_refresh_account` selection branches and `_write_extracted_cookies` validation/disk-write/metadata/verification failure paths.
- **`firefox_accounts`** — the `FileNotFoundError` / `OSError`/`RuntimeError` / `sqlite3.DatabaseError` extractor error handlers and the no-profile early return.
- **`_firefox_containers`** — platform-specific root-dir resolution (darwin/win32/linux), profile-path resolution edge branches, sqlite millisecond-expiry detection, row reshaping, domain matching, and malformed-DB handling.

Also bumps the `_firefox_containers.py` per-file coverage floor `75 → 95` to match the new level.

## Testing

- Full suite green: `7223 passed, 52 skipped` (was 7139 passed).
- `ruff check` / `ruff format` clean.
- `scripts/check_coverage_thresholds.py` passes all per-file floors.

https://claude.ai/code/session_01QcRamK2CYTpkBpMBEjPqwj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcRamK2CYTpkBpMBEjPqwj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage across CLI flows, cookie handling and writes, Firefox/profile and container handling, error classification, URL-parsing edge cases, agent template loading, and Python-version checks — including many new tests exercising success and failure paths and message formatting.
* **Chores**
  * Increased a per-file test coverage threshold in the project configuration to a higher required level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->