### PR TITLE
feat(artifacts): recognize interactive mind maps (type 4 / variant 4) — #1256 Phase 1

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1586,6 +1586,8 @@ await client.notes.delete_mind_map(nb_id, mind_map_id)
 
 **Note:** Mind maps are detected by checking if the content contains `'"children":' or `'"nodes":'` keys, which indicate JSON mind map data structure.
 
+**Two mind-map kinds (issue #1256):** NotebookLM has two distinct mind-map objects — the **note-backed** kind above (`list_mind_maps()`), and the newer **interactive** kind the web GUI now creates (a studio artifact, internally `type 4 / variant 4`). As of this release the interactive kind is recognized: it appears in `client.artifacts.list(ArtifactType.MIND_MAP)` (no longer mis-typed as `unknown`), and `Artifact.is_interactive_mind_map` distinguishes the backing. Full read/generate/rename and `download_mind_map` support for the interactive kind arrives with the unified mind-map API; until then, `download_mind_map` raises a clear `ArtifactDownloadError` for an interactive id rather than a misleading "not found".
+
 ---
 
 ### SettingsAPI (`client.settings`)

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -477,36 +477,43 @@ class ArtifactDownloadService:
         """Download a mind map as JSON."""
         mind_maps_service = self._mind_maps
 
-        # Interactive (studio-artifact) mind maps live in the artifact
-        # collection, not the note-backed list this method reads. Detect them
-        # up front (only when an explicit id is given) so an interactive id
-        # gets a clear "not supported here" message instead of the misleading
-        # ArtifactNotReadyError / ArtifactNotFoundError below.
-        if artifact_id:
-            studio_rows = await self._list_raw(notebook_id)
-            for row in studio_rows:
-                if not isinstance(row, list):
-                    continue
-                artifact = Artifact.from_api_response(row)
-                if artifact.id == artifact_id and artifact.is_interactive_mind_map:
-                    raise ArtifactDownloadError(
-                        "interactive_mind_map",
-                        artifact_id=artifact_id,
-                        details=(
-                            "interactive mind maps are not downloadable via "
-                            "download_mind_map yet; unified mind-map support is pending"
-                        ),
-                    )
-
+        # Fetch the note-backed list first: it is the primary backing for this
+        # method, so an explicit id that resolves here (the happy path) avoids
+        # the extra _list_raw artifact-collection network call entirely.
         mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
-        if not mind_maps:
-            raise ArtifactNotReadyError("mind_map")
 
         if artifact_id:
             mind_map = next((mm for mm in mind_maps if mm[0] == artifact_id), None)
-            if not mind_map:
+            if mind_map is None:
+                # The id is not a note-backed mind map. Interactive
+                # (studio-artifact) mind maps live in the artifact collection,
+                # not the note-backed list — check there so an interactive id
+                # gets a clear "not supported here" message instead of the
+                # misleading ArtifactNotReadyError / ArtifactNotFoundError below.
+                studio_rows = await self._list_raw(notebook_id)
+                for row in studio_rows:
+                    if not isinstance(row, list):
+                        continue
+                    artifact = Artifact.from_api_response(row)
+                    if artifact.id == artifact_id and artifact.is_interactive_mind_map:
+                        raise ArtifactDownloadError(
+                            "interactive_mind_map",
+                            artifact_id=artifact_id,
+                            details=(
+                                "interactive mind maps are not downloadable via "
+                                "download_mind_map yet; unified mind-map support is pending"
+                            ),
+                        )
+                # Not interactive either: preserve the prior error precedence —
+                # an empty note-backed list reads as "not ready", a populated
+                # list with no matching id reads as "not found".
+                if not mind_maps:
+                    raise ArtifactNotReadyError("mind_map")
                 raise ArtifactNotFoundError(artifact_id, artifact_type="mind_map")
         else:
+            # No explicit id: the first note-backed mind map (if any) is used.
+            if not mind_maps:
+                raise ArtifactNotReadyError("mind_map")
             mind_map = mind_maps[0]
 
         try:

--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -476,6 +476,28 @@ class ArtifactDownloadService:
     ) -> str:
         """Download a mind map as JSON."""
         mind_maps_service = self._mind_maps
+
+        # Interactive (studio-artifact) mind maps live in the artifact
+        # collection, not the note-backed list this method reads. Detect them
+        # up front (only when an explicit id is given) so an interactive id
+        # gets a clear "not supported here" message instead of the misleading
+        # ArtifactNotReadyError / ArtifactNotFoundError below.
+        if artifact_id:
+            studio_rows = await self._list_raw(notebook_id)
+            for row in studio_rows:
+                if not isinstance(row, list):
+                    continue
+                artifact = Artifact.from_api_response(row)
+                if artifact.id == artifact_id and artifact.is_interactive_mind_map:
+                    raise ArtifactDownloadError(
+                        "interactive_mind_map",
+                        artifact_id=artifact_id,
+                        details=(
+                            "interactive mind maps are not downloadable via "
+                            "download_mind_map yet; unified mind-map support is pending"
+                        ),
+                    )
+
         mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
         if not mind_maps:
             raise ArtifactNotReadyError("mind_map")

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -10,7 +10,14 @@ import httpx
 
 from ._row_adapters_artifacts import ArtifactRow
 from ._runtime_contracts import RpcCaller
-from .rpc import ArtifactTypeCode, RPCError, RPCMethod
+from .rpc import (
+    FLASHCARDS_VARIANT,
+    INTERACTIVE_MIND_MAP_VARIANT,
+    QUIZ_VARIANT,
+    ArtifactTypeCode,
+    RPCError,
+    RPCMethod,
+)
 from .types import Artifact, ArtifactNotReadyError, ArtifactType
 
 logger = logging.getLogger(__name__)
@@ -50,12 +57,29 @@ def _matches_artifact_type(artifact: Artifact, artifact_type: ArtifactType | Non
         return True
 
     if artifact_type == ArtifactType.QUIZ:
-        return artifact._artifact_type == ArtifactTypeCode.QUIZ.value and artifact._variant == 2
+        return (
+            artifact._artifact_type == ArtifactTypeCode.QUIZ.value
+            and artifact._variant == QUIZ_VARIANT
+        )
     if artifact_type == ArtifactType.FLASHCARDS:
-        return artifact._artifact_type == ArtifactTypeCode.QUIZ.value and artifact._variant == 1
+        return (
+            artifact._artifact_type == ArtifactTypeCode.QUIZ.value
+            and artifact._variant == FLASHCARDS_VARIANT
+        )
+    if artifact_type == ArtifactType.MIND_MAP:
+        # Two backings: note-backed (synthetic type 5) and interactive
+        # (studio artifact, type 4 / variant 4). Match either.
+        return (
+            artifact._artifact_type == ArtifactTypeCode.MIND_MAP.value
+            or artifact.is_interactive_mind_map
+        )
     if artifact_type == ArtifactType.UNKNOWN:
         if artifact._artifact_type == ArtifactTypeCode.QUIZ.value:
-            return artifact._variant not in (1, 2)
+            return artifact._variant not in (
+                FLASHCARDS_VARIANT,
+                QUIZ_VARIANT,
+                INTERACTIVE_MIND_MAP_VARIANT,
+            )
         return artifact._artifact_type not in _KNOWN_ARTIFACT_TYPE_CODES
 
     type_code = _ARTIFACT_TYPE_CODES_BY_KIND.get(artifact_type)

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -9,7 +9,14 @@ from enum import Enum
 from typing import Any
 
 from .._row_adapters_artifacts import ArtifactRow
-from ..rpc.types import ArtifactStatus, ArtifactTypeCode, artifact_status_to_str
+from ..rpc.types import (
+    FLASHCARDS_VARIANT,
+    INTERACTIVE_MIND_MAP_VARIANT,
+    QUIZ_VARIANT,
+    ArtifactStatus,
+    ArtifactTypeCode,
+    artifact_status_to_str,
+)
 from .common import UnknownTypeWarning, _datetime_from_timestamp
 
 
@@ -62,10 +69,14 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     """
     # Handle QUIZ/FLASHCARDS distinction.
     if artifact_type == ArtifactTypeCode.QUIZ.value:
-        if variant == 1:
+        if variant == FLASHCARDS_VARIANT:
             return ArtifactType.FLASHCARDS
-        elif variant == 2:
+        elif variant == QUIZ_VARIANT:
             return ArtifactType.QUIZ
+        elif variant == INTERACTIVE_MIND_MAP_VARIANT:
+            # Interactive mind map: a studio artifact in the type-4 family,
+            # distinct from the note-backed mind map (synthetic type 5).
+            return ArtifactType.MIND_MAP
         else:
             key = (artifact_type, variant)
             if key not in _warned_artifact_types:
@@ -282,12 +293,29 @@ class Artifact:
     @property
     def is_quiz(self) -> bool:
         """Check if this is a quiz (type 4, variant 2)."""
-        return self._artifact_type == ArtifactTypeCode.QUIZ.value and self._variant == 2
+        return self._artifact_type == ArtifactTypeCode.QUIZ.value and self._variant == QUIZ_VARIANT
 
     @property
     def is_flashcards(self) -> bool:
         """Check if this is flashcards (type 4, variant 1)."""
-        return self._artifact_type == ArtifactTypeCode.QUIZ.value and self._variant == 1
+        return (
+            self._artifact_type == ArtifactTypeCode.QUIZ.value
+            and self._variant == FLASHCARDS_VARIANT
+        )
+
+    @property
+    def is_interactive_mind_map(self) -> bool:
+        """Whether this is an interactive (studio-artifact) mind map.
+
+        Interactive mind maps are studio artifacts in the type-4 family
+        (``type 4 / variant 4``), as opposed to note-backed mind maps which
+        the library surfaces with the synthetic type code 5. Both report
+        ``kind == ArtifactType.MIND_MAP``; this distinguishes the backing.
+        """
+        return (
+            self._artifact_type == ArtifactTypeCode.QUIZ.value
+            and self._variant == INTERACTIVE_MIND_MAP_VARIANT
+        )
 
     @property
     def report_subtype(self) -> str | None:

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -163,7 +163,9 @@ class Artifact:
     status: int  # 1=processing, 2=pending, 3=completed, 4=failed
     created_at: datetime | None = None
     url: str | None = None
-    _variant: int | None = field(default=None, repr=False)  # For type 4: 1=flashcards, 2=quiz
+    _variant: int | None = field(
+        default=None, repr=False
+    )  # For type 4: 1=flashcards, 2=quiz, 4=interactive_mind_map
 
     @property
     def kind(self) -> ArtifactType:

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -22,7 +22,10 @@ from .encoder import build_request_body, encode_rpc_request, nest_source_ids
 from .overrides import resolve_rpc_id
 from .types import (
     BATCHEXECUTE_URL,
+    FLASHCARDS_VARIANT,
+    INTERACTIVE_MIND_MAP_VARIANT,
     QUERY_URL,
+    QUIZ_VARIANT,
     UPLOAD_URL,
     ArtifactStatus,
     ArtifactTypeCode,
@@ -59,6 +62,9 @@ __all__ = [
     "get_upload_url",
     "resolve_rpc_id",
     "ArtifactTypeCode",
+    "FLASHCARDS_VARIANT",
+    "QUIZ_VARIANT",
+    "INTERACTIVE_MIND_MAP_VARIANT",
     "ArtifactStatus",
     "artifact_status_to_str",
     "AudioFormat",

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -82,7 +82,7 @@ class RPCMethod(str, Enum):
     RENAME_ARTIFACT = "rc3d8d"
     EXPORT_ARTIFACT = "Krh3pd"
     SHARE_ARTIFACT = "RGP97b"
-    GET_INTERACTIVE_HTML = "v9rmvd"  # Fetch quiz/flashcard HTML content
+    GET_INTERACTIVE_HTML = "v9rmvd"  # Fetch quiz/flashcard HTML content (also serves interactive mind map data at [0][9][3])
     REVISE_SLIDE = "KmcKPe"  # Revise individual slide with prompt
 
     # Research
@@ -132,7 +132,7 @@ class ArtifactTypeCode(int, Enum):
         2  # Includes: Briefing Doc, Study Guide, Blog Post, White Paper, Research Proposal, etc.
     )
     VIDEO = 3
-    QUIZ = 4  # Also used for flashcards
+    QUIZ = 4  # Also used for flashcards and interactive mind maps (variant 4)
     QUIZ_FLASHCARD = 4  # Alias for backward compatibility
     MIND_MAP = 5
     # Note: Type 6 appears unused in current API
@@ -145,9 +145,9 @@ class ArtifactTypeCode(int, Enum):
 # type-4 (QUIZ) family. The interactive mind map is a studio artifact
 # (type 4 / variant 4) created via CREATE_ARTIFACT, distinct from the
 # note-backed mind map (surfaced with the synthetic type code 5).
-FLASHCARDS_VARIANT = 1
-QUIZ_VARIANT = 2
-INTERACTIVE_MIND_MAP_VARIANT = 4
+FLASHCARDS_VARIANT: Final[int] = 1
+QUIZ_VARIANT: Final[int] = 2
+INTERACTIVE_MIND_MAP_VARIANT: Final[int] = 4
 
 
 class ArtifactStatus(int, Enum):

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -141,6 +141,15 @@ class ArtifactTypeCode(int, Enum):
     DATA_TABLE = 9
 
 
+# Variant codes at artifact_data[9][1][0], distinguishing sub-kinds within the
+# type-4 (QUIZ) family. The interactive mind map is a studio artifact
+# (type 4 / variant 4) created via CREATE_ARTIFACT, distinct from the
+# note-backed mind map (surfaced with the synthetic type code 5).
+FLASHCARDS_VARIANT = 1
+QUIZ_VARIANT = 2
+INTERACTIVE_MIND_MAP_VARIANT = 4
+
+
 class ArtifactStatus(int, Enum):
     """Processing status of an artifact.
 

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -42,9 +42,14 @@ from notebooklm.types import (
 
 def _make_service(**overrides):
     """Build a service with inert MagicMock collaborators."""
+    listing = MagicMock()
+    # ``download_mind_map`` now consults the studio list (via ``_list_raw``) to
+    # detect interactive mind maps before the note-backed path; default it to an
+    # awaitable empty list so the inert service skips that guard.
+    listing.list_raw = AsyncMock(return_value=[])
     kwargs = {
         "rpc": MagicMock(),
-        "listing": MagicMock(),
+        "listing": listing,
         "mind_maps": MagicMock(),
     }
     kwargs.update(overrides)

--- a/tests/unit/test_interactive_mind_map.py
+++ b/tests/unit/test_interactive_mind_map.py
@@ -1,0 +1,139 @@
+"""Phase-1: recognition of interactive (studio-artifact) mind maps.
+
+The web GUI now generates an *interactive* mind map as a studio artifact in the
+type-4 (QUIZ) family with variant 4 — distinct from the note-backed mind map the
+library surfaces with the synthetic type code 5. These tests pin the wire
+recognition: kind mapping, the listing-filter union, the `is_interactive_mind_map`
+discriminator, and the download-guard message. See issue #1256.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+
+import pytest
+
+from notebooklm._artifact_listing import _matches_artifact_type
+from notebooklm._types.artifacts import _map_artifact_kind, _warned_artifact_types
+from notebooklm._types.common import UnknownTypeWarning
+from notebooklm.rpc.types import INTERACTIVE_MIND_MAP_VARIANT
+from notebooklm.types import Artifact, ArtifactType
+
+
+@pytest.fixture(autouse=True)
+def _clear_warned_set():
+    # `_warned_artifact_types` is a module-level set: a warning fires only once
+    # per (type, variant) for the whole session, so reset around each test or
+    # the `pytest.warns`/no-warning assertions become order-dependent (P1.c).
+    _warned_artifact_types.clear()
+    yield
+    _warned_artifact_types.clear()
+
+
+def _art(type_code: int, variant: int | None = None) -> Artifact:
+    return Artifact(id="art_1", title="MM", _artifact_type=type_code, status=3, _variant=variant)
+
+
+# --- T1.1: the constant -------------------------------------------------------
+
+
+def test_interactive_mind_map_variant_constant():
+    assert INTERACTIVE_MIND_MAP_VARIANT == 4
+    from notebooklm.rpc import INTERACTIVE_MIND_MAP_VARIANT as reexported
+
+    assert reexported == 4
+
+
+# --- T1.2: kind mapping -------------------------------------------------------
+
+
+def test_variant_4_maps_to_mind_map_without_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UnknownTypeWarning)  # any warning → test failure
+        assert _map_artifact_kind(4, 4) == ArtifactType.MIND_MAP
+
+
+def test_quiz_and_flashcards_variants_unchanged():
+    assert _map_artifact_kind(4, 1) == ArtifactType.FLASHCARDS
+    assert _map_artifact_kind(4, 2) == ArtifactType.QUIZ
+
+
+@pytest.mark.parametrize("variant", [3, None])
+def test_other_type4_variants_still_warn_unknown(variant):
+    with pytest.warns(UnknownTypeWarning):
+        assert _map_artifact_kind(4, variant) == ArtifactType.UNKNOWN
+
+
+# --- T1.4: the discriminator --------------------------------------------------
+
+
+def test_is_interactive_mind_map_property():
+    assert _art(4, 4).is_interactive_mind_map is True
+    assert _art(4, 2).is_interactive_mind_map is False  # quiz
+    assert _art(4, 1).is_interactive_mind_map is False  # flashcards
+    assert _art(5, None).is_interactive_mind_map is False  # note-backed synthetic
+
+
+# --- T1.3: listing-filter union ----------------------------------------------
+
+
+def test_list_mind_map_matches_both_backings():
+    assert _matches_artifact_type(_art(5, None), ArtifactType.MIND_MAP)  # note-backed
+    assert _matches_artifact_type(_art(4, 4), ArtifactType.MIND_MAP)  # interactive
+    assert not _matches_artifact_type(_art(4, 2), ArtifactType.MIND_MAP)  # quiz
+
+
+def test_list_unknown_excludes_interactive_but_keeps_genuine_unknown():
+    assert not _matches_artifact_type(_art(4, 4), ArtifactType.UNKNOWN)
+    assert _matches_artifact_type(_art(4, 3), ArtifactType.UNKNOWN)  # genuine unknown variant
+
+
+# --- T1.5: download guard -----------------------------------------------------
+
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+
+from notebooklm._artifact_downloads import ArtifactDownloadService  # noqa: E402
+from notebooklm.types import ArtifactDownloadError  # noqa: E402
+
+# Raw studio row whose [9][1][0] == 4 → Artifact.is_interactive_mind_map is True.
+_INTERACTIVE_ROW = ["int_mm", "MM", 4, None, 3, None, None, None, None, [None, [4]]]
+
+
+def _download_service(studio_rows, note_rows):
+    listing = MagicMock()
+    listing.list_raw = AsyncMock(return_value=studio_rows)
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=note_rows)
+    mind_maps.extract_content = MagicMock(side_effect=lambda row: row[1])
+    return ArtifactDownloadService(rpc=MagicMock(), listing=listing, mind_maps=mind_maps)
+
+
+@pytest.mark.asyncio
+async def test_download_interactive_id_with_zero_note_backed_maps(tmp_path):
+    """The common interactive-only case: must NOT misreport as 'not ready'."""
+    svc = _download_service(studio_rows=[_INTERACTIVE_ROW], note_rows=[])
+    with pytest.raises(ArtifactDownloadError) as ei:
+        await svc.download_mind_map("nb", str(tmp_path / "x.json"), artifact_id="int_mm")
+    assert "interactive" in str(ei.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_download_interactive_id_with_unrelated_note_backed_maps(tmp_path):
+    """Interactive id while other note-backed maps exist: not 'not found'."""
+    note = ["other_note", '{"name": "x", "children": []}']
+    svc = _download_service(studio_rows=[_INTERACTIVE_ROW], note_rows=[note])
+    with pytest.raises(ArtifactDownloadError) as ei:
+        await svc.download_mind_map("nb", str(tmp_path / "x.json"), artifact_id="int_mm")
+    assert "interactive" in str(ei.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_download_note_backed_id_still_works(tmp_path):
+    """The guard must not disturb genuine note-backed downloads."""
+    content = '{"name": "Root", "children": []}'
+    svc = _download_service(studio_rows=[], note_rows=[["note_mm", content]])
+    out = str(tmp_path / "mm.json")
+    result = await svc.download_mind_map("nb", out, artifact_id="note_mm")
+    assert result == out
+    assert json.loads((tmp_path / "mm.json").read_text()) == {"name": "Root", "children": []}

--- a/tests/unit/test_interactive_mind_map.py
+++ b/tests/unit/test_interactive_mind_map.py
@@ -136,4 +136,7 @@ async def test_download_note_backed_id_still_works(tmp_path):
     out = str(tmp_path / "mm.json")
     result = await svc.download_mind_map("nb", out, artifact_id="note_mm")
     assert result == out
-    assert json.loads((tmp_path / "mm.json").read_text()) == {"name": "Root", "children": []}
+    assert json.loads((tmp_path / "mm.json").read_text(encoding="utf-8")) == {
+        "name": "Root",
+        "children": [],
+    }


### PR DESCRIPTION
**Phase 1 of #1256** (recognition + typing only; first of a stacked series).

NotebookLM's web GUI now creates mind maps as **studio artifacts** in the type-4 (QUIZ) family with **variant 4** — distinct from the **note-backed** kind the library surfaces as synthetic type 5. The library mis-typed these as `unknown` and emitted a spurious `UnknownTypeWarning`, and they were invisible to `artifacts.list(MIND_MAP)`.

### What this does
- **Names the type-4 variant taxonomy** — `FLASHCARDS_VARIANT` (1), `QUIZ_VARIANT` (2), `INTERACTIVE_MIND_MAP_VARIANT` (4) in `rpc/types.py` — and replaces the scattered `1`/`2`/`4` magic numbers across `_map_artifact_kind`, `_matches_artifact_type`, and `Artifact.is_quiz`/`is_flashcards`.
- **Recognizes the interactive kind**: `type 4 / variant 4 → ArtifactType.MIND_MAP` (no more warning); adds `Artifact.is_interactive_mind_map` to distinguish the backing.
- **Fixes discovery**: `artifacts.list(ArtifactType.MIND_MAP)` now returns **both** backings (note-backed synthetic type-5 and interactive type-4/variant-4); `artifacts.list(UNKNOWN)` no longer leaks interactive maps.
- **Clear download error**: `download_mind_map(artifact_id=<interactive>)` now raises an explicit `ArtifactDownloadError` (checked *before* the note-backed `ArtifactNotReadyError`/`ArtifactNotFoundError` paths) instead of a misleading "not found".

### Scope
Recognition only. **Generate / rename / full-download** of the interactive kind, plus the unified `client.mind_maps` API, land in **Phase 2** (which stacks on this branch). The interactive read/generate/rename/delete RPCs (`v9rmvd`/`R7cb6c`/`rc3d8d`/`V5N4be`) were all validated live; `GET_INTERACTIVE_HTML` returns the JSON tree at `[0][9][3]`.

### Tests
- New `tests/unit/test_interactive_mind_map.py` (11 tests): constant, kind mapping (incl. no-warning + warned-set hygiene), `is_interactive_mind_map`, the `list(MIND_MAP)`/`list(UNKNOWN)` union, and the download-guard across all three branches.
- Full unit suite green (6940 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive mind maps created via the web GUI are now properly recognized and accessible through the API.
  * Added ability to distinguish between note-backed and interactive mind maps.

* **Bug Fixes**
  * Improved error handling when attempting to download interactive mind maps—now returns a clear error message instead of reporting them as missing.

* **Documentation**
  * Updated API documentation to clarify the two distinct mind-map types and their access methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->