### PR TITLE
refactor(chat): unify anti-XSSI prefix stripper

### DIFF
--- a/src/notebooklm/_chat_wire.py
+++ b/src/notebooklm/_chat_wire.py
@@ -19,6 +19,7 @@ from ._env import get_default_bl, get_default_language
 from .auth import format_authuser_value
 from .exceptions import ChatError, ChatResponseParseError, UnknownRPCMethodError
 from .rpc._safe_index import safe_index
+from .rpc.decoder import strip_anti_xssi
 from .rpc.encoder import nest_source_ids
 from .rpc.types import get_query_url
 from .types import ChatReference
@@ -153,8 +154,11 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
       ``StreamingChatParseResult("", refs, conv_id)`` — empty answer is
       a valid outcome, not a parse failure.
     """
-    if response_text.startswith(")]}'"):
-        response_text = response_text[4:]
+    # Shared anti-XSSI stripper (rpc.decoder.strip_anti_xssi) is the single
+    # owner of the )]}' prefix removal. For the real chat wire format the
+    # prefix is always followed by a newline, so the subsequent ``.strip()``
+    # yields a byte-for-byte-identical result to the prior blind ``[4:]`` slice.
+    response_text = strip_anti_xssi(response_text)
 
     lines = response_text.strip().split("\n")
     best_marked_answer = ""

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -266,6 +266,43 @@ def test_parse_response_handles_xssi_length_prefix_raw_json_and_server_conversat
     assert result.conversation_id == "server-conv-2"
 
 
+def test_xssi_prefix_strip_matches_shared_helper_on_real_wire_format() -> None:
+    """The chat parser delegates anti-XSSI stripping to ``strip_anti_xssi``.
+
+    On the real chat wire format the ``)]}'`` prefix is always followed by a
+    newline, so routing through the shared stripper yields the same parsed
+    answer whether or not the prefix is present (regression guard for the
+    duplicate-stripper consolidation in issue #1205).
+    """
+    chunk = _chunk("Prefixed answer.", conversation_id="conv")
+
+    with_prefix = parse_streaming_chat_response(_length_prefixed(chunk, xssi=True))
+    without_prefix = parse_streaming_chat_response(_length_prefixed(chunk, xssi=False))
+
+    assert with_prefix.answer == without_prefix.answer == "Prefixed answer."
+    assert with_prefix.conversation_id == without_prefix.conversation_id == "conv"
+
+
+def test_chat_parser_uses_shared_strip_anti_xssi(monkeypatch) -> None:
+    """``parse_streaming_chat_response`` calls the shared ``strip_anti_xssi``."""
+    import notebooklm._chat_wire as chat_wire
+
+    seen: list[str] = []
+    real_strip = chat_wire.strip_anti_xssi
+
+    def _spy(response: str) -> str:
+        seen.append(response)
+        return real_strip(response)
+
+    monkeypatch.setattr(chat_wire, "strip_anti_xssi", _spy)
+
+    response = _length_prefixed(_chunk("Answer.", conversation_id="conv"))
+    result = parse_streaming_chat_response(response)
+
+    assert result.answer == "Answer."
+    assert seen == [response]
+
+
 def test_marked_answer_beats_longer_unmarked_text() -> None:
     marked = _chunk("Marked.", marked=True)
     unmarked = _chunk("This unmarked text is longer than the answer marker.", marked=False)


### PR DESCRIPTION
Part of #1205 (2/5: unify anti-XSSI stripper)

## What

The streamed-chat wire parser (`src/notebooklm/_chat_wire.py`) re-implemented the `)]}'` anti-XSSI prefix removal as a blind `response_text[4:]` slice, duplicating the canonical regex-anchored `strip_anti_xssi` in `src/notebooklm/rpc/decoder.py`. Issue #1205 flags this duplicate-with-divergence pattern as the top defect generator.

This collapses the two into one owner: the chat parser now imports and calls the shared `strip_anti_xssi`.

## Why it's safe (happy path byte-for-byte identical)

The shared `strip_anti_xssi` is regex-anchored on `\)]\}'\r?\n` — it consumes the prefix plus its trailing newline. The chat parser still runs `.strip().split("\n")` right after. On the real chat wire format the prefix is always emitted followed by a newline (`)]}'\n...`), so:

- old: `[4:]` removes the 4-char prefix, then `.strip()` removes the leading newline
- new: `strip_anti_xssi` removes prefix + newline, then `.strip()` is a no-op on the boundary

Both produce the identical `lines` list. Verified against all wire fixtures and the `_length_prefixed` test helper, which all use `)]}'\n`.

## Tests

- Added `test_xssi_prefix_strip_matches_shared_helper_on_real_wire_format` — parse result identical with/without the prefix.
- Added `test_chat_parser_uses_shared_strip_anti_xssi` — asserts the shared helper is the one invoked.
- All existing chat-parser / decoder / streaming tests stay green (612 passed).

## Gates

- `ruff check` / `ruff format`: clean
- `mypy src/notebooklm`: clean
- `audit_public_api_compat.py`: no new public break
- `pytest -k "chat or stream or citation or wire or decoder or xssi"`: 612 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code consistency in chat response handling by consolidating prefix-stripping logic.

* **Tests**
  * Added comprehensive unit tests for anti-XSSI prefix handling in chat response parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->