### PR TITLE
polish(chat): _raise_chat_error_frame -> NoReturn + reuse held answer row in _chat_protocol

### DIFF
--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -12,7 +12,7 @@ import logging
 import math
 import re
 from dataclasses import dataclass, replace
-from typing import Any, Protocol
+from typing import Any, NoReturn, Protocol
 from urllib.parse import quote, urlencode
 
 from ._env import get_default_bl, get_default_language, is_strict_decode_enabled
@@ -354,10 +354,12 @@ def _extract_chunk_with_parseable(
                     )
                 continue
             if len(first) > 0:
-                # Load-bearing answer-text leaf. On the happy path
-                # ``inner_data[0][0]`` is valid so this is byte-for-byte
-                # identical; under drift it raises rather than dropping text.
-                text = safe_index(inner_data, 0, 0, method_id=None, source=_CHUNK_SOURCE)
+                # Load-bearing answer-text leaf. ``first`` already holds
+                # ``inner_data[0]`` and the ``len(first) > 0`` guard makes
+                # ``first[0]`` valid, so reuse it instead of re-traversing from
+                # ``inner_data``: byte-for-byte identical on the happy path,
+                # with a more localized ``(0,)`` drift path under drift.
+                text = safe_index(first, 0, method_id=None, source=_CHUNK_SOURCE)
                 if not isinstance(text, str) or not text:
                     continue
 
@@ -392,7 +394,7 @@ def _extract_chunk_with_parseable(
     return None, False, refs, None, parseable
 
 
-def _raise_chat_error_frame(item: list) -> None:
+def _raise_chat_error_frame(item: list) -> NoReturn:
     """Surface a server-side ``"er"`` error frame as a ``ChatError``.
 
     The streamed batchexecute backend emits ``["er", rpc_id, code, ...]``


### PR DESCRIPTION
Fixes #1230

Two low/nit polish findings from the claude-bot review of #1219 (merged as `e987bbfb`) that landed *after* the squash-merge snapshot, so they were never in main. Both are non-functional and behavior-preserving on the chat happy path.

## Finding 1 (low) — annotate `_raise_chat_error_frame` as `-> NoReturn`
`_raise_chat_error_frame` unconditionally raises `ChatError` but was annotated `-> None`. With `-> NoReturn`, mypy can treat the call as a flow-control narrowing point and flag any dead code placed after it. Imports `NoReturn` from `typing`.

## Finding 2 (nit) — reuse the already-held answer row
In `_extract_chunk_with_parseable`, the answer-text leaf was read with `safe_index(inner_data, 0, 0, ...)` even though `first` already holds `inner_data[0]`. The `len(first) > 0` guard makes `safe_index(first, 0, ...)` equivalent (extracted text byte-for-byte identical on the happy path) and yields a more localized `(0,)` drift path.

## Gates
- `uv run ruff check .` / `uv run ruff format .` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — no issues in 184 source files
- `uv run pytest -q -k "chat or stream or citation or protocol"` — 443 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)