### PR TITLE
fix(mind-maps): make interactive mind-map paths fail loud (#1270)

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -18,6 +18,8 @@ from urllib.parse import ParseResult, unquote, urlparse
 import httpx
 
 from ._artifact_formatters import _extract_app_data, _format_interactive_content, _parse_data_table
+from ._mind_maps_api import extract_interactive_tree_leaf
+from ._row_adapters_notes import NoteRow
 from .auth import load_httpx_cookies
 from .exceptions import UnknownRPCMethodError, ValidationError
 from .rpc import ArtifactTypeCode, RPCMethod, safe_index
@@ -238,19 +240,13 @@ class ArtifactDownloadService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if result is None:
-            return None
-        try:
-            tree_json = safe_index(
-                result,
-                0,
-                9,
-                3,
-                method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
-                source="_artifact_downloads._get_interactive_mind_map_tree",
-            )
-        except UnknownRPCMethodError:
-            return None
+        # ``extract_interactive_tree_leaf`` re-raises ``UnknownRPCMethodError``
+        # on genuine ``[0][9]`` shape drift (failing loud like the sibling HTML
+        # accessor ``_get_artifact_content``) while tolerating an absent ``[3]``
+        # leaf as the legitimate "tree not populated yet" window (issue #1270).
+        tree_json = extract_interactive_tree_leaf(
+            result, source="_artifact_downloads._get_interactive_mind_map_tree"
+        )
         return tree_json if isinstance(tree_json, str) else None
 
     async def download_audio(
@@ -518,7 +514,11 @@ class ArtifactDownloadService:
         json_string: str | None = None
 
         if artifact_id:
-            mind_map = next((mm for mm in mind_maps if mm[0] == artifact_id), None)
+            # Read the row id through the ``NoteRow`` adapter seam rather than a
+            # raw ``mm[0]`` index so a numeric / non-str id is ``str``-coerced
+            # consistently with the rest of the mind-map path (issue #1270) and
+            # any future row-shape change is absorbed in one place.
+            mind_map = next((mm for mm in mind_maps if NoteRow(mm).id == artifact_id), None)
             if mind_map is not None:
                 json_string = mind_maps_service.extract_content(mind_map)
             else:

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -634,9 +634,15 @@ class ArtifactsAPI:
                     mind_map_data = mind_map_json
                     mind_map_json = json_module.dumps(mind_map_json)
 
+                # Only accept ``name`` when it is a non-empty ``str`` — a
+                # malformed tree with a ``null``/numeric ``name`` would otherwise
+                # flow into the note title and frozen ``MindMap.title: str``
+                # (issue #1270).
                 title = "Mind Map"
-                if isinstance(mind_map_data, dict) and "name" in mind_map_data:
-                    title = mind_map_data["name"]
+                if isinstance(mind_map_data, dict):
+                    name = mind_map_data.get("name")
+                    if isinstance(name, str) and name:
+                        title = name
 
                 # ``NoteService.create_note`` raises ``RPCError`` when the
                 # server omits a usable row id (issue #1162); on success it

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from ._artifact_payloads import build_interactive_mind_map_artifact_params
@@ -26,6 +27,82 @@ if TYPE_CHECKING:
     from ._mind_map import NoteBackedMindMapService
     from ._notebooks import NotebooksAPI
     from ._runtime_contracts import RpcCaller
+
+logger = logging.getLogger(__name__)
+
+# The interactive (studio-artifact) mind map exposes its ``{"name", "children"}``
+# node tree at ``[0][9][3]`` of the ``GET_INTERACTIVE_HTML`` response (vs the HTML
+# body at ``[0][9][0]``). The leaf at ``[3]`` is the only position that may be
+# legitimately absent during the brief window after completion before the
+# options block is fully populated.
+_INTERACTIVE_TREE_LEAF_POS = 3
+
+
+def extract_interactive_tree_leaf(result: Any, *, source: str) -> Any | None:
+    """Return the raw ``[0][9][3]`` interactive mind-map tree leaf, or ``None``.
+
+    Distinguishes a *genuinely absent leaf* (the options block is a list but
+    its ``[3]`` tree slot is not populated yet — the legitimate "not ready"
+    window) from *real shape drift* (``[0]`` or ``[0][9]`` moved out from under
+    us, or ``[0][9]`` is no longer a list). Drift re-raises
+    ``UnknownRPCMethodError`` so the library fails loud like the sibling HTML
+    accessor ``_get_artifact_content`` (issue #1270); only the missing ``[3]``
+    leaf within a present *list* options block is tolerated. A tolerated-but-
+    absent leaf emits a WARNING with the rpcid/source so a reshape that drops
+    just the leaf position still leaves a drift signal in the logs.
+    """
+    if result is None:
+        return None
+    # Descend to the options block (``[0][9]``) strictly: if Google moves the
+    # interactive payload off ``[0][9]`` entirely, this raises and surfaces the
+    # drift instead of masquerading as "not ready".
+    options_block = safe_index(
+        result,
+        0,
+        9,
+        method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
+        source=source,
+    )
+    # Only a *list* options block too short for index 3 is the legitimate
+    # "tree not populated yet" window — a non-list ``[0][9]`` is genuine drift,
+    # so fail loud rather than masking it as not-ready. (We raise explicitly
+    # rather than via ``safe_index`` because some non-list types — e.g. ``str``
+    # — are subscriptable and would not trip ``safe_index``'s descent guard.)
+    if not isinstance(options_block, list):
+        raise UnknownRPCMethodError(
+            f"safe_index drift at path (0, 9): options block is "
+            f"{type(options_block).__name__}, not a list",
+            method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
+            path=(0, 9),
+            source=source,
+            data_at_failure=repr(options_block)[:200],
+        )
+    if len(options_block) <= _INTERACTIVE_TREE_LEAF_POS:
+        logger.warning(
+            "Interactive mind-map tree leaf absent at [0][9][%d] (rpcid=%s, source=%s); "
+            "treating as not-yet-populated. If this persists, Google may have reshaped "
+            "the %s response.",
+            _INTERACTIVE_TREE_LEAF_POS,
+            RPCMethod.GET_INTERACTIVE_HTML.value,
+            source,
+            RPCMethod.GET_INTERACTIVE_HTML.name,
+        )
+        return None
+    return options_block[_INTERACTIVE_TREE_LEAF_POS]
+
+
+def _tree_title(tree: dict[str, Any] | None, default: str = "Mind Map") -> str:
+    """Return a mind-map title from ``tree["name"]`` only when it is a non-empty ``str``.
+
+    The frozen :class:`MindMap.title` is typed ``str``; a malformed tree with a
+    ``null``/numeric ``name`` would otherwise smuggle a non-``str`` into it
+    (issue #1270). Falls back to ``default`` for any non-string / empty name.
+    """
+    if tree is not None:
+        name = tree.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return default
 
 
 def _parse_tree(content: Any) -> dict[str, Any] | None:
@@ -134,7 +211,7 @@ class MindMapsAPI:
                 notebook_id, source_ids, language, instructions
             )
             tree = res.mind_map if isinstance(res.mind_map, dict) else None
-            title = tree["name"] if tree and "name" in tree else "Mind Map"
+            title = _tree_title(tree)
             return MindMap(
                 id=res.note_id or "",
                 notebook_id=notebook_id,
@@ -164,7 +241,10 @@ class MindMapsAPI:
             )
         if wait:
             await self._artifacts.wait_for_completion(notebook_id, new_id)
-        art = await self._find_interactive(notebook_id, new_id)
+        # ``allow_unclassified=True``: we hold the concrete id from
+        # CREATE_ARTIFACT, so id-match a settling type-4 row whose variant slot
+        # has not yet filled rather than degrading to the placeholder MindMap.
+        art = await self._find_interactive(notebook_id, new_id, allow_unclassified=True)
         # After completion, fetch the tree so interactive maps return the same
         # populated ``MindMap.tree`` as note-backed ones. Skip when not waiting
         # (still pending) — ``get_tree`` would have nothing to read yet.
@@ -221,6 +301,15 @@ class MindMapsAPI:
         if kind == MindMapKind.NOTE_BACKED:
             await self._mind_maps.rename_mind_map(notebook_id, mind_map_id, new_title)
         else:
+            # Pre-validate the id on the explicit-interactive path. Without this,
+            # ``RENAME_ARTIFACT`` silently no-ops on a wrong id (the RPC returns
+            # null), diverging from the ``kind=None`` path which raises
+            # ``ValueError`` for an unknown id. Fail loud instead (issue #1270;
+            # aligns with the "fail loud + return object" direction of #1255).
+            if await self._find_interactive(notebook_id, mind_map_id) is None:
+                raise ValueError(
+                    f"Interactive mind map {mind_map_id!r} not found in notebook {notebook_id!r}"
+                )
             await self._artifacts.rename(notebook_id, mind_map_id, new_title)
 
     async def delete(
@@ -277,17 +366,11 @@ class MindMapsAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        try:
-            tree_json = safe_index(
-                result,
-                0,
-                9,
-                3,
-                method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
-                source="_mind_maps_api.get_tree",
-            )
-        except UnknownRPCMethodError:
-            return None
+        # ``extract_interactive_tree_leaf`` re-raises ``UnknownRPCMethodError``
+        # on genuine ``[0][9]`` shape drift (failing loud like the sibling HTML
+        # accessor) while tolerating an absent ``[3]`` leaf as the legitimate
+        # "tree not populated yet" window (issue #1270).
+        tree_json = extract_interactive_tree_leaf(result, source="_mind_maps_api.get_tree")
         return _parse_tree(tree_json)
 
     async def _detect_kind(self, notebook_id: str, mind_map_id: str) -> MindMapKind:
@@ -299,8 +382,37 @@ class MindMapsAPI:
             return MindMapKind.INTERACTIVE
         raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
 
-    async def _find_interactive(self, notebook_id: str, artifact_id: str) -> Any | None:
-        for art in await self._artifacts.list(notebook_id, ArtifactType.MIND_MAP):
-            if art.id == artifact_id and art.is_interactive_mind_map:
+    async def _find_interactive(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        *,
+        allow_unclassified: bool = False,
+    ) -> Any | None:
+        """Resolve a known interactive-mind-map id to its :class:`Artifact`.
+
+        By default matches only a *confirmed* interactive map
+        (``type 4 / variant 4``) so the auto-detect ``rename`` / ``delete`` /
+        ``get_tree`` callers and the explicit-interactive ``rename`` validation
+        never mistake a settling (or malformed) quiz/flashcard — also a type-4
+        row that may transiently read ``variant=None`` — for a mind map.
+
+        ``allow_unclassified=True`` additionally accepts a type-4 row whose
+        ``variant`` slot has not yet populated (``variant=None``). Only the
+        ``generate`` path passes this: it already holds the concrete id returned
+        by ``CREATE_ARTIFACT`` for an interactive map, so id-matching the
+        settling artifact is safe there and keeps ``generate(wait=True)`` from
+        degrading to the ``title="Mind Map"`` placeholder (no ``created_at``)
+        when completion is observed a tick before the variant slot fills
+        (issue #1270).
+
+        Lists unfiltered (rather than filtered to ``MIND_MAP``) because a
+        ``variant=None`` type-4 row is *excluded* from the ``MIND_MAP`` filter
+        and would otherwise be invisible during the settling window.
+        """
+        for art in await self._artifacts.list(notebook_id):
+            if art.id != artifact_id:
+                continue
+            if art.is_interactive_mind_map or (allow_unclassified and art.is_unclassified_type4):
                 return art
         return None

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import builtins
 import json
 import logging
+import reprlib
 from typing import TYPE_CHECKING, Any
 
 from ._artifact_payloads import build_interactive_mind_map_artifact_params
@@ -75,7 +76,10 @@ def extract_interactive_tree_leaf(result: Any, *, source: str) -> Any | None:
             method_id=RPCMethod.GET_INTERACTIVE_HTML.value,
             path=(0, 9),
             source=source,
-            data_at_failure=repr(options_block)[:200],
+            # ``reprlib.repr`` bounds the diagnostic preview without first
+            # materialising the full repr of a pathologically large/deep
+            # ``options_block`` (mirrors ``safe_index``'s own ``_truncate``).
+            data_at_failure=reprlib.repr(options_block),
         )
     if len(options_block) <= _INTERACTIVE_TREE_LEAF_POS:
         logger.warning(

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -320,6 +320,21 @@ class Artifact:
         )
 
     @property
+    def is_unclassified_type4(self) -> bool:
+        """Whether this is a type-4 artifact whose variant slot is not yet populated.
+
+        A just-created interactive mind map (or quiz/flashcards) is a type-4
+        (QUIZ-family) artifact, but the variant code at ``[9][1][0]`` may read
+        ``None`` for a brief window after creation before the options block
+        fills in. During that window the row is neither classifiable as
+        interactive-mind-map nor quiz/flashcards. Callers that resolved a
+        concrete id (e.g. ``MindMapsAPI._find_interactive`` after
+        ``CREATE_ARTIFACT``) use this to id-match the settling artifact rather
+        than degrading to a placeholder (issue #1270).
+        """
+        return self._artifact_type == ArtifactTypeCode.QUIZ.value and self._variant is None
+
+    @property
     def report_subtype(self) -> str | None:
         """Get the report subtype for type 2 artifacts.
 

--- a/tests/unit/test_interactive_mind_map.py
+++ b/tests/unit/test_interactive_mind_map.py
@@ -182,3 +182,63 @@ async def test_download_note_backed_id_still_works(tmp_path):
         "name": "Root",
         "children": [],
     }
+
+
+# --- #1270: download fail-loud + numeric-id seam ------------------------------
+
+from notebooklm.exceptions import UnknownRPCMethodError  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_download_interactive_tree_real_drift_reraises(tmp_path):
+    """A genuine [0][9] reshape in the tree response fails loud (issue #1270)."""
+    # GET_INTERACTIVE_HTML returns a short [0] row: descent to [0][9] fails
+    # before the leaf -> drift -> UnknownRPCMethodError (not silent not-ready).
+    listing = MagicMock()
+    listing.list_raw = AsyncMock(return_value=[_INTERACTIVE_ROW])
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=[])
+    rpc = MagicMock(spec=RpcCaller, rpc_call=AsyncMock(return_value=[[1, 2, 3]]))
+    svc = ArtifactDownloadService(rpc=rpc, listing=listing, mind_maps=mind_maps)
+    with pytest.raises(UnknownRPCMethodError):
+        await svc.download_mind_map("nb", str(tmp_path / "x.json"), artifact_id="int_mm")
+
+
+@pytest.mark.asyncio
+async def test_download_interactive_tree_absent_leaf_is_not_ready(tmp_path):
+    """A populated options block missing only the [3] leaf reads as not ready."""
+    listing = MagicMock()
+    listing.list_raw = AsyncMock(return_value=[_INTERACTIVE_ROW])
+    mind_maps = MagicMock()
+    mind_maps.list_mind_maps = AsyncMock(return_value=[])
+    # [0][9] present but too short to carry the [3] tree leaf.
+    response = [[None] * 9 + [[None, None]]]
+    rpc = MagicMock(spec=RpcCaller, rpc_call=AsyncMock(return_value=response))
+    svc = ArtifactDownloadService(rpc=rpc, listing=listing, mind_maps=mind_maps)
+    with pytest.raises(ArtifactNotReadyError):
+        await svc.download_mind_map("nb", str(tmp_path / "x.json"), artifact_id="int_mm")
+
+
+@pytest.mark.asyncio
+async def test_download_note_backed_numeric_id_matches_via_noterow(tmp_path):
+    """A numeric row id is str-coerced through NoteRow(mm).id, not raw mm[0]."""
+    content = '{"name": "Root", "children": []}'
+    # Row id is the integer 12345; the caller passes the string "12345".
+    svc = _download_service(studio_rows=[], note_rows=[[12345, content]])
+    out = str(tmp_path / "mm.json")
+    result = await svc.download_mind_map("nb", out, artifact_id="12345")
+    assert result == out
+    assert json.loads((tmp_path / "mm.json").read_text(encoding="utf-8")) == {
+        "name": "Root",
+        "children": [],
+    }
+
+
+# --- #1270 sub-fix 2: the transient type-4 discriminator ----------------------
+
+
+def test_is_unclassified_type4_property():
+    assert _art(4, None).is_unclassified_type4 is True  # settling window
+    assert _art(4, 4).is_unclassified_type4 is False  # resolved interactive
+    assert _art(4, 2).is_unclassified_type4 is False  # resolved quiz
+    assert _art(5, None).is_unclassified_type4 is False  # note-backed synthetic

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -6,14 +6,20 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from notebooklm._mind_maps_api import MindMapsAPI
-from notebooklm.exceptions import ArtifactError
+from notebooklm._mind_maps_api import MindMapsAPI, extract_interactive_tree_leaf
+from notebooklm.exceptions import ArtifactError, UnknownRPCMethodError
 from notebooklm.rpc.types import RPCMethod
 from notebooklm.types import Artifact, MindMapKind, MindMapResult
 
 
 def _interactive_artifact(artifact_id: str, title: str = "INT") -> Artifact:
     return Artifact(id=artifact_id, title=title, _artifact_type=4, status=3, _variant=4)
+
+
+def _pending_type4_artifact(artifact_id: str, title: str = "INT") -> Artifact:
+    # Just-created interactive map: completed (status=3) but the variant slot
+    # at [9][1][0] is not yet populated, so _variant reads None.
+    return Artifact(id=artifact_id, title=title, _artifact_type=4, status=3, _variant=None)
 
 
 def _make_api(*, note_rows=None, interactive=None):
@@ -55,7 +61,9 @@ async def test_list_unions_both_backings():
 
 @pytest.mark.asyncio
 async def test_rename_dispatches_by_kind():
-    api, _, mind_maps, artifacts, _ = _make_api()
+    # The explicit-interactive path pre-validates the id (issue #1270), so the
+    # interactive artifact must exist for the rename to dispatch.
+    api, _, mind_maps, artifacts, _ = _make_api(interactive=[_interactive_artifact("int_mm")])
     await api.rename("nb", "note_mm", "X", kind=MindMapKind.NOTE_BACKED)
     mind_maps.rename_mind_map.assert_awaited_once_with("nb", "note_mm", "X")
     artifacts.rename.assert_not_awaited()
@@ -152,3 +160,171 @@ async def test_detect_kind_raises_when_absent():
     api, *_ = _make_api()
     with pytest.raises(ValueError, match="not found"):
         await api.rename("nb", "ghost", "X")
+
+
+# --- #1270 sub-fix 1: get_tree drift vs absent-leaf ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tree_interactive_absent_leaf_tolerated_with_warning(caplog):
+    """A populated options block missing only the [3] tree leaf is 'not ready'."""
+    api, rpc, *_ = _make_api()
+    row = [None] * 10
+    row[9] = [None, None]  # [0][9] present but too short to carry the [3] leaf
+    rpc.configure_mock(rpc_call=AsyncMock(return_value=[row]))
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._mind_maps_api"):
+        tree = await api.get_tree("nb", "int_mm", kind=MindMapKind.INTERACTIVE)
+    assert tree is None  # tolerated as not-yet-populated
+    # ...but a WARNING with the rpcid/source leaves a drift breadcrumb.
+    assert any(RPCMethod.GET_INTERACTIVE_HTML.value in r.message for r in caplog.records)
+    assert any("_mind_maps_api.get_tree" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_tree_interactive_real_drift_reraises():
+    """Genuine [0][9] reshape must fail loud, not masquerade as 'not ready'."""
+    api, rpc, *_ = _make_api()
+    # [0] is a short row: descent to [0][9] fails before reaching the leaf.
+    rpc.configure_mock(rpc_call=AsyncMock(return_value=[[1, 2, 3]]))
+    with pytest.raises(UnknownRPCMethodError):
+        await api.get_tree("nb", "int_mm", kind=MindMapKind.INTERACTIVE)
+
+
+@pytest.mark.asyncio
+async def test_get_tree_interactive_null_response_returns_none():
+    """A null GET_INTERACTIVE_HTML response stays 'not ready' (no drift)."""
+    api, rpc, *_ = _make_api()
+    rpc.configure_mock(rpc_call=AsyncMock(return_value=None))
+    assert await api.get_tree("nb", "int_mm", kind=MindMapKind.INTERACTIVE) is None
+
+
+def test_extract_interactive_tree_leaf_helper():
+    """The shared helper: null -> None, drift -> raise, present -> value."""
+    assert extract_interactive_tree_leaf(None, source="t") is None
+    row = [None] * 10
+    row[9] = [None, None, None, "TREE"]
+    assert extract_interactive_tree_leaf([row], source="t") == "TREE"
+    # [0] too short to reach [0][9] -> drift.
+    with pytest.raises(UnknownRPCMethodError):
+        extract_interactive_tree_leaf([[1, 2, 3]], source="t")
+    # A non-list [0][9] is drift too (not a tolerated short-list).
+    non_list_row = [None] * 10
+    non_list_row[9] = "not-a-list"
+    with pytest.raises(UnknownRPCMethodError):
+        extract_interactive_tree_leaf([non_list_row], source="t")
+    # A list [0][9] that is too short for index 3 is the tolerated not-ready leaf.
+    short_row = [None] * 10
+    short_row[9] = [None, None]
+    assert extract_interactive_tree_leaf([short_row], source="t") is None
+
+
+# --- #1270 sub-fix 2: transient type-4 variant=None classification -----------
+
+
+@pytest.mark.asyncio
+async def test_find_interactive_matches_pending_variant_none_by_id():
+    """generate(wait=True) must keep the real title during the settling window."""
+    api, rpc, _, artifacts, _ = _make_api(
+        interactive=[_pending_type4_artifact("new_int", "Real Title")]
+    )
+    tree_row = [None] * 10
+    tree_row[9] = [None, None, None, '{"name": "I", "children": []}']
+    rpc.configure_mock(
+        rpc_call=AsyncMock(
+            side_effect=[
+                [["new_int", "Real Title", 4]],  # CREATE_ARTIFACT echo
+                [tree_row],  # GET_INTERACTIVE_HTML tree
+            ]
+        )
+    )
+    mm = await api.generate("nb", kind=MindMapKind.INTERACTIVE, wait=True)
+    assert mm.id == "new_int"
+    # Did NOT degrade to the title="Mind Map" placeholder.
+    assert mm.title == "Real Title"
+    assert mm.tree == {"name": "I", "children": []}
+
+
+@pytest.mark.asyncio
+async def test_generate_interactive_unresolved_id_falls_back_to_placeholder():
+    """If even the unfiltered list never shows the id, fall back gracefully."""
+    api, rpc, _, artifacts, _ = _make_api(interactive=[])
+    rpc.configure_mock(
+        rpc_call=AsyncMock(
+            side_effect=[
+                [["ghost_int", "T", 4]],  # CREATE_ARTIFACT echo
+                None,  # GET_INTERACTIVE_HTML tree not ready
+            ]
+        )
+    )
+    mm = await api.generate("nb", kind=MindMapKind.INTERACTIVE, wait=True)
+    assert mm.id == "ghost_int"
+    assert mm.title == "Mind Map"  # placeholder fallback preserved
+
+
+# --- #1270 sub-fix 3: rename(kind=INTERACTIVE) pre-validates the id ----------
+
+
+@pytest.mark.asyncio
+async def test_rename_interactive_bad_id_raises_not_silent_noop():
+    api, _, _, artifacts, _ = _make_api(interactive=[_interactive_artifact("real_int")])
+    with pytest.raises(ValueError, match="not found"):
+        await api.rename("nb", "ghost", "X", kind=MindMapKind.INTERACTIVE)
+    artifacts.rename.assert_not_awaited()  # never dispatched the no-op RPC
+
+
+@pytest.mark.asyncio
+async def test_rename_interactive_good_id_dispatches():
+    api, _, _, artifacts, _ = _make_api(interactive=[_interactive_artifact("real_int")])
+    await api.rename("nb", "real_int", "X", kind=MindMapKind.INTERACTIVE)
+    artifacts.rename.assert_awaited_once_with("nb", "real_int", "X")
+
+
+@pytest.mark.asyncio
+async def test_rename_interactive_rejects_settling_type4_variant_none():
+    """The unclassified-type4 fallback is scoped to generate only: rename/detect
+    must NOT accept a settling (or malformed) quiz/flashcard as a mind map."""
+    api, _, _, artifacts, _ = _make_api(interactive=[_pending_type4_artifact("settling")])
+    # Explicit-interactive rename: the strict path rejects a variant=None row.
+    with pytest.raises(ValueError, match="not found"):
+        await api.rename("nb", "settling", "X", kind=MindMapKind.INTERACTIVE)
+    artifacts.rename.assert_not_awaited()
+    # Auto-detect (kind=None) also rejects it -> ValueError, never dispatched.
+    with pytest.raises(ValueError, match="not found"):
+        await api.rename("nb", "settling", "X")
+    artifacts.rename.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_tree_interactive_non_list_options_block_reraises():
+    """A non-list [0][9] is genuine drift -> fail loud, not 'not ready'."""
+    api, rpc, *_ = _make_api()
+    row = [None] * 10
+    row[9] = "not-a-list"  # [0][9] is no longer a list -> drift
+    rpc.configure_mock(rpc_call=AsyncMock(return_value=[row]))
+    with pytest.raises(UnknownRPCMethodError):
+        await api.get_tree("nb", "int_mm", kind=MindMapKind.INTERACTIVE)
+
+
+# --- #1270 sub-fix 4: non-str title coercion ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_note_backed_non_str_name_falls_back_to_placeholder():
+    api, _, _, artifacts, _ = _make_api()
+    artifacts.generate_mind_map = AsyncMock(
+        return_value=MindMapResult(mind_map={"name": 123, "children": []}, note_id="n1")
+    )
+    mm = await api.generate("nb", ["s1"], kind=MindMapKind.NOTE_BACKED)
+    assert mm.title == "Mind Map"  # numeric name rejected, placeholder used
+
+
+@pytest.mark.asyncio
+async def test_generate_note_backed_empty_name_falls_back_to_placeholder():
+    api, _, _, artifacts, _ = _make_api()
+    artifacts.generate_mind_map = AsyncMock(
+        return_value=MindMapResult(mind_map={"name": "", "children": []}, note_id="n1")
+    )
+    mm = await api.generate("nb", ["s1"], kind=MindMapKind.NOTE_BACKED)
+    assert mm.title == "Mind Map"  # empty name rejected, placeholder used


### PR DESCRIPTION
Fixes #1270.

The #1256 interactive-mind-map code had a cluster of silent/soft failures that contradict the library's otherwise-rigorous fail-loud posture. This fixes all four sub-items together.

## Sub-fixes

**1. `get_tree` / `download_mind_map` no longer swallow protocol drift as "not ready"** (`_mind_maps_api.py`, `_artifact_downloads.py`)
A new shared `extract_interactive_tree_leaf(result, *, source)` helper descends `[0][9][3]` of the `GET_INTERACTIVE_HTML` response and distinguishes:
- **absent leaf** — `[0][9]` is a *list* too short for index `3`: tolerated as the legitimate "tree not populated yet" window, but emits a `WARNING` carrying the rpcid/source so a reshape that drops just the leaf still leaves a drift breadcrumb;
- **real drift** — `[0]`/`[0][9]` moved, or `[0][9]` is a non-list: re-raises `UnknownRPCMethodError`, failing loud like the sibling HTML accessor `_get_artifact_content`.

This replaces the old `except UnknownRPCMethodError: return None` that returned `None` *forever* with no drift signal if Google moved the tree off `[0][9][3]`.

**2. Pending interactive map (`type 4, variant=None`) no longer degrades `generate`** (`_types/artifacts.py`, `_mind_maps_api.py`)
A just-created interactive artifact whose options block has not yet populated reads `variant=None`, so it was excluded from the `MIND_MAP` filter and `_find_interactive` returned `None` — meaning `generate(wait=True)` fell to the `MindMap(title="Mind Map")` placeholder (wrong title, no `created_at`) when completion was observed a tick before the variant slot filled.
New `Artifact.is_unclassified_type4` + an `allow_unclassified` flag on `_find_interactive` (passed **only** by `generate`, which already holds the concrete `CREATE_ARTIFACT` id) id-match the settling row. The auto-detect `rename`/`delete`/`get_tree` and explicit-interactive `rename` paths stay **strict** so a settling/malformed quiz/flashcard is never mistaken for a mind map.

**3. `mind_maps.rename(kind=INTERACTIVE)` now fails loud** (`_mind_maps_api.py`)
The explicit-kind path pre-validates the id via `_find_interactive`, so a wrong id raises `ValueError` instead of silently no-opping `RENAME_ARTIFACT` — matching the `kind=None` path. Cross-references #1255 ("return the renamed object + fail loud").

**4. Low/cheap** (same files)
- `title = tree["name"]` is used only when it is a non-empty `str` (note-backed `generate` in both `_mind_maps_api` and `_artifacts`), so a `null`/numeric `name` no longer smuggles a non-`str` into the frozen `MindMap.title: str`.
- `download_mind_map` reads the row id via `NoteRow(mm).id` instead of raw `mm[0]` (str-coerces numeric ids, routes through the adapter seam).

## Verification
- New focused unit tests for each sub-fix in `tests/unit/test_mind_maps_api.py` and `tests/unit/test_interactive_mind_map.py`, including negative cases: real-drift re-raise, non-list options-block re-raise, settling-row rejection on the strict rename/auto-detect paths, numeric-id download.
- Full suite green: `7798 passed, 52 skipped`. Existing replay tests (`test_mind_maps_vcr.py`, the cli_vcr generate/download/list tests) and cassettes (`mind_maps_interactive.yaml`, `generate_mind_map_interactive.yaml`, `artifacts_download_mind_map.yaml`) unchanged.
- `ruff format` + `ruff check` clean; `mypy src/notebooklm` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable interactive mind-map downloads: tolerates not-yet-ready responses, warns when leaf data is absent, and surfaces errors for genuine response-shape drift.
  * Better mind‑map title handling: uses provided name only when it’s a non-empty string, otherwise falls back to "Mind Map".
  * Improved artifact matching for generation/download/rename to correctly identify settling interactive maps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->