### PR TITLE
test: migrate dict-subscript access to typed attributes

### DIFF
--- a/tests/integration/concurrency/test_research_task_crosswire.py
+++ b/tests/integration/concurrency/test_research_task_crosswire.py
@@ -88,13 +88,13 @@ async def test_scenario_a_explicit_task_id_returns_matching_task(
             warnings.simplefilter("error", DeprecationWarning)
             result_a = await client.research.poll("nb_xwire", task_id="task_A")
 
-    assert result_a["task_id"] == "task_A"
-    assert result_a["query"] == "query A"
+    assert result_a.task_id == "task_A"
+    assert result_a.query == "query A"
     # The ``tasks`` list should reflect the filtered view — only the
     # matched task remains, otherwise downstream callers iterating
     # ``tasks`` would still see the un-asked-for sibling.
-    assert [t["task_id"] for t in result_a["tasks"]] == ["task_A"]
-    assert result_a["sources"][0]["research_task_id"] == "task_A"
+    assert [t.task_id for t in result_a.tasks] == ["task_A"]
+    assert result_a.sources[0].research_task_id == "task_A"
 
     # Fresh response for the second call — httpx_mock is per-request FIFO.
     httpx_mock.add_response(content=response_body.encode(), method="POST")
@@ -103,10 +103,10 @@ async def test_scenario_a_explicit_task_id_returns_matching_task(
             warnings.simplefilter("error", DeprecationWarning)
             result_b = await client.research.poll("nb_xwire", task_id="task_B")
 
-    assert result_b["task_id"] == "task_B"
-    assert result_b["query"] == "query B"
-    assert [t["task_id"] for t in result_b["tasks"]] == ["task_B"]
-    assert result_b["sources"][0]["research_task_id"] == "task_B"
+    assert result_b.task_id == "task_B"
+    assert result_b.query == "query B"
+    assert [t.task_id for t in result_b.tasks] == ["task_B"]
+    assert result_b.sources[0].research_task_id == "task_B"
 
 
 @pytest.mark.asyncio
@@ -132,8 +132,8 @@ async def test_scenario_b_no_task_id_single_in_flight_no_warning(
             warnings.simplefilter("always")
             result = await client.research.poll("nb_solo")
 
-    assert result["task_id"] == "task_solo"
-    assert result["query"] == "solo query"
+    assert result.task_id == "task_solo"
+    assert result.query == "solo query"
     # No deprecation warning — single in-flight task is unambiguous.
     deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert deprecation_warnings == [], (
@@ -167,10 +167,10 @@ async def test_scenario_c_no_task_id_multiple_in_flight_warns(
             result = await client.research.poll("nb_ambig")
 
     # Old behavior: latest (first) task wins.
-    assert result["task_id"] == "task_A"
-    assert result["query"] == "query A"
+    assert result.task_id == "task_A"
+    assert result.query == "query A"
     # All parsed tasks remain in ``tasks`` (old shape).
-    assert [t["task_id"] for t in result["tasks"]] == ["task_A", "task_B"]
+    assert [t.task_id for t in result.tasks] == ["task_A", "task_B"]
 
     # DeprecationWarning must fire exactly once for this ambiguity.
     deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -383,6 +383,6 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
-    assert result["mind_map"] == mind_map_dict
-    assert result["note_id"] == "note_stub"
+    assert result.mind_map == mind_map_dict
+    assert result.note_id == "note_stub"
     assert mind_map_count == 1

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -1786,8 +1786,8 @@ class TestGenerateMindMapParsing:
             ):
                 result = await client.artifacts.generate_mind_map("nb_123")
 
-        assert result["mind_map"] == mind_map_dict
-        assert result["note_id"] == "note_created_001"
+        assert result.mind_map == mind_map_dict
+        assert result.note_id == "note_created_001"
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_handles_dict_not_string(
@@ -1834,8 +1834,8 @@ class TestGenerateMindMapParsing:
             ):
                 result = await client.artifacts.generate_mind_map("nb_123")
 
-        assert result["mind_map"] == mind_map_dict
-        assert result["note_id"] == "note_dict_001"
+        assert result.mind_map == mind_map_dict
+        assert result.note_id == "note_dict_001"
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_with_source_ids_none_fetches_sources(

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -275,5 +275,5 @@ async def test_start_fast_research_happy_path_one_post(auth_tokens) -> None:
         await client._collaborators.kernel.get_http_client().aclose()
 
     assert result is not None
-    assert result["task_id"] == "task_xyz"
+    assert result.task_id == "task_xyz"
     assert request_count == 1

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -654,8 +654,8 @@ class TestSourcesAPI:
 
         assert "summary" in guide
         assert "keywords" in guide
-        assert "**summary**" in guide["summary"]
-        assert guide["keywords"] == ["keyword1", "keyword2", "keyword3"]
+        assert "**summary**" in guide.summary
+        assert guide.keywords == ("keyword1", "keyword2", "keyword3")
 
     @pytest.mark.asyncio
     async def test_get_guide_empty(
@@ -672,8 +672,8 @@ class TestSourcesAPI:
         async with NotebookLMClient(auth_tokens) as client:
             guide = await client.sources.get_guide("nb_123", "src_001")
 
-        assert guide["summary"] == ""
-        assert guide["keywords"] == []
+        assert guide.summary == ""
+        assert guide.keywords == ()
 
     @pytest.mark.asyncio
     async def test_rename_source(
@@ -2378,8 +2378,8 @@ class TestGetGuideEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             guide = await client.sources.get_guide("nb_123", "src_001")
 
-        assert guide["summary"] == ""
-        assert guide["keywords"] == []
+        assert guide.summary == ""
+        assert guide.keywords == ()
 
     @pytest.mark.asyncio
     async def test_get_guide_inner_not_list(
@@ -2396,8 +2396,8 @@ class TestGetGuideEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             guide = await client.sources.get_guide("nb_123", "src_001")
 
-        assert guide["summary"] == ""
-        assert guide["keywords"] == []
+        assert guide.summary == ""
+        assert guide.keywords == ()
 
     @pytest.mark.asyncio
     async def test_get_guide_result_false(
@@ -2413,8 +2413,8 @@ class TestGetGuideEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             guide = await client.sources.get_guide("nb_123", "src_001")
 
-        assert guide["summary"] == ""
-        assert guide["keywords"] == []
+        assert guide.summary == ""
+        assert guide.keywords == ()
 
 
 class TestGetFulltextResult0Branches:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -162,9 +162,9 @@ class TestSourcesAPI:
             guide = await client.sources.get_guide(READONLY_NOTEBOOK_ID, sources[0].id)
         assert guide is not None
         # Verify values are actually populated (catches parsing bugs like issue #70)
-        assert guide["summary"], "Expected non-empty summary from source guide"
-        assert isinstance(guide["keywords"], list)
-        assert len(guide["keywords"]) > 0, "Expected non-empty keywords from source guide"
+        assert guide.summary, "Expected non-empty summary from source guide"
+        assert isinstance(guide.keywords, tuple)
+        assert len(guide.keywords) > 0, "Expected non-empty keywords from source guide"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -998,7 +998,7 @@ class TestResearchAPI:
             )
         assert result is not None
         assert "task_id" in result
-        assert result["mode"] == "fast"
+        assert result.mode == "fast"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -1019,7 +1019,7 @@ class TestResearchAPI:
             # Poll for results
             result = await client.research.poll(
                 MUTABLE_NOTEBOOK_ID,
-                task_id=start_result["task_id"],
+                task_id=start_result.task_id,
             )
         assert result is not None
         assert "status" in result
@@ -1043,7 +1043,7 @@ class TestResearchAPI:
             # Poll until we have sources (with timeout via cassette)
             poll_result = await client.research.poll(
                 MUTABLE_NOTEBOOK_ID,
-                task_id=start_result["task_id"],
+                task_id=start_result.task_id,
             )
             if not poll_result.get("sources"):
                 pytest.skip("No research sources found")
@@ -1051,8 +1051,8 @@ class TestResearchAPI:
             # Import first source
             imported = await client.research.import_sources(
                 MUTABLE_NOTEBOOK_ID,
-                start_result["task_id"],
-                poll_result["sources"][:1],
+                start_result.task_id,
+                poll_result.sources[:1],
             )
         assert isinstance(imported, list)
 
@@ -1070,4 +1070,4 @@ class TestResearchAPI:
             )
         assert result is not None
         assert "task_id" in result
-        assert result["mode"] == "deep"
+        assert result.mode == "deep"

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -145,8 +145,8 @@ class TestGetSourceGuide:
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
-        assert result["summary"] == "This is a **summary** of the document."
-        assert result["keywords"] == ["Topic 1", "Topic 2", "Topic 3"]
+        assert result.summary == "This is a **summary** of the document."
+        assert result.keywords == ("Topic 1", "Topic 2", "Topic 3")
 
     @pytest.mark.asyncio
     async def test_get_source_guide_handles_empty(self, mock_client):
@@ -155,8 +155,8 @@ class TestGetSourceGuide:
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
-        assert result["summary"] == ""
-        assert result["keywords"] == []
+        assert result.summary == ""
+        assert result.keywords == ()
 
 
 class TestGetSuggestedReportFormats:

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -447,9 +447,9 @@ class TestMindMapGeneration:
         result = await api.generate_mind_map("nb_123")
 
         assert result is not None
-        assert "mind_map" in result
+        assert result.mind_map is not None
         # note_id is from the explicit CREATE_NOTE call.
-        assert result["note_id"] == "created_note_123"
+        assert result.note_id == "created_note_123"
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_with_dict(self, mock_artifacts_api):
@@ -479,9 +479,9 @@ class TestMindMapGeneration:
         result = await api.generate_mind_map("nb_123")
 
         assert result is not None
-        assert result["mind_map"]["nodes"][0]["id"] == "1"
+        assert result.mind_map["nodes"][0]["id"] == "1"
         # note_id is from the explicit CREATE_NOTE call.
-        assert result["note_id"] == "created_note_123"
+        assert result.note_id == "created_note_123"
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_empty_result(self, mock_artifacts_api):
@@ -494,8 +494,8 @@ class TestMindMapGeneration:
 
         result = await api.generate_mind_map("nb_123")
 
-        assert result["mind_map"] is None
-        assert result["note_id"] is None
+        assert result.mind_map is None
+        assert result.note_id is None
 
 
 class TestDownloadUrl:

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -173,8 +173,8 @@ class TestResearch:
                 notebook_id="nb_123", query="Quantum computing", mode="fast"
             )
 
-        assert result["task_id"] == "task_123"
-        assert result["mode"] == "fast"
+        assert result.task_id == "task_123"
+        assert result.mode == "fast"
 
     @pytest.mark.asyncio
     async def test_poll_research_completed(self, auth_tokens, httpx_mock, build_rpc_response):
@@ -192,14 +192,14 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert len(result["sources"]) == 1
-        assert result["sources"][0]["url"] == "http://example.com"
-        assert result["sources"][0]["result_type"] == 1
-        assert result["summary"] == "Summary text"
-        assert result["report"] == ""
-        assert len(result["tasks"]) == 1
-        assert result["tasks"][0]["task_id"] == "task_123"
+        assert result.status == "completed"
+        assert len(result.sources) == 1
+        assert result.sources[0].url == "http://example.com"
+        assert result.sources[0].result_type == 1
+        assert result.summary == "Summary text"
+        assert result.report == ""
+        assert len(result.tasks) == 1
+        assert result.tasks[0].task_id == "task_123"
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_pins_discovered_task_id(
@@ -265,11 +265,11 @@ class TestResearch:
                     initial_interval=1,
                 )
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "task_A"
-        assert result["query"] == "query A"
-        assert result["sources"][0]["research_task_id"] == "task_A"
-        assert result["sources"][0]["title"] == "Final A"
+        assert result.status == "completed"
+        assert result.task_id == "task_A"
+        assert result.query == "query A"
+        assert result.sources[0].research_task_id == "task_A"
+        assert result.sources[0].title == "Final A"
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_accepts_initial_task_id(
@@ -313,9 +313,9 @@ class TestResearch:
                     initial_interval=1,
                 )
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "task_A"
-        assert result["sources"][0]["title"] == "Result A"
+        assert result.status == "completed"
+        assert result.task_id == "task_A"
+        assert result.sources[0].title == "Result A"
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_returns_no_research(
@@ -375,8 +375,8 @@ class TestResearch:
                 initial_interval=1,
             )
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "task_123"
+        assert result.status == "completed"
+        assert result.task_id == "task_123"
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_returns_failed_terminal_status(
@@ -408,8 +408,8 @@ class TestResearch:
                 initial_interval=1,
             )
 
-        assert result["status"] == "failed"
-        assert result["task_id"] == "task_123"
+        assert result.status == "failed"
+        assert result.task_id == "task_123"
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_raises_timeout(
@@ -574,9 +574,9 @@ class TestResearch:
                 notebook_id="nb_123", query="AI research", mode="deep"
             )
 
-        assert result["task_id"] == "task_456"
-        assert result["report_id"] == "report_123"
-        assert result["mode"] == "deep"
+        assert result.task_id == "task_456"
+        assert result.report_id == "report_123"
+        assert result.mode == "deep"
 
     @pytest.mark.asyncio
     async def test_start_research_invalid_source(self, auth_tokens):
@@ -627,7 +627,7 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
+        assert result.status == "no_research"
 
     @pytest.mark.asyncio
     async def test_poll_in_progress(self, auth_tokens, httpx_mock, build_rpc_response):
@@ -645,8 +645,8 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "in_progress"
-        assert result["query"] == "research query"
+        assert result.status == "in_progress"
+        assert result.query == "research query"
 
     @pytest.mark.asyncio
     async def test_poll_deep_research_sources(self, auth_tokens, httpx_mock, build_rpc_response):
@@ -659,14 +659,14 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert len(result["sources"]) == 1
-        assert result["sources"][0]["title"] == "Deep Research Finding"
-        assert result["sources"][0]["url"] == ""
-        assert result["sources"][0]["result_type"] == 5
-        assert result["sources"][0]["research_task_id"] == "task_123"
-        assert result["sources"][0]["report_markdown"] == "# Report markdown"
-        assert result["report"] == "# Report markdown"
+        assert result.status == "completed"
+        assert len(result.sources) == 1
+        assert result.sources[0].title == "Deep Research Finding"
+        assert result.sources[0].url == ""
+        assert result.sources[0].result_type == 5
+        assert result.sources[0].research_task_id == "task_123"
+        assert result.sources[0].report_markdown == "# Report markdown"
+        assert result.report == "# Report markdown"
 
     @pytest.mark.asyncio
     async def test_poll_returns_all_tasks(self, auth_tokens, httpx_mock, build_rpc_response):
@@ -688,12 +688,12 @@ class TestResearch:
             with pytest.warns(DeprecationWarning, match="task_id"):
                 result = await client.research.poll("nb_123")
 
-        assert result["task_id"] == "task_latest"
-        assert result["query"] == "latest query"
-        assert len(result["tasks"]) == 2
-        assert result["tasks"][0]["task_id"] == "task_latest"
-        assert result["tasks"][1]["task_id"] == "task_older"
-        assert result["tasks"][1]["query"] == "older query"
+        assert result.task_id == "task_latest"
+        assert result.query == "latest query"
+        assert len(result.tasks) == 2
+        assert result.tasks[0].task_id == "task_latest"
+        assert result.tasks[1].task_id == "task_older"
+        assert result.tasks[1].query == "older query"
 
     @pytest.mark.asyncio
     async def test_poll_joins_legacy_report_chunks(
@@ -708,8 +708,8 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["report"] == "chunk one\n\nchunk two"
-        assert result["tasks"][0]["report"] == "chunk one\n\nchunk two"
+        assert result.report == "chunk one\n\nchunk two"
+        assert result.tasks[0].report == "chunk one\n\nchunk two"
 
     @pytest.mark.asyncio
     async def test_poll_deep_research_current_report_shape(
@@ -734,12 +734,12 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "report_123"
-        assert result["sources"][0]["title"] == "Deep Research Report"
-        assert result["sources"][0]["report_markdown"] == "# Current report markdown"
-        assert result["sources"][0]["research_task_id"] == "report_123"
-        assert result["report"] == "# Current report markdown"
+        assert result.status == "completed"
+        assert result.task_id == "report_123"
+        assert result.sources[0].title == "Deep Research Report"
+        assert result.sources[0].report_markdown == "# Current report markdown"
+        assert result.sources[0].research_task_id == "report_123"
+        assert result.report == "# Current report markdown"
 
     @pytest.mark.asyncio
     async def test_poll_fast_research_string_drive_result_type(
@@ -754,10 +754,10 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["sources"][0]["url"] == "https://drive.example.com/doc"
-        assert result["sources"][0]["title"] == "Drive Doc"
-        assert result["sources"][0]["result_type"] == 2
+        assert result.status == "completed"
+        assert result.sources[0].url == "https://drive.example.com/doc"
+        assert result.sources[0].title == "Drive Doc"
+        assert result.sources[0].result_type == 2
 
     @pytest.mark.asyncio
     async def test_poll_status_code_6_completed(self, auth_tokens, httpx_mock, build_rpc_response):
@@ -769,7 +769,7 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
+        assert result.status == "completed"
 
     @pytest.mark.asyncio
     async def test_poll_unknown_non_null_status_code_failed(
@@ -783,7 +783,7 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "failed"
+        assert result.status == "failed"
 
     @pytest.mark.asyncio
     async def test_import_sources_skips_result_type_5(
@@ -1151,11 +1151,11 @@ class TestResearch:
                 notebook_id="nb_123", query="AI research query", mode="fast"
             )
             assert start_result is not None
-            task_id = start_result["task_id"]
+            task_id = start_result.task_id
 
             poll_result = await client.research.poll("nb_123")
-            assert poll_result["status"] == "completed"
-            sources = poll_result["sources"]
+            assert poll_result.status == "completed"
+            sources = poll_result.sources
             assert len(sources) == 3
 
             for src in sources:
@@ -1220,16 +1220,16 @@ class TestResearch:
                 notebook_id="nb_123", query="deep AI research", mode="deep"
             )
             assert start_result is not None
-            assert start_result["mode"] == "deep"
+            assert start_result.mode == "deep"
 
             poll_result = await client.research.poll("nb_123")
-            assert poll_result["status"] == "completed"
-            assert poll_result["task_id"] == "report_789"
-            sources = poll_result["sources"]
+            assert poll_result.status == "completed"
+            assert poll_result.task_id == "report_789"
+            sources = poll_result.sources
             assert len(sources) == 4
 
             # Sources with URLs can be imported; sources without URLs are filtered
-            sources_with_urls = [s for s in sources if s.get("url")]
+            sources_with_urls = [s for s in sources if s.url]
             assert len(sources_with_urls) == 2
 
             # for deep research the authoritative id on the wire is
@@ -1239,7 +1239,7 @@ class TestResearch:
             # mismatch guard accepts the batch.
             imported = await client.research.import_sources(
                 notebook_id="nb_123",
-                task_id=poll_result["task_id"],
+                task_id=poll_result.task_id,
                 sources=sources,  # Pass all, filtering happens internally
             )
 
@@ -1260,8 +1260,8 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
-        assert result["tasks"] == []
+        assert result.status == "no_research"
+        assert result.tasks == ()
 
     @pytest.mark.asyncio
     async def test_poll_no_research_all_invalid_returns_tasks_key(
@@ -1274,8 +1274,8 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
-        assert result["tasks"] == []
+        assert result.status == "no_research"
+        assert result.tasks == ()
 
     @pytest.mark.asyncio
     async def test_poll_unknown_string_result_type_preserved(
@@ -1290,7 +1290,7 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["sources"][0]["result_type"] == "video"
+        assert result.sources[0].result_type == "video"
 
     @pytest.mark.asyncio
     async def test_poll_legacy_report_mixed_chunks(
@@ -1305,7 +1305,7 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["report"] == "chunk1\n\nchunk2"
+        assert result.report == "chunk1\n\nchunk2"
 
     @pytest.mark.asyncio
     async def test_poll_source_single_element_list_title_dropped(
@@ -1320,4 +1320,4 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["sources"] == []
+        assert result.sources == ()

--- a/tests/unit/test_research_api.py
+++ b/tests/unit/test_research_api.py
@@ -28,9 +28,9 @@ class TestResearchAPI:
             )
 
         assert result is not None
-        assert result["task_id"] == "task_123"
-        assert result["report_id"] == "report_456"
-        assert result["mode"] == "fast"
+        assert result.task_id == "task_123"
+        assert result.report_id == "report_456"
+        assert result.mode == "fast"
 
         request = httpx_mock.get_request()
         assert "Ljjv0c" in str(request.url)
@@ -52,8 +52,8 @@ class TestResearchAPI:
             )
 
         assert result is not None
-        assert result["task_id"] == "task_789"
-        assert result["mode"] == "fast"
+        assert result.task_id == "task_789"
+        assert result.mode == "fast"
 
     @pytest.mark.asyncio
     async def test_start_deep_web_research(
@@ -70,7 +70,7 @@ class TestResearchAPI:
             result = await client.research.start("nb_123", "AI ethics", source="web", mode="deep")
 
         assert result is not None
-        assert result["mode"] == "deep"
+        assert result.mode == "deep"
 
         request = httpx_mock.get_request()
         assert "QA9ei" in str(request.url)
@@ -148,13 +148,13 @@ class TestResearchAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "task_123"
-        assert len(result["sources"]) == 2
-        assert result["sources"][0]["url"] == "https://example.com"
-        assert result["sources"][0]["title"] == "Quantum Guide"
-        assert result["sources"][0]["result_type"] == 1
-        assert "Summary" in result["summary"]
+        assert result.status == "completed"
+        assert result.task_id == "task_123"
+        assert len(result.sources) == 2
+        assert result.sources[0].url == "https://example.com"
+        assert result.sources[0].title == "Quantum Guide"
+        assert result.sources[0].result_type == 1
+        assert "Summary" in result.summary
         assert "report" in result
 
     @pytest.mark.asyncio
@@ -185,8 +185,8 @@ class TestResearchAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "in_progress"
-        assert result["task_id"] == "task_456"
+        assert result.status == "in_progress"
+        assert result.task_id == "task_456"
 
     @pytest.mark.asyncio
     async def test_poll_no_research(
@@ -202,7 +202,7 @@ class TestResearchAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
+        assert result.status == "no_research"
 
     @pytest.mark.asyncio
     async def test_import_sources(
@@ -278,8 +278,8 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["task_id"] == "task_wrap"
-        assert result["query"] == "wrapped query"
+        assert result.task_id == "task_wrap"
+        assert result.query == "wrapped query"
 
     @pytest.mark.asyncio
     async def test_poll_skips_non_list_task_data(
@@ -325,7 +325,7 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
+        assert result.status == "no_research"
 
     @pytest.mark.asyncio
     async def test_poll_skips_non_list_task_info(
@@ -345,7 +345,7 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "no_research"
+        assert result.status == "no_research"
 
     @pytest.mark.asyncio
     async def test_poll_sources_and_summary_has_only_sources_no_summary(
@@ -380,9 +380,9 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["summary"] == ""
-        assert len(result["sources"]) == 1
+        assert result.status == "completed"
+        assert result.summary == ""
+        assert len(result.sources) == 1
 
     @pytest.mark.asyncio
     async def test_poll_skips_short_source_entry(
@@ -419,8 +419,8 @@ class TestPollEdgeCases:
             result = await client.research.poll("nb_123")
 
         # Only the valid source is returned
-        assert len(result["sources"]) == 1
-        assert result["sources"][0]["url"] == "https://valid.com"
+        assert len(result.sources) == 1
+        assert result.sources[0].url == "https://valid.com"
 
     @pytest.mark.asyncio
     async def test_poll_deep_research_source_none_first_element(
@@ -464,12 +464,12 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert len(result["sources"]) == 1
-        assert result["sources"][0]["title"] == "Deep Research Title"
-        assert result["sources"][0]["url"] == ""
-        assert result["sources"][0]["result_type"] == 5
-        assert result["report"] == "# Deep Report\nContent here"
+        assert result.status == "completed"
+        assert len(result.sources) == 1
+        assert result.sources[0].title == "Deep Research Title"
+        assert result.sources[0].url == ""
+        assert result.sources[0].result_type == 5
+        assert result.report == "# Deep Report\nContent here"
 
     @pytest.mark.asyncio
     async def test_poll_status_code_6_is_completed(
@@ -504,8 +504,8 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["task_id"] == "task_deep6"
+        assert result.status == "completed"
+        assert result.task_id == "task_deep6"
 
     @pytest.mark.asyncio
     async def test_poll_fast_research_source_with_url(
@@ -540,9 +540,9 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "in_progress"
-        assert result["sources"][0]["url"] == "https://fast.example.com"
-        assert result["sources"][0]["title"] == "Fast Title"
+        assert result.status == "in_progress"
+        assert result.sources[0].url == "https://fast.example.com"
+        assert result.sources[0].title == "Fast Title"
 
     @pytest.mark.asyncio
     async def test_poll_source_with_no_title_or_url_skipped(
@@ -579,8 +579,8 @@ class TestPollEdgeCases:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result["status"] == "completed"
-        assert result["sources"] == []
+        assert result.status == "completed"
+        assert result.sources == ()
 
     @pytest.mark.asyncio
     async def test_poll_all_tasks_too_short_raises(

--- a/tests/unit/test_source_content_renderer.py
+++ b/tests/unit/test_source_content_renderer.py
@@ -269,5 +269,5 @@ async def test_get_guide_shape_variants_return_stable_defaults(response: Any) ->
     guide = await renderer.get_guide("nb_1", "src_1")
 
     assert set(guide) == {"summary", "keywords"}
-    assert isinstance(guide["summary"], str)
-    assert isinstance(guide["keywords"], list)
+    assert isinstance(guide.summary, str)
+    assert isinstance(guide.keywords, tuple)


### PR DESCRIPTION
## Summary

- Migrate the test suite's own **incidental dict-subscript access** (`result["key"]`) on the new typed-return dataclasses to **typed attribute access** (`result.key`), across 11 test files.
- Eliminates **164 self-inflicted `DeprecationWarning`s** per run. The typed-returns migration (#1209/#1250) replaced `dict[str, Any]` returns with frozen dataclasses (`ResearchTask` / `ResearchStart` / `ResearchSource` / `MindMapResult` / `SourceGuide`) carrying a `MappingCompatMixin` dict-subscript bridge that warns on `result["key"]` — but the tests themselves still used the deprecated form.
- Total suite warnings drop **169 → 5**; the 5 survivors are unrelated (Python 3.14 `asyncio` event-loop-policy deprecations + a pytest-asyncio config notice).

## Why this matters

The tests now dogfood the modern attribute API, so they won't break when the `MappingCompatMixin` bridge is removed in v0.8.0. It also makes the warning stream during test runs meaningful again instead of 169 lines of noise.

## What changed (test-only — no `src/` changes)

11 files, **161 insertions / 161 deletions** (pure line-for-line swaps):

| File | Lines |
|------|------:|
| `tests/unit/test_research.py` | 72 |
| `tests/unit/test_research_api.py` | 38 |
| `tests/integration/concurrency/test_research_task_crosswire.py` | 13 |
| `tests/integration/test_sources_integration.py` | 10 |
| `tests/integration/test_vcr_comprehensive.py` | 9 |
| `tests/unit/test_artifact_downloads.py` | 6 |
| `tests/integration/test_artifacts_integration.py` | 4 |
| `tests/unit/test_api_coverage.py` | 4 |
| `tests/integration/test_artifact_generation_idempotency.py` | 2 |
| `tests/unit/test_source_content_renderer.py` | 2 |
| `tests/integration/test_research_idempotency.py` | 1 |

### Conversion care taken
- **tuple vs list**: `keywords` / `sources` / `tasks` are now tuples — list-literal expectations were changed to tuple literals (`[...]`→`(...)`, `[]`→`()`). (`tuple == list` is always `False` in Python, so any missed conversion fails loudly rather than passing wrong.)
- **nested dataclasses**: `result["sources"][0]["url"]` → `result.sources[0].url` (both levels).
- **`.mind_map` is `Any` (a genuine dict)**: `result["mind_map"]["nodes"]` → `result.mind_map["nodes"]` (only the outer subscript converts).
- **intentional bridge tests preserved**: `pytest.warns(DeprecationWarning)` blocks that deliberately exercise the deprecated dict-subscript path keep using dict-access.
- **silent mixin paths untouched**: `"key" in result` membership and `.get(...)` shape-probes are non-warning, left as-is.

## Test plan

- [x] Full unit + integration suite: **7599 passed, 52 skipped** (unchanged from baseline)
- [x] Global `grep -c "dict-style access is deprecated"` over `tests/unit tests/integration`: **0**
- [x] Reviewer re-ran changed files with bridge warnings escalated to errors (`-W error::DeprecationWarning:notebooklm._deprecation`): **0 failures**
- [x] `ruff check` + `ruff format --check`: clean

## Deferred polish findings

None. (Possible follow-up, intentionally **not** in this PR: a targeted `filterwarnings = ["error::DeprecationWarning:notebooklm._deprecation"]` in `pyproject.toml` to make any future dict-access backslide fail CI — that touches config and deserves its own change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across the suite to validate API responses using typed object attributes instead of dictionary-style indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->