### PR TITLE
fix(transport): clamp decode-time auth-retry sleep to the aggregate deadline (#1271)

### DIFF
--- a/src/notebooklm/_auth_refresh_retry.py
+++ b/src/notebooklm/_auth_refresh_retry.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._client_metrics import ClientMetrics
+    from ._deadline import RuntimeDeadline
 
 
 class RefreshBudget:
@@ -102,6 +103,7 @@ async def refresh_and_count(
     log_label: str,
     logger: logging.Logger,
     metrics: ClientMetrics | None,
+    retry_deadline: RuntimeDeadline | None = None,
 ) -> None:
     """Run the shared refresh body common to both auth-retry layers.
 
@@ -118,7 +120,13 @@ async def refresh_and_count(
        it ``from refresh_error`` so the refresh error stays chained as
        ``__cause__`` exactly as both copies did historically.
     4. Optional post-refresh sleep when ``refresh_retry_delay > 0`` — preserves
-       the historical timing both copies applied between refresh and retry.
+       the historical timing both copies applied between refresh and retry. When
+       ``retry_deadline`` is supplied the delay is clamped to the remaining
+       aggregate budget (issue #1271), so the post-refresh sleep can never
+       overshoot the logical call's timeout — symmetric with
+       ``RetryMiddleware._resolve_retry_sleep`` on the HTTP-status layer. An
+       already-exhausted deadline clamps the sleep to ``0`` and the retry
+       proceeds immediately.
     5. Log ``"Token refresh successful, retrying <label>"``.
     6. Increment ``rpc_auth_retries`` once per successful refresh. (Before
        consolidation only the HTTP-status copy did this; the decoded-RPC copy
@@ -140,8 +148,18 @@ async def refresh_and_count(
         logger.warning("Token refresh failed: %s", refresh_error)
         raise on_refresh_failure(refresh_error) from refresh_error
 
-    if refresh_retry_delay > 0:
-        await sleep(refresh_retry_delay)
+    # Clamp the post-refresh delay to the remaining aggregate budget so the
+    # decode-time retry honors the logical call's timeout the same way the
+    # HTTP-status retry layer does (issue #1271). Without a deadline the full
+    # delay is slept (historical behavior); an exhausted deadline clamps to 0,
+    # which skips the sleep and lets the retry proceed immediately.
+    effective_delay = (
+        refresh_retry_delay
+        if retry_deadline is None
+        else retry_deadline.clamp_sleep(refresh_retry_delay)
+    )
+    if effective_delay > 0:
+        await sleep(effective_delay)
     logger.info("Token refresh successful, retrying %s", log_label)
     if metrics is not None:
         metrics.increment(rpc_auth_retries=1)

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -6,6 +6,7 @@ __all__ = ["DecodeResponse", "RpcExecutor"]
 
 import json
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
@@ -14,6 +15,7 @@ from urllib.parse import urlencode
 import httpx
 
 from ._auth_refresh_retry import RefreshBudget, refresh_and_count
+from ._deadline import RuntimeDeadline
 from ._env import get_default_language
 from ._idempotency import (
     IDEMPOTENCY_REGISTRY,
@@ -102,6 +104,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         _refresh_budget: RefreshBudget | None = None,
+        _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any:
         """Run an RPC wrapped with telemetry and request-id bookkeeping.
 
@@ -126,6 +129,16 @@ class RpcExecutor:
         internal-only parameter (leading underscore): external callers leave it
         ``None``; :meth:`_execute_once` mints one and threads it through the
         chain and the retry recursion.
+
+        ``_retry_deadline`` carries the logical call's aggregate
+        :class:`notebooklm._deadline.RuntimeDeadline` (started from
+        ``timeout_provider`` on the first ``_execute_once``) across the
+        decode-time retry recursion so the post-refresh sleep is clamped to the
+        remaining budget instead of overshooting it (issue #1271) — symmetric
+        with ``RetryMiddleware`` on the HTTP-status layer. Like
+        ``_refresh_budget`` it is internal-only and minted once per logical
+        call; threading it through the recursion keeps the budget anchored to
+        the original start time rather than resetting it on the retry leg.
         """
         # Pre-open guard — preserves the historical ``RuntimeError`` surface by
         # routing through ``Kernel.get_http_client()`` (which raises the same
@@ -151,6 +164,7 @@ class RpcExecutor:
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
                 _refresh_budget=_refresh_budget,
+                _retry_deadline=_retry_deadline,
             )
 
         self._metrics.increment(rpc_calls_started=1)
@@ -171,6 +185,7 @@ class RpcExecutor:
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
                 _refresh_budget=_refresh_budget,
+                _retry_deadline=_retry_deadline,
             )
         finally:
             if _reqid_token is not None:
@@ -187,6 +202,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         _refresh_budget: RefreshBudget | None = None,
+        _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
@@ -199,8 +215,16 @@ class RpcExecutor:
         # decoded-auth-error`` sequence drives ONE refresh (issue #1205).
         # Standalone ``_execute_once`` test calls pass ``None`` and get a fresh
         # budget, preserving the single-refresh-per-call contract in isolation.
+        #
+        # The aggregate ``RuntimeDeadline`` is minted on the SAME first
+        # ``_execute_once`` and threaded through the retry recursion alongside
+        # the budget (issue #1271), so the decode-time post-refresh sleep is
+        # clamped to the time remaining since the logical call began rather than
+        # restarting the clock on the retry leg.
         if _refresh_budget is None:
             _refresh_budget = RefreshBudget()
+        if _retry_deadline is None:
+            _retry_deadline = self._start_retry_deadline()
 
         # Consult the idempotency registry. The registry is the single
         # source of truth for "how should this RPC behave under retry?";
@@ -327,6 +351,7 @@ class RpcExecutor:
                     disable_internal_retries=disable_internal_retries,
                     operation_variant=operation_variant,
                     _refresh_budget=_refresh_budget,
+                    _retry_deadline=_retry_deadline,
                 )
                 return refreshed
 
@@ -461,6 +486,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         _refresh_budget: RefreshBudget,
+        _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any | None:
         """Refresh auth after a decode-time auth error and retry once.
 
@@ -482,6 +508,19 @@ class RpcExecutor:
         always holds the already-consumed shared budget. Forcing it to be
         passed forecloses a contrived direct call from minting a fresh budget
         on the retry leg and allowing a second refresh.
+
+        ``_retry_deadline`` carries the logical call's aggregate
+        :class:`notebooklm._deadline.RuntimeDeadline` so the decode-time retry
+        honors the timeout the same way the HTTP-status layer does (issue
+        #1271): :func:`refresh_and_count` clamps the post-refresh sleep to the
+        remaining budget, and once that sleep returns an exhausted deadline
+        makes this method *give up* — re-raising ``original_error`` instead of
+        issuing a retry POST that would run past the aggregate timeout, exactly
+        as ``RetryMiddleware`` re-raises rather than re-invoking the chain. The
+        deadline is also threaded into the retry :meth:`rpc_call` so the
+        recursion keeps the same anchored deadline. ``None`` reproduces the
+        historical unclamped sleep and unconditional retry (e.g. when
+        ``timeout_provider`` yields a ``None`` / non-finite timeout).
         """
         await refresh_and_count(
             refresh=self._auth_refresh.await_refresh,
@@ -491,7 +530,19 @@ class RpcExecutor:
             log_label=f"RPC {method.name}",
             logger=logger,
             metrics=self._metrics,
+            retry_deadline=_retry_deadline,
         )
+
+        # Give up symmetrically with ``RetryMiddleware`` (issue #1271): if the
+        # aggregate budget is already spent after the (clamped) post-refresh
+        # sleep, re-raise the original decoded auth error instead of issuing a
+        # retry POST that would overshoot the logical call's timeout. The
+        # refresh still happened (a productive side effect — the next call on
+        # this client benefits from the fresh token), mirroring the HTTP layer
+        # where the refresh middleware runs independently of the retry budget.
+        if _retry_deadline is not None and _retry_deadline.expired():
+            logger.warning("%s", _retry_deadline.timeout_message(f"RPC {method.name} auth retry"))
+            raise original_error
 
         return await self.rpc_call(
             method,
@@ -502,7 +553,24 @@ class RpcExecutor:
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
             _refresh_budget=_refresh_budget,
+            _retry_deadline=_retry_deadline,
         )
+
+    def _start_retry_deadline(self) -> RuntimeDeadline | None:
+        """Start the logical call's aggregate deadline from ``timeout_provider``.
+
+        Mirrors ``RetryMiddleware._start_retry_deadline`` so both auth-retry
+        layers derive their deadline from the same client timeout source
+        (``lifecycle._timeout``) and treat a ``None`` or non-finite timeout the
+        same way: ``None`` (no clamp), preserving the historical unclamped
+        post-refresh sleep when the operator disabled the aggregate timeout. The
+        ``None`` guard precedes ``float()`` so a disabled timeout returns no
+        deadline instead of raising ``TypeError`` mid-call.
+        """
+        timeout = self._timeout_provider()
+        if timeout is None or not math.isfinite(float(timeout)):
+            return None
+        return RuntimeDeadline.start(float(timeout))
 
 
 if TYPE_CHECKING:

--- a/tests/unit/test_auth_refresh_retry.py
+++ b/tests/unit/test_auth_refresh_retry.py
@@ -17,6 +17,7 @@ import pytest
 
 from notebooklm._auth_refresh_retry import RefreshBudget, refresh_and_count
 from notebooklm._client_metrics import ClientMetrics
+from notebooklm._deadline import RuntimeDeadline
 
 # ---------------------------------------------------------------------------
 # RefreshBudget
@@ -103,6 +104,101 @@ async def test_refresh_and_count_zero_delay_skips_sleep() -> None:
     )
 
     assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# refresh_and_count — deadline clamping (issue #1271)
+# ---------------------------------------------------------------------------
+
+
+def _fixed_clock(value: float) -> RuntimeDeadline:
+    """A RuntimeDeadline whose monotonic clock never advances past ``started_at``."""
+    return RuntimeDeadline(timeout=value, started_at=0.0, monotonic=lambda: 0.0)
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_clamps_post_refresh_sleep_to_deadline() -> None:
+    """A large ``refresh_retry_delay`` is clamped to the remaining budget.
+
+    Symmetry with ``RetryMiddleware._resolve_retry_sleep`` (issue #1271): the
+    decode-time post-refresh sleep must never wait past the aggregate
+    ``RuntimeDeadline``. Here 5s of budget remains but the configured delay is
+    100s, so the actual sleep is clamped to 5s.
+    """
+    sleeps: list[float] = []
+
+    async def refresh() -> None:
+        return None
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    await refresh_and_count(
+        refresh=refresh,
+        on_refresh_failure=lambda _e: AssertionError("unreachable"),
+        sleep=sleep,
+        refresh_retry_delay=100.0,
+        log_label="RPC X",
+        logger=logging.getLogger("notebooklm.test_arr_clamp"),
+        metrics=None,
+        retry_deadline=_fixed_clock(5.0),
+    )
+
+    assert sleeps == [5.0]
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_skips_sleep_when_deadline_exhausted() -> None:
+    """An already-expired deadline drops the post-refresh sleep entirely.
+
+    With zero remaining budget the clamp yields 0, so the decode-time retry
+    proceeds immediately rather than sleeping the full configured delay.
+    """
+    sleeps: list[float] = []
+
+    async def refresh() -> None:
+        return None
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    await refresh_and_count(
+        refresh=refresh,
+        on_refresh_failure=lambda _e: AssertionError("unreachable"),
+        sleep=sleep,
+        refresh_retry_delay=100.0,
+        log_label="RPC X",
+        logger=logging.getLogger("notebooklm.test_arr_exhausted"),
+        metrics=None,
+        retry_deadline=_fixed_clock(0.0),
+    )
+
+    assert sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_count_no_deadline_sleeps_full_delay() -> None:
+    """Without a deadline the historical unclamped sleep is preserved."""
+    sleeps: list[float] = []
+
+    async def refresh() -> None:
+        return None
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    await refresh_and_count(
+        refresh=refresh,
+        on_refresh_failure=lambda _e: AssertionError("unreachable"),
+        sleep=sleep,
+        refresh_retry_delay=100.0,
+        log_label="RPC X",
+        logger=logging.getLogger("notebooklm.test_arr_nodeadline"),
+        metrics=None,
+        retry_deadline=None,
+    )
+
+    assert sleeps == [100.0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -250,6 +250,7 @@ async def test_retry_inherits_parent_request_id():
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         _refresh_budget=None,
+        _retry_deadline=None,
     ):
         captured_ids.append(get_request_id())
         # First call: raise to trigger retry path; second call: succeed.

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -360,6 +360,64 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
 
 
 @pytest.mark.asyncio
+async def test_decode_time_auth_retry_gives_up_when_aggregate_deadline_exhausted() -> None:
+    """Issue #1271: an exhausted aggregate deadline gives up after the refresh.
+
+    The executor mints a ``RuntimeDeadline`` from ``timeout_provider`` for the
+    logical call. With a zero aggregate timeout the deadline is already
+    exhausted, so after the (productive) refresh the executor must NOT sleep the
+    large ``refresh_retry_delay`` and must NOT issue a retry POST that would run
+    past the budget — it re-raises the original decoded auth error, symmetric
+    with ``RetryMiddleware`` re-raising instead of re-invoking the chain.
+    """
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=100.0,
+        timeout=0.0,
+    )
+    sleep_calls: list[float] = []
+    auth_rpc_error = RPCError("authentication expired")
+    decode_calls = 0
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        nonlocal decode_calls
+        decode_calls += 1
+        raise auth_rpc_error
+
+    async def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(
+            owner,
+            decode_response=decode,
+            is_auth_error=lambda exc: True,
+            sleep=sleep,
+        )._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            ["param"],
+            "/notebook/abc",
+            True,
+            False,
+            disable_internal_retries=False,
+        )
+
+    # The refresh still ran (productive: the next call benefits from the fresh
+    # token), but the exhausted budget suppressed both the post-refresh sleep
+    # and the retry POST. The original decoded auth error propagates.
+    assert raised.value is auth_rpc_error
+    assert owner.refresh_calls == 1
+    assert sleep_calls == []
+    # Exactly one transport POST — the retry was NOT issued past the deadline.
+    assert len(owner.perform_calls) == 1
+    assert decode_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_decode_time_auth_retry_preserves_none_result() -> None:
     async def refresh_callback() -> object:
         return object()
@@ -640,6 +698,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         _refresh_budget: Any = None,
+        _retry_deadline: Any = None,
     ) -> dict[str, bool]:
         assert method is RPCMethod.LIST_NOTEBOOKS
         assert params == ["param"]


### PR DESCRIPTION
Fixes #1271

## Problem

The HTTP-status retry layer (`RetryMiddleware`) clamps every backoff sleep against a `RuntimeDeadline` wired to the client timeout, so a retry can never overshoot the aggregate budget. The **decode-time** auth-refresh layer (`RpcExecutor.try_refresh_and_retry` → `refresh_and_count`) had no equivalent clamp: it slept the full `refresh_retry_delay` unconditionally (`_auth_refresh_retry.py:143`), silently ignoring the timeout the HTTP path rigorously enforces.

Bounded to one retry + one small fixed delay in default config, but if an operator raises `chain_host._refresh_retry_delay`, a decode-time auth retry slept the full duration regardless of how much wall-clock the logical call already consumed — asymmetric enforcement.

## Fix

- Mint a `RuntimeDeadline` from `timeout_provider` (`lifecycle._timeout`, the same source the HTTP layer uses) on the first `_execute_once` of a logical call, and thread it — alongside the shared `RefreshBudget` — through the decode-time retry recursion so the budget stays anchored to the logical call's start rather than resetting on the retry leg.
- `refresh_and_count` now **clamps** the post-refresh sleep to the remaining budget (`retry_deadline.clamp_sleep(...)`); an exhausted deadline skips the sleep entirely.
- Once the (clamped) sleep returns, `try_refresh_and_retry` **gives up** if the deadline is exhausted — re-raising the original decoded auth error instead of issuing a retry POST that would run past the aggregate timeout. This mirrors `RetryMiddleware` re-raising rather than re-invoking the chain, keeping both auth-retry layers symmetric.
- `_start_retry_deadline` guards `None`/non-finite timeout the same way `RetryMiddleware._start_retry_deadline` does (the `None` check precedes `float()`), so a disabled aggregate timeout yields no clamp and preserves the historical unclamped behavior.

The #1205 shared-`RefreshBudget` once-per-call behavior is untouched, and the HTTP-layer `refresh_and_count` call site is unaffected (it passes no deadline — its enforcement lives in the outer `RetryMiddleware`). No double-jeopardy: the two deadlines govern disjoint sleeps (HTTP 429/5xx backoff vs. the decode-time post-refresh sleep).

## Verification

- New unit tests in `tests/unit/test_auth_refresh_retry.py`: the post-refresh sleep is clamped to remaining budget; an exhausted deadline skips the sleep; no deadline preserves the full historical delay.
- New executor test in `tests/unit/test_rpc_executor.py`: with a small (zero) aggregate budget and a large `refresh_retry_delay`, the decode-time retry does NOT sleep past the deadline — it gives up and re-raises the original auth error with exactly one transport POST.
- Full suite: `7786 passed, 52 skipped`. `ruff format`/`check` clean, `mypy` clean (188 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timeout handling for authentication refresh retries—RPC call deadlines now limit retry delays to prevent exceeding aggregate call timeouts.

* **Tests**
  * Added comprehensive tests validating deadline clamping behavior during auth retry operations and timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->