### PR TITLE
test: close coverage gaps in large/under-tested modules

### DIFF
--- a/tests/unit/cli/test_context_coverage.py
+++ b/tests/unit/cli/test_context_coverage.py
@@ -1,0 +1,217 @@
+"""Coverage gap tests for ``notebooklm.cli.context``.
+
+Targets the error-handling branches of the context-file read/write/clear
+helpers: corrupted-JSON and OS-error warnings, lock contention and
+unavailability during ``clear``, and the locked-clear fast paths
+(missing file race, corrupt JSON, non-dict payload, no-op when unchanged).
+
+All tests pass an explicit ``context_path_fn`` so nothing touches the real
+``~/.notebooklm/context.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from filelock import Timeout
+
+from notebooklm.cli import context as ctx
+
+
+def _path_fn(target: Path):
+    """Build a ``context_path_fn`` that always returns ``target``."""
+
+    def _fn(*, storage_path=None):
+        return target
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# _get_context_value
+# ---------------------------------------------------------------------------
+
+
+class TestGetContextValue:
+    def test_invalid_shape_warns_and_returns_none(self, tmp_path, caplog):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            result = ctx._get_context_value("notebook_id", context_path_fn=_path_fn(target))
+        assert result is None
+        assert "invalid shape" in caplog.text
+
+    def test_corrupt_json_warns_and_returns_none(self, tmp_path, caplog):
+        target = tmp_path / "context.json"
+        target.write_text("{not json", encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            result = ctx._get_context_value("notebook_id", context_path_fn=_path_fn(target))
+        assert result is None
+        assert "corrupted" in caplog.text
+
+    def test_os_error_warns_and_returns_none(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        def _boom(*a, **kw):
+            raise OSError("read failed")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        with caplog.at_level("WARNING"):
+            result = ctx._get_context_value("notebook_id", context_path_fn=_path_fn(target))
+        assert result is None
+        assert "Cannot read context file" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _set_context_value
+# ---------------------------------------------------------------------------
+
+
+class TestSetContextValue:
+    def test_corrupt_json_warns(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        def _boom(*a, **kw):
+            raise json.JSONDecodeError("bad", "doc", 0)
+
+        monkeypatch.setattr(ctx, "atomic_update_json", _boom)
+        with caplog.at_level("WARNING"):
+            ctx._set_context_value("conversation_id", "c1", context_path_fn=_path_fn(target))
+        assert "corrupted" in caplog.text
+
+    def test_os_error_warns(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        def _boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(ctx, "atomic_update_json", _boom)
+        with caplog.at_level("WARNING"):
+            ctx._set_context_value("conversation_id", "c1", context_path_fn=_path_fn(target))
+        assert "Failed to write context file" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _clear_context_file (lock-level outcomes)
+# ---------------------------------------------------------------------------
+
+
+class TestClearContextFileLockOutcomes:
+    def test_lock_timeout_returns_contended(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        class _FakeLock:
+            def __init__(self, *a, **kw):
+                pass
+
+            def __enter__(self):
+                raise Timeout("lock-path")
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(ctx, "FileLock", _FakeLock)
+        with caplog.at_level("WARNING"):
+            status = ctx._clear_context_file(target, clear_account=False)
+        assert status == "contended"
+        assert "contended" in caplog.text
+
+    def test_lock_os_error_returns_unavailable(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        class _FakeLock:
+            def __init__(self, *a, **kw):
+                pass
+
+            def __enter__(self):
+                raise OSError("lock unavailable")
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(ctx, "FileLock", _FakeLock)
+        with caplog.at_level("WARNING"):
+            status = ctx._clear_context_file(target, clear_account=False)
+        assert status == "unavailable"
+        assert "unavailable" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _clear_context_file_locked
+# ---------------------------------------------------------------------------
+
+
+class TestClearContextFileLocked:
+    def test_missing_file_race_returns_unchanged(self, tmp_path):
+        target = tmp_path / "context.json"  # never created
+        assert ctx._clear_context_file_locked(target, clear_account=False) == "unchanged"
+
+    def test_corrupt_json_unlinks_and_clears(self, tmp_path):
+        target = tmp_path / "context.json"
+        target.write_text("{not json", encoding="utf-8")
+        assert ctx._clear_context_file_locked(target, clear_account=False) == "cleared"
+        assert not target.exists()
+
+    def test_non_dict_payload_unlinks_and_clears(self, tmp_path):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps(["list", "payload"]), encoding="utf-8")
+        assert ctx._clear_context_file_locked(target, clear_account=False) == "cleared"
+        assert not target.exists()
+
+    def test_account_preserved_writes_and_clears(self, tmp_path):
+        target = tmp_path / "context.json"
+        target.write_text(
+            json.dumps({"account": {"email": "a@b.c"}, "notebook_id": "nb_1"}),
+            encoding="utf-8",
+        )
+        assert ctx._clear_context_file_locked(target, clear_account=False) == "cleared"
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data == {"account": {"email": "a@b.c"}}
+
+    def test_only_account_field_is_noop_unchanged(self, tmp_path):
+        # data == original after clearing non-account fields → "unchanged".
+        target = tmp_path / "context.json"
+        original = {"account": {"email": "a@b.c"}}
+        target.write_text(json.dumps(original), encoding="utf-8")
+        assert ctx._clear_context_file_locked(target, clear_account=False) == "unchanged"
+        assert json.loads(target.read_text(encoding="utf-8")) == original
+
+    def test_os_error_during_clear_returns_unavailable(self, tmp_path, caplog, monkeypatch):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+
+        real_read_text = Path.read_text
+
+        def _boom(self, *a, **kw):
+            if self == target:
+                raise OSError("read failed mid-clear")
+            return real_read_text(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        with caplog.at_level("WARNING"):
+            status = ctx._clear_context_file_locked(target, clear_account=False)
+        assert status == "unavailable"
+        assert "unavailable" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# clear_context public wrapper (sanity over "cleared" mapping)
+# ---------------------------------------------------------------------------
+
+
+class TestClearContextWrapper:
+    def test_returns_true_when_cleared(self, tmp_path):
+        target = tmp_path / "context.json"
+        target.write_text(json.dumps({"notebook_id": "nb_1"}), encoding="utf-8")
+        assert ctx.clear_context(clear_account=True, context_path_fn=_path_fn(target)) is True
+        assert not target.exists()
+
+    def test_returns_false_when_missing(self, tmp_path):
+        target = tmp_path / "context.json"
+        assert ctx.clear_context(context_path_fn=_path_fn(target)) is False

--- a/tests/unit/cli/test_login_refresh_coverage.py
+++ b/tests/unit/cli/test_login_refresh_coverage.py
@@ -1,0 +1,388 @@
+"""Coverage-focused unit tests for ``cli/services/login/refresh.py``.
+
+These tests target failure / edge branches not exercised by the broader
+``test_login.py`` / ``test_login_multi_account.py`` suites:
+
+* ``_login_browser_cookies_single`` — targeted-extraction write-outcome exit
+  (line 154).
+* ``_login_all_accounts_from_browser`` — enumeration-outcome exit, the
+  no-accounts early return, and the per-account write-outcome exit (lines
+  231, 234-235, 275).
+* ``_refresh_from_browser_cookies`` — enumeration-outcome exit, the
+  no-accounts exit, and the write-outcome exit (lines 297, 300-301, 317).
+* ``_login_with_browser_cookies`` — the OSError save path, the
+  account-metadata clear/write branches, and each cookie-verification
+  failure branch (lines 376-379, 385-391, 400-405, 413-433).
+
+Collaborators are patched at their ``refresh`` module import sites so each
+driver runs in isolation without a real browser / network.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from notebooklm.cli.services.login import refresh
+from notebooklm.cli.services.login.outcomes import BrowserCookieOutcome
+
+REFRESH = "notebooklm.cli.services.login.refresh"
+
+
+def _account(email: str, *, authuser: int = 0, browser_profile: str = "Default") -> Any:
+    return SimpleNamespace(email=email, authuser=authuser, browser_profile=browser_profile)
+
+
+def _outcome(message: str = "[red]boom[/red]") -> BrowserCookieOutcome:
+    """Build a concrete failure outcome instance."""
+    obj = BrowserCookieOutcome.__new__(BrowserCookieOutcome)
+    object.__setattr__(obj, "code", "TEST_FAILURE")
+    object.__setattr__(obj, "message", message)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# _login_browser_cookies_single — targeted write-outcome exit (line 154)
+# ---------------------------------------------------------------------------
+
+
+def test_login_single_enum_outcome_exits(tmp_path) -> None:
+    """An enumeration outcome in the targeted path exits 1 (line 123)."""
+    with (
+        patch(f"{REFRESH}._enumerate_browser_accounts", return_value=_outcome()),
+        patch(f"{REFRESH}.get_storage_path", return_value=tmp_path / "s.json"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_browser_cookies_single(
+            "chrome",
+            storage=None,
+            account_email="bob@example.com",
+            profile_name=None,
+            active_profile="work",
+        )
+    assert exc_info.value.code == 1
+
+
+def test_login_single_targeted_write_outcome_exits(tmp_path) -> None:
+    """A write-outcome from the targeted extraction path exits 1 (line 154)."""
+    account = _account("bob@example.com", browser_profile="Default")
+    per_profile = {"Default": ["cookie"]}
+
+    with (
+        patch(
+            f"{REFRESH}._enumerate_browser_accounts",
+            return_value=(per_profile, [account]),
+        ),
+        patch(f"{REFRESH}._select_account", return_value=account),
+        patch(f"{REFRESH}._confirm_profile_account_overwrite"),
+        patch(f"{REFRESH}._write_extracted_cookies", return_value=_outcome()),
+        patch(f"{REFRESH}.get_storage_path", return_value=tmp_path / "s.json"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_browser_cookies_single(
+            "chrome",
+            storage=None,
+            account_email="bob@example.com",
+            profile_name=None,
+            active_profile="work",
+        )
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _login_all_accounts_from_browser — 231, 234-235, 275
+# ---------------------------------------------------------------------------
+
+
+def test_login_all_accounts_enum_outcome_exits() -> None:
+    """An enumeration outcome exits 1 (line 231)."""
+    with (
+        patch(f"{REFRESH}._enumerate_browser_accounts", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_all_accounts_from_browser("chrome")
+    assert exc_info.value.code == 1
+
+
+def test_login_all_accounts_no_accounts_returns(capsys) -> None:
+    """No discovered accounts returns early with a notice (lines 234-235)."""
+    with (
+        patch(f"{REFRESH}._enumerate_browser_accounts", return_value=({}, [])),
+        # list_profiles is imported lazily inside the function; patch source.
+        patch("notebooklm.paths.list_profiles", return_value=[]),
+    ):
+        refresh._login_all_accounts_from_browser("chrome")
+    out = capsys.readouterr().out
+    assert "No accounts discovered" in out
+
+
+def test_login_all_accounts_write_outcome_exits(tmp_path) -> None:
+    """A per-account write outcome exits 1 (line 275)."""
+    account = _account("alice@example.com", browser_profile="Default")
+    per_profile = {"Default": ["cookie"]}
+
+    with (
+        patch(
+            f"{REFRESH}._enumerate_browser_accounts",
+            return_value=(per_profile, [account]),
+        ),
+        patch("notebooklm.paths.list_profiles", return_value=[]),
+        patch(f"{REFRESH}._profiles_by_account_email", return_value={}),
+        patch(f"{REFRESH}._resolve_all_accounts_target", return_value="alice"),
+        patch(f"{REFRESH}.email_to_profile_name", return_value="alice"),
+        patch(f"{REFRESH}.get_storage_path", return_value=tmp_path / "alice.json"),
+        patch(f"{REFRESH}._write_extracted_cookies", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_all_accounts_from_browser("chrome")
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _refresh_from_browser_cookies — 297, 300-301, 317
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_enum_outcome_exits(tmp_path) -> None:
+    """An enumeration outcome exits 1 (line 297)."""
+    with (
+        patch(f"{REFRESH}._enumerate_browser_accounts", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._refresh_from_browser_cookies(
+            "chrome", storage_path=tmp_path / "s.json", profile="work", quiet=True
+        )
+    assert exc_info.value.code == 1
+
+
+def test_refresh_no_accounts_exits(tmp_path, capsys) -> None:
+    """No signed-in accounts exits 1 (lines 300-301)."""
+    with (
+        patch(f"{REFRESH}._enumerate_browser_accounts", return_value=({}, [])),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._refresh_from_browser_cookies(
+            "chrome", storage_path=tmp_path / "s.json", profile="work", quiet=True
+        )
+    assert exc_info.value.code == 1
+    assert "No signed-in Google accounts" in capsys.readouterr().out
+
+
+def test_refresh_select_outcome_exits(tmp_path) -> None:
+    """A select-refresh-account outcome exits 1 (line 306)."""
+    account = _account("carol@example.com", browser_profile="Default")
+    per_profile = {"Default": ["cookie"]}
+
+    with (
+        patch(
+            f"{REFRESH}._enumerate_browser_accounts",
+            return_value=(per_profile, [account]),
+        ),
+        patch(f"{REFRESH}.read_account_metadata", return_value={}),
+        patch(f"{REFRESH}._select_refresh_account", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._refresh_from_browser_cookies(
+            "chrome", storage_path=tmp_path / "s.json", profile="work", quiet=True
+        )
+    assert exc_info.value.code == 1
+
+
+def test_refresh_success_prints_summary(tmp_path, capsys) -> None:
+    """A successful non-quiet refresh prints the ok/account summary (318-321)."""
+    account = _account("carol@example.com", browser_profile="Default")
+    per_profile = {"Default": ["cookie"]}
+
+    with (
+        patch(
+            f"{REFRESH}._enumerate_browser_accounts",
+            return_value=(per_profile, [account]),
+        ),
+        patch(f"{REFRESH}.read_account_metadata", return_value={}),
+        patch(f"{REFRESH}._select_refresh_account", return_value=account),
+        patch(f"{REFRESH}._write_extracted_cookies", return_value=None),
+        patch(f"{REFRESH}._sync_server_language_to_config"),
+    ):
+        refresh._refresh_from_browser_cookies(
+            "chrome", storage_path=tmp_path / "s.json", profile="work", quiet=False
+        )
+    out = capsys.readouterr().out
+    assert "refreshed from chrome" in out
+    assert "carol@example.com" in out
+
+
+def test_refresh_write_outcome_exits(tmp_path) -> None:
+    """A write outcome exits 1 (line 317)."""
+    account = _account("carol@example.com", browser_profile="Default")
+    per_profile = {"Default": ["cookie"]}
+
+    with (
+        patch(
+            f"{REFRESH}._enumerate_browser_accounts",
+            return_value=(per_profile, [account]),
+        ),
+        patch(f"{REFRESH}.read_account_metadata", return_value={}),
+        patch(f"{REFRESH}._select_refresh_account", return_value=account),
+        patch(f"{REFRESH}._write_extracted_cookies", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._refresh_from_browser_cookies(
+            "chrome", storage_path=tmp_path / "s.json", profile="work", quiet=True
+        )
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _login_with_browser_cookies — save / metadata / verification branches
+# ---------------------------------------------------------------------------
+
+
+def _enter_login_base(stack: ExitStack) -> None:
+    """Enter common patches: valid cookies + happy validation, neutral deps."""
+    storage_state = {"cookies": [{"name": "SID"}], "origins": []}
+    stack.enter_context(patch(f"{REFRESH}._read_browser_cookies", return_value=["raw"]))
+    stack.enter_context(
+        patch(f"{REFRESH}.validate_with_recovery", return_value=(storage_state, None))
+    )
+    stack.enter_context(patch(f"{REFRESH}.cookie_names_from_storage", return_value=["SID"]))
+    stack.enter_context(patch(f"{REFRESH}.missing_cookies_hint", return_value="hint"))
+    stack.enter_context(patch(f"{REFRESH}._sync_server_language_to_config"))
+    # ``run_async`` is patched by callers, so the awaitable built from
+    # ``fetch_tokens_with_domains`` would never be awaited. Replace it with a
+    # plain (non-async) MagicMock so no orphan coroutine is created.
+    stack.enter_context(
+        patch(f"{REFRESH}.fetch_tokens_with_domains", new=MagicMock(return_value=None))
+    )
+
+
+def test_login_with_cookies_read_outcome_exits(tmp_path) -> None:
+    """An outcome from ``_read_browser_cookies`` exits 1 (line 349)."""
+    with (
+        patch(f"{REFRESH}._read_browser_cookies", return_value=_outcome()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    assert exc_info.value.code == 1
+
+
+def test_login_with_cookies_validation_error_exits(tmp_path, capsys) -> None:
+    """A validation error from ``validate_with_recovery`` exits 1 (line 349)."""
+    with (
+        patch(f"{REFRESH}._read_browser_cookies", return_value=["raw"]),
+        patch(
+            f"{REFRESH}.validate_with_recovery",
+            return_value=({"cookies": []}, "missing required cookies"),
+        ),
+        patch(f"{REFRESH}.cookie_names_from_storage", return_value=[]),
+        patch(f"{REFRESH}.missing_cookies_hint", return_value="install hint"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    assert exc_info.value.code == 1
+    assert "No valid Google authentication cookies" in capsys.readouterr().out
+
+
+def test_login_with_cookies_save_oserror_exits(tmp_path) -> None:
+    """An OSError while writing storage exits 1 (lines 376-379)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json", side_effect=OSError("disk full")))
+        with pytest.raises(SystemExit) as exc_info:
+            refresh._login_with_browser_cookies(tmp_path / "out" / "storage.json", "chrome")
+    assert exc_info.value.code == 1
+
+
+def test_login_with_cookies_write_metadata_oserror_warns(tmp_path, capsys) -> None:
+    """A write_account_metadata OSError warns but does not exit (385-391)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(
+            patch(
+                "notebooklm.auth.write_account_metadata",
+                side_effect=OSError("metadata write fail"),
+            )
+        )
+        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        refresh._login_with_browser_cookies(
+            tmp_path / "storage.json", "chrome", authuser=1, email="x@example.com"
+        )
+    out = capsys.readouterr().out
+    assert "account metadata write failed" in out
+
+
+def test_login_with_cookies_clear_metadata_oserror_logged(tmp_path, caplog) -> None:
+    """A clear_account_metadata OSError on a default login is logged (400-401)."""
+    import logging
+
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(
+            patch("notebooklm.auth.clear_account_metadata", side_effect=OSError("clear fail"))
+        )
+        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        stack.enter_context(caplog.at_level(logging.WARNING, logger=REFRESH))
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    assert any(
+        "Failed to clear stale account metadata" in rec.getMessage() for rec in caplog.records
+    )
+
+
+def test_login_with_cookies_account_line_printed(tmp_path, capsys) -> None:
+    """When an email is provided the Account: line is printed (line 405)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(patch("notebooklm.auth.write_account_metadata"))
+        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        refresh._login_with_browser_cookies(
+            tmp_path / "storage.json", "chrome", authuser=2, email="dave@example.com"
+        )
+    out = capsys.readouterr().out
+    assert "dave@example.com" in out
+
+
+def test_login_with_cookies_verify_valueerror_warns(tmp_path, capsys) -> None:
+    """A ValueError from verification warns but does not exit (413-421)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
+        stack.enter_context(
+            patch(f"{REFRESH}.run_async", side_effect=ValueError("invalid cookies"))
+        )
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    out = capsys.readouterr().out
+    assert "failed validation" in out
+
+
+def test_login_with_cookies_verify_network_error_warns(tmp_path, capsys) -> None:
+    """A network RequestError warns but does not exit (422-429)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
+        stack.enter_context(
+            patch(f"{REFRESH}.run_async", side_effect=httpx.RequestError("connect failed"))
+        )
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    out = capsys.readouterr().out
+    assert "network issue" in out
+
+
+def test_login_with_cookies_verify_unexpected_error_warns(tmp_path, capsys) -> None:
+    """An unexpected error warns but does not exit (430-436)."""
+    with ExitStack() as stack:
+        _enter_login_base(stack)
+        stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
+        stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
+        stack.enter_context(patch(f"{REFRESH}.run_async", side_effect=RuntimeError("boom")))
+        refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
+    out = capsys.readouterr().out
+    assert "Unexpected error during verification" in out

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -1,0 +1,589 @@
+"""Coverage-focused unit tests for ``cli/services/playwright_login.py``.
+
+These tests target branches not exercised by the existing
+``test_login.py`` / ``test_playwright_login_stderr.py`` suites:
+
+* :func:`_select_playwright_account` ambiguity-reason branches.
+* :func:`repair_playwright_account_metadata` clear-metadata-failure path.
+* :func:`windows_playwright_event_loop` win32 policy swap.
+* :func:`ensure_chromium_installed` timeout + generic-exception pre-flight
+  failures.
+* :func:`recover_page` TargetClosed + non-TargetClosed PlaywrightError paths.
+* :func:`validate_login_flag_conflicts` remaining mutual-exclusion gates.
+* :func:`prepare_login_paths` explicit-storage and profile branches.
+* :func:`run_playwright_login` ``_capture_page_html`` PlaywrightError path
+  and cookie-forcing inner-recovery re-raise.
+
+Each test drives the helper directly (or via the small public surface)
+with stub/mocked collaborators so no real browser / network is required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notebooklm.cli.services import playwright_login
+from notebooklm.cli.services.playwright_login import (
+    _select_playwright_account,
+    ensure_chromium_installed,
+    prepare_login_paths,
+    recover_page,
+    repair_playwright_account_metadata,
+    validate_login_flag_conflicts,
+    windows_playwright_event_loop,
+)
+
+# ---------------------------------------------------------------------------
+# _select_playwright_account
+# ---------------------------------------------------------------------------
+
+
+def _account(email: str, authuser: int = 0) -> Any:
+    return SimpleNamespace(email=email, authuser=authuser)
+
+
+def test_select_account_active_email_multiple_matches_is_ambiguous() -> None:
+    """Two discovered accounts with the same email cannot be disambiguated."""
+    accounts = [_account("dup@example.com", 0), _account("dup@example.com", 1)]
+    selected, reason = _select_playwright_account(accounts, active_email="dup@example.com")
+    assert selected is None
+    assert reason is not None
+    assert "multiple discovered accounts matched dup@example.com" in reason
+
+
+def test_select_account_active_email_no_match() -> None:
+    """The active page email was not among the discovered accounts."""
+    accounts = [_account("other@example.com", 0)]
+    selected, reason = _select_playwright_account(accounts, active_email="missing@example.com")
+    assert selected is None
+    assert reason is not None
+    assert "missing@example.com was not discovered" in reason
+
+
+def test_select_account_single_match() -> None:
+    """Exactly one matching account selects cleanly."""
+    target = _account("alice@example.com", 0)
+    selected, reason = _select_playwright_account([target], active_email="alice@example.com")
+    assert selected is target
+    assert reason is None
+
+
+def test_select_account_no_active_email_multiple_accounts_is_ambiguous() -> None:
+    """Multiple accounts with no page email cannot be picked silently."""
+    accounts = [_account("a@example.com", 0), _account("b@example.com", 1)]
+    selected, reason = _select_playwright_account(accounts, active_email=None)
+    assert selected is None
+    assert reason is not None
+    assert "multiple Google accounts were discovered" in reason
+
+
+def test_select_account_no_active_email_no_accounts() -> None:
+    """Empty discovery list returns the no-accounts reason (line 408)."""
+    selected, reason = _select_playwright_account([], active_email=None)
+    assert selected is None
+    assert reason == "no Google accounts were discovered"
+
+
+# ---------------------------------------------------------------------------
+# repair_playwright_account_metadata — clear-metadata-failure path (459-460)
+# ---------------------------------------------------------------------------
+
+
+def test_repair_metadata_clear_failure_is_logged(tmp_path, caplog) -> None:
+    """When enumeration raises AND clear_account_metadata raises, the clear
+    failure is logged (lines 459-460) and the function returns False."""
+    import logging
+
+    storage_path = tmp_path / "storage.json"
+
+    def _boom_build(_path):
+        raise ValueError("bad storage state")
+
+    def _boom_clear(_path):
+        raise OSError("cannot clear")
+
+    with (
+        patch("notebooklm.auth.build_httpx_cookies_from_storage", side_effect=_boom_build),
+        patch("notebooklm.auth.clear_account_metadata", side_effect=_boom_clear),
+        patch("notebooklm.auth.extract_email_from_html", return_value=None),
+        caplog.at_level(logging.WARNING, logger="notebooklm.cli.services.playwright_login"),
+    ):
+        result = repair_playwright_account_metadata(storage_path, page_html=None, quiet=True)
+
+    assert result is False
+    assert any(
+        "Failed to clear stale account metadata" in rec.getMessage() for rec in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# windows_playwright_event_loop — win32 policy swap (500-505)
+# ---------------------------------------------------------------------------
+
+
+def test_windows_event_loop_swaps_and_restores_policy(monkeypatch) -> None:
+    """On win32 the context manager swaps in the default policy and restores."""
+    import asyncio
+
+    monkeypatch.setattr(playwright_login.sys, "platform", "win32")
+
+    sentinel_original = object()
+    swapped_policies: list[Any] = []
+
+    monkeypatch.setattr(asyncio, "get_event_loop_policy", lambda: sentinel_original)
+    monkeypatch.setattr(
+        asyncio, "set_event_loop_policy", lambda policy: swapped_policies.append(policy)
+    )
+
+    class _DefaultPolicy:
+        pass
+
+    monkeypatch.setattr(asyncio, "DefaultEventLoopPolicy", _DefaultPolicy)
+
+    with windows_playwright_event_loop():
+        # First swap installs a fresh DefaultEventLoopPolicy.
+        assert isinstance(swapped_policies[-1], _DefaultPolicy)
+
+    # On exit the original policy is restored.
+    assert swapped_policies[-1] is sentinel_original
+
+
+def test_windows_event_loop_noop_off_win32(monkeypatch) -> None:
+    """Off win32 the context manager is a pure no-op."""
+    monkeypatch.setattr(playwright_login.sys, "platform", "linux")
+    with windows_playwright_event_loop():
+        pass  # no exception, nothing swapped
+
+
+# ---------------------------------------------------------------------------
+# ensure_chromium_installed — timeout + generic exception pre-flight (575-588)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_chromium_timeout_warns_and_continues(monkeypatch, capsys) -> None:
+    """A TimeoutExpired during the dry-run probe surfaces a warning and returns."""
+
+    def fake_run(cmd, **_):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ensure_chromium_installed()  # must not raise
+
+    out = capsys.readouterr().out
+    assert "pre-flight check timed out" in out
+    # Console may wrap "Proceeding anyway" across a line boundary; normalise.
+    assert "Proceeding" in out and "anyway" in out
+
+
+def test_ensure_chromium_generic_exception_warns_and_continues(monkeypatch, capsys) -> None:
+    """A generic exception (e.g. FileNotFoundError) is swallowed with a warning."""
+
+    def fake_run(cmd, **_):
+        raise FileNotFoundError("playwright CLI missing")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ensure_chromium_installed()  # must not raise
+
+    out = capsys.readouterr().out
+    assert "pre-flight check failed" in out
+    # Console may wrap "Proceeding anyway" across a line boundary; normalise.
+    assert "Proceeding" in out and "anyway" in out
+
+
+# ---------------------------------------------------------------------------
+# recover_page — TargetClosed exit + non-TargetClosed re-raise (607-614)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_playwright
+def test_recover_page_target_closed_exits(monkeypatch) -> None:
+    """A TargetClosed error while recovering exits 1 with the browser-closed help."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    context = MagicMock()
+    context.new_page.side_effect = PlaywrightError(
+        "Target page, context or browser has been closed"
+    )
+    console_ = MagicMock()
+
+    with pytest.raises(SystemExit) as exc_info:
+        recover_page(context, console_)
+
+    assert exc_info.value.code == 1
+    console_.print.assert_called_once()
+    assert "browser window was closed" in console_.print.call_args[0][0].lower()
+
+
+@pytest.mark.requires_playwright
+def test_recover_page_non_target_closed_reraises() -> None:
+    """A non-TargetClosed PlaywrightError is re-raised after logging."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    context = MagicMock()
+    context.new_page.side_effect = PlaywrightError("some other failure")
+    console_ = MagicMock()
+
+    with pytest.raises(PlaywrightError):
+        recover_page(context, console_)
+
+
+@pytest.mark.requires_playwright
+def test_recover_page_success_returns_new_page() -> None:
+    """The happy path returns ``context.new_page()`` directly."""
+    fresh = object()
+    context = MagicMock()
+    context.new_page.return_value = fresh
+    assert recover_page(context, MagicMock()) is fresh
+
+
+# ---------------------------------------------------------------------------
+# validate_login_flag_conflicts — remaining mutual-exclusion gates (676-694)
+# ---------------------------------------------------------------------------
+
+
+def _base_flags(**overrides: Any) -> dict[str, Any]:
+    flags: dict[str, Any] = {
+        "browser_cookies": "chrome",
+        "account_email": None,
+        "all_accounts": False,
+        "update": False,
+        "profile_name": None,
+        "storage": None,
+    }
+    flags.update(overrides)
+    return flags
+
+
+def test_validate_flags_account_requires_browser_cookies() -> None:
+    """--account without --browser-cookies exits 1."""
+    with pytest.raises(SystemExit):
+        validate_login_flag_conflicts(
+            **_base_flags(browser_cookies=None, account_email="bob@example.com")
+        )
+
+
+def test_validate_flags_all_accounts_with_account_conflicts() -> None:
+    """--all-accounts + --account exits 1."""
+    with pytest.raises(SystemExit):
+        validate_login_flag_conflicts(
+            **_base_flags(all_accounts=True, account_email="bob@example.com")
+        )
+
+
+def test_validate_flags_all_accounts_with_storage_conflicts() -> None:
+    """--all-accounts + --storage exits 1 (lines 686-691)."""
+    with pytest.raises(SystemExit):
+        validate_login_flag_conflicts(**_base_flags(all_accounts=True, storage="/tmp/s.json"))
+
+
+def test_validate_flags_update_requires_all_accounts() -> None:
+    """--update without --all-accounts exits 1."""
+    with pytest.raises(SystemExit):
+        validate_login_flag_conflicts(**_base_flags(update=True, all_accounts=False))
+
+
+def test_validate_flags_clean_combo_passes() -> None:
+    """A valid flag combination does not raise."""
+    validate_login_flag_conflicts(**_base_flags())
+
+
+# ---------------------------------------------------------------------------
+# prepare_login_paths — explicit storage + profile branches (713, 715)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_login_paths_explicit_storage(tmp_path, monkeypatch) -> None:
+    """Explicit ``--storage`` wins and is returned verbatim (line 713)."""
+    monkeypatch.setattr(playwright_login.sys, "platform", "linux")
+    browser_profile = tmp_path / "profile"
+
+    with patch.object(
+        playwright_login,
+        "_resolve_paths_helper",
+        side_effect=lambda name, default: (
+            (lambda: browser_profile)
+            if name == "get_browser_profile_dir"
+            else (lambda profile=None: tmp_path / "ignored")
+        ),
+    ):
+        storage_path, returned_profile = prepare_login_paths(
+            profile=None, storage=str(tmp_path / "explicit.json"), fresh=False
+        )
+
+    assert storage_path == Path(str(tmp_path / "explicit.json"))
+    assert returned_profile == browser_profile
+
+
+def test_prepare_login_paths_with_profile(tmp_path, monkeypatch) -> None:
+    """The profile branch resolves via ``get_storage_path(profile=...)`` (line 715)."""
+    monkeypatch.setattr(playwright_login.sys, "platform", "linux")
+    browser_profile = tmp_path / "profile"
+    profile_storage = tmp_path / "work" / "storage.json"
+
+    def fake_resolve(name, default):
+        if name == "get_browser_profile_dir":
+            return lambda: browser_profile
+
+        def _get_storage_path(profile=None):
+            assert profile == "work"
+            return profile_storage
+
+        return _get_storage_path
+
+    with patch.object(playwright_login, "_resolve_paths_helper", side_effect=fake_resolve):
+        storage_path, returned_profile = prepare_login_paths(
+            profile="work", storage=None, fresh=False
+        )
+
+    assert storage_path == profile_storage
+    assert returned_profile == browser_profile
+
+
+# ---------------------------------------------------------------------------
+# run_playwright_login — _capture_page_html PlaywrightError (826-828) and
+# cookie-forcing inner-recovery non-target-closed re-raise (968)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_playwright
+def test_run_playwright_login_capture_html_error_is_swallowed(tmp_path) -> None:
+    """When ``page.content()`` raises PlaywrightError, metadata HTML is None
+    (covers ``_capture_page_html`` except branch, lines 826-828)."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    storage_file = tmp_path / "storage.json"
+    browser_dir = tmp_path / "profile"
+
+    mock_context = MagicMock()
+    mock_page = MagicMock()
+    mock_page.url = "https://notebooklm.google.com/"
+    mock_page.content.side_effect = PlaywrightError("cannot read content")
+    mock_context.pages = [mock_page]
+    mock_context.storage_state.return_value = {"cookies": [], "origins": []}
+
+    mock_playwright = MagicMock()
+    mock_playwright.chromium.launch_persistent_context.return_value = mock_context
+
+    class _FakeSyncPlaywright:
+        def __enter__(self):
+            return mock_playwright
+
+        def __exit__(self, *exc):
+            return False
+
+    repair_calls: list[Any] = []
+
+    with (
+        patch(
+            "notebooklm.cli.services.playwright_login.ensure_chromium_installed",
+        ),
+        patch(
+            "playwright.sync_api.sync_playwright",
+            side_effect=lambda: _FakeSyncPlaywright(),
+        ),
+        patch(
+            "notebooklm.cli.services.playwright_login.repair_playwright_account_metadata",
+            side_effect=lambda storage_path, *, page_html=None, quiet=False: repair_calls.append(
+                page_html
+            ),
+        ),
+    ):
+        playwright_login.run_playwright_login(
+            playwright_login.PlaywrightLoginPlan(
+                browser="chromium",
+                browser_profile=browser_dir,
+                storage_path=storage_file,
+            )
+        )
+
+    # content() raised, so the page-html passed to repair is None.
+    assert repair_calls == [None]
+
+
+@pytest.mark.requires_playwright
+def test_run_playwright_login_cookie_forcing_inner_recovery_reraises(tmp_path) -> None:
+    """If the recovered page's cookie-forcing goto raises a non-navigation,
+    non-target-closed PlaywrightError, it propagates (line 968)."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    storage_file = tmp_path / "storage.json"
+    browser_dir = tmp_path / "profile"
+
+    mock_context = MagicMock()
+    mock_page_stale = MagicMock()
+    mock_page_stale.url = "https://notebooklm.google.com/"
+
+    goto_count = 0
+
+    def stale_goto(url, **kwargs):
+        nonlocal goto_count
+        goto_count += 1
+        # First goto (initial navigation before login) succeeds.
+        if goto_count == 1:
+            return None
+        # Cookie-forcing goto: stale page is dead -> trigger recovery.
+        raise PlaywrightError("Target page, context or browser has been closed")
+
+    mock_page_stale.goto.side_effect = stale_goto
+
+    mock_page_recovered = MagicMock()
+    mock_page_recovered.url = "https://notebooklm.google.com/"
+    # The recovered page's goto raises a NON-target-closed, NON-navigation
+    # PlaywrightError, which must propagate (line 968 -> raise).
+    mock_page_recovered.goto.side_effect = PlaywrightError("net::ERR_SOMETHING_ELSE while loading")
+
+    mock_context.pages = [mock_page_stale]
+    mock_context.new_page.return_value = mock_page_recovered
+    mock_context.storage_state.return_value = {"cookies": [], "origins": []}
+
+    mock_playwright = MagicMock()
+    mock_playwright.chromium.launch_persistent_context.return_value = mock_context
+
+    class _FakeSyncPlaywright:
+        def __enter__(self):
+            return mock_playwright
+
+        def __exit__(self, *exc):
+            return False
+
+    with (
+        patch("notebooklm.cli.services.playwright_login.ensure_chromium_installed"),
+        patch(
+            "playwright.sync_api.sync_playwright",
+            side_effect=lambda: _FakeSyncPlaywright(),
+        ),
+        pytest.raises(PlaywrightError, match="ERR_SOMETHING_ELSE"),
+    ):
+        playwright_login.run_playwright_login(
+            playwright_login.PlaywrightLoginPlan(
+                browser="chromium",
+                browser_profile=browser_dir,
+                storage_path=storage_file,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# redact_subprocess_output — non-string env value skip (line 292)
+# ---------------------------------------------------------------------------
+
+
+def test_redact_subprocess_output_skips_non_string_env_value() -> None:
+    """A non-string env value is skipped via ``continue`` (line 292)."""
+    # The mapping intentionally carries a non-str value to exercise the
+    # ``isinstance(raw_value, str)`` guard's false branch.
+    env: dict[str, Any] = {"GOOD": "supersecretvalue", "BAD": 12345}
+    out = playwright_login.redact_subprocess_output("leak supersecretvalue here", env=env)
+    assert "<redacted>" in out
+    assert "supersecretvalue" not in out
+
+
+# ---------------------------------------------------------------------------
+# ensure_chromium_installed — install success path (line 575)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_chromium_install_success(monkeypatch, capsys) -> None:
+    """When the dry-run reports a missing browser and install succeeds, the
+    success banner is printed (line 575)."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_):
+        calls.append(cmd)
+        if "--dry-run" in cmd:
+            return SimpleNamespace(stdout="chromium will download to ...", stderr="", returncode=0)
+        # The real install call.
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ensure_chromium_installed()
+
+    out = capsys.readouterr().out
+    assert "installed successfully" in out
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# prepare_login_paths — win32 directory-creation branch (lines 738-739)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_login_paths_win32_skips_mode(tmp_path, monkeypatch) -> None:
+    """On win32 the parent dirs are created without ``mode=`` (lines 738-739)."""
+    monkeypatch.setattr(playwright_login.sys, "platform", "win32")
+    browser_profile = tmp_path / "profile"
+    storage_target = tmp_path / "win" / "storage.json"
+
+    def fake_resolve(name, default):
+        if name == "get_browser_profile_dir":
+            return lambda: browser_profile
+        return lambda profile=None: storage_target
+
+    with patch.object(playwright_login, "_resolve_paths_helper", side_effect=fake_resolve):
+        storage_path, returned_profile = prepare_login_paths(
+            profile=None, storage=None, fresh=False
+        )
+
+    assert storage_path == storage_target
+    assert returned_profile == browser_profile
+    assert storage_target.parent.is_dir()
+    assert browser_profile.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# run_playwright_login — wait_for_url non-target-closed PlaywrightError (942)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_playwright
+def test_run_playwright_login_wait_for_url_other_error_reraises(tmp_path) -> None:
+    """A non-target-closed PlaywrightError from ``wait_for_url`` propagates
+    (line 942)."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    storage_file = tmp_path / "storage.json"
+    browser_dir = tmp_path / "profile"
+
+    mock_context = MagicMock()
+    mock_page = MagicMock()
+    # URL is NOT on the base host, so the wait_for_url branch is taken.
+    mock_page.url = "https://accounts.google.com/signin"
+    mock_page.goto.return_value = None
+    mock_page.wait_for_url.side_effect = PlaywrightError("net::ERR_WEIRD other failure")
+    mock_context.pages = [mock_page]
+    mock_context.storage_state.return_value = {"cookies": [], "origins": []}
+
+    mock_playwright = MagicMock()
+    mock_playwright.chromium.launch_persistent_context.return_value = mock_context
+
+    class _FakeSyncPlaywright:
+        def __enter__(self):
+            return mock_playwright
+
+        def __exit__(self, *exc):
+            return False
+
+    with (
+        patch("notebooklm.cli.services.playwright_login.ensure_chromium_installed"),
+        patch(
+            "playwright.sync_api.sync_playwright",
+            side_effect=lambda: _FakeSyncPlaywright(),
+        ),
+        pytest.raises(PlaywrightError, match="ERR_WEIRD"),
+    ):
+        playwright_login.run_playwright_login(
+            playwright_login.PlaywrightLoginPlan(
+                browser="chromium",
+                browser_profile=browser_dir,
+                storage_path=storage_file,
+            )
+        )

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -131,20 +131,26 @@ def test_windows_event_loop_swaps_and_restores_policy(monkeypatch) -> None:
     """On win32 the context manager swaps in the default policy and restores."""
     import asyncio
 
-    monkeypatch.setattr(playwright_login.sys, "platform", "win32")
-
     sentinel_original = object()
     swapped_policies: list[Any] = []
-
-    monkeypatch.setattr(asyncio, "get_event_loop_policy", lambda: sentinel_original)
-    monkeypatch.setattr(
-        asyncio, "set_event_loop_policy", lambda policy: swapped_policies.append(policy)
-    )
 
     class _DefaultPolicy:
         pass
 
+    # Patch the asyncio seams *before* faking ``sys.platform`` to win32. On
+    # Python 3.14 ``asyncio.DefaultEventLoopPolicy`` is resolved lazily via the
+    # module ``__getattr__``, and under a faked win32 platform that lookup
+    # reaches ``windows_events`` — which is never imported on a Linux/macOS
+    # host, raising ``NameError`` during monkeypatch's old-value capture. Doing
+    # the captures while the real platform is still in effect avoids that; once
+    # the names are replaced, ``__getattr__`` is no longer consulted.
+    monkeypatch.setattr(asyncio, "get_event_loop_policy", lambda: sentinel_original)
+    monkeypatch.setattr(
+        asyncio, "set_event_loop_policy", lambda policy: swapped_policies.append(policy)
+    )
     monkeypatch.setattr(asyncio, "DefaultEventLoopPolicy", _DefaultPolicy)
+
+    monkeypatch.setattr(playwright_login.sys, "platform", "win32")
 
     with windows_playwright_event_loop():
         # First swap installs a fresh DefaultEventLoopPolicy.

--- a/tests/unit/cli/test_source_cmd_coverage.py
+++ b/tests/unit/cli/test_source_cmd_coverage.py
@@ -1,0 +1,286 @@
+"""Coverage gap tests for ``notebooklm.cli.source_cmd`` render helpers.
+
+These exercise the small pure render/handler helpers that own the
+text-vs-JSON branching and exit-code policy for ``source`` subcommands:
+
+* ``_resolve_source_fulltext_output_path`` force/no-clobber conflict
+* ``_handle_source_mutation_error`` status-message → JSON-extra vs text-hint
+* ``_render_source_delete_result`` status-message emission
+* ``_render_source_refresh_result`` ``result is True`` branch
+* ``_exit_with_add_research_status`` JSON envelope + exit
+* ``_render_add_research_result`` JSON branches for ``no_research``,
+  ``failed``/``timeout``, ``unknown_status``
+* ``_dispatch_source_clean_result`` text partial-failure overflow + exit
+
+Plus one ``source add`` CLI invocation to cover the validation-error
+JSON branch in the command body.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import click
+import pytest
+
+from notebooklm.cli import source_cmd
+from notebooklm.cli.services.source_clean import SourceCleanResult
+from notebooklm.cli.services.source_mutations import (
+    SourceDeleteResult,
+    SourceMutationError,
+    SourceRefreshResult,
+)
+from notebooklm.cli.services.source_research import (
+    SourceAddResearchPlan,
+    SourceAddResearchResult,
+)
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import create_mock_client
+
+
+def _research_result(outcome: str, **kw) -> SourceAddResearchResult:
+    plan = SourceAddResearchPlan(
+        notebook_id="nb_1",
+        query="q",
+        search_source="web",
+        mode="fast",
+        import_all=False,
+        cited_only=False,
+        no_wait=False,
+        timeout=60,
+        json_output=True,
+    )
+    return SourceAddResearchResult(outcome=outcome, plan=plan, **kw)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_source_fulltext_output_path — force + no-clobber conflict (line 223)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFulltextOutputPath:
+    def test_force_and_no_clobber_conflict_text_raises_usage_error(self, tmp_path):
+        path = tmp_path / "out.md"
+        path.write_text("existing", encoding="utf-8")
+        with pytest.raises(click.UsageError, match="both --force and --no-clobber"):
+            source_cmd._resolve_source_fulltext_output_path(
+                str(path), force=True, no_clobber=True, json_output=False
+            )
+
+    def test_force_and_no_clobber_conflict_json_exits(self, tmp_path, capsys):
+        path = tmp_path / "out.md"
+        path.write_text("existing", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            source_cmd._resolve_source_fulltext_output_path(
+                str(path), force=True, no_clobber=True, json_output=True
+            )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["code"] == "VALIDATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# _render_source_wait_outcome — defensive unreachable guard (line 399)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSourceWaitOutcomeGuard:
+    def test_unknown_outcome_type_raises_assertion(self):
+        class _Bogus:
+            pass
+
+        with pytest.raises(AssertionError, match="unreachable"):
+            source_cmd._render_source_wait_outcome(_Bogus(), json_output=False)
+
+
+# ---------------------------------------------------------------------------
+# _handle_source_mutation_error — status-message branches (452-457)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSourceMutationError:
+    def test_status_message_routed_to_json_extra(self, capsys):
+        exc = SourceMutationError(
+            "boom", "DELETE_FAILED", extra={"k": "v"}, status_message="[red]bad[/red]"
+        )
+        with pytest.raises(SystemExit):
+            source_cmd._handle_source_mutation_error(exc, json_output=True)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["code"] == "DELETE_FAILED"
+        # Markup stripped to plain text in the JSON extra.
+        assert payload["status_message"] == "bad"
+        assert payload["k"] == "v"
+
+    def test_status_message_routed_to_text_hint(self, capsys):
+        exc = SourceMutationError("boom", "DELETE_FAILED", status_message="[red]hint here[/red]")
+        with pytest.raises(SystemExit):
+            source_cmd._handle_source_mutation_error(exc, json_output=False)
+        err = capsys.readouterr().err
+        assert "boom" in err
+        assert "hint here" in err
+
+
+# ---------------------------------------------------------------------------
+# _render_source_delete_result — status-message emission (line 476)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSourceDeleteResult:
+    def test_status_message_emitted_text_mode(self, capsys):
+        ctx = click.Context(click.Command("x"))
+        result = SourceDeleteResult(
+            source_id="src_1",
+            notebook_id="nb_1",
+            success=True,
+            status="completed",
+            status_message="[dim]queued[/dim]",
+        )
+        source_cmd._render_source_delete_result(result, json_output=False, ctx=ctx)
+        out = capsys.readouterr().out
+        assert "queued" in out
+        assert "Deleted source" in out
+
+
+# ---------------------------------------------------------------------------
+# _render_source_refresh_result — result is True branch (line 519)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSourceRefreshResult:
+    def test_result_is_true_prints_source_id(self, capsys):
+        ctx = click.Context(click.Command("x"))
+        result = SourceRefreshResult(source_id="src_1", notebook_id="nb_1", result=True)
+        source_cmd._render_source_refresh_result(result, json_output=False, ctx=ctx)
+        out = capsys.readouterr().out
+        assert "Source refreshed" in out
+        assert "src_1" in out
+
+
+# ---------------------------------------------------------------------------
+# _exit_with_add_research_status (918-921)
+# ---------------------------------------------------------------------------
+
+
+class TestExitWithAddResearchStatus:
+    def test_emits_payload_and_exits_one(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            source_cmd._exit_with_add_research_status("failed", "boom", raw_status="weird")
+        assert exc_info.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == {"status": "failed", "error": "boom", "raw_status": "weird"}
+
+
+# ---------------------------------------------------------------------------
+# _render_add_research_result — JSON outcome branches (962-988)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAddResearchResultJson:
+    def test_no_research_json(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(
+                _research_result("no_research"), json_output=True
+            )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "no_research"
+
+    def test_failed_json(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(_research_result("failed"), json_output=True)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "failed"
+        assert payload["error"] == "Research failed"
+
+    def test_timeout_json(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(_research_result("timeout"), json_output=True)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "timeout"
+        assert payload["error"] == "Research timed out"
+
+    def test_unknown_status_json(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(
+                _research_result("unknown_status", status="weird"), json_output=True
+            )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "unknown_status"
+        assert payload["raw_status"] == "weird"
+
+
+class TestRenderAddResearchResultText:
+    def test_no_research_text_exits(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(
+                _research_result("no_research"), json_output=False
+            )
+        assert "Research failed to start" in capsys.readouterr().out
+
+    def test_failed_text_exits(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(_research_result("failed"), json_output=False)
+        assert "Research failed" in capsys.readouterr().out
+
+    def test_unknown_status_text_exits(self, capsys):
+        with pytest.raises(SystemExit):
+            source_cmd._render_add_research_result(
+                _research_result("unknown_status", status="weird"), json_output=False
+            )
+        assert "weird" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_source_clean_result — text partial-failure overflow (1477, 1482)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSourceCleanResultTextFailures:
+    def test_text_partial_failure_overflow_and_exit(self, capsys):
+        ctx = click.Context(click.Command("x"))
+        failures = tuple((f"src_{i}", f"err {i}") for i in range(8))
+        result = SourceCleanResult(
+            notebook_id="nb_1",
+            status="completed",
+            candidates=(),
+            deleted_count=2,
+            failures=failures,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            source_cmd._dispatch_source_clean_result(result, json_output=False, yes=True, ctx=ctx)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        # Only the first 5 failures are listed, then an overflow summary.
+        assert "and 3 more" in out
+        assert "8 deletion(s) failed" in out
+
+
+# ---------------------------------------------------------------------------
+# source add — validation-error JSON branch in the command body (line 691)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAddValidationErrorJson:
+    def test_invalid_url_json_emits_validation_error(self, runner, mock_auth):
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client_cls.return_value = create_mock_client()
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add",
+                        "http://",  # malformed URL — no host component
+                        "--type",
+                        "url",
+                        "-n",
+                        "nb_123",
+                        "--json",
+                    ],
+                )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["code"] == "VALIDATION_ERROR"

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -1,0 +1,1067 @@
+"""Coverage-focused tests for ``_artifact_downloads`` error/edge branches.
+
+These tests target branches not exercised by ``test_artifact_downloads.py`` /
+``test_download_url.py``: module-level helpers, ``UnknownRPCMethodError`` /
+missing-URL handling per download type, format validation, interactive
+artifact-id lookup, parse-error wrapping, the batch non-HTTPS reject path,
+the streaming HTML-payload reject, the ``_await_writer_exit`` cancellation
+shield-loop, and the producer ``except``-block queue-drain.
+
+The ``ArtifactDownloadService`` is constructed directly with ``MagicMock``
+collaborators (mirroring ``TestStoragePathEncapsulation`` in
+``test_artifact_downloads.py``), and ``_select_artifact`` is stubbed to
+return a row whose typed accessors raise/return the value under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+import threading
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import httpx
+import pytest
+
+from notebooklm import _artifact_downloads as artifact_downloads
+from notebooklm._artifact_downloads import (
+    ArtifactDownloadService,
+    _await_writer_exit,
+    _download_display_host,
+    _is_trusted_download_host,
+)
+from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.types import (
+    ArtifactDownloadError,
+    ArtifactNotFoundError,
+    ArtifactNotReadyError,
+    ArtifactParseError,
+)
+
+
+def _make_service(**overrides):
+    """Build a service with inert MagicMock collaborators."""
+    kwargs = {
+        "rpc": MagicMock(),
+        "listing": MagicMock(),
+        "mind_maps": MagicMock(),
+    }
+    kwargs.update(overrides)
+    return ArtifactDownloadService(**kwargs)
+
+
+def _row_with(prop_name, *, value=None, exc=None):
+    """Return a MagicMock row whose ``prop_name`` returns value or raises."""
+    row = MagicMock()
+    if exc is not None:
+        type(row)  # noqa: B018 -- ensure attribute access path
+        setattr(type(row), prop_name, PropertyMock(side_effect=exc))
+    else:
+        setattr(row, prop_name, value)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_trusted_download_host_none_returns_false():
+    """Line 136: ``None`` hostname is never trusted."""
+    assert _is_trusted_download_host(None) is False
+
+
+def test_download_display_host_falls_back_to_netloc():
+    """Line 149: with no parsed hostname, strip userinfo from netloc."""
+    from urllib.parse import urlparse
+
+    # A URL whose netloc is only userinfo yields hostname=None, so the
+    # netloc fallback (stripping the ``user@`` prefix) is exercised.
+    p2 = urlparse("scheme://user@")
+    assert p2.hostname is None
+    assert _download_display_host(p2) == ""
+
+    # And the normal case returns the hostname directly.
+    assert _download_display_host(urlparse("https://host.example/x")) == "host.example"
+
+
+# ---------------------------------------------------------------------------
+# _list_mind_maps delegation (line 174)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_mind_maps_delegates_to_service():
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=["mm"])
+    service = _make_service(mind_maps=mind_maps)
+
+    result = await service._list_mind_maps("nb_1")
+
+    assert result == ["mm"]
+    mind_maps.list_mind_maps.assert_awaited_once_with("nb_1")
+
+
+# ---------------------------------------------------------------------------
+# Audio (lines 242-243)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_audio_unknown_rpc_method_wrapped():
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    row = _row_with("audio_url", exc=UnknownRPCMethodError("boom"))
+    service._select_artifact = MagicMock(return_value=row)
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_audio("nb", "/tmp/a.mp4")
+
+
+@pytest.mark.asyncio
+async def test_download_audio_missing_url_raises():
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("audio_url", value=None))
+
+    with pytest.raises(ArtifactParseError, match="Could not extract download URL"):
+        await service.download_audio("nb", "/tmp/a.mp4")
+
+
+# ---------------------------------------------------------------------------
+# Video (lines 277-278, 285)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_video_unknown_rpc_method_wrapped():
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("video_url", exc=UnknownRPCMethodError("boom"))
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_video("nb", "/tmp/v.mp4")
+
+
+@pytest.mark.asyncio
+async def test_download_video_missing_url_raises():
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("video_url", value=""))
+
+    with pytest.raises(ArtifactParseError, match="Could not extract download URL"):
+        await service.download_video("nb", "/tmp/v.mp4")
+
+
+# ---------------------------------------------------------------------------
+# Infographic (lines 310, 317-318)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_infographic_missing_url_raises():
+    """Line 310: empty infographic URL -> ArtifactParseError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("infographic_url", value=None))
+
+    with pytest.raises(ArtifactParseError, match="Could not find metadata"):
+        await service.download_infographic("nb", "/tmp/i.png")
+
+
+@pytest.mark.asyncio
+async def test_download_infographic_index_error_wrapped():
+    """Lines 317-318: structural IndexError/TypeError wrapped as parse error."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("infographic_url", exc=TypeError("bad shape"))
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_infographic("nb", "/tmp/i.png")
+
+
+# ---------------------------------------------------------------------------
+# Slide deck (lines 334, 350, 356)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_slide_deck_invalid_format_rejected():
+    """Line 334: only pdf/pptx are accepted."""
+    service = _make_service()
+    with pytest.raises(Exception, match="Invalid format"):
+        await service.download_slide_deck("nb", "/tmp/s.bin", output_format="docx")
+
+
+@pytest.mark.asyncio
+async def test_download_slide_deck_pptx_url_missing():
+    """Line 350: missing PPTX URL -> ArtifactDownloadError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("slide_deck_pptx_url", value=None))
+
+    with pytest.raises(ArtifactDownloadError, match="PPTX URL not available"):
+        await service.download_slide_deck("nb", "/tmp/s.pptx", output_format="pptx")
+
+
+@pytest.mark.asyncio
+async def test_download_slide_deck_pdf_url_missing():
+    """Line 356: missing PDF URL -> ArtifactDownloadError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("slide_deck_pdf_url", value=None))
+
+    with pytest.raises(ArtifactDownloadError, match="Could not find PDF download URL"):
+        await service.download_slide_deck("nb", "/tmp/s.pdf", output_format="pdf")
+
+
+@pytest.mark.asyncio
+async def test_download_slide_deck_unknown_rpc_method_wrapped():
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("slide_deck_pdf_url", exc=UnknownRPCMethodError("boom"))
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_slide_deck("nb", "/tmp/s.pdf")
+
+
+# ---------------------------------------------------------------------------
+# Interactive artifact (lines 398-400, 411)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interactive_invalid_format_rejected():
+    service = _make_service()
+    with pytest.raises(Exception, match="Invalid output_format"):
+        await service.download_interactive_artifact("nb", "/tmp/q.json", None, "xml", "quiz")
+
+
+@pytest.mark.asyncio
+async def test_interactive_specific_id_not_found():
+    """Lines 398-400: requested artifact_id absent among completed."""
+    completed = MagicMock(id="other", is_completed=True, created_at=None, title="Q")
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[completed])
+
+    with pytest.raises(ArtifactNotFoundError):
+        await service.download_interactive_artifact(
+            "nb", "/tmp/q.json", "wanted_id", "json", "quiz"
+        )
+
+
+@pytest.mark.asyncio
+async def test_interactive_json_decode_error_wrapped(monkeypatch):
+    """Line 411: JSONDecodeError from app-data extraction -> ArtifactParseError."""
+    artifact = MagicMock(id="q1", is_completed=True, created_at=None, title="Q")
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[artifact])
+    service._get_artifact_content = AsyncMock(return_value="<html></html>")
+    monkeypatch.setattr(
+        artifact_downloads,
+        "_extract_app_data",
+        MagicMock(side_effect=json.JSONDecodeError("bad", "doc", 0)),
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse content"):
+        await service.download_interactive_artifact("nb", "/tmp/q.json", None, "json", "quiz")
+
+
+@pytest.mark.asyncio
+async def test_interactive_no_completed_raises_not_ready():
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[MagicMock(is_completed=False)])
+
+    with pytest.raises(ArtifactNotReadyError):
+        await service.download_interactive_artifact("nb", "/tmp/q.json", None, "json", "quiz")
+
+
+@pytest.mark.asyncio
+async def test_interactive_empty_content_raises_download_error():
+    artifact = MagicMock(id="q1", is_completed=True, created_at=None, title="Q")
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[artifact])
+    service._get_artifact_content = AsyncMock(return_value=None)
+
+    with pytest.raises(ArtifactDownloadError, match="Failed to fetch content"):
+        await service.download_interactive_artifact("nb", "/tmp/q.json", None, "json", "quiz")
+
+
+# ---------------------------------------------------------------------------
+# Report (lines 449, 464-465)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_report_non_string_markdown_raises():
+    """Line 449: non-str report markdown -> ArtifactParseError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(return_value=_row_with("report_markdown", value=[1, 2, 3]))
+
+    with pytest.raises(ArtifactParseError, match="Invalid structure"):
+        await service.download_report("nb", "/tmp/r.md")
+
+
+@pytest.mark.asyncio
+async def test_download_report_unknown_rpc_method_wrapped():
+    """Lines 464-465: UnknownRPCMethodError -> ArtifactParseError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("report_markdown", exc=UnknownRPCMethodError("boom"))
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_report("nb", "/tmp/r.md")
+
+
+# ---------------------------------------------------------------------------
+# Mind map (lines 494, 508-509)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_mind_map_none_content_raises():
+    """Line 494: extract_content returning None -> ArtifactParseError."""
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=[["mm_1", None, None, None, "Title"]])
+    mind_maps.extract_content = MagicMock(return_value=None)
+    service = _make_service(mind_maps=mind_maps)
+
+    with pytest.raises(ArtifactParseError, match="Invalid structure"):
+        await service.download_mind_map("nb", "/tmp/m.json")
+
+
+@pytest.mark.asyncio
+async def test_download_mind_map_bad_json_wrapped():
+    """Lines 508-509: invalid JSON string -> ArtifactParseError."""
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=[["mm_1", None, None, None, "Title"]])
+    mind_maps.extract_content = MagicMock(return_value="{not valid json")
+    service = _make_service(mind_maps=mind_maps)
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_mind_map("nb", "/tmp/m.json")
+
+
+# ---------------------------------------------------------------------------
+# Data table (line 550)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_data_table_parse_error_wrapped(monkeypatch):
+    """Line 550: ValueError from parsing -> ArtifactParseError."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("data_table_raw_payload", value=["raw"])
+    )
+    monkeypatch.setattr(
+        artifact_downloads,
+        "_parse_data_table",
+        MagicMock(side_effect=ValueError("bad table")),
+    )
+
+    with pytest.raises(ArtifactParseError, match="Failed to parse structure"):
+        await service.download_data_table("nb", "/tmp/t.csv")
+
+
+# ---------------------------------------------------------------------------
+# Quiz/flashcards delegation (lines 565, 577)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_quiz_delegates():
+    service = _make_service()
+    service.download_interactive_artifact = AsyncMock(return_value="/tmp/q.json")
+
+    result = await service.download_quiz("nb", "/tmp/q.json")
+
+    assert result == "/tmp/q.json"
+    service.download_interactive_artifact.assert_awaited_once_with(
+        "nb", "/tmp/q.json", None, "json", "quiz"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_flashcards_delegates():
+    service = _make_service()
+    service.download_interactive_artifact = AsyncMock(return_value="/tmp/f.json")
+
+    result = await service.download_flashcards("nb", "/tmp/f.json", output_format="markdown")
+
+    assert result == "/tmp/f.json"
+    service.download_interactive_artifact.assert_awaited_once_with(
+        "nb", "/tmp/f.json", None, "markdown", "flashcards"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch non-HTTPS reject (line 600)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_urls_batch_non_https_recorded_as_failure(tmp_path):
+    """Line 600: http:// URL is rejected and aggregated into ``failed``."""
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    with patch.object(artifact_downloads, "_load_httpx_cookies", return_value={}):
+        result = await service.download_urls_batch(
+            [("http://storage.googleapis.com/x.bin", str(tmp_path / "out.bin"))]
+        )
+
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    url, exc = result.failed[0]
+    assert url == "http://storage.googleapis.com/x.bin"
+    assert isinstance(exc, ArtifactDownloadError)
+    assert "must use HTTPS" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Streaming HTML payload reject (line 698)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_html_payload_rejected(tmp_path):
+    """Line 698: an HTML content-type aborts with an auth-hint error."""
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        if False:  # pragma: no cover
+            yield b""
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    output_path = tmp_path / "out.bin"
+    with (
+        patch.object(httpx, "AsyncClient", return_value=mock_client),
+        patch.object(artifact_downloads, "load_httpx_cookies", return_value=MagicMock()),
+        pytest.raises(ArtifactDownloadError, match="received HTML instead of media"),
+    ):
+        await service.download_url("https://storage.googleapis.com/x.bin", str(output_path))
+
+    assert not output_path.exists()
+    assert list(tmp_path.glob("out.bin.*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# _await_writer_exit cancellation shield-loop (lines 96, 100, 102-103)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_await_writer_exit_reraises_cancel_after_join():
+    """Lines 96/100/102-103: a cancellation arriving during the join is
+    preserved and re-raised once the writer thread has exited."""
+    release = threading.Event()
+
+    def _block():
+        release.wait(timeout=5)
+
+    writer = threading.Thread(target=_block, daemon=True)
+    writer.start()
+
+    task = asyncio.ensure_future(_await_writer_exit(writer, re_raise_cancel=True))
+
+    # Let the helper start awaiting the shielded join, then cancel it.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    # The shield keeps the inner join alive; release the thread so the
+    # join completes and the loop exits, then the preserved cancel is
+    # re-raised.
+    await asyncio.sleep(0.05)
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not writer.is_alive()
+
+
+@pytest.mark.asyncio
+async def test_await_writer_exit_cleanup_path_swallows_cancel():
+    """re_raise_cancel=False (cleanup path) returns normally even after a
+    cancellation was observed mid-join (line 102 false branch)."""
+    release = threading.Event()
+
+    def _block():
+        release.wait(timeout=5)
+
+    writer = threading.Thread(target=_block, daemon=True)
+    writer.start()
+
+    task = asyncio.ensure_future(_await_writer_exit(writer, re_raise_cancel=False))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0.05)
+    release.set()
+
+    # No CancelledError surfaces because re_raise_cancel is False.
+    await task
+    assert not writer.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Producer except-block queue drain (lines 844-848, 852)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_error_path_drains_full_queue(tmp_path):
+    """Lines 840-852: when the producer fails mid-stream while the bounded
+    queue is already full (the writer is parked and not consuming), the
+    ``except`` block must drop one buffered item (``get_nowait``) to make
+    room for the ``None`` sentinel, otherwise ``put_nowait(None)`` keeps
+    raising ``queue.Full`` and the writer stays blocked forever.
+
+    To force the queue-full path deterministically the writer thread is
+    made to block on its very first ``write`` (it never drains the queue),
+    so the producer saturates the bounded queue. ``aiter_bytes`` then
+    raises a network error, driving the producer into the failure handler
+    with a full queue. Releasing the blocked write lets the sentinel land
+    and the writer exit so cleanup can unlink the temp file.
+    """
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    real_open = open
+    release_writer = threading.Event()
+
+    class _BlockingHandle:
+        """File-like wrapper whose first ``write`` blocks until released.
+
+        The writer thread does one ``chunk_q.get()`` and then parks on its
+        first ``write``, so it never drains the rest of the queue — letting
+        the test hold the bounded queue at full capacity while the producer
+        enters its failure handler.
+        """
+
+        def __init__(self, fh):
+            self._fh = fh
+            self._blocked_once = False
+
+        def write(self, data):
+            if not self._blocked_once:
+                self._blocked_once = True
+                release_writer.wait(timeout=5)
+            return self._fh.write(data)
+
+        def __enter__(self):
+            self._fh.__enter__()
+            return self
+
+        def __exit__(self, *exc):
+            return self._fh.__exit__(*exc)
+
+    def blocking_open(path, *args, **kwargs):
+        if str(path).endswith(".tmp"):
+            return _BlockingHandle(real_open(path, *args, **kwargs))
+        return real_open(path, *args, **kwargs)
+
+    # Capture the bounded queue the producer/writer share so the test can
+    # deterministically fill it to capacity before forcing the failure.
+    created_queues: list[queue.Queue] = []
+    real_queue_cls = queue.Queue
+
+    def _capturing_queue(*args, **kwargs):
+        q = real_queue_cls(*args, **kwargs)
+        created_queues.append(q)
+        return q
+
+    # A non-httpx error so it propagates straight through the outer
+    # ``except httpx.*`` handlers (which would otherwise re-wrap it) and
+    # out to the temp-file cleanup, keeping the assertion on the original
+    # exception type.
+    boom = RuntimeError("connection dropped mid-stream")
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        # First, yield a single chunk so the writer's ``open`` runs and the
+        # writer thread parks on its first ``write`` holding one item.
+        yield b"x" * 1024
+        # Wait until the shared queue object exists and the writer has
+        # parked (so it will not consume further), then top the queue off
+        # to its max so the producer's failure-handler ``put_nowait(None)``
+        # is guaranteed to hit ``queue.Full`` and drive the ``get_nowait``
+        # drain (lines 844-852).
+        await asyncio.to_thread(_fill_queue_to_full)
+        raise boom
+
+    def _fill_queue_to_full() -> None:
+        # Busy-wait briefly for the queue to be created and the writer to
+        # park, then saturate it.
+        import time
+
+        deadline = time.monotonic() + 5
+        while not created_queues and time.monotonic() < deadline:
+            time.sleep(0.005)
+        q = created_queues[0]
+        # Give the writer a beat to perform its single ``get`` and park.
+        time.sleep(0.05)
+        while True:
+            try:
+                q.put_nowait(b"pad")
+            except queue.Full:
+                break
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    # Release the parked writer shortly after the failure handler starts so
+    # the writer can exit once the sentinel lands; the producer's
+    # synchronous drain loop (no awaits) has already executed by then.
+    async def _release_soon():
+        await asyncio.sleep(0.2)
+        release_writer.set()
+
+    output_path = tmp_path / "out.bin"
+    releaser = asyncio.ensure_future(_release_soon())
+    try:
+        with (
+            patch.object(httpx, "AsyncClient", return_value=mock_client),
+            patch.object(artifact_downloads, "load_httpx_cookies", return_value=MagicMock()),
+            patch.object(artifact_downloads, "open", blocking_open, create=True),
+            patch.object(artifact_downloads.queue, "Queue", _capturing_queue),
+            pytest.raises(RuntimeError, match="connection dropped"),
+        ):
+            await service.download_url("https://storage.googleapis.com/x.bin", str(output_path))
+    finally:
+        release_writer.set()
+        await releaser
+
+    # Temp file cleaned up; writer exited.
+    assert not output_path.exists()
+    assert list(tmp_path.glob("out.bin.*.tmp")) == []
+    # Sanity: the bounded queue size constant is what we relied on.
+    assert artifact_downloads._DOWNLOAD_WRITER_QUEUE_SIZE < 50
+
+
+# ---------------------------------------------------------------------------
+# Writer fails immediately: short-circuit + surfaced error (lines 764-774,
+# 798, 827)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_writer_failure_surfaced(tmp_path):
+    """Writer thread fails on ``open`` -> captures the error and sets
+    ``writer_failed``. The producer short-circuits (line 798 ``break``) and
+    re-raises the writer's captured exception (line 827), exercising the
+    writer ``except`` block (lines 764-774) too.
+    """
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    boom = OSError("disk full")
+    real_open = open
+
+    def failing_open(path, *args, **kwargs):
+        if str(path).endswith(".tmp"):
+            raise boom
+        return real_open(path, *args, **kwargs)
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        for _ in range(50):
+            yield b"x" * 1024
+            await asyncio.sleep(0)
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    output_path = tmp_path / "out.bin"
+    with (
+        patch.object(httpx, "AsyncClient", return_value=mock_client),
+        patch.object(artifact_downloads, "load_httpx_cookies", return_value=MagicMock()),
+        patch.object(artifact_downloads, "open", failing_open, create=True),
+        pytest.raises(OSError, match="disk full"),
+    ):
+        await service.download_url("https://storage.googleapis.com/x.bin", str(output_path))
+
+    assert not output_path.exists()
+    assert list(tmp_path.glob("out.bin.*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# Back-pressure: producer falls back to to_thread(put) when the queue is
+# full (lines 807-808, 813-814)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_backpressure_to_thread_put(tmp_path):
+    """A slow writer forces the queue full so the producer's chunk ``put``
+    and the final ``None`` sentinel ``put`` both fall back to
+    ``asyncio.to_thread(chunk_q.put, ...)`` (lines 807-808 and 813-814).
+
+    The writer sleeps briefly per write so the bounded queue saturates
+    while the producer streams many small chunks, but the download still
+    completes successfully.
+    """
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    real_open = open
+
+    class _SlowHandle:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def write(self, data):
+            # Slow the writer so the bounded queue fills and the producer
+            # must block on ``to_thread(put)``.
+            import time
+
+            time.sleep(0.01)
+            return self._fh.write(data)
+
+        def __enter__(self):
+            self._fh.__enter__()
+            return self
+
+        def __exit__(self, *exc):
+            return self._fh.__exit__(*exc)
+
+    def slow_open(path, *args, **kwargs):
+        if str(path).endswith(".tmp"):
+            return _SlowHandle(real_open(path, *args, **kwargs))
+        return real_open(path, *args, **kwargs)
+
+    content_chunks = [b"y" * 1024 for _ in range(40)]
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        for chunk in content_chunks:
+            yield chunk
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    output_path = tmp_path / "out.bin"
+    with (
+        patch.object(httpx, "AsyncClient", return_value=mock_client),
+        patch.object(artifact_downloads, "load_httpx_cookies", return_value=MagicMock()),
+        patch.object(artifact_downloads, "open", slow_open, create=True),
+    ):
+        result = await service.download_url(
+            "https://storage.googleapis.com/x.bin", str(output_path)
+        )
+
+    assert result == str(output_path)
+    assert output_path.read_bytes() == b"".join(content_chunks)
+    assert list(tmp_path.glob("out.bin.*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# download_url scheme/host policy rejects (line 665)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_non_https_rejected(tmp_path):
+    """Line 665: a single-URL ``download_url`` rejects non-HTTPS schemes
+    (the batch surface absorbs, but ``download_url`` raises)."""
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    with pytest.raises(ArtifactDownloadError, match="must use HTTPS"):
+        await service.download_url("http://storage.googleapis.com/x.bin", str(tmp_path / "out.bin"))
+
+
+# ---------------------------------------------------------------------------
+# _list_raw delegation (line 182)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_raw_delegates_to_listing():
+    listing = MagicMock()
+    listing.list_raw = AsyncMock(return_value=["raw"])
+    service = _make_service(listing=listing)
+
+    result = await service._list_raw("nb_1")
+
+    assert result == ["raw"]
+    listing.list_raw.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _get_artifact_content safe_index path (line 217)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_artifact_content_indexes_result():
+    """Line 217: a non-null RPC result is indexed via ``safe_index``."""
+    # safe_index(result, 0, 9, 0) -> result[0][9][0] is the HTML string.
+    inner = [None] * 10
+    inner[9] = ["<html>quiz</html>"]
+    # Configure rpc_call at construction (ADR-007 forbids dynamic AsyncMock
+    # attribute assignment onto a duck-typed collaborator).
+    rpc = MagicMock(rpc_call=AsyncMock(return_value=[inner]))
+    service = _make_service(rpc=rpc)
+
+    result = await service._get_artifact_content("nb_1", "quiz_1")
+
+    assert result == "<html>quiz</html>"
+
+
+# ---------------------------------------------------------------------------
+# Interactive artifact success write path (lines 415-426)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interactive_artifact_writes_output(tmp_path, monkeypatch):
+    """Lines 415-426: the happy path formats content and writes the file."""
+    artifact = MagicMock(id="q1", is_completed=True, created_at=None, title="My Quiz")
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[artifact])
+    service._get_artifact_content = AsyncMock(return_value="<html>quiz</html>")
+    monkeypatch.setattr(
+        artifact_downloads, "_extract_app_data", MagicMock(return_value={"quiz": []})
+    )
+    monkeypatch.setattr(
+        artifact_downloads,
+        "_format_interactive_content",
+        MagicMock(return_value="FORMATTED"),
+    )
+
+    out = tmp_path / "nested" / "quiz.json"
+    result = await service.download_interactive_artifact("nb", str(out), None, "json", "quiz")
+
+    assert result == str(out)
+    assert out.read_text(encoding="utf-8") == "FORMATTED"
+
+
+@pytest.mark.asyncio
+async def test_interactive_artifact_default_title_when_untitled(tmp_path, monkeypatch):
+    """Line 415 branch: a flashcards artifact with no title uses the
+    flashcards default title."""
+    artifact = MagicMock(id="f1", is_completed=True, created_at=None, title=None)
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[artifact])
+    service._get_artifact_content = AsyncMock(return_value="<html>cards</html>")
+    monkeypatch.setattr(artifact_downloads, "_extract_app_data", MagicMock(return_value={}))
+    captured_titles: list[str] = []
+
+    def _fmt(app_data, title, fmt, html, is_quiz):
+        captured_titles.append(title)
+        return "OUT"
+
+    monkeypatch.setattr(artifact_downloads, "_format_interactive_content", _fmt)
+
+    out = tmp_path / "cards.md"
+    await service.download_interactive_artifact("nb", str(out), None, "markdown", "flashcards")
+
+    assert captured_titles == ["Untitled Flashcards"]
+
+
+# ---------------------------------------------------------------------------
+# _list_artifacts delegation (line 182)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_artifacts_delegates_to_listing():
+    from notebooklm.types import ArtifactType
+
+    listing = MagicMock()
+    listing.list_artifacts = AsyncMock(return_value=["typed"])
+    service = _make_service(listing=listing)
+
+    result = await service._list_artifacts("nb_1", ArtifactType.QUIZ)
+
+    assert result == ["typed"]
+    listing.list_artifacts.assert_awaited_once()
+    _, kwargs = listing.list_artifacts.call_args
+    assert kwargs["list_raw"] == service._list_raw
+    assert kwargs["list_mind_maps"] == service._list_mind_maps
+
+
+# ---------------------------------------------------------------------------
+# Success-path branch arcs that fall through to download_url / file write
+# (349->369, 399->404, 486->491)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slide_deck_pptx_success_falls_through(tmp_path):
+    """Branch 349->369: a present PPTX URL skips the error and downloads."""
+    service = _make_service()
+    service._list_raw = AsyncMock(return_value=[])
+    service._select_artifact = MagicMock(
+        return_value=_row_with("slide_deck_pptx_url", value="https://x.google.com/s.pptx")
+    )
+    service.download_url = AsyncMock(return_value=str(tmp_path / "s.pptx"))
+
+    result = await service.download_slide_deck("nb", str(tmp_path / "s.pptx"), output_format="pptx")
+
+    assert result == str(tmp_path / "s.pptx")
+    service.download_url.assert_awaited_once_with(
+        "https://x.google.com/s.pptx", str(tmp_path / "s.pptx")
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_specific_id_found_branch(tmp_path, monkeypatch):
+    """Branch 399->404: a matching ``artifact_id`` is selected and used."""
+    wanted = MagicMock(id="wanted", is_completed=True, created_at=None, title="Q")
+    other = MagicMock(id="other", is_completed=True, created_at=None, title="Q2")
+    service = _make_service()
+    service._list_artifacts = AsyncMock(return_value=[other, wanted])
+    captured: list[str] = []
+
+    async def _get_content(nb, art_id):
+        captured.append(art_id)
+        return "<html>quiz</html>"
+
+    service._get_artifact_content = _get_content
+    monkeypatch.setattr(artifact_downloads, "_extract_app_data", MagicMock(return_value={}))
+    monkeypatch.setattr(
+        artifact_downloads, "_format_interactive_content", MagicMock(return_value="OUT")
+    )
+
+    out = tmp_path / "q.json"
+    await service.download_interactive_artifact("nb", str(out), "wanted", "json", "quiz")
+
+    assert captured == ["wanted"]
+    assert out.read_text(encoding="utf-8") == "OUT"
+
+
+@pytest.mark.asyncio
+async def test_mind_map_specific_id_found_branch(tmp_path):
+    """Branch 486->491: a matching mind-map ``artifact_id`` is selected."""
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(
+        return_value=[
+            ["other", None, None, None, "Other"],
+            ["wanted", None, None, None, "Wanted"],
+        ]
+    )
+    mind_maps.extract_content = MagicMock(return_value='{"name": "Root"}')
+    service = _make_service(mind_maps=mind_maps)
+
+    out = tmp_path / "mm.json"
+    result = await service.download_mind_map("nb", str(out), artifact_id="wanted")
+
+    assert result == str(out)
+    # The matching row (id == "wanted") is the one passed to extract_content.
+    (selected_row,), _ = mind_maps.extract_content.call_args
+    assert selected_row[0] == "wanted"
+    assert json.loads(out.read_text(encoding="utf-8")) == {"name": "Root"}
+
+
+# ---------------------------------------------------------------------------
+# Producer except-block: queue.Empty race branch (lines 848-852)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_url_error_path_drain_observes_empty_queue(tmp_path):
+    """Lines 848-852: when the producer fails and tries to enqueue the
+    ``None`` sentinel, the first ``put_nowait`` can hit ``queue.Full`` and
+    the follow-up ``get_nowait`` can find the queue already drained by the
+    writer (``queue.Empty``). The loop then retries the put successfully.
+
+    This race is reproduced deterministically with a ``queue.Queue``
+    subclass that, for the sentinel only, raises ``Full`` on the first put
+    and ``Empty`` on the immediately following get, then accepts the
+    sentinel on the retry — exactly the interleaving the production comment
+    describes.
+    """
+    service = _make_service(storage_path=tmp_path / "storage.json")
+
+    class _RacyQueue(queue.Queue):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._sentinel_full_pending = True
+            self._empty_pending = True
+
+        def put_nowait(self, item):
+            # Force the sentinel's first put to look full so the drain
+            # branch (846-852) runs, then accept it on the retry.
+            if item is None and self._sentinel_full_pending:
+                self._sentinel_full_pending = False
+                raise queue.Full
+            return super().put_nowait(item)
+
+        def get_nowait(self):
+            if self._empty_pending:
+                self._empty_pending = False
+                raise queue.Empty
+            return super().get_nowait()
+
+    boom = RuntimeError("connection dropped mid-stream")
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        yield b"x" * 1024
+        await asyncio.sleep(0)
+        raise boom
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": "video/mp4"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    output_path = tmp_path / "out.bin"
+    with (
+        patch.object(httpx, "AsyncClient", return_value=mock_client),
+        patch.object(artifact_downloads, "load_httpx_cookies", return_value=MagicMock()),
+        patch.object(artifact_downloads.queue, "Queue", _RacyQueue),
+        pytest.raises(RuntimeError, match="connection dropped"),
+    ):
+        await service.download_url("https://storage.googleapis.com/x.bin", str(output_path))
+
+    assert not output_path.exists()
+    assert list(tmp_path.glob("out.bin.*.tmp")) == []

--- a/tests/unit/test_auth_account_coverage.py
+++ b/tests/unit/test_auth_account_coverage.py
@@ -158,14 +158,16 @@ class TestDropLegacyAccountKey:
         storage = tmp_path / "storage_state.json"
         (tmp_path / "context.json").write_text("not json", encoding="utf-8")
         _drop_legacy_account_key(storage)  # no raise
-        assert (tmp_path / "context.json").read_text() == "not json"
+        assert (tmp_path / "context.json").read_text(encoding="utf-8") == "not json"
 
     def test_non_dict_or_missing_account_key_returns(self, tmp_path):
         # data is a dict but no account key → return without write (line 360-361).
         storage = tmp_path / "storage_state.json"
         (tmp_path / "context.json").write_text(json.dumps({"notebook_id": "nb"}), encoding="utf-8")
         _drop_legacy_account_key(storage)
-        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+        assert json.loads((tmp_path / "context.json").read_text(encoding="utf-8")) == {
+            "notebook_id": "nb"
+        }
 
     def test_account_key_removed_but_other_state_preserved(self, tmp_path):
         # account dropped, remaining state rewritten (line 363-364).
@@ -175,7 +177,9 @@ class TestDropLegacyAccountKey:
             encoding="utf-8",
         )
         _drop_legacy_account_key(storage)
-        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+        assert json.loads((tmp_path / "context.json").read_text(encoding="utf-8")) == {
+            "notebook_id": "nb"
+        }
 
     def test_account_only_context_file_unlinked(self, tmp_path):
         # When account was the sole key, the file is removed (line 366).
@@ -205,7 +209,7 @@ class TestDropLegacyAccountKey:
         monkeypatch.setattr(_auth_account, "FileLock", _BoomLock)
         _drop_legacy_account_key(storage)  # swallows OSError, no raise
         # Untouched because the lock failed before any read/write.
-        assert json.loads(context.read_text()) == {"account": {"authuser": 1}}
+        assert json.loads(context.read_text(encoding="utf-8")) == {"account": {"authuser": 1}}
 
 
 class TestLoadStorageStateForWrite:
@@ -245,14 +249,14 @@ class TestClearInBandAccount:
         storage = tmp_path / "storage_state.json"
         storage.write_text("not json", encoding="utf-8")
         _clear_in_band_account(storage)  # debug-log + return, no raise
-        assert storage.read_text() == "not json"
+        assert storage.read_text(encoding="utf-8") == "not json"
 
     def test_non_dict_payload_returns(self, tmp_path):
         # data loads but is not a dict → return (line 481).
         storage = tmp_path / "storage_state.json"
         storage.write_text(json.dumps(["x"]), encoding="utf-8")
         _clear_in_band_account(storage)
-        assert json.loads(storage.read_text()) == ["x"]
+        assert json.loads(storage.read_text(encoding="utf-8")) == ["x"]
 
     def test_namespace_missing_account_key_returns(self, tmp_path):
         # namespace present but no account key → return (line 483-484).
@@ -262,15 +266,15 @@ class TestClearInBandAccount:
         )
         _clear_in_band_account(storage)
         # Untouched.
-        assert json.loads(storage.read_text())["notebooklm"] == {"version": 1}
+        assert json.loads(storage.read_text(encoding="utf-8"))["notebooklm"] == {"version": 1}
 
     def test_account_cleared_drops_version_only_namespace(self, tmp_path):
         # account removed; remaining namespace is {version} → namespace dropped.
         storage = tmp_path / "storage_state.json"
         write_account_metadata(storage, authuser=2, email="bob@example.com")
-        assert "notebooklm" in json.loads(storage.read_text())
+        assert "notebooklm" in json.loads(storage.read_text(encoding="utf-8"))
         _clear_in_band_account(storage)
-        data = json.loads(storage.read_text())
+        data = json.loads(storage.read_text(encoding="utf-8"))
         assert "notebooklm" not in data
 
     def test_account_cleared_keeps_namespace_with_extra_keys(self, tmp_path):
@@ -290,7 +294,7 @@ class TestClearInBandAccount:
             encoding="utf-8",
         )
         _clear_in_band_account(storage)
-        namespace = json.loads(storage.read_text())["notebooklm"]
+        namespace = json.loads(storage.read_text(encoding="utf-8"))["notebooklm"]
         assert "account" not in namespace
         assert namespace["extra"] == "keep-me"
 
@@ -311,8 +315,10 @@ class TestClearAccountMetadataFacade:
 
         clear_account_metadata(storage)
 
-        assert "notebooklm" not in json.loads(storage.read_text())
-        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+        assert "notebooklm" not in json.loads(storage.read_text(encoding="utf-8"))
+        assert json.loads((tmp_path / "context.json").read_text(encoding="utf-8")) == {
+            "notebook_id": "nb"
+        }
 
 
 class TestAccountEmailAndAuthuserValue:
@@ -327,7 +333,7 @@ class TestAccountEmailAndAuthuserValue:
         storage = tmp_path / "storage_state.json"
         write_account_metadata(storage, authuser=1, email="alice@example.com")
         # Overwrite the in-band email with a blank string.
-        data = json.loads(storage.read_text())
+        data = json.loads(storage.read_text(encoding="utf-8"))
         data["notebooklm"]["account"]["email"] = "   "
         storage.write_text(json.dumps(data), encoding="utf-8")
         assert get_account_email_for_storage(storage) is None
@@ -353,7 +359,7 @@ class TestDropLegacyMalformedUnderLock:
         context = tmp_path / "context.json"
         context.write_text("{not valid json", encoding="utf-8")
         _drop_legacy_account_key(storage)  # no raise
-        assert context.read_text() == "{not valid json"
+        assert context.read_text(encoding="utf-8") == "{not valid json"
 
 
 class TestWriteAccountMetadataNamespaceReplace:
@@ -366,7 +372,7 @@ class TestWriteAccountMetadataNamespaceReplace:
             encoding="utf-8",
         )
         write_account_metadata(storage, authuser=3, email="carol@example.com")
-        namespace = json.loads(storage.read_text())["notebooklm"]
+        namespace = json.loads(storage.read_text(encoding="utf-8"))["notebooklm"]
         assert namespace["version"] == 1
         assert namespace["account"] == {"authuser": 3, "email": "carol@example.com"}
 
@@ -385,7 +391,7 @@ class TestWriteAccountMetadataNamespaceReplace:
             encoding="utf-8",
         )
         write_account_metadata(storage, authuser=5, email="dave@example.com")
-        namespace = json.loads(storage.read_text())["notebooklm"]
+        namespace = json.loads(storage.read_text(encoding="utf-8"))["notebooklm"]
         assert namespace["account"] == {"authuser": 5, "email": "dave@example.com"}
         assert namespace["extra"] == "keep"
 
@@ -414,7 +420,7 @@ class TestDropLegacyTocTouRecheck:
         monkeypatch.setattr(Path, "exists", flaky_exists)
         _drop_legacy_account_key(storage)  # returns without touching the file
         # File is left intact because the inner re-check short-circuited.
-        assert json.loads(context.read_text()) == {"account": {"authuser": 1}}
+        assert json.loads(context.read_text(encoding="utf-8")) == {"account": {"authuser": 1}}
 
 
 class TestClearInBandLockFailure:
@@ -438,4 +444,4 @@ class TestClearInBandLockFailure:
         # Should swallow the OSError and not raise.
         _clear_in_band_account(storage)
         # File untouched because the lock failed before any write.
-        assert "notebooklm" in json.loads(storage.read_text())
+        assert "notebooklm" in json.loads(storage.read_text(encoding="utf-8"))

--- a/tests/unit/test_auth_account_coverage.py
+++ b/tests/unit/test_auth_account_coverage.py
@@ -1,0 +1,441 @@
+"""Coverage-focused tests for ``notebooklm._auth.account`` branches.
+
+Targets the read/clear/migration helpers and error-handling branches that the
+concern-aligned ``test_auth_account.py`` suite does not exercise: malformed /
+non-dict storage payloads, the ``_probe_authuser`` non-200 path, legacy
+``context.json`` migration cleanup, the corrupt-storage ``RuntimeError`` guard,
+and the in-band clear helper's no-op / lock branches.
+
+New file per ADR-007: patches owning modules at the bare-name call site rather
+than editing the existing concern-aligned test file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from notebooklm._auth import account as _auth_account
+from notebooklm._auth.account import (
+    Account,
+    _clear_in_band_account,
+    _drop_legacy_account_key,
+    _load_storage_state_for_write,
+    _probe_authuser,
+    _read_in_band_account,
+    _read_legacy_account,
+    clear_account_metadata,
+    enumerate_accounts,
+    format_authuser_value,
+    get_account_email_for_storage,
+    read_account_metadata_from_storage_state,
+    write_account_metadata,
+)
+
+
+class TestProbeAuthuserNon200:
+    """``_probe_authuser`` returns ``None`` for non-200 responses (line 131)."""
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_none(self):
+        async def fake_get(*args, **kwargs):
+            request = httpx.Request("GET", "https://notebooklm.google.com/?authuser=0")
+            return httpx.Response(503, content=b"down", request=request)
+
+        class _Client:
+            get = staticmethod(fake_get)
+
+        result = await _probe_authuser(_Client(), 0)  # type: ignore[arg-type]
+        assert result is None
+
+
+class TestEnumerateAccountsPokeHook:
+    """``enumerate_accounts`` runs the optional poke hook before probing (line 184)."""
+
+    @pytest.mark.asyncio
+    async def test_poke_session_hook_invoked(self, monkeypatch):
+        poked: list[object] = []
+
+        async def fake_poke(client, storage_path):
+            poked.append((client, storage_path))
+
+        async def fake_probe(client, n):
+            return "alice@example.com" if n == 0 else "alice@example.com"
+
+        monkeypatch.setattr(_auth_account, "_probe_authuser", fake_probe)
+
+        jar = httpx.Cookies()
+        jar.set("SID", "x", domain=".google.com")
+        accounts = await enumerate_accounts(jar, max_authuser=2, poke_session=fake_poke)
+
+        assert poked, "poke_session hook was not invoked"
+        assert accounts == [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+    @pytest.mark.asyncio
+    async def test_poke_session_none_skips_hook(self, monkeypatch):
+        # poke_session defaults to None on the bare ``_auth.account`` entry
+        # point → the hook is skipped (183->185 false arc).
+        async def fake_probe(client, n):
+            return "alice@example.com"
+
+        monkeypatch.setattr(_auth_account, "_probe_authuser", fake_probe)
+
+        jar = httpx.Cookies()
+        jar.set("SID", "x", domain=".google.com")
+        accounts = await enumerate_accounts(jar, max_authuser=2)
+
+        assert accounts == [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+
+class TestReadInBandAccount:
+    """In-band reader malformed / non-dict branches (lines 232-234, 241)."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _read_in_band_account(tmp_path / "missing.json") == {}
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("not json", encoding="utf-8")
+        assert _read_in_band_account(storage) == {}
+
+    def test_non_dict_storage_state_returns_empty(self):
+        # read_account_metadata_from_storage_state guard: non-dict → {} (line 241).
+        assert read_account_metadata_from_storage_state(["not", "a", "dict"]) == {}
+
+    def test_namespace_not_dict_returns_empty(self):
+        assert read_account_metadata_from_storage_state({"notebooklm": "oops"}) == {}
+
+    def test_account_not_dict_returns_empty(self):
+        assert (
+            read_account_metadata_from_storage_state(
+                {"notebooklm": {"account": "oops", "version": 1}}
+            )
+            == {}
+        )
+
+    def test_well_formed_account_returned(self):
+        assert read_account_metadata_from_storage_state(
+            {"notebooklm": {"version": 1, "account": {"authuser": 3}}}
+        ) == {"authuser": 3}
+
+
+class TestReadLegacyAccount:
+    """Legacy ``context.json`` reader non-dict branch (line 260)."""
+
+    def test_missing_context_returns_empty(self, tmp_path):
+        assert _read_legacy_account(tmp_path / "storage_state.json") == {}
+
+    def test_malformed_legacy_json_returns_empty(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text("not json", encoding="utf-8")
+        assert _read_legacy_account(storage) == {}
+
+    def test_non_dict_legacy_payload_returns_empty(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text(json.dumps(["x"]), encoding="utf-8")
+        assert _read_legacy_account(storage) == {}
+
+    def test_legacy_account_returned(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text(
+            json.dumps({"account": {"authuser": 4}}), encoding="utf-8"
+        )
+        assert _read_legacy_account(storage) == {"authuser": 4}
+
+
+class TestDropLegacyAccountKey:
+    """``_drop_legacy_account_key`` migration branches (lines 353, 366, 368)."""
+
+    def test_no_context_file_is_noop(self, tmp_path):
+        # context.json missing → early return (line ~348-349).
+        _drop_legacy_account_key(tmp_path / "storage_state.json")
+
+    def test_malformed_context_json_skipped(self, tmp_path):
+        # Read under lock raises → debug log + return (line ~357-359).
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text("not json", encoding="utf-8")
+        _drop_legacy_account_key(storage)  # no raise
+        assert (tmp_path / "context.json").read_text() == "not json"
+
+    def test_non_dict_or_missing_account_key_returns(self, tmp_path):
+        # data is a dict but no account key → return without write (line 360-361).
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text(json.dumps({"notebook_id": "nb"}), encoding="utf-8")
+        _drop_legacy_account_key(storage)
+        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+
+    def test_account_key_removed_but_other_state_preserved(self, tmp_path):
+        # account dropped, remaining state rewritten (line 363-364).
+        storage = tmp_path / "storage_state.json"
+        (tmp_path / "context.json").write_text(
+            json.dumps({"notebook_id": "nb", "account": {"authuser": 1}}),
+            encoding="utf-8",
+        )
+        _drop_legacy_account_key(storage)
+        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+
+    def test_account_only_context_file_unlinked(self, tmp_path):
+        # When account was the sole key, the file is removed (line 366).
+        storage = tmp_path / "storage_state.json"
+        context = tmp_path / "context.json"
+        context.write_text(json.dumps({"account": {"authuser": 1}}), encoding="utf-8")
+        _drop_legacy_account_key(storage)
+        assert not context.exists()
+
+    def test_oserror_from_lock_is_swallowed(self, tmp_path, monkeypatch):
+        # Best-effort migration: an OSError acquiring the lock is swallowed
+        # (lines 367-369).
+        storage = tmp_path / "storage_state.json"
+        context = tmp_path / "context.json"
+        context.write_text(json.dumps({"account": {"authuser": 1}}), encoding="utf-8")
+
+        class _BoomLock:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                raise OSError("lock unavailable")
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(_auth_account, "FileLock", _BoomLock)
+        _drop_legacy_account_key(storage)  # swallows OSError, no raise
+        # Untouched because the lock failed before any read/write.
+        assert json.loads(context.read_text()) == {"account": {"authuser": 1}}
+
+
+class TestLoadStorageStateForWrite:
+    """``_load_storage_state_for_write`` synthetic + corruption guards
+    (lines 430-433)."""
+
+    def test_missing_file_returns_synthetic_document(self, tmp_path):
+        result = _load_storage_state_for_write(tmp_path / "missing.json")
+        assert result == {"cookies": [], "origins": []}
+
+    def test_corrupt_json_raises_runtime_error(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="is corrupted"):
+            _load_storage_state_for_write(storage)
+
+    def test_non_dict_shape_raises_runtime_error(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(RuntimeError, match="unexpected shape"):
+            _load_storage_state_for_write(storage)
+
+    def test_valid_dict_returned(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(json.dumps({"cookies": []}), encoding="utf-8")
+        assert _load_storage_state_for_write(storage) == {"cookies": []}
+
+
+class TestClearInBandAccount:
+    """``_clear_in_band_account`` no-op / branch coverage
+    (lines 447, 469-471, 473, 481, 483-484)."""
+
+    def test_missing_file_is_noop(self, tmp_path):
+        _clear_in_band_account(tmp_path / "missing.json")  # early return
+
+    def test_malformed_json_skipped(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("not json", encoding="utf-8")
+        _clear_in_band_account(storage)  # debug-log + return, no raise
+        assert storage.read_text() == "not json"
+
+    def test_non_dict_payload_returns(self, tmp_path):
+        # data loads but is not a dict → return (line 481).
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(json.dumps(["x"]), encoding="utf-8")
+        _clear_in_band_account(storage)
+        assert json.loads(storage.read_text()) == ["x"]
+
+    def test_namespace_missing_account_key_returns(self, tmp_path):
+        # namespace present but no account key → return (line 483-484).
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(
+            json.dumps({"cookies": [], "notebooklm": {"version": 1}}), encoding="utf-8"
+        )
+        _clear_in_band_account(storage)
+        # Untouched.
+        assert json.loads(storage.read_text())["notebooklm"] == {"version": 1}
+
+    def test_account_cleared_drops_version_only_namespace(self, tmp_path):
+        # account removed; remaining namespace is {version} → namespace dropped.
+        storage = tmp_path / "storage_state.json"
+        write_account_metadata(storage, authuser=2, email="bob@example.com")
+        assert "notebooklm" in json.loads(storage.read_text())
+        _clear_in_band_account(storage)
+        data = json.loads(storage.read_text())
+        assert "notebooklm" not in data
+
+    def test_account_cleared_keeps_namespace_with_extra_keys(self, tmp_path):
+        # namespace carries an extra (non-version) key → namespace retained.
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(
+            json.dumps(
+                {
+                    "cookies": [],
+                    "notebooklm": {
+                        "version": 1,
+                        "account": {"authuser": 1},
+                        "extra": "keep-me",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _clear_in_band_account(storage)
+        namespace = json.loads(storage.read_text())["notebooklm"]
+        assert "account" not in namespace
+        assert namespace["extra"] == "keep-me"
+
+
+class TestClearAccountMetadataFacade:
+    """``clear_account_metadata`` covers in-band + legacy paths together."""
+
+    def test_none_storage_path_is_noop(self):
+        clear_account_metadata(None)
+
+    def test_clears_both_in_band_and_legacy(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        write_account_metadata(storage, authuser=1, email="alice@example.com")
+        (tmp_path / "context.json").write_text(
+            json.dumps({"notebook_id": "nb", "account": {"authuser": 1}}),
+            encoding="utf-8",
+        )
+
+        clear_account_metadata(storage)
+
+        assert "notebooklm" not in json.loads(storage.read_text())
+        assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb"}
+
+
+class TestAccountEmailAndAuthuserValue:
+    """Residual branches in email/authuser-value resolution (lines 317, 329->331)."""
+
+    def test_get_account_email_returns_none_when_absent(self, tmp_path):
+        # No metadata at all → falls through to None (line 317).
+        assert get_account_email_for_storage(tmp_path / "storage_state.json") is None
+
+    def test_get_account_email_returns_none_for_blank_email(self, tmp_path):
+        # Persisted email is whitespace-only → stripped to "" → None (line 317).
+        storage = tmp_path / "storage_state.json"
+        write_account_metadata(storage, authuser=1, email="alice@example.com")
+        # Overwrite the in-band email with a blank string.
+        data = json.loads(storage.read_text())
+        data["notebooklm"]["account"]["email"] = "   "
+        storage.write_text(json.dumps(data), encoding="utf-8")
+        assert get_account_email_for_storage(storage) is None
+
+    def test_format_authuser_value_blank_email_falls_back_to_index(self):
+        # Whitespace-only email is ignored; integer index is used (329->331).
+        assert format_authuser_value(2, "   ") == "2"
+
+    def test_format_authuser_value_prefers_real_email(self):
+        assert format_authuser_value(0, "bob@example.com") == "bob@example.com"
+
+    def test_format_authuser_value_default_index(self):
+        assert format_authuser_value() == "0"
+
+
+class TestDropLegacyMalformedUnderLock:
+    """``_drop_legacy_account_key`` malformed-read-under-lock branch (line 354)."""
+
+    def test_malformed_json_under_lock_is_skipped(self, tmp_path):
+        # The file exists with content that survives the first existence check
+        # but fails json parsing while holding the lock → debug-log + return.
+        storage = tmp_path / "storage_state.json"
+        context = tmp_path / "context.json"
+        context.write_text("{not valid json", encoding="utf-8")
+        _drop_legacy_account_key(storage)  # no raise
+        assert context.read_text() == "{not valid json"
+
+
+class TestWriteAccountMetadataNamespaceReplace:
+    """``write_account_metadata`` namespace handling (lines 410, 410->412)."""
+
+    def test_non_dict_namespace_is_replaced(self, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(
+            json.dumps({"cookies": [], "origins": [], "notebooklm": "corrupt"}),
+            encoding="utf-8",
+        )
+        write_account_metadata(storage, authuser=3, email="carol@example.com")
+        namespace = json.loads(storage.read_text())["notebooklm"]
+        assert namespace["version"] == 1
+        assert namespace["account"] == {"authuser": 3, "email": "carol@example.com"}
+
+    def test_existing_dict_namespace_is_updated_in_place(self, tmp_path):
+        # File already carries a valid ``notebooklm`` dict namespace → the
+        # ``isinstance`` guard is True so the reassignment is skipped (410->412).
+        storage = tmp_path / "storage_state.json"
+        storage.write_text(
+            json.dumps(
+                {
+                    "cookies": [],
+                    "origins": [],
+                    "notebooklm": {"version": 1, "extra": "keep", "account": {"authuser": 0}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        write_account_metadata(storage, authuser=5, email="dave@example.com")
+        namespace = json.loads(storage.read_text())["notebooklm"]
+        assert namespace["account"] == {"authuser": 5, "email": "dave@example.com"}
+        assert namespace["extra"] == "keep"
+
+
+class TestDropLegacyTocTouRecheck:
+    """Inner existence re-check return under the lock (line 354)."""
+
+    def test_file_vanishes_after_lock_acquired(self, tmp_path, monkeypatch):
+        storage = tmp_path / "storage_state.json"
+        context = tmp_path / "context.json"
+        context.write_text(json.dumps({"account": {"authuser": 1}}), encoding="utf-8")
+
+        original_exists = Path.exists
+        calls = {"n": 0}
+
+        def flaky_exists(self):
+            # First call (outer guard) sees the file; second call (inner
+            # re-check under the lock) reports it gone, exercising the TOCTOU
+            # return at line 354.
+            if self == context:
+                calls["n"] += 1
+                if calls["n"] >= 2:
+                    return False
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", flaky_exists)
+        _drop_legacy_account_key(storage)  # returns without touching the file
+        # File is left intact because the inner re-check short-circuited.
+        assert json.loads(context.read_text()) == {"account": {"authuser": 1}}
+
+
+class TestClearInBandLockFailure:
+    """Best-effort OSError handling in ``_clear_in_band_account`` (line 491-492)."""
+
+    def test_oserror_from_lock_is_swallowed(self, tmp_path, monkeypatch):
+        storage = tmp_path / "storage_state.json"
+        write_account_metadata(storage, authuser=1)
+
+        class _BoomLock:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                raise OSError("lock unavailable")
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(_auth_account, "FileLock", _BoomLock)
+        # Should swallow the OSError and not raise.
+        _clear_in_band_account(storage)
+        # File untouched because the lock failed before any write.
+        assert "notebooklm" in json.loads(storage.read_text())

--- a/tests/unit/test_auth_refresh_coverage.py
+++ b/tests/unit/test_auth_refresh_coverage.py
@@ -1,0 +1,416 @@
+"""Coverage-focused tests for ``notebooklm._auth.refresh`` branches.
+
+Targets the refresh-cmd driver branches that the concern-aligned
+``test_auth_refresh.py`` / ``test_refresh_cmd_shlex.py`` /
+``test_refresh_cmd_redaction.py`` suites do not exercise: the
+``_should_try_refresh`` attempted-flag guard, ``_run_refresh_cmd``
+missing-command and subprocess-failure (timeout / OSError) raises, the
+shell-mode and empty-target basename extraction in the non-zero-exit raise,
+the ``_settle`` future-cancel callback, and the post-refresh retry
+``route_kwargs`` (``account_email`` / ``force_authuser_query``) plumbing.
+
+New file per ADR-007: patches the owning ``_auth.refresh`` module at the
+bare-name call site rather than editing the existing concern-aligned files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._auth import refresh as _auth_refresh
+
+
+@pytest.fixture(autouse=True)
+def _clear_refresh_env(monkeypatch):
+    """Each test starts with no inherited refresh-cmd env vars / flags."""
+    monkeypatch.delenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, raising=False)
+    monkeypatch.delenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, raising=False)
+    monkeypatch.delenv(_auth_refresh._REFRESH_ATTEMPTED_ENV, raising=False)
+
+
+class TestShouldTryRefresh:
+    """``_should_try_refresh`` guard branches (line 247)."""
+
+    def test_false_when_context_flag_set(self, monkeypatch):
+        # ContextVar attempted flag set → no second refresh attempt (line 247).
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        token = _auth_refresh._REFRESH_ATTEMPTED_CONTEXT.set(True)
+        try:
+            assert _auth_refresh._should_try_refresh(ValueError("authentication expired")) is False
+        finally:
+            _auth_refresh._REFRESH_ATTEMPTED_CONTEXT.reset(token)
+
+    def test_false_when_env_attempted_flag_set(self, monkeypatch):
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setenv(_auth_refresh._REFRESH_ATTEMPTED_ENV, "1")
+        assert _auth_refresh._should_try_refresh(ValueError("authentication expired")) is False
+
+    def test_false_when_cmd_env_unset(self):
+        assert _auth_refresh._should_try_refresh(ValueError("authentication expired")) is False
+
+    def test_true_for_auth_signal_with_cmd_set(self, monkeypatch):
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        assert _auth_refresh._should_try_refresh(ValueError("Redirected to login")) is True
+
+    def test_false_for_non_auth_error(self, monkeypatch):
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        assert _auth_refresh._should_try_refresh(ValueError("network down")) is False
+
+
+class TestRunRefreshCmdMissing:
+    """``_run_refresh_cmd`` raises when the env var is unset (line 315)."""
+
+    @pytest.mark.asyncio
+    async def test_missing_cmd_raises_runtime_error(self):
+        with pytest.raises(RuntimeError, match="is not set; cannot refresh cookies"):
+            await _auth_refresh._run_refresh_cmd()
+
+
+class TestRunRefreshCmdSubprocessFailure:
+    """``subprocess.run`` raising → RuntimeError (lines 370-371)."""
+
+    def _stub_storage(self, monkeypatch, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("{}")
+        monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
+        return storage
+
+    @pytest.mark.asyncio
+    async def test_timeout_expired_becomes_runtime_error(self, monkeypatch, tmp_path):
+        self._stub_storage(monkeypatch, tmp_path)
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="echo", timeout=60)
+
+        monkeypatch.setattr(subprocess, "run", _raise_timeout)
+        with pytest.raises(RuntimeError, match="failed to execute"):
+            await _auth_refresh._run_refresh_cmd()
+
+    @pytest.mark.asyncio
+    async def test_oserror_becomes_runtime_error(self, monkeypatch, tmp_path):
+        self._stub_storage(monkeypatch, tmp_path)
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+
+        def _raise_oserror(*args, **kwargs):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(subprocess, "run", _raise_oserror)
+        with pytest.raises(RuntimeError, match="failed to execute"):
+            await _auth_refresh._run_refresh_cmd()
+
+
+class TestRunRefreshCmdNonZeroExitBasename:
+    """Non-zero exit basename extraction for shell / empty targets (390-393)."""
+
+    def _stub_storage(self, monkeypatch, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("{}")
+        monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
+
+    def _stub_nonzero_run(self, monkeypatch):
+        class _Result:
+            returncode = 7
+            stdout = "secret-out"
+            stderr = "secret-err"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Result())
+
+    @pytest.mark.asyncio
+    async def test_shell_mode_string_target_basename(self, monkeypatch, tmp_path):
+        # Shell-mode keeps ``run_target`` as a raw string; basename comes from
+        # its first whitespace-split token (lines 390-391).
+        self._stub_storage(monkeypatch, tmp_path)
+        monkeypatch.setenv(
+            _auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV,
+            "/opt/secrets/do-refresh.sh --token=hunter2 | tee log",
+        )
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "1")
+        self._stub_nonzero_run(monkeypatch)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await _auth_refresh._run_refresh_cmd()
+
+        message = exc_info.value.args[0]
+        assert "exited 7" in message
+        assert "do-refresh.sh" in message
+        # Neither the directory nor the token leak into the user-facing message.
+        assert "/opt/secrets" not in message
+        assert "hunter2" not in message
+
+    @pytest.mark.asyncio
+    async def test_shell_mode_whitespace_only_target_uses_shell_literal(
+        self, monkeypatch, tmp_path
+    ):
+        # Whitespace-only command string in shell-mode → ``run_target.strip()``
+        # is empty so the basename falls back to the literal ``"shell"`` (393).
+        self._stub_storage(monkeypatch, tmp_path)
+        # The env-not-set guard treats "" as missing; spaces bypass it while
+        # still stripping to empty in the basename branch.
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "   ")
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "1")
+        self._stub_nonzero_run(monkeypatch)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await _auth_refresh._run_refresh_cmd()
+
+        message = exc_info.value.args[0]
+        assert "exited 7" in message
+        assert "executable: shell" in message
+
+
+class TestSplitRefreshCmdWindowsBranch:
+    """Cover the Windows ``CommandLineToArgvW`` branch on non-Windows hosts.
+
+    Lines 270-295 are gated on ``os.name == "nt"`` and call into
+    ``ctypes.windll`` (which does not exist off-Windows). We fake ``os.name``
+    and inject a stand-in ``ctypes.windll`` so the parsing logic — including
+    the NULL-pointer empty-input guard and the empty-entry filter — is
+    exercised on Linux CI.
+    """
+
+    @staticmethod
+    def _install_fake_windll(monkeypatch, *, parsed: list[str] | None, null: bool = False):
+        freed = {"count": 0}
+
+        def _argv_for(_cmd, argc_ref):
+            if null:
+                argc_ref._obj.value = 0
+                return None  # NULL pointer → empty-input guard (282->286).
+            argc_ref._obj.value = len(parsed or [])
+            # Return a simple index-addressable container; the source reads
+            # ``argv_ptr[i]`` for ``i in range(argc.value)``.
+            return list(parsed or [])
+
+        class _Shell32:
+            CommandLineToArgvW = staticmethod(_argv_for)
+
+        class _Kernel32:
+            @staticmethod
+            def LocalFree(_ptr):
+                freed["count"] += 1
+                return None
+
+        class _WinDLL:
+            shell32 = _Shell32()
+            kernel32 = _Kernel32()
+
+        monkeypatch.setattr(_auth_refresh.os, "name", "nt")
+        monkeypatch.setattr(ctypes, "windll", _WinDLL(), raising=False)
+
+        # ``ctypes.byref`` wraps the ``c_int`` so the fake can mutate ``.value``.
+        real_byref = ctypes.byref
+
+        class _Ref:
+            def __init__(self, obj):
+                self._obj = obj
+
+        monkeypatch.setattr(ctypes, "byref", lambda obj: _Ref(obj))
+        # ``cast`` is only used to free the buffer; make it a passthrough so it
+        # does not choke on our list stand-in.
+        monkeypatch.setattr(ctypes, "cast", lambda ptr, typ: ptr)
+        return freed, real_byref
+
+    def test_windows_parses_quoted_tokens_and_frees(self, monkeypatch):
+        freed, _ = self._install_fake_windll(
+            monkeypatch, parsed=[r"C:\Program Files\python.exe", "script.py"]
+        )
+        argv = _auth_refresh._split_refresh_cmd('"C:\\Program Files\\python.exe" script.py')
+        assert argv == [r"C:\Program Files\python.exe", "script.py"]
+        # The ``finally`` LocalFree cleanup ran (line 295).
+        assert freed["count"] == 1
+
+    def test_windows_filters_empty_entries(self, monkeypatch):
+        # Whitespace-only input → CommandLineToArgvW returns a single empty
+        # entry; the comprehension filters it so the caller's empty-argv guard
+        # trips (line 293 filter).
+        self._install_fake_windll(monkeypatch, parsed=[""])
+        assert _auth_refresh._split_refresh_cmd("   ") == []
+
+    def test_windows_null_pointer_returns_empty(self, monkeypatch):
+        # NULL pointer for some empty-input edge cases → early empty list
+        # return (lines 282->286).
+        self._install_fake_windll(monkeypatch, parsed=None, null=True)
+        assert _auth_refresh._split_refresh_cmd("") == []
+
+
+class TestSettleCallbackCancel:
+    """``_settle`` propagates task cancellation to the future (line 195)."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_task_cancels_future(self, monkeypatch):
+        # Drive ``_coalesced_run_refresh_cmd`` where the underlying
+        # ``_run_refresh_cmd`` task is cancelled mid-flight. ``_settle`` must
+        # call ``future.cancel()`` (line 195), surfacing CancelledError to the
+        # awaiter.
+        started = asyncio.Event()
+
+        async def _slow_refresh(storage_path=None, profile=None):
+            started.set()
+            await asyncio.sleep(10)
+
+        monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", _slow_refresh)
+
+        async def _drive():
+            await _auth_refresh._coalesced_run_refresh_cmd(
+                "cancel-key", Path("/tmp/storage_state.json"), None
+            )
+
+        task = asyncio.create_task(_drive())
+        await started.wait()
+        # Cancel the leader subprocess task directly so ``_settle`` runs the
+        # ``t.cancelled()`` → ``future.cancel()`` branch.
+        inflight = list(_auth_refresh._REFRESH_INFLIGHT_TASKS)
+        assert inflight, "expected an in-flight refresh task"
+        for t in inflight:
+            t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+class TestFetchTokensCancelSettleRace:
+    """Caller-cancel + already-settled in-flight future race (lines 575, 578, 580, 581).
+
+    When ``_coalesced_run_refresh_cmd`` raises ``CancelledError`` (caller-side
+    cancellation) but the underlying subprocess future is already ``done()``
+    and left in the registry by ``_settle``, ``_fetch_tokens_with_refresh``
+    inspects the future's terminal state: a cancelled future yields a synthetic
+    ``CancelledError`` (575->578); a failed future yields its exception
+    (580); either way the loop breaks (581) and the caller propagates
+    ``CancelledError``.
+    """
+
+    def _common_patches(self, monkeypatch, storage):
+        async def fake_fetch_tokens_with_jar(cookie_jar, storage_path=None, **route_kwargs):
+            raise ValueError("Authentication expired. Redirected to login.")
+
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+
+    @pytest.mark.asyncio
+    async def test_done_future_with_exception_propagates_cancel(self, monkeypatch, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("{}")
+        self._common_patches(monkeypatch, storage)
+        refresh_key = str(storage.expanduser().resolve())
+
+        async def fake_coalesced(key, resolved_storage_path, profile):
+            # Insert a DONE future carrying an exception into the per-loop
+            # registry, then raise CancelledError to simulate caller-side
+            # cancellation arriving after the subprocess settled with failure.
+            loop = asyncio.get_running_loop()
+            fut: asyncio.Future[None] = loop.create_future()
+            fut.set_exception(RuntimeError("subprocess boom"))
+            registry = _auth_refresh._get_inflight_registry()
+            with _auth_refresh._REFRESH_STATE_LOCK:
+                registry[key] = fut
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(_auth_refresh, "_coalesced_run_refresh_cmd", fake_coalesced)
+
+        with pytest.raises(asyncio.CancelledError):
+            await _auth_refresh._fetch_tokens_with_refresh(httpx.Cookies(), storage, None)
+
+        # Clean up the leftover registry entry so other tests start clean.
+        registry = _auth_refresh._get_inflight_registry()
+        with _auth_refresh._REFRESH_STATE_LOCK:
+            registry.pop(refresh_key, None)
+
+    @pytest.mark.asyncio
+    async def test_done_future_cancelled_propagates_cancel(self, monkeypatch, tmp_path):
+        storage = tmp_path / "storage_state2.json"
+        storage.write_text("{}")
+        self._common_patches(monkeypatch, storage)
+        refresh_key = str(storage.expanduser().resolve())
+
+        async def fake_coalesced(key, resolved_storage_path, profile):
+            # Insert a DONE *cancelled* future, then raise CancelledError. This
+            # drives the ``inflight.cancelled()`` branch (575 -> 578).
+            loop = asyncio.get_running_loop()
+            fut: asyncio.Future[None] = loop.create_future()
+            fut.cancel()
+            # Allow the cancellation to settle the future as cancelled.
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                pass
+            registry = _auth_refresh._get_inflight_registry()
+            with _auth_refresh._REFRESH_STATE_LOCK:
+                registry[key] = fut
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(_auth_refresh, "_coalesced_run_refresh_cmd", fake_coalesced)
+
+        with pytest.raises(asyncio.CancelledError):
+            await _auth_refresh._fetch_tokens_with_refresh(httpx.Cookies(), storage, None)
+
+        registry = _auth_refresh._get_inflight_registry()
+        with _auth_refresh._REFRESH_STATE_LOCK:
+            registry.pop(refresh_key, None)
+
+
+class TestPostRefreshRetryRouteKwargs:
+    """Post-refresh retry forwards account_email / force_authuser_query (637, 639)."""
+
+    @pytest.mark.asyncio
+    async def test_retry_forwards_account_email_and_force_authuser(self, monkeypatch, tmp_path):
+        storage = tmp_path / "storage_state.json"
+        storage.write_text("{}")
+
+        # First fetch raises an auth-expiry ValueError to trigger refresh; the
+        # retry fetch records the route kwargs it received.
+        calls: list[dict[str, Any]] = []
+        state = {"first": True}
+
+        async def fake_fetch_tokens_with_jar(cookie_jar, storage_path=None, **route_kwargs):
+            if state["first"]:
+                state["first"] = False
+                raise ValueError("Authentication expired. Redirected to login.")
+            calls.append(route_kwargs)
+            return "csrf_after", "sess_after"
+
+        async def fake_coalesced(refresh_key, resolved_storage_path, profile):
+            return None
+
+        def fake_build_jar(path):
+            return httpx.Cookies()
+
+        def fake_replace(target, source):
+            return None
+
+        def fake_snapshot(jar):
+            return None
+
+        monkeypatch.setenv(_auth_refresh.NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+        monkeypatch.setattr(_auth_refresh, "_coalesced_run_refresh_cmd", fake_coalesced)
+        monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build_jar)
+        monkeypatch.setattr(_auth_refresh, "_replace_cookie_jar", fake_replace)
+        monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
+
+        csrf, session_id, refreshed, _snap = await _auth_refresh._fetch_tokens_with_refresh(
+            httpx.Cookies(),
+            storage,
+            None,
+            authuser=0,
+            account_email="bob@example.com",
+            force_authuser_query=True,
+        )
+
+        assert refreshed is True
+        assert csrf == "csrf_after"
+        assert session_id == "sess_after"
+        assert calls, "retry fetch was not invoked"
+        retry_kwargs = calls[0]
+        assert retry_kwargs["account_email"] == "bob@example.com"
+        assert retry_kwargs["force_authuser_query"] is True
+        assert retry_kwargs["authuser"] == 0

--- a/tests/unit/test_auth_refresh_coverage.py
+++ b/tests/unit/test_auth_refresh_coverage.py
@@ -78,7 +78,7 @@ class TestRunRefreshCmdSubprocessFailure:
 
     def _stub_storage(self, monkeypatch, tmp_path):
         storage = tmp_path / "storage_state.json"
-        storage.write_text("{}")
+        storage.write_text("{}", encoding="utf-8")
         monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
         return storage
 
@@ -112,7 +112,7 @@ class TestRunRefreshCmdNonZeroExitBasename:
 
     def _stub_storage(self, monkeypatch, tmp_path):
         storage = tmp_path / "storage_state.json"
-        storage.write_text("{}")
+        storage.write_text("{}", encoding="utf-8")
         monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage)
 
     def _stub_nonzero_run(self, monkeypatch):
@@ -298,7 +298,7 @@ class TestFetchTokensCancelSettleRace:
     @pytest.mark.asyncio
     async def test_done_future_with_exception_propagates_cancel(self, monkeypatch, tmp_path):
         storage = tmp_path / "storage_state.json"
-        storage.write_text("{}")
+        storage.write_text("{}", encoding="utf-8")
         self._common_patches(monkeypatch, storage)
         refresh_key = str(storage.expanduser().resolve())
 
@@ -327,7 +327,7 @@ class TestFetchTokensCancelSettleRace:
     @pytest.mark.asyncio
     async def test_done_future_cancelled_propagates_cancel(self, monkeypatch, tmp_path):
         storage = tmp_path / "storage_state2.json"
-        storage.write_text("{}")
+        storage.write_text("{}", encoding="utf-8")
         self._common_patches(monkeypatch, storage)
         refresh_key = str(storage.expanduser().resolve())
 
@@ -363,7 +363,7 @@ class TestPostRefreshRetryRouteKwargs:
     @pytest.mark.asyncio
     async def test_retry_forwards_account_email_and_force_authuser(self, monkeypatch, tmp_path):
         storage = tmp_path / "storage_state.json"
-        storage.write_text("{}")
+        storage.write_text("{}", encoding="utf-8")
 
         # First fetch raises an auth-expiry ValueError to trigger refresh; the
         # retry fetch records the route kwargs it received.

--- a/tests/unit/test_chromium_profiles_coverage.py
+++ b/tests/unit/test_chromium_profiles_coverage.py
@@ -1,0 +1,133 @@
+"""Coverage gap tests for ``notebooklm.cli._chromium_profiles``.
+
+These exercise the per-platform user-data-dir tables, the platform dispatch
+helper, the ``Local State`` ``info_cache`` non-dict guard, and the
+profile-choice formatting helpers — branches not covered by the existing
+``tests/unit/test_chromium_profiles.py`` suite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from notebooklm.cli import _chromium_profiles
+from notebooklm.cli._chromium_profiles import (
+    ChromiumProfile,
+    _format_chromium_profile_choices,
+    _linux_user_data_dirs,
+    _load_local_state_names,
+    _macos_user_data_dirs,
+    _platform_user_data_dirs,
+    _windows_user_data_dirs,
+)
+
+
+class TestMacosUserDataDirs:
+    def test_returns_expected_browser_keys(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/Users/test")))
+        dirs = _macos_user_data_dirs()
+        assert set(dirs) == {
+            "chrome",
+            "chromium",
+            "brave",
+            "edge",
+            "arc",
+            "vivaldi",
+            "opera",
+            "opera-gx",
+        }
+        assert dirs["chrome"] == Path("/Users/test/Library/Application Support/Google/Chrome")
+        assert dirs["brave"] == Path(
+            "/Users/test/Library/Application Support/BraveSoftware/Brave-Browser"
+        )
+
+
+class TestWindowsUserDataDirs:
+    def test_localappdata_and_appdata_present(self, monkeypatch):
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\test\AppData\Local")
+        monkeypatch.setenv("APPDATA", r"C:\Users\test\AppData\Roaming")
+        dirs = _windows_user_data_dirs()
+        # LOCALAPPDATA-backed browsers
+        assert "chrome" in dirs
+        assert "edge" in dirs
+        assert (
+            dirs["chrome"]
+            == Path(r"C:\Users\test\AppData\Local") / "Google" / "Chrome" / "User Data"
+        )
+        # APPDATA (Roaming)-backed Opera
+        assert (
+            dirs["opera"]
+            == Path(r"C:\Users\test\AppData\Roaming") / "Opera Software" / "Opera Stable"
+        )
+        assert dirs["opera-gx"] == (
+            Path(r"C:\Users\test\AppData\Roaming") / "Opera Software" / "Opera GX Stable"
+        )
+
+    def test_missing_env_vars_yields_empty(self, monkeypatch):
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.delenv("APPDATA", raising=False)
+        assert _windows_user_data_dirs() == {}
+
+
+class TestPlatformUserDataDirs:
+    def test_darwin_dispatches_to_macos(self, monkeypatch):
+        monkeypatch.setattr(_chromium_profiles.sys, "platform", "darwin")
+        sentinel = {"chrome": Path("/macos")}
+        monkeypatch.setattr(_chromium_profiles, "_macos_user_data_dirs", lambda: sentinel)
+        assert _platform_user_data_dirs() is sentinel
+
+    @pytest.mark.parametrize("platform", ["win32", "cygwin"])
+    def test_windows_dispatches_to_windows(self, monkeypatch, platform):
+        monkeypatch.setattr(_chromium_profiles.sys, "platform", platform)
+        sentinel = {"chrome": Path("/windows")}
+        monkeypatch.setattr(_chromium_profiles, "_windows_user_data_dirs", lambda: sentinel)
+        assert _platform_user_data_dirs() is sentinel
+
+    def test_other_dispatches_to_linux(self, monkeypatch):
+        monkeypatch.setattr(_chromium_profiles.sys, "platform", "linux")
+        sentinel = {"chrome": Path("/linux")}
+        monkeypatch.setattr(_chromium_profiles, "_linux_user_data_dirs", lambda: sentinel)
+        assert _platform_user_data_dirs() is sentinel
+
+    def test_linux_uses_xdg_config_home(self, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/custom/config")
+        dirs = _linux_user_data_dirs()
+        assert dirs["chrome"] == Path("/custom/config/google-chrome")
+
+
+class TestLoadLocalStateInfoCacheGuard:
+    def test_info_cache_not_a_dict_returns_empty(self, tmp_path):
+        local_state = tmp_path / "Local State"
+        local_state.write_text(
+            json.dumps({"profile": {"info_cache": ["not", "a", "dict"]}}),
+            encoding="utf-8",
+        )
+        assert _load_local_state_names(tmp_path) == {}
+
+
+class TestFormatChromiumProfileChoices:
+    def test_empty_returns_none_sentinel(self):
+        assert _format_chromium_profile_choices([]) == "none"
+
+    def test_non_empty_joins_choices(self):
+        profiles = [
+            ChromiumProfile(
+                browser="chrome",
+                directory_name="Default",
+                human_name="Personal",
+                cookies_db=Path("/x/Default/Cookies"),
+            ),
+            ChromiumProfile(
+                browser="chrome",
+                directory_name="Profile 1",
+                human_name="Work",
+                cookies_db=Path("/x/Profile 1/Cookies"),
+            ),
+        ]
+        out = _format_chromium_profile_choices(profiles)
+        assert "Personal (directory: Default)" in out
+        assert "Work (directory: Profile 1)" in out
+        assert ", " in out

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -1,0 +1,748 @@
+"""Targeted coverage tests for ``notebooklm._source_upload``.
+
+These tests exercise the error handlers, edge-case branches, and
+streaming/finalize paths in the upload pipeline that the existing
+``test_sources_upload.py`` / ``test_source_upload_pipeline.py`` suites do
+not reach. They directly drive the module-level helper functions plus the
+``SourceUploadPipeline`` collaborator slots so the assertions reflect real
+behaviour rather than tautologies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import SplitResult, urlsplit
+
+import httpx
+import pytest
+
+from notebooklm._source_upload import (
+    SourceUploadPipeline,
+    _build_invalid_argument_source_limit_hint,
+    _coerce_source_id_candidate,
+    _default_port_for_scheme,
+    _extract_register_file_source_id,
+    _looks_like_id_string,
+    _redact_upload_url,
+    _redacted_upload_authority,
+    _register_response_shape_label,
+    _resolve_upload_content_type,
+    _validate_resumable_upload_url,
+)
+from notebooklm.exceptions import (
+    AuthError,
+    NetworkError,
+    ValidationError,
+)
+from notebooklm.rpc import RPCError
+from notebooklm.types import Source, SourceAddError
+
+# =============================================================================
+# Module-level helper functions
+# =============================================================================
+
+
+def test_default_port_for_scheme_unknown_scheme_returns_none() -> None:
+    """Non-http(s) schemes have no implicit default port (line 110)."""
+    assert _default_port_for_scheme("https") == 443
+    assert _default_port_for_scheme("http") == 80
+    assert _default_port_for_scheme("ftp") is None
+
+
+def test_redacted_upload_authority_returns_none_when_host_missing() -> None:
+    """A URL with no hostname yields ``None`` authority (line 116)."""
+    parsed = urlsplit("file:///local/path")
+    assert parsed.hostname is None
+    assert _redacted_upload_authority(parsed) is None
+
+
+def test_redacted_upload_authority_brackets_ipv6_host() -> None:
+    """IPv6 hosts are wrapped in brackets and keep the port suffix."""
+    parsed = urlsplit("https://[2001:db8::1]:8443/upload")
+    assert _redacted_upload_authority(parsed) == "[2001:db8::1]:8443"
+
+
+def test_redact_upload_url_returns_placeholder_when_scheme_missing() -> None:
+    """A scheme-less / authority-less URL redacts to the placeholder (line 134)."""
+    assert _redact_upload_url("not-a-url") == "[REDACTED_UPLOAD_URL]"
+    assert _redact_upload_url("///just/a/path") == "[REDACTED_UPLOAD_URL]"
+
+
+def test_redact_upload_url_value_error_returns_placeholder() -> None:
+    """A urlsplit ValueError is swallowed into the redacted placeholder."""
+    with patch(
+        "notebooklm._source_upload.urlsplit",
+        side_effect=ValueError("bad url"),
+    ):
+        assert _redact_upload_url("https://example.com/x") == "[REDACTED_UPLOAD_URL]"
+
+
+def test_validate_resumable_upload_url_value_error_wrapped() -> None:
+    """A urlsplit ValueError becomes a ValidationError (lines 146-147)."""
+
+    def _boom(_url: str) -> SplitResult:
+        raise ValueError("malformed")
+
+    # ADR-007 forbids string-target ``monkeypatch.setattr`` on notebooklm
+    # internals; use ``unittest.mock.patch`` instead.
+    with (
+        patch("notebooklm._source_upload.urlsplit", _boom),
+        pytest.raises(ValidationError, match="Upload URL is not valid"),
+    ):
+        _validate_resumable_upload_url("https://example.com/?upload_id=x")
+
+
+def test_validate_resumable_upload_url_missing_host_raises() -> None:
+    """An https URL with no host is rejected (line 154).
+
+    ``https:///path`` parses with scheme ``https`` but ``hostname is None``,
+    so it reaches the host-missing guard rather than the scheme guard.
+    """
+    with pytest.raises(ValidationError, match="must include a host"):
+        _validate_resumable_upload_url("https:///upload/_/?upload_id=session")
+
+
+def test_register_response_shape_label_all_branches() -> None:
+    """Every shape label branch is exercised (lines 407, 414)."""
+    assert _register_response_shape_label({"a": 1}) == "object"
+    assert _register_response_shape_label([1, 2]) == "array"
+    assert _register_response_shape_label("hi") == "string"
+    assert _register_response_shape_label(None) == "null"
+    assert _register_response_shape_label(123) == "int"
+
+
+def test_looks_like_id_string_rejects_whitespace_and_slash() -> None:
+    """Candidates containing space/tab/slash are not id-like (line 422)."""
+    assert _looks_like_id_string("has space1") is False
+    assert _looks_like_id_string("has\ttab1") is False
+    assert _looks_like_id_string("path/to/1") is False
+    # Sanity: a plausible id still passes.
+    assert _looks_like_id_string("src_1234") is True
+
+
+def test_coerce_source_id_candidate_rejects_overlong_string() -> None:
+    """Strings longer than 1000 chars are rejected outright (line 380)."""
+    assert _coerce_source_id_candidate("x" * 1001, "f.pdf") is None
+
+
+def test_coerce_source_id_candidate_rejects_filename_echo() -> None:
+    """A value equal to the filename is rejected (line 383)."""
+    assert _coerce_source_id_candidate("report.pdf", "report.pdf") is None
+    # Empty after strip is also rejected.
+    assert _coerce_source_id_candidate("   ", "report.pdf") is None
+
+
+def test_resolve_upload_content_type_blank_mime_raises() -> None:
+    """A whitespace-only explicit mime_type is rejected (line 431)."""
+    from pathlib import Path
+
+    with pytest.raises(ValidationError, match="cannot be empty or whitespace-only"):
+        _resolve_upload_content_type(Path("a.bin"), "   ")
+
+
+def test_extract_register_file_source_id_ambiguous_field_candidates() -> None:
+    """Two distinct context-matched SOURCE_IDs are ambiguous -> None (line 271).
+
+    Each inner dict carries a matching ``SOURCE_NAME`` so both SOURCE_IDs are
+    collected as field candidates; two distinct ids -> ambiguous -> None.
+    """
+    result = [
+        {
+            "SOURCE_NAME": "report.pdf",
+            "SOURCE_ID": "11111111-2222-3333-4444-555555555555",
+        },
+        {
+            "SOURCE_NAME": "report.pdf",
+            "SOURCE_ID": "99999999-8888-7777-6666-555555555555",
+        },
+    ]
+    assert _extract_register_file_source_id(result, "report.pdf") is None
+
+
+def test_extract_register_file_source_id_ambiguous_row_candidates() -> None:
+    """Two distinct contextual row SOURCE_IDs are ambiguous -> None (line 277).
+
+    No SOURCE_ID/id field candidates exist, so extraction falls through to
+    the contextual-row walk, which finds two filename-paired ids.
+    """
+    uuid_a = "11111111-2222-3333-4444-555555555555"
+    uuid_b = "99999999-8888-7777-6666-555555555555"
+    result = [
+        [uuid_a, "report.pdf"],
+        [uuid_b, "report.pdf"],
+    ]
+    assert _extract_register_file_source_id(result, "report.pdf") is None
+
+
+def test_extract_register_file_source_id_skips_non_string_dict_keys() -> None:
+    """Dict keys that are not strings are skipped during the walk (line 307)."""
+    uuid = "11111111-2222-3333-4444-555555555555"
+    result = {1: "ignored", ("tuple",): "ignored", "SOURCE_ID": uuid}
+    assert _extract_register_file_source_id(result, "report.pdf") == uuid
+
+
+# =============================================================================
+# _build_invalid_argument_source_limit_hint()
+# =============================================================================
+
+
+class TestSourceLimitHint:
+    """Cover each branch of the ADD_SOURCE_FILE status-code-3 hint builder."""
+
+    @pytest.mark.asyncio
+    async def test_limit_lookup_exception_logged_and_ignored(self) -> None:
+        """A failing source-limit lookup must not mask the upload error (181-182)."""
+        logger = MagicMock()
+
+        async def _boom() -> int | None:
+            raise RuntimeError("limit lookup down")
+
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=None,
+            get_source_limit=_boom,
+            logger=logger,
+        )
+        # No count and no usable limit -> empty hint (line 219).
+        assert hint == ""
+        logger.debug.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_nonpositive_limit_coerced_to_none(self) -> None:
+        """A non-positive limit is treated as unavailable (line 188)."""
+
+        async def _zero() -> int | None:
+            return 0
+
+        # count below floor + no usable limit -> empty (line 219).
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=3,
+            get_source_limit=_zero,
+            logger=MagicMock(),
+        )
+        assert hint == ""
+
+    @pytest.mark.asyncio
+    async def test_count_at_or_above_limit_returns_at_limit_hint(self) -> None:
+        """count >= limit yields the 'reached its limit' hint (around 191-197)."""
+
+        async def _limit() -> int | None:
+            return 100
+
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=100,
+            get_source_limit=_limit,
+            logger=MagicMock(),
+        )
+        assert "100/100" in hint
+        assert "per-notebook source limit" in hint
+
+    @pytest.mark.asyncio
+    async def test_count_below_limit_returns_below_limit_hint(self) -> None:
+        """count < limit yields the 'below the advertised limit' hint (line 198)."""
+
+        async def _limit() -> int | None:
+            return 100
+
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=10,
+            get_source_limit=_limit,
+            logger=MagicMock(),
+        )
+        assert "10/100" in hint
+        assert "below" in hint
+
+    @pytest.mark.asyncio
+    async def test_count_above_floor_without_limit_returns_floor_hint(self) -> None:
+        """count >= floor with no limit yields the tier-summary hint (204-205)."""
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=75,
+            get_source_limit=None,
+            logger=MagicMock(),
+        )
+        assert "75 sources" in hint
+        assert "50/100/300/600" in hint
+
+    @pytest.mark.asyncio
+    async def test_limit_only_without_count_returns_limit_hint(self) -> None:
+        """A usable limit but no count yields the advertised-limit hint (212-213)."""
+
+        async def _limit() -> int | None:
+            return 300
+
+        hint = await _build_invalid_argument_source_limit_hint(
+            source_count=None,
+            get_source_limit=_limit,
+            logger=MagicMock(),
+        )
+        assert "Advertised source limit for this tier is 300" in hint
+
+
+# =============================================================================
+# SourceUploadPipeline collaborator/instance branches
+# =============================================================================
+
+
+class _Lifecycle:
+    def __init__(self) -> None:
+        self.asserted = 0
+
+    def assert_bound_loop(self) -> None:
+        self.asserted += 1
+
+
+class _Drain:
+    def operation_scope(self, _label: str):
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            yield None
+
+        return scope()
+
+
+def _make_pipeline(
+    *,
+    kernel: Any | None = None,
+    rpc: Any | None = None,
+    async_client_factory: Any | None = None,
+    get_source_limit: Any | None = None,
+) -> SourceUploadPipeline:
+    auth = MagicMock()
+    auth.authuser = 0
+    auth.account_email = None
+    return SourceUploadPipeline(
+        rpc=rpc or MagicMock(),
+        drain=_Drain(),
+        lifecycle=_Lifecycle(),
+        kernel=kernel if kernel is not None else MagicMock(),
+        auth=auth,
+        async_client_factory=async_client_factory,
+        get_source_limit=get_source_limit,
+    )
+
+
+def test_live_cookies_uses_get_http_client_when_kernel_lacks_cookies() -> None:
+    """A kernel without a ``cookies`` attribute falls back to get_http_client (521)."""
+
+    class KernelWithHttpClient:
+        # No ``cookies`` attribute on purpose.
+        def __init__(self) -> None:
+            jar = httpx.Cookies()
+            jar.set("x", "y", domain="example.com")
+            self._jar = jar
+            self.get_http_client = MagicMock(return_value=MagicMock(cookies=jar))
+
+    kernel = KernelWithHttpClient()
+    pipeline = _make_pipeline(kernel=kernel)
+    cookies = pipeline._live_cookies()
+    assert cookies is kernel._jar
+    kernel.get_http_client.assert_called_once()
+
+
+def test_live_cookies_returns_empty_jar_when_cookies_is_none() -> None:
+    """A kernel exposing ``cookies = None`` and no http client returns an empty jar (522-523)."""
+
+    class KernelNoCookies:
+        cookies = None
+        get_http_client = None
+
+    pipeline = _make_pipeline(kernel=KernelNoCookies())
+    cookies = pipeline._live_cookies()
+    assert isinstance(cookies, httpx.Cookies)
+    assert len(cookies.jar) == 0
+
+
+def test_live_cookies_casts_non_cookies_truthy_value() -> None:
+    """A truthy non-Cookies ``cookies`` with no http client is cast through (line 524)."""
+    sentinel = object()
+
+    class KernelOddCookies:
+        cookies = sentinel
+        get_http_client = None
+
+    pipeline = _make_pipeline(kernel=KernelOddCookies())
+    assert pipeline._live_cookies() is sentinel
+
+
+@pytest.mark.asyncio
+async def test_list_sources_delegates_to_lister() -> None:
+    """``list_sources`` proxies to the internal SourceLister (line 915)."""
+    pipeline = _make_pipeline()
+    expected = [Source(id="s1", title="a.pdf")]
+    pipeline._lister.list = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+    result = await pipeline.list_sources("nb_1")
+    assert result == expected
+    pipeline._lister.list.assert_awaited_once_with("nb_1")
+
+
+@pytest.mark.asyncio
+async def test_add_file_asserts_bound_loop_before_work(tmp_path) -> None:
+    """``add_file`` calls assert_bound_loop before touching the semaphore (605-607)."""
+    lifecycle = _Lifecycle()
+    auth = MagicMock()
+    auth.authuser = 0
+    auth.account_email = None
+    pipeline = SourceUploadPipeline(
+        rpc=MagicMock(),
+        drain=_Drain(),
+        lifecycle=lifecycle,
+        kernel=MagicMock(),
+        auth=auth,
+    )
+    # Make assert_bound_loop the thing that fails so we prove it runs first,
+    # before any filesystem resolution or semaphore allocation.
+    lifecycle.assert_bound_loop = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("wrong loop")
+    )
+    with pytest.raises(RuntimeError, match="wrong loop"):
+        await pipeline.add_file("nb_1", str(tmp_path / "missing.pdf"))
+    lifecycle.assert_bound_loop.assert_called_once()
+
+
+# =============================================================================
+# register_file_source() probe / create branches
+# =============================================================================
+
+
+class TestRegisterFileSourceBranches:
+    """Cover baseline-failure, probe, and missing-id recovery paths."""
+
+    @pytest.mark.asyncio
+    async def test_baseline_list_failure_logs_and_makes_baseline_unavailable(self) -> None:
+        """A failing baseline list() leaves the baseline unavailable (772, 802-808).
+
+        With baseline unavailable, a same-titled probe match is treated as an
+        ambiguity rather than silently returned. We drive a create RPC failure
+        (NetworkError) so idempotent_create runs the probe, which then finds a
+        same-titled source and raises SourceAddError.
+        """
+        pipeline = _make_pipeline()
+        logger = MagicMock()
+
+        list_calls = {"n": 0}
+
+        async def _list(_nb: str) -> list[Source]:
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                # Baseline call fails -> baseline unavailable.
+                raise RuntimeError("baseline boom")
+            # Probe call returns a same-titled source.
+            return [Source(id="pre_existing", title="report.pdf")]
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            raise NetworkError("transport down")
+
+        with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=logger,
+                rpc_call=_rpc_call,
+            )
+        logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_returns_none_when_no_match(self) -> None:
+        """The probe returns None when no same-titled new source exists (line 828).
+
+        Baseline succeeds (empty), the create RPC fails transiently so the
+        probe runs, finds nothing, and idempotent_create exhausts retries and
+        re-raises the transport error.
+        """
+        pipeline = _make_pipeline()
+
+        async def _list(_nb: str) -> list[Source]:
+            return []
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            raise NetworkError("still down")
+
+        with pytest.raises(NetworkError):
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=MagicMock(),
+                rpc_call=_rpc_call,
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_id_recovered_by_probe(self) -> None:
+        """A successful create with an untrustworthy id is recovered via probe (873, 890).
+
+        The create RPC returns a shape with no trustworthy SOURCE_ID, so
+        ``_create`` runs the probe which finds a freshly committed (not in
+        baseline) source and returns its id.
+        """
+        pipeline = _make_pipeline()
+        logger = MagicMock()
+
+        list_calls = {"n": 0}
+
+        async def _list(_nb: str) -> list[Source]:
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return []  # baseline: empty
+            return [Source(id="fresh_src", title="report.pdf")]
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            # Numeric-only response: no trustworthy SOURCE_ID extractable.
+            return [[[1, 2, 3]]]
+
+        result = await pipeline.register_file_source(
+            "nb_1",
+            "report.pdf",
+            list_sources=_list,
+            logger=logger,
+            rpc_call=_rpc_call,
+        )
+        assert result == "fresh_src"
+        # The "probe found a freshly committed source" info line fired.
+        assert logger.info.called
+
+    @pytest.mark.asyncio
+    async def test_missing_id_probe_transport_failure_wrapped(self) -> None:
+        """A probe transport failure after a successful create wraps to SourceAddError (around 876-889).
+
+        The create RPC succeeds (no usable id), then the probe list() raises a
+        transport error. Because the create already committed, this must NOT be
+        re-POSTed; it is wrapped into SourceAddError.
+        """
+        pipeline = _make_pipeline()
+
+        list_calls = {"n": 0}
+
+        async def _list(_nb: str) -> list[Source]:
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return []  # baseline ok
+            raise AuthError("probe auth failed")
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            return [[[1, 2, 3]]]  # no usable id
+
+        with pytest.raises(SourceAddError, match="did not provide a trustworthy"):
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=MagicMock(),
+                rpc_call=_rpc_call,
+            )
+
+    @pytest.mark.asyncio
+    async def test_probe_multiple_new_matches_raises_ambiguity(self) -> None:
+        """The probe raising on >1 new same-titled source surfaces ambiguity (line 819).
+
+        Baseline is empty, the create RPC fails transiently so the probe runs;
+        the probe then sees two new sources sharing the filename and raises
+        SourceAddError rather than guessing.
+        """
+        pipeline = _make_pipeline()
+
+        list_calls = {"n": 0}
+
+        async def _list(_nb: str) -> list[Source]:
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return []  # baseline empty
+            return [
+                Source(id="new_a", title="report.pdf"),
+                Source(id="new_b", title="report.pdf"),
+            ]
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            raise NetworkError("transport down")
+
+        with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=MagicMock(),
+                rpc_call=_rpc_call,
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_id_probe_ambiguity_propagates(self) -> None:
+        """A SourceAddError raised by the post-create probe propagates (line 875).
+
+        The create RPC succeeds with no usable id, then the probe finds two
+        new same-titled sources and raises SourceAddError; ``_create`` must
+        re-raise it unchanged rather than wrap it as a transport failure.
+        """
+        pipeline = _make_pipeline()
+
+        list_calls = {"n": 0}
+
+        async def _list(_nb: str) -> list[Source]:
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return []  # baseline empty
+            return [
+                Source(id="new_a", title="report.pdf"),
+                Source(id="new_b", title="report.pdf"),
+            ]
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            return [[[1, 2, 3]]]  # no usable id -> triggers probe
+
+        with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=MagicMock(),
+                rpc_call=_rpc_call,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rpc_error_with_invalid_argument_code_adds_limit_hint(self) -> None:
+        """An RPCError with code 3 attaches a source-limit hint (845-849)."""
+        pipeline = _make_pipeline()
+
+        async def _list(_nb: str) -> list[Source]:
+            return [Source(id=f"s{i}", title=f"f{i}.pdf") for i in range(60)]
+
+        rpc_err = RPCError("invalid argument")
+        rpc_err.rpc_code = 3  # type: ignore[attr-defined]
+
+        async def _rpc_call(*_a: Any, **_k: Any) -> Any:
+            raise rpc_err
+
+        with pytest.raises(SourceAddError) as exc_info:
+            await pipeline.register_file_source(
+                "nb_1",
+                "report.pdf",
+                list_sources=_list,
+                logger=MagicMock(),
+                rpc_call=_rpc_call,
+            )
+        # The floor-based hint (>= 50 sources, no explicit limit) is appended.
+        assert "50/100/300/600" in str(exc_info.value)
+
+
+# =============================================================================
+# upload_file_streaming() — file-object (non-Path) streaming + finalize
+# =============================================================================
+
+
+class TestUploadFileStreamingFileObject:
+    """Drive the IO[bytes] branch of file_stream plus progress callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_streams_file_object_with_progress(self, tmp_path) -> None:
+        """A file-object source streams chunks and reports progress (1062-1063, 1086-1091)."""
+        data = b"hello world payload"
+        src = tmp_path / "payload.bin"
+        src.write_bytes(data)
+        file_obj = open(src, "rb")  # noqa: SIM115
+
+        progress: list[tuple[int, int]] = []
+
+        def _on_progress(done: int, total: int) -> None:
+            progress.append((done, total))
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def _factory_cm(**_kwargs: Any):
+            client = AsyncMock()
+
+            async def _post(url: str, headers: dict[str, str], content: Any) -> Any:
+                captured["headers"] = headers
+                chunks = [chunk async for chunk in content]
+                captured["body"] = b"".join(chunks)
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                return resp
+
+            client.post = _post
+            yield client
+
+        factory = MagicMock(side_effect=lambda **kw: _factory_cm(**kw))
+        pipeline = _make_pipeline(async_client_factory=factory)
+
+        upload_url = "https://notebooklm.google.com/upload/_/?upload_id=session"
+        try:
+            await pipeline.upload_file_streaming(
+                upload_url,
+                file_obj,
+                filename="payload.bin",
+                on_progress=_on_progress,
+                total_bytes=len(data),
+            )
+        finally:
+            if not file_obj.closed:
+                file_obj.close()
+
+        assert captured["body"] == data
+        # Initial 0-progress callback plus at least one chunk callback.
+        assert progress[0] == (0, len(data))
+        assert progress[-1] == (len(data), len(data))
+        # Finalize headers are present.
+        assert captured["headers"]["x-goog-upload-command"] == "upload, finalize"
+        # The done-callback should have closed the caller's FD.
+        assert file_obj.closed
+
+    @pytest.mark.asyncio
+    async def test_streams_file_object_without_progress(self, tmp_path) -> None:
+        """A file-object source streams without a progress callback (branch 1089->1091)."""
+        data = b"payload-no-progress"
+        src = tmp_path / "payload.bin"
+        src.write_bytes(data)
+        file_obj = open(src, "rb")  # noqa: SIM115
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def _factory_cm(**_kwargs: Any):
+            client = AsyncMock()
+
+            async def _post(url: str, headers: dict[str, str], content: Any) -> Any:
+                chunks = [chunk async for chunk in content]
+                captured["body"] = b"".join(chunks)
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                return resp
+
+            client.post = _post
+            yield client
+
+        factory = MagicMock(side_effect=lambda **kw: _factory_cm(**kw))
+        pipeline = _make_pipeline(async_client_factory=factory)
+        try:
+            await pipeline.upload_file_streaming(
+                "https://notebooklm.google.com/upload/_/?upload_id=session",
+                file_obj,
+                filename="payload.bin",
+                total_bytes=len(data),
+            )
+        finally:
+            if not file_obj.closed:
+                file_obj.close()
+        assert captured["body"] == data
+
+    @pytest.mark.asyncio
+    async def test_pre_wire_exception_closes_file_object(self, tmp_path) -> None:
+        """An exception before the finalize task is wired closes the caller FD (1143-1146).
+
+        We pass an invalid upload URL so ``_validate_resumable_upload_url``
+        raises before ``close_wired`` is set. The except-handler must close the
+        caller-supplied file object.
+        """
+        src = tmp_path / "payload.bin"
+        src.write_bytes(b"data")
+        file_obj = open(src, "rb")  # noqa: SIM115
+
+        pipeline = _make_pipeline()
+        with pytest.raises(ValidationError):
+            await pipeline.upload_file_streaming(
+                "http://insecure.example.com/?upload_id=x",  # not https -> validation fails
+                file_obj,
+                filename="payload.bin",
+            )
+        assert file_obj.closed


### PR DESCRIPTION
## Summary

Follow-up to #1226. That PR cleaned up the *low-percentage small* modules; this one targets the complementary set — **decent percentage but large module, so a meaningful absolute untested surface**. Adds 224 focused unit tests across 9 new files, raising total project coverage **95.1% → 96.9%** (test-only; no source changes).

### Per-module coverage

| Module | Before | After |
|--------|-------:|------:|
| `_artifact_downloads.py` | 87% | 100% |
| `_auth/account.py` | 88% | 100% |
| `_auth/refresh.py` | 87% | 99.7% |
| `cli/context.py` | 85% | 99.4% |
| `cli/source_cmd.py` | 93% | 99.5% |
| `cli/services/login/refresh.py` | 82% | 98.8% |
| `cli/services/playwright_login.py` | 88% | 98.2% |
| `cli/_chromium_profiles.py` | 82% | 97.7% |
| `_source_upload.py` | 89% | 97.9% |

### What the new tests exercise

- **`_artifact_downloads`** — writer-failure surfacing, bounded-queue backpressure (`asyncio.to_thread` fallback), the producer/consumer drain races, non-HTTPS rejection, and `safe_index` content extraction.
- **`_source_upload`** — URL redaction/validation `ValueError` wrapping, source-id coercion/echo guards, invalid-argument limit hints, live-cookie fallbacks, loop-affinity guard, and the streaming-upload finalize path.
- **`_auth/refresh`** — external refresh-cmd timeout/non-zero-exit handling, Windows `CommandLineToArgvW` arg-splitting, in-flight future cancel/settle races, and post-refresh retry kwarg forwarding.
- **`_auth/account`** — email-for-storage/authuser formatting fallbacks, TOCTOU re-check under lock, metadata namespace handling, and poke-hook invocation.
- **`cli/context`** — corrupt-JSON / OSError warnings and lock-contention outcomes across get/set/clear.
- **`cli/source_cmd`** — the render/handler/JSON-output helpers and validation-error exit paths.
- **`cli/services/login/refresh`** & **`playwright_login`** — enum/no-account/write outcome exits, metadata + verification branches, Chromium-install banner, and `wait_for_url` error re-raise.
- **`cli/_chromium_profiles`** — macOS/Windows/Linux user-data-dir tables and `Local State` guards.

A handful of structurally-unreachable lines (dead `return` after `exit_with_code`, regex-unreachable sort fallback) and timing-sensitive cancel-race branches are intentionally left, noted in commit history.

## Testing

- All 224 new tests pass together (no cross-test pollution).
- Full suite green; total coverage 96.9%.
- ADR-007 monkeypatch-policy lint passes (no string-target/object-attribute monkeypatch or dynamic AsyncMock attribute assignment on internals).
- `ruff check` / `ruff format` clean.

https://claude.ai/code/session_01QcRamK2CYTpkBpMBEjPqwj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcRamK2CYTpkBpMBEjPqwj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit and integration test coverage across CLI context handling, login/refresh flows, Playwright-based login, source commands and uploads, artifact downloads, Chromium profile resolution, and auth account/refresh logic—exercising edge cases, error-handling, race conditions, IO/lock scenarios, streaming/download paths, and installer/browser flows to improve reliability and regression detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->