### PR TITLE
ci: run Test + CodeQL on the `next` branch (0.7.0 staging line)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
   schedule:
     - cron: '0 12 * * 1'  # Monday at noon UTC
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `next` to the `test.yml` (Test matrix + Code Quality) and `codeql.yml` (Analyze/CodeQL) branch filters so PRs targeting `next` get the full merge-gating CI.

**Why:** `next` will be the staging line for the v0.7.0 **breaking** API changes — `rename()`→re-fetched object + raise (#1255), `delete()`→`None` (#1211), and the mind-map fold-in — so `main` stays 0.6.x-stable and `pip install git+main` keeps the 0.6.0 API. Without this, PRs to `next` would get no Test/CodeQL gate (both were pinned to `[main]`).

No change to main's CI behavior; this only extends the existing gates to a second branch. (dependency-audit/verify are path/dispatch-based, not per-PR gates, so they're unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and testing workflows to support additional branches, improving development pipeline coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->