### PR TITLE
test: invariant guards for recurring defect classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,12 @@ jobs:
       # ``.github/dependabot.yml``.
       run: uv run python scripts/check_action_pinning.py
 
+    - name: Assert no deprecation targets the shipping version
+      # Release gate: a DeprecationWarning must never name the version in
+      # pyproject.toml as its removal target. Lapsed shims are allowlisted
+      # inside the script with a tracking issue.
+      run: uv run python scripts/check_deprecation_targets.py
+
     - name: Assert coverage thresholds match
       run: uv run python scripts/check_coverage_thresholds.py
 

--- a/scripts/check_deprecation_targets.py
+++ b/scripts/check_deprecation_targets.py
@@ -1,0 +1,275 @@
+"""Release gate: a deprecation must never name the version shipping it.
+
+The recurring defect (issue #1214): a ``DeprecationWarning`` message says the
+feature "will be removed in vX.Y.Z" while ``pyproject.toml`` is *currently at*
+vX.Y.Z. Shipping that release publishes a deprecation whose stated removal
+target is the release itself — the shim is simultaneously "still here" and
+"already past its removal version", which is incoherent and means the shim
+should have been deleted (or the target bumped) before the release.
+
+This gate scans every ``warnings.warn(...)`` / ``DeprecationWarning(...)``
+message string under ``src/notebooklm/`` and fails if any names the version
+in ``pyproject.toml`` as a *removal target* (``removed in vX.Y.Z`` /
+``will be removed in vX.Y.Z`` / ``removal in vX.Y.Z``). It is wired alongside
+the other ``scripts/check_*.py`` static gates and is also exercised by
+``tests/unit/test_check_deprecation_targets.py``.
+
+Allowlist
+---------
+``LAPSED_ALLOWLIST`` holds deprecation sites whose stated removal target has
+*already lapsed* and whose shim removal is tracked separately. They are
+allowlisted (keyed by file + the offending version) with the tracking issue so
+this gate does not block the current release; once the tracking PR deletes the
+shim, the matching site disappears and the entry should be dropped (a stale
+allowlist entry is reported, keeping the list tightening).
+
+Usage::
+
+    python scripts/check_deprecation_targets.py
+    python scripts/check_deprecation_targets.py --pyproject path/to/pyproject.toml
+
+Exit codes:
+    0  No deprecation message names the current release as its removal target
+       (modulo documented allowlist entries).
+    1  One or more offending deprecation messages found (printed with file:line).
+    2  Argument / parse error (missing pyproject, unreadable version, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 path
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ImportError:
+        print(
+            "tomli is required on Python 3.10. Install with: uv pip install tomli",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+
+# Calls whose first string argument is treated as a user-facing deprecation
+# message. ``warnings.warn`` is the canonical path; ``DeprecationWarning(...)``
+# covers messages built for a raised/constructed warning instance.
+_DEPRECATION_CALL_NAMES = frozenset({"warnings.warn", "warn", "DeprecationWarning"})
+
+
+class _Offender:
+    __slots__ = ("path", "lineno", "version", "snippet")
+
+    def __init__(self, path: str, lineno: int, version: str, snippet: str) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.version = version
+        self.snippet = snippet
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.path, self.version)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — deprecation sites whose stated removal target has already lapsed.
+#
+# These are removed by a separate tracking PR; allowlisting them (with the
+# issue reference) keeps this gate from blocking the current release while the
+# shim deletion lands. Keyed by (relative-posix-path, offending-version).
+# ---------------------------------------------------------------------------
+class _LapsedEntry:
+    __slots__ = ("path", "version", "issue", "reason")
+
+    def __init__(self, path: str, version: str, issue: int, reason: str) -> None:
+        self.path = path
+        self.version = version
+        self.issue = issue
+        self.reason = reason
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.path, self.version)
+
+
+LAPSED_ALLOWLIST: tuple[_LapsedEntry, ...] = (
+    _LapsedEntry(
+        "src/notebooklm/_artifact_polling.py",
+        "0.6.0",
+        1213,
+        "poll_interval shim: removal target v0.6.0 already shipped; deleted by #1224.",
+    ),
+    _LapsedEntry(
+        "src/notebooklm/_sources.py",
+        "0.6.0",
+        1213,
+        "positional wait/wait_timeout shim: removal target v0.6.0 already shipped; "
+        "deleted by #1224.",
+    ),
+    _LapsedEntry(
+        "src/notebooklm/rpc/_safe_index.py",
+        "0.6.0",
+        1213,
+        "NOTEBOOKLM_STRICT_DECODE=0 soft-mode opt-out: removal target v0.6.0 already "
+        "shipped; deleted by #1224.",
+    ),
+)
+
+_ALLOWLIST_BY_KEY = {entry.key: entry for entry in LAPSED_ALLOWLIST}
+
+
+def _read_version(pyproject: Path) -> str:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    try:
+        version = data["project"]["version"]
+    except (KeyError, TypeError) as exc:  # pragma: no cover - malformed pyproject
+        raise KeyError("project.version not found in pyproject.toml") from exc
+    if not isinstance(version, str):  # pragma: no cover - defensive
+        raise TypeError(f"project.version is not a string: {version!r}")
+    return version
+
+
+def _removal_pattern(version: str) -> re.Pattern[str]:
+    """Match removal language naming *version* (with or without a ``v`` prefix).
+
+    Examples matched (version == ``0.6.0``)::
+
+        will be removed in v0.6.0
+        removed in 0.6.0
+        removal in v0.6.0
+        scheduled for removal in 0.6.0
+    """
+    escaped = re.escape(version)
+    return re.compile(
+        r"(?:will\s+be\s+)?remov(?:ed|al)\s+in\s+v?" + escaped + r"\b",
+        re.IGNORECASE,
+    )
+
+
+def _flatten_message(node: ast.AST) -> str:
+    """Best-effort flatten of a (possibly f-string / concatenated) message arg.
+
+    Concatenated string literals (``"a" "b"``) parse as a single ``Constant``;
+    implicit ``+`` concatenation and f-strings need walking. We collect every
+    string constant reachable from the first argument so split removal phrases
+    like ``"... removed in " f"v{X}"`` are not the concern here (the version is
+    a literal in the offending sites), but multi-literal messages still match.
+    """
+    parts: list[str] = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            parts.append(child.value)
+    return " ".join(parts)
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _scan(version: str) -> list[_Offender]:
+    pattern = _removal_pattern(version)
+    offenders: list[_Offender] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_name(node.func) not in _DEPRECATION_CALL_NAMES:
+                continue
+            if not node.args:
+                continue
+            message = _flatten_message(node.args[0])
+            if pattern.search(message):
+                snippet = message.strip()
+                if len(snippet) > 100:
+                    snippet = snippet[:97] + "..."
+                offenders.append(_Offender(rel, node.lineno, version, snippet))
+    return offenders
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--pyproject",
+        default=str(REPO_ROOT / "pyproject.toml"),
+        help="Path to pyproject.toml (default: repo root)",
+    )
+    args = ap.parse_args(argv)
+
+    pyproject = Path(args.pyproject)
+    if not pyproject.is_file():
+        print(f"pyproject.toml not found: {pyproject}", file=sys.stderr)
+        return 2
+    try:
+        version = _read_version(pyproject)
+    except (KeyError, TypeError, ValueError) as exc:
+        print(f"Could not read project.version: {exc}", file=sys.stderr)
+        return 2
+
+    offenders = _scan(version)
+
+    blocking: list[_Offender] = []
+    matched_allowlist_keys: set[tuple[str, str]] = set()
+    for offender in offenders:
+        if offender.key in _ALLOWLIST_BY_KEY:
+            matched_allowlist_keys.add(offender.key)
+            continue
+        blocking.append(offender)
+
+    stale = sorted(
+        f"  {entry.path} (v{entry.version}, #{entry.issue})"
+        for entry in LAPSED_ALLOWLIST
+        if entry.key not in matched_allowlist_keys
+    )
+
+    if blocking:
+        print(
+            f"Deprecation message(s) name the current release version "
+            f"v{version} as their removal target:",
+            file=sys.stderr,
+        )
+        for offender in blocking:
+            print(f"  {offender.path}:{offender.lineno}: {offender.snippet}", file=sys.stderr)
+        print(
+            "\nA deprecation must never point at the version shipping it. Either "
+            "delete the shim before this release, or bump the stated removal "
+            "target to a future version. If the removal is tracked separately, "
+            "add the site to LAPSED_ALLOWLIST with its tracking issue.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if stale:
+        print(
+            "Stale deprecation-target allowlist entries (no matching deprecation "
+            "message found — remove from LAPSED_ALLOWLIST):",
+            file=sys.stderr,
+        )
+        for line in stale:
+            print(line, file=sys.stderr)
+        return 1
+
+    allowlisted = len(matched_allowlist_keys)
+    suffix = f" ({allowlisted} allowlisted, lapsed)" if allowlisted else ""
+    print(
+        f"OK: no deprecation message names the current release v{version} as a "
+        f"removal target{suffix}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_deprecation_targets.py
+++ b/scripts/check_deprecation_targets.py
@@ -189,9 +189,18 @@ def _scan(version: str) -> list[_Offender]:
                 continue
             if _call_name(node.func) not in _DEPRECATION_CALL_NAMES:
                 continue
-            if not node.args:
+            # The message is the first positional arg, or the ``message=``
+            # keyword (``warnings.warn(message=...)``). Checking both keeps a
+            # keyword-form deprecation from bypassing the gate.
+            message_node: ast.AST | None = node.args[0] if node.args else None
+            if message_node is None:
+                for kw in node.keywords:
+                    if kw.arg == "message":
+                        message_node = kw.value
+                        break
+            if message_node is None:
                 continue
-            message = _flatten_message(node.args[0])
+            message = _flatten_message(message_node)
             if pattern.search(message):
                 snippet = message.strip()
                 if len(snippet) > 100:

--- a/scripts/check_deprecation_targets.py
+++ b/scripts/check_deprecation_targets.py
@@ -59,8 +59,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
 
 # Calls whose first string argument is treated as a user-facing deprecation
-# message. ``warnings.warn`` is the canonical path; ``DeprecationWarning(...)``
-# covers messages built for a raised/constructed warning instance.
+# message:
+#   * ``warnings.warn`` — the canonical attribute-access form.
+#   * bare ``warn`` — the ``from warnings import warn; warn(...)`` form.
+#   * ``DeprecationWarning(...)`` — a constructed/raised warning instance.
+# The bare ``warn`` is broad on purpose (a release gate prefers a false
+# positive over a missed deprecation); the version-naming regex in
+# ``_removal_pattern`` keeps incidental ``warn()`` calls from matching unless
+# they actually name the shipping version as a removal target.
 _DEPRECATION_CALL_NAMES = frozenset({"warnings.warn", "warn", "DeprecationWarning"})
 
 
@@ -244,6 +250,8 @@ def main(argv: list[str] | None = None) -> int:
         if entry.key not in matched_allowlist_keys
     )
 
+    # Report BOTH problems in one pass: a developer fixing a blocking offender
+    # should also see any stale allowlist entry without needing a second run.
     if blocking:
         print(
             f"Deprecation message(s) name the current release version "
@@ -259,7 +267,6 @@ def main(argv: list[str] | None = None) -> int:
             "add the site to LAPSED_ALLOWLIST with its tracking issue.",
             file=sys.stderr,
         )
-        return 1
 
     if stale:
         print(
@@ -269,6 +276,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         for line in stale:
             print(line, file=sys.stderr)
+
+    if blocking or stale:
         return 1
 
     allowlisted = len(matched_allowlist_keys)

--- a/tests/_lint/test_asyncio_loop_affinity_guard.py
+++ b/tests/_lint/test_asyncio_loop_affinity_guard.py
@@ -193,13 +193,24 @@ def _is_primitive_construction(
 
 
 class _ConstructionSite:
-    __slots__ = ("path", "lineno", "primitive", "owner")
+    __slots__ = ("path", "lineno", "primitive", "owner", "owner_line")
 
-    def __init__(self, path: str, lineno: int, primitive: str, owner: str | None) -> None:
+    def __init__(
+        self,
+        path: str,
+        lineno: int,
+        primitive: str,
+        owner: str | None,
+        owner_line: int | None,
+    ) -> None:
         self.path = path
         self.lineno = lineno
         self.primitive = primitive
+        # ``owner`` is the class *name* (used for allowlist keying + display);
+        # ``owner_line`` is its start line (used for the methods lookup so
+        # same-named classes in different scopes don't collide).
         self.owner = owner
+        self.owner_line = owner_line
 
     @property
     def key(self) -> tuple[str, str | None]:
@@ -210,12 +221,18 @@ class _ConstructionSite:
         return f"{self.path}:{self.lineno} asyncio.{self.primitive} (owner={owner})"
 
 
-def _class_methods(module: ast.Module) -> dict[str, set[str]]:
-    """Map each top-level/nested class name to the methods it defines."""
-    methods: dict[str, set[str]] = {}
+def _class_methods(module: ast.Module) -> dict[int, set[str]]:
+    """Map each class's *start line* to the methods it defines.
+
+    Keyed by start line (unique within a file) rather than by class name so two
+    same-named classes in different scopes (e.g. a helper ``_State`` nested in
+    two separate outer classes) don't collide and silently misreport
+    compliance.
+    """
+    methods: dict[int, set[str]] = {}
     for node in ast.walk(module):
         if isinstance(node, ast.ClassDef):
-            methods[node.name] = {
+            methods[node.lineno] = {
                 child.name
                 for child in node.body
                 if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -223,13 +240,15 @@ def _class_methods(module: ast.Module) -> dict[str, set[str]]:
     return methods
 
 
-def _enclosing_class(class_ranges: list[tuple[int, int, str]], lineno: int) -> str | None:
-    """Return the innermost class whose body spans *lineno*, if any."""
+def _enclosing_class(
+    class_ranges: list[tuple[int, int, str]], lineno: int
+) -> tuple[str, int] | None:
+    """Return ``(name, start_line)`` of the innermost class spanning *lineno*."""
     best: tuple[int, int, str] | None = None
     for start, end, name in class_ranges:
         if start <= lineno <= end and (best is None or start > best[0]):
             best = (start, end, name)
-    return best[2] if best else None
+    return (best[2], best[0]) if best else None
 
 
 def _asyncio_import_bindings(module: ast.Module) -> tuple[str, dict[str, str]]:
@@ -254,9 +273,9 @@ def _asyncio_import_bindings(module: ast.Module) -> tuple[str, dict[str, str]]:
     return asyncio_alias, imported_primitives
 
 
-def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[str, set[str]]]]:
+def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[int, set[str]]]]:
     sites: list[_ConstructionSite] = []
-    methods_by_file: dict[str, dict[str, set[str]]] = {}
+    methods_by_file: dict[str, dict[int, set[str]]] = {}
     for path in sorted(SRC_ROOT.rglob("*.py")):
         module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         rel = path.relative_to(REPO_ROOT).as_posix()
@@ -271,8 +290,10 @@ def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[str, set[str]]]]:
             primitive = _is_primitive_construction(node, asyncio_alias, imported_primitives)
             if primitive is None:
                 continue
-            owner = _enclosing_class(class_ranges, node.lineno)
-            sites.append(_ConstructionSite(rel, node.lineno, primitive, owner))
+            enclosing = _enclosing_class(class_ranges, node.lineno)
+            owner = enclosing[0] if enclosing else None
+            owner_line = enclosing[1] if enclosing else None
+            sites.append(_ConstructionSite(rel, node.lineno, primitive, owner, owner_line))
     return sites, methods_by_file
 
 
@@ -289,7 +310,10 @@ def test_every_asyncio_primitive_is_loop_affinity_guarded() -> None:
 
     violations: list[str] = []
     for site in sites:
-        owner_methods = methods_by_file.get(site.path, {}).get(site.owner or "", set())
+        file_methods = methods_by_file.get(site.path, {})
+        owner_methods = (
+            file_methods.get(site.owner_line, set()) if site.owner_line is not None else set()
+        )
         compliant = site.owner is not None and all(
             method in owner_methods for method in REQUIRED_GUARD_METHODS
         )
@@ -334,15 +358,21 @@ def test_loop_affinity_allowlist_has_no_stale_entries() -> None:
 
 
 def test_loop_affinity_followup_entries_reference_a_tracking_issue() -> None:
-    """Known-gap allowlist entries (not alt-guarded) must cite a tracking issue."""
-    # The ChatAPI locks are the only entry that is a *gap* rather than an
-    # alternative documented guard; it must carry an issue reference so the
-    # follow-up is trackable and the entry can be retired.
-    chat_entry = _ALLOWLIST_BY_KEY[("src/notebooklm/_chat.py", "ChatAPI")]
-    assert chat_entry.issue == CHAT_LOCKS_FOLLOWUP_ISSUE, (
-        "ChatAPI loop-affinity gap must reference its tracking issue "
-        f"(#{CHAT_LOCKS_FOLLOWUP_ISSUE})."
-    )
+    """Known-gap allowlist entries (not alt-guarded) must cite a tracking issue.
+
+    A *gap* entry is one that carries an ``issue`` (vs. an alternative-guard
+    entry, which is documented by reason only). Every such entry must reference
+    a positive issue number so the follow-up is trackable and the entry can be
+    retired. Iterating (rather than hard-keying on ``_chat.py``/``ChatAPI``)
+    keeps the guard robust if the gap class is renamed or relocated.
+    """
+    gap_entries = [entry for entry in ALLOWLIST if entry.issue is not None]
+    assert gap_entries, "expected at least one gap entry carrying a tracking issue"
+    for entry in gap_entries:
+        assert isinstance(entry.issue, int) and entry.issue > 0, (
+            f"gap entry for {entry.path} (owner={entry.owner}) must cite a "
+            "positive tracking issue number."
+        )
 
 
 def _detect(source: str) -> set[str]:

--- a/tests/_lint/test_asyncio_loop_affinity_guard.py
+++ b/tests/_lint/test_asyncio_loop_affinity_guard.py
@@ -164,15 +164,32 @@ def _call_name(node: ast.AST) -> str:
     return ""
 
 
-def _is_primitive_construction(node: ast.AST) -> str | None:
-    """Return the primitive name if *node* constructs an ``asyncio`` primitive."""
+def _is_primitive_construction(
+    node: ast.AST,
+    asyncio_alias: str,
+    imported_primitives: dict[str, str],
+) -> str | None:
+    """Return the primitive name if *node* constructs an ``asyncio`` primitive.
+
+    Handles all three import styles so a primitive can't bypass the lint by
+    importing differently:
+
+    * ``asyncio.Lock()`` — attribute access on the module (possibly aliased
+      via ``import asyncio as aio``; ``asyncio_alias`` carries the local name).
+    * ``Lock()`` / ``L()`` — a name brought in by
+      ``from asyncio import Lock`` / ``from asyncio import Lock as L``
+      (``imported_primitives`` maps the local name to the canonical primitive).
+    """
     if not isinstance(node, ast.Call):
         return None
     name = _call_name(node.func)
-    if not name.startswith("asyncio."):
-        return None
-    leaf = name.rsplit(".", 1)[-1]
-    return leaf if leaf in LOOP_BOUND_PRIMITIVES else None
+    prefix = f"{asyncio_alias}."
+    if name.startswith(prefix):
+        leaf = name.rsplit(".", 1)[-1]
+        return leaf if leaf in LOOP_BOUND_PRIMITIVES else None
+    if name in imported_primitives:
+        return imported_primitives[name]
+    return None
 
 
 class _ConstructionSite:
@@ -215,6 +232,28 @@ def _enclosing_class(class_ranges: list[tuple[int, int, str]], lineno: int) -> s
     return best[2] if best else None
 
 
+def _asyncio_import_bindings(module: ast.Module) -> tuple[str, dict[str, str]]:
+    """Resolve how ``asyncio`` and its primitives are bound in *module*.
+
+    Returns ``(asyncio_alias, imported_primitives)`` where ``asyncio_alias`` is
+    the local name for ``import asyncio[ as X]`` (default ``"asyncio"``) and
+    ``imported_primitives`` maps each local name introduced by
+    ``from asyncio import Primitive[ as Y]`` to the canonical primitive name.
+    """
+    asyncio_alias = "asyncio"
+    imported_primitives: dict[str, str] = {}
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "asyncio":
+                    asyncio_alias = alias.asname or "asyncio"
+        elif isinstance(node, ast.ImportFrom) and node.module == "asyncio":
+            for alias in node.names:
+                if alias.name in LOOP_BOUND_PRIMITIVES:
+                    imported_primitives[alias.asname or alias.name] = alias.name
+    return asyncio_alias, imported_primitives
+
+
 def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[str, set[str]]]]:
     sites: list[_ConstructionSite] = []
     methods_by_file: dict[str, dict[str, set[str]]] = {}
@@ -227,8 +266,9 @@ def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[str, set[str]]]]:
             for node in ast.walk(module)
             if isinstance(node, ast.ClassDef)
         ]
+        asyncio_alias, imported_primitives = _asyncio_import_bindings(module)
         for node in ast.walk(module):
-            primitive = _is_primitive_construction(node)
+            primitive = _is_primitive_construction(node, asyncio_alias, imported_primitives)
             if primitive is None:
                 continue
             owner = _enclosing_class(class_ranges, node.lineno)
@@ -303,3 +343,27 @@ def test_loop_affinity_followup_entries_reference_a_tracking_issue() -> None:
         "ChatAPI loop-affinity gap must reference its tracking issue "
         f"(#{CHAT_LOCKS_FOLLOWUP_ISSUE})."
     )
+
+
+def _detect(source: str) -> set[str]:
+    """Run the import-aware primitive detector over a synthetic module body."""
+    module = ast.parse(source)
+    asyncio_alias, imported = _asyncio_import_bindings(module)
+    found: set[str] = set()
+    for node in ast.walk(module):
+        primitive = _is_primitive_construction(node, asyncio_alias, imported)
+        if primitive is not None:
+            found.add(primitive)
+    return found
+
+
+def test_detector_handles_all_import_styles() -> None:
+    """``asyncio.Lock()``, aliased module, and ``from asyncio import`` all match."""
+    assert _detect("import asyncio\nx = asyncio.Lock()\n") == {"Lock"}
+    assert _detect("import asyncio as aio\nx = aio.Semaphore(1)\n") == {"Semaphore"}
+    assert _detect("from asyncio import Lock\nx = Lock()\n") == {"Lock"}
+    assert _detect("from asyncio import Event as E\nx = E()\n") == {"Event"}
+    # A same-named symbol from an unrelated module must NOT match.
+    assert _detect("from threading import Lock\nx = Lock()\n") == set()
+    # Non-primitive asyncio constructs must NOT match.
+    assert _detect("import asyncio\nx = asyncio.Queue()\n") == set()

--- a/tests/_lint/test_asyncio_loop_affinity_guard.py
+++ b/tests/_lint/test_asyncio_loop_affinity_guard.py
@@ -1,0 +1,305 @@
+"""Loop-affinity invariant guard for ``asyncio`` synchronisation primitives.
+
+The #1196 class of bug: a lazily-constructed ``asyncio`` primitive
+(``Lock`` / ``Semaphore`` / ``Event`` / ``Condition``) is created the first
+time it is touched, which binds it to *whatever event loop is running at that
+moment*. If the owning client is closed and reopened on a **different** loop,
+reusing the stale primitive either raises "bound to a different event loop"
+(Python 3.10/3.11) or misparks waiters. The fix that landed in #1196 (and its
+siblings) is a uniform loop-affinity protocol on the owning class:
+
+* ``set_bound_loop(loop)`` — ``ClientLifecycle.open()`` captures the running
+  loop and propagates it to every collaborator so a cross-loop call can be
+  rejected at the call site.
+* ``reset_after_open()`` — discards the cached primitive so the next access
+  from inside the new loop rebuilds it on that loop.
+
+This lint enumerates **every** ``asyncio`` primitive construction site under
+``src/notebooklm/`` (via AST, so docstring mentions don't count) and asserts
+that the construction site is *guarded*: either the owning class exposes the
+``set_bound_loop`` + ``reset_after_open`` protocol, or the site is on a
+documented allowlist with a reason (and, for known follow-up gaps, a
+tracking-issue reference).
+
+Without this guard, a sibling primitive added later silently regresses the
+#1196 class: nothing fails until a user reopens a client on a fresh loop in
+production. The lint fails loudly the moment a new unguarded primitive lands.
+
+Modelled after the AST-based lints in ``tests/_lint/`` (e.g.
+``test_error_handler_allowlist.py``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+
+# ``asyncio`` synchronisation primitives whose construction binds to the
+# running event loop. ``Queue`` is intentionally excluded — the codebase does
+# not construct loop-bound ``asyncio.Queue`` instances on a lazy path today;
+# if one is added, extend this set and add it to the scan deliberately.
+LOOP_BOUND_PRIMITIVES = frozenset({"Lock", "Semaphore", "BoundedSemaphore", "Event", "Condition"})
+
+# Methods that together make up the canonical #1196 loop-affinity protocol.
+# A class is considered compliant when it defines BOTH.
+REQUIRED_GUARD_METHODS = ("set_bound_loop", "reset_after_open")
+
+# Tracking issue for bringing the ``ChatAPI`` conversation locks under the
+# canonical owner-level protocol. They are guarded indirectly today (the
+# injected ``loop_guard.assert_bound_loop()`` fires in ``ChatAPI.ask`` before
+# the lock is acquired), but ``ChatAPI`` itself does not own
+# ``set_bound_loop`` / ``reset_after_open``.
+CHAT_LOCKS_FOLLOWUP_ISSUE = 1225
+
+
+class _AllowlistEntry:
+    """A documented exemption for one primitive construction site.
+
+    Keyed by ``(relative-posix-path, owning-class-or-None)`` so it survives
+    line-number churn from rebases and reorderings. Every entry carries a
+    human reason; follow-up gaps additionally carry a tracking issue.
+    """
+
+    __slots__ = ("path", "owner", "reason", "issue")
+
+    def __init__(
+        self,
+        path: str,
+        owner: str | None,
+        reason: str,
+        issue: int | None = None,
+    ) -> None:
+        self.path = path
+        self.owner = owner
+        self.reason = reason
+        self.issue = issue
+
+    @property
+    def key(self) -> tuple[str, str | None]:
+        return (self.path, self.owner)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — documented exemptions from the owner-level protocol.
+#
+# Each entry is a primitive whose construction site is loop-safe by an
+# ALTERNATIVE documented mechanism, or a known follow-up gap with a tracking
+# issue. The lint asserts exact membership: an allowlisted site that no longer
+# constructs a primitive is reported as stale so the list keeps tightening.
+# ---------------------------------------------------------------------------
+ALLOWLIST: tuple[_AllowlistEntry, ...] = (
+    # NOTE: ``ClientComposed``, ``TransportDrainTracker``, and
+    # ``SourceUploadPipeline`` are NOT allowlisted — they each define the full
+    # ``set_bound_loop`` + ``reset_after_open`` protocol and so are detected as
+    # compliant by the owner-method scan.
+    #
+    # ``set_bound_loop`` only (no ``reset_after_open``): the lazy ``asyncio.Lock``
+    # is rebuilt implicitly because these coordinators are reconstructed per
+    # ``open()`` and the call-site ``assert_bound_loop(self._bound_loop)`` in
+    # ``await_refresh`` / ``snapshot`` rejects cross-loop misuse before the
+    # lazy lock is touched. ``set_bound_loop(None)`` on close clears the
+    # binding so the next ``open()`` rebinds. A ``reset_after_open`` would be
+    # a no-op here (the locks are never held across ``open()``).
+    _AllowlistEntry(
+        "src/notebooklm/_session_auth.py",
+        "AuthRefreshCoordinator",
+        "Guarded by set_bound_loop + call-site assert_bound_loop; the lazy "
+        "Lock is never held across open() so reset_after_open is unnecessary.",
+    ),
+    _AllowlistEntry(
+        "src/notebooklm/_reqid_counter.py",
+        "ReqidCounter",
+        "Guarded by set_bound_loop + call-site assert_bound_loop in "
+        "next_reqid; the lazy Lock is never held across open().",
+    ),
+    # Module-global, PER-RUNNING-LOOP registries: the lock is keyed by
+    # ``asyncio.get_running_loop()`` in a ``WeakKeyDictionary``, so every loop
+    # gets its own lock and a stale cross-loop primitive can never be reused.
+    # These have no enclosing class to host the protocol; the per-loop keying
+    # is the structural guard.
+    _AllowlistEntry(
+        "src/notebooklm/_auth/keepalive.py",
+        None,
+        "Module-global per-running-loop lock registry (keyed by "
+        "asyncio.get_running_loop()); structurally immune to cross-loop reuse.",
+    ),
+    _AllowlistEntry(
+        "src/notebooklm/_auth/refresh.py",
+        None,
+        "Module-global per-running-loop lock registry (keyed by "
+        "asyncio.get_running_loop()); structurally immune to cross-loop reuse.",
+    ),
+    # KNOWN FOLLOW-UP GAP (#1225): the ChatAPI per-conversation /
+    # per-notebook locks are NOT under the owner-level protocol yet. They are
+    # guarded indirectly (ChatAPI.ask calls loop_guard.assert_bound_loop()
+    # before acquiring the lock) and GC themselves via WeakValueDictionary,
+    # but ChatAPI does not own set_bound_loop / reset_after_open. Tracked by
+    # #1225; remove this entry when ChatAPI joins the protocol.
+    _AllowlistEntry(
+        "src/notebooklm/_chat.py",
+        "ChatAPI",
+        "Known follow-up: guarded indirectly by injected "
+        "loop_guard.assert_bound_loop() in ask(); owner-level protocol pending.",
+        issue=CHAT_LOCKS_FOLLOWUP_ISSUE,
+    ),
+)
+
+_ALLOWLIST_BY_KEY = {entry.key: entry for entry in ALLOWLIST}
+
+
+# ---------------------------------------------------------------------------
+# AST scanning
+# ---------------------------------------------------------------------------
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _is_primitive_construction(node: ast.AST) -> str | None:
+    """Return the primitive name if *node* constructs an ``asyncio`` primitive."""
+    if not isinstance(node, ast.Call):
+        return None
+    name = _call_name(node.func)
+    if not name.startswith("asyncio."):
+        return None
+    leaf = name.rsplit(".", 1)[-1]
+    return leaf if leaf in LOOP_BOUND_PRIMITIVES else None
+
+
+class _ConstructionSite:
+    __slots__ = ("path", "lineno", "primitive", "owner")
+
+    def __init__(self, path: str, lineno: int, primitive: str, owner: str | None) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.primitive = primitive
+        self.owner = owner
+
+    @property
+    def key(self) -> tuple[str, str | None]:
+        return (self.path, self.owner)
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        owner = self.owner or "<module>"
+        return f"{self.path}:{self.lineno} asyncio.{self.primitive} (owner={owner})"
+
+
+def _class_methods(module: ast.Module) -> dict[str, set[str]]:
+    """Map each top-level/nested class name to the methods it defines."""
+    methods: dict[str, set[str]] = {}
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef):
+            methods[node.name] = {
+                child.name
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+    return methods
+
+
+def _enclosing_class(class_ranges: list[tuple[int, int, str]], lineno: int) -> str | None:
+    """Return the innermost class whose body spans *lineno*, if any."""
+    best: tuple[int, int, str] | None = None
+    for start, end, name in class_ranges:
+        if start <= lineno <= end and (best is None or start > best[0]):
+            best = (start, end, name)
+    return best[2] if best else None
+
+
+def _scan() -> tuple[list[_ConstructionSite], dict[str, dict[str, set[str]]]]:
+    sites: list[_ConstructionSite] = []
+    methods_by_file: dict[str, dict[str, set[str]]] = {}
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        methods_by_file[rel] = _class_methods(module)
+        class_ranges = [
+            (node.lineno, getattr(node, "end_lineno", node.lineno) or node.lineno, node.name)
+            for node in ast.walk(module)
+            if isinstance(node, ast.ClassDef)
+        ]
+        for node in ast.walk(module):
+            primitive = _is_primitive_construction(node)
+            if primitive is None:
+                continue
+            owner = _enclosing_class(class_ranges, node.lineno)
+            sites.append(_ConstructionSite(rel, node.lineno, primitive, owner))
+    return sites, methods_by_file
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_every_asyncio_primitive_is_loop_affinity_guarded() -> None:
+    """Every lazy ``asyncio`` primitive is guarded or explicitly allowlisted."""
+    sites, methods_by_file = _scan()
+
+    assert sites, "scan found no asyncio primitives — the AST walk likely broke"
+
+    violations: list[str] = []
+    for site in sites:
+        owner_methods = methods_by_file.get(site.path, {}).get(site.owner or "", set())
+        compliant = site.owner is not None and all(
+            method in owner_methods for method in REQUIRED_GUARD_METHODS
+        )
+        if compliant:
+            continue
+        if site.key in _ALLOWLIST_BY_KEY:
+            continue
+        owner = site.owner or "<module-level>"
+        missing = [m for m in REQUIRED_GUARD_METHODS if m not in owner_methods]
+        violations.append(
+            f"  {site.path}:{site.lineno}  asyncio.{site.primitive}  "
+            f"(owner={owner}; missing {missing or 'class'}). "
+            "Add set_bound_loop + reset_after_open to the owning class (the "
+            "#1196 pattern), or add a documented allowlist entry."
+        )
+
+    if violations:
+        raise AssertionError(
+            "Unguarded asyncio synchronisation primitive(s) detected. Each lazy "
+            "Lock/Semaphore/Event/Condition binds to the loop it is first built "
+            "on; an owning class must expose the #1196 loop-affinity protocol "
+            "(set_bound_loop + reset_after_open) or be allowlisted in "
+            "tests/_lint/test_asyncio_loop_affinity_guard.py::ALLOWLIST.\n\n"
+            + "\n".join(violations)
+        )
+
+
+def test_loop_affinity_allowlist_has_no_stale_entries() -> None:
+    """Every allowlist entry must still correspond to a real primitive site."""
+    sites, _ = _scan()
+    live_keys = {site.key for site in sites}
+    stale = sorted(
+        f"  {entry.path} (owner={entry.owner or '<module-level>'})"
+        for entry in ALLOWLIST
+        if entry.key not in live_keys
+    )
+    if stale:
+        raise AssertionError(
+            "Stale loop-affinity allowlist entries (no matching primitive "
+            "construction site found — remove from ALLOWLIST):\n" + "\n".join(stale)
+        )
+
+
+def test_loop_affinity_followup_entries_reference_a_tracking_issue() -> None:
+    """Known-gap allowlist entries (not alt-guarded) must cite a tracking issue."""
+    # The ChatAPI locks are the only entry that is a *gap* rather than an
+    # alternative documented guard; it must carry an issue reference so the
+    # follow-up is trackable and the entry can be retired.
+    chat_entry = _ALLOWLIST_BY_KEY[("src/notebooklm/_chat.py", "ChatAPI")]
+    assert chat_entry.issue == CHAT_LOCKS_FOLLOWUP_ISSUE, (
+        "ChatAPI loop-affinity gap must reference its tracking issue "
+        f"(#{CHAT_LOCKS_FOLLOWUP_ISSUE})."
+    )

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -502,6 +502,12 @@ def _build_json_invocation(path: str) -> list[str]:
                 argv.append(_JSON_CONTRACT_DUMMY_ARGS.get(param.name, _choice_value(param)))
         elif isinstance(param, click.Option) and param.required:
             argv.append(param.opts[0])
+            # "1" works for INT/STRING options and is enough to clear Click's
+            # parser so the command body (and its auth bootstrap) is reached.
+            # If a --json command ever gains a required option with a
+            # restrictive type (UUID, existing-Path, ...) that rejects "1",
+            # Click would exit 2 before auth; add such names to a dummy-option
+            # map here, mirroring _JSON_CONTRACT_DUMMY_ARGS for arguments.
             argv.append(_choice_value(param) if isinstance(param.type, click.Choice) else "1")
     if any(isinstance(param, click.Option) and param.name == "notebook_id" for param in cmd.params):
         argv.extend(["-n", "nb_contract"])

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -444,6 +444,20 @@ _JSON_CONTRACT_DUMMY_ARGS = {
 }
 
 
+def _split_stderr_runner() -> CliRunner:
+    """A ``CliRunner`` that captures stderr separately when Click supports it.
+
+    Click 8.2 removed the ``mix_stderr`` constructor parameter (stderr is split
+    by default). Inspect the signature so the kwarg is passed only when present,
+    rather than relying on a ``TypeError`` to detect the unsupported case.
+    """
+    import inspect
+
+    if "mix_stderr" in inspect.signature(CliRunner.__init__).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
 def _has_json_flag(cmd: click.Command) -> bool:
     for param in cmd.params:
         if isinstance(param, click.Option) and (
@@ -526,11 +540,7 @@ def test_json_error_envelope_and_exit_code_are_uniform(command_path: str) -> Non
     ``test_json_stdout_routing_and_exit_codes_for_download_runtime``.
     """
     argv = _build_json_invocation(command_path)
-
-    try:
-        runner = CliRunner(mix_stderr=False)
-    except TypeError:  # pragma: no cover - older click without the kwarg
-        runner = CliRunner()
+    runner = _split_stderr_runner()
 
     with patch(
         "notebooklm.cli.helpers.get_auth_tokens",

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -392,5 +392,178 @@ def test_json_stdout_routing_and_exit_codes_for_download_runtime(
         assert payload["code"] == expected_code
 
 
+# ---------------------------------------------------------------------------
+# Uniform ``--json`` error-envelope + exit-code contract (issue #1214 part b).
+#
+# Today the typed-envelope matrix is pinned for the ``download`` command only
+# (see ``test_json_stdout_routing_and_exit_codes_for_download_runtime``). The
+# class of regression this guards: a *new* ``--json``-bearing command that
+# forgets to route failures through ``handle_errors`` and instead leaks a raw
+# traceback, a bare string, or a non-JSON line to stdout. Such a command
+# silently breaks every automation parsing the typed envelope.
+#
+# The canonical envelope (``cli/error_handler.py::_output_error``) is::
+#
+#     {"error": true, "code": "<UPPER_SNAKE>", "message": "<str>", ...}
+#
+# with exit code 1 for user/application errors (auth, rate-limit, validation),
+# 2 for unexpected bugs, 130 for Ctrl-C, and 0 for success. This test drives a
+# uniform *missing-auth* failure (the same trigger the download test uses for
+# its ``AUTH_REQUIRED`` case) across EVERY ``--json`` command discovered by
+# command-tree introspection and asserts the typed envelope + exit code 1 +
+# clean stderr.
+# ---------------------------------------------------------------------------
+
+# Commands whose ``--json`` output is intentionally NOT the error envelope:
+# diagnostic / local-state commands that report status and succeed (exit 0)
+# even without usable auth, emitting their own structured payload. Each is an
+# explicit, documented exemption so the exemption is intentional rather than an
+# accidental gap. Mirrors the prompt's documented exemptions
+# (``agent show`` / ``skill install`` / ``profile``); the concrete commands
+# that actually carry ``--json`` today and bypass the error envelope are:
+JSON_CONTRACT_EXEMPTIONS: dict[str, str] = {
+    "auth check": "Diagnostic command: emits a status report payload and exits 0.",
+    "doctor": "Diagnostic/repair command: emits a checks report payload, not the error envelope.",
+    "language get": "Settings read: emits the resolved language, no auth required.",
+    "language list": "Settings read: emits the supported-language table, no auth required.",
+    "language set": "Settings write helper: emits the applied language payload.",
+    "profile list": "Local profile listing: reads on-disk profiles, no auth required.",
+    "status": "Context status: emits the active-notebook context payload, no auth required.",
+}
+
+# Dummy required-argument values so a command body is reached past Click's
+# argument parsing. Keyed by Click parameter name.
+_JSON_CONTRACT_DUMMY_ARGS = {
+    "artifact_id": "art_1",
+    "question": "hello",
+    "title": "Untitled",
+    "description": "desc",
+    "code": "en",
+    "email": "person@example.com",
+    "content": "body",
+}
+
+
+def _has_json_flag(cmd: click.Command) -> bool:
+    for param in cmd.params:
+        if isinstance(param, click.Option) and (
+            param.name in ("json_output", "json") or "--json" in param.opts
+        ):
+            return True
+    return False
+
+
+def _json_command_paths() -> list[str]:
+    """Every visible leaf command that exposes a ``--json`` flag."""
+    paths: list[str] = []
+
+    def walk(cmd: click.Command, path: list[str]) -> None:
+        if isinstance(cmd, click.Group):
+            ctx = click.Context(cmd)
+            for name in cmd.list_commands(ctx):
+                sub = cmd.get_command(ctx, name)
+                if sub is None or getattr(sub, "hidden", False):
+                    continue
+                walk(sub, [*path, name])
+        elif _has_json_flag(cmd):
+            paths.append(" ".join(path))
+
+    walk(cli, [])
+    return sorted(paths)
+
+
+def _choice_value(param: click.Parameter) -> str:
+    if isinstance(param.type, click.Choice):
+        return param.type.choices[0]
+    return "x"
+
+
+def _build_json_invocation(path: str) -> list[str]:
+    cmd = _command_for(path)
+    argv = [*path.split(), "--json"]
+    for param in cmd.params:
+        if isinstance(param, click.Argument) and param.required:
+            count = param.nargs if param.nargs and param.nargs > 0 else 1
+            for _ in range(count):
+                argv.append(_JSON_CONTRACT_DUMMY_ARGS.get(param.name, _choice_value(param)))
+        elif isinstance(param, click.Option) and param.required:
+            argv.append(param.opts[0])
+            argv.append(_choice_value(param) if isinstance(param.type, click.Choice) else "1")
+    if any(isinstance(param, click.Option) and param.name == "notebook_id" for param in cmd.params):
+        argv.extend(["-n", "nb_contract"])
+    return argv
+
+
+def _enforced_json_command_paths() -> list[str]:
+    return [path for path in _json_command_paths() if path not in JSON_CONTRACT_EXEMPTIONS]
+
+
+def test_json_contract_exemptions_are_real_commands() -> None:
+    """Every exemption must name a real ``--json`` command (no stale entries)."""
+    json_paths = set(_json_command_paths())
+    stale = sorted(name for name in JSON_CONTRACT_EXEMPTIONS if name not in json_paths)
+    assert not stale, (
+        "Stale --json contract exemptions (no such --json command — remove from "
+        f"JSON_CONTRACT_EXEMPTIONS): {stale}"
+    )
+
+
+def test_json_contract_covers_a_representative_command_set() -> None:
+    """Guard against the introspection silently matching nothing."""
+    enforced = _enforced_json_command_paths()
+    # If this ever drops sharply, the command-tree walk likely broke or a whole
+    # group started bypassing the envelope; both deserve a hard failure.
+    assert len(enforced) >= 30, enforced
+
+
+@pytest.mark.parametrize("command_path", _enforced_json_command_paths())
+def test_json_error_envelope_and_exit_code_are_uniform(command_path: str) -> None:
+    """Every non-exempt ``--json`` command emits the typed envelope on failure.
+
+    Drives a uniform missing-auth failure and asserts the canonical
+    ``{"error": true, "code": <str>, "message": <str>}`` envelope on stdout,
+    exit code 1, and empty stderr — the same shape pinned for ``download`` in
+    ``test_json_stdout_routing_and_exit_codes_for_download_runtime``.
+    """
+    argv = _build_json_invocation(command_path)
+
+    try:
+        runner = CliRunner(mix_stderr=False)
+    except TypeError:  # pragma: no cover - older click without the kwarg
+        runner = CliRunner()
+
+    with patch(
+        "notebooklm.cli.helpers.get_auth_tokens",
+        side_effect=FileNotFoundError("Storage file not found"),
+    ):
+        result = runner.invoke(cli, argv, catch_exceptions=False)
+
+    assert result.exit_code == 1, (
+        f"{command_path!r} should exit 1 on missing auth, got "
+        f"{result.exit_code}. stdout={result.stdout!r}"
+    )
+
+    try:
+        stderr = result.stderr
+    except ValueError:  # pragma: no cover - runner without split capture
+        stderr = ""
+    assert stderr == "", f"{command_path!r} wrote to stderr in --json mode: {stderr!r}"
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - failure path
+        raise AssertionError(
+            f"{command_path!r} did not emit JSON in --json mode: {result.stdout!r}"
+        ) from exc
+
+    assert payload.get("error") is True, f"{command_path!r} envelope missing error=true: {payload}"
+    assert isinstance(payload.get("code"), str) and payload["code"], (
+        f"{command_path!r} envelope missing string code: {payload}"
+    )
+    assert isinstance(payload.get("message"), str), (
+        f"{command_path!r} envelope missing string message: {payload}"
+    )
+
+
 if __name__ == "__main__":
     print(json.dumps(build_phase10_cli_contract(), indent=2, sort_keys=True))

--- a/tests/unit/test_check_deprecation_targets.py
+++ b/tests/unit/test_check_deprecation_targets.py
@@ -86,12 +86,19 @@ def test_live_repository_passes_the_gate(script) -> None:
     assert "OK" in out
 
 
-def test_lapsed_allowlist_entries_reference_tracking_issue(script) -> None:
-    """Every allowlist entry must cite issue #1213 (the shim-removal tracker)."""
+def test_lapsed_allowlist_entries_are_well_formed(script) -> None:
+    """Every allowlist entry must cite a tracking issue and name a version.
+
+    Kept generic (positive int issue, non-empty version + reason) rather than
+    pinning the current ``#1213`` / ``0.6.0`` values so a future lapsed entry
+    for a different issue/version does not spuriously fail this guard.
+    """
     assert script.LAPSED_ALLOWLIST, "allowlist unexpectedly empty"
     for entry in script.LAPSED_ALLOWLIST:
-        assert entry.issue == 1213, entry.path
-        assert entry.version == "0.6.0", entry.path
+        assert isinstance(entry.issue, int) and entry.issue > 0, entry.path
+        assert isinstance(entry.version, str) and entry.version, entry.path
+        assert isinstance(entry.reason, str) and entry.reason, entry.path
+        assert entry.path.startswith("src/notebooklm/"), entry.path
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +170,28 @@ def test_deprecation_naming_other_version_does_not_trip(script, synthetic, tmp_p
     rc, out, _err = _run(script, ["--pyproject", str(pyproject)])
     assert rc == 0, out
     assert "OK" in out
+
+
+def test_keyword_message_argument_is_scanned(script, synthetic, tmp_path) -> None:
+    """A ``warnings.warn(message=...)`` keyword form must not bypass the gate."""
+    (synthetic / "_feature.py").write_text(
+        dedent(
+            """
+            import warnings
+
+            def f():
+                warnings.warn(
+                    message="old_param will be removed in v0.7.0.",
+                    category=DeprecationWarning,
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, _out, err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 1, err
+    assert "_feature.py" in err
 
 
 def test_direct_deprecationwarning_construction_is_scanned(script, synthetic, tmp_path) -> None:

--- a/tests/unit/test_check_deprecation_targets.py
+++ b/tests/unit/test_check_deprecation_targets.py
@@ -1,0 +1,238 @@
+"""Tests for ``scripts/check_deprecation_targets.py`` (issue #1214 part c).
+
+The release gate fails if any ``warnings.warn`` / ``DeprecationWarning``
+message under ``src/notebooklm/`` names the version currently in
+``pyproject.toml`` as its *removal target*. A deprecation must never point at
+the version shipping it.
+
+Tests cover:
+
+* The gate is GREEN against the live repository tree (the lapsed v0.6.0 shims
+  are allowlisted via ``LAPSED_ALLOWLIST`` referencing #1213).
+* The allowlist entries reference the tracking issue (#1213).
+* A synthetic offender naming the current version is caught (rc 1).
+* The ``removed in`` / ``will be removed in`` / ``scheduled for removal in``
+  phrasings are all detected, with and without the ``v`` prefix.
+* A deprecation naming a *different* version does not trip the gate.
+* An allowlisted offender does not block; removing the offender makes the
+  allowlist entry stale (rc 1).
+* Missing / malformed ``pyproject.toml`` returns rc 2.
+
+Script is imported via spec-loading to match the convention used by
+``test_check_action_pinning.py`` (``scripts/`` is not a Python package).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_deprecation_targets.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_deprecation_targets", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def script():
+    return _load_module()
+
+
+def _write_pyproject(tmp_path: Path, version: str) -> Path:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        dedent(
+            f"""
+            [project]
+            name = "example"
+            version = "{version}"
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return pyproject
+
+
+def _run(script, argv: list[str]) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = script.main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Live-repo guard
+# ---------------------------------------------------------------------------
+
+
+def test_live_repository_passes_the_gate(script) -> None:
+    """The real tree is green: lapsed shims are allowlisted; nothing else trips."""
+    rc, out, err = _run(script, [])
+    assert rc == 0, err
+    assert "OK" in out
+
+
+def test_lapsed_allowlist_entries_reference_tracking_issue(script) -> None:
+    """Every allowlist entry must cite issue #1213 (the shim-removal tracker)."""
+    assert script.LAPSED_ALLOWLIST, "allowlist unexpectedly empty"
+    for entry in script.LAPSED_ALLOWLIST:
+        assert entry.issue == 1213, entry.path
+        assert entry.version == "0.6.0", entry.path
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-tree behaviour (monkeypatch SRC_ROOT/REPO_ROOT onto the module)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def synthetic(script, tmp_path, monkeypatch):
+    """Point the script's scan at an isolated synthetic source tree."""
+    src = tmp_path / "src" / "notebooklm"
+    src.mkdir(parents=True)
+    monkeypatch.setattr(script, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(script, "SRC_ROOT", src)
+    # Neutralise the real allowlist so synthetic offenders are not masked.
+    monkeypatch.setattr(script, "LAPSED_ALLOWLIST", ())
+    monkeypatch.setattr(script, "_ALLOWLIST_BY_KEY", {})
+    return src
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "will be removed in v0.7.0",
+        "will be removed in 0.7.0",
+        "removed in v0.7.0",
+        "scheduled for removal in v0.7.0",
+        "removal in 0.7.0",
+    ],
+)
+def test_offender_naming_current_version_is_caught(script, synthetic, tmp_path, phrase) -> None:
+    (synthetic / "_feature.py").write_text(
+        dedent(
+            f"""
+            import warnings
+
+            def f():
+                warnings.warn(
+                    "old_param is deprecated and {phrase}; use new_param.",
+                    DeprecationWarning,
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, _out, err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 1, err
+    assert "_feature.py" in err
+    assert "removal target" in err
+
+
+def test_deprecation_naming_other_version_does_not_trip(script, synthetic, tmp_path) -> None:
+    (synthetic / "_feature.py").write_text(
+        dedent(
+            """
+            import warnings
+
+            def f():
+                warnings.warn(
+                    "old_param is deprecated and will be removed in v1.0.0.",
+                    DeprecationWarning,
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, out, _err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 0, out
+    assert "OK" in out
+
+
+def test_direct_deprecationwarning_construction_is_scanned(script, synthetic, tmp_path) -> None:
+    (synthetic / "_feature.py").write_text(
+        dedent(
+            """
+            def f():
+                raise DeprecationWarning(
+                    "feature X scheduled for removal in v0.7.0."
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, _out, err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 1, err
+    assert "_feature.py" in err
+
+
+def test_allowlisted_offender_does_not_block(script, synthetic, tmp_path, monkeypatch) -> None:
+    (synthetic / "_legacy.py").write_text(
+        dedent(
+            """
+            import warnings
+
+            def f():
+                warnings.warn(
+                    "legacy will be removed in v0.7.0.",
+                    DeprecationWarning,
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+    entry = script._LapsedEntry("src/notebooklm/_legacy.py", "0.7.0", 9999, "tracked elsewhere")
+    monkeypatch.setattr(script, "LAPSED_ALLOWLIST", (entry,))
+    monkeypatch.setattr(script, "_ALLOWLIST_BY_KEY", {entry.key: entry})
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, out, _err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 0, out
+    assert "allowlisted" in out
+
+
+def test_stale_allowlist_entry_is_reported(script, synthetic, tmp_path, monkeypatch) -> None:
+    # No source file names v0.7.0, but an allowlist entry claims one does.
+    (synthetic / "_clean.py").write_text("x = 1\n", encoding="utf-8")
+    entry = script._LapsedEntry("src/notebooklm/_legacy.py", "0.7.0", 9999, "gone")
+    monkeypatch.setattr(script, "LAPSED_ALLOWLIST", (entry,))
+    monkeypatch.setattr(script, "_ALLOWLIST_BY_KEY", {entry.key: entry})
+    pyproject = _write_pyproject(tmp_path, "0.7.0")
+    rc, _out, err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 1, err
+    assert "Stale" in err
+
+
+# ---------------------------------------------------------------------------
+# Argument / parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pyproject_returns_rc_2(script, tmp_path) -> None:
+    rc, _out, err = _run(script, ["--pyproject", str(tmp_path / "nope.toml")])
+    assert rc == 2
+    assert "not found" in err
+
+
+def test_malformed_pyproject_returns_rc_2(script, tmp_path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "x"\n', encoding="utf-8")  # no version
+    rc, _out, err = _run(script, ["--pyproject", str(pyproject)])
+    assert rc == 2
+    assert "project.version" in err


### PR DESCRIPTION
Fixes #1214 (parts a–c; part d via #1221)

From the v0.6.0 architecture gap review: several defect classes keep recurring with no invariant test guarding against regression. This adds three loud-on-regression guard tests.

## (a) asyncio loop-affinity lint
`tests/_lint/test_asyncio_loop_affinity_guard.py` enumerates **every** `asyncio` `Lock`/`Semaphore`/`Event`/`Condition` construction site under `src/notebooklm/` (via AST, so docstring mentions don't count) and asserts each is loop-affinity guarded — the owning class exposes the #1196 protocol (`set_bound_loop` + `reset_after_open`), or the site is on a documented allowlist.

- Compliant by the owner-method scan: `ClientComposed`, `TransportDrainTracker`, `SourceUploadPipeline`.
- Allowlisted with an alternative documented guard: `AuthRefreshCoordinator` / `ReqidCounter` (`set_bound_loop` + call-site `assert_bound_loop`), and the module-global per-running-loop lock registries in `_auth/keepalive.py` / `_auth/refresh.py`.
- Allowlisted as a **known follow-up gap**: the `ChatAPI` conversation/new-conversation locks (guarded indirectly today via the injected `loop_guard.assert_bound_loop()` in `ask()`), tracked by **#1225**.

## (b) uniform `--json` envelope + exit-code contract
`tests/unit/cli/test_phase10_cli_contract.py` gains a parametrized test asserting the typed `{"error": true, "code": <str>, "message": <str>}` envelope + exit code 1 + clean stderr for **every** `--json`-bearing command (66 commands), up from the `download`-only matrix. Commands are discovered with the existing `build_phase10_cli_contract` command-tree introspection. Documented diagnostic/local-state exemptions (`auth check`, `doctor`, `language *`, `profile list`, `status`) are listed explicitly so each exemption is intentional.

## (c) deprecation-version release gate
`scripts/check_deprecation_targets.py` fails if any deprecation message in `src/` names the version currently in `pyproject.toml` as its removal target (a deprecation must never point at the version shipping it). It is **allowlist-aware**: the lapsed v0.6.0 shims being removed in **#1224** (#1213) are allowlisted referencing #1213 so the gate does not block now, and they drop off once #1224 merges (the stale-entry check then flags them for removal). Wired into `.github/workflows/test.yml` alongside the other `check_*.py` gates and covered by `tests/unit/test_check_deprecation_targets.py`.

> Part (d) per-method error/quota/multi-frame golden envelopes is being delivered by **#1221** and is intentionally not duplicated here.

## Verification
- `uv run ruff check . && uv run ruff format .` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- new tests + full `tests/unit` suite green (6456 passed)
- `scripts/check_deprecation_targets.py`, `check_claude_md_freshness.py`, `audit_public_api_compat.py` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure deprecation notices do not name the current release version as their removal target.
  * Added unit tests covering the deprecation gate behavior and its allowlist semantics.
  * Added lint tests enforcing asyncio loop-bound primitive guarding.
  * Added CLI contract tests enforcing uniform error envelopes for JSON commands.

* **Chores**
  * Added a CI quality-gate step to run the deprecation-check script and fail the pipeline on violations or stale allowlist entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->