### PR TITLE
refactor(sources): dedup rename payload + share source-lifecycle collaborators

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -493,13 +493,9 @@ class SourceUploadPipeline:
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
         self._bound_loop: asyncio.AbstractEventLoop | None = None
-        # Single owner for the source-lifecycle verbs (list / get / poll):
-        # ``SourcesAPI`` injects its own ``SourceLister`` / ``SourcePoller``
-        # so the pipeline's ``list_sources`` / ``get_source`` /
-        # ``wait_until_ready`` / ``wait_until_registered`` delegate to the
-        # SAME shared collaborators instead of re-constructing parallel
-        # copies. Direct callers (and the pipeline's own unit tests) get
-        # freshly-constructed defaults when they pass nothing.
+        # Defaults; SourcesAPI replaces these via configure_source_lifecycle()
+        # so the pipeline shares its lister/poller (single owner for the
+        # source-lifecycle verbs). Direct callers keep these fresh instances.
         self._lister = lister if lister is not None else SourceLister(self._rpc)
         self._poller = poller if poller is not None else SourcePoller()
         self._get_source_limit = get_source_limit
@@ -516,7 +512,7 @@ class SourceUploadPipeline:
     ) -> None:
         """Adopt ``SourcesAPI``'s shared lister/poller as the single owner.
 
-        Called from :class:`notebooklm._sources.SourcesAPI.__init__`
+        Called from ``SourcesAPI.__init__``
         (alongside :meth:`configure_source_limit_lookup`) so the pipeline's
         source-lifecycle verbs (``list_sources`` / ``get_source`` /
         ``wait_until_ready`` / ``wait_until_registered``) delegate to the

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -479,6 +479,8 @@ class SourceUploadPipeline:
         record_upload_queue_wait: QueueWaitRecorder | None = None,
         async_client_factory: AsyncClientFactory | None = None,
         get_source_limit: GetSourceLimit | None = None,
+        lister: SourceLister | None = None,
+        poller: SourcePoller | None = None,
     ):
         self._rpc = rpc
         self._drain = drain
@@ -491,13 +493,40 @@ class SourceUploadPipeline:
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
         self._bound_loop: asyncio.AbstractEventLoop | None = None
-        self._lister = SourceLister(self._rpc)
-        self._poller = SourcePoller()
+        # Single owner for the source-lifecycle verbs (list / get / poll):
+        # ``SourcesAPI`` injects its own ``SourceLister`` / ``SourcePoller``
+        # so the pipeline's ``list_sources`` / ``get_source`` /
+        # ``wait_until_ready`` / ``wait_until_registered`` delegate to the
+        # SAME shared collaborators instead of re-constructing parallel
+        # copies. Direct callers (and the pipeline's own unit tests) get
+        # freshly-constructed defaults when they pass nothing.
+        self._lister = lister if lister is not None else SourceLister(self._rpc)
+        self._poller = poller if poller is not None else SourcePoller()
         self._get_source_limit = get_source_limit
 
     def configure_source_limit_lookup(self, get_source_limit: GetSourceLimit | None) -> None:
         """Set the optional source-limit lookup used in registration hints."""
         self._get_source_limit = get_source_limit
+
+    def configure_source_lifecycle(
+        self,
+        *,
+        lister: SourceLister,
+        poller: SourcePoller,
+    ) -> None:
+        """Adopt ``SourcesAPI``'s shared lister/poller as the single owner.
+
+        Called from :class:`notebooklm._sources.SourcesAPI.__init__`
+        (alongside :meth:`configure_source_limit_lookup`) so the pipeline's
+        source-lifecycle verbs (``list_sources`` / ``get_source`` /
+        ``wait_until_ready`` / ``wait_until_registered``) delegate to the
+        SAME ``SourceLister`` / ``SourcePoller`` instances the public
+        ``SourcesAPI`` uses, instead of parallel copies built in the
+        pipeline constructor. Direct callers that never run through
+        ``SourcesAPI`` keep the freshly-constructed defaults.
+        """
+        self._lister = lister
+        self._poller = poller
 
     def _resolve_upload_timeout(self, default: httpx.Timeout) -> httpx.Timeout:
         """Return the configured upload timeout, or ``default`` if unset."""

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -20,6 +20,7 @@ from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
 from ._source_polling import SourcePoller
 from ._source_upload import SourceUploadPipeline
+from ._source_upload_payloads import build_rename_source_params
 from ._url_utils import is_youtube_url
 from .rpc import RPCMethod
 from .types import (
@@ -98,6 +99,14 @@ class SourcesAPI:
         self._max_concurrent_uploads = max_concurrent_uploads
         self._uploader = uploader
         self._uploader.configure_source_limit_lookup(self._get_source_limit)
+        # Single owner for the source-lifecycle verbs: the upload pipeline
+        # delegates its ``list_sources`` / ``get_source`` / ``wait_*`` verbs
+        # to the SAME ``SourceLister`` / ``SourcePoller`` instances this API
+        # uses, rather than re-constructing parallel copies (issue #1205).
+        self._uploader.configure_source_lifecycle(
+            lister=self._lister,
+            poller=self._poller,
+        )
 
     async def _rpc_call(
         self,
@@ -577,7 +586,7 @@ class SourcesAPI:
             Updated Source object.
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
-        params = [None, [source_id], [[[new_title]]]]
+        params = build_rename_source_params(source_id, new_title)
         result = await self._rpc.rpc_call(
             RPCMethod.UPDATE_SOURCE,
             params,

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -100,6 +100,19 @@ def sources_api(mock_core):
     return SourcesAPI(mock_core, uploader=uploader)
 
 
+def test_sources_api_makes_uploader_share_lifecycle_collaborators(sources_api):
+    """SourcesAPI is the single owner of the source-lifecycle verbs.
+
+    The upload pipeline's ``list_sources`` / ``get_source`` / ``wait_*``
+    helpers must delegate to the SAME ``SourceLister`` / ``SourcePoller``
+    instances the public API uses, rather than parallel copies built in the
+    pipeline constructor (issue #1205). ``SourcesAPI.__init__`` injects its
+    own collaborators via ``configure_source_lifecycle``.
+    """
+    assert sources_api._uploader._lister is sources_api._lister
+    assert sources_api._uploader._poller is sources_api._poller
+
+
 def _self_runtime_auth_attr_read(node: ast.AST, attr: str) -> bool:
     return (
         isinstance(node, ast.Attribute)


### PR DESCRIPTION
Part of #1205 (3/5: Sources rename-payload + pipeline-verb dedup)

Removes two related duplications in the Sources layer so each source-lifecycle concern has a single owner.

## 1. Duplicated UPDATE_SOURCE rename payload
`SourcesAPI.rename` inlined the position-sensitive literal `[None, [source_id], [[[new_title]]]]`, duplicating the canonical `build_rename_source_params` builder that `SourceUploadPipeline.rename` already used. `SourcesAPI.rename` now calls `build_rename_source_params(source_id, new_title)` — one builder owns the payload shape, and the CLAUDE.md "position-sensitive params" pitfall is fixed in one place.

## 2. Parallel duplicate lifecycle collaborators
`SourceUploadPipeline` constructed its own `SourceLister` / `SourcePoller`, parallel to the ones `SourcesAPI` owns, even though both already share the same RPC executor. `SourcesAPI` is now the single owner: it injects its lister/poller into the pipeline via a new `configure_source_lifecycle()` setter (mirroring the existing `configure_source_limit_lookup()` post-construction hook).

The pipeline keeps its `list_sources` / `get_source` / `wait_until_ready` / `wait_until_registered` methods as instance-level patch seams (the upload unit tests patch `_uploader.wait_until_ready` etc. and assert they're awaited), but they now delegate to the **same** shared collaborators rather than parallel copies. Direct callers that bypass `SourcesAPI` (and the pipeline's own unit tests) keep freshly-constructed defaults.

## Behavior preservation
- `add_file` (upload + optional rename + wait) and `client.sources.*` work identically.
- Public `SourcesAPI` surface unchanged (`audit_public_api_compat.py`: no new break).
- Added a focused test asserting the pipeline shares `SourcesAPI`'s lister/poller.

## Gates
- `ruff check .` / `ruff format .`: clean
- `mypy src/notebooklm --ignore-missing-imports`: clean (184 files)
- `audit_public_api_compat.py`: OK (no new break)
- `pytest -k "source or upload or rename or poll"`: 1371 passed
- full `pytest`: 7355 passed, 52 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Source upload now shares lifecycle handlers with the main sources API to ensure consistent listing, retrieval, and polling behavior across uploads, reducing duplicate coordination and improving reliability when managing uploads.
* **Tests**
  * Added a unit test that verifies the uploader and API use the same lifecycle collaborators for coordinated source operations, preventing regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->