### PR TITLE
fix(io): reject storage_state.json in atomic_update_json to prevent lock divergence

### DIFF
--- a/src/notebooklm/_atomic_io.py
+++ b/src/notebooklm/_atomic_io.py
@@ -64,7 +64,10 @@ logger = logging.getLogger(__name__)
 # #1215). ``atomic_update_json`` derives a *non-dotted* ``<name>.lock`` instead,
 # so it rejects this name rather than acquire a divergent lock file and
 # re-introduce the lost-update race. Kept as a plain literal here to avoid an
-# import edge from this leaf module into ``notebooklm._auth``.
+# import edge from this leaf module into ``notebooklm._auth``. Stored
+# already-casefolded so the guard can compare ``path.name.casefold()`` against
+# it directly (case-insensitive filesystems resolve casing variants to the same
+# file).
 _STORAGE_STATE_FILENAME = "storage_state.json"
 
 _WINDOWS_REPLACE_TRANSIENT_WINERRORS = {
@@ -220,7 +223,12 @@ def atomic_update_json(
             ``recover_from_corrupt`` is False.
         OSError: From filesystem operations (mkdir, write, replace).
     """
-    if path.name == _STORAGE_STATE_FILENAME:
+    # Case-insensitive match: on macOS (APFS/HFS+ default) and Windows (NTFS),
+    # ``Storage_State.json`` resolves to the same file as ``storage_state.json``,
+    # so a case-sensitive ``==`` would let a casing variant slip past the guard
+    # and re-introduce the divergent-lock race. ``casefold`` is the robust
+    # Unicode-aware lowercaser for this comparison.
+    if path.name.casefold() == _STORAGE_STATE_FILENAME:
         raise ValueError(
             f"atomic_update_json must not be called with a {_STORAGE_STATE_FILENAME!r} "
             "path: its '<name>.lock' lock derivation diverges from the canonical "

--- a/src/notebooklm/_atomic_io.py
+++ b/src/notebooklm/_atomic_io.py
@@ -229,13 +229,17 @@ def atomic_update_json(
     # and re-introduce the divergent-lock race. ``casefold`` is the robust
     # Unicode-aware lowercaser for this comparison.
     if path.name.casefold() == _STORAGE_STATE_FILENAME:
+        # Echo the caller's actual filename (which may be a casing variant on a
+        # case-insensitive filesystem) so the error matches what they passed,
+        # while still naming the canonical lock for context.
         raise ValueError(
-            f"atomic_update_json must not be called with a {_STORAGE_STATE_FILENAME!r} "
-            "path: its '<name>.lock' lock derivation diverges from the canonical "
-            "dotted '.storage_state.json.lock' sentinel (_storage_state_lock_path, "
-            "#1215), so it would acquire the wrong lock and risk a lost-update race. "
-            "Use the dedicated notebooklm._auth writers (save_cookies_to_storage / "
-            "write_account_metadata / _clear_in_band_account) instead."
+            f"atomic_update_json must not be called with a {path.name!r} "
+            f"({_STORAGE_STATE_FILENAME!r}) path: its '<name>.lock' lock derivation "
+            "diverges from the canonical dotted '.storage_state.json.lock' sentinel "
+            "(_storage_state_lock_path, #1215), so it would acquire the wrong lock "
+            "and risk a lost-update race. Use the dedicated notebooklm._auth writers "
+            "(save_cookies_to_storage / write_account_metadata / _clear_in_band_account) "
+            "instead."
         )
     lock_path = path.with_suffix(path.suffix + ".lock")
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/notebooklm/_atomic_io.py
+++ b/src/notebooklm/_atomic_io.py
@@ -19,6 +19,28 @@ intentionally left on disk after release: ``filelock`` reuses them across
 invocations, and unlinking under contention introduces a TOCTOU race where a
 second process could create-and-acquire a fresh lock while the first is mid-
 delete. They are zero-byte and cheap.
+
+Lock-path derivation contract
+-----------------------------
+
+:func:`atomic_update_json` derives its lock as ``<name>.lock`` via
+``path.with_suffix(path.suffix + ".lock")`` (e.g. ``config.json`` ->
+``config.json.lock``). This pattern is **deliberately distinct** from the
+*dotted* ``.<name>.lock`` sentinel that the canonical ``storage_state.json``
+mutators serialize on (``_auth.paths._storage_state_lock_path`` ->
+``.storage_state.json.lock``; see #1215). Because the two patterns yield two
+*different* files, routing a ``storage_state.json`` path through
+``atomic_update_json`` would acquire the *wrong* lock and silently re-introduce
+the lost-update race that #1215 closed.
+
+To enforce that contract by construction rather than by hand-synced string
+literals, :func:`atomic_update_json` rejects ``storage_state.json`` paths up
+front (see :data:`_STORAGE_STATE_FILENAME`). The ``config.json`` /
+``context.json`` callers keep their existing ``<name>.lock`` files unchanged;
+only ``storage_state.json`` is special-cased. Cookie/account writers must use
+the dedicated locked writers in :mod:`notebooklm._auth`
+(``save_cookies_to_storage`` / ``write_account_metadata`` /
+``_clear_in_band_account``), which all share ``_storage_state_lock_path``.
 """
 
 from __future__ import annotations
@@ -36,6 +58,14 @@ from typing import Any
 from filelock import FileLock
 
 logger = logging.getLogger(__name__)
+
+# Filename whose mutators MUST serialize on the canonical dotted
+# ``.storage_state.json.lock`` sentinel (``_auth.paths._storage_state_lock_path``,
+# #1215). ``atomic_update_json`` derives a *non-dotted* ``<name>.lock`` instead,
+# so it rejects this name rather than acquire a divergent lock file and
+# re-introduce the lost-update race. Kept as a plain literal here to avoid an
+# import edge from this leaf module into ``notebooklm._auth``.
+_STORAGE_STATE_FILENAME = "storage_state.json"
 
 _WINDOWS_REPLACE_TRANSIENT_WINERRORS = {
     5,  # ERROR_ACCESS_DENIED
@@ -142,6 +172,16 @@ def atomic_update_json(
     (or an empty dict if the file does not exist), passes them to ``mutator``,
     and writes the result back via :func:`atomic_write_json`.
 
+    .. warning::
+        ``storage_state.json`` paths are **rejected** with :class:`ValueError`.
+        This helper's ``<name>.lock`` derivation diverges from the canonical
+        dotted ``.storage_state.json.lock`` sentinel that every
+        ``storage_state.json`` mutator shares (``_storage_state_lock_path``,
+        #1215); acquiring the wrong lock would silently re-introduce a
+        lost-update race. Cookie/account writers must use the dedicated locked
+        writers in :mod:`notebooklm._auth` instead. See the module docstring's
+        *Lock-path derivation contract* section.
+
     The lock is held across the entire read-modify-write sequence so that
     two concurrent CLI invocations cannot lose updates by writing stale
     snapshots over each other. The default ``timeout`` is generous enough to
@@ -172,11 +212,23 @@ def atomic_update_json(
             (default), :class:`json.JSONDecodeError` propagates to the caller.
 
     Raises:
+        ValueError: If ``path`` names ``storage_state.json`` — its lock
+            derivation diverges from the canonical ``_storage_state_lock_path``;
+            use the dedicated :mod:`notebooklm._auth` writers instead.
         filelock.Timeout: If the lock cannot be acquired within ``timeout``.
         json.JSONDecodeError: If the existing file is not valid JSON and
             ``recover_from_corrupt`` is False.
         OSError: From filesystem operations (mkdir, write, replace).
     """
+    if path.name == _STORAGE_STATE_FILENAME:
+        raise ValueError(
+            f"atomic_update_json must not be called with a {_STORAGE_STATE_FILENAME!r} "
+            "path: its '<name>.lock' lock derivation diverges from the canonical "
+            "dotted '.storage_state.json.lock' sentinel (_storage_state_lock_path, "
+            "#1215), so it would acquire the wrong lock and risk a lost-update race. "
+            "Use the dedicated notebooklm._auth writers (save_cookies_to_storage / "
+            "write_account_metadata / _clear_in_band_account) instead."
+        )
     lock_path = path.with_suffix(path.suffix + ".lock")
     path.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(lock_path), timeout=timeout):

--- a/tests/unit/test_atomic_update_json.py
+++ b/tests/unit/test_atomic_update_json.py
@@ -315,3 +315,103 @@ def test_concurrent_corrupt_recovery_does_not_lose_valid_write(tmp_path: Path) -
     # Both writers' keys must be present — neither lost the other's update.
     assert final.get("recovered_by") == "A", f"recovery worker lost: {final}"
     assert final.get("peer_wrote") == "B", f"peer worker lost: {final}"
+
+
+# ---------------------------------------------------------------------------
+# Lock-path derivation contract (#1220)
+#
+# ``atomic_update_json`` derives a NON-dotted ``<name>.lock`` sibling, which
+# diverges from the canonical dotted ``.storage_state.json.lock`` sentinel that
+# every ``storage_state.json`` mutator shares (``_storage_state_lock_path``,
+# #1215). To stop a future caller silently acquiring the wrong lock and
+# re-introducing the #1215 lost-update race, the helper rejects
+# ``storage_state.json`` paths up front. The config/context callers keep their
+# existing ``<name>.lock`` files unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_storage_state_json_path(tmp_path: Path) -> None:
+    """A ``storage_state.json`` path must be rejected with ``ValueError``.
+
+    Its ``<name>.lock`` derivation diverges from the canonical dotted
+    ``.storage_state.json.lock`` (``_storage_state_lock_path``), so routing it
+    here would acquire the wrong lock — the exact #1215 footgun #1220 closes.
+    """
+    target = tmp_path / "storage_state.json"
+
+    mutator_calls: list[dict] = []
+
+    def mutator(current: dict) -> dict:
+        mutator_calls.append(dict(current))
+        return current
+
+    with pytest.raises(ValueError, match="storage_state.json"):
+        atomic_update_json(target, mutator)
+
+    # The guard fires before any I/O: no file, no mutator call, and crucially
+    # NEITHER lock variant is created on disk.
+    assert mutator_calls == []
+    assert not target.exists()
+    assert not (tmp_path / "storage_state.json.lock").exists()  # divergent (would-be)
+    assert not (tmp_path / ".storage_state.json.lock").exists()  # canonical dotted
+
+
+def test_rejection_holds_with_recover_flag(tmp_path: Path) -> None:
+    """The guard also fires when ``recover_from_corrupt=True`` is requested."""
+    target = tmp_path / "storage_state.json"
+    target.write_text("{ corrupt", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="storage_state.json"):
+        atomic_update_json(target, lambda d: d, recover_from_corrupt=True)
+
+    # The pre-existing (corrupt) file is left untouched — no recovery write.
+    assert target.read_text(encoding="utf-8") == "{ corrupt"
+
+
+def test_rejection_matches_canonical_lock_helper(tmp_path: Path) -> None:
+    """Cross-check: the rejected name is exactly the one whose canonical lock
+    is the dotted sentinel, and that sentinel differs from this helper's
+    ``<name>.lock`` derivation.
+    """
+    from notebooklm._auth.paths import _storage_state_lock_path
+
+    target = tmp_path / "storage_state.json"
+    canonical = _storage_state_lock_path(target)
+    divergent = target.with_suffix(target.suffix + ".lock")
+
+    # Sanity: the two derivations really are different files.
+    assert canonical.name == ".storage_state.json.lock"
+    assert divergent.name == "storage_state.json.lock"
+    assert canonical != divergent
+
+    # And the helper refuses to operate on this path at all.
+    with pytest.raises(ValueError):
+        atomic_update_json(target, lambda d: d)
+
+
+@pytest.mark.parametrize("filename", ["config.json", "context.json"])
+def test_allowed_paths_use_unchanged_nondotted_lock(tmp_path: Path, filename: str) -> None:
+    """``config.json`` / ``context.json`` lock derivation is UNCHANGED.
+
+    The guard only special-cases ``storage_state.json``; the legitimate callers
+    keep acquiring their existing non-dotted ``<name>.lock`` sibling. We prove
+    this by pre-acquiring that exact lock and asserting the call times out on
+    it — i.e. it really is the file the helper contends on.
+    """
+    target = tmp_path / filename
+    expected_lock = target.with_suffix(target.suffix + ".lock")
+    assert expected_lock.name == f"{filename}.lock"  # non-dotted, unchanged
+
+    holder = FileLock(str(expected_lock))
+    holder.acquire()
+    try:
+        with pytest.raises(Timeout):
+            atomic_update_json(target, lambda d: {**d, "k": "v"}, timeout=0.1)
+    finally:
+        holder.release()
+
+    # After release the call succeeds and writes through the same lock file.
+    atomic_update_json(target, lambda d: {**d, "ok": True}, timeout=1.0)
+    assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+    # The dotted sentinel was never created for these allowed names.
+    assert not (tmp_path / f".{filename}.lock").exists()

--- a/tests/unit/test_atomic_update_json.py
+++ b/tests/unit/test_atomic_update_json.py
@@ -330,14 +330,22 @@ def test_concurrent_corrupt_recovery_does_not_lose_valid_write(tmp_path: Path) -
 # ---------------------------------------------------------------------------
 
 
-def test_rejects_storage_state_json_path(tmp_path: Path) -> None:
-    """A ``storage_state.json`` path must be rejected with ``ValueError``.
+# Casing variants are rejected too: on case-insensitive filesystems (macOS
+# APFS/HFS+, Windows NTFS) ``Storage_State.json`` resolves to the same file as
+# ``storage_state.json``, so a case-sensitive guard would let a variant slip
+# past and re-introduce the divergent-lock race. The guard compares casefolded.
+@pytest.mark.parametrize(
+    "filename",
+    ["storage_state.json", "Storage_State.json", "STORAGE_STATE.JSON"],
+)
+def test_rejects_storage_state_json_path(tmp_path: Path, filename: str) -> None:
+    """A ``storage_state.json`` path (any casing) must be rejected with ``ValueError``.
 
     Its ``<name>.lock`` derivation diverges from the canonical dotted
     ``.storage_state.json.lock`` (``_storage_state_lock_path``), so routing it
     here would acquire the wrong lock — the exact #1215 footgun #1220 closes.
     """
-    target = tmp_path / "storage_state.json"
+    target = tmp_path / filename
 
     mutator_calls: list[dict] = []
 
@@ -349,11 +357,11 @@ def test_rejects_storage_state_json_path(tmp_path: Path) -> None:
         atomic_update_json(target, mutator)
 
     # The guard fires before any I/O: no file, no mutator call, and crucially
-    # NEITHER lock variant is created on disk.
+    # NEITHER lock variant is created on disk (for the given casing).
     assert mutator_calls == []
     assert not target.exists()
-    assert not (tmp_path / "storage_state.json.lock").exists()  # divergent (would-be)
-    assert not (tmp_path / ".storage_state.json.lock").exists()  # canonical dotted
+    assert not (tmp_path / f"{filename}.lock").exists()  # divergent (would-be)
+    assert not (tmp_path / f".{filename}.lock").exists()  # canonical-shaped dotted
 
 
 def test_rejection_holds_with_recover_flag(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1220

## Problem

`atomic_update_json` in `_atomic_io.py` derives its lock as the *non-dotted* `<name>.lock` (`path.with_suffix(path.suffix + ".lock")` → e.g. `config.json.lock`). This **diverges** from the canonical *dotted* `.storage_state.json.lock` sentinel that every `storage_state.json` mutator now shares via `_storage_state_lock_path` (#1215).

The two patterns yield two *different* files. Today there is no live bug — `atomic_update_json`'s only callers operate on `context.json` / `config.json` (verified by grep). But a future caller routing a `storage_state.json` path through `atomic_update_json` would silently acquire the **wrong** lock file and re-introduce the exact lost-update race #1215 closed.

## Fix

Picked the **guard/reject** option from #1220 (the cleanest of the three): `atomic_update_json` now rejects `storage_state.json` paths up front with a clear `ValueError` that directs callers to the dedicated `notebooklm._auth` writers (`save_cookies_to_storage` / `write_account_metadata` / `_clear_in_band_account`), which all serialize on `_storage_state_lock_path`.

Why reject rather than route through `_storage_state_lock_path`:
- Keeps the leaf `_atomic_io` module free of any `notebooklm._auth` import (no layering inversion) — it checks a plain filename literal `_STORAGE_STATE_FILENAME` instead.
- `storage_state.json` already has dedicated locked writers; `atomic_update_json` should never be its write path. Rejecting makes that explicit by construction.
- The guard fires before any I/O, so neither lock variant is created and the mutator never runs.

The `config.json` / `context.json` callers are **unaffected** and keep their existing non-dotted `<name>.lock` files.

A new module-level **"Lock-path derivation contract"** note documents why the two derivations differ and which filename must use which lock.

## Tests

- `storage_state.json` is rejected with `ValueError` (with and without `recover_from_corrupt`), before any file/lock creation or mutator call.
- Cross-check that the rejected name's canonical lock really is the dotted `.storage_state.json.lock` sentinel and differs from the helper's `<name>.lock` derivation.
- `config.json` / `context.json` lock derivation is **unchanged**: the helper still contends on the non-dotted `<name>.lock` (proved via a pre-acquired-lock timeout) and never creates the dotted variant.

## Gates

- `uv run ruff check .` + `uv run ruff format .` clean
- `uv run mypy src/notebooklm --ignore-missing-imports` → Success, no issues
- `uv run pytest -q -k "atomic or lock or storage or io"` → 3712 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent generic atomic JSON updates from modifying storage state files; such updates are now rejected to avoid lost-update races.

* **Tests**
  * Added unit tests to enforce the rejection and to confirm existing atomic update behavior remains unchanged for other config files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->