### PR TITLE
fix(sources): unify the two divergent Source parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > **Not removed:** awaiting `NotebookLMClient.from_storage(...)` still works —
 > its deprecation targets v1.0, not v0.6.0.
 
+### Fixed
+
+- **`Source.from_api_response` now reports the real processing `status`.** The
+  `ADD_SOURCE` / rename parsing path previously never read the status block and
+  always fell back to `SourceStatus.READY`, while `client.sources.list()` /
+  `get()` and the source poller read the decoded status. Both parsers now
+  funnel through a single `Source.from_row` construction site, so a `Source`
+  produced from an add/rename response carries the same `status` (and `url` /
+  `created_at`) as the listing path. The `Source.status` field annotation was
+  also corrected from `int` to `SourceStatus` (still an `int`-compatible enum).
+
 ## [0.6.0] - 2026-05-29
 
 ### Breaking changes

--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -148,14 +148,10 @@ class SourceLister:
             )
             return None
 
-        return Source(
-            id=row.id,
-            title=row.title,
-            url=row.url,
-            _type_code=row.type_code,
-            created_at=row.created_at,
-            status=row.status,
-        )
+        # Funnel through the single ``Source`` construction site shared
+        # with ``Source.from_api_response`` so the list/get/poll path and
+        # the ADD_SOURCE/rename path produce identical Sources.
+        return Source.from_row(row)
 
 
 __all__ = ["SourceLister"]

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -6,13 +6,16 @@ import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..rpc.types import SourceStatus
 from .common import (
     UnknownTypeWarning,
     _datetime_from_timestamp,
 )
+
+if TYPE_CHECKING:
+    from .._row_adapters_sources import SourceRow
 
 
 class SourceType(str, Enum):
@@ -139,7 +142,13 @@ class Source:
     url: str | None = None
     _type_code: int | None = field(default=None, repr=False)
     created_at: datetime | None = None
-    status: int = SourceStatus.READY
+    # ``status`` holds a :class:`~notebooklm.rpc.SourceStatus` member (an
+    # ``int`` enum) decoded from the GET_NOTEBOOK source-list status block.
+    # The annotation was previously ``int`` even though every construction
+    # path (the listing service and :meth:`from_api_response`) populates it
+    # with a ``SourceStatus``; ``SourceStatus`` is the accurate declared type
+    # and remains ``int``-compatible at runtime and for equality.
+    status: SourceStatus = SourceStatus.READY
 
     @property
     def kind(self) -> SourceType:
@@ -162,6 +171,32 @@ class Source:
         return self.status == SourceStatus.ERROR
 
     @classmethod
+    def from_row(cls, row: SourceRow) -> Source:
+        """Build a :class:`Source` from a normalized :class:`SourceRow`.
+
+        This is the **single** construction site for a :class:`Source`
+        from a parsed source row. Both :meth:`from_api_response` (the
+        public classmethod used by ``ADD_SOURCE`` / rename paths) and
+        :meth:`notebooklm._source_listing.SourceLister._parse_source`
+        (the ``GET_NOTEBOOK`` list/get/poll path) funnel through here so
+        every code path produces identical :class:`Source` instances —
+        including the decoded :attr:`status`.
+
+        The flat shape historically yields ``_type_code=None`` and skips
+        metadata-derived fields; :class:`SourceRow` already returns
+        ``None`` / ``SourceStatus.READY`` for those slots on a flat row,
+        so a single field mapping covers all three wire shapes.
+        """
+        return cls(
+            id=row.id,
+            title=row.title,
+            url=row.url,
+            _type_code=row.type_code,
+            created_at=row.created_at,
+            status=row.status,
+        )
+
+    @classmethod
     def from_api_response(cls, data: list[Any], notebook_id: str | None = None) -> Source:
         """Parse source data from various API response formats.
 
@@ -169,30 +204,23 @@ class Source:
         medium nested, flat) is centralised in
         :meth:`notebooklm._row_adapters_sources.SourceRow.from_unknown_shape`;
         position knowledge for the entry layout lives on
-        :class:`SourceRow` itself. This method only translates the
-        adapter's typed properties into the :class:`Source` dataclass.
-        See ``docs/improvement.md`` §6.2 for context.
+        :class:`SourceRow` itself. This method only normalizes the wire
+        shape into a :class:`SourceRow` and defers to :meth:`from_row` —
+        the single construction site shared with the
+        ``GET_NOTEBOOK`` list/get/poll path
+        (:meth:`notebooklm._source_listing.SourceLister._parse_source`) —
+        so all paths produce identical :class:`Source` instances,
+        including the decoded :attr:`status`. ``status`` earlier silently
+        fell back to the ``SourceStatus.READY`` default here while the
+        listing path read it from the row. See ``docs/improvement.md``
+        §6.2 for context.
         """
         # Keep the row-adapter dependency local so importing the source
         # dataclass package does not pull source-row parsing helpers into
         # the top-level public type facade.
-        from .._row_adapters_sources import SourceRow, SourceRowShape
+        from .._row_adapters_sources import SourceRow
 
-        row = SourceRow.from_unknown_shape(data)
-
-        # Flat shape preserves the historical contract: ``_type_code``
-        # is always ``None`` and metadata-derived fields are not
-        # consulted (legacy ``return cls(id=..., title=..., _type_code=None)``).
-        if row.shape is SourceRowShape.FLAT:
-            return cls(id=row.id, title=row.title, _type_code=None)
-
-        return cls(
-            id=row.id,
-            title=row.title,
-            url=row.url,
-            _type_code=row.type_code,
-            created_at=row.created_at,
-        )
+        return cls.from_row(SourceRow.from_unknown_shape(data))
 
 
 @dataclass

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -218,8 +218,7 @@ class Source:
         so all paths produce identical :class:`Source` instances,
         including the decoded :attr:`status`. ``status`` earlier silently
         fell back to the ``SourceStatus.READY`` default here while the
-        listing path read it from the row. See ``docs/improvement.md``
-        §6.2 for context.
+        listing path read it from the row.
         """
         # Keep the row-adapter dependency local so importing the source
         # dataclass package does not pull source-row parsing helpers into

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -183,9 +183,15 @@ class Source:
         including the decoded :attr:`status`.
 
         The flat shape historically yields ``_type_code=None`` and skips
-        metadata-derived fields; :class:`SourceRow` already returns
-        ``None`` / ``SourceStatus.READY`` for those slots on a flat row,
-        so a single field mapping covers all three wire shapes.
+        metadata-derived fields. That invariant is now an emergent
+        property of :class:`SourceRow` rather than an explicit early
+        return: a flat row (``[id, title, ...]``) has no list at
+        ``_raw[2]``, so :attr:`SourceRow.metadata` returns ``None`` and
+        :attr:`~SourceRow.type_code` / :attr:`~SourceRow.url` /
+        :attr:`~SourceRow.created_at` all resolve to ``None`` while
+        :attr:`~SourceRow.status` resolves to ``SourceStatus.READY``. The
+        single field mapping below therefore covers all three wire shapes
+        identically.
         """
         return cls(
             id=row.id,

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -658,6 +658,27 @@ class TestSource:
         assert source.is_processing is True
         assert source.is_ready is False
 
+    def test_from_api_response_deeply_nested_carries_status(self):
+        """The deeply-nested dispatch path also decodes the status block.
+
+        ``from_unknown_shape`` unwraps the extra outer list and funnels
+        the entry through the same ``from_row`` construction, so the
+        decoded status must survive on the deeply-nested shape too.
+        """
+        from notebooklm.rpc.types import SourceStatus
+
+        entry = [
+            ["src_deep_err"],
+            "Deep Errored Source",
+            [None, None, None, None, 3, None, None, ["https://example.com"]],
+            [None, SourceStatus.ERROR],
+        ]
+        source = Source.from_api_response([[entry]])
+
+        assert source.id == "src_deep_err"
+        assert source.status == SourceStatus.ERROR
+        assert source.is_error is True
+
     def test_from_api_response_status_defaults_ready_without_block(self):
         """A row without a status block keeps the historical READY default."""
         from notebooklm.rpc.types import SourceStatus

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -633,6 +633,79 @@ class TestSource:
         with pytest.raises(ValueError, match="Invalid source data"):
             Source.from_api_response(None)
 
+    def test_from_api_response_carries_status(self):
+        """``from_api_response`` decodes ``status`` from the row's status block.
+
+        Previously the classmethod never set ``status``, so it silently
+        fell back to ``SourceStatus.READY`` even when the wire carried a
+        PROCESSING/ERROR status block. After unifying on the single
+        ``SourceRow``-based construction it now reads the same status the
+        listing path does.
+        """
+        from notebooklm.rpc.types import SourceStatus
+
+        data = [
+            [
+                ["src_proc"],
+                "Processing Source",
+                [None, None, [1704067200, 0], None, 5, None, None, ["https://example.com"]],
+                [None, SourceStatus.PROCESSING],
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.status == SourceStatus.PROCESSING
+        assert source.is_processing is True
+        assert source.is_ready is False
+
+    def test_from_api_response_status_defaults_ready_without_block(self):
+        """A row without a status block keeps the historical READY default."""
+        from notebooklm.rpc.types import SourceStatus
+
+        # Medium-nested entry with no status block at index 3.
+        data = [[["src_no_status"], "No Status", [None, None, None, None, 5]]]
+        source = Source.from_api_response(data)
+
+        assert source.status == SourceStatus.READY
+
+        # Flat shape also defaults to READY.
+        flat = Source.from_api_response(["src_flat", "Flat"])
+        assert flat.status == SourceStatus.READY
+
+    def test_from_api_response_matches_listing_path(self):
+        """``from_api_response`` and the ``GET_NOTEBOOK`` listing path produce
+        identical ``Source`` instances from the same entry — the two parsers
+        are now a single source of truth (issue #1205, part 1/5).
+        """
+        from notebooklm._row_adapters_sources import SourceRow
+        from notebooklm.rpc import RPCMethod
+        from notebooklm.rpc.types import SourceStatus
+
+        # An entry exactly as ``SourceLister._parse_source`` receives it.
+        entry = [
+            ["src_match"],
+            "Matching Source",
+            [None, 11, [1704067200, 0], None, 5, None, None, ["https://example.com"]],
+            [None, SourceStatus.PROCESSING],
+        ]
+
+        # Listing path: ``SourceLister._parse_source`` wraps the entry with
+        # ``SourceRow.from_entry`` and funnels it through ``Source.from_row``.
+        listing_source = Source.from_row(
+            SourceRow.from_entry(entry, method_id=RPCMethod.GET_NOTEBOOK.value)
+        )
+
+        # Public classmethod path: the same entry wrapped in the medium-
+        # nested envelope that ``ADD_SOURCE``/rename responses carry.
+        api_source = Source.from_api_response([entry])
+
+        assert api_source == listing_source
+        assert api_source.status == listing_source.status == SourceStatus.PROCESSING
+        assert api_source.url == listing_source.url == "https://example.com"
+        assert api_source.created_at == listing_source.created_at
+        # type code lives at metadata[4] (== 5 → WEB_PAGE) for both paths.
+        assert api_source.kind == listing_source.kind == SourceType.WEB_PAGE
+
 
 class TestSourceTypeCompatMapping:
     """Tests for the _SOURCE_TYPE_COMPAT_MAP backward-compatible mapping."""


### PR DESCRIPTION
Part of #1205 (1/5: unify Source parsers)

## Problem

There were **two divergent parsers** that turn a raw RPC source row into a `Source`:

- `Source.from_api_response` (`src/notebooklm/_types/sources.py`) — used by the
  `ADD_SOURCE` / rename paths (`_source_add.py`, `_sources.py`, `_source_upload.py`).
  It built a `Source` **without `status`**, so the field always fell back to the
  `status: int = SourceStatus.READY` default. The annotation was also wrong: the
  field actually holds a `SourceStatus`, not a bare `int`.
- `SourceLister._parse_source` (`src/notebooklm/_source_listing.py`) — used by the
  `client.sources.list()` / `get()` / poll paths. It built `Source(..., status=row.status, ...)`
  from a `SourceRow`, correctly carrying the decoded processing status.

A `Source` returned from an add/rename therefore silently reported `READY` even when
the wire carried a `PROCESSING`/`ERROR`/`PREPARING` status block.

## Change

Both paths now funnel through a **single construction site**, `Source.from_row(SourceRow)`:

- `Source.from_api_response` normalizes the wire shape via `SourceRow.from_unknown_shape`
  and defers to `from_row` (which sets `status=row.status`).
- `SourceLister._parse_source` wraps the entry via `SourceRow.from_entry` and defers to
  the same `from_row`.

The flat shape still yields `_type_code=None` and `SourceStatus.READY` (the `SourceRow`
returns those defaults when no metadata / status block is present), so all prior behavior
is preserved — `list()` / `get()` and the poller produce identical `Source` instances,
and add/rename results now carry the real `status` / `url` / `created_at`.

The `Source.status` field annotation is corrected from `int` to `SourceStatus`
(still an `int`-compatible enum, so equality and the public-API audit are unaffected).

## Tests

Added to `tests/unit/test_types.py::TestSource`:
- `test_from_api_response_carries_status` — a PROCESSING status block is now decoded.
- `test_from_api_response_status_defaults_ready_without_block` — no status block still
  defaults to READY (flat and medium-nested).
- `test_from_api_response_matches_listing_path` — the classmethod and the `GET_NOTEBOOK`
  listing path produce **identical** `Source` instances from the same entry.

## Gates

- `ruff check` / `ruff format --check`: clean
- `mypy src/notebooklm --ignore-missing-imports`: clean
- `scripts/audit_public_api_compat.py`: no new public break (10 pre-existing allowlisted)
- `pytest -k "source or row_adapter or listing or types"`: 1562 passed
- full `tests/unit tests/integration`: 7254 passed, 52 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source objects now report real processing status (no longer defaulting to READY).
  * Source creation is unified across flows so status, URL, and creation timestamp are consistent.
  * Status typing corrected so status-related properties behave predictably.

* **Tests**
  * Added unit tests covering status parsing and parity between construction paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->