### PR TITLE
fix(transport): accept fractional-second Retry-After values (#1275)

### DIFF
--- a/src/notebooklm/_transport_errors.py
+++ b/src/notebooklm/_transport_errors.py
@@ -48,10 +48,10 @@ def parse_retry_after(value: str | None) -> int | None:
     # (inf/nan) values, which float() accepts but math.ceil() can't handle.
     try:
         seconds = float(value)
+        if math.isfinite(seconds):
+            return min(MAX_RETRY_AFTER_SECONDS, max(0, math.ceil(seconds)))
     except ValueError:
-        seconds = None
-    if seconds is not None and math.isfinite(seconds):
-        return min(MAX_RETRY_AFTER_SECONDS, max(0, math.ceil(seconds)))
+        pass
     # HTTP-date form (RFC 7231 section 7.1.1.1)
     try:
         dt = parsedate_to_datetime(value)

--- a/src/notebooklm/_transport_errors.py
+++ b/src/notebooklm/_transport_errors.py
@@ -12,6 +12,7 @@ __all__ = [
 ]
 
 import logging
+import math
 import time
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -25,7 +26,11 @@ MAX_RETRY_AFTER_SECONDS = 300
 
 
 def parse_retry_after(value: str | None) -> int | None:
-    """Parse RFC 7231 Retry-After: integer-seconds OR HTTP-date.
+    """Parse a Retry-After header: integer-seconds OR HTTP-date (RFC 7231).
+
+    Fractional-seconds (e.g. ``"1.5"``) are non-conformant but emitted by some
+    servers/proxies; they are accepted and rounded UP so we never retry faster
+    than the server asked.
 
     Returns seconds-until-retry as a non-negative int, clamped to
     ``MAX_RETRY_AFTER_SECONDS``. Returns ``None`` for empty or unparseable input.
@@ -38,6 +43,15 @@ def parse_retry_after(value: str | None) -> int | None:
         return min(MAX_RETRY_AFTER_SECONDS, max(0, int(value)))
     except ValueError:
         pass
+    # Fractional-seconds form: non-RFC-7231 but emitted by some servers/proxies.
+    # Round UP so we never retry faster than the server asked. Reject non-finite
+    # (inf/nan) values, which float() accepts but math.ceil() can't handle.
+    try:
+        seconds = float(value)
+    except ValueError:
+        seconds = None
+    if seconds is not None and math.isfinite(seconds):
+        return min(MAX_RETRY_AFTER_SECONDS, max(0, math.ceil(seconds)))
     # HTTP-date form (RFC 7231 section 7.1.1.1)
     try:
         dt = parsedate_to_datetime(value)

--- a/tests/unit/test_retry_after.py
+++ b/tests/unit/test_retry_after.py
@@ -30,12 +30,31 @@ def test_parse_retry_after_past_date():
     assert parse_retry_after(date_str) == 0
 
 
+def test_parse_retry_after_fractional_seconds():
+    # Fractional seconds are non-RFC-7231 but emitted by some servers/proxies.
+    # Round UP so we never retry faster than the server asked.
+    assert parse_retry_after("1.5") == 2
+    assert parse_retry_after("0.4") == 1
+    assert parse_retry_after("0.0") == 0
+    assert parse_retry_after(" 2.5 ") == 3
+    # Integer-seconds form still parses unchanged (no spurious ceil).
+    assert parse_retry_after("3") == 3
+    # Negative fractional clamps to 0, same as integer.
+    assert parse_retry_after("-1.5") == 0
+    # Fractional is still capped.
+    assert parse_retry_after(f"{MAX_RETRY_AFTER_SECONDS + 0.5}") == MAX_RETRY_AFTER_SECONDS
+
+
 def test_parse_retry_after_invalid():
     assert parse_retry_after("not a date") is None
     assert parse_retry_after("") is None
     assert parse_retry_after("   ") is None
     # Partially valid but not what we want
     assert parse_retry_after("2026-05-13") is None
+    # Non-finite floats must be rejected, not crash math.ceil.
+    assert parse_retry_after("inf") is None
+    assert parse_retry_after("nan") is None
+    assert parse_retry_after("-inf") is None
 
 
 def test_runtime_deadline_pins_expired_and_exceeded_boundaries():


### PR DESCRIPTION
Fixes #1275

## Problem

`parse_retry_after` in `_transport_errors.py` rejected a fractional `Retry-After: 1.5` header: `int("1.5")` raises `ValueError`, the HTTP-date parser then also failed, and the function returned `None` — discarding the server's explicit pacing hint in favour of exponential backoff. RFC 7231 only defines integer-seconds and HTTP-date, but some real servers/proxies emit fractional seconds.

## Fix

Add a fractional-seconds branch between the integer-seconds and HTTP-date paths:
- Parse with `float(value)` and round **UP** via `math.ceil` so we never retry faster than the server asked.
- Reject non-finite values (`inf`/`nan`, and overflow strings like `1e10000` which `float()` coerces to `inf`) via `math.isfinite`; they fall through to the date parser and ultimately return `None`.
- Integer-seconds and HTTP-date paths are unchanged; negative and garbage values are still clamped/rejected exactly as before. Result stays clamped to `MAX_RETRY_AFTER_SECONDS`.

Scope: `src/notebooklm/_transport_errors.py` + `tests/unit/test_retry_after.py` only.

## Verification

- New tests: `"1.5"` → 2, `"0.4"` → 1, `"0.0"` → 0, `" 2.5 "` → 3, integer `"3"` → 3, `"-1.5"` → 0, cap respected; invalid: `inf`/`nan`/`-inf` → `None`. HTTP-date and past-date paths still pass unchanged.
- `pytest` full suite: **7783 passed, 52 skipped**.
- `ruff format` + `ruff check`: clean.
- `mypy src/notebooklm --ignore-missing-imports`: clean (188 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Retry-After headers to accept fractional-second values, rounding up to determine retry intervals.
  * Added validation to reject invalid or non-finite Retry-After values (e.g., "inf", "nan").

* **Tests**
  * Expanded test coverage for Retry-After parsing, including fractional seconds, edge cases, and invalid inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->