### PR TITLE
docs(auth): validate_with_recovery docstring says "PSIDTS absent or expired"

### DIFF
--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -585,9 +585,10 @@ def validate_with_recovery(
     Wraps :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
     plus :func:`notebooklm._auth.cookies.extract_cookies_from_storage` with one
     retry through :func:`recover_psidts_in_memory` (issue #990). When the
-    recovery preconditions hold (SID present, PSIDTS absent, secondary
-    binding intact), the rotated cookies are appended to ``rookiepy_cookies``
-    in place so downstream persistence picks them up.
+    recovery preconditions hold (SID present, PSIDTS absent or expired,
+    secondary binding intact — see :func:`_psidts_needs_recovery`), the
+    rotated cookies are appended to ``rookiepy_cookies`` in place so
+    downstream persistence picks them up.
 
     Lives in the auth subpackage rather than the CLI login package so both
     CLI call sites can route through ``notebooklm.auth`` without adding a


### PR DESCRIPTION
Fixes #1227

Cosmetic follow-up from #1218. That PR widened the inline cold-start recovery precondition so it fires when `__Secure-1PSIDTS` is **absent OR present-but-expired**, but the `validate_with_recovery` docstring still read "PSIDTS absent", implying only the absent case.

This updates the precondition wording to "PSIDTS absent or expired" and references `_psidts_needs_recovery` so the docstring matches the actual behavior (`recover_psidts_in_memory` → `_psidts_needs_recovery`).

Docstring-only; no behavior change.

## Gates
- `uv run ruff check . && uv run ruff format .` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — no issues
- `uv run python scripts/check_claude_md_freshness.py` — OK
- `uv run pytest -q -k "psidts or recovery"` — 69 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication recovery documentation for improved clarity on edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->