### PR TITLE
test: apply #1265 review nits (casefold + ImportError guards) (#1263)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,15 +16,15 @@ _PLAYWRIGHT_INSTALLED = importlib.util.find_spec("playwright") is not None
 # Mirror of ``tests/vcr_config._is_vcr_record_mode`` — duplicated (not imported)
 # so the *root* conftest, loaded for every test, stays free of the heavier
 # ``vcr_config`` (vcrpy) import. Kept byte-for-byte identical to the canonical
-# (no ``.strip()``) so the two never disagree on a padded value and split the
-# config into a half-recording state; ``test_home_isolation`` pins the parity.
-# (#1263)
+# (same ``.casefold()``, no ``.strip()``) so the two never disagree on a padded
+# value and split the config into a half-recording state; ``test_home_isolation``
+# pins the parity. (#1263)
 _VCR_RECORD_ENV = "NOTEBOOKLM_VCR_RECORD"
 
 
 def _vcr_recording() -> bool:
     """Whether VCR is in record mode (``NOTEBOOKLM_VCR_RECORD`` truthy)."""
-    return os.environ.get(_VCR_RECORD_ENV, "").lower() in ("1", "true", "yes")
+    return os.environ.get(_VCR_RECORD_ENV, "").casefold() in ("1", "true", "yes")
 
 
 def _should_use_real_home(*, e2e: bool, vcr: bool, recording: bool) -> bool:

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -22,7 +22,8 @@ import pytest
 _spec = importlib.util.spec_from_file_location(
     "tests_root_conftest", Path(__file__).resolve().parents[1] / "conftest.py"
 )
-assert _spec is not None and _spec.loader is not None
+if _spec is None or _spec.loader is None:  # pragma: no cover - import wiring guard
+    raise ImportError("Could not load tests/conftest.py via importlib")
 _root_conftest = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_root_conftest)
 _should_use_real_home = _root_conftest._should_use_real_home
@@ -33,7 +34,8 @@ _vcr_recording = _root_conftest._vcr_recording
 _vcr_spec = importlib.util.spec_from_file_location(
     "tests_vcr_config_for_parity", Path(__file__).resolve().parents[1] / "vcr_config.py"
 )
-assert _vcr_spec is not None and _vcr_spec.loader is not None
+if _vcr_spec is None or _vcr_spec.loader is None:  # pragma: no cover - import wiring guard
+    raise ImportError("Could not load tests/vcr_config.py via importlib")
 _vcr_config = importlib.util.module_from_spec(_vcr_spec)
 _vcr_spec.loader.exec_module(_vcr_config)
 _is_vcr_record_mode = _vcr_config._is_vcr_record_mode

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -118,7 +118,7 @@ def _is_vcr_record_mode() -> bool:
     module's VCR-instance config and ``tests/integration/conftest.py``
     consume this helper to avoid drift between the two checks.
     """
-    return os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in ("1", "true", "yes")
+    return os.environ.get("NOTEBOOKLM_VCR_RECORD", "").casefold() in ("1", "true", "yes")
 
 
 def get_error_injection_mode() -> str | None:

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -81,9 +81,8 @@ def _load_sibling(module_name: str, file_name: str) -> Any:
     spec = importlib.util.spec_from_file_location(
         module_name, Path(__file__).resolve().parent / file_name
     )
-    assert spec is not None and spec.loader is not None, (
-        f"Could not load {file_name} next to vcr_config.py"
-    )
+    if spec is None or spec.loader is None:  # pragma: no cover - import wiring guard
+        raise ImportError(f"Could not load {file_name} next to vcr_config.py")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION
Follow-up to #1265, which was squash-merged at its original tip before two addressed-feedback commits landed on the branch. This lands those two reviewer nits on `main`:

- **`.casefold()` over `.lower()`** (Gemini + claude[bot]): record-mode env parsing now uses `.casefold()` for Unicode-aware case folding, per the project's general string-comparison rule. Applied to **both** `tests/conftest.py:_vcr_recording()` and the canonical `tests/vcr_config.py:_is_vcr_record_mode()` so the two stay byte-for-byte identical — the `test_vcr_recording_matches_canonical` parity test (incl. padded `" 1"`/`"1 "`) enforces this. No `.strip()` is added to either side; single-sided stripping is the half-recording divergence #1263 guards against.
- **`raise ImportError` instead of bare `assert`** (claude[bot]): the two module-level importlib spec/loader guards in `tests/unit/test_home_isolation.py` now raise `ImportError` with a message, so the diagnostic survives `python -O` and is clearer if the file-path loading ever breaks.

Test-infra only; no `src/` changes. Full suite green (7782 passed, 52 skipped), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test robustness by making environment-variable parsing case-insensitive and more reliable.
  * Replaced assert-based module-loading guards with explicit error handling to fail fast and provide clearer failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->