### PR TITLE
refactor(auth): unify the two auth-refresh-and-retry paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ RPC Layer (rpc/)
 | `_backoff.py` | Shared capped exponential-backoff calculation with deterministic test injection |
 | `_reqid_counter.py` | `ReqidCounter` — monotonic `_reqid` for the chat backend |
 | `_runtime_auth.py` | `AuthRefreshCoordinator` — refresh task + auth-snapshot lock |
+| `_auth_refresh_retry.py` | Shared auth refresh-and-retry core for the two retry layers (HTTP-status `AuthRefreshMiddleware` + decoded-RPC `RpcExecutor`): the once-per-logical-call `RefreshBudget` token and the common `refresh_and_count` body (log/refresh/sleep/`rpc_auth_retries` metric). Unifies the previously-divergent copies per issue #1205; the two layers keep their distinct triggers and refresh-failure exception shapes. |
 | `_runtime_lifecycle.py` | `ClientLifecycle` — loop-affinity guard + keepalive task |
 | `_runtime_transport.py` | `RuntimeTransport` — authed-POST transport wrapper that drives the middleware chain and typed transport response handling |
 | `_rpc_executor.py` | RPC dispatch executor. Takes its `Kernel`, `RuntimeTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5). The `RpcOwner` Protocol that previously re-declared the former `Session` facade's private attribute surface was deleted in Wave 4 of session-decoupling (#1068); only the local `DecodeResponse` Protocol remains. |
@@ -187,6 +188,7 @@ src/notebooklm/
 ├── urls.py                      # Public URL helper facade
 ├── utils.py                     # Public async utility helpers
 ├── _atomic_io.py                # Atomic JSON write/update helpers
+├── _auth_refresh_retry.py       # Shared auth refresh-and-retry core (RefreshBudget + refresh_and_count) for both retry layers
 ├── _backoff.py                  # Shared retry backoff calculation
 ├── _callbacks.py                # Sync/async callback invocation helper
 ├── _client_composed.py          # Client-owned composition holder

--- a/src/notebooklm/_auth_refresh_retry.py
+++ b/src/notebooklm/_auth_refresh_retry.py
@@ -1,0 +1,150 @@
+"""Shared auth refresh-and-retry core for the two retry layers.
+
+NotebookLM recovers from an auth failure at **two** distinct layers, and
+issue #1205 flagged that they were implemented as divergent copies:
+
+* **HTTP-status layer** — :class:`notebooklm._middleware_auth_refresh.AuthRefreshMiddleware`
+  catches a raw ``httpx.HTTPStatusError`` 400/401/403 from ``Kernel.post``,
+  refreshes, rebuilds the request envelope, and re-invokes the chain leaf
+  once.
+* **Decoded-RPC layer** — :meth:`notebooklm._rpc_executor.RpcExecutor.try_refresh_and_retry`
+  catches an auth-shaped decoded ``RPCError`` (HTTP 200 carrying an auth
+  error in the batchexecute payload), refreshes, and re-calls ``rpc_call``
+  once.
+
+The *triggers* are genuinely different (raw transport error vs decoded RPC
+error) and must stay separate, but the **refresh-then-retry core** —
+"log → await refresh → on failure log+raise → optional sleep → log success
+→ count the auth-retry metric" — was duplicated, and the copies had drifted:
+they raised different exception shapes on refresh failure and only the
+HTTP-status copy incremented ``rpc_auth_retries``.
+
+This module owns that common core exactly once:
+
+* :class:`RefreshBudget` — a single-consume token that bounds a *logical*
+  RPC call to **one** refresh across BOTH layers. The executor mints one
+  budget per logical ``rpc_call`` and threads it through the chain context
+  (so :class:`AuthRefreshMiddleware` sees it) AND keeps a reference for the
+  decode-time leg. Without the shared budget a ``wire-401 → refresh →
+  decoded-auth-error`` sequence would refresh twice — the HTTP-status copy's
+  per-chain ``auth_refreshed`` flag and the decode copy's ``_is_retry`` flag
+  could not see each other (issue #1205, the audit's named double-refresh
+  concern).
+* :func:`refresh_and_count` — the shared refresh body. It performs the log
+  lines, the coalesced single-flight refresh, the refresh-failure raise
+  (delegated to a caller-supplied ``on_refresh_failure`` so each layer keeps
+  its own externally-observable exception shape), the optional post-refresh
+  sleep, and the ``rpc_auth_retries`` metric increment. The caller performs
+  its own layer-specific retry afterward (chain re-invoke vs ``rpc_call``
+  recursion).
+
+The two layers keep their distinct retry *mechanics* and their distinct
+*failure exception types* (callers and tests depend on
+``TransportAuthExpired`` from the chain and the original ``RPCError`` from
+the decoder); what they now share is the refresh core and the once-per-call
+budget.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._client_metrics import ClientMetrics
+
+
+class RefreshBudget:
+    """Single-consume once-per-logical-call refresh token.
+
+    A logical RPC call may attempt **at most one** auth refresh, even though
+    that call can surface an auth failure at two different layers (a raw
+    ``httpx.HTTPStatusError`` from the wire, then — if the first refresh's
+    retry succeeds at the HTTP layer but the decoded payload still carries an
+    auth error — a decoded ``RPCError``). The same budget instance is shared
+    across both layers so the second layer observes the first layer's
+    consumption.
+
+    :meth:`consume` returns ``True`` exactly once (transferring the budget to
+    the caller) and ``False`` on every subsequent call. It is **not**
+    coroutine-safe in the sense of guarding against interleaved ``await``
+    across tasks — it is single-threaded asyncio state read and written
+    synchronously within one logical call's control flow, mirroring the
+    pre-consolidation ``_is_retry`` recursion flag and the per-chain
+    ``RPC_CONTEXT_AUTH_REFRESHED`` boolean it unifies.
+    """
+
+    __slots__ = ("_available",)
+
+    def __init__(self) -> None:
+        self._available = True
+
+    @property
+    def available(self) -> bool:
+        """``True`` while the single refresh has not yet been consumed."""
+        return self._available
+
+    def consume(self) -> bool:
+        """Claim the refresh budget. Returns ``True`` only on the first call."""
+        if not self._available:
+            return False
+        self._available = False
+        return True
+
+
+async def refresh_and_count(
+    *,
+    refresh: Callable[[], Awaitable[object]],
+    on_refresh_failure: Callable[[Exception], BaseException],
+    sleep: Callable[[float], Awaitable[object]],
+    refresh_retry_delay: float,
+    log_label: str,
+    logger: logging.Logger,
+    metrics: ClientMetrics | None,
+) -> None:
+    """Run the shared refresh body common to both auth-retry layers.
+
+    Sequence (identical to the pre-consolidation copies):
+
+    1. Log ``"<label> auth error detected, attempting token refresh"``.
+    2. ``await refresh()`` — the coalesced single-flight refresh
+       (``AuthRefreshCoordinator.await_refresh`` in production, directly or
+       via the chain host's dynamic delegate).
+    3. On refresh failure: log ``"Token refresh failed: <error>"`` and hand
+       the original error to ``on_refresh_failure``, which *returns* the
+       layer-specific exception to raise (``TransportAuthExpired`` for the
+       chain, the original ``RPCError`` for the decoder). This function raises
+       it ``from refresh_error`` so the refresh error stays chained as
+       ``__cause__`` exactly as both copies did historically.
+    4. Optional post-refresh sleep when ``refresh_retry_delay > 0`` — preserves
+       the historical timing both copies applied between refresh and retry.
+    5. Log ``"Token refresh successful, retrying <label>"``.
+    6. Increment ``rpc_auth_retries`` once per successful refresh. (Before
+       consolidation only the HTTP-status copy did this; the decoded-RPC copy
+       silently skipped it — issue #1205's metrics divergence. Counting on
+       both layers is the corrected, unified behavior.)
+
+    Returns ``None`` on success; the caller then performs its own
+    layer-specific retry (chain re-invoke vs ``rpc_call`` recursion). On
+    refresh failure this never returns — ``on_refresh_failure`` raises.
+
+    The ``raise <exc> from refresh_error`` cause-chaining is performed inside
+    this function so the refresh error is attached as ``__cause__`` exactly as
+    both copies did historically.
+    """
+    logger.info("%s auth error detected, attempting token refresh", log_label)
+    try:
+        await refresh()
+    except Exception as refresh_error:
+        logger.warning("Token refresh failed: %s", refresh_error)
+        raise on_refresh_failure(refresh_error) from refresh_error
+
+    if refresh_retry_delay > 0:
+        await sleep(refresh_retry_delay)
+    logger.info("Token refresh successful, retrying %s", log_label)
+    if metrics is not None:
+        metrics.increment(rpc_auth_retries=1)
+
+
+__all__ = ["RefreshBudget", "refresh_and_count"]

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -71,6 +71,7 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 
+from ._auth_refresh_retry import RefreshBudget, refresh_and_count
 from ._middleware import NextCall, RpcRequest, RpcResponse, materialize_rpc_request
 from ._middleware_context import (
     RPC_CONTEXT_AUTH_REFRESHED,
@@ -78,6 +79,7 @@ from ._middleware_context import (
     RPC_CONTEXT_BUILD_REQUEST,
     RPC_CONTEXT_DISABLE_INTERNAL_RETRIES,
     RPC_CONTEXT_LOG_LABEL,
+    RPC_CONTEXT_REFRESH_BUDGET,
 )
 from ._request_types import AuthSnapshot, BuildRequest
 from ._runtime_config import CORE_LOGGER_NAME
@@ -181,14 +183,25 @@ class AuthRefreshMiddleware:
         sentinel fallback matches DrainMiddleware / RetryMiddleware /
         ErrorInjectionMiddleware).
 
-        Tracks ``RPC_CONTEXT_AUTH_REFRESHED`` to enforce **at most one
-        refresh per logical call** even when ``RetryMiddleware`` (outside
-        this middleware) re-invokes the chain on a 429/5xx that fires
-        after a successful refresh. Without this flag the sequence
-        ``401 → refresh → 429 → Retry retry → 401`` would refresh twice
-        (codex iter-1 catch on PR 12.8). With it, the second 401
+        Enforces **at most one refresh per logical call** even when
+        ``RetryMiddleware`` (outside this middleware) re-invokes the chain on
+        a 429/5xx that fires after a successful refresh. Without this guard
+        the sequence ``401 → refresh → 429 → Retry retry → 401`` would refresh
+        twice (codex iter-1 catch on PR 12.8). With it, the second 401
         propagates without a redundant refresh, matching the pre-PR-12.7
         "one refresh max per logical call" contract.
+
+        The guard reads a shared
+        :class:`notebooklm._auth_refresh_retry.RefreshBudget` from
+        ``request.context[RPC_CONTEXT_REFRESH_BUDGET]`` when present — the
+        executor seeds one per logical ``rpc_call`` so this HTTP-status layer
+        and the decoded-RPC layer in :class:`RpcExecutor` share ONE refresh
+        allowance and a ``wire-401 → refresh → decoded-auth-error`` sequence
+        cannot drive two refreshes (issue #1205). The per-chain
+        ``RPC_CONTEXT_AUTH_REFRESHED`` boolean is still written (and read as a
+        fallback when no budget is threaded, e.g. the chat path) so the
+        RetryMiddleware-re-entry suppression and the terminal freshness
+        rebuild keep observing the post-refresh marker on the shared context.
 
         Pass-through paths:
         - No refresh callback configured → propagate any exception unchanged.
@@ -226,10 +239,19 @@ class AuthRefreshMiddleware:
         try:
             return await next_call(request)
         except httpx.HTTPStatusError as exc:
+            budget = cast(
+                "RefreshBudget | None",
+                request.context.get(RPC_CONTEXT_REFRESH_BUDGET),
+            )
+            already_refreshed = (
+                not budget.available
+                if budget is not None
+                else bool(request.context.get(RPC_CONTEXT_AUTH_REFRESHED))
+            )
             if (
                 not self._refresh_callback_enabled()
                 or not self._is_auth_error(exc)
-                or request.context.get(RPC_CONTEXT_AUTH_REFRESHED)
+                or already_refreshed
                 or bool(request.context.get(RPC_CONTEXT_DISABLE_INTERNAL_RETRIES, False))
             ):
                 # ``disable_internal_retries`` is the post-resolution
@@ -241,30 +263,39 @@ class AuthRefreshMiddleware:
                 # propagate the original auth error untouched.
                 raise
 
-            self._logger.info(
-                "%s auth error detected, attempting token refresh",
-                log_label,
-            )
-            try:
-                await self._refresh_callable()
-            except Exception as refresh_error:
-                self._logger.warning("Token refresh failed: %s", refresh_error)
-                raise TransportAuthExpired(
+            # Bind the original auth error to a stable local: ``except ... as
+            # exc`` unbinds ``exc`` at block exit, and the failure wrapper
+            # closure must keep it after that point.
+            original_auth_error = exc
+
+            # Shared refresh body (log → refresh → on-failure raise → sleep →
+            # log → metric). Refresh failure wraps the original auth
+            # ``HTTPStatusError`` in ``TransportAuthExpired`` — the chain's
+            # historical refresh-failure shape that callers / tests pin.
+            await refresh_and_count(
+                refresh=self._refresh_callable,
+                on_refresh_failure=lambda _refresh_error: TransportAuthExpired(
                     f"auth refresh failed for {log_label}",
-                    original=exc,
-                ) from refresh_error
+                    original=original_auth_error,
+                ),
+                sleep=resolve_sleep(self._sleep),
+                refresh_retry_delay=self._refresh_retry_delay(),
+                log_label=log_label,
+                logger=self._logger,
+                metrics=self._metrics,
+            )
 
-            # Mark BEFORE the retry so a 429 thrown by the retry then
-            # caught by ``RetryMiddleware`` (outside us) doesn't trigger
-            # a second refresh when it re-enters our chain leg.
+            # Mark AFTER a successful refresh (a refresh failure raised above
+            # and never reaches here). Consuming the shared budget is what
+            # blocks the decoded-RPC layer in ``RpcExecutor`` from refreshing
+            # a second time on the SAME logical call (issue #1205). The
+            # per-chain boolean is also set so a 429 thrown by the retry then
+            # caught by ``RetryMiddleware`` (outside us) doesn't trigger a
+            # second refresh when it re-enters our chain leg, and so the
+            # terminal freshness rebuild observes the post-refresh marker.
+            if budget is not None:
+                budget.consume()
             request.context[RPC_CONTEXT_AUTH_REFRESHED] = True
-
-            delay = self._refresh_retry_delay()
-            if delay > 0:
-                await resolve_sleep(self._sleep)(delay)
-            self._logger.info("Token refresh successful, retrying %s", log_label)
-            if self._metrics is not None:
-                self._metrics.increment(rpc_auth_retries=1)
 
             retry_request = await self._rebuild_request_after_refresh(request)
 

--- a/src/notebooklm/_middleware_context.py
+++ b/src/notebooklm/_middleware_context.py
@@ -11,6 +11,15 @@ RPC_CONTEXT_LOG_LABEL: Final = "log_label"
 RPC_CONTEXT_AUTH_SNAPSHOT: Final = "auth_snapshot"
 RPC_CONTEXT_AUTH_REFRESHED: Final = "auth_refreshed"
 RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS: Final = "rpc_queue_wait_seconds"
+# Optional :class:`notebooklm._auth_refresh_retry.RefreshBudget`. Seeded by
+# ``RpcExecutor.rpc_call`` so the HTTP-status refresh layer
+# (``AuthRefreshMiddleware``) and the decoded-RPC refresh layer
+# (``RpcExecutor``) share ONE once-per-logical-call refresh allowance — a
+# wire-401 + decoded-auth-error sequence then drives a single refresh
+# (issue #1205). Absent for callers that drive the chain without a budget
+# (e.g. the chat path), in which case ``AuthRefreshMiddleware`` falls back to
+# the per-chain :data:`RPC_CONTEXT_AUTH_REFRESHED` boolean.
+RPC_CONTEXT_REFRESH_BUDGET: Final = "refresh_budget"
 
 ALLOWED_RPC_CONTEXT_KEYS: Final[frozenset[str]] = frozenset(
     {
@@ -21,6 +30,7 @@ ALLOWED_RPC_CONTEXT_KEYS: Final[frozenset[str]] = frozenset(
         RPC_CONTEXT_AUTH_SNAPSHOT,
         RPC_CONTEXT_AUTH_REFRESHED,
         RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS,
+        RPC_CONTEXT_REFRESH_BUDGET,
     }
 )
 
@@ -31,6 +41,7 @@ __all__ = [
     "RPC_CONTEXT_BUILD_REQUEST",
     "RPC_CONTEXT_DISABLE_INTERNAL_RETRIES",
     "RPC_CONTEXT_LOG_LABEL",
+    "RPC_CONTEXT_REFRESH_BUDGET",
     "RPC_CONTEXT_RPC_METHOD",
     "RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS",
 ]

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -101,7 +101,7 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        refresh_budget: RefreshBudget | None = None,
+        _refresh_budget: RefreshBudget | None = None,
     ) -> Any:
         """Run an RPC wrapped with telemetry and request-id bookkeeping.
 
@@ -118,13 +118,14 @@ class RpcExecutor:
         executor can pick a method-variant-specific policy for wire shapes
         such as ``ADD_SOURCE`` and ``CREATE_NOTE``.
 
-        ``refresh_budget`` carries the shared once-per-logical-call
+        ``_refresh_budget`` carries the shared once-per-logical-call
         :class:`notebooklm._auth_refresh_retry.RefreshBudget` across the
         decode-time retry recursion so the HTTP-status refresh layer (in the
         chain) and the decoded-RPC refresh layer (here) cannot both refresh on
-        the same logical call (issue #1205). The outer call leaves it ``None``;
-        :meth:`_execute_once` mints one and threads it through the chain and
-        the retry recursion.
+        the same logical call (issue #1205). Like ``_is_retry`` it is an
+        internal-only parameter (leading underscore): external callers leave it
+        ``None``; :meth:`_execute_once` mints one and threads it through the
+        chain and the retry recursion.
         """
         # Pre-open guard — preserves the historical ``RuntimeError`` surface by
         # routing through ``Kernel.get_http_client()`` (which raises the same
@@ -149,7 +150,7 @@ class RpcExecutor:
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
-                refresh_budget=refresh_budget,
+                _refresh_budget=_refresh_budget,
             )
 
         self._metrics.increment(rpc_calls_started=1)
@@ -169,7 +170,7 @@ class RpcExecutor:
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
-                refresh_budget=refresh_budget,
+                _refresh_budget=_refresh_budget,
             )
         finally:
             if _reqid_token is not None:
@@ -185,21 +186,21 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        refresh_budget: RefreshBudget | None = None,
+        _refresh_budget: RefreshBudget | None = None,
     ) -> Any:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
 
         # Mint the shared once-per-logical-call refresh budget on the FIRST
-        # ``_execute_once`` of a logical call (``refresh_budget is None``). The
+        # ``_execute_once`` of a logical call (``_refresh_budget is None``). The
         # same instance is threaded into the chain (so the HTTP-status refresh
         # layer in ``AuthRefreshMiddleware`` consumes it) AND into the
         # decode-time retry recursion below, so a ``wire-401 → refresh →
         # decoded-auth-error`` sequence drives ONE refresh (issue #1205).
         # Standalone ``_execute_once`` test calls pass ``None`` and get a fresh
         # budget, preserving the single-refresh-per-call contract in isolation.
-        if refresh_budget is None:
-            refresh_budget = RefreshBudget()
+        if _refresh_budget is None:
+            _refresh_budget = RefreshBudget()
 
         # Consult the idempotency registry. The registry is the single
         # source of truth for "how should this RPC behave under retry?";
@@ -234,7 +235,7 @@ class RpcExecutor:
                 log_label=f"RPC {method.name}",
                 disable_internal_retries=effective_disable_internal_retries,
                 rpc_method=method.name,
-                refresh_budget=refresh_budget,
+                refresh_budget=_refresh_budget,
             )
         except TransportAuthExpired as exc:
             # Preserve the historical raw transport exception on refresh failure.
@@ -300,10 +301,13 @@ class RpcExecutor:
             # effect (issue #1157), so we surface the original error and let
             # the caller's probe-then-create wrapper disambiguate instead.
             #
-            # ``refresh_budget.consume()`` is the LAST guard (short-circuit so
-            # it's only consumed when every other condition holds). It is the
-            # shared once-per-logical-call allowance: it returns ``False`` once
-            # the HTTP-status layer (``AuthRefreshMiddleware``) has already
+            # ``_refresh_budget.consume()`` is the LAST guard and MUST remain
+            # last: it is side-effecting (claims the single refresh allowance),
+            # so it relies on ``and`` short-circuit to only consume when every
+            # other condition already holds. Reordering it earlier would burn
+            # the budget on calls that then fall through to a plain raise. It is
+            # the shared once-per-logical-call allowance: it returns ``False``
+            # once the HTTP-status layer (``AuthRefreshMiddleware``) has already
             # refreshed on this call, suppressing a redundant decode-time
             # refresh (issue #1205), and it returns ``False`` on the
             # ``_is_retry`` recursion leg — replacing the old ``not _is_retry``
@@ -312,7 +316,7 @@ class RpcExecutor:
                 not effective_disable_internal_retries
                 and self._refresh_callback_enabled_provider()
                 and self._is_auth_error(exc)
-                and refresh_budget.consume()
+                and _refresh_budget.consume()
             ):
                 refreshed = await self.try_refresh_and_retry(
                     method,
@@ -322,7 +326,7 @@ class RpcExecutor:
                     exc,
                     disable_internal_retries=disable_internal_retries,
                     operation_variant=operation_variant,
-                    refresh_budget=refresh_budget,
+                    _refresh_budget=_refresh_budget,
                 )
                 return refreshed
 
@@ -456,7 +460,7 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        refresh_budget: RefreshBudget | None = None,
+        _refresh_budget: RefreshBudget | None = None,
     ) -> Any | None:
         """Refresh auth after a decode-time auth error and retry once.
 
@@ -490,7 +494,7 @@ class RpcExecutor:
             _is_retry=True,
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
-            refresh_budget=refresh_budget,
+            _refresh_budget=_refresh_budget,
         )
 
 

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 
 import httpx
 
+from ._auth_refresh_retry import RefreshBudget, refresh_and_count
 from ._env import get_default_language
 from ._idempotency import (
     IDEMPOTENCY_REGISTRY,
@@ -100,6 +101,7 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
+        refresh_budget: RefreshBudget | None = None,
     ) -> Any:
         """Run an RPC wrapped with telemetry and request-id bookkeeping.
 
@@ -115,6 +117,14 @@ class RpcExecutor:
         the :class:`IdempotencyRegistry` lookup in :meth:`_execute_once` so the
         executor can pick a method-variant-specific policy for wire shapes
         such as ``ADD_SOURCE`` and ``CREATE_NOTE``.
+
+        ``refresh_budget`` carries the shared once-per-logical-call
+        :class:`notebooklm._auth_refresh_retry.RefreshBudget` across the
+        decode-time retry recursion so the HTTP-status refresh layer (in the
+        chain) and the decoded-RPC refresh layer (here) cannot both refresh on
+        the same logical call (issue #1205). The outer call leaves it ``None``;
+        :meth:`_execute_once` mints one and threads it through the chain and
+        the retry recursion.
         """
         # Pre-open guard — preserves the historical ``RuntimeError`` surface by
         # routing through ``Kernel.get_http_client()`` (which raises the same
@@ -139,6 +149,7 @@ class RpcExecutor:
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
+                refresh_budget=refresh_budget,
             )
 
         self._metrics.increment(rpc_calls_started=1)
@@ -158,6 +169,7 @@ class RpcExecutor:
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
+                refresh_budget=refresh_budget,
             )
         finally:
             if _reqid_token is not None:
@@ -173,9 +185,21 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
+        refresh_budget: RefreshBudget | None = None,
     ) -> Any:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
+
+        # Mint the shared once-per-logical-call refresh budget on the FIRST
+        # ``_execute_once`` of a logical call (``refresh_budget is None``). The
+        # same instance is threaded into the chain (so the HTTP-status refresh
+        # layer in ``AuthRefreshMiddleware`` consumes it) AND into the
+        # decode-time retry recursion below, so a ``wire-401 → refresh →
+        # decoded-auth-error`` sequence drives ONE refresh (issue #1205).
+        # Standalone ``_execute_once`` test calls pass ``None`` and get a fresh
+        # budget, preserving the single-refresh-per-call contract in isolation.
+        if refresh_budget is None:
+            refresh_budget = RefreshBudget()
 
         # Consult the idempotency registry. The registry is the single
         # source of truth for "how should this RPC behave under retry?";
@@ -210,6 +234,7 @@ class RpcExecutor:
                 log_label=f"RPC {method.name}",
                 disable_internal_retries=effective_disable_internal_retries,
                 rpc_method=method.name,
+                refresh_budget=refresh_budget,
             )
         except TransportAuthExpired as exc:
             # Preserve the historical raw transport exception on refresh failure.
@@ -274,11 +299,20 @@ class RpcExecutor:
             # auth-shaped error surfaced. Re-POSTing would duplicate the side
             # effect (issue #1157), so we surface the original error and let
             # the caller's probe-then-create wrapper disambiguate instead.
+            #
+            # ``refresh_budget.consume()`` is the LAST guard (short-circuit so
+            # it's only consumed when every other condition holds). It is the
+            # shared once-per-logical-call allowance: it returns ``False`` once
+            # the HTTP-status layer (``AuthRefreshMiddleware``) has already
+            # refreshed on this call, suppressing a redundant decode-time
+            # refresh (issue #1205), and it returns ``False`` on the
+            # ``_is_retry`` recursion leg — replacing the old ``not _is_retry``
+            # gate — so the decode-time retry stays bounded to one.
             if (
-                not _is_retry
-                and not effective_disable_internal_retries
+                not effective_disable_internal_retries
                 and self._refresh_callback_enabled_provider()
                 and self._is_auth_error(exc)
+                and refresh_budget.consume()
             ):
                 refreshed = await self.try_refresh_and_retry(
                     method,
@@ -288,6 +322,7 @@ class RpcExecutor:
                     exc,
                     disable_internal_retries=disable_internal_retries,
                     operation_variant=operation_variant,
+                    refresh_budget=refresh_budget,
                 )
                 return refreshed
 
@@ -421,21 +456,32 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
+        refresh_budget: RefreshBudget | None = None,
     ) -> Any | None:
-        """Refresh auth after a decode-time auth error and retry once."""
-        logger.info("RPC %s auth error detected, attempting token refresh", method.name)
+        """Refresh auth after a decode-time auth error and retry once.
 
-        try:
-            await self._auth_refresh.await_refresh()
-        except Exception as refresh_error:
-            logger.warning("Token refresh failed: %s", refresh_error)
-            raise original_error from refresh_error
+        Shares the refresh body with the HTTP-status layer via
+        :func:`notebooklm._auth_refresh_retry.refresh_and_count`. The
+        decoded-RPC layer's refresh-failure shape is the ORIGINAL ``RPCError``
+        (``original_error``) re-raised ``from refresh_error`` — callers and
+        tests pin that exact identity, distinct from the chain layer's
+        ``TransportAuthExpired``.
 
-        refresh_retry_delay = self._refresh_retry_delay_provider()
-        if refresh_retry_delay > 0:
-            await self._sleep(refresh_retry_delay)
+        Unlike the HTTP-status layer, this method increments
+        ``rpc_auth_retries`` too (via the shared helper); before the #1205
+        consolidation only the chain layer counted the auth retry, which was
+        an accidental divergence.
+        """
+        await refresh_and_count(
+            refresh=self._auth_refresh.await_refresh,
+            on_refresh_failure=lambda _refresh_error: original_error,
+            sleep=self._sleep,
+            refresh_retry_delay=self._refresh_retry_delay_provider(),
+            log_label=f"RPC {method.name}",
+            logger=logger,
+            metrics=self._metrics,
+        )
 
-        logger.info("Token refresh successful, retrying RPC %s", method.name)
         return await self.rpc_call(
             method,
             params,
@@ -444,6 +490,7 @@ class RpcExecutor:
             _is_retry=True,
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
+            refresh_budget=refresh_budget,
         )
 
 

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -460,7 +460,7 @@ class RpcExecutor:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        _refresh_budget: RefreshBudget | None = None,
+        _refresh_budget: RefreshBudget,
     ) -> Any | None:
         """Refresh auth after a decode-time auth error and retry once.
 
@@ -475,6 +475,14 @@ class RpcExecutor:
         ``rpc_auth_retries`` too (via the shared helper); before the #1205
         consolidation only the chain layer counted the auth retry, which was
         an accidental divergence.
+
+        ``_refresh_budget`` is REQUIRED (no default): this method is only
+        reached from :meth:`_execute_once` after its
+        ``_refresh_budget.consume()`` gate returned ``True``, so the caller
+        always holds the already-consumed shared budget. Forcing it to be
+        passed forecloses a contrived direct call from minting a fresh budget
+        on the retry leg and allowing a second refresh (coderabbit/claude #1240
+        review).
         """
         await refresh_and_count(
             refresh=self._auth_refresh.await_refresh,

--- a/src/notebooklm/_runtime_transport.py
+++ b/src/notebooklm/_runtime_transport.py
@@ -69,6 +69,7 @@ from ._middleware_context import (
     RPC_CONTEXT_BUILD_REQUEST,
     RPC_CONTEXT_DISABLE_INTERNAL_RETRIES,
     RPC_CONTEXT_LOG_LABEL,
+    RPC_CONTEXT_REFRESH_BUDGET,
     RPC_CONTEXT_RPC_METHOD,
     RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS,
 )
@@ -76,6 +77,7 @@ from ._request_types import AuthSnapshot, BuildRequest
 from ._transport_errors import raise_mapped_post_error
 
 if TYPE_CHECKING:
+    from ._auth_refresh_retry import RefreshBudget
     from ._client_metrics import ClientMetrics
     from ._kernel import Kernel
 
@@ -243,6 +245,7 @@ class RuntimeTransport:
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
+        refresh_budget: RefreshBudget | None = None,
     ) -> httpx.Response:
         """Authed POST entry point — routes through the middleware chain.
 
@@ -255,6 +258,15 @@ class RuntimeTransport:
         request. ``RPC_CONTEXT_BUILD_REQUEST`` remains as the bounded
         rebuild recipe for auth-refresh and pre-terminal freshness
         checks.
+
+        ``refresh_budget`` is an optional
+        :class:`notebooklm._auth_refresh_retry.RefreshBudget` seeded by the
+        RPC executor so the HTTP-status refresh layer
+        (:class:`AuthRefreshMiddleware`) shares its once-per-logical-call
+        refresh allowance with the executor's decoded-RPC refresh layer
+        (issue #1205). Callers that drive the chain without a budget (the
+        chat path) pass ``None``; the middleware then falls back to its
+        per-chain ``RPC_CONTEXT_AUTH_REFRESHED`` boolean.
 
         Raises:
             RuntimeError: if the chain provider returns ``None``. The
@@ -277,6 +289,7 @@ class RuntimeTransport:
             RPC_CONTEXT_LOG_LABEL: log_label,
             RPC_CONTEXT_DISABLE_INTERNAL_RETRIES: disable_internal_retries,
             RPC_CONTEXT_RPC_METHOD: rpc_method,
+            RPC_CONTEXT_REFRESH_BUDGET: refresh_budget,
         }
         snapshot = await self._snapshot_provider()
 

--- a/src/notebooklm/_runtime_transport.py
+++ b/src/notebooklm/_runtime_transport.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -284,13 +284,19 @@ class RuntimeTransport:
         # fixture); it raises only when the currently-running loop differs
         # from the one captured at ``open()``-time.
         self._bound_loop_check()
-        context = {
+        context: dict[str, Any] = {
             RPC_CONTEXT_BUILD_REQUEST: build_request,
             RPC_CONTEXT_LOG_LABEL: log_label,
             RPC_CONTEXT_DISABLE_INTERNAL_RETRIES: disable_internal_retries,
             RPC_CONTEXT_RPC_METHOD: rpc_method,
-            RPC_CONTEXT_REFRESH_BUDGET: refresh_budget,
         }
+        # Only seed the shared refresh budget when one is supplied. Callers
+        # that drive the chain without a budget (the chat path) leave the key
+        # ABSENT, matching the ``RPC_CONTEXT_REFRESH_BUDGET`` docstring; the
+        # auth-refresh middleware then falls back to its per-chain
+        # ``RPC_CONTEXT_AUTH_REFRESHED`` boolean (gemini/claude #1240 review).
+        if refresh_budget is not None:
+            context[RPC_CONTEXT_REFRESH_BUDGET] = refresh_budget
         snapshot = await self._snapshot_provider()
 
         request = materialize_rpc_request(

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -150,6 +150,131 @@ class TestAutoRefreshIntegration:
         assert decode_count[0] == 2, "Should have retried once"
 
     @pytest.mark.asyncio
+    async def test_wire_401_then_decoded_auth_error_refreshes_once(self):
+        """Issue #1205: a wire-401 followed by a decoded auth error on the SAME
+        logical call must drive exactly ONE refresh.
+
+        Before consolidation the HTTP-status layer (``AuthRefreshMiddleware``)
+        and the decoded-RPC layer (``RpcExecutor``) tracked their once-per-call
+        guard independently — the chain's per-request ``auth_refreshed`` flag
+        and the executor's ``_is_retry`` flag could not see each other. So a
+        ``401 → refresh#1 → 200 → decoded-auth-error → refresh#2`` sequence
+        refreshed twice. The shared :class:`RefreshBudget` threaded through both
+        layers now bounds the logical call to a single refresh; the decoded
+        auth error surfaces to the caller instead of triggering a second
+        refresh.
+        """
+        auth = AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="old_csrf",
+            session_id="sid",
+        )
+
+        client = NotebookLMClient(auth)
+        client._composed.chain_host._refresh_retry_delay = 0
+
+        refresh_calls = []
+
+        async def tracking_refresh():
+            refresh_calls.append(True)
+            client._auth.csrf_token = "new_csrf"
+            client._collaborators.auth_coord.update_auth_headers(
+                auth=client._auth,
+                kernel=client._collaborators.kernel,
+            )
+            return client._auth
+
+        client._collaborators.auth_coord._refresh_callback = tracking_refresh
+
+        call_count = [0]
+
+        async def mock_post(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Wire 401 → HTTP-status layer refreshes (refresh #1) and
+                # retries the POST.
+                request = httpx.Request("POST", args[0])
+                response = httpx.Response(401, request=request)
+                raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+            # The post-refresh retry returns HTTP 200; the decoded payload
+            # still carries an auth error.
+            response = MagicMock()
+            response.text = "mock response"
+            response.raise_for_status = MagicMock()
+            return response
+
+        auth_rpc_error = RPCError("authentication expired")
+
+        def mock_decode(*args, **kwargs):
+            raise auth_rpc_error
+
+        client._seams.decode_response = mock_decode
+
+        async with client:
+            install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
+
+            # The decoded auth error surfaces — the shared budget was already
+            # spent by the HTTP-status refresh, so the decoded layer does NOT
+            # refresh again and re-raises the original auth error.
+            with pytest.raises(RPCError) as raised:
+                await client.notebooks.list()
+
+        assert raised.value is auth_rpc_error
+        assert len(refresh_calls) == 1, "wire-401 + decoded-auth-error must refresh exactly once"
+        # Two POSTs: the initial 401 and the single post-refresh retry. No
+        # third POST, because the decoded layer did not refresh-and-retry.
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_decoded_auth_retry_increments_auth_retry_metric(self):
+        """Issue #1205: the decoded-RPC refresh layer now counts the auth retry.
+
+        Before consolidation only the HTTP-status layer incremented
+        ``rpc_auth_retries``; the decode-time refresh-and-retry leg silently
+        skipped it. The shared refresh body counts on both layers.
+        """
+        auth = AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="old_csrf",
+            session_id="sid",
+        )
+
+        client = NotebookLMClient(auth)
+        client._composed.chain_host._refresh_retry_delay = 0
+
+        async def tracking_refresh():
+            client._auth.csrf_token = "new_csrf"
+            client._collaborators.auth_coord.update_auth_headers(
+                auth=client._auth,
+                kernel=client._collaborators.kernel,
+            )
+            return client._auth
+
+        client._collaborators.auth_coord._refresh_callback = tracking_refresh
+
+        async def mock_post(*args, **kwargs):
+            response = MagicMock()
+            response.text = "mock response"
+            response.raise_for_status = MagicMock()
+            return response
+
+        decode_count = [0]
+
+        def mock_decode(*args, **kwargs):
+            decode_count[0] += 1
+            if decode_count[0] == 1:
+                raise RPCError("Authentication expired")
+            return [[["nb1"], ["Notebook 1"]]]
+
+        client._seams.decode_response = mock_decode
+
+        async with client:
+            install_post_as_stream(None, client._collaborators.kernel.get_http_client(), mock_post)
+            await client.notebooks.list()
+
+        assert client._collaborators.metrics.snapshot().rpc_auth_retries == 1
+
+    @pytest.mark.asyncio
     async def test_refresh_delay_is_applied(self):
         """Test that retry delay is actually applied."""
         auth = AuthTokens(

--- a/tests/unit/test_auth_refresh_retry.py
+++ b/tests/unit/test_auth_refresh_retry.py
@@ -1,0 +1,171 @@
+"""Unit tests for the shared auth refresh-and-retry core (issue #1205).
+
+Pins the contract documented in ``src/notebooklm/_auth_refresh_retry.py``:
+
+- :class:`RefreshBudget` is a single-consume once-per-logical-call token.
+- :func:`refresh_and_count` owns the common refresh body shared by the
+  HTTP-status layer (``AuthRefreshMiddleware``) and the decoded-RPC layer
+  (``RpcExecutor``): log → refresh → on-failure raise (caller-shaped) →
+  optional sleep → log → ``rpc_auth_retries`` metric increment.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm._auth_refresh_retry import RefreshBudget, refresh_and_count
+from notebooklm._client_metrics import ClientMetrics
+
+# ---------------------------------------------------------------------------
+# RefreshBudget
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_budget_consumes_exactly_once() -> None:
+    budget = RefreshBudget()
+    assert budget.available is True
+    assert budget.consume() is True
+    assert budget.available is False
+    # Every subsequent consume returns False — the single allowance is spent.
+    assert budget.consume() is False
+    assert budget.consume() is False
+    assert budget.available is False
+
+
+# ---------------------------------------------------------------------------
+# refresh_and_count — success path
+# ---------------------------------------------------------------------------
+
+
+async def _noop_sleep(_seconds: float) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_success_logs_sleeps_and_counts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    refresh_calls: list[None] = []
+    sleeps: list[float] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    metrics = ClientMetrics()
+
+    def _should_not_fail(_error: Exception) -> BaseException:  # pragma: no cover
+        raise AssertionError("on_refresh_failure must not be called on success")
+
+    with caplog.at_level(logging.INFO, logger="notebooklm.test_arr"):
+        await refresh_and_count(
+            refresh=refresh,
+            on_refresh_failure=_should_not_fail,
+            sleep=sleep,
+            refresh_retry_delay=0.25,
+            log_label="RPC LIST_NOTEBOOKS",
+            logger=logging.getLogger("notebooklm.test_arr"),
+            metrics=metrics,
+        )
+
+    assert refresh_calls == [None]
+    assert sleeps == [0.25]
+    assert metrics.snapshot().rpc_auth_retries == 1
+    info_msgs = [r.message for r in caplog.records if r.levelname == "INFO"]
+    assert any(
+        "RPC LIST_NOTEBOOKS auth error detected, attempting token refresh" in m for m in info_msgs
+    )
+    assert any("Token refresh successful, retrying RPC LIST_NOTEBOOKS" in m for m in info_msgs)
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_zero_delay_skips_sleep() -> None:
+    sleeps: list[float] = []
+
+    async def refresh() -> None:
+        return None
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    await refresh_and_count(
+        refresh=refresh,
+        on_refresh_failure=lambda _e: AssertionError("unreachable"),
+        sleep=sleep,
+        refresh_retry_delay=0.0,
+        log_label="RPC X",
+        logger=logging.getLogger("notebooklm.test_arr2"),
+        metrics=None,
+    )
+
+    assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# refresh_and_count — failure path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_failure_raises_caller_shape_chained(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    refresh_error = RuntimeError("login expired")
+    sentinel = ValueError("caller-shaped failure")
+
+    async def refresh() -> None:
+        raise refresh_error
+
+    metrics = ClientMetrics()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="notebooklm.test_arr3"),
+        pytest.raises(ValueError) as excinfo,
+    ):
+        await refresh_and_count(
+            refresh=refresh,
+            on_refresh_failure=lambda _e: sentinel,
+            sleep=_noop_sleep,
+            refresh_retry_delay=0.25,
+            log_label="RPC LIST_NOTEBOOKS",
+            logger=logging.getLogger("notebooklm.test_arr3"),
+            metrics=metrics,
+        )
+
+    # The caller-supplied exception is raised, chained from the refresh error.
+    assert excinfo.value is sentinel
+    assert excinfo.value.__cause__ is refresh_error
+    # No metric increment and no sleep happen on a refresh failure.
+    assert metrics.snapshot().rpc_auth_retries == 0
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("Token refresh failed: login expired" in m for m in warn_msgs)
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_failure_receives_refresh_error() -> None:
+    refresh_error = RuntimeError("boom")
+    received: list[Exception] = []
+
+    async def refresh() -> None:
+        raise refresh_error
+
+    def on_failure(error: Exception) -> BaseException:
+        received.append(error)
+        return KeyError("mapped")
+
+    with pytest.raises(KeyError):
+        await refresh_and_count(
+            refresh=refresh,
+            on_refresh_failure=on_failure,
+            sleep=_noop_sleep,
+            refresh_retry_delay=0.0,
+            log_label="RPC X",
+            logger=logging.getLogger("notebooklm.test_arr4"),
+            metrics=None,
+        )
+
+    assert received == [refresh_error]

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -396,6 +396,7 @@ def _build_rpc_executor() -> Any:
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
+        refresh_budget: Any = None,
     ) -> httpx.Response:
         captured["disable_internal_retries"] = disable_internal_retries
         captured["log_label"] = log_label

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -249,6 +249,7 @@ async def test_retry_inherits_parent_request_id():
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
+        refresh_budget=None,
     ):
         captured_ids.append(get_request_id())
         # First call: raise to trigger retry path; second call: succeed.

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -249,7 +249,7 @@ async def test_retry_inherits_parent_request_id():
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        refresh_budget=None,
+        _refresh_budget=None,
     ):
         captured_ids.append(get_request_id())
         # First call: raise to trigger retry path; second call: succeed.

--- a/tests/unit/test_middleware_context_contract.py
+++ b/tests/unit/test_middleware_context_contract.py
@@ -12,6 +12,7 @@ from notebooklm._middleware_context import (
     RPC_CONTEXT_BUILD_REQUEST,
     RPC_CONTEXT_DISABLE_INTERNAL_RETRIES,
     RPC_CONTEXT_LOG_LABEL,
+    RPC_CONTEXT_REFRESH_BUDGET,
     RPC_CONTEXT_RPC_METHOD,
     RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS,
 )
@@ -155,6 +156,7 @@ def test_allowed_rpc_context_keys_match_adr_vocabulary() -> None:
         RPC_CONTEXT_AUTH_SNAPSHOT,
         RPC_CONTEXT_AUTH_REFRESHED,
         RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS,
+        RPC_CONTEXT_REFRESH_BUDGET,
     } == ALLOWED_RPC_CONTEXT_KEYS
 
 

--- a/tests/unit/test_refresh_lock_lazy_init.py
+++ b/tests/unit/test_refresh_lock_lazy_init.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from _helpers.client_factory import build_client_shell_for_tests
+from notebooklm._auth_refresh_retry import RefreshBudget
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 from notebooklm.rpc import AuthError, RPCMethod
@@ -102,6 +103,7 @@ async def _trigger_refresh(core: NotebookLMClient) -> object:
         "/",
         False,
         AuthError("simulated"),
+        _refresh_budget=RefreshBudget(),
     )
 
 

--- a/tests/unit/test_refresh_state_machine.py
+++ b/tests/unit/test_refresh_state_machine.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from notebooklm._auth_refresh_retry import RefreshBudget
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import AuthError, RPCMethod
 
@@ -45,6 +46,7 @@ async def _trigger_refresh(core):
         "/",
         False,
         AuthError("simulated"),
+        _refresh_budget=RefreshBudget(),
     )
 
 

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -655,6 +655,8 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
     monkeypatch.setattr(core._collaborators.auth_coord, "await_refresh", fake_await_refresh)
     monkeypatch.setattr(executor, "rpc_call", fake_rpc_call)
 
+    from notebooklm._auth_refresh_retry import RefreshBudget
+
     result = await executor.try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,
         ["param"],
@@ -662,6 +664,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         True,
         RPCError("auth"),
         disable_internal_retries=True,
+        _refresh_budget=RefreshBudget(),
     )
 
     assert core._rpc_executor is executor

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -95,6 +95,7 @@ class _Owner:
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
+        refresh_budget: Any = None,
     ) -> httpx.Response:
         url, body, headers = build_request(self.snapshot)
         self.perform_calls.append(
@@ -104,6 +105,7 @@ class _Owner:
                 "url": url,
                 "body": body,
                 "headers": headers,
+                "refresh_budget": refresh_budget,
             }
         )
         return self.response
@@ -244,6 +246,7 @@ async def test_constructor_injected_decode_response_drives_executor(monkeypatch)
         log_label: str,
         disable_internal_retries: bool = False,
         rpc_method: str | None = None,
+        refresh_budget: Any = None,
     ) -> httpx.Response:
         return _ok_response("wire")
 
@@ -468,6 +471,131 @@ async def test_decode_time_auth_retry_skipped_when_caller_disables_retries() -> 
 
 
 @pytest.mark.asyncio
+async def test_decode_time_auth_retry_threads_refresh_budget_to_transport() -> None:
+    """Issue #1205: the executor seeds the chain with the shared RefreshBudget.
+
+    The same budget instance reaches ``perform_authed_post`` (so the
+    HTTP-status layer can consume it) on BOTH the initial attempt and the
+    decode-time retry. The budget is consumed by the decode-time refresh, so
+    the retry leg's transport call carries a spent budget.
+    """
+    from notebooklm._auth_refresh_retry import RefreshBudget
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    decode_calls = 0
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        nonlocal decode_calls
+        decode_calls += 1
+        if decode_calls == 1:
+            raise RPCError("authentication expired")
+        return {"ok": True}
+
+    result = await _executor(
+        owner,
+        decode_response=decode,
+        is_auth_error=lambda exc: True,
+    )._execute_once(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        False,
+    )
+
+    assert result == {"ok": True}
+    # Two transport calls (initial + decode-time retry); both carry the SAME
+    # budget instance, which is spent after the decode-time refresh.
+    budgets = [call["refresh_budget"] for call in owner.perform_calls]
+    assert len(budgets) == 2
+    assert all(isinstance(b, RefreshBudget) for b in budgets)
+    assert budgets[0] is budgets[1]
+    assert budgets[0].available is False
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_skips_when_shared_budget_already_spent() -> None:
+    """Issue #1205: a budget already consumed (e.g. by the HTTP-status layer)
+    suppresses the decode-time refresh.
+
+    Mirrors the production sequence where ``AuthRefreshMiddleware`` refreshed
+    on a wire-401, consumed the shared budget, and the post-refresh retry
+    returned a decoded auth error: the executor must NOT refresh a second time.
+    """
+    from notebooklm._auth_refresh_retry import RefreshBudget
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    auth_rpc_error = RPCError("authentication expired")
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise auth_rpc_error
+
+    spent_budget = RefreshBudget()
+    assert spent_budget.consume() is True  # pre-spend it
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(
+            owner,
+            decode_response=decode,
+            is_auth_error=lambda exc: True,
+        )._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+            refresh_budget=spent_budget,
+        )
+
+    assert raised.value is auth_rpc_error
+    assert owner.refresh_calls == 0
+    # Exactly one POST — no decode-time refresh-and-retry replay.
+    assert len(owner.perform_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_increments_auth_retry_metric() -> None:
+    """Issue #1205: the decode-time refresh leg counts ``rpc_auth_retries``.
+
+    Before consolidation only the HTTP-status layer incremented this metric;
+    the shared refresh body now counts on both layers.
+    """
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    decode_calls = 0
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        nonlocal decode_calls
+        decode_calls += 1
+        if decode_calls == 1:
+            raise RPCError("authentication expired")
+        return {"ok": True}
+
+    await _executor(
+        owner,
+        decode_response=decode,
+        is_auth_error=lambda exc: True,
+    )._execute_once(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        False,
+    )
+
+    assert {"rpc_auth_retries": 1} in owner.metric_increments
+
+
+@pytest.mark.asyncio
 async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
     """Pin that the constructor-injected ``sleep`` reaches the executor.
 
@@ -511,6 +639,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
+        refresh_budget: Any = None,
     ) -> dict[str, bool]:
         assert method is RPCMethod.LIST_NOTEBOOKS
         assert params == ["param"]

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -550,7 +550,7 @@ async def test_decode_time_auth_retry_skips_when_shared_budget_already_spent() -
             "/",
             False,
             False,
-            refresh_budget=spent_budget,
+            _refresh_budget=spent_budget,
         )
 
     assert raised.value is auth_rpc_error
@@ -639,7 +639,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
-        refresh_budget: Any = None,
+        _refresh_budget: Any = None,
     ) -> dict[str, bool]:
         assert method is RPCMethod.LIST_NOTEBOOKS
         assert params == ["param"]


### PR DESCRIPTION
Part of #1205 (5/5: unify auth-refresh-and-retry paths)

## Problem

Auth refresh-and-retry was implemented **twice** with divergent guards, exception shapes, and metrics:

- **HTTP-status layer** (`_middleware_auth_refresh.py`): catches a raw 401/403 `httpx.HTTPStatusError` from `Kernel.post`, refreshes, rebuilds the request envelope, retries the chain once. Once-per-call guard: `RPC_CONTEXT_AUTH_REFRESHED` boolean. Refresh failure → `TransportAuthExpired(...) from refresh_error`. Increments `rpc_auth_retries`.
- **Decoded-RPC layer** (`_rpc_executor.py::try_refresh_and_retry`): catches an auth-shaped decoded `RPCError` (HTTP 200 carrying an auth error in the batchexecute payload), refreshes, re-calls `rpc_call(_is_retry=True)`. Once-per-call guard: the `_is_retry` recursion flag. Refresh failure → original `RPCError` `from refresh_error`. Did **not** increment the metric.

Because the two once-per-call guards could not see each other, a `wire-401 → refresh#1 → 200 → decoded-auth-error → refresh#2` sequence drove **two** refreshes on a single logical call — the audit's named double-refresh concern.

## What this PR consolidates

New `src/notebooklm/_auth_refresh_retry.py` owns the common core exactly once:

- **`refresh_and_count(...)`** — the shared refresh body: log "auth error detected" → `await refresh()` → on failure log + raise the caller-shaped exception `from refresh_error` → optional `refresh_retry_delay` sleep → log "refresh successful" → increment `rpc_auth_retries`.
- **`RefreshBudget`** — a single-consume once-per-logical-call token.

Wiring:

- `RpcExecutor` mints **one** `RefreshBudget` per logical `rpc_call` and threads it through (a) the chain context via the new `RPC_CONTEXT_REFRESH_BUDGET` key (so `AuthRefreshMiddleware` consumes it) and (b) the decode-time retry recursion. The HTTP-status layer and the decoded-RPC layer now share **one** refresh allowance — the `wire-401-then-decoded-auth-error` sequence drives a single refresh.
- Both layers call `refresh_and_count`. The decoded layer now also increments `rpc_auth_retries`, fixing the metrics divergence the issue cites.

## Preserved exactly (no regression)

- **Distinct triggers stay distinct** — raw transport 401/403 vs decoded auth `RPCError`.
- **Distinct refresh-failure exception shapes stay distinct** — `TransportAuthExpired` from the chain (so `rpc_call`'s `except TransportAuthExpired` re-raises the raw `httpx.HTTPStatusError`, and chat maps to `ChatError`); the original `RPCError` from the decoder. Both are pinned by existing tests.
- **#1157 non-idempotent-replay guard** — the effective `disable_internal_retries` classification still suppresses replay on both paths.
- **Single-flight `AuthRefreshCoordinator.await_refresh` coalescing** — untouched.
- **Chat path** drives the chain without a budget, so `AuthRefreshMiddleware` falls back to its per-chain `RPC_CONTEXT_AUTH_REFRESHED` boolean — chat behavior is unchanged.

## What was deliberately NOT merged

The two layers' triggers and their externally-observable refresh-failure exception types were left distinct (callers/tests depend on both, and they are RPC-layer-appropriate: a wire HTTP error vs a decoded RPC error). Forcing one type would regress `test_no_retry_on_cookie_expiration` (HTTP-path failure surfaces a raw `httpx.HTTPStatusError`) and the decoded-path identity assertions. Per the issue's "if a full unification risks behavior change, implement only the safe subset," this PR ships the shared helper + shared once-per-call budget + the metrics-divergence fix.

## Gates

- `ruff check .` + `ruff format .`: clean
- `mypy src/notebooklm --ignore-missing-imports`: clean
- `python scripts/audit_public_api_compat.py`: no new breaks
- `pytest -k "auth or refresh or retry or idempot or rpc_executor or middleware"`: 1368 passed
- `pytest tests/integration/concurrency/`: 106 passed
- Full `pytest`: 7364 passed, 52 skipped

New tests: `tests/unit/test_auth_refresh_retry.py` (budget + shared body), executor-level budget-gate + metric tests in `tests/unit/test_rpc_executor.py`, and the headline `wire-401-then-decoded-auth-error refreshes once` + decoded-metric integration tests in `tests/integration/test_auto_refresh.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated auth-refresh so at-most-one token refresh occurs per logical API call, preventing duplicate retries and improving reliability.
  * Improved error propagation so original auth errors surface consistently after refresh attempts.
  * Ensures decode-time and transport-time refreshes share a single allowance to avoid redundant retries.

* **Documentation**
  * Updated docs to describe the consolidated refresh-and-retry behavior.

* **Tests**
  * Added integration and unit tests validating single-refresh behavior, retry counts, and auth-retry metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->