### PR TITLE
ci: retire the `next` staging branch (ship 0.7.0 breaking changes on main)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, next]
+    branches: [main]
   pull_request:
-    branches: [main, next]
+    branches: [main]
   schedule:
     - cron: '0 12 * * 1'  # Monday at noon UTC
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     # Main branch: 6 AM UTC (10 PM PST / 1 AM EST)
     - cron: '0 6 * * *'
-    # next (0.7.0 staging) branch: 6 PM UTC — a 12h offset from main so the two
-    # nightly E2E runs never hit the shared live account / generation notebook
-    # at the same time. Keep these crons distinct; resolve-branch routes each
-    # to its branch via ``github.event.schedule``.
-    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       test_filter:
@@ -40,20 +35,13 @@ jobs:
         # is set automatically by the runner.
         env:
           EVENT_NAME: ${{ github.event_name }}
-          SCHEDULE: ${{ github.event.schedule }}
           CUSTOM_BRANCH: ${{ inputs.custom_branch }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "schedule" ]; then
-            # Each cron targets a different branch so the two nightly E2E runs
-            # never overlap on the shared live account. The 18:00 UTC cron is
-            # the next (0.7.0 staging) line; everything else is main. Release
-            # branches stay manual (workflow_dispatch).
-            case "$SCHEDULE" in
-              '0 18 * * *') TARGET="next" ;;
-              *)            TARGET="main" ;;
-            esac
+            # Scheduled runs test main only. Release branches are manual.
+            TARGET="main"
           else
             # Manual: use custom_branch if set, otherwise use triggering branch
             if [ -n "$CUSTOM_BRANCH" ]; then
@@ -63,11 +51,9 @@ jobs:
             fi
           fi
           echo "branch=$TARGET" >> "$GITHUB_OUTPUT"
-          # Check if it's a trusted branch allowed to use live-API secrets.
-          # ``next`` is the maintainer-owned 0.7.0 staging line (same trust as
-          # main/release), so it may run the secret-bearing E2E job.
+          # Check if it's main or a release branch
           case "$TARGET" in
-            main|next|release/*)
+            main|release/*)
               echo "is_standard=true" >> "$GITHUB_OUTPUT"
               ;;
             *)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, next]
+    branches: [main]
   pull_request:
-    branches: [main, next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The rename/delete API-consistency changes (#1255, #1211) are shipping as **clean breaks directly on `main` in 0.7.0** rather than from a quarantine branch — a multi-model design review + a code check concluded their old returns were never usable contracts (so no deprecation runway is owed), which makes them backward-compatible-enough for `main` and the `next` staging branch pure carrying cost.

Reverts the `next` CI scaffolding:
- **#1283** — removes `next` from the Test + CodeQL gate branches.
- **#1284** — removes the 18:00-UTC nightly E2E cron + its schedule routing (which would otherwise fail nightly once `next` is deleted, and would redundantly hit the shared live-API account).

`get()`'s `None`-on-miss (#1247) keeps its real deprecation runway to v0.8.0 — unaffected.

**After merge:** delete the `origin/next` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow configurations to consolidate branch targeting on the primary branch, streamlining the continuous integration and testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->