### PR TITLE
fix(artifacts): don't unwrap an already-flat suggest_reports list (#1243)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1001,7 +1001,19 @@ class ArtifactsAPI:
 
         suggestions = []
         if result and isinstance(result, list) and len(result) > 0:
-            items = result[0] if isinstance(result[0], list) else result
+            # GET_SUGGESTED_REPORTS returns either a wrapped list of rows
+            # (``[[row1, row2, ...]]``) or an already-flat list of rows
+            # (``[row1, row2, ...]``). Only unwrap the wrapped case, detected
+            # by a single outer element whose first inner element is itself a
+            # list (a row). Unwrapping the flat case would mistake the first
+            # row's scalar fields for the suggestion rows and return nothing.
+            items = result
+            if (
+                len(result) == 1
+                and isinstance(result[0], list)
+                and (not result[0] or isinstance(result[0][0], list))
+            ):
+                items = result[0]
             for item in items:
                 if isinstance(item, list) and len(item) >= 5:
                     suggestions.append(

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -1084,9 +1084,29 @@ class TestSuggestReportsUnwrap:
         assert suggestions[0].prompt == "Write a briefing."
 
     @pytest.mark.asyncio
+    async def test_wrapped_single_suggestion_parses(self, mock_artifacts_api):
+        """A wrapped single row (``[[row]]``) unwraps to one suggestion."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = [[list(self._ROWS[0])]]
+
+        suggestions = await api.suggest_reports("nb_123")
+
+        assert len(suggestions) == 1
+        assert suggestions[0].title == "Briefing Doc"
+        assert suggestions[0].prompt == "Write a briefing."
+
+    @pytest.mark.asyncio
     async def test_empty_result_returns_empty(self, mock_artifacts_api):
         """An empty response yields no suggestions."""
         api, mock_core = mock_artifacts_api
         mock_core.rpc_executor.rpc_call.return_value = []
+
+        assert await api.suggest_reports("nb_123") == []
+
+    @pytest.mark.asyncio
+    async def test_wrapped_empty_returns_empty(self, mock_artifacts_api):
+        """A wrapped-empty response (``[[]]``) yields no suggestions without error."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = [[]]
 
         assert await api.suggest_reports("nb_123") == []

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -1008,3 +1008,85 @@ class TestPollStatusMediaReadiness:
         status = await api.poll_status("nb_123", "task_123")
         # Should remain in_progress (original status)
         assert status.status == "in_progress"
+
+
+# =============================================================================
+# suggest_reports: unwrap heuristic for GET_SUGGESTED_REPORTS (issue #1243)
+# =============================================================================
+
+
+class TestSuggestReportsUnwrap:
+    """GET_SUGGESTED_REPORTS arrives either wrapped (``[[row, row]]``) or
+    already-flat (``[row, row]``). Both must parse to the same suggestions.
+
+    Regression for issue #1243: the previous ``result[0]`` unwrap mistook the
+    first row's scalar fields for the suggestion rows in the flat case and
+    returned ``[]``.
+    """
+
+    # ``ReportSuggestion`` reads item[0]=title, item[1]=description,
+    # item[4]=prompt, item[5]=audience_level; rows therefore need >= 5 fields.
+    _ROWS = [
+        ["Briefing Doc", "Briefing on topic.", None, None, "Write a briefing.", 2],
+        ["Study Guide", "Study guide on topic.", None, None, "Write a guide.", 1],
+    ]
+
+    @pytest.mark.asyncio
+    async def test_wrapped_shape_parses(self, mock_artifacts_api):
+        """``[[row, row]]`` (real wire shape) parses to both suggestions."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = [list(self._ROWS)]
+
+        suggestions = await api.suggest_reports("nb_123")
+
+        assert [(s.title, s.prompt, s.audience_level) for s in suggestions] == [
+            ("Briefing Doc", "Write a briefing.", 2),
+            ("Study Guide", "Write a guide.", 1),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_flat_shape_parses(self, mock_artifacts_api):
+        """``[row, row]`` (already-flat) parses identically to the wrapped shape."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = list(self._ROWS)
+
+        suggestions = await api.suggest_reports("nb_123")
+
+        assert [(s.title, s.prompt, s.audience_level) for s in suggestions] == [
+            ("Briefing Doc", "Write a briefing.", 2),
+            ("Study Guide", "Write a guide.", 1),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_wrapped_and_flat_agree(self, mock_artifacts_api):
+        """The wrapped and flat shapes yield identical suggestions."""
+        api, mock_core = mock_artifacts_api
+
+        mock_core.rpc_executor.rpc_call.return_value = [list(self._ROWS)]
+        wrapped = await api.suggest_reports("nb_123")
+
+        mock_core.rpc_executor.rpc_call.return_value = list(self._ROWS)
+        flat = await api.suggest_reports("nb_123")
+
+        assert wrapped == flat
+        assert len(flat) == 2
+
+    @pytest.mark.asyncio
+    async def test_flat_single_suggestion_parses(self, mock_artifacts_api):
+        """A single flat row (``[row]``) is not mistaken for a wrapped list."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = [list(self._ROWS[0])]
+
+        suggestions = await api.suggest_reports("nb_123")
+
+        assert len(suggestions) == 1
+        assert suggestions[0].title == "Briefing Doc"
+        assert suggestions[0].prompt == "Write a briefing."
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty(self, mock_artifacts_api):
+        """An empty response yields no suggestions."""
+        api, mock_core = mock_artifacts_api
+        mock_core.rpc_executor.rpc_call.return_value = []
+
+        assert await api.suggest_reports("nb_123") == []


### PR DESCRIPTION
Fixes #1243

## Problem

`ArtifactsAPI.suggest_reports` (`src/notebooklm/_artifacts.py`) unwrapped the `GET_SUGGESTED_REPORTS` response with `result[0] if isinstance(result[0], list) else result`. `result[0]` is a list for both the wrapped shape (`[[row1, row2]]`) and the already-flat shape (`[row1, row2]`). In the **flat** case, `items` became the first suggestion row (`row1`), so the loop iterated over that row's scalar fields, found nothing matching `len(item) >= 5`, and returned `[]`.

## Verification (this is a real bug)

- The VCR cassette `tests/cassettes/artifacts_suggest_reports.yaml` decodes to the **wrapped** shape `[[row1..row4]]` (rows of 6 fields) — the current code already handles this correctly.
- The golden fixture `tests/fixtures/rpc_golden/GET_SUGGESTED_REPORTS.json` decodes to the **flat** shape `[row1, row2]` — the current code returns `[]` for this, dropping all suggestions.

Both shapes occur in practice, so the heuristic must handle both.

## Fix

Only unwrap when the outer list is a single element whose first inner element is itself a list (a row):

```python
items = result
if (
    len(result) == 1
    and isinstance(result[0], list)
    and (not result[0] or isinstance(result[0][0], list))
):
    items = result[0]
```

The wrapped shape unwraps; the flat shape (including a single flat suggestion) is left intact. The public signature of `suggest_reports` is unchanged, and `scripts/audit_public_api_compat.py` reports no new break.

## Tests

Adds `TestSuggestReportsUnwrap` covering the wrapped, flat, single-flat, and empty shapes, and asserting the wrapped and flat shapes parse to identical suggestions.

## Gates

- `uv run ruff check .` / `uv run ruff format .` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run python scripts/audit_public_api_compat.py` — no new public break
- `uv run pytest -q -k "suggest or report or artifact"` — 1007 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of suggested-reports responses that can arrive in different nested shapes, preventing incorrect unwrapping and ensuring consistent report suggestions.

* **Tests**
  * Added comprehensive tests covering multiple response shapes, single-row and empty cases, and a regression case to prevent future breakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->