### PR TITLE
fix(concurrency): bring ChatAPI conversation locks under the loop-affinity protocol

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -724,6 +724,14 @@ class ChatAPI:
             True on success. The server returns an empty body; any
             RPC-level error raises before this returns.
         """
+        # Catch cross-loop misuse before acquiring the per-conversation lock
+        # below — like ``ask`` does — so a client reused from a different loop
+        # fails fast at the call site instead of hanging on (or rebuilding) a
+        # lock bound to a dead loop. The owner-level ``set_bound_loop`` /
+        # ``reset_after_open`` protocol (#1225) only resets the locks on a
+        # *reopen*; an already-open client driven cross-loop is still rejected
+        # here by the injected guard.
+        self._loop_guard.assert_bound_loop()
         logger.debug("Deleting conversation %s in notebook %s", conversation_id, notebook_id)
         # Hold the per-``conversation_id`` lock the same way ``ask`` does
         # for follow-ups, so a concurrent follow-up ``ask`` can't read

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -201,6 +201,66 @@ class ChatAPI:
         self._new_conversation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
+        # Event-loop binding for the two lazy lock maps above. Captured at
+        # ``ClientLifecycle.open()`` time via :meth:`set_bound_loop` (mirroring
+        # :class:`notebooklm._client_composed.ClientComposed` and
+        # :class:`notebooklm._source_upload.SourceUploadPipeline`). Each lock
+        # in the maps binds to whichever loop is running the first time it is
+        # awaited; if the client is closed on loop A and reopened on loop B, a
+        # stale lock bound to the now-dead loop A must never be reused — see
+        # :meth:`set_bound_loop` / :meth:`reset_after_open`.
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the conversation locks.
+
+        Called by :meth:`ClientLifecycle.open` after it captures the running
+        loop, mirroring the identically-named method on
+        :class:`notebooklm._client_composed.ClientComposed`,
+        :class:`notebooklm._source_upload.SourceUploadPipeline`,
+        :class:`TransportDrainTracker`, :class:`ReqidCounter`, and
+        :class:`AuthRefreshCoordinator`. Passing ``None`` clears the binding
+        for the next ``open()`` (which rebinds to a fresh loop).
+
+        When the loop actually changes, the two lazy lock maps are cleared
+        here too so this method is self-consistent even if called
+        independently of :meth:`reset_after_open` (e.g. directly in a test or a
+        future caller): a stale ``asyncio.Lock`` bound to the old loop must
+        never be reused after a rebind. The production ``open()`` path also
+        calls :meth:`reset_after_open` immediately after, so the clear is
+        idempotent there.
+
+        The cross-loop guard for :meth:`ask` is the injected
+        ``loop_guard.assert_bound_loop`` (already called at the top of
+        :meth:`ask` before any lock is acquired); this binding only governs
+        when the lazy locks are rebuilt.
+        """
+        if loop is not self._bound_loop:
+            self._conversation_locks.clear()
+            self._new_conversation_locks.clear()
+        self._bound_loop = loop
+
+    def reset_after_open(self) -> None:
+        """Discard the lazy conversation locks so a reopened client rebinds them.
+
+        Called from :meth:`ClientLifecycle.open` (alongside the
+        per-collaborator ``set_bound_loop`` propagation) so a client that was
+        closed and reopened on a *different* event loop builds fresh
+        ``asyncio.Lock`` instances on the new loop instead of reusing stale
+        ones bound to the old (now-dead) loop. On Python 3.10/3.11 reusing a
+        stale lock can raise "bound to a different event loop" or mispark
+        waiters; on 3.12+ the breakage is largely masked, but resetting keeps
+        the behaviour consistent across versions.
+
+        Mirrors
+        :meth:`notebooklm._source_upload.SourceUploadPipeline.reset_after_open`.
+        Deliberately narrow: clearing the two ``WeakValueDictionary`` maps is
+        enough because each per-key lock is reconstructed lazily on the next
+        :meth:`_get_conversation_lock` / :meth:`_get_new_conversation_lock`
+        call from inside the new loop.
+        """
+        self._conversation_locks.clear()
+        self._new_conversation_locks.clear()
 
     def _get_conversation_lock(self, conversation_id: str) -> asyncio.Lock:
         """Return the (lazily created) lock for ``conversation_id``.

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -321,9 +321,10 @@ class ClientLifecycle:
         # points (``drain``, ``next_reqid``, ``await_refresh``) so a
         # cross-loop call surfaces an actionable ``RuntimeError`` at the
         # call site rather than hanging on a primitive bound to a dead
-        # loop. ``ChatAPI`` / ``ArtifactPollingService`` reach the bound
-        # loop through ``ClientLifecycle.get_bound_loop()`` so no further
-        # propagation is needed there.
+        # loop. ``ArtifactPollingService`` reaches the bound loop through
+        # ``ClientLifecycle.get_bound_loop()`` so no further propagation is
+        # needed there. (``ChatAPI`` now receives direct ``set_bound_loop``
+        # propagation below — #1225.)
         drain_tracker.set_bound_loop(self._bound_loop)
         reqid.set_bound_loop(self._bound_loop)
         auth_coord.set_bound_loop(self._bound_loop)

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -84,6 +84,7 @@ from ._session_config import CORE_LOGGER_NAME
 from .auth import AuthTokens
 
 if TYPE_CHECKING:
+    from ._chat import ChatAPI
     from ._client_composed import ClientComposed
     from ._cookie_persistence import CookiePersistence
     from ._reqid_counter import ReqidCounter
@@ -282,6 +283,7 @@ class ClientLifecycle:
         cookie_persistence: CookiePersistence,
         composed: ClientComposed,
         uploader: SourceUploadPipeline,
+        chat: ChatAPI,
     ) -> None:
         """Open the HTTP client connection.
 
@@ -340,6 +342,15 @@ class ClientLifecycle:
         # bound to the now-dead loop A. Propagating the captured loop lets the
         # uploader discard the stale semaphore on a loop change.
         uploader.set_bound_loop(self._bound_loop)
+        # The ChatAPI per-conversation / per-notebook locks are the last lazy
+        # loop-bound primitives without the owner-level protocol (#1225): each
+        # ``asyncio.Lock`` in the two ``WeakValueDictionary`` maps binds to the
+        # loop it is first awaited on, so a client closed on loop A and
+        # reopened on loop B would otherwise reuse a lock bound to the now-dead
+        # loop A. Propagating the captured loop lets ChatAPI discard the stale
+        # locks on a loop change (the per-call ``loop_guard.assert_bound_loop``
+        # in ``ask`` already rejects cross-loop *use*; this governs rebuild).
+        chat.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
         # admits new transport work again. Wave 1 of plan
         # ``host-protocol-removal`` encapsulated the legacy direct write
@@ -360,6 +371,13 @@ class ClientLifecycle:
         # semaphore is reconstructed lazily on the next ``get_upload_semaphore``
         # call from inside the new loop; ``max_concurrent_uploads`` is untouched.
         uploader.reset_after_open()
+        # Same close→reopen reset for the ChatAPI conversation locks so a
+        # reopened client rebuilds each per-key lock on the new loop instead of
+        # reusing a stale one bound to the prior (now-dead) loop (#1225). Narrow
+        # by design — the locks are reconstructed lazily on the next
+        # ``_get_conversation_lock`` / ``_get_new_conversation_lock`` call from
+        # inside the new loop.
+        chat.reset_after_open()
 
         # Delegate HTTP-client construction and open-time cookie baseline
         # capture to the concrete transport kernel. The lifecycle still owns

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -465,6 +465,7 @@ class NotebookLMClient:
             cookie_persistence=self._collaborators.cookie_persistence,
             composed=self._composed,
             uploader=self._source_uploader,
+            chat=self.chat,
         )
         return self
 

--- a/tests/_helpers/client_factory.py
+++ b/tests/_helpers/client_factory.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from notebooklm._chat import ChatAPI
 from notebooklm._client_composed import ClientComposed
 from notebooklm._client_seams import resolve_client_seams
 from notebooklm._session_config import (
@@ -105,5 +106,17 @@ def build_client_shell_for_tests(
         auth=auth,
         max_concurrent_uploads=max_concurrent_uploads,
         record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
+    )
+    # ``ClientLifecycle.open`` (driven via ``client.__aenter__``) also resets
+    # the ChatAPI conversation-lock loop binding through ``client.chat``
+    # (issue #1225), so the shell must wire a real ChatAPI the same way
+    # ``NotebookLMClient.__init__`` does. Defaults are sufficient: the shell
+    # exercises lifecycle open/close + cross-loop reset, not the full chat
+    # graph, so a bare ChatAPI over the composed collaborators is enough.
+    client.chat = ChatAPI(
+        rpc=internals.executor,
+        transport=composed.transport,
+        reqid=internals.collaborators.reqid,
+        loop_guard=internals.collaborators.lifecycle,
     )
     return client

--- a/tests/_lint/test_asyncio_loop_affinity_guard.py
+++ b/tests/_lint/test_asyncio_loop_affinity_guard.py
@@ -87,10 +87,7 @@ ALLOWLIST: tuple[_AllowlistEntry, ...] = (
     # NOTE: ``ClientComposed``, ``TransportDrainTracker``,
     # ``SourceUploadPipeline``, and ``ChatAPI`` are NOT allowlisted — they each
     # define the full ``set_bound_loop`` + ``reset_after_open`` protocol and so
-    # are detected as compliant by the owner-method scan. ``ChatAPI`` joined the
-    # protocol in #1225 (the per-conversation / per-notebook lock maps), which
-    # retired the follow-up allowlist entry that used to live at the bottom of
-    # this list.
+    # are detected as compliant by the owner-method scan.
     #
     # ``set_bound_loop`` only (no ``reset_after_open``): the lazy ``asyncio.Lock``
     # is rebuilt implicitly because these coordinators are reconstructed per
@@ -349,10 +346,9 @@ def test_loop_affinity_followup_entries_reference_a_tracking_issue() -> None:
     retired. Iterating (rather than hard-keying on a specific class) keeps the
     guard robust if a future gap class is renamed or relocated.
 
-    There are intentionally **no** gap entries today — the last one
-    (``ChatAPI``'s conversation locks, #1225) was retired when ChatAPI joined
-    the owner-level protocol. This test therefore validates the *shape* of any
-    gap entry that lands in the future rather than requiring one to exist.
+    There are intentionally **no** gap entries today. This test therefore
+    validates the *shape* of any gap entry that lands in the future rather
+    than requiring one to exist.
     """
     gap_entries = [entry for entry in ALLOWLIST if entry.issue is not None]
     for entry in gap_entries:

--- a/tests/_lint/test_asyncio_loop_affinity_guard.py
+++ b/tests/_lint/test_asyncio_loop_affinity_guard.py
@@ -47,13 +47,6 @@ LOOP_BOUND_PRIMITIVES = frozenset({"Lock", "Semaphore", "BoundedSemaphore", "Eve
 # A class is considered compliant when it defines BOTH.
 REQUIRED_GUARD_METHODS = ("set_bound_loop", "reset_after_open")
 
-# Tracking issue for bringing the ``ChatAPI`` conversation locks under the
-# canonical owner-level protocol. They are guarded indirectly today (the
-# injected ``loop_guard.assert_bound_loop()`` fires in ``ChatAPI.ask`` before
-# the lock is acquired), but ``ChatAPI`` itself does not own
-# ``set_bound_loop`` / ``reset_after_open``.
-CHAT_LOCKS_FOLLOWUP_ISSUE = 1225
-
 
 class _AllowlistEntry:
     """A documented exemption for one primitive construction site.
@@ -91,10 +84,13 @@ class _AllowlistEntry:
 # constructs a primitive is reported as stale so the list keeps tightening.
 # ---------------------------------------------------------------------------
 ALLOWLIST: tuple[_AllowlistEntry, ...] = (
-    # NOTE: ``ClientComposed``, ``TransportDrainTracker``, and
-    # ``SourceUploadPipeline`` are NOT allowlisted — they each define the full
-    # ``set_bound_loop`` + ``reset_after_open`` protocol and so are detected as
-    # compliant by the owner-method scan.
+    # NOTE: ``ClientComposed``, ``TransportDrainTracker``,
+    # ``SourceUploadPipeline``, and ``ChatAPI`` are NOT allowlisted — they each
+    # define the full ``set_bound_loop`` + ``reset_after_open`` protocol and so
+    # are detected as compliant by the owner-method scan. ``ChatAPI`` joined the
+    # protocol in #1225 (the per-conversation / per-notebook lock maps), which
+    # retired the follow-up allowlist entry that used to live at the bottom of
+    # this list.
     #
     # ``set_bound_loop`` only (no ``reset_after_open``): the lazy ``asyncio.Lock``
     # is rebuilt implicitly because these coordinators are reconstructed per
@@ -131,19 +127,6 @@ ALLOWLIST: tuple[_AllowlistEntry, ...] = (
         None,
         "Module-global per-running-loop lock registry (keyed by "
         "asyncio.get_running_loop()); structurally immune to cross-loop reuse.",
-    ),
-    # KNOWN FOLLOW-UP GAP (#1225): the ChatAPI per-conversation /
-    # per-notebook locks are NOT under the owner-level protocol yet. They are
-    # guarded indirectly (ChatAPI.ask calls loop_guard.assert_bound_loop()
-    # before acquiring the lock) and GC themselves via WeakValueDictionary,
-    # but ChatAPI does not own set_bound_loop / reset_after_open. Tracked by
-    # #1225; remove this entry when ChatAPI joins the protocol.
-    _AllowlistEntry(
-        "src/notebooklm/_chat.py",
-        "ChatAPI",
-        "Known follow-up: guarded indirectly by injected "
-        "loop_guard.assert_bound_loop() in ask(); owner-level protocol pending.",
-        issue=CHAT_LOCKS_FOLLOWUP_ISSUE,
     ),
 )
 
@@ -358,16 +341,20 @@ def test_loop_affinity_allowlist_has_no_stale_entries() -> None:
 
 
 def test_loop_affinity_followup_entries_reference_a_tracking_issue() -> None:
-    """Known-gap allowlist entries (not alt-guarded) must cite a tracking issue.
+    """Any known-gap allowlist entry (not alt-guarded) must cite a tracking issue.
 
     A *gap* entry is one that carries an ``issue`` (vs. an alternative-guard
     entry, which is documented by reason only). Every such entry must reference
     a positive issue number so the follow-up is trackable and the entry can be
-    retired. Iterating (rather than hard-keying on ``_chat.py``/``ChatAPI``)
-    keeps the guard robust if the gap class is renamed or relocated.
+    retired. Iterating (rather than hard-keying on a specific class) keeps the
+    guard robust if a future gap class is renamed or relocated.
+
+    There are intentionally **no** gap entries today — the last one
+    (``ChatAPI``'s conversation locks, #1225) was retired when ChatAPI joined
+    the owner-level protocol. This test therefore validates the *shape* of any
+    gap entry that lands in the future rather than requiring one to exist.
     """
     gap_entries = [entry for entry in ALLOWLIST if entry.issue is not None]
-    assert gap_entries, "expected at least one gap entry carrying a tracking issue"
     for entry in gap_entries:
         assert isinstance(entry.issue, int) and entry.issue > 0, (
             f"gap entry for {entry.path} (owner={entry.owner}) must cite a "

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -385,6 +385,120 @@ def test_upload_pipeline_reopen_on_new_loop_rebinds_semaphore(
     asyncio.run(_reopen_and_use_semaphore_under_loop_b())
 
 
+def test_chat_locks_reopen_on_new_loop_rebind(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """Issue #1225: close on loop A, reopen on loop B → ChatAPI conversation locks rebind.
+
+    The ``ChatAPI`` per-conversation / per-notebook locks
+    (``ChatAPI._conversation_locks`` / ``_new_conversation_locks``, two
+    ``WeakValueDictionary`` maps of lazily-built ``asyncio.Lock``) were the
+    last lazy loop-bound primitives in the client without the owner-level
+    ``set_bound_loop`` + ``reset_after_open`` protocol. Each lock binds to
+    whichever loop is running the first time it is awaited; a client closed on
+    loop A and reopened on loop B that reused a lock bound to the now-dead loop
+    A raises "bound to a different event loop" (Python 3.10/3.11) or misparks
+    waiters on the contended-acquire path.
+
+    Post-fix ``ClientLifecycle.open`` calls ``ChatAPI.set_bound_loop`` +
+    ``reset_after_open`` (mirroring the RPC- and upload-semaphore resets), so
+    the lock maps are cleared on a loop change and each per-key lock is rebuilt
+    fresh on the new loop.
+
+    Like the semaphore tests above, this is intentionally NOT ``async def``: we
+    own two ``asyncio.run`` calls explicitly so the open and the reopen happen
+    on two genuinely distinct loop objects.
+
+    A bare ``asyncio.Lock`` only consults ``_get_loop()`` (and thus binds to a
+    loop) on the contended waiter path — the uncontended fast path returns
+    before touching the loop. So we drive a *blocked* second acquire on each
+    loop to force the binding that exercises the stale-loop hazard pre-fix.
+    """
+    transport = mock_transport_concurrent
+    transport.set_delay(0.0)
+
+    core = build_client_shell_for_tests(auth=_make_auth())
+    chat = core.chat
+    conv_id = "conv-1225"
+
+    async def _force_contended_acquire(lock: asyncio.Lock) -> None:
+        """Drive the blocked-waiter path so ``lock`` binds to the running loop.
+
+        Hold the lock, start a second ``acquire`` that must block (creating a
+        waiter future via ``_get_loop()`` — the loop-binding step), then
+        release so the waiter proceeds. On a stale cross-loop lock this is
+        where 3.10/3.11 raise "bound to a different event loop".
+        """
+        await lock.acquire()
+        waiter = asyncio.ensure_future(lock.acquire())
+        # Yield so the waiter runs far enough to park on the held lock.
+        await asyncio.sleep(0)
+        assert not waiter.done()
+        lock.release()
+        await waiter
+        lock.release()
+
+    async def _open_force_lock_and_close_under_loop_a() -> asyncio.Lock:
+        await core.__aenter__()
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        # Force a conversation lock to actually be constructed and bound to
+        # loop A — that is the stale primitive a naive reopen reuses. The lock
+        # is RETURNED so the caller keeps a strong reference; without it the
+        # WeakValueDictionary entry would GC the moment this coroutine's locals
+        # are dropped, masking whether the reset (vs. plain GC) cleared the map.
+        lock = chat._get_conversation_lock(conv_id)
+        await _force_contended_acquire(lock)
+        assert conv_id in chat._conversation_locks
+        await core.close()
+        return lock
+
+    # Keep a strong reference across the loop boundary so the WeakValueDictionary
+    # entry bound to loop A is still present when we assert the reset cleared it.
+    pinned_lock = asyncio.run(_open_force_lock_and_close_under_loop_a())
+    # The reset happens on open(), not close(): the stale loop-A lock is still
+    # cached here (pinned by ``pinned_lock``), bound to the now-dead loop A.
+    assert pinned_lock is not None
+    assert chat._conversation_locks.get(conv_id) is pinned_lock
+
+    async def _reopen_and_use_lock_under_loop_b() -> None:
+        await core.__aenter__()
+        # reset_after_open() must have cleared the loop-A lock map so the next
+        # _get_conversation_lock() rebuilds a fresh lock on loop B (even though
+        # ``pinned_lock`` still holds a strong ref to the old one).
+        assert chat._conversation_locks.get(conv_id) is None
+        prior_cookies = core._collaborators.kernel.get_http_client().cookies
+        await core._collaborators.kernel.get_http_client().aclose()
+        install_http_client_for_test(
+            core._collaborators.kernel,
+            httpx.AsyncClient(
+                cookies=prior_cookies,
+                transport=transport,
+                timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+            ),
+        )
+        try:
+            # Drive a contended acquire on the rebuilt lock under loop B.
+            # Pre-fix this would reuse the stale loop-A lock and (on 3.10/3.11)
+            # raise the cross-loop RuntimeError on the waiter path; post-fix the
+            # lock is fresh and binds cleanly to loop B.
+            lock_b = chat._get_conversation_lock(conv_id)
+            assert lock_b is not pinned_lock
+            await _force_contended_acquire(lock_b)
+        finally:
+            await core.close()
+
+    asyncio.run(_reopen_and_use_lock_under_loop_b())
+
+
 async def test_bound_loop_captured_on_open(
     mock_transport_concurrent: ConcurrentMockTransport,
 ) -> None:

--- a/tests/unit/test_chat_delete_conversation.py
+++ b/tests/unit/test_chat_delete_conversation.py
@@ -7,10 +7,12 @@ the server-side delete succeeds.
 Wave 8 of the session-decoupling plan (ADR-014 Rule 2 Corollary): the
 chat-local ``ChatRuntime`` Protocol composite was deleted in favour of
 direct constructor injection of the underlying collaborators. These
-tests now use narrow ``MagicMock(spec=RpcCaller)`` fakes for the only
-collaborator ``delete_conversation`` actually touches (the ``rpc``
-dispatcher); the other three collaborators (transport, reqid,
-loop_guard) are unused by this method and are mocked without specs.
+tests use narrow ``MagicMock(spec=...)`` fakes for the two collaborators
+``delete_conversation`` actually touches: the ``rpc`` dispatcher and the
+``loop_guard`` (whose ``assert_bound_loop`` is invoked up front to reject
+cross-loop misuse before the per-conversation lock is acquired, #1225).
+The remaining two collaborators (transport, reqid) are unused by this
+method and are mocked without specs.
 """
 
 from __future__ import annotations
@@ -20,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._chat import ChatAPI
-from notebooklm._session_contracts import RpcCaller
+from notebooklm._session_contracts import LoopGuard, RpcCaller
 from notebooklm.rpc import RPCMethod
 
 
@@ -43,7 +45,10 @@ def api(mock_rpc: MagicMock) -> ChatAPI:
         rpc=mock_rpc,
         transport=MagicMock(),
         reqid=MagicMock(),
-        loop_guard=MagicMock(),
+        # ``delete_conversation`` calls ``loop_guard.assert_bound_loop()`` up
+        # front (#1225), so the guard needs a ``LoopGuard`` spec — a bare
+        # ``MagicMock`` rejects ``assert_*`` attribute access as a typo guard.
+        loop_guard=MagicMock(spec=LoopGuard),
     )
 
 

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -152,6 +152,14 @@ class _StubHost:
         # invocations are asserted by
         # ``test_open_captures_bound_loop_and_resets_drain``.
         self._uploader = MagicMock()
+        # ``open()`` also propagates the bound loop into the ChatAPI and resets
+        # its lazy per-conversation / per-notebook lock maps (#1225): it calls
+        # ``chat.set_bound_loop(loop)`` and ``chat.reset_after_open()`` so a
+        # client reopened on a different loop rebuilds the conversation locks on
+        # the new loop. The ``MagicMock`` default lets both calls land without
+        # configuring side effects; the invocations are asserted by
+        # ``test_open_captures_bound_loop_and_resets_drain``.
+        self._chat = MagicMock()
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
@@ -201,6 +209,7 @@ async def _open(lifecycle: ClientLifecycle, host: _StubHost) -> None:
         cookie_persistence=host.cookie_persistence,
         composed=host._composed,
         uploader=host._uploader,
+        chat=host._chat,
     )
 
 
@@ -281,6 +290,12 @@ async def test_open_captures_bound_loop_and_resets_drain() -> None:
     # rebinds on close→reopen.
     host._uploader.set_bound_loop.assert_called_once_with(asyncio.get_running_loop())
     host._uploader.reset_after_open.assert_called_once_with()
+    # Issue #1225: the ChatAPI conversation locks are the last lazily-built
+    # loop-bound primitives and must receive the same set_bound_loop /
+    # reset_after_open treatment so the per-conversation / per-notebook locks
+    # rebind on close→reopen.
+    host._chat.set_bound_loop.assert_called_once_with(asyncio.get_running_loop())
+    host._chat.reset_after_open.assert_called_once_with()
 
     await _close(lifecycle, host)
 


### PR DESCRIPTION
Fixes #1225

## Problem

`ChatAPI` holds two lazily-populated, loop-bound lock maps — `_conversation_locks` and `_new_conversation_locks` (`WeakValueDictionary` of `asyncio.Lock`). They were the **last unguarded lazy asyncio primitive** in the client: they lacked the #1196 `set_bound_loop` / `reset_after_open` guard, so a client closed on loop A and reopened on loop B could reuse a lock bound to the now-dead loop A — raising "bound to a different event loop" on Python 3.10/3.11 or misparking waiters on the contended-acquire path.

The #1229 affinity lint had ALLOWLISTED these locks as a known follow-up gap (tracked by #1225).

## Fix (mirrors merged #1196 / #1217 exactly)

- **`ChatAPI`** (`_chat.py`): add `set_bound_loop(loop)` (clears both lock maps when the bound loop changes) + `reset_after_open()` (clears both maps), mirroring `ClientComposed` and `SourceUploadPipeline`.
- **`ClientLifecycle.open`** (`_session_lifecycle.py`): wire `chat.set_bound_loop(...)` + `chat.reset_after_open()` into the existing `composed` / `reqid` / `auth_coord` / `uploader` cascade. `client.py` threads `chat=self.chat` into `lifecycle.open` the same way `self._source_uploader` was threaded in #1217.
- **Lint** (`tests/_lint/test_asyncio_loop_affinity_guard.py`): remove the obsolete ChatAPI allowlist entry so the lint now ENFORCES the guard on ChatAPI (detected as a compliant owner via the owner-method scan). The "at least one gap entry" assertion is relaxed to validate the *shape* of any future gap entry rather than requiring one.
- **Regression test** (`tests/integration/concurrency/test_cross_loop_affinity.py`): add `test_chat_locks_reopen_on_new_loop_rebind` — close on loop A, reopen on loop B, and assert the conversation lock map was cleared by `reset_after_open()` (not plain GC, verified via a pinned strong reference) and a fresh lock binds cleanly to loop B via a contended acquire.

The per-call `loop_guard.assert_bound_loop()` in `ask()` still rejects cross-loop *use*; this change governs lazy *rebuild* on a loop change.

## Gates

- `ruff check` / `ruff format`: clean
- `mypy src/notebooklm --ignore-missing-imports`: Success, no issues in 184 files
- Full suite: **7279 passed, 52 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents hangs or errors when reopening the client during asynchronous operations, improving reliability.
  * Ensures chat conversations and locks are correctly refreshed after reconnects so chat actions continue to work.
  * Improves overall stability and resource cleanup during client open/close cycles across async contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->