### PR TITLE
feat(api): WaitTimeoutError umbrella + standardize wait poll-interval kwarg (#1208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > **Not removed:** awaiting `NotebookLMClient.from_storage(...)` still works —
 > its deprecation targets v1.0, not v0.6.0.
 
+### Added
+
+- **`WaitTimeoutError` — one catchable base for every wait/poll timeout.** A
+  new public exception (`notebooklm.WaitTimeoutError`) is the common base of
+  `SourceTimeoutError`, `ArtifactTimeoutError` (and its
+  `ArtifactPendingTimeoutError` / `ArtifactInProgressTimeoutError` subclasses),
+  and the new `ResearchTimeoutError`, so a single `except WaitTimeoutError`
+  clause catches a wait timeout from any domain. It mixes in the built-in
+  `TimeoutError`, so this is **fully backward-compatible**: existing
+  `except TimeoutError` clauses keep catching every wait timeout unchanged.
+  ```python
+  from notebooklm import WaitTimeoutError
+  try:
+      await client.sources.wait_until_ready(nb_id, src_id)
+      await client.artifacts.wait_for_completion(nb_id, task_id)
+      await client.research.wait_for_completion(nb_id, research_task_id)
+  except WaitTimeoutError:   # was three separate / inconsistent timeout types
+      ...
+  ```
+- **`ResearchError` / `ResearchTimeoutError`.** The research domain gained a
+  catchable base (`ResearchError`, mirroring `SourceError` / `ArtifactError`)
+  and a domain timeout (`ResearchTimeoutError`). `ResearchAPI.wait_for_completion`
+  previously raised the bare built-in `TimeoutError`; it now raises
+  `ResearchTimeoutError`, a `WaitTimeoutError` (and therefore still a
+  `TimeoutError`), exposing `notebook_id` / `task_id` / `timeout` /
+  `timeout_seconds` / `last_status`. (`ResearchTaskMismatchError` stays a
+  `ValidationError` — it is caller-input validation, not a wait timeout.)
+
+### Changed / Deprecated
+
+- **`ResearchAPI.wait_for_completion(interval=...)` → `initial_interval=...`.**
+  The research waiter's poll-cadence keyword is now `initial_interval`,
+  matching `SourcesAPI.wait_until_ready` and
+  `ArtifactsAPI.wait_for_completion`. The old `interval=` keyword still works
+  as a **deprecated alias** (warns in 0.7.0, removed in v0.8.0): passing a
+  non-default value emits a `DeprecationWarning` (suppressible with
+  `NOTEBOOKLM_QUIET_DEPRECATIONS=1`), and passing both `interval` and
+  `initial_interval` raises `TypeError`. Default-shape calls stay silent and
+  the signature is otherwise unchanged, so the public-API compatibility audit
+  stays clean. See [`docs/deprecations.md`](docs/deprecations.md) for the
+  migration.
+  > **Decision — `wait_timeout` kept.** The `wait_timeout` keyword on the
+  > `SourcesAPI.add_*` family was deliberately **not** renamed to `timeout`:
+  > on those add methods `timeout` would be ambiguous with a per-request HTTP
+  > timeout, whereas the dedicated waiter methods already spell their budget
+  > `timeout`. The research `interval` → `initial_interval` rename was the only
+  > standardization with a clear, unambiguous win.
+
 ### Deprecated
 
 - **`sources.get()` / `artifacts.get()` / `notes.get()` returning `None` for a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ RPC Layer (rpc/)
 | `_env.py`, `config.py` | Runtime environment defaults and the public config re-export surface |
 | `_logging.py`, `log.py` | Redaction/correlation logging internals and the public logging helper surface |
 | `_callbacks.py` | Sync-or-async callback invocation helper used by telemetry/retry hooks |
-| `_deprecation.py` | `warn_get_returns_none` — single place for the `get()`-returns-`None` `DeprecationWarning` (suppressible via `NOTEBOOKLM_QUIET_DEPRECATIONS`). The public `sources/artifacts/notes.get()` warn on a miss; the private `_get_or_none()` body never warns. Flip to raising `*NotFoundError` happens in v0.8.0 (tracked in issue #1247 / `docs/deprecations.md`). |
+| `_deprecation.py` | Deprecation helpers, both gated by `NOTEBOOKLM_QUIET_DEPRECATIONS`: `warn_get_returns_none` — single place for the `get()`-returns-`None` `DeprecationWarning` (public `sources/artifacts/notes.get()` warn on a miss; the private `_get_or_none()` body never warns; flip to raising `*NotFoundError` in v0.8.0, issue #1247); and `deprecated_kwarg` / `deprecations_quiet` — keyword-alias helper that names the v0.8.0 removal and errors when both the old and new keyword are passed (used by `ResearchAPI.wait_for_completion` `interval` → `initial_interval`). See `docs/deprecations.md`. |
 | `_runtime_helpers.py` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval` |
 | `_error_injection.py` | Synthetic-error env-var resolver + startup guard |
 | `_client_metrics.py` | `ClientMetrics` — `ClientMetricsSnapshot` counters + `on_rpc_event` callback |
@@ -194,7 +194,7 @@ src/notebooklm/
 ├── _client_composed.py          # Client-owned composition holder
 ├── _client_seams.py             # Constructor-only injectable seams
 ├── _deadline.py                 # RuntimeDeadline helper for aggregate timeouts
-├── _deprecation.py              # warn_get_returns_none + NOTEBOOKLM_QUIET_DEPRECATIONS gate
+├── _deprecation.py              # Deprecation helpers (warn_get_returns_none + deprecated_kwarg keyword-alias) gated by NOTEBOOKLM_QUIET_DEPRECATIONS
 ├── _env.py                      # Runtime environment/default endpoint helpers
 ├── _idempotency.py              # Mutating-RPC idempotency registry + wrappers
 ├── _kernel.py                   # Concrete Kernel transport core

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_REFRESH_PROFILE` | Child-process hint set for `NOTEBOOKLM_REFRESH_CMD`; names the resolved profile being refreshed | resolved profile |
 | `NOTEBOOKLM_REFRESH_STORAGE_PATH` | Child-process hint set for `NOTEBOOKLM_REFRESH_CMD`; path to the `storage_state.json` file the command must rewrite | resolved storage path |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
-| `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the `get()`-returns-`None` `DeprecationWarning` (`sources.get` / `artifacts.get` / `notes.get` returning `None` on a miss; see `docs/deprecations.md`). Set to a truthy value (`1` / `true` / `yes` / `on`, case-insensitive) to silence it. | (warning emitted) |
+| `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the project's public-API `DeprecationWarning`s: the `get()`-returns-`None` warning (`sources.get` / `artifacts.get` / `notes.get` on a miss) and deprecated keyword aliases (e.g. `ResearchAPI.wait_for_completion(interval=...)`). Set to a truthy value (`1` / `true` / `yes` / `on`, case-insensitive) to silence them; see `docs/deprecations.md`. | (warnings emitted) |
 | `NOTEBOOKLM_VCR_RECORD_ERRORS` | Synthetic-error injection mode for VCR test cassettes (`429`, `5xx`, `expired_csrf`) | - |
 
 ### Public config API vs internal resolvers
@@ -174,7 +174,7 @@ be audited from one location.
 | `NOTEBOOKLM_DEBUG_RPC` | Legacy alias that sets the package logger to `DEBUG`. Prefer `NOTEBOOKLM_LOG_LEVEL=DEBUG` for new code. | (See `NOTEBOOKLM_LOG_LEVEL`.) | `_logging.configure_logging` |
 | `NOTEBOOKLM_NOTEBOOK` | Default notebook ID when no `-n/--notebook` flag is passed. Composes with `notebooklm use <id>` so per-shell overrides do not clobber the persisted active-notebook context. | `-n/--notebook` flag → `NOTEBOOKLM_NOTEBOOK` → active context (from `notebooklm use`) → error | `cli.helpers.require_notebook` (Click also reads it natively via `cli/options.py:notebook_option`'s `envvar=`) |
 | `NOTEBOOKLM_RPC_OVERRIDES` | **JSON object** mapping `RPCMethod` enum names to RPC ID strings (e.g. `{"LIST_NOTEBOOKS": "AbC123"}`). Overrides runtime RPC IDs — community self-patch when Google rotates a method ID. Empty string / unset disables the mechanism; invalid JSON or non-object payloads emit a `WARNING` and are ignored. | Process env, evaluated per RPC resolve (cached on the raw env string). | `notebooklm.rpc.overrides._parse_rpc_overrides` |
-| `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the `get()`-returns-`None` `DeprecationWarning`. When `sources.get` / `artifacts.get` / `notes.get` are about to return `None` for a missing entity, they emit a `DeprecationWarning` (the methods will raise `*NotFoundError` instead in v0.8.0; see `docs/deprecations.md`). Set to a truthy value (`1` / `true` / `yes` / `on`) to silence it. | (warning emitted) | `_deprecation._deprecations_quiet` |
+| `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the project's public-API `DeprecationWarning`s. Two families are gated: (1) the `get()`-returns-`None` warning, emitted when `sources.get` / `artifacts.get` / `notes.get` are about to return `None` for a missing entity (these will raise `*NotFoundError` instead in v0.8.0); and (2) deprecated keyword aliases (e.g. `ResearchAPI.wait_for_completion(interval=...)` → `initial_interval=...`) — the keyword still works, only its warning is silenced. Set to a truthy value (`1` / `true` / `yes` / `on`) to silence them. See `docs/deprecations.md`. | (warnings emitted) | `_deprecation._deprecations_quiet` / `deprecations_quiet` |
 | `NOTEBOOKLM_STRICT_DECODE` | **Retired (ignored since v0.7.0).** Strict decoding is the only mode — `safe_index` always raises `UnknownRPCMethodError` on schema drift. The former `0` warn-and-fallback opt-out was removed; setting the variable has no effect. | (ignored) | — |
 | `NOTEBOOKLM_BASE_URL` | NotebookLM base URL. Constrained to `https://notebooklm.google.com` (personal) or `https://notebooklm.cloud.google.com` (enterprise); other schemes/hosts/paths raise `ValueError`. | Process env on every base-URL lookup. | `_env.get_base_url` |
 | `NOTEBOOKLM_BL` | `bl` (build label) URL parameter sent on the chat streaming endpoint (`ChatAPI.ask`). Pins the frontend build the request is attributed to. | Process env on every chat stream call; whitespace-only falls back to `_env.DEFAULT_BL`. | `_env.get_default_bl` |
@@ -191,8 +191,11 @@ be audited from one location.
 `NOTEBOOKLM_STRICT_DECODE` is ignored as of v0.7.0 (strict decoding is the
 only mode); no value changes decoder behavior.
 `NOTEBOOKLM_QUIET_DEPRECATIONS` treats `1` / `true` / `yes` / `on`
-(case-insensitive) as truthy to suppress the `get()`-returns-`None`
-`DeprecationWarning`; everything else leaves the warning enabled.
+(case-insensitive) as truthy; any other value (including unset) leaves
+deprecation warnings enabled. It silences the project's public-API
+`DeprecationWarning`s — the `get()`-returns-`None` warning and deprecated
+keyword aliases (e.g. `ResearchAPI.wait_for_completion`'s legacy `interval=`) —
+without changing their behavior.
 `NOTEBOOKLM_NOTEBOOK` is treated as unset when empty or whitespace-only so a
 bare `export NOTEBOOKLM_NOTEBOOK=` does not block `notebooklm use` /
 `-n/--notebook` from resolving.
@@ -307,23 +310,39 @@ back to `en`. For the generate commands, the resolution order is:
 
 ### NOTEBOOKLM_QUIET_DEPRECATIONS
 
-Suppresses the `get()`-returns-`None` `DeprecationWarning`. When
-`client.sources.get()`, `client.artifacts.get()`, or `client.notes.get()` are
-about to return `None` for a missing entity, they emit a `DeprecationWarning`
-on the miss. These methods will **raise** the matching `*NotFoundError`
-(`SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError`) instead
-in **v0.8.0** — see [`deprecations.md`](deprecations.md) for the migration
-(wrap the call in `try/except <Resource>NotFoundError`) and the flip tracking
-issue ([#1247](https://github.com/teng-lin/notebooklm-py/issues/1247)).
+Suppresses the project's public-API `DeprecationWarning`s while you migrate. Set
+it to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to silence
+them; any other value (including unset) leaves them enabled. Two families are
+gated:
 
-Set the variable to a truthy value (`1` / `true` / `yes` / `on`,
-case-insensitive) to silence the warning while you migrate; any other value (or
-leaving it unset) keeps the warning enabled. Successful lookups never warn — the
-deprecation fires only on a miss.
+1. **`get()`-returns-`None`.** When `client.sources.get()`,
+   `client.artifacts.get()`, or `client.notes.get()` are about to return `None`
+   for a missing entity, they emit a `DeprecationWarning` on the miss. These
+   methods will **raise** the matching `*NotFoundError` (`SourceNotFoundError` /
+   `ArtifactNotFoundError` / `NoteNotFoundError`) instead in **v0.8.0** — see
+   [`deprecations.md`](deprecations.md) for the migration (wrap the call in
+   `try/except <Resource>NotFoundError`) and the flip tracking issue
+   ([#1247](https://github.com/teng-lin/notebooklm-py/issues/1247)). Successful
+   lookups never warn — the deprecation fires only on a miss.
+2. **Deprecated keyword aliases.** When a public method renames a parameter, the
+   old keyword keeps working for one cycle and emits a `DeprecationWarning`. The
+   current gated alias is `ResearchAPI.wait_for_completion(interval=...)`,
+   deprecated in favor of `initial_interval=...` and removed in v0.8.0. The
+   keyword still resolves to its replacement; only the warning is silenced.
 
-> **Note:** this variable was previously a no-op (it once gated a since-removed
-> `source add --mime-type` notice). It is now wired to the `get()`-returns-`None`
-> deprecation above.
+The helper that reads this variable is
+`notebooklm._deprecation._deprecations_quiet` (public alias
+`deprecations_quiet`).
+
+```bash
+# Silence the project's public-API deprecation warnings while migrating
+export NOTEBOOKLM_QUIET_DEPRECATIONS=1
+```
+
+> Note: this variable does **not** affect `source add --mime-type` /
+> `client.sources.add_file(mime_type=...)` — `mime_type` is a supported
+> parameter and emits no warning. (It was previously a no-op that once gated a
+> since-removed `--mime-type` notice; it is now wired to the deprecations above.)
 
 ### Timeouts
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -16,7 +16,7 @@ the broader stability policy (semver promise, supported Python versions, the
 | `sources.get()` / `artifacts.get()` / `notes.get()` returning `None` on a miss | `try/except SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError` | v0.7.0 | v0.8.0 | Behavior unchanged this release (still returns `None`); a `DeprecationWarning` now fires **only on a miss**. In v0.8.0 these raise the matching `*NotFoundError`, unifying the not-found contract with `notebooks.get()` (which already raises). `SourceNotFoundError` and `ArtifactNotFoundError` already exist; **`NoteNotFoundError` is added in v0.8.0** (the warning's migration hint flags this), so notes callers should defer the `except NoteNotFoundError` clause until v0.8.0. Warning emitted via `src/notebooklm/_deprecation.py::warn_get_returns_none`; suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS`. Flip tracked by [#1247](https://github.com/teng-lin/notebooklm-py/issues/1247) |
 | `NotesAPI.create_from_chat(...)` | `ChatAPI.save_answer_as_note(...)` | v0.5.0 | v0.7.0 | Warning at `src/notebooklm/_notes.py:192` |
 | Awaiting `NotebookLMClient.from_storage(...)` | `async with NotebookLMClient.from_storage(...) as client:` | v0.5.0 | v1.0 | The `__await__` form still works; warning at `src/notebooklm/client.py:__await__` |
-| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.6.x | v0.7.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.7.0 | v0.8.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
 
 ### Migration: `ResearchAPI.wait_for_completion` poll-interval keyword
 
@@ -57,11 +57,11 @@ inference), so both are now supported parameters. The earlier
 | Positional `wait` / `wait_timeout` on `SourcesAPI.add_url`, `SourcesAPI.add_text`, `SourcesAPI.add_file`, `SourcesAPI.add_drive` | Pass `wait=...` and `wait_timeout=...` as keywords | v0.5.0 | v0.7.0 | `wait` / `wait_timeout` are now keyword-only; positional calls raise `TypeError`. CLI already used keyword arguments |
 | `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` — same cadence, clearer name | v0.5.0 | v0.7.0 | The `poll_interval` keyword was removed; passing it raises `TypeError` |
 
-## Scheduled removal — v0.7.0
+## Scheduled removal — v0.8.0
 
 | Deprecated | Replacement | Deprecated since | Removal | Notes |
 |------------|-------------|------------------|---------|-------|
-| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.6.x | v0.7.0 | The `interval` keyword warns in the 0.6.x series and is removed in v0.7.0; after removal, passing it raises `TypeError`. Until then it stays working with a `DeprecationWarning`. |
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.7.0 | v0.8.0 | The `interval` keyword warns starting in v0.7.0 and is removed in v0.8.0; after removal, passing it raises `TypeError`. Until then it stays working with a `DeprecationWarning`. |
 
 ## Removed in v0.6.0
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -16,7 +16,7 @@ the broader stability policy (semver promise, supported Python versions, the
 | `sources.get()` / `artifacts.get()` / `notes.get()` returning `None` on a miss | `try/except SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError` | v0.7.0 | v0.8.0 | Behavior unchanged this release (still returns `None`); a `DeprecationWarning` now fires **only on a miss**. In v0.8.0 these raise the matching `*NotFoundError`, unifying the not-found contract with `notebooks.get()` (which already raises). `SourceNotFoundError` and `ArtifactNotFoundError` already exist; **`NoteNotFoundError` is added in v0.8.0** (the warning's migration hint flags this), so notes callers should defer the `except NoteNotFoundError` clause until v0.8.0. Warning emitted via `src/notebooklm/_deprecation.py::warn_get_returns_none`; suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS`. Flip tracked by [#1247](https://github.com/teng-lin/notebooklm-py/issues/1247) |
 | `NotesAPI.create_from_chat(...)` | `ChatAPI.save_answer_as_note(...)` | v0.5.0 | v0.7.0 | Warning at `src/notebooklm/_notes.py:192` |
 | Awaiting `NotebookLMClient.from_storage(...)` | `async with NotebookLMClient.from_storage(...) as client:` | v0.5.0 | v1.0 | The `__await__` form still works; warning at `src/notebooklm/client.py:__await__` |
-| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.7.0 | v0.8.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.6.x | v0.7.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
 
 ### Migration: `ResearchAPI.wait_for_completion` poll-interval keyword
 
@@ -57,11 +57,11 @@ inference), so both are now supported parameters. The earlier
 | Positional `wait` / `wait_timeout` on `SourcesAPI.add_url`, `SourcesAPI.add_text`, `SourcesAPI.add_file`, `SourcesAPI.add_drive` | Pass `wait=...` and `wait_timeout=...` as keywords | v0.5.0 | v0.7.0 | `wait` / `wait_timeout` are now keyword-only; positional calls raise `TypeError`. CLI already used keyword arguments |
 | `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` — same cadence, clearer name | v0.5.0 | v0.7.0 | The `poll_interval` keyword was removed; passing it raises `TypeError` |
 
-## Scheduled removal — v0.8.0
+## Scheduled removal — v0.7.0
 
 | Deprecated | Replacement | Deprecated since | Removal | Notes |
 |------------|-------------|------------------|---------|-------|
-| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.7.0 | v0.8.0 | In v0.8.0 the `interval` keyword is removed; passing it will raise `TypeError`. Until then it stays working with a `DeprecationWarning`. |
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.6.x | v0.7.0 | The `interval` keyword warns in the 0.6.x series and is removed in v0.7.0; after removal, passing it raises `TypeError`. Until then it stays working with a `DeprecationWarning`. |
 
 ## Removed in v0.6.0
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -57,12 +57,6 @@ inference), so both are now supported parameters. The earlier
 | Positional `wait` / `wait_timeout` on `SourcesAPI.add_url`, `SourcesAPI.add_text`, `SourcesAPI.add_file`, `SourcesAPI.add_drive` | Pass `wait=...` and `wait_timeout=...` as keywords | v0.5.0 | v0.7.0 | `wait` / `wait_timeout` are now keyword-only; positional calls raise `TypeError`. CLI already used keyword arguments |
 | `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` — same cadence, clearer name | v0.5.0 | v0.7.0 | The `poll_interval` keyword was removed; passing it raises `TypeError` |
 
-## Scheduled removal — v0.8.0
-
-| Deprecated | Replacement | Deprecated since | Removal | Notes |
-|------------|-------------|------------------|---------|-------|
-| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.7.0 | v0.8.0 | The `interval` keyword warns starting in v0.7.0 and is removed in v0.8.0; after removal, passing it raises `TypeError`. Until then it stays working with a `DeprecationWarning`. |
-
 ## Removed in v0.6.0
 
 | Removed | Replacement | Deprecated since | Removed in | Notes |

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -16,6 +16,32 @@ the broader stability policy (semver promise, supported Python versions, the
 | `sources.get()` / `artifacts.get()` / `notes.get()` returning `None` on a miss | `try/except SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError` | v0.7.0 | v0.8.0 | Behavior unchanged this release (still returns `None`); a `DeprecationWarning` now fires **only on a miss**. In v0.8.0 these raise the matching `*NotFoundError`, unifying the not-found contract with `notebooks.get()` (which already raises). `SourceNotFoundError` and `ArtifactNotFoundError` already exist; **`NoteNotFoundError` is added in v0.8.0** (the warning's migration hint flags this), so notes callers should defer the `except NoteNotFoundError` clause until v0.8.0. Warning emitted via `src/notebooklm/_deprecation.py::warn_get_returns_none`; suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS`. Flip tracked by [#1247](https://github.com/teng-lin/notebooklm-py/issues/1247) |
 | `NotesAPI.create_from_chat(...)` | `ChatAPI.save_answer_as_note(...)` | v0.5.0 | v0.7.0 | Warning at `src/notebooklm/_notes.py:192` |
 | Awaiting `NotebookLMClient.from_storage(...)` | `async with NotebookLMClient.from_storage(...) as client:` | v0.5.0 | v1.0 | The `__await__` form still works; warning at `src/notebooklm/client.py:__await__` |
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.7.0 | v0.8.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
+
+### Migration: `ResearchAPI.wait_for_completion` poll-interval keyword
+
+```python
+# BEFORE (still works in v0.7.0, emits a DeprecationWarning)
+await client.research.wait_for_completion(nb_id, task_id, interval=2.0)
+
+# AFTER — canonical keyword, matches the source/artifact waiters
+await client.research.wait_for_completion(nb_id, task_id, initial_interval=2.0)
+```
+
+The rename closes the last wait/poll inconsistency: every `wait_*` waiter now
+spells its poll cadence `initial_interval` and routes its timeout through a
+single catchable base, [`WaitTimeoutError`](python-api.md#waittimeouterror).
+Set `NOTEBOOKLM_QUIET_DEPRECATIONS=1` to silence the warning while migrating.
+
+> **Decision — `wait_timeout` kept as-is.** The `wait_timeout` keyword on the
+> `SourcesAPI.add_*` family (`add_url` / `add_text` / `add_file` / `add_drive`)
+> was deliberately **not** renamed to `timeout`. On those methods `timeout`
+> would be ambiguous with a per-request HTTP timeout, and `wait_timeout`
+> already reads as "how long to wait for readiness after adding". The waiter
+> methods (`wait_until_ready` / `wait_until_registered` / the artifact and
+> research `wait_for_completion`) already spell the budget `timeout`, so the
+> only standardization with a clear win was the research `interval` →
+> `initial_interval` rename above.
 
 `SourcesAPI.add_file(mime_type=...)` and `notebooklm source add --mime-type`
 (file sources) are **no longer deprecated**: `mime_type` was re-wired to set
@@ -30,6 +56,12 @@ inference), so both are now supported parameters. The earlier
 | `NOTEBOOKLM_STRICT_DECODE=0` soft-mode opt-out | Unset the variable (strict is the only mode) | v0.5.0 | v0.7.0 | The env var is now ignored; `safe_index` always raises `UnknownRPCMethodError` on shape drift. Rationale in `docs/stability.md` "Strict decode" + ADR-011 |
 | Positional `wait` / `wait_timeout` on `SourcesAPI.add_url`, `SourcesAPI.add_text`, `SourcesAPI.add_file`, `SourcesAPI.add_drive` | Pass `wait=...` and `wait_timeout=...` as keywords | v0.5.0 | v0.7.0 | `wait` / `wait_timeout` are now keyword-only; positional calls raise `TypeError`. CLI already used keyword arguments |
 | `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` — same cadence, clearer name | v0.5.0 | v0.7.0 | The `poll_interval` keyword was removed; passing it raises `TypeError` |
+
+## Scheduled removal — v0.8.0
+
+| Deprecated | Replacement | Deprecated since | Removal | Notes |
+|------------|-------------|------------------|---------|-------|
+| `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` | v0.7.0 | v0.8.0 | In v0.8.0 the `interval` keyword is removed; passing it will raise `TypeError`. Until then it stays working with a `DeprecationWarning`. |
 
 ## Removed in v0.6.0
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -233,7 +233,9 @@ sit at the intersection — they're catchable as **any** of `NotFoundError`
 | `SourceNotFoundError` | `NotFoundError`, `RPCError`, `SourceError`, `NotebookLMError` |
 | `ArtifactNotFoundError` | `NotFoundError`, `RPCError`, `ArtifactError`, `NotebookLMError` |
 | `ArtifactFeatureUnavailableError` | `RPCError`, `ArtifactError`, `NotebookLMError` |
-| `ArtifactTimeoutError` | `TimeoutError`, `ArtifactError`, `NotebookLMError` |
+| `SourceTimeoutError` | `WaitTimeoutError`, `TimeoutError`, `SourceError`, `NotebookLMError` |
+| `ArtifactTimeoutError` | `WaitTimeoutError`, `TimeoutError`, `ArtifactError`, `NotebookLMError` |
+| `ResearchTimeoutError` | `WaitTimeoutError`, `TimeoutError`, `ResearchError`, `NotebookLMError` |
 
 Use the table to pick the right level of catch. `client.sources.get(...)`,
 `client.artifacts.get(...)`, and `client.notes.get(...)` currently return
@@ -266,6 +268,36 @@ patterns without parsing the message.
 The CLI defaults to longer wait budgets for media generation (`audio`: 1200s,
 `video`: 1800s, `cinematic-video`: 3600s). In Python, pass the same budget
 explicitly with `wait_for_completion(..., timeout=...)`.
+
+##### WaitTimeoutError
+
+`WaitTimeoutError` (added in v0.7.0) is the cross-domain umbrella for every
+`wait_*` / polling timeout. It mixes in the built-in `TimeoutError`, so
+existing `except TimeoutError` clauses keep working unchanged, and it is the
+common base of `SourceTimeoutError`, `ArtifactTimeoutError` (and its
+`ArtifactPendingTimeoutError` / `ArtifactInProgressTimeoutError` subclasses),
+and `ResearchTimeoutError`. Catch it once to handle a wait timeout from any
+domain in a single clause:
+
+```python
+from notebooklm import WaitTimeoutError
+
+try:
+    ready = await client.sources.wait_until_ready(nb_id, src_id)
+    status = await client.artifacts.wait_for_completion(nb_id, task_id)
+    result = await client.research.wait_for_completion(nb_id, research_task_id)
+except WaitTimeoutError as exc:
+    # Catches SourceTimeoutError, ArtifactTimeoutError, ResearchTimeoutError.
+    log.warning("wait timed out: %s", exc)
+```
+
+`ResearchAPI.wait_for_completion` previously raised the bare built-in
+`TimeoutError`; it now raises `ResearchTimeoutError`, which is a
+`WaitTimeoutError` (and therefore still a `TimeoutError`), so the change is
+backward-compatible. The poll cadence keyword on that method is now
+`initial_interval=` (matching the source/artifact waiters); the old `interval=`
+keyword still works with a `DeprecationWarning` and is removed in v0.8.0 — see
+[deprecations](deprecations.md#migration-researchapiwait_for_completion-poll-interval-keyword).
 
 ##### Catching any "not found" across domains
 
@@ -1363,7 +1395,7 @@ if result.references:
 |--------|------------|---------|-------------|
 | `start(notebook_id, query, source, mode)` | `str, str, str="web", str="fast"` | `dict \| None` | Start research (mode: "fast" or "deep"); raises `ValidationError` on invalid source/mode |
 | `poll(notebook_id, task_id=None)` | `str, str \| None = None` | `dict` | Check research status |
-| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls |
+| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, initial_interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls. Raises `ResearchTimeoutError` (a `WaitTimeoutError`/`TimeoutError`). The legacy `interval=` keyword is a deprecated alias for `initial_interval=` (removed in v0.8.0). |
 | `import_sources(notebook_id, task_id, sources)` | `str, str, list` | `list[dict]` | Import findings |
 
 **Method Signatures:**
@@ -1405,7 +1437,8 @@ async def wait_for_completion(
     task_id: str | None = None,
     *,
     timeout: float = 1800,
-    interval: float = 5,
+    initial_interval: float = 5,   # canonical poll-cadence keyword
+    interval: float = 5,           # DEPRECATED alias for initial_interval (removed in v0.8.0)
 ) -> dict:
     """
     Loops on poll() until research returns "completed" / "failed" or the
@@ -1416,7 +1449,13 @@ async def wait_for_completion(
     the same notebook cannot cross-wire results.
 
     Returns: final poll() dict.
-    Raises: TimeoutError on timeout; ValueError for invalid timeout/interval.
+    Raises:
+      - ResearchTimeoutError on timeout (a WaitTimeoutError and a built-in
+        TimeoutError, so `except TimeoutError` / `except WaitTimeoutError`
+        both catch it).
+      - ValueError for invalid timeout or non-positive poll interval.
+      - TypeError if both the deprecated `interval=` and `initial_interval=`
+        are passed.
     """
 
 async def import_sources(notebook_id: str, task_id: str, sources: list[dict]) -> list[dict]:
@@ -1458,7 +1497,7 @@ status = await client.research.wait_for_completion(
     nb_id,
     task_id=task_id,
     timeout=1800,
-    interval=5,
+    initial_interval=5,  # canonical keyword; `interval=` is a deprecated alias
 )
 
 # Import discovered sources (using the same task_id discriminator)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -296,7 +296,7 @@ except WaitTimeoutError as exc:
 `WaitTimeoutError` (and therefore still a `TimeoutError`), so the change is
 backward-compatible. The poll cadence keyword on that method is now
 `initial_interval=` (matching the source/artifact waiters); the old `interval=`
-keyword still works with a `DeprecationWarning` and is removed in v0.8.0 — see
+keyword still works with a `DeprecationWarning` and is removed in v0.7.0 — see
 [deprecations](deprecations.md#migration-researchapiwait_for_completion-poll-interval-keyword).
 
 ##### Catching any "not found" across domains
@@ -1395,7 +1395,7 @@ if result.references:
 |--------|------------|---------|-------------|
 | `start(notebook_id, query, source, mode)` | `str, str, str="web", str="fast"` | `dict \| None` | Start research (mode: "fast" or "deep"); raises `ValidationError` on invalid source/mode |
 | `poll(notebook_id, task_id=None)` | `str, str \| None = None` | `dict` | Check research status |
-| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, initial_interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls. Raises `ResearchTimeoutError` (a `WaitTimeoutError`/`TimeoutError`). The legacy `interval=` keyword is a deprecated alias for `initial_interval=` (removed in v0.8.0). |
+| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, initial_interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls. Raises `ResearchTimeoutError` (a `WaitTimeoutError`/`TimeoutError`). The legacy `interval=` keyword is a deprecated alias for `initial_interval=` (removed in v0.7.0). |
 | `import_sources(notebook_id, task_id, sources)` | `str, str, list` | `list[dict]` | Import findings |
 
 **Method Signatures:**
@@ -1438,7 +1438,7 @@ async def wait_for_completion(
     *,
     timeout: float = 1800,
     initial_interval: float = 5,   # canonical poll-cadence keyword
-    interval: float = 5,           # DEPRECATED alias for initial_interval (removed in v0.8.0)
+    interval: float = 5,           # DEPRECATED alias for initial_interval (removed in v0.7.0)
 ) -> dict:
     """
     Loops on poll() until research returns "completed" / "failed" or the

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -296,7 +296,7 @@ except WaitTimeoutError as exc:
 `WaitTimeoutError` (and therefore still a `TimeoutError`), so the change is
 backward-compatible. The poll cadence keyword on that method is now
 `initial_interval=` (matching the source/artifact waiters); the old `interval=`
-keyword still works with a `DeprecationWarning` and is removed in v0.7.0 — see
+keyword still works with a `DeprecationWarning` and is removed in v0.8.0 — see
 [deprecations](deprecations.md#migration-researchapiwait_for_completion-poll-interval-keyword).
 
 ##### Catching any "not found" across domains
@@ -1395,7 +1395,7 @@ if result.references:
 |--------|------------|---------|-------------|
 | `start(notebook_id, query, source, mode)` | `str, str, str="web", str="fast"` | `dict \| None` | Start research (mode: "fast" or "deep"); raises `ValidationError` on invalid source/mode |
 | `poll(notebook_id, task_id=None)` | `str, str \| None = None` | `dict` | Check research status |
-| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, initial_interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls. Raises `ResearchTimeoutError` (a `WaitTimeoutError`/`TimeoutError`). The legacy `interval=` keyword is a deprecated alias for `initial_interval=` (removed in v0.7.0). |
+| `wait_for_completion(notebook_id, task_id=None, *, timeout=1800, initial_interval=5)` | `str, str \| None, float, float` | `dict` | Wait for research to complete, pinning the discovered task ID between polls. Raises `ResearchTimeoutError` (a `WaitTimeoutError`/`TimeoutError`). The legacy `interval=` keyword is a deprecated alias for `initial_interval=` (removed in v0.8.0). |
 | `import_sources(notebook_id, task_id, sources)` | `str, str, list` | `list[dict]` | Import findings |
 
 **Method Signatures:**
@@ -1438,7 +1438,7 @@ async def wait_for_completion(
     *,
     timeout: float = 1800,
     initial_interval: float = 5,   # canonical poll-cadence keyword
-    interval: float = 5,           # DEPRECATED alias for initial_interval (removed in v0.7.0)
+    interval: float = 5,           # DEPRECATED alias for initial_interval (removed in v0.8.0)
 ) -> dict:
     """
     Loops on poll() until research returns "completed" / "failed" or the

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -80,6 +80,7 @@ ChatReference, ReportSuggestion, SuggestedTopic
 # Exceptions (all inherit from NotebookLMError)
 NotebookLMError                    # Base exception
 NotFoundError                      # Cross-domain umbrella for *NotFoundError
+WaitTimeoutError                   # Cross-domain umbrella for wait/poll timeouts (also a built-in TimeoutError)
 RPCError, AuthError, RateLimitError, RPCTimeoutError, ServerError
 NetworkError, DecodingError, UnknownRPCMethodError
 ClientError, ConfigurationError, ValidationError
@@ -87,10 +88,15 @@ ClientError, ConfigurationError, ValidationError
 # Note: *NotFoundError classes mix in RPCError (catchable as either RPCError
 # or the domain base). v0.6.0 restored this symmetry across all three "not
 # found" types — see docs/python-api.md#error-handling for migration prose.
+# Note: *TimeoutError classes mix in WaitTimeoutError (and the built-in
+# TimeoutError). v0.7.0 added the WaitTimeoutError umbrella so `except
+# WaitTimeoutError` catches source/artifact/research wait timeouts uniformly,
+# while `except TimeoutError` keeps working — see docs/python-api.md#waittimeouterror.
 SourceError, SourceAddError, SourceProcessingError, SourceTimeoutError, SourceNotFoundError
 NotebookError, NotebookNotFoundError
 ArtifactError, ArtifactDownloadError, ArtifactFeatureUnavailableError, ArtifactNotFoundError, ArtifactNotReadyError, ArtifactParseError
 ArtifactTimeoutError, ArtifactPendingTimeoutError, ArtifactInProgressTimeoutError
+ResearchError, ResearchTimeoutError, ResearchTaskMismatchError
 ChatError
 
 # Enums

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -88,7 +88,9 @@ from .exceptions import (
     NotFoundError,
     RateLimitError,
     # Domain: Research
+    ResearchError,
     ResearchTaskMismatchError,
+    ResearchTimeoutError,
     RPCError,
     RPCResponseTooLargeError,
     RPCTimeoutError,
@@ -101,6 +103,8 @@ from .exceptions import (
     SourceTimeoutError,
     UnknownRPCMethodError,
     ValidationError,
+    # Cross-domain umbrellas (wait/poll timeouts)
+    WaitTimeoutError,
 )
 
 # Public API: Types and dataclasses
@@ -239,7 +243,11 @@ __all__ = [
     "ArtifactPendingTimeoutError",
     "ArtifactInProgressTimeoutError",
     # Domain Exceptions: Research
+    "ResearchError",
+    "ResearchTimeoutError",
     "ResearchTaskMismatchError",
+    # Cross-domain umbrella: wait/poll timeouts
+    "WaitTimeoutError",
     # Warnings
     "UnknownTypeWarning",
     # User-facing type enums (str enums for .kind property)

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -23,7 +23,11 @@ Two families live here:
 
 Both families share the single ``NOTEBOOKLM_QUIET_DEPRECATIONS`` suppression
 gate (read live, never cached) and a parameterized ``stacklevel`` so the
-warning's ``filename``/``lineno`` point at the *user's* call site.
+warning's ``filename``/``lineno`` point at the *user's* call site. The warning
+message always names the removal version (so ``scripts/check_deprecation_targets.py``
+can verify the shipping release never names *itself* as the removal target), and
+passing BOTH the old and new keyword raises :class:`TypeError` rather than
+silently preferring one.
 """
 
 from __future__ import annotations
@@ -159,7 +163,7 @@ def deprecated_kwarg(
         owner: Human-readable owner of the parameter for the warning message,
             e.g. ``"ResearchAPI.wait_for_completion"``.
         removal: Version in which the deprecated keyword is removed. Defaults
-            to v0.8.0. Named in the warning text so the release gate can verify
+            to v0.7.0. Named in the warning text so the release gate can verify
             it is never the shipping version.
         sentinel: The "not provided" marker for both ``old_value`` and
             ``new_value``. Defaults to ``None``; pass a private sentinel object

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -8,12 +8,29 @@ every deprecated call site.
 This is an implementation module. There is no public surface here; the public
 deprecation *policy* (what is deprecated, since when, removal target) is
 documented in ``docs/deprecations.md``.
+
+Two families live here:
+
+* ``warn_get_returns_none`` — marks ``<resource>.get()`` returning ``None`` on
+  a miss as deprecated (issue #1247).
+* ``deprecated_kwarg`` — the keyword-alias pattern used when a public method
+  renames a parameter but keeps the old name working for one MINOR cycle. The
+  canonical case is the wait/poll timeout standardization (issue #1208):
+  ``ResearchAPI.wait_for_completion`` renamed ``interval`` to
+  ``initial_interval`` (matching ``SourcesAPI.wait_until_ready`` /
+  ``ArtifactsAPI.wait_for_completion``) and accepts the old name as a
+  deprecated alias removed in v0.8.0.
+
+Both families share the single ``NOTEBOOKLM_QUIET_DEPRECATIONS`` suppression
+gate (read live, never cached) and a parameterized ``stacklevel`` so the
+warning's ``filename``/``lineno`` point at the *user's* call site.
 """
 
 from __future__ import annotations
 
 import os
 import warnings
+from typing import TypeVar
 
 # Suppression gate. Setting ``NOTEBOOKLM_QUIET_DEPRECATIONS`` to a truthy value
 # silences the warnings emitted through this module. This re-activates the
@@ -28,11 +45,30 @@ _QUIET_ENV_VAR = "NOTEBOOKLM_QUIET_DEPRECATIONS"
 # ``docs/deprecations.md`` so callers can find the migration guidance.
 GET_RETURNS_NONE_FLIP_ISSUE = 1247
 
+# Canonical removal target for the kwarg aliases introduced by issue #1208.
+# Kept as a module constant so the message text and the docs stay in lockstep
+# and the release gate has a single string to scan. Warns in 0.7.0, removed in
+# 0.8.0.
+DEFAULT_REMOVAL = "0.8.0"
+
+_T = TypeVar("_T")
+
 
 def _deprecations_quiet() -> bool:
     """Return ``True`` when deprecation warnings are suppressed via env var."""
     raw = os.environ.get(_QUIET_ENV_VAR, "")
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def deprecations_quiet() -> bool:
+    """Public alias for :func:`_deprecations_quiet`.
+
+    ``NOTEBOOKLM_QUIET_DEPRECATIONS=1`` (or any truthy ``1``/``true``/``yes``/
+    ``on`` spelling, case-insensitive) silences the ``DeprecationWarning``
+    emitted by :func:`deprecated_kwarg`. Any other value — including unset —
+    leaves the warning enabled.
+    """
+    return _deprecations_quiet()
 
 
 def _not_found_error_exists(exc_name: str) -> bool:
@@ -92,3 +128,78 @@ def warn_get_returns_none(resource: str, *, removal: str = "0.8.0") -> None:
     # the user's call site (3). Points the warning's filename/lineno at the
     # caller that wrote ``await client.<resource>s.get(...)``.
     warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+
+def deprecated_kwarg(
+    old_value: _T | None,
+    new_value: _T | None,
+    *,
+    old: str,
+    new: str,
+    owner: str,
+    removal: str = DEFAULT_REMOVAL,
+    sentinel: object = None,
+    stacklevel: int = 3,
+) -> _T | None:
+    """Resolve a renamed keyword, warning if the deprecated name was used.
+
+    Maps a deprecated keyword (``old``) onto its replacement (``new``) for a
+    single public method. Returns the value that the method should actually
+    use, after emitting a :class:`DeprecationWarning` when (and only when) the
+    caller passed the deprecated name.
+
+    Args:
+        old_value: The value the caller passed for the deprecated keyword, or
+            ``sentinel`` when the caller did not pass it.
+        new_value: The value the caller passed for the canonical keyword, or
+            ``sentinel`` when the caller did not pass it.
+        old: Name of the deprecated keyword (for messages), e.g. ``"interval"``.
+        new: Name of the canonical replacement keyword, e.g.
+            ``"initial_interval"``.
+        owner: Human-readable owner of the parameter for the warning message,
+            e.g. ``"ResearchAPI.wait_for_completion"``.
+        removal: Version in which the deprecated keyword is removed. Defaults
+            to v0.8.0. Named in the warning text so the release gate can verify
+            it is never the shipping version.
+        sentinel: The "not provided" marker for both ``old_value`` and
+            ``new_value``. Defaults to ``None``; pass a private sentinel object
+            when ``None`` is itself a meaningful value.
+        stacklevel: ``warnings.warn`` stacklevel. The default of ``3`` points
+            the warning at the caller of the public method (caller →
+            public method → this helper). Adjust when the helper is invoked
+            through additional wrapper frames.
+
+    Returns:
+        ``new_value`` when the caller used the canonical keyword; ``old_value``
+        when the caller used the deprecated keyword (after warning); otherwise
+        ``sentinel`` (neither provided — the method keeps its own default).
+
+    Raises:
+        TypeError: If the caller passed BOTH the deprecated and the canonical
+            keyword. They name the same concept, so two values is ambiguous.
+    """
+    new_provided = new_value is not sentinel
+    old_provided = old_value is not sentinel
+
+    if old_provided and new_provided:
+        raise TypeError(
+            f"{owner}() received both {new!r} and the deprecated alias {old!r}; pass only {new!r}."
+        )
+
+    if old_provided:
+        if not _deprecations_quiet():
+            warnings.warn(
+                (
+                    f"{owner}({old}=...) is deprecated and will be removed in "
+                    f"v{removal}; use {new}=... instead (same behavior). "
+                    f"Set {_QUIET_ENV_VAR}=1 to silence this warning."
+                ),
+                DeprecationWarning,
+                stacklevel=stacklevel,
+            )
+        return old_value
+
+    # Neither provided (``new_value`` already equals ``sentinel``) or only the
+    # canonical keyword was passed: return it directly so the static type stays
+    # ``_T | None`` rather than the widened ``object`` of ``sentinel``.
+    return new_value

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -163,7 +163,7 @@ def deprecated_kwarg(
         owner: Human-readable owner of the parameter for the warning message,
             e.g. ``"ResearchAPI.wait_for_completion"``.
         removal: Version in which the deprecated keyword is removed. Defaults
-            to v0.7.0. Named in the warning text so the release gate can verify
+            to v0.8.0. Named in the warning text so the release gate can verify
             it is never the shipping version.
         sentinel: The "not provided" marker for both ``old_value`` and
             ``new_value``. Defaults to ``None``; pass a private sentinel object

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -463,7 +463,10 @@ class ResearchAPI:
                 v0.8.0). Passing a non-default value emits a
                 :class:`DeprecationWarning`; passing both a non-default
                 ``interval`` and an explicit ``initial_interval`` raises
-                :class:`TypeError`. Default-shape calls stay silent.
+                :class:`TypeError`. Default-shape calls stay silent — note that
+                ``interval=5`` (the exact default) does *not* warn, since it is
+                indistinguishable from not passing the keyword at all; only
+                non-default ``interval`` values trigger the migration prompt.
 
         Returns:
             The final :meth:`poll` result for ``completed`` or ``failed``
@@ -479,7 +482,8 @@ class ResearchAPI:
             ValueError: If ``timeout`` is negative or the poll interval is not
                 positive.
             TypeError: If both a non-default ``interval`` and an explicit
-                ``initial_interval`` are passed.
+                ``initial_interval`` are passed, or if the resolved poll
+                interval is not a number.
         """
         # ``interval`` keeps its original default of ``5`` so the public-API
         # compatibility audit sees no signature change; we treat it as
@@ -497,16 +501,24 @@ class ResearchAPI:
             sentinel=_INITIAL_INTERVAL_UNSET,
             stacklevel=3,
         )
-        poll_interval: float = (
-            _DEFAULT_RESEARCH_POLL_INTERVAL
-            if not isinstance(resolved_interval, (int, float))
-            else float(resolved_interval)
-        )
+        # Only the sentinel means "neither keyword supplied" — fall back to the
+        # default cadence. An *explicit* non-numeric value (e.g. interval=None
+        # or initial_interval="1") is a caller bug; fail fast with TypeError
+        # rather than silently coercing it back to the default, matching the
+        # old ``interval`` path which would have raised on such a value.
+        if resolved_interval is _INITIAL_INTERVAL_UNSET:
+            poll_interval = _DEFAULT_RESEARCH_POLL_INTERVAL
+        elif isinstance(resolved_interval, bool) or not isinstance(resolved_interval, (int, float)):
+            raise TypeError("poll interval must be a number")
+        else:
+            poll_interval = float(resolved_interval)
 
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
         if poll_interval <= 0:
-            raise ValueError("initial_interval must be positive")
+            # Neutral wording: the caller may have used the deprecated
+            # ``interval`` alias rather than ``initial_interval``.
+            raise ValueError("poll interval must be positive")
 
         loop = asyncio.get_running_loop()
         start = loop.time()

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -15,12 +15,14 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from . import research as _research_pub
+from ._deprecation import deprecated_kwarg
 from ._notebook_metadata import NotebookSourceLister, create_default_source_lister
 from ._research_task_parser import ResearchSource, ResearchTask, parse_research_task_models
 from ._runtime_contracts import RpcCaller
 from .exceptions import (
     NetworkError,
     ResearchTaskMismatchError,
+    ResearchTimeoutError,
     RPCError,
     RPCTimeoutError,
     ValidationError,
@@ -36,6 +38,19 @@ __all__ = ["CitedSourceSelection", "ResearchAPI"]
 logger = logging.getLogger(__name__)
 
 ResearchSourceInput = ResearchSource | Mapping[str, Any]
+
+# Sentinel marking "the canonical ``initial_interval`` keyword was not passed"
+# in ``wait_for_completion``. The deprecated ``interval`` keyword keeps its
+# original default of ``5`` (so the public-API compatibility audit sees an
+# unchanged signature), while ``initial_interval`` is a newly-added keyword
+# that defaults to this sentinel. Resolution prefers ``initial_interval`` when
+# the caller supplied it and otherwise falls back to ``interval``.
+_INITIAL_INTERVAL_UNSET: Any = object()
+
+# Original default cadence for the legacy ``interval`` keyword (seconds between
+# status checks). Preserved verbatim so default-shape callers keep the same
+# behavior and the API-compat audit sees no default change.
+_DEFAULT_RESEARCH_POLL_INTERVAL = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +441,7 @@ class ResearchAPI:
         *,
         timeout: float = 1800,
         interval: float = 5,
+        initial_interval: float = _INITIAL_INTERVAL_UNSET,
     ) -> dict[str, Any]:
         """Poll until research reaches a terminal state or times out.
 
@@ -439,7 +455,15 @@ class ResearchAPI:
             task_id: Optional research task discriminator. Pass the value
                 returned by :meth:`start` when available.
             timeout: Maximum seconds to wait.
-            interval: Seconds between status checks.
+            initial_interval: Seconds between status checks (default: 5). This
+                is the canonical poll-interval keyword, matching
+                :meth:`SourcesAPI.wait_until_ready` and
+                :meth:`ArtifactsAPI.wait_for_completion`.
+            interval: **Deprecated** alias for ``initial_interval`` (removed in
+                v0.8.0). Passing a non-default value emits a
+                :class:`DeprecationWarning`; passing both a non-default
+                ``interval`` and an explicit ``initial_interval`` raises
+                :class:`TypeError`. Default-shape calls stay silent.
 
         Returns:
             The final :meth:`poll` result for ``completed`` or ``failed``
@@ -448,15 +472,41 @@ class ResearchAPI:
             live-API state before the task appears in ``POLL_RESEARCH``.
 
         Raises:
-            TimeoutError: If research does not reach a terminal status before
-                ``timeout`` elapses.
-            ValueError: If ``timeout`` is negative or ``interval`` is not
+            ResearchTimeoutError: If research does not reach a terminal status
+                before ``timeout`` elapses. Subclass of
+                :class:`WaitTimeoutError` and the built-in :class:`TimeoutError`,
+                so ``except TimeoutError`` continues to catch it.
+            ValueError: If ``timeout`` is negative or the poll interval is not
                 positive.
+            TypeError: If both a non-default ``interval`` and an explicit
+                ``initial_interval`` are passed.
         """
+        # ``interval`` keeps its original default of ``5`` so the public-API
+        # compatibility audit sees no signature change; we treat it as
+        # "provided" only when the caller changed it from that default. This
+        # keeps default-shape calls silent while still warning on legacy use.
+        legacy_interval: Any = (
+            interval if interval != _DEFAULT_RESEARCH_POLL_INTERVAL else _INITIAL_INTERVAL_UNSET
+        )
+        resolved_interval = deprecated_kwarg(
+            legacy_interval,
+            initial_interval,
+            old="interval",
+            new="initial_interval",
+            owner="ResearchAPI.wait_for_completion",
+            sentinel=_INITIAL_INTERVAL_UNSET,
+            stacklevel=3,
+        )
+        poll_interval: float = (
+            _DEFAULT_RESEARCH_POLL_INTERVAL
+            if not isinstance(resolved_interval, (int, float))
+            else float(resolved_interval)
+        )
+
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
-        if interval <= 0:
-            raise ValueError("interval must be positive")
+        if poll_interval <= 0:
+            raise ValueError("initial_interval must be positive")
 
         loop = asyncio.get_running_loop()
         start = loop.time()
@@ -482,12 +532,14 @@ class ResearchAPI:
             elapsed = loop.time() - start
             if elapsed >= timeout:
                 task_label = pinned_task_id or "unknown"
-                raise TimeoutError(
-                    f"Research task {task_label} timed out after {timeout}s "
-                    f"(last status: {status_val})"
+                raise ResearchTimeoutError(
+                    notebook_id,
+                    task_label,
+                    timeout,
+                    last_status=status_val,
                 )
 
-            sleep_for = min(interval, timeout - elapsed)
+            sleep_for = min(poll_interval, timeout - elapsed)
             if sleep_for > 0:
                 await asyncio.sleep(sleep_for)
 

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -460,7 +460,7 @@ class ResearchAPI:
                 :meth:`SourcesAPI.wait_until_ready` and
                 :meth:`ArtifactsAPI.wait_for_completion`.
             interval: **Deprecated** alias for ``initial_interval`` (removed in
-                v0.8.0). Passing a non-default value emits a
+                v0.7.0). Passing a non-default value emits a
                 :class:`DeprecationWarning`; passing both a non-default
                 ``interval`` and an explicit ``initial_interval`` raises
                 :class:`TypeError`. Default-shape calls stay silent.

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -460,7 +460,7 @@ class ResearchAPI:
                 :meth:`SourcesAPI.wait_until_ready` and
                 :meth:`ArtifactsAPI.wait_for_completion`.
             interval: **Deprecated** alias for ``initial_interval`` (removed in
-                v0.7.0). Passing a non-default value emits a
+                v0.8.0). Passing a non-default value emits a
                 :class:`DeprecationWarning`; passing both a non-default
                 ``interval`` and an explicit ``initial_interval`` raises
                 :class:`TypeError`. Default-shape calls stay silent.

--- a/src/notebooklm/cli/services/research.py
+++ b/src/notebooklm/cli/services/research.py
@@ -139,7 +139,7 @@ async def execute_research_wait(
             status = await client.research.wait_for_completion(
                 nb_id_resolved,
                 timeout=float(plan.timeout),
-                interval=float(plan.interval),
+                initial_interval=float(plan.interval),
             )
         except TimeoutError:
             return ResearchWaitResult(

--- a/src/notebooklm/cli/services/source_research.py
+++ b/src/notebooklm/cli/services/source_research.py
@@ -134,7 +134,7 @@ async def execute_source_add_research(
             plan.notebook_id,
             task_id=task_id,
             timeout=float(plan.timeout),
-            interval=float(_POLL_INTERVAL_S),
+            initial_interval=float(_POLL_INTERVAL_S),
         )
     except TimeoutError:
         return SourceAddResearchResult(

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -70,6 +70,7 @@ __all__ = [
     "NotebookLMError",
     # Cross-domain umbrellas
     "NotFoundError",
+    "WaitTimeoutError",
     # Validation/Config
     "ValidationError",
     "ConfigurationError",
@@ -113,6 +114,8 @@ __all__ = [
     "ArtifactPendingTimeoutError",
     "ArtifactInProgressTimeoutError",
     # Domain: Research
+    "ResearchError",
+    "ResearchTimeoutError",
     "ResearchTaskMismatchError",
 ]
 
@@ -173,6 +176,43 @@ class NotFoundError(NotebookLMError):
         for migration guidance (the broad ``except RPCError`` clause now
         intercepts a missing source / artifact that previously fell
         through to the specific ``*NotFoundError`` handler).
+    """
+
+
+class WaitTimeoutError(NotebookLMError, TimeoutError):
+    """Common base for *wait/poll* timeouts across the library.
+
+    Every ``wait_*`` / polling method that gives up after a time budget raises
+    a subclass of this umbrella, so callers can catch any wait timeout — source
+    readiness, artifact generation, or research completion — in one clause::
+
+        try:
+            await client.sources.wait_until_ready(nb_id, src_id)
+            await client.artifacts.wait_for_completion(nb_id, task_id)
+            await client.research.wait_for_completion(nb_id, task_id)
+        except WaitTimeoutError as e:
+            # Catches SourceTimeoutError, ArtifactTimeoutError (and its
+            # pending/in-progress subclasses), and ResearchTimeoutError.
+            handle_wait_timeout(e)
+
+    ``WaitTimeoutError`` also mixes in the built-in :class:`TimeoutError`, so
+    existing ``except TimeoutError`` clauses keep catching every wait timeout
+    exactly as before — this umbrella is *additive*. It widens the inheritance
+    of :class:`SourceTimeoutError`, :class:`ArtifactTimeoutError` (and its
+    :class:`ArtifactPendingTimeoutError` / :class:`ArtifactInProgressTimeoutError`
+    subclasses), and :class:`ResearchTimeoutError`; their existing domain bases
+    (``SourceError`` / ``ArtifactError`` / ``ResearchError``) are unchanged, so
+    every prior ``except`` clause continues to work.
+
+    .. note::
+
+        Added in v0.7.0. ``ArtifactsAPI.wait_for_completion`` and
+        ``ResearchAPI.wait_for_completion`` previously raised
+        :class:`ArtifactTimeoutError` (already a ``TimeoutError``) and the bare
+        built-in :class:`TimeoutError` respectively. Routing the research path
+        through :class:`ResearchTimeoutError` (a ``WaitTimeoutError`` and thus
+        still a ``TimeoutError``) is backward-compatible for ``except
+        TimeoutError`` callers and newly catchable via the umbrella.
     """
 
 
@@ -865,8 +905,13 @@ class SourceProcessingError(SourceError):
         super().__init__(msg)
 
 
-class SourceTimeoutError(SourceError):
+class SourceTimeoutError(WaitTimeoutError, SourceError):
     """Timed out waiting for source readiness.
+
+    Inherits from :class:`WaitTimeoutError` (and therefore the built-in
+    :class:`TimeoutError`) in addition to :class:`SourceError`. The
+    ``WaitTimeoutError`` mixin is additive: ``except SourceError`` and the new
+    ``except WaitTimeoutError`` / ``except TimeoutError`` clauses all catch it.
 
     Attributes:
         source_id: The ID of the source.
@@ -1069,13 +1114,15 @@ class ArtifactFeatureUnavailableError(RPCError, ArtifactError):
         )
 
 
-class ArtifactTimeoutError(ArtifactError, TimeoutError):
+class ArtifactTimeoutError(ArtifactError, WaitTimeoutError):
     """Artifact generation did not reach a terminal state before timeout.
 
     The exception remains catchable as built-in :class:`TimeoutError` for
-    backward compatibility, while exposing structured fields for callers that
-    need to distinguish queued tasks from tasks that started but did not
-    complete.
+    backward compatibility (via the :class:`WaitTimeoutError` umbrella, which
+    mixes in ``TimeoutError``), and is now also catchable via
+    ``except WaitTimeoutError`` alongside source and research wait timeouts,
+    while exposing structured fields for callers that need to distinguish
+    queued tasks from tasks that started but did not complete.
 
     Attributes:
         notebook_id: Notebook containing the artifact task.
@@ -1176,6 +1223,60 @@ class ArtifactInProgressTimeoutError(ArtifactTimeoutError):
 # =============================================================================
 # Domain: Research
 # =============================================================================
+
+
+class ResearchError(NotebookLMError):
+    """Base for research operations.
+
+    Added in v0.7.0 to give the research domain a catchable base mirroring
+    :class:`SourceError` / :class:`ArtifactError`. :class:`ResearchTimeoutError`
+    inherits from it (and from :class:`WaitTimeoutError`).
+
+    ``ResearchTaskMismatchError`` deliberately does NOT inherit from this base:
+    it remains a :class:`ValidationError` so existing ``except ValidationError``
+    clauses on :meth:`ResearchAPI.import_sources` keep catching it unchanged.
+    """
+
+
+class ResearchTimeoutError(WaitTimeoutError, ResearchError):
+    """Research task did not reach a terminal state before timeout.
+
+    Raised by :meth:`ResearchAPI.wait_for_completion` when the research task
+    does not reach ``completed`` / ``failed`` within the wait budget.
+
+    Inherits from :class:`WaitTimeoutError` (and therefore the built-in
+    :class:`TimeoutError`) and :class:`ResearchError`. Before v0.7.0 this path
+    raised the bare built-in :class:`TimeoutError`; routing it through this
+    subclass is backward-compatible for ``except TimeoutError`` callers and
+    newly catchable via ``except WaitTimeoutError`` / ``except ResearchError``.
+
+    Attributes:
+        notebook_id: Notebook containing the research task.
+        task_id: The research task ID (``"unknown"`` when no task id was
+            resolved before the timeout).
+        timeout: Wait budget in seconds.
+        timeout_seconds: Alias for ``timeout``.
+        last_status: Last observed research status before timeout.
+    """
+
+    def __init__(
+        self,
+        notebook_id: str,
+        task_id: str,
+        timeout: float,
+        *,
+        last_status: str | None = None,
+    ):
+        self.notebook_id = notebook_id
+        self.task_id = task_id
+        self.timeout = timeout
+        self.timeout_seconds = timeout
+        self.last_status = last_status
+        status_info = f" (last status: {last_status})" if last_status is not None else ""
+        super().__init__(
+            f"Research task {task_id} in notebook {notebook_id} timed out "
+            f"after {timeout}s{status_info}"
+        )
 
 
 class ResearchTaskMismatchError(ValidationError):

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -163,13 +163,17 @@ def create_mock_client():
         *,
         timeout=1800,
         interval=5,
+        initial_interval=None,
     ):
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
-        if interval <= 0:
-            raise ValueError("interval must be positive")
+        # Mirror the real API: ``initial_interval`` is the canonical keyword and
+        # wins when supplied; ``interval`` is the deprecated alias kept working.
+        effective_interval = initial_interval if initial_interval is not None else interval
+        if effective_interval <= 0:
+            raise ValueError("initial_interval must be positive")
         pinned_task_id = task_id
-        attempts = max(1, math.ceil(timeout / interval) + 1)
+        attempts = max(1, math.ceil(timeout / effective_interval) + 1)
         status = {"status": "no_research"}
         for _ in range(attempts):
             status = await mock_client.research.poll(notebook_id, task_id=pinned_task_id)

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -171,7 +171,7 @@ def create_mock_client():
         # wins when supplied; ``interval`` is the deprecated alias kept working.
         effective_interval = initial_interval if initial_interval is not None else interval
         if effective_interval <= 0:
-            raise ValueError("initial_interval must be positive")
+            raise ValueError("poll interval must be positive")
         pinned_task_id = task_id
         attempts = max(1, math.ceil(timeout / effective_interval) + 1)
         status = {"status": "no_research"}

--- a/tests/unit/test_cli_source_services.py
+++ b/tests/unit/test_cli_source_services.py
@@ -212,7 +212,7 @@ async def test_source_add_research_waits_with_started_task_id_and_imports(
         "nb_1",
         task_id="task_123",
         timeout=30.0,
-        interval=5.0,
+        initial_interval=5.0,
     )
     import_research_sources.assert_awaited_once_with(
         client,
@@ -577,7 +577,7 @@ async def test_source_add_research_delegates_timeout_budget_to_research_api() ->
         "nb_1",
         task_id="task_123",
         timeout=6.0,
-        interval=5.0,
+        initial_interval=5.0,
     )
 
 

--- a/tests/unit/test_deprecation_helper.py
+++ b/tests/unit/test_deprecation_helper.py
@@ -1,0 +1,106 @@
+"""Unit tests for the ``notebooklm._deprecation`` keyword-alias helper."""
+
+import warnings
+
+import pytest
+
+from notebooklm._deprecation import (
+    DEFAULT_REMOVAL,
+    deprecated_kwarg,
+    deprecations_quiet,
+)
+
+_UNSET = object()
+
+
+class TestDeprecatedKwarg:
+    def test_new_only_returns_new_without_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning would fail the test
+            result = deprecated_kwarg(
+                None,
+                3.0,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+            )
+        assert result == 3.0
+
+    def test_neither_returns_sentinel_without_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = deprecated_kwarg(
+                _UNSET,
+                _UNSET,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+                sentinel=_UNSET,
+            )
+        assert result is _UNSET
+
+    def test_old_only_warns_and_returns_old(self):
+        with pytest.warns(DeprecationWarning) as record:
+            result = deprecated_kwarg(
+                7.0,
+                None,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+            )
+        assert result == 7.0
+        msg = str(record[0].message)
+        # Names both keywords, the removal version, and the suppress switch.
+        assert "interval" in msg
+        assert "initial_interval" in msg
+        assert f"v{DEFAULT_REMOVAL}" in msg
+        assert "NOTEBOOKLM_QUIET_DEPRECATIONS" in msg
+
+    def test_both_passed_raises_type_error(self):
+        with pytest.raises(TypeError, match="both 'initial_interval'"):
+            deprecated_kwarg(
+                1.0,
+                2.0,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+            )
+
+    def test_custom_removal_named_in_message(self):
+        with pytest.warns(DeprecationWarning, match="v9.9.9"):
+            deprecated_kwarg(
+                1.0,
+                None,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+                removal="9.9.9",
+            )
+
+    def test_quiet_env_suppresses_warning(self, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_QUIET_DEPRECATIONS", "1")
+        assert deprecations_quiet() is True
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # would fail if a warning fired
+            result = deprecated_kwarg(
+                7.0,
+                None,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+            )
+        assert result == 7.0  # still resolves the value, just silently
+
+    def test_quiet_env_unset_is_not_quiet(self, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_QUIET_DEPRECATIONS", raising=False)
+        assert deprecations_quiet() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+    def test_quiet_env_truthy_spellings(self, monkeypatch, value):
+        monkeypatch.setenv("NOTEBOOKLM_QUIET_DEPRECATIONS", value)
+        assert deprecations_quiet() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "", "off", "2"])
+    def test_quiet_env_falsey_spellings(self, monkeypatch, value):
+        monkeypatch.setenv("NOTEBOOKLM_QUIET_DEPRECATIONS", value)
+        assert deprecations_quiet() is False

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -28,6 +28,9 @@ from notebooklm.exceptions import (
     NotebookNotFoundError,
     NotFoundError,
     RateLimitError,
+    ResearchError,
+    ResearchTaskMismatchError,
+    ResearchTimeoutError,
     RPCError,
     RPCTimeoutError,
     ServerError,
@@ -38,6 +41,7 @@ from notebooklm.exceptions import (
     SourceTimeoutError,
     UnknownRPCMethodError,
     ValidationError,
+    WaitTimeoutError,
 )
 from notebooklm.types import AccountLimits, AccountTier, GenerationStatus
 
@@ -351,6 +355,97 @@ class TestNotFoundErrorUmbrella:
             SourceNotFoundError,
             ArtifactNotFoundError,
         ]
+
+
+class TestWaitTimeoutErrorUmbrella:
+    """The WaitTimeoutError umbrella catches every wait/poll timeout.
+
+    Added in v0.7.0 (issue #1208). It is purely additive: it mixes in the
+    built-in :class:`TimeoutError`, so existing ``except TimeoutError`` clauses
+    keep catching every wait timeout, and it widens the inheritance of the
+    source / artifact / research timeout types without disturbing their
+    domain bases.
+    """
+
+    def test_umbrella_inherits_timeout_and_base(self):
+        assert issubclass(WaitTimeoutError, TimeoutError)
+        assert issubclass(WaitTimeoutError, NotebookLMError)
+
+    def test_all_wait_timeouts_subclass_umbrella(self):
+        for exc_class in (
+            SourceTimeoutError,
+            ArtifactTimeoutError,
+            ArtifactPendingTimeoutError,
+            ArtifactInProgressTimeoutError,
+            ResearchTimeoutError,
+        ):
+            assert issubclass(exc_class, WaitTimeoutError), exc_class.__name__
+            # Still a built-in TimeoutError (backward-compatible catchability).
+            assert issubclass(exc_class, TimeoutError), exc_class.__name__
+
+    def test_domain_bases_unchanged(self):
+        """Widening to WaitTimeoutError must not disturb the domain bases."""
+        assert issubclass(SourceTimeoutError, SourceError)
+        assert issubclass(ArtifactTimeoutError, ArtifactError)
+        assert issubclass(ResearchTimeoutError, ResearchError)
+        assert issubclass(ResearchError, NotebookLMError)
+
+    def test_umbrella_catches_source_artifact_research(self):
+        """One ``except WaitTimeoutError`` clause catches all three domains."""
+        caught: list[type] = []
+        for exc in (
+            SourceTimeoutError("src-1", 12.0),
+            ArtifactTimeoutError("nb-1", "task-1", 30.0),
+            ResearchTimeoutError("nb-1", "task-1", 60.0),
+        ):
+            try:
+                raise exc
+            except WaitTimeoutError as e:
+                caught.append(type(e))
+        assert caught == [
+            SourceTimeoutError,
+            ArtifactTimeoutError,
+            ResearchTimeoutError,
+        ]
+
+    def test_builtin_timeout_error_still_catches_all(self):
+        """Backward compatibility: ``except TimeoutError`` still works."""
+        for exc in (
+            SourceTimeoutError("src-1", 12.0),
+            ArtifactTimeoutError("nb-1", "task-1", 30.0),
+            ResearchTimeoutError("nb-1", "task-1", 60.0),
+        ):
+            with pytest.raises(TimeoutError):
+                raise exc
+
+    def test_research_timeout_attributes(self):
+        err = ResearchTimeoutError("nb-1", "task-7", 60.0, last_status="in_progress")
+        assert err.notebook_id == "nb-1"
+        assert err.task_id == "task-7"
+        assert err.timeout == 60.0
+        assert err.timeout_seconds == 60.0
+        assert err.last_status == "in_progress"
+        assert "task-7" in str(err)
+        assert "in_progress" in str(err)
+
+    def test_research_task_mismatch_stays_validation_error(self):
+        """ResearchTaskMismatchError stays a ValidationError, not ResearchError.
+
+        It is a caller-input validation failure on ``import_sources``, so it
+        keeps its :class:`ValidationError` base and is deliberately NOT moved
+        under the new :class:`ResearchError` domain base.
+        """
+        assert issubclass(ResearchTaskMismatchError, ValidationError)
+        assert not issubclass(ResearchTaskMismatchError, ResearchError)
+        assert not issubclass(ResearchTaskMismatchError, WaitTimeoutError)
+
+    def test_umbrella_and_research_exports(self):
+        assert notebooklm.WaitTimeoutError is WaitTimeoutError
+        assert notebooklm.ResearchError is ResearchError
+        assert notebooklm.ResearchTimeoutError is ResearchTimeoutError
+        assert "WaitTimeoutError" in notebooklm.__all__
+        assert "ResearchError" in notebooklm.__all__
+        assert "ResearchTimeoutError" in notebooklm.__all__
 
 
 class TestRPCErrorAttributes:

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -178,7 +178,7 @@ def _make_client(extra_setup=None) -> MagicMock:
             raise ValueError("timeout must be non-negative")
         effective_interval = initial_interval if initial_interval is not None else interval
         if effective_interval <= 0:
-            raise ValueError("initial_interval must be positive")
+            raise ValueError("poll interval must be positive")
         pinned_task_id = task_id
         attempts = max(1, math.ceil(timeout / effective_interval) + 1)
         status = {"status": "no_research"}

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -172,13 +172,15 @@ def _make_client(extra_setup=None) -> MagicMock:
         *,
         timeout: float = 1800,
         interval: float = 5,
+        initial_interval: float | None = None,
     ) -> dict:
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
-        if interval <= 0:
-            raise ValueError("interval must be positive")
+        effective_interval = initial_interval if initial_interval is not None else interval
+        if effective_interval <= 0:
+            raise ValueError("initial_interval must be positive")
         pinned_task_id = task_id
-        attempts = max(1, math.ceil(timeout / interval) + 1)
+        attempts = max(1, math.ceil(timeout / effective_interval) + 1)
         status = {"status": "no_research"}
         for _ in range(attempts):
             status = await client.research.poll(notebook_id, task_id=pinned_task_id)

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -399,7 +399,9 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "NotebookLMError",
     "NotebookNotFoundError",
     "RateLimitError",
+    "ResearchError",
     "ResearchTaskMismatchError",
+    "ResearchTimeoutError",
     "RPCError",
     "RPCResponseTooLargeError",
     "RPCTimeoutError",
@@ -411,6 +413,7 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "SourceTimeoutError",
     "UnknownRPCMethodError",
     "ValidationError",
+    "WaitTimeoutError",
 ]
 
 _TYPES_PRIVATE_HELPER_SEAMS = [

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -451,8 +451,25 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ValueError, match="timeout must be non-negative"):
                 await client.research.wait_for_completion("nb_123", timeout=-1)
-            with pytest.raises(ValueError, match="initial_interval must be positive"):
+            # Neutral "poll interval" wording so callers on the deprecated
+            # interval= alias don't see a name they never used.
+            with pytest.raises(ValueError, match="poll interval must be positive"):
                 await client.research.wait_for_completion("nb_123", initial_interval=0)
+            with (
+                pytest.raises(ValueError, match="poll interval must be positive"),
+                pytest.warns(DeprecationWarning),
+            ):
+                await client.research.wait_for_completion("nb_123", interval=0)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_rejects_non_numeric_interval(self, auth_tokens):
+        """An explicit non-numeric interval fails fast instead of coercing."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(TypeError, match="poll interval must be a number"):
+                await client.research.wait_for_completion(
+                    "nb_123",
+                    initial_interval="1",  # type: ignore[arg-type]
+                )
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_interval_alias_deprecated(

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -262,7 +262,7 @@ class TestResearch:
                 result = await client.research.wait_for_completion(
                     "nb_123",
                     timeout=10,
-                    interval=1,
+                    initial_interval=1,
                 )
 
         assert result["status"] == "completed"
@@ -310,7 +310,7 @@ class TestResearch:
                     "nb_123",
                     task_id="task_A",
                     timeout=10,
-                    interval=1,
+                    initial_interval=1,
                 )
 
         assert result["status"] == "completed"
@@ -328,7 +328,7 @@ class TestResearch:
             result = await client.research.wait_for_completion(
                 "nb_123",
                 timeout=10,
-                interval=1,
+                initial_interval=1,
             )
 
         assert result == {"status": "no_research", "tasks": []}
@@ -369,7 +369,7 @@ class TestResearch:
                 "nb_123",
                 task_id="task_123",
                 timeout=10,
-                interval=1,
+                initial_interval=1,
             )
 
         assert result["status"] == "completed"
@@ -402,7 +402,7 @@ class TestResearch:
                 "nb_123",
                 task_id="task_123",
                 timeout=10,
-                interval=1,
+                initial_interval=1,
             )
 
         assert result["status"] == "failed"
@@ -430,21 +430,100 @@ class TestResearch:
         )
         httpx_mock.add_response(content=response_body.encode(), method="POST")
 
+        from notebooklm.exceptions import ResearchTimeoutError, WaitTimeoutError
+
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(TimeoutError, match="task_123"):
+            # Raises the domain ResearchTimeoutError, which is catchable via the
+            # WaitTimeoutError umbrella AND the built-in TimeoutError.
+            with pytest.raises(ResearchTimeoutError, match="task_123") as exc_info:
                 await client.research.wait_for_completion(
                     "nb_123",
                     timeout=0,
-                    interval=1,
+                    initial_interval=1,
                 )
+            assert isinstance(exc_info.value, WaitTimeoutError)
+            assert isinstance(exc_info.value, TimeoutError)
+            assert exc_info.value.task_id == "task_123"
+            assert exc_info.value.timeout == 0
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_rejects_invalid_budget(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ValueError, match="timeout must be non-negative"):
                 await client.research.wait_for_completion("nb_123", timeout=-1)
-            with pytest.raises(ValueError, match="interval must be positive"):
-                await client.research.wait_for_completion("nb_123", interval=0)
+            with pytest.raises(ValueError, match="initial_interval must be positive"):
+                await client.research.wait_for_completion("nb_123", initial_interval=0)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_interval_alias_deprecated(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """The legacy ``interval`` kwarg still works but emits a warning."""
+        response_body = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_123",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=1,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.warns(DeprecationWarning, match="initial_interval"):
+                with pytest.raises(TimeoutError):
+                    await client.research.wait_for_completion(
+                        "nb_123",
+                        timeout=0,
+                        interval=1,
+                    )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_default_shape_is_silent(
+        self, auth_tokens, httpx_mock, build_rpc_response, recwarn
+    ):
+        """Default-shape calls (no interval kwarg) emit no deprecation warning."""
+        response_body = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_123",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=1,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(TimeoutError):
+                await client.research.wait_for_completion("nb_123", timeout=0)
+        assert not [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_both_intervals_raises(self, auth_tokens):
+        """Passing both ``interval`` and ``initial_interval`` raises TypeError."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(TypeError, match="both 'initial_interval'"):
+                await client.research.wait_for_completion(
+                    "nb_123",
+                    interval=2,
+                    initial_interval=3,
+                )
 
     @pytest.mark.asyncio
     async def test_import_research(self, auth_tokens, httpx_mock, build_rpc_response):

--- a/tests/unit/test_research_service.py
+++ b/tests/unit/test_research_service.py
@@ -91,7 +91,7 @@ async def test_completed_returns_outcome_with_sources(base_plan):
     client.research.wait_for_completion.assert_awaited_once_with(
         "nb_123",
         timeout=5.0,
-        interval=1.0,
+        initial_interval=1.0,
     )
 
 
@@ -227,7 +227,7 @@ async def test_wait_delegates_timeout_and_interval_to_library():
     client.research.wait_for_completion.assert_awaited_once_with(
         "nb_123",
         timeout=10.0,
-        interval=1.0,
+        initial_interval=1.0,
     )
 
 


### PR DESCRIPTION
Fixes #1208 (additive; deprecated `interval=` alias warns in v0.7.0, removed in v0.8.0)

Part of the API-consistency wave (#1208 + #1206 + #1209). The additive `WaitTimeoutError` umbrella is unconditional; the deprecated `interval=` alias warns starting in v0.7.0 and is removed in v0.8.0.

## What

Standardizes the `wait_*` / polling timeout surface so callers can write one `except` clause for any wait timeout and use one consistent poll-interval keyword — all **additive**, with the old behavior preserved behind `DeprecationWarning`s.

### `WaitTimeoutError` umbrella (additive — no deprecation)
- New public `WaitTimeoutError(NotebookLMError, TimeoutError)` is the common base for every wait/poll timeout.
- `SourceTimeoutError`, `ArtifactTimeoutError` (and its `ArtifactPendingTimeoutError` / `ArtifactInProgressTimeoutError` subclasses) now inherit it.
- `ResearchAPI.wait_for_completion` previously raised the **bare builtin `TimeoutError`**; it now raises the new `ResearchTimeoutError` (a `WaitTimeoutError`, still a `TimeoutError`). Added a `ResearchError` domain base alongside it.
- `except TimeoutError` keeps working unchanged; `except WaitTimeoutError` now catches source/artifact/research timeouts uniformly.
- Exported `WaitTimeoutError`, `ResearchError`, `ResearchTimeoutError` from `notebooklm.exceptions.__all__` and the top-level package.

### Kwarg standardization (deprecated alias)
- New `src/notebooklm/_deprecation.py`: `deprecated_kwarg(...)` emits a `DeprecationWarning` naming v0.8.0 (suppressible via `NOTEBOOKLM_QUIET_DEPRECATIONS`, correct `stacklevel`), and raises `TypeError` if both keywords are passed.
- `ResearchAPI.wait_for_completion(interval=...)` → canonical `initial_interval=...` (matching `SourcesAPI.wait_until_ready` and `ArtifactsAPI.wait_for_completion`). `interval=` stays a deprecated alias. Internal CLI callers migrated to `initial_interval=` so the library does not self-warn.

### `wait_timeout` decision (per the issue)
`wait_timeout=` on the `SourcesAPI.add_*` family was **deliberately not** renamed to `timeout`: on those add methods `timeout` would be ambiguous with a per-request HTTP timeout, whereas the dedicated waiter methods already spell their budget `timeout`. So the research `interval` → `initial_interval` rename was the only standardization with a clear, unambiguous win.

## Compatibility
- The public-API compat audit stays **clean**: `interval`'s default is kept at its original `5` (the new `initial_interval` defaults to a private sentinel), so no existing signature's default changed — `initial_interval` is purely additive.
- `except TimeoutError` callers are unaffected; the research path is now newly catchable via `except WaitTimeoutError` / `except ResearchError`.

## Tests
- `except WaitTimeoutError` catches source + artifact + research timeouts; `except TimeoutError` still does.
- Deprecated `interval=` warns + still works; default-shape calls stay silent; both-passed raises `TypeError`; `NOTEBOOKLM_QUIET_DEPRECATIONS` suppresses; no internal self-warning.

## Gates (all green)
`ruff check`/`format`, `mypy`, `audit_public_api_compat.py` (clean), `check_deprecation_targets.py`, `check_claude_md_freshness.py`, full `pytest` (7639 passed, 52 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified wait/poll timeout umbrella (WaitTimeoutError) and new research-specific errors (ResearchError, ResearchTimeoutError) with richer timeout diagnostics.

* **Deprecations**
  * Polling keyword renamed: interval → initial_interval. interval stays as deprecated alias (emits warnings; mutually exclusive with initial_interval; removal planned for v0.8.0).
  * NOTEBOOKLM_QUIET_DEPRECATIONS to suppress deprecation warnings.

* **Documentation**
  * Updated docs and changelog to reflect exceptions, API signature/behavior, and migration guidance.

* **Tests**
  * Unit tests updated to cover new exceptions, deprecation helper, and keyword rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->