### PR TITLE
fix(auth): make disk the sole arbiter for PSIDTS recovery success (#1273)

### DIFF
--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -348,7 +348,9 @@ def _is_psidts_persisted(storage_path: Path) -> bool:
     return not _psidts_needs_recovery(names, expiry)
 
 
-def _psidts_save_succeeded(storage_path: Path) -> bool:
+def _psidts_save_succeeded(
+    result: _auth_storage.CookieSaveResult | bool, storage_path: Path
+) -> bool:
     """Did a fresh ``__Secure-1PSIDTS`` actually land on disk after the save?
 
     The coarse ``CookieSaveResult.ok`` bool from
@@ -368,9 +370,18 @@ def _psidts_save_succeeded(storage_path: Path) -> bool:
     So disk — not the save bool — is the sole arbiter. Re-read it and accept the
     heal iff a present, unexpired PSIDTS is stored. :func:`_is_psidts_persisted`
     mirrors the precondition gate, so a stale or expired row (ours or a
-    sibling's) doesn't masquerade as a heal.
+    sibling's) doesn't masquerade as a heal. On a decline, the coarse ``result``
+    is folded into a diagnostic warning here (the only thing it is used for) so
+    callers stay a single boolean branch.
     """
-    return _is_psidts_persisted(storage_path)
+    if _is_psidts_persisted(storage_path):
+        return True
+    logger.warning(
+        "Inline PSIDTS recovery: %s did not persist (save ok=%s); on-disk state still lacks it",
+        _PSIDTS_COOKIE,
+        getattr(result, "ok", result),
+    )
+    return False
 
 
 def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
@@ -449,12 +460,7 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
         logger.warning("Inline PSIDTS recovery: persist to %s raised %s", storage_path, exc)
         return False
 
-    if not _psidts_save_succeeded(storage_path):
-        logger.warning(
-            "Inline PSIDTS recovery: %s did not persist (save ok=%s); on-disk state still lacks it",
-            _PSIDTS_COOKIE,
-            getattr(result, "ok", result),
-        )
+    if not _psidts_save_succeeded(result, storage_path):
         return False
 
     logger.info(

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -207,9 +207,12 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
 
     On success the rotated cookies are merged into the file at ``storage_path``
     via :func:`notebooklm._auth.storage.save_cookies_to_storage` (snapshot/delta
-    semantics, atomic write, cross-process file lock). ``save_cookies_to_storage``
-    is contract-bound to return ``False`` (not raise) on a persistence failure;
-    we check the return value and surface the persist failure as ``False`` so
+    semantics, atomic write, cross-process file lock). The save's coarse bool is
+    an unreliable heal signal in both directions, so :func:`_attempt_rotation`
+    re-reads disk (:func:`_psidts_save_succeeded`) as the sole arbiter of whether
+    a fresh PSIDTS actually landed — a concurrent sibling-cookie CAS rejection
+    must not invert a healthy heal, and a no-op save over a stale row must not
+    fake one (issue #1273). A genuine persist failure surfaces as ``False`` so
     the caller's preflight retry sees the unhealed state and re-raises honestly.
     On any failure the function returns ``False`` and the caller's original
     ``ValueError`` stands.
@@ -345,6 +348,31 @@ def _is_psidts_persisted(storage_path: Path) -> bool:
     return not _psidts_needs_recovery(names, expiry)
 
 
+def _psidts_save_succeeded(storage_path: Path) -> bool:
+    """Did a fresh ``__Secure-1PSIDTS`` actually land on disk after the save?
+
+    The coarse ``CookieSaveResult.ok`` bool from
+    :func:`~notebooklm._auth.storage.save_cookies_to_storage` is *not* a reliable
+    proxy for "PSIDTS healed", in either direction:
+
+    - ``ok`` is ``False`` whenever *any* key is CAS-rejected, even when a fresh
+      PSIDTS is on disk — both the benign "an unrelated sibling cookie lost the
+      race, our PSIDTS wrote through" case (issue #1273) and the "our PSIDTS
+      delta was rejected because a sibling already persisted a fresh PSIDTS
+      first" case leave disk healthy.
+    - ``ok`` is ``True`` even when the save was a no-op that left a *stale*
+      PSIDTS untouched: if ``RotateCookies`` 200s without minting a new cookie,
+      the expired on-disk row lingers in the request jar, the delta is empty,
+      and the save reports success while disk is still unhealed.
+
+    So disk — not the save bool — is the sole arbiter. Re-read it and accept the
+    heal iff a present, unexpired PSIDTS is stored. :func:`_is_psidts_persisted`
+    mirrors the precondition gate, so a stale or expired row (ours or a
+    sibling's) doesn't masquerade as a heal.
+    """
+    return _is_psidts_persisted(storage_path)
+
+
 def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
     """Fire one ``RotateCookies`` POST and persist the rotated cookies.
 
@@ -401,25 +429,31 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
         )
         return False
 
-    # ``save_cookies_to_storage`` returns False (not raises) on every
+    # ``save_cookies_to_storage`` returns a falsy result (not raises) on every
     # persist-failure path: missing file, invalid payload, CAS conflict,
     # atomic-write failure (see ``_auth/storage.py:380-429``). The bare
     # ``except`` below catches the *unexpected* raises only (future refactor
-    # could change the contract); the explicit return-value check is what
-    # surfaces the documented failure modes.
+    # could change the contract).
+    #
+    # We ask for the detailed ``CookieSaveResult`` (``return_result=True``) for
+    # the diagnostic log only — the coarse bool is an unreliable heal signal in
+    # both directions (a sibling-cookie CAS rejection falsely reads ``ok=False``
+    # while PSIDTS healed; a no-op save over a stale PSIDTS falsely reads
+    # ``ok=True``). Whether PSIDTS actually healed is decided by re-reading disk
+    # in :func:`_psidts_save_succeeded` (issue #1273).
     try:
-        persisted = _auth_storage.save_cookies_to_storage(
-            rotated_jar, storage_path, original_snapshot=snapshot
+        result = _auth_storage.save_cookies_to_storage(
+            rotated_jar, storage_path, original_snapshot=snapshot, return_result=True
         )
     except Exception as exc:  # noqa: BLE001 - persistence failure is non-fatal here
         logger.warning("Inline PSIDTS recovery: persist to %s raised %s", storage_path, exc)
         return False
 
-    if not persisted:
+    if not _psidts_save_succeeded(storage_path):
         logger.warning(
-            "Inline PSIDTS recovery: save_cookies_to_storage returned False; "
-            "on-disk state still lacks %s",
+            "Inline PSIDTS recovery: %s did not persist (save ok=%s); on-disk state still lacks it",
             _PSIDTS_COOKIE,
+            getattr(result, "ok", result),
         )
         return False
 

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -540,9 +540,9 @@ class TestRecoveryConcurrentCasRejection:
             if do_real_write:
                 real_save(cookie_jar, path, **{**kwargs, "return_result": True})
             if seed_disk_cookie is not None and path is not None:
-                data = json.loads(path.read_text())
+                data = json.loads(path.read_text(encoding="utf-8"))
                 data["cookies"].append(seed_disk_cookie)
-                path.write_text(json.dumps(data))
+                path.write_text(json.dumps(data), encoding="utf-8")
             result = _auth_storage.CookieSaveResult(
                 ok=False, cas_rejected_keys=frozenset({rejected_key})
             )
@@ -573,7 +573,7 @@ class TestRecoveryConcurrentCasRejection:
         )
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         assert "__Secure-1PSIDTS" in {c["name"] for c in saved["cookies"]}
 
     @pytest.mark.no_default_keepalive_mock

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -478,6 +478,193 @@ class TestRecoveryFailureModes:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
 
+    @pytest.mark.no_default_keepalive_mock
+    def test_expired_psidts_with_200_minting_nothing_returns_false(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """A no-op save over a *stale* PSIDTS must not be a false heal.
+
+        Disk starts with an EXPIRED PSIDTS (so the gate fires recovery). The
+        POST 200s but mints no fresh PSIDTS, so the expired row lingers in the
+        request jar and the save is a no-op that reports ``ok=True``. Recovery
+        keys on disk, not on the coarse bool, so it must DECLINE — the stale
+        cookie is still all that's on disk (codex review of #1273).
+        """
+        storage_path = tmp_path / "storage_state.json"
+        expired_psidts = {
+            "name": "__Secure-1PSIDTS",
+            "value": "stale_value",
+            "domain": ".google.com",
+            "path": "/",
+            "expires": 1_000_000_000,  # 2001 — comfortably in the past
+        }
+        _write_storage(storage_path, [*_RECOVERABLE_COOKIES, expired_psidts])
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response(include_psidts=False))
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+
+class TestRecoveryConcurrentCasRejection:
+    """Recovery keys on PSIDTS-on-disk, not on the coarse save bool (#1273).
+
+    ``save_cookies_to_storage`` returns a coarse ``False`` whenever *any* key is
+    CAS-rejected, even when a fresh PSIDTS is on disk. The coarse bool conflates
+    (a) "an unrelated sibling cookie lost the CAS race but our PSIDTS wrote
+    through" and (b) "our PSIDTS delta was rejected because a sibling already
+    persisted a *fresh* PSIDTS first" — both leave disk healthy. So recovery
+    must re-read disk and accept the heal iff a present, unexpired PSIDTS is
+    stored, never trust ``cas_rejected_keys`` membership alone.
+    """
+
+    @staticmethod
+    def _patch_save_with_cas_rejection(
+        monkeypatch, *, rejected_key, do_real_write: bool, seed_disk_cookie=None
+    ):
+        """Replace ``save_cookies_to_storage`` with a CAS-rejecting stand-in.
+
+        The stand-in honours ``return_result`` exactly like the real function
+        (bool projection by default, ``CookieSaveResult`` when asked) so the
+        test is faithful regardless of which signature the recovery path uses.
+        When ``do_real_write`` is set, the rotated cookies are genuinely
+        persisted first, modelling "our PSIDTS wrote through but a sibling lost".
+        ``seed_disk_cookie`` lets a test inject a sibling-written row onto disk
+        before reporting the coarse failure, modelling "a sibling persisted a
+        fresh PSIDTS first, so our delta was CAS-rejected".
+        """
+        from notebooklm._auth import storage as _auth_storage
+
+        real_save = _auth_storage.save_cookies_to_storage
+
+        def _save(cookie_jar, path=None, **kwargs):
+            return_result = kwargs.get("return_result", False)
+            if do_real_write:
+                real_save(cookie_jar, path, **{**kwargs, "return_result": True})
+            if seed_disk_cookie is not None and path is not None:
+                data = json.loads(path.read_text())
+                data["cookies"].append(seed_disk_cookie)
+                path.write_text(json.dumps(data))
+            result = _auth_storage.CookieSaveResult(
+                ok=False, cas_rejected_keys=frozenset({rejected_key})
+            )
+            return result if return_result else result.ok
+
+        monkeypatch.setattr(psidts_recovery._auth_storage, "save_cookies_to_storage", _save)
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_succeeds_when_sibling_cookie_cas_rejected_but_psidts_written(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Our PSIDTS wrote through; a *different* cookie was CAS-rejected.
+
+        Models heavily-parallel multi-process CLI usage: a sibling process
+        wins a CAS race on some unrelated cookie, so the save reports a coarse
+        ``False`` even though the rotated PSIDTS persisted. Recovery must
+        SUCCEED, not decline.
+        """
+        from notebooklm._auth import storage as _auth_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        sibling_key = _auth_storage.CookieSnapshotKey("SID", ".google.com", "/")
+        self._patch_save_with_cas_rejection(
+            monkeypatch, rejected_key=sibling_key, do_real_write=True
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+        saved = json.loads(storage_path.read_text())
+        assert "__Secure-1PSIDTS" in {c["name"] for c in saved["cookies"]}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_succeeds_when_psidts_cas_rejected_but_sibling_wrote_fresh_psidts(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Our PSIDTS delta lost the CAS race because a sibling wrote a fresh one.
+
+        A PSIDTS CAS rejection means disk diverged from our snapshot — which
+        happens precisely when a sibling process persisted its *own* fresh
+        PSIDTS first. Disk is healthy, so recovery must SUCCEED even though our
+        write was the one rejected. Trusting ``cas_rejected_keys`` membership
+        alone would wrongly decline here (codex review of #1273).
+        """
+        from notebooklm._auth import storage as _auth_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_key = _auth_storage.CookieSnapshotKey("__Secure-1PSIDTS", ".google.com", "/")
+        sibling_psidts = {
+            "name": "__Secure-1PSIDTS",
+            "value": "sibling_fresh_value",
+            "domain": ".google.com",
+            "path": "/",
+            "expires": 99_999_999_999,  # comfortably in the future
+        }
+        self._patch_save_with_cas_rejection(
+            monkeypatch,
+            rejected_key=psidts_key,
+            do_real_write=False,
+            seed_disk_cookie=sibling_psidts,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_declines_when_psidts_cas_rejected_and_disk_lacks_psidts(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """PSIDTS rejected and disk still lacks a fresh PSIDTS → must decline.
+
+        Defends the false-heal direction: when no fresh PSIDTS is on disk after
+        the save, recovery must keep failing rather than report success.
+        """
+        from notebooklm._auth import storage as _auth_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_key = _auth_storage.CookieSnapshotKey("__Secure-1PSIDTS", ".google.com", "/")
+        self._patch_save_with_cas_rejection(
+            monkeypatch, rejected_key=psidts_key, do_real_write=False
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_declines_when_disk_only_has_expired_psidts(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A stale (expired) sibling PSIDTS row must NOT masquerade as a heal.
+
+        The disk re-read mirrors the precondition gate, so an expired on-disk
+        PSIDTS counts as absent and recovery must still decline.
+        """
+        from notebooklm._auth import storage as _auth_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_key = _auth_storage.CookieSnapshotKey("__Secure-1PSIDTS", ".google.com", "/")
+        expired_psidts = {
+            "name": "__Secure-1PSIDTS",
+            "value": "stale_value",
+            "domain": ".google.com",
+            "path": "/",
+            "expires": 1_000_000_000,  # 2001 — comfortably in the past
+        }
+        self._patch_save_with_cas_rejection(
+            monkeypatch,
+            rejected_key=psidts_key,
+            do_real_write=False,
+            seed_disk_cookie=expired_psidts,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
 
 class TestLoadAuthFromStorageIntegration:
     """The recovery must be wired into :func:`load_auth_from_storage`."""

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -38,7 +38,7 @@ _RECOVERABLE_COOKIES: list[dict] = [
 
 
 def _write_storage(path: Path, cookies: list[dict]) -> None:
-    path.write_text(json.dumps({"cookies": cookies, "origins": []}))
+    path.write_text(json.dumps({"cookies": cookies, "origins": []}), encoding="utf-8")
 
 
 def _make_psidts_response(status_code: int = 200, *, include_psidts: bool = True):
@@ -274,7 +274,7 @@ class TestPsidtsExpiryGate:
 
         rotate_requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
         assert len(rotate_requests) == 1
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         fresh = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
         assert fresh["value"] == "fresh_psidts_value"
 
@@ -394,7 +394,7 @@ class TestRecoveryHappyPath:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
 
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         names = {c["name"] for c in saved["cookies"]}
         assert "__Secure-1PSIDTS" in names
         psidts = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
@@ -426,7 +426,7 @@ class TestRecoveryHappyPath:
 
         psidts_recovery._recover_psidts_inline(storage_path)
 
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         names = {c["name"] for c in saved["cookies"]}
         for original in _RECOVERABLE_COOKIES:
             assert original["name"] in names
@@ -444,7 +444,7 @@ class TestRecoveryFailureModes:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         # PSIDTS must NOT have been written.
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         assert "__Secure-1PSIDTS" not in {c["name"] for c in saved["cookies"]}
 
     @pytest.mark.no_default_keepalive_mock
@@ -466,7 +466,7 @@ class TestRecoveryFailureModes:
         )
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         assert "__Secure-1PSIDTS" not in {c["name"] for c in saved["cookies"]}
 
     @pytest.mark.no_default_keepalive_mock
@@ -777,7 +777,7 @@ class TestBuildHttpxCookiesFromStorageIntegration:
         cookie_names = {c.name for c in jar.jar}
         assert "__Secure-1PSIDTS" in cookie_names
         # The file on disk must also have been healed so subsequent loaders see it.
-        saved = json.loads(storage_path.read_text())
+        saved = json.loads(storage_path.read_text(encoding="utf-8"))
         assert "__Secure-1PSIDTS" in {c["name"] for c in saved["cookies"]}
 
     @pytest.mark.no_default_keepalive_mock
@@ -1023,7 +1023,7 @@ class TestEdgeCases:
     def test_malformed_storage_cookies_non_list(self, tmp_path, httpx_mock: HTTPXMock):
         """``"cookies"`` key not a list → return False without firing POST."""
         storage_path = tmp_path / "storage_state.json"
-        storage_path.write_text(json.dumps({"cookies": "not-a-list"}))
+        storage_path.write_text(json.dumps({"cookies": "not-a-list"}), encoding="utf-8")
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -1032,11 +1032,14 @@ class TestEdgeCases:
     def test_save_returning_false_propagates_as_failure(
         self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
     ):
-        """``save_cookies_to_storage`` returns False on persist failure (not raises).
+        """A failed persist (no disk write) must make recovery decline.
 
-        Recovery must capture the return value — otherwise it logs a misleading
-        INFO ``Recovered ... and persisted`` while on-disk state is still broken
-        (Claude Important + Codex Important: issue #865).
+        The mock returns a falsy save result *without* writing to disk, so the
+        disk re-read in ``_psidts_save_succeeded`` finds no fresh PSIDTS and
+        recovery returns False. Recovery keys on disk, not on the save's return
+        value (issue #1273), so a failed persistence — for any reason — declines
+        rather than logging a misleading ``Recovered ... and persisted`` INFO
+        over still-broken state (issue #865).
         """
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)


### PR DESCRIPTION
Fixes #1273

## Problem

`_attempt_rotation` in `_auth/psidts_recovery.py` declined PSIDTS recovery whenever `save_cookies_to_storage` returned a coarse `False`. That bool collapses to `False` whenever **any** key is CAS-rejected — including an *unrelated* sibling cookie that lost a concurrent CAS race while the rotated PSIDTS actually wrote through. Under heavily-parallel multi-process CLI usage, the user then saw an auth failure despite a healthy heal.

## Fix

Make **disk the sole arbiter** of whether PSIDTS healed. `_attempt_rotation` now calls `save_cookies_to_storage(return_result=True)` (the `CookieSaveResult` is kept only for the diagnostic log) and decides success by re-reading disk via `_psidts_save_succeeded` → `_is_psidts_persisted`.

The coarse save bool is unreliable in **both** directions, so neither is trusted:

- **`ok=False` but PSIDTS healed** — an unrelated sibling cookie was CAS-rejected (the reported #1273 case), *or* our PSIDTS delta was rejected precisely because a sibling already persisted a fresh PSIDTS first. Disk is healthy in both.
- **`ok=True` but unhealed** — a no-op save left a *stale/expired* PSIDTS untouched (`RotateCookies` 200s without minting one; the expired row lingers in the request jar). Trusting `ok` would fake a heal. (Surfaced during review.)

`_is_psidts_persisted` mirrors the precondition gate, so a stale/expired row (ours or a sibling's) never masquerades as a heal. All existing recovery + storage behaviour and tests are preserved.

## Tests (5 new)

- sibling cookie CAS-rejected, our PSIDTS wrote through → **succeeds**
- our PSIDTS CAS-rejected because a sibling wrote a fresh PSIDTS first → **succeeds** (disk healthy)
- PSIDTS CAS-rejected and disk still lacks a fresh PSIDTS → **declines**
- disk only has an expired/stale PSIDTS row → **declines**
- `ok=True` no-op save over a stale PSIDTS → **declines** (false-heal regression)

## Verification

- `pytest` (full suite): **7787 passed, 52 skipped**
- `ruff format` + `ruff check`: clean
- `mypy src/notebooklm --ignore-missing-imports`: clean
- Polish gate: code-simplifier (collapsed the helper to a single disk read), two codex review rounds (both Important findings addressed, final pass clean), ultrathink (found + fixed the second coarse-bool conflation in the same path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session/token recovery to verify actual on-disk persistence after rotation, preventing false-success outcomes when concurrent writes or expired tokens are present.

* **Tests**
  * Added regression and concurrency tests for expired-token scenarios and compare-and-swap races to ensure recovery only succeeds when a fresh token is truly persisted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->