### PR TITLE
fix(test): record VCR cassettes through pytest — defer NOTEBOOKLM_HOME isolation + auth mock when recording (#1263)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -472,10 +472,17 @@ NOTEBOOKLM_VCR_RECORD=1 uv run pytest tests/integration/test_vcr_*.py -v
 > the CLI auth path resolve live credentials to record against. CLI-VCR tests
 > additionally skip their `mock_auth_for_vcr` patch in record mode for the same
 > reason. Replay runs and non-VCR tests stay isolated (a stray
-> `NOTEBOOKLM_VCR_RECORD` on a normal run never un-isolates a unit test). The
+> `NOTEBOOKLM_VCR_RECORD` on a normal run never un-isolates a non-VCR test). The
 > test must carry the `vcr` marker — most do via a module-level `pytestmark`.
 > Before #1263 this deferral did not exist and cassettes could only be recorded
 > with a standalone script.
+>
+> **Limitation:** a few cli_vcr tests (`settings` / `profile` / `doctor`)
+> re-pin `NOTEBOOKLM_HOME` at their own tmp dir to isolate config/profile
+> writes. They override this deferral and so are not auto-recordable through
+> pytest — re-record those with a standalone script (or, as a future
+> enhancement, inject `NOTEBOOKLM_AUTH_JSON` from the real storage so auth is
+> resolved independently of `NOTEBOOKLM_HOME`).
 
 The scrubbing pipeline (`tests/vcr_config.py`) redacts cookies, CSRF tokens,
 emails, and other sensitive patterns before the cassette hits disk. Verify

--- a/docs/development.md
+++ b/docs/development.md
@@ -464,6 +464,19 @@ The script is a manual maintainer helper — CI never runs it.
 NOTEBOOKLM_VCR_RECORD=1 uv run pytest tests/integration/test_vcr_*.py -v
 ```
 
+> **Recording reads your real `~/.notebooklm` profile.** Normally the suite
+> pins `NOTEBOOKLM_HOME` at a throwaway tmp dir (autouse `_isolate_notebooklm_home`
+> in `tests/conftest.py`) so runs are reproducible and never touch your real
+> profile. Under `NOTEBOOKLM_VCR_RECORD=1`, `@pytest.mark.vcr` tests instead read
+> the real profile — so `get_vcr_auth()` (via `AuthTokens.from_storage()`) and
+> the CLI auth path resolve live credentials to record against. CLI-VCR tests
+> additionally skip their `mock_auth_for_vcr` patch in record mode for the same
+> reason. Replay runs and non-VCR tests stay isolated (a stray
+> `NOTEBOOKLM_VCR_RECORD` on a normal run never un-isolates a unit test). The
+> test must carry the `vcr` marker — most do via a module-level `pytestmark`.
+> Before #1263 this deferral did not exist and cassettes could only be recorded
+> with a standalone script.
+
 The scrubbing pipeline (`tests/vcr_config.py`) redacts cookies, CSRF tokens,
 emails, and other sensitive patterns before the cassette hits disk. Verify
 the result with the cassette guard before committing:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,32 @@ from notebooklm.rpc import RPCMethod
 _PLAYWRIGHT_INSTALLED = importlib.util.find_spec("playwright") is not None
 
 
+# Mirror of ``tests/vcr_config._is_vcr_record_mode`` — duplicated (not imported)
+# so the *root* conftest, loaded for every test, stays free of the heavier
+# ``vcr_config`` (vcrpy) import. Keep the truthy spelling set in sync. (#1263)
+_VCR_RECORD_ENV = "NOTEBOOKLM_VCR_RECORD"
+
+
+def _vcr_recording() -> bool:
+    """Whether VCR is in record mode (``NOTEBOOKLM_VCR_RECORD`` truthy)."""
+    return os.environ.get(_VCR_RECORD_ENV, "").strip().lower() in ("1", "true", "yes")
+
+
+def _should_use_real_home(*, e2e: bool, vcr: bool, recording: bool) -> bool:
+    """Whether a test should see the developer's real ``~/.notebooklm`` profile
+    rather than an isolated tmp ``NOTEBOOKLM_HOME``.
+
+    - **E2E** tests always use it (they mint live tokens).
+    - **VCR** tests use it only while *recording* (``NOTEBOOKLM_VCR_RECORD=1``):
+      recording captures against the live API and needs real auth, which both
+      ``get_vcr_auth()`` (via ``AuthTokens.from_storage()``) and the CLI auth
+      path read out of ``NOTEBOOKLM_HOME``. Replay runs and non-VCR tests stay
+      isolated, so the suite is reproducible and a stray ``NOTEBOOKLM_VCR_RECORD``
+      on a normal run never lets a test touch the real profile (issue #1263).
+    """
+    return e2e or (vcr and recording)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_notebooklm_home(request, tmp_path, monkeypatch):
     """Pin ``NOTEBOOKLM_HOME`` at a per-test tmp dir.
@@ -25,10 +51,17 @@ def _isolate_notebooklm_home(request, tmp_path, monkeypatch):
     ``NOTEBOOKLM_HOME`` at a tmp dir gives every test the same empty-storage
     view CI sees, so the suite is reproducible across machines.
 
-    E2E tests opt out: they need the real ``~/.notebooklm/`` profile to mint
-    live tokens, so the marker bypasses this fixture.
+    Two opt-outs use the real ``~/.notebooklm/`` profile instead (see
+    :func:`_should_use_real_home`): ``@pytest.mark.e2e`` tests (mint live
+    tokens) and ``@pytest.mark.vcr`` tests while recording
+    (``NOTEBOOKLM_VCR_RECORD=1``) — the latter lets a cassette be recorded
+    through pytest rather than a standalone script (issue #1263).
     """
-    if request.node.get_closest_marker("e2e"):
+    if _should_use_real_home(
+        e2e=request.node.get_closest_marker("e2e") is not None,
+        vcr=request.node.get_closest_marker("vcr") is not None,
+        recording=_vcr_recording(),
+    ):
         return
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "notebooklm-home"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,16 @@ _PLAYWRIGHT_INSTALLED = importlib.util.find_spec("playwright") is not None
 
 # Mirror of ``tests/vcr_config._is_vcr_record_mode`` — duplicated (not imported)
 # so the *root* conftest, loaded for every test, stays free of the heavier
-# ``vcr_config`` (vcrpy) import. Keep the truthy spelling set in sync. (#1263)
+# ``vcr_config`` (vcrpy) import. Kept byte-for-byte identical to the canonical
+# (no ``.strip()``) so the two never disagree on a padded value and split the
+# config into a half-recording state; ``test_home_isolation`` pins the parity.
+# (#1263)
 _VCR_RECORD_ENV = "NOTEBOOKLM_VCR_RECORD"
 
 
 def _vcr_recording() -> bool:
     """Whether VCR is in record mode (``NOTEBOOKLM_VCR_RECORD`` truthy)."""
-    return os.environ.get(_VCR_RECORD_ENV, "").strip().lower() in ("1", "true", "yes")
+    return os.environ.get(_VCR_RECORD_ENV, "").lower() in ("1", "true", "yes")
 
 
 def _should_use_real_home(*, e2e: bool, vcr: bool, recording: bool) -> bool:
@@ -39,6 +42,31 @@ def _should_use_real_home(*, e2e: bool, vcr: bool, recording: bool) -> bool:
     return e2e or (vcr and recording)
 
 
+def _isolation_home(request, tmp_path):
+    """The ``NOTEBOOKLM_HOME`` the autouse fixture should pin, or ``None`` to
+    leave the developer's real ``~/.notebooklm`` profile in place.
+
+    Split out from the fixture so the marker/env wiring is directly unit-testable
+    (see ``tests/unit/test_home_isolation.py``) without unwrapping the fixture.
+
+    Keys on the ``vcr`` *marker* only (not the ``@notebooklm_vcr.use_cassette``
+    decorator / ``vcr`` fixture that the integration tier also recognizes): a
+    cassette test must carry ``@pytest.mark.vcr`` to record against the real
+    profile — most do via a module-level ``pytestmark``. Tests that re-pin
+    ``NOTEBOOKLM_HOME`` themselves (e.g. the settings/profile/doctor cli_vcr
+    tests, which isolate config writes on purpose) override this deferral and are
+    not auto-recordable through pytest. Both gaps fail safe (isolated home, not a
+    leaked real one).
+    """
+    if _should_use_real_home(
+        e2e=request.node.get_closest_marker("e2e") is not None,
+        vcr=request.node.get_closest_marker("vcr") is not None,
+        recording=_vcr_recording(),
+    ):
+        return None
+    return str(tmp_path / "notebooklm-home")
+
+
 @pytest.fixture(autouse=True)
 def _isolate_notebooklm_home(request, tmp_path, monkeypatch):
     """Pin ``NOTEBOOKLM_HOME`` at a per-test tmp dir.
@@ -52,18 +80,14 @@ def _isolate_notebooklm_home(request, tmp_path, monkeypatch):
     view CI sees, so the suite is reproducible across machines.
 
     Two opt-outs use the real ``~/.notebooklm/`` profile instead (see
-    :func:`_should_use_real_home`): ``@pytest.mark.e2e`` tests (mint live
-    tokens) and ``@pytest.mark.vcr`` tests while recording
+    :func:`_should_use_real_home` / :func:`_isolation_home`): ``@pytest.mark.e2e``
+    tests (mint live tokens) and ``@pytest.mark.vcr`` tests while recording
     (``NOTEBOOKLM_VCR_RECORD=1``) — the latter lets a cassette be recorded
     through pytest rather than a standalone script (issue #1263).
     """
-    if _should_use_real_home(
-        e2e=request.node.get_closest_marker("e2e") is not None,
-        vcr=request.node.get_closest_marker("vcr") is not None,
-        recording=_vcr_recording(),
-    ):
-        return
-    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "notebooklm-home"))
+    home = _isolation_home(request, tmp_path)
+    if home is not None:
+        monkeypatch.setenv("NOTEBOOKLM_HOME", home)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 # Add tests directory to path for vcr_config import
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from integration.conftest import skip_no_cassettes  # noqa: E402
+from integration.conftest import _is_vcr_record_mode, skip_no_cassettes  # noqa: E402
 from vcr_config import notebooklm_vcr  # noqa: E402
 
 # Re-export for use by test files
@@ -76,7 +76,16 @@ def mock_auth_for_vcr():
     also carries ``@pytest.mark.vcr`` (either directly or via a module-level
     ``pytestmark``), so the global autouse already disables the poke before
     this fixture runs.
+
+    Recording (``NOTEBOOKLM_VCR_RECORD=1``) is the exception: the CLI must load
+    the *real* profile's cookies/tokens to reach the live API, so the mock is
+    skipped. The root ``_isolate_notebooklm_home`` fixture likewise defers to
+    the real ``~/.notebooklm`` for vcr tests in record mode, so the normal
+    ``load_auth_from_storage`` path resolves real auth (issue #1263).
     """
+    if _is_vcr_record_mode():
+        yield
+        return
     mock_cookies = {
         "SID": "vcr_mock_sid",
         "HSID": "vcr_mock_hsid",

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -26,6 +26,44 @@ assert _spec is not None and _spec.loader is not None
 _root_conftest = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_root_conftest)
 _should_use_real_home = _root_conftest._should_use_real_home
+_vcr_recording = _root_conftest._vcr_recording
+
+# The canonical record-mode check the root conftest mirrors — loaded the same way
+# so the parity test below can assert the two never disagree.
+_vcr_spec = importlib.util.spec_from_file_location(
+    "tests_vcr_config_for_parity", Path(__file__).resolve().parents[1] / "vcr_config.py"
+)
+assert _vcr_spec is not None and _vcr_spec.loader is not None
+_vcr_config = importlib.util.module_from_spec(_vcr_spec)
+_vcr_spec.loader.exec_module(_vcr_config)
+_is_vcr_record_mode = _vcr_config._is_vcr_record_mode
+
+# The fixture delegates its decision to this plain function (path to pin, or
+# ``None`` to keep the real profile) — directly callable with a fake request.
+_isolation_home = _root_conftest._isolation_home
+
+
+class _FakeNode:
+    def __init__(self, markers: set[str]) -> None:
+        self._markers = markers
+
+    def get_closest_marker(self, name: str) -> object | None:
+        return object() if name in self._markers else None
+
+
+class _FakeRequest:
+    def __init__(self, markers: set[str]) -> None:
+        self.node = _FakeNode(markers)
+
+
+def _resolved_home(markers, *, recording, tmp_path, monkeypatch):
+    """Run the fixture's decision with a fake request node; return the home it
+    would pin (a tmp path) or ``None`` (defer to the real profile)."""
+    if recording:
+        monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD", "1")
+    else:
+        monkeypatch.delenv("NOTEBOOKLM_VCR_RECORD", raising=False)
+    return _isolation_home(_FakeRequest(markers), tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -62,3 +100,46 @@ def test_normal_test_home_is_isolated() -> None:
     home = os.environ.get("NOTEBOOKLM_HOME", "")
     assert home.endswith("notebooklm-home"), home
     assert Path(home) != Path.home() / ".notebooklm"
+
+
+@pytest.mark.parametrize(
+    "value", ["1", "true", "TRUE", "Yes", "yes", "0", "false", "", "1 ", " 1", "nope"]
+)
+def test_vcr_recording_matches_canonical(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The root conftest's local ``_vcr_recording`` never disagrees with the
+    canonical ``vcr_config._is_vcr_record_mode`` it mirrors — otherwise a padded
+    value could half-enable recording (real home, but VCR still in replay)."""
+    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD", value)
+    assert _vcr_recording() == _is_vcr_record_mode()
+
+
+# --- Fixture-wiring regression: the fixture's decision under each mode ----------
+# ``_isolation_home`` returns a tmp path to pin (isolated) or ``None`` to leave
+# the real profile in place (deferred).
+
+
+def test_isolation_home_isolates_non_vcr_test_even_under_record_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The safety property through the real decision path: a stray
+    ``NOTEBOOKLM_VCR_RECORD=1`` never un-isolates a non-VCR test."""
+    home = _resolved_home(set(), recording=True, tmp_path=tmp_path, monkeypatch=monkeypatch)
+    assert home is not None and home.endswith("notebooklm-home")
+
+
+def test_isolation_home_defers_for_vcr_test_in_record_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vcr test in record mode keeps the real profile (``None``) so recording
+    resolves real auth."""
+    assert (
+        _resolved_home({"vcr"}, recording=True, tmp_path=tmp_path, monkeypatch=monkeypatch) is None
+    )
+
+
+def test_isolation_home_isolates_vcr_test_in_replay_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vcr test in REPLAY mode (the CI default) is still isolated."""
+    home = _resolved_home({"vcr"}, recording=False, tmp_path=tmp_path, monkeypatch=monkeypatch)
+    assert home is not None and home.endswith("notebooklm-home")

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -1,0 +1,64 @@
+"""Tests for the ``NOTEBOOKLM_HOME`` isolation opt-outs (issue #1263).
+
+The autouse ``_isolate_notebooklm_home`` fixture pins ``NOTEBOOKLM_HOME`` at a
+per-test tmp dir for reproducibility. Two opt-outs use the developer's real
+``~/.notebooklm`` profile instead: ``@pytest.mark.e2e`` tests (always) and
+``@pytest.mark.vcr`` tests *while recording* (``NOTEBOOKLM_VCR_RECORD=1``), so a
+contributor can record a cassette through pytest instead of a standalone script.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+# Load the root conftest by file path to reach its module-level decision helper
+# without depending on pytest's ``conftest`` import-name resolution. This is the
+# same file-path idiom the conftest itself uses for ``vcr_config`` /
+# ``cassette_patterns`` (``tests/`` is not a package).
+_spec = importlib.util.spec_from_file_location(
+    "tests_root_conftest", Path(__file__).resolve().parents[1] / "conftest.py"
+)
+assert _spec is not None and _spec.loader is not None
+_root_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_root_conftest)
+_should_use_real_home = _root_conftest._should_use_real_home
+
+
+@pytest.mark.parametrize(
+    ("e2e", "vcr", "recording", "expected"),
+    [
+        # Plain unit/integration test → always isolated, even if someone runs
+        # the whole suite with NOTEBOOKLM_VCR_RECORD=1 set (a non-VCR test is
+        # never un-isolated, so the real profile is never touched by accident).
+        (False, False, False, False),
+        (False, False, True, False),
+        # VCR test → isolated on replay (the CI default), real home only when
+        # actually recording.
+        (False, True, False, False),
+        (False, True, True, True),
+        # E2E test → always the real profile (mints live tokens).
+        (True, False, False, True),
+        (True, False, True, True),
+        (True, True, False, True),
+        (True, True, True, True),
+    ],
+)
+def test_should_use_real_home_truth_table(
+    e2e: bool, vcr: bool, recording: bool, expected: bool
+) -> None:
+    assert _should_use_real_home(e2e=e2e, vcr=vcr, recording=recording) is expected
+
+
+def test_normal_test_home_is_isolated() -> None:
+    """A normal (non-e2e, non-vcr) test sees the isolated tmp NOTEBOOKLM_HOME.
+
+    Guards the safety property the fix must preserve: the default path still
+    points at a per-test tmp dir, never the developer's real ``~/.notebooklm``.
+    """
+    home = os.environ.get("NOTEBOOKLM_HOME", "")
+    assert home.endswith("notebooklm-home"), home
+    assert Path(home) != Path.home() / ".notebooklm"


### PR DESCRIPTION
## Fixes #1263

The autouse `_isolate_notebooklm_home` fixture (`tests/conftest.py`) pins `NOTEBOOKLM_HOME` at a per-test tmp dir for **every** test. That's correct for replay/unit runs (reproducible empty storage), but it also hides the developer's real `~/.notebooklm` during **recording**: both the API path (`get_vcr_auth()` → `AuthTokens.from_storage()`) and the CLI auth path read `NOTEBOOKLM_HOME`, so `NOTEBOOKLM_VCR_RECORD=1` under pytest couldn't authenticate. Cassettes could only be captured with a hand-rolled standalone script — even though `docs/development.md` already advertised the pytest flow.

## Fix (issue's option 1, scoped for safety)

Defer the isolation to the real profile **only when it's actually needed**, via a pure, exhaustively-tested decision helper:

```python
def _should_use_real_home(*, e2e, vcr, recording) -> bool:
    return e2e or (vcr and recording)
```

- **e2e** tests → real profile (unchanged; they mint live tokens).
- **vcr** tests → real profile **only while recording** (`NOTEBOOKLM_VCR_RECORD=1`); isolated on replay (the CI default).
- everything else → always isolated.

So a stray `NOTEBOOKLM_VCR_RECORD` on a normal run never un-isolates a unit test or lets it touch the real profile — the key safety property. CLI-VCR tests additionally skip their `mock_auth_for_vcr` patch in record mode so the CLI loads real auth (the API path uses `get_vcr_auth()`, which was already record-aware).

## Verification

- **End-to-end:** `NOTEBOOKLM_VCR_RECORD=1 pytest` on a vcr-marked CLI test now records a real cassette against the live API (verified with a throwaway read-only `list` recording; the scrub hooks still ran and `is_clean()` passed — then discarded).
- **Unit:** `tests/unit/test_home_isolation.py` pins the full truth table (8 combos) + asserts a normal test stays isolated.
- **Replay regression:** full suite unchanged — **7665 passed, 52 skipped**; ruff + mypy clean. The 69 cli_vcr replay tests still mock auth + isolate as before.

## Docs

`docs/development.md` recording section now explains that recording reads your real `~/.notebooklm` profile (and why), and that replay/non-VCR runs stay isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified development docs on VCR recording mode and how test runs use a real user profile when recording; noted a few CLI tests still require manual recording.

* **Tests**
  * Improved test isolation logic so VCR recording uses real credentials while replay and non-VCR tests remain isolated.
  * Added unit and integration tests covering home-directory isolation and record vs replay behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->