### PR TITLE
ci: stagger nightly E2E for the `next` branch (18:00 UTC, 12h off main)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Main branch: 6 AM UTC (10 PM PST / 1 AM EST)
     - cron: '0 6 * * *'
+    # next (0.7.0 staging) branch: 6 PM UTC — a 12h offset from main so the two
+    # nightly E2E runs never hit the shared live account / generation notebook
+    # at the same time. Keep these crons distinct; resolve-branch routes each
+    # to its branch via ``github.event.schedule``.
+    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       test_filter:
@@ -35,13 +40,20 @@ jobs:
         # is set automatically by the runner.
         env:
           EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
           CUSTOM_BRANCH: ${{ inputs.custom_branch }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "schedule" ]; then
-            # Scheduled runs test main only. Release branches are manual.
-            TARGET="main"
+            # Each cron targets a different branch so the two nightly E2E runs
+            # never overlap on the shared live account. The 18:00 UTC cron is
+            # the next (0.7.0 staging) line; everything else is main. Release
+            # branches stay manual (workflow_dispatch).
+            case "$SCHEDULE" in
+              '0 18 * * *') TARGET="next" ;;
+              *)            TARGET="main" ;;
+            esac
           else
             # Manual: use custom_branch if set, otherwise use triggering branch
             if [ -n "$CUSTOM_BRANCH" ]; then
@@ -51,9 +63,11 @@ jobs:
             fi
           fi
           echo "branch=$TARGET" >> "$GITHUB_OUTPUT"
-          # Check if it's main or a release branch
+          # Check if it's a trusted branch allowed to use live-API secrets.
+          # ``next`` is the maintainer-owned 0.7.0 staging line (same trust as
+          # main/release), so it may run the secret-bearing E2E job.
           case "$TARGET" in
-            main|release/*)
+            main|next|release/*)
               echo "is_standard=true" >> "$GITHUB_OUTPUT"
               ;;
             *)


### PR DESCRIPTION
Per the `next`-branch (0.7.0 staging) setup: **don't overlap main and next nightly E2E**, since they share one live NotebookLM account + the same read-only/generation-notebook secrets. Concurrent runs would contend (rate limits, colliding writes to the generation notebook, flakes).

**Change** (`nightly.yml`):
- Add a second cron `0 18 * * *` (6 PM UTC) routed to `next` via `github.event.schedule` — a **12h offset** from main's 6 AM. Existing main cron + manual/release dispatch unchanged.
- Add `next` to the `is_standard` secret-gate so its E2E job can use the live-API secrets — same trust level as main/release (maintainer-owned staging line). The `environment: protected-readonly` second layer still applies.

The per-branch `concurrency` group already prevents same-branch overlap; this adds the cross-branch time separation. Mirrors the existing E2E (6 AM) / rpc-health (7 AM) stagger.

> ⚠️ **Merge only after the `next` branch exists** — otherwise the 18:00 cron's `actions/checkout ref: next` fails until it does.

(rpc-health.yml could be staggered for next the same way later if wanted; this PR scopes to nightly E2E per the ask.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly continuous integration workflow configuration for improved staging branch testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->