### PR TITLE
fix(research): accept typed cited sources

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2388,7 +2388,7 @@ def extract_report_urls(report: str) -> set[str]:
 
 ```python
 def select_cited_sources(
-    sources: list[dict[str, Any]],
+    sources: Sequence[dict[str, Any] | ResearchSource],
     report: str,
 ) -> CitedSourceSelection:
     """Return research sources cited by the completed report.
@@ -2403,9 +2403,9 @@ from notebooklm.research import select_cited_sources
 
 status = await client.research.poll(notebook_id, task_id=task_id)
 # Filter only the sources that were explicitly cited in the report markdown
-selection = select_cited_sources(status["sources"], status["report"])
+selection = select_cited_sources(status.sources, status.report)
 
-print(f"Total sources: {len(status['sources'])}")
+print(f"Total sources: {len(status.sources)}")
 print(f"Cited sources: {len(selection.sources)}")
 ```
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2401,7 +2401,7 @@ Example:
 ```python
 from notebooklm.research import select_cited_sources
 
-status = await client.research.poll(notebook_id, task_id=task_id)
+status = await client.research.wait_for_completion(notebook_id, task_id=task_id)
 # Filter only the sources that were explicitly cited in the report markdown
 selection = select_cited_sources(status.sources, status.report)
 

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import time
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
@@ -22,6 +22,7 @@ from ._research_task_parser import parse_research_task_models
 from ._runtime_contracts import RpcCaller
 from ._types.research import (
     ResearchSource,
+    ResearchSourceInput,
     ResearchStart,
     ResearchStatus,
     ResearchTask,
@@ -50,8 +51,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-
-ResearchSourceInput = ResearchSource | Mapping[str, Any]
 
 # Sentinel marking "the canonical ``initial_interval`` keyword was not passed"
 # in ``wait_for_completion``. The deprecated ``interval`` keyword keeps its
@@ -261,7 +260,7 @@ class ResearchAPI:
     @classmethod
     def select_cited_sources(
         cls,
-        sources: list[dict[str, Any]],
+        sources: Sequence[ResearchSourceInput],
         report: str,
     ) -> CitedSourceSelection:
         """Return research sources cited by the completed report.

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
+from .research import ResearchSourceInput
+
 if TYPE_CHECKING:
     import httpx
 
@@ -111,7 +113,7 @@ class AccountTier:
 class CitedSourceSelection:
     """Result of applying cited-only filtering to research sources."""
 
-    sources: list[dict[str, Any]]
+    sources: list[ResearchSourceInput]
     cited_url_count: int
     matched_url_source_count: int
     used_fallback: bool = False

--- a/src/notebooklm/_types/research.py
+++ b/src/notebooklm/_types/research.py
@@ -124,6 +124,9 @@ class ResearchSource(MappingCompatMixin):
         return public
 
 
+ResearchSourceInput = ResearchSource | Mapping[str, Any]
+
+
 @dataclass(frozen=True)
 class ResearchTask(MappingCompatMixin):
     """A research task and, at the top level, the sibling tasks seen in a poll.

--- a/src/notebooklm/cli/research_import.py
+++ b/src/notebooklm/cli/research_import.py
@@ -10,7 +10,7 @@ shim that delegates to the library method.
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from ..research import select_cited_sources
 from ..types import CitedSourceSelection
@@ -27,7 +27,7 @@ class ResearchImportResult:
     """Result of importing research sources from CLI commands."""
 
     imported: list[dict[str, str]]
-    sources: list[dict]
+    sources: list[dict[str, Any]]
     cited_selection: CitedSourceSelection | None = None
 
 
@@ -35,7 +35,7 @@ async def import_with_retry(
     client,
     notebook_id: str,
     task_id: str,
-    sources: list[dict],
+    sources: list[dict[str, Any]],
     *,
     max_elapsed: float = 1800,
     initial_delay: float = 5,
@@ -68,13 +68,15 @@ async def import_with_retry(
 
 
 def _select_research_sources_for_import(
-    sources: list[dict], report: str, cited_only: bool
-) -> tuple[list[dict], CitedSourceSelection | None]:
+    sources: list[dict[str, Any]], report: str, cited_only: bool
+) -> tuple[list[dict[str, Any]], CitedSourceSelection | None]:
     if not cited_only or not sources:
         return sources, None
 
     cited_selection = select_cited_sources(sources, report)
-    return cited_selection.sources, cited_selection
+    # CLI research import serializes typed task sources to dicts before
+    # selection, so this re-narrowing is safe at the CLI boundary.
+    return cast(list[dict[str, Any]], cited_selection.sources), cited_selection
 
 
 def _display_cited_import_selection(
@@ -101,7 +103,7 @@ async def import_research_sources(
     client,
     notebook_id: str,
     task_id: str,
-    sources: list[dict],
+    sources: list[dict[str, Any]],
     *,
     report: str = "",
     cited_only: bool = False,

--- a/src/notebooklm/research.py
+++ b/src/notebooklm/research.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from collections.abc import Sequence
 from urllib.parse import urlsplit, urlunsplit
 
 from ._research_task_parser import RESEARCH_RESULT_TYPE_REPORT, parse_result_type
+from ._types.research import ResearchSourceInput
 from .types import CitedSourceSelection
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def extract_report_urls(report: str) -> set[str]:
 
 
 def select_cited_sources(
-    sources: list[dict[str, Any]],
+    sources: Sequence[ResearchSourceInput],
     report: str,
 ) -> CitedSourceSelection:
     """Return research sources cited by the completed report.
@@ -73,6 +74,8 @@ def select_cited_sources(
     generated report itself. If no cited URL subset can be resolved, falls
     back to the original source list to avoid an empty import surprise.
     """
+    source_list: list[ResearchSourceInput] = sources if isinstance(sources, list) else list(sources)
+
     cited_urls = extract_report_urls(report)
     if not cited_urls:
         logger.warning(
@@ -80,7 +83,7 @@ def select_cited_sources(
             "falling back to all importable research sources"
         )
         return CitedSourceSelection(
-            sources=sources,
+            sources=source_list,
             cited_url_count=0,
             matched_url_source_count=0,
             used_fallback=True,
@@ -88,17 +91,17 @@ def select_cited_sources(
 
     report_sources = [
         source
-        for source in sources
+        for source in source_list
         if parse_result_type(source.get("result_type")) == RESEARCH_RESULT_TYPE_REPORT
         and source.get("report_markdown")
     ]
     report_source_ids = {id(source) for source in report_sources}
     matched_url_sources = [
         source
-        for source in sources
+        for source in source_list
         if id(source) not in report_source_ids
-        and isinstance(source.get("url"), str)
-        and normalize_citation_url(source["url"]) in cited_urls
+        and isinstance((url := source.get("url")), str)
+        and normalize_citation_url(url) in cited_urls
     ]
 
     if not matched_url_sources:
@@ -107,7 +110,7 @@ def select_cited_sources(
             "matched research sources; falling back to all importable research sources"
         )
         return CitedSourceSelection(
-            sources=sources,
+            sources=source_list,
             cited_url_count=len(cited_urls),
             matched_url_source_count=0,
             used_fallback=True,

--- a/src/notebooklm/research.py
+++ b/src/notebooklm/research.py
@@ -74,7 +74,7 @@ def select_cited_sources(
     generated report itself. If no cited URL subset can be resolved, falls
     back to the original source list to avoid an empty import surprise.
     """
-    source_list: list[ResearchSourceInput] = sources if isinstance(sources, list) else list(sources)
+    source_list = list(sources)
 
     cited_urls = extract_report_urls(report)
     if not cited_urls:

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -125,9 +125,10 @@ _warned_source_types = _source_types._warned_source_types
 # but intentionally absent from ``__all__``.
 ArtifactTypeCode = _ArtifactTypeCode
 
-# Kept in this facade's globals so ``typing.get_type_hints(CitedSourceSelection)``
-# can resolve annotations after ``CitedSourceSelection.__module__`` is rewritten
-# to ``notebooklm.types`` below. Intentionally absent from ``__all__``.
+# Guards the ``ResearchSourceInput`` import from being removed as unused:
+# ``typing.get_type_hints(CitedSourceSelection)`` needs it in this facade's
+# globals after ``CitedSourceSelection.__module__`` is rewritten below.
+# Intentionally absent from ``__all__``.
 _CITED_SOURCE_SELECTION_TYPE_HINT_GLOBALS = (ResearchSourceInput,)
 
 

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -45,6 +45,7 @@ from ._types.notes import Note
 from ._types.research import (
     MindMapResult,
     ResearchSource,
+    ResearchSourceInput,
     ResearchStart,
     ResearchStatus,
     ResearchTask,
@@ -123,6 +124,11 @@ _warned_source_types = _source_types._warned_source_types
 # Imported for the historical ``notebooklm.types.ArtifactTypeCode`` attribute,
 # but intentionally absent from ``__all__``.
 ArtifactTypeCode = _ArtifactTypeCode
+
+# Kept in this facade's globals so ``typing.get_type_hints(CitedSourceSelection)``
+# can resolve annotations after ``CitedSourceSelection.__module__`` is rewritten
+# to ``notebooklm.types`` below. Intentionally absent from ``__all__``.
+_CITED_SOURCE_SELECTION_TYPE_HINT_GLOBALS = (ResearchSourceInput,)
 
 
 __all__ = [

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -3,12 +3,20 @@
 import json
 import logging
 import warnings
+from collections.abc import Mapping, Sequence
+from typing import get_args, get_origin, get_type_hints
 from urllib.parse import parse_qs
 
 import pytest
 
 import notebooklm._research as research_module
-from notebooklm import NotebookLMClient
+from notebooklm import (
+    CitedSourceSelection,
+    NotebookLMClient,
+    ResearchSource,
+    ResearchStatus,
+    ResearchTask,
+)
 from notebooklm._research import ResearchAPI
 from notebooklm.research import extract_report_urls, normalize_citation_url, select_cited_sources
 from notebooklm.rpc import RPCMethod
@@ -119,6 +127,85 @@ class TestCitedSourceSelection:
             "Deep Research Report",
             "Cited",
         ]
+
+    @pytest.mark.parametrize(
+        "selector",
+        [select_cited_sources, ResearchAPI.select_cited_sources],
+        ids=["public_function", "research_api_wrapper"],
+    )
+    def test_select_cited_sources_accepts_typed_task_sources(self, selector):
+        report_source = ResearchSource(
+            url="",
+            title="Deep Research Report",
+            result_type=5,
+            report_markdown="# Report",
+        )
+        cited_source = ResearchSource(
+            url="https://example.com/cited/",
+            title="Cited",
+            result_type=1,
+        )
+        uncited_source = ResearchSource(
+            url="https://example.com/uncited",
+            title="Uncited",
+            result_type=1,
+        )
+        task = ResearchTask(
+            task_id="task_123",
+            status=ResearchStatus.COMPLETED,
+            sources=(report_source, cited_source, uncited_source),
+            report="Final report cites [the source](https://example.com/cited).",
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            selection = selector(task.sources, task.report)
+
+        assert selection.used_fallback is False
+        assert selection.cited_url_count == 1
+        assert selection.matched_url_source_count == 1
+        assert selection.sources == [report_source, cited_source]
+
+    def test_select_cited_sources_fallback_accepts_typed_task_sources(self):
+        source = ResearchSource(
+            url="https://example.com/source",
+            title="Source",
+            result_type=1,
+        )
+        task = ResearchTask(
+            task_id="task_123",
+            status=ResearchStatus.COMPLETED,
+            sources=(source,),
+            report="# Report without links",
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            selection = select_cited_sources(task.sources, task.report)
+
+        assert selection.used_fallback is True
+        assert selection.sources == [source]
+
+    def test_select_cited_sources_source_annotations_accept_research_source(self):
+        selector_sources_hints = [
+            get_type_hints(select_cited_sources)["sources"],
+            get_type_hints(ResearchAPI.select_cited_sources)["sources"],
+        ]
+
+        for sources_hint in selector_sources_hints:
+            assert get_origin(sources_hint) is Sequence
+            (item_hint,) = get_args(sources_hint)
+            item_args = get_args(item_hint) or (item_hint,)
+
+            assert ResearchSource in item_args
+            assert any(get_origin(item_arg) is Mapping for item_arg in item_args)
+
+        selection_sources_hint = get_type_hints(CitedSourceSelection)["sources"]
+        assert get_origin(selection_sources_hint) is list
+        (item_hint,) = get_args(selection_sources_hint)
+        item_args = get_args(item_hint) or (item_hint,)
+        assert ResearchSource in item_args
+        assert any(get_origin(item_arg) is Mapping for item_arg in item_args)
 
     def test_select_cited_sources_deduplicates_report_entries_with_urls(self):
         report_source = {


### PR DESCRIPTION
## Summary
- Widen `select_cited_sources` and `ResearchAPI.select_cited_sources` source inputs to accept typed `ResearchSource` values via the shared `ResearchSourceInput` alias.
- Keep cited-source selection warning-free for typed `ResearchTask.sources`, including fallback paths, and widen `CitedSourceSelection.sources` accordingly.
- Update public API docs and tests for typed-source selection.

Fixes #1252

## Test plan
- [x] `uv run pytest tests/unit/test_research.py -q`
- [x] `uv run pytest tests/unit/test_research.py tests/unit/test_research_service.py tests/unit/test_types.py -q`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run python scripts/audit_public_api_compat.py`

## Deferred polish findings
- Optional: whether to export `ResearchSourceInput` in `__all__` remains a policy choice; it is intentionally available for annotation resolution but not documented as a public import in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API docs and examples to use attribute-style access and clearer examples.
* **New Features**
  * Research sources input now accepts both typed objects and plain dictionaries.
* **Type Safety**
  * Improved type hints for better IDE support and validation.
* **Tests**
  * Added unit tests covering the research selection behavior and type-hinting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->