### PR TITLE
docs(auth): document refresh-cmd env forwarding + scrub note (#1274)

### DIFF
--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -1555,7 +1555,26 @@ the library:
    in the child env so the script knows which profile to refresh.
 3. Sets `_NOTEBOOKLM_REFRESH_ATTEMPTED=1` in the child env to prevent
    recursive refresh loops if the script itself invokes `notebooklm`.
-4. Reloads cookies from `storage_state.json`, replays token fetch once.
+4. Scrubs `NOTEBOOKLM_AUTH_JSON` from the child env — it is a
+   credential-equivalent storage_state payload the command never needs (it
+   receives the on-disk path via step 2 instead, when present). It is the
+   only first-party storage_state credential payload forwarded, so it is the
+   one var that can be scrubbed without risking the refresh contract.
+5. Reloads cookies from `storage_state.json`, replays token fetch once.
+
+> **SECURITY — inherited environment.** The refresh command inherits the
+> **full parent environment** (so it can find `PATH`/`HOME`/proxy settings
+> and re-invoke this library), minus the `NOTEBOOKLM_AUTH_JSON` scrub in
+> step 4. We deliberately do **not** impose an allowlist, because a refresh
+> command commonly re-invokes `notebooklm` and legitimately needs much of
+> the inherited env. As a result, **any other secret in the launching
+> shell** (e.g. `GOOGLE_*` tokens, CI secrets, API keys — and any token the
+> operator embeds in `NOTEBOOKLM_REFRESH_CMD` itself) is inherited by the
+> refresh command and every grandchild it spawns, and is visible via
+> `/proc/<pid>/environ` to the same UID. Operators MUST NOT keep unrelated
+> secrets in the environment that launches the refresh command; scope
+> secrets to the processes that need them
+> ([#1274](https://github.com/teng-lin/notebooklm-py/issues/1274)).
 
 A `ContextVar` (`_REFRESH_ATTEMPTED_CONTEXT`) gates same-task retries in
 the parent process, and a per-loop / per-resolved-storage-path asyncio

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -305,6 +305,32 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     ``shell=True`` behavior (e.g., when the command relies on shell features
     like pipes, redirection, or env-var expansion).
 
+    Environment forwarding:
+        The refresh command inherits the **full parent environment** (so it
+        can find ``PATH``, ``HOME``, proxy settings, and any custom config the
+        operator relies on), with three deliberate adjustments:
+
+        * ``NOTEBOOKLM_AUTH_JSON`` is **scrubbed** — it carries a
+          credential-equivalent storage_state payload the child never needs
+          (the child gets the on-disk storage path via
+          ``NOTEBOOKLM_REFRESH_STORAGE_PATH`` instead). It is the only
+          first-party storage_state credential payload we forward, so it is the
+          one var we can scrub without risking the refresh contract.
+        * ``_NOTEBOOKLM_REFRESH_ATTEMPTED`` is injected as the recursion guard.
+        * ``NOTEBOOKLM_REFRESH_PROFILE`` / ``NOTEBOOKLM_REFRESH_STORAGE_PATH``
+          are injected so the command refreshes the right profile in place.
+
+        SECURITY: only ``NOTEBOOKLM_AUTH_JSON`` is scrubbed. We deliberately do
+        **not** impose an allowlist, because a refresh command commonly
+        re-invokes this library and legitimately needs much of the inherited
+        env. As a consequence, **any other secret in the launching shell**
+        (e.g. ``GOOGLE_*`` tokens, CI secrets, API keys — and any token the
+        operator embeds in ``NOTEBOOKLM_REFRESH_CMD`` itself) is inherited by
+        the refresh command and every grandchild it spawns, and is visible via
+        ``/proc/<pid>/environ`` to the same UID. Operators MUST NOT keep
+        unrelated secrets in the environment that launches the refresh command;
+        scope secrets to the processes that need them.
+
     Raises:
         RuntimeError: If the refresh command is missing, parses to an empty
             argv, is malformed (unterminated quote), times out, or exits
@@ -313,6 +339,10 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     cmd = os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV)
     if not cmd:
         raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} is not set; cannot refresh cookies.")
+    # Forward the full parent env (PATH/HOME/proxy/etc. the command needs),
+    # minus the one credential-equivalent var below. See the "Environment
+    # forwarding" section of this function's docstring for the SECURITY note
+    # on why a hard allowlist is deliberately avoided (issue #1274).
     refresh_env = os.environ.copy()
     # ``NOTEBOOKLM_AUTH_JSON`` carries the full Playwright storage_state — a
     # credential-equivalent payload. Forwarding it via ``os.environ.copy()``
@@ -320,7 +350,12 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     # ``/proc/<pid>/environ`` to the same UID) and into any grandchild the
     # refresh command spawns. The refresh command already receives the
     # canonical on-disk storage path via ``NOTEBOOKLM_REFRESH_STORAGE_PATH``
-    # (set just below), so the in-env JSON is not needed by the child.
+    # (set just below), so the in-env JSON is not needed by the child. It is the
+    # only first-party storage_state credential payload we forward (audited
+    # #1274); the rest (PROFILE/HOME/BASE_URL/...) are config the child may
+    # legitimately consume when it re-invokes this library, so they stay. Any
+    # token an operator embeds in ``NOTEBOOKLM_REFRESH_CMD`` is intentionally
+    # inherited — see this function's docstring SECURITY note.
     refresh_env.pop("NOTEBOOKLM_AUTH_JSON", None)
     refresh_env[_REFRESH_ATTEMPTED_ENV] = "1"
     refresh_env["NOTEBOOKLM_REFRESH_PROFILE"] = resolve_profile(profile)

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -288,6 +288,66 @@ class TestSplitRefreshCmd:
         assert _split_refresh_cmd("   ") == []
 
 
+class TestSubprocessEnv:
+    """Env-forwarding contract for the refresh subprocess (issue #1274).
+
+    The parent env is forwarded so the command can find ``PATH``/``HOME``
+    etc., but the credential-equivalent ``NOTEBOOKLM_AUTH_JSON`` must be
+    scrubbed and the refresh control vars must be injected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auth_json_scrubbed_from_subprocess_env(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        # A credential-equivalent payload sitting in the launching shell.
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", '{"cookies": [{"value": "secret"}]}')
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        env = recorder.calls[0]["kwargs"]["env"]
+        assert "NOTEBOOKLM_AUTH_JSON" not in env, (
+            "NOTEBOOKLM_AUTH_JSON must be scrubbed from the refresh subprocess env"
+        )
+
+    @pytest.mark.asyncio
+    async def test_inherited_path_forwarded(self, monkeypatch, tmp_path):
+        """Conservative inheritance: ``PATH`` (and the wider parent env) is
+        still forwarded so the refresh command can locate its executable.
+        """
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setenv("PATH", "/custom/bin:/usr/bin")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        env = recorder.calls[0]["kwargs"]["env"]
+        assert env.get("PATH") == "/custom/bin:/usr/bin"
+
+    @pytest.mark.asyncio
+    async def test_refresh_control_vars_injected(self, monkeypatch, tmp_path):
+        """The recursion-guard + storage-path/profile vars are injected so the
+        child sees the canonical on-disk state instead of the in-env JSON.
+        """
+        storage = _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd(profile="work")
+
+        env = recorder.calls[0]["kwargs"]["env"]
+        assert env[refresh_mod._REFRESH_ATTEMPTED_ENV] == "1"
+        assert env["NOTEBOOKLM_REFRESH_STORAGE_PATH"] == str(storage)
+        # The explicit profile is injected verbatim so the child refreshes the
+        # right profile in place.
+        assert env["NOTEBOOKLM_REFRESH_PROFILE"] == "work"
+
+
 class TestEndToEndWithRealSubprocess:
     """Integration smoke: real subprocess invocation under shell=False."""
 


### PR DESCRIPTION
Fixes #1274

## Problem

`_run_refresh_cmd` in `src/notebooklm/_auth/refresh.py` forwards the **full parent environment** (`os.environ.copy()`) to the token-refresh subprocess, scrubbing only `NOTEBOOKLM_AUTH_JSON`. Any *other* credential-bearing var in the launching shell (e.g. a `GOOGLE_*` token, a CI secret) is inherited by the refresh command and every grandchild it spawns, visible via `/proc/<pid>/environ` to the same UID. The code recognized this hazard for `NOTEBOOKLM_AUTH_JSON` but scrubbed only that one var — a false sense of containment. Severity: **Low** (by-design env inheritance, same-UID exposure only).

## Resolution: document-only (no behavior change)

This is a **documentation + test** change — the runtime scrub is unchanged.

I deliberately did **not** add a hard allowlist. A refresh command commonly re-invokes this library (`notebooklm login ...`) and legitimately needs much of the inherited env (`PATH`, `HOME`, proxy settings, `NOTEBOOKLM_PROFILE`/`NOTEBOOKLM_HOME`/...). Narrowing the forwarded env risks silently breaking the refresh contract for a Low-severity, same-UID-only exposure.

I audited every `NOTEBOOKLM_*` var in the source: `NOTEBOOKLM_AUTH_JSON` is the only first-party **storage_state credential payload** forwarded, so it is the one var that can be scrubbed without risk — which the existing code already does. (Per reviewer feedback, the docs also note that a token an operator embeds in `NOTEBOOKLM_REFRESH_CMD` itself is likewise inherited.)

### What changed
- **`_run_refresh_cmd` docstring** — new "Environment forwarding" section + explicit **SECURITY** note: the full parent env is forwarded (minus `NOTEBOOKLM_AUTH_JSON`); operators MUST NOT keep unrelated secrets in the launching shell.
- **Inline comment** near the `pop` — cross-references #1274 and explains why a hard allowlist is avoided.
- **`docs/auth-cookie-lifecycle.md` §9.2** — added the `NOTEBOOKLM_AUTH_JSON` scrub as a numbered step + a SECURITY callout mirroring the docstring.
- **Regression tests** (`tests/unit/test_refresh_cmd_shlex.py::TestSubprocessEnv`) pin: `NOTEBOOKLM_AUTH_JSON` is absent from the subprocess env, `PATH` is still forwarded (conservative inheritance), and the control vars (`_NOTEBOOKLM_REFRESH_ATTEMPTED`, `NOTEBOOKLM_REFRESH_STORAGE_PATH`, `NOTEBOOKLM_REFRESH_PROFILE`) are injected with the expected values.

## Verification
- `pytest` full suite: **7785 passed, 52 skipped**
- `ruff format` + `ruff check`: clean
- `mypy src/notebooklm --ignore-missing-imports`: success (188 files)
- Polish gate: code-simplifier intent + codex + claude reviews; addressed the "only NOTEBOOKLM_* var carrying secret material" over-claim (reworded to first-party storage_state payload + noted refresh-cmd inline tokens), the on-disk-path env-only hedge, and tightened the profile-injection assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded authentication refresh documentation to clarify environment variable inheritance behavior
  * Added security guidance for operators regarding sensitive data in parent shell environments

* **Tests**
  * Added test coverage for authentication refresh subprocess environment handling
  * Tests validate proper credential scrubbing and environment variable inheritance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->