### PR TITLE
fix(sources): forward method_id to SourceRow; document unused notebook_id

### DIFF
--- a/src/notebooklm/_source_add.py
+++ b/src/notebooklm/_source_add.py
@@ -79,7 +79,7 @@ class SourceAddService:
 
             if result is None:
                 raise SourceAddError(url, message=f"API returned no data for URL: {url}")
-            return Source.from_api_response(result)
+            return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
         async def _probe() -> Source | None:
             try:
@@ -160,7 +160,7 @@ class SourceAddService:
         if result is None:
             raise SourceAddError(title, message=f"API returned no data for text source: {title}")
 
-        source = Source.from_api_response(result)
+        source = Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
         if wait:
             return await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
@@ -235,7 +235,7 @@ class SourceAddService:
                 raise SourceAddError(
                     title, message=f"API returned no data for Drive source: {title}"
                 )
-            return Source.from_api_response(result)
+            return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
         # Drive URLs canonically embed the file_id as a path segment, e.g.
         # ``https://docs.google.com/document/d/<file_id>/edit``. Match the

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -983,7 +983,11 @@ class SourceUploadPipeline:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return Source.from_api_response(result) if result else Source(id=source_id, title=new_title)
+        return (
+            Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
+            if result
+            else Source(id=source_id, title=new_title)
+        )
 
     async def start_resumable_upload(
         self,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -584,7 +584,11 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return Source.from_api_response(result) if result else Source(id=source_id, title=new_title)
+        return (
+            Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
+            if result
+            else Source(id=source_id, title=new_title)
+        )
 
     async def refresh(self, notebook_id: str, source_id: str) -> bool:
         """Refresh a source to get updated content (for URL/Drive sources).

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -203,7 +203,13 @@ class Source:
         )
 
     @classmethod
-    def from_api_response(cls, data: list[Any], notebook_id: str | None = None) -> Source:
+    def from_api_response(
+        cls,
+        data: list[Any],
+        notebook_id: str | None = None,
+        *,
+        method_id: str | None = None,
+    ) -> Source:
         """Parse source data from various API response formats.
 
         Multi-shape dispatch (the three wire shapes — deeply nested,
@@ -219,13 +225,35 @@ class Source:
         including the decoded :attr:`status`. ``status`` earlier silently
         fell back to the ``SourceStatus.READY`` default here while the
         listing path read it from the row.
+
+        Args:
+            data: Raw decoded source payload (one of the three wire
+                shapes handled by
+                :meth:`~notebooklm._row_adapters_sources.SourceRow.from_unknown_shape`).
+            notebook_id: Accepted for call-site symmetry and forward
+                compatibility but currently unused — the parsed source
+                wire shape carries no notebook reference, so this value
+                does not influence the returned :class:`Source`. It is
+                retained (rather than dropped) because
+                ``Source.from_api_response`` is tracked public surface;
+                removing the parameter would be a backward-incompatible
+                signature change flagged by
+                ``scripts/audit_public_api_compat.py``.
+            method_id: Originating RPC method id (e.g.
+                ``RPCMethod.ADD_SOURCE.value`` /
+                ``RPCMethod.UPDATE_SOURCE.value``) used only to tag
+                ``safe_index`` drift diagnostics with the real method.
+                Defaults to ``None``, which lets
+                :meth:`~notebooklm._row_adapters_sources.SourceRow.from_unknown_shape`
+                fall back to its ``GET_NOTEBOOK`` default — preserving
+                the historical behavior for callers that do not pass it.
         """
         # Keep the row-adapter dependency local so importing the source
         # dataclass package does not pull source-row parsing helpers into
         # the top-level public type facade.
         from .._row_adapters_sources import SourceRow
 
-        return cls.from_row(SourceRow.from_unknown_shape(data))
+        return cls.from_row(SourceRow.from_unknown_shape(data, method_id=method_id))
 
 
 @dataclass

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -727,6 +727,91 @@ class TestSource:
         # type code lives at metadata[4] (== 5 → WEB_PAGE) for both paths.
         assert api_source.kind == listing_source.kind == SourceType.WEB_PAGE
 
+    def test_from_api_response_forwards_method_id_to_row(self):
+        """``method_id`` threads through to the constructed ``SourceRow`` so
+        drift diagnostics name the originating RPC (issue #1242).
+
+        The ADD_SOURCE / rename construction paths pass the real method id;
+        without forwarding it the row defaults to ``GET_NOTEBOOK`` and any
+        ``safe_index`` drift log is mis-tagged.
+        """
+        from notebooklm._row_adapters_sources import SourceRow
+        from notebooklm.rpc import RPCMethod
+
+        captured: dict[str, str | None] = {}
+        real_from_unknown_shape = SourceRow.from_unknown_shape
+
+        def _spy(data, *, method_id=None):
+            captured["method_id"] = method_id
+            return real_from_unknown_shape(data, method_id=method_id)
+
+        entry = [["src_add"], "Added Source", [None, 5, [1704067200, 0]]]
+        with patch.object(SourceRow, "from_unknown_shape", staticmethod(_spy)):
+            Source.from_api_response([entry], method_id=RPCMethod.ADD_SOURCE.value)
+
+        assert captured["method_id"] == RPCMethod.ADD_SOURCE.value
+
+    def test_from_api_response_default_method_id_is_get_notebook(self):
+        """Without an explicit ``method_id`` the row falls back to the
+        historical ``GET_NOTEBOOK`` default — preserving prior behavior for
+        callers that do not pass it (issue #1242 backward-compat)."""
+        from notebooklm._row_adapters_sources import SourceRow
+        from notebooklm.rpc import RPCMethod
+
+        entry = [["src_default"], "Default", [None, 5, [1704067200, 0]]]
+        row = SourceRow.from_unknown_shape([entry])
+
+        assert row.method_id == RPCMethod.GET_NOTEBOOK.value
+
+    def test_from_api_response_drift_tags_real_method_id(self, monkeypatch):
+        """A ``safe_index`` drift on an ADD_SOURCE-built row surfaces an
+        ``UnknownRPCMethodError`` tagged with ADD_SOURCE, not the default
+        ``GET_NOTEBOOK`` (issue #1242).
+
+        ``SourceRow.created_at_raw`` is the adapter's only ``safe_index``
+        call site; force it to drift so we can assert the tagged method id
+        flows from ``from_api_response``'s ``method_id`` argument.
+        """
+        from notebooklm import _row_adapters_sources
+        from notebooklm.exceptions import UnknownRPCMethodError
+        from notebooklm.rpc import RPCMethod
+
+        def _drift(data, *path, method_id, source):
+            raise UnknownRPCMethodError(
+                "forced drift",
+                method_id=method_id,
+                path=tuple(path),
+                source=source,
+            )
+
+        monkeypatch.setattr(_row_adapters_sources, "safe_index", _drift)
+
+        # metadata[2] is a non-empty list so created_at_raw reaches safe_index.
+        entry = [["src_drift"], "Drift", [None, 5, [1704067200, 0]]]
+        row = _row_adapters_sources.SourceRow.from_unknown_shape(
+            [entry], method_id=RPCMethod.ADD_SOURCE.value
+        )
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            _ = row.created_at_raw
+
+        assert exc_info.value.method_id == RPCMethod.ADD_SOURCE.value
+
+    def test_from_api_response_accepts_unused_notebook_id(self):
+        """``notebook_id`` is retained for call-site symmetry / forward-compat
+        but does not influence the parsed source (issue #1241).
+
+        It is kept (not dropped) because ``Source.from_api_response`` is
+        tracked public surface; ``scripts/audit_public_api_compat.py`` flags
+        removing the parameter as a backward-incompatible signature change.
+        """
+        data = [[["src_nb"], "With Notebook Id", [None, 5, [1704067200, 0]]]]
+
+        without_id = Source.from_api_response(data)
+        with_id = Source.from_api_response(data, "nb_ignored")
+        with_keyword = Source.from_api_response(data, notebook_id="nb_ignored")
+
+        assert without_id == with_id == with_keyword
+
 
 class TestSourceTypeCompatMapping:
     """Tests for the _SOURCE_TYPE_COMPAT_MAP backward-compatible mapping."""


### PR DESCRIPTION
Fixes #1241, fixes #1242

Two small follow-ups from #1237 (Source-parser unification), both editing `Source.from_api_response` in `src/notebooklm/_types/sources.py`.

## #1242 — forward `method_id` to `SourceRow.from_unknown_shape`

`Source.from_api_response` called `SourceRow.from_unknown_shape(data)` without a `method_id`, so the row defaulted to `GET_NOTEBOOK`. Any `safe_index` drift log emitted for a row built via the ADD_SOURCE / rename path was therefore mis-tagged as `GET_NOTEBOOK` instead of the actual method.

- Added an **optional keyword-only** `method_id` parameter to `from_api_response` and threaded it through to `from_unknown_shape`. Additive → non-breaking. Default `None` preserves the historical `GET_NOTEBOOK` fallback for callers that do not pass it.
- Updated the internal non-`GET_NOTEBOOK` callers to pass the real method id:
  - `_source_add.py` `add_url` / `add_text` / `add_drive` → `RPCMethod.ADD_SOURCE.value`
  - `_sources.py` `rename` and `_source_upload.py` `rename` → `RPCMethod.UPDATE_SOURCE.value`

## #1241 — unused `notebook_id` parameter

Resolved by **keeping** the parameter. `Source.from_api_response` is tracked public surface (`Source` is exported from the top-level `notebooklm` package), and `scripts/audit_public_api_compat.py` flags removing `notebook_id` as a `changed-signature` break (verified empirically). The parameter is now documented as accepted for call-site symmetry / forward-compat but currently unused — no unapproved public-API break introduced.

## Tests

Added to `tests/unit/test_types.py::TestSource`:
- `method_id` forwards through to the constructed `SourceRow`.
- Default (no `method_id`) falls back to `GET_NOTEBOOK`.
- A forced `safe_index` drift on an ADD_SOURCE-built row surfaces an `UnknownRPCMethodError` tagged with `ADD_SOURCE` (not the `GET_NOTEBOOK` default).
- `notebook_id` is accepted (positional + keyword) and does not influence the parsed source.

## Gates (all green)

- `ruff check .` / `ruff format .` — clean, no changes
- `mypy src/notebooklm --ignore-missing-imports` — no issues
- `scripts/audit_public_api_compat.py` — OK, no new break
- `pytest -k "source or types or row_adapter or listing"` — 1622 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced source operation tracking and diagnostics for improved reliability.

* **Tests**
  * Added unit test coverage for source creation and update operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->