### PR TITLE
test: casefold NOTEBOOKLM_VCR_RECORD_ERRORS parsing for parity with _is_vcr_record_mode (#1268)

### DIFF
--- a/src/notebooklm/_error_injection.py
+++ b/src/notebooklm/_error_injection.py
@@ -95,8 +95,10 @@ def _get_error_injection_mode() -> str | None:
     raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip()
     if not raw:
         return None
-    # Lowercase-normalize so callers can use ``"5XX"`` / ``"429"`` / etc.
-    normalized = raw.lower()
+    # Case-fold-normalize so callers can use ``"5XX"`` / ``"429"`` / etc.
+    # (``casefold`` over ``lower`` for the project's Unicode-aware
+    # case-insensitive comparison rule; ASCII-identical here — #1268).
+    normalized = raw.casefold()
     valid = {"429", "5xx", "expired_csrf"}
     if normalized not in valid:
         return None

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -133,7 +133,10 @@ def get_error_injection_mode() -> str | None:
     same canonical set in :mod:`tests.cassette_patterns` so they cannot
     drift.
     """
-    raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip().lower()
+    # ``.casefold()`` (not ``.lower()``) for parity with ``_is_vcr_record_mode``
+    # and the project's Unicode-aware case-insensitive rule — ASCII-identical
+    # for VALID_ERROR_MODES, so this is consistency hygiene (#1268).
+    raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip().casefold()
     if not raw:
         return None
     return raw if raw in VALID_ERROR_MODES else None


### PR DESCRIPTION
## Fixes #1268

Follow-up from the #1267 review (claude[bot] out-of-scope observation). After #1265/#1267 switched `_is_vcr_record_mode()` to `.casefold()`, the sibling `get_error_injection_mode()` (parsing `NOTEBOOKLM_VCR_RECORD_ERRORS`) still used `.lower()` in **two** spots:
- `tests/vcr_config.py::get_error_injection_mode` (`.strip().lower()`)
- the src mirror `src/notebooklm/_error_injection.py::get_error_injection_mode` (`raw.lower()`)

Both changed to `.casefold()` in lockstep (the issue flagged the drift risk), per the project's Unicode-aware case-insensitive rule.

**Behavior-preserving:** `VALID_ERROR_MODES` (`429`/`5xx`/`expired_csrf`) are ASCII, so `.casefold()` == `.lower()` here — pure consistency hygiene. The existing case-insensitive tests (`test_vcr_get_error_injection_mode_case_insensitive` → `5XX`; `test_core_get_error_injection_mode_case_insensitive` → `EXPIRED_CSRF`) still pass unchanged.

### Verification
- `tests/unit/test_vcr_config.py` + `tests/unit/test_error_injection_middleware.py`: 68 passed.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment variable parsing to support Unicode-aware case-insensitive matching for configuration values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->