### PR TITLE
feat(api)!: rename returns object + raises; delete returns None (idempotent) [0.7.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-30
+
 ### Breaking changes
 
 > **⚠ BREAKING — `rename()` returns the renamed object; `delete()` returns `None`.**
@@ -921,7 +923,8 @@ This is the initial public release of `notebooklm-py`. While core functionality 
 - **Authentication expiry**: CSRF tokens expire after some time. Re-run `notebooklm login` if you encounter auth errors.
 - **Large file uploads**: Files over 50MB may fail or timeout. Split large documents if needed.
 
-[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/teng-lin/notebooklm-py/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+> **⚠ BREAKING — `rename()` returns the renamed object; `delete()` returns `None`.**
+>
+> These return-type changes ship **now, as a clean break with no deprecation
+> runway**, because the old returns were never usable contracts a caller could
+> depend on in good faith. (Contrast `get()`'s `None`-on-miss, which **is** a
+> real, documented contract and keeps its full deprecation runway to v0.8.0 —
+> see issue #1247. The coherent story: **reads/renames are missing-strict;
+> deletes are absence-idempotent.**)
+>
+> **`rename()` → returns the renamed object, raises `*NotFoundError` on a
+> missing target** (issues #1255, #1256):
+>
+> - `artifacts.rename` previously returned `None` **even on success** (an
+>   unusable return); it now re-fetches and returns the renamed `Artifact`,
+>   raising `ArtifactNotFoundError` when the target is absent.
+> - `sources.rename` previously **fabricated** an unverified
+>   `Source(id, title)` when the RPC echoed nothing (a silent-false-success
+>   bug); it now prefers the `UPDATE_SOURCE` echo, falls back to an internal
+>   fetch, returns the real `Source`, and raises `SourceNotFoundError` when the
+>   target is absent. **The fabrication is gone.**
+> - `notebooks.rename` already returned the re-fetched `Notebook` (the
+>   reference behavior) — unchanged.
+> - `mind_maps.rename` (both note-backed and interactive backings) now returns
+>   the renamed `MindMap` and raises on a missing target.
+> - **Error taxonomy:** only *genuine absence* (empty-payload / absent-from-list,
+>   detected via a content/list lookup — **not** a transport 404) maps to a
+>   `*NotFoundError`. Transport / `429` / `5xx` / auth errors propagate **as
+>   themselves** and are never laundered into a synthetic `*NotFoundError`.
+> - **Bulk opt-out:** every `rename()` accepts `return_object: bool = True`.
+>   Pass `return_object=False` to skip the hydrate re-fetch and return `None`
+>   (artifacts' re-fetch is a full `LIST_ARTIFACTS`, so bulk renamers that
+>   ignore the return should opt out to avoid N extra list calls).
+>
+> **`delete()` → returns `None`, idempotent on a missing target** (issue #1211):
+>
+> - `notebooks` / `sources` / `artifacts` / `notes.delete` and
+>   `notes.delete_mind_map` (and `mind_maps.delete`) previously returned a
+>   hardcoded `True`; they now return `None`. The old `True` was a tautology
+>   (never `False`), but `True → None` is a *real, observable* flip from truthy
+>   to falsy:
+>   ```python
+>   # BEFORE (entered the block; delete always returned True)
+>   if await client.sources.delete(nb_id, src_id):
+>       ...  # this branch no longer runs — delete() now returns None (falsy)
+>   ```
+>   Drop the `if`; call `delete()` for its effect. Use `get()` first if you
+>   need to assert existence.
+> - **Idempotent:** deleting an already-absent target **succeeds** (returns
+>   `None`); it does **not** raise `*NotFoundError`. This matches HTTP `DELETE`
+>   idempotency and keeps retry/teardown loops clean. (The one exception is
+>   `mind_maps.delete` *without* an explicit `kind`, which must list to pick
+>   the right RPC family and so raises `ValueError` for an unknown id; pass
+>   `kind=` to delete idempotently.)
+> - **Real failures still raise:** `allow_null=True` tolerates only a null
+>   *result*, not an RPC/HTTP error — a `403` / `5xx` / auth / transport
+>   failure on delete still propagates. "Idempotent on missing" is not "swallow
+>   all errors."
+
 > **⚠ BREAKING — lapsed v0.6.0-targeted deprecations removed.**
 >
 > These deprecation shims advertised removal in v0.6.0, which has shipped, so

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -889,6 +889,22 @@ async with NotebookLMClient.from_storage(rate_limit_max_retries=0) as client:
 
 ---
 
+> **v0.7.0 breaking change — `delete()` / `rename()` returns (issues #1211, #1255).**
+> Applies to `notebooks`, `sources`, `artifacts`, `notes`, and `mind_maps`:
+>
+> - **`delete()` returns `None`** (was a hardcoded `True`). `True → None` flips
+>   truthy → falsy, so `if await client.X.delete(id): ...` **no longer enters
+>   its block** — drop the `if` and call `delete()` for its effect. `delete()`
+>   is **idempotent**: deleting an already-absent target succeeds (returns
+>   `None`) and does not raise `*NotFoundError`; real failures
+>   (`403`/`5xx`/auth/transport) still raise. Use `get()` first to assert
+>   existence.
+> - **`rename()` returns the renamed object** and raises `*NotFoundError`
+>   (`ValueError` for mind maps) on a missing target — detected via a
+>   content/list lookup, never a transport 404. Pass **`return_object=False`**
+>   to skip the hydrate re-fetch and return `None`; that opt-out **also skips
+>   missing-target detection**, so a missing target does not raise under it.
+
 ### NotebooksAPI (`client.notebooks`)
 
 **CLI equivalent:** [Notebook Commands](cli-reference.md#notebook-commands) — `notebooklm list`, `create`, `delete`, `rename`, `summary`.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -898,8 +898,8 @@ async with NotebookLMClient.from_storage(rate_limit_max_retries=0) as client:
 | `list()` | - | `list[Notebook]` | List all notebooks |
 | `create(title)` | `title: str` | `Notebook` | Create a notebook |
 | `get(notebook_id)` | `notebook_id: str` | `Notebook` | Get notebook details |
-| `delete(notebook_id)` | `notebook_id: str` | `bool` | Delete a notebook |
-| `rename(notebook_id, new_title)` | `notebook_id: str, new_title: str` | `Notebook` | Rename a notebook |
+| `delete(notebook_id)` | `notebook_id: str` | `None` | Delete a notebook (idempotent; returns `None` whether or not it existed) |
+| `rename(notebook_id, new_title)` | `notebook_id: str, new_title: str` | `Notebook` | Rename a notebook (re-fetched; raises `NotebookNotFoundError` if missing) |
 | `get_description(notebook_id)` | `notebook_id: str` | `NotebookDescription` | Get AI summary and topics |
 | `get_metadata(notebook_id)` | `notebook_id: str` | `NotebookMetadata` | Get notebook metadata and sources |
 | `get_summary(notebook_id)` | `notebook_id: str` | `str` | Get raw summary text |
@@ -959,10 +959,10 @@ print(url)
 | `add_text(notebook_id, title, content, *, wait=False, wait_timeout=120.0, idempotent=False)` | `str, str, str, *, bool, float, bool` | `Source` | Add text content. `wait` / `wait_timeout` are keyword-only (the positional-wait shim was removed in v0.7.0). |
 | `add_file(notebook_id, file_path, mime_type=None, *, wait=False, wait_timeout=120.0, title=None, on_progress=None)` | `str, str \| Path, str \| None, *, bool, float, str \| None, Callable \| None` | `Source` | Upload file. `mime_type` is a **supported** parameter — it overrides filename-extension inference to set the resumable-upload content-type header (omit it to infer from the extension). `wait` / `wait_timeout` are keyword-only (the positional-wait shim was removed in v0.7.0). `title` sets the display name via a post-upload `UPDATE_SOURCE` and forces a brief registration wait even when `wait=False`. `on_progress(bytes_sent, total_bytes)` may be sync or async. |
 | `add_drive(notebook_id, file_id, title, mime_type="application/vnd.google-apps.document", *, wait=False, wait_timeout=120.0)` | `str, str, str, str, *, bool, float` | `Source` | Add Google Drive doc. `mime_type` defaults to Google Docs; override for Slides/Sheets/PDF via `DriveMimeType` (see `notebooklm.types`). `wait` / `wait_timeout` are keyword-only (the positional-wait shim was removed in v0.7.0). |
-| `rename(notebook_id, source_id, new_title)` | `str, str, str` | `Source` | Rename source |
+| `rename(notebook_id, source_id, new_title, *, return_object=True)` | `str, str, str` | `Source \| None` | Rename source (prefers the `UPDATE_SOURCE` echo, else re-fetched; raises `SourceNotFoundError` if missing). `return_object=False` returns `None` without hydrating. |
 | `refresh(notebook_id, source_id)` | `str, str` | `bool` | Refresh URL/Drive source |
 | `check_freshness(notebook_id, source_id)` | `str, str` | `bool` | Check if source needs refresh |
-| `delete(notebook_id, source_id)` | `str, str` | `bool` | Delete source |
+| `delete(notebook_id, source_id)` | `str, str` | `None` | Delete source (idempotent; returns `None` whether or not it existed) |
 | `wait_until_ready(notebook_id, source_id, timeout=120.0, ...)` | `str, str, float, ...` | `Source` | Poll until `status == READY` (fully processed). Raises `SourceTimeoutError`/`SourceProcessingError`/`SourceNotFoundError`. |
 | `wait_until_registered(notebook_id, source_id, timeout=30.0, ...)` | `str, str, float, ...` | `Source` | Poll until the source is visible server-side (any non-ERROR status). Completes quickly (seconds for typical sources); intended for narrow follow-up RPCs (e.g. `UPDATE_SOURCE`) that only require registration, not full processing. |
 | `wait_for_sources(notebook_id, source_ids, timeout=120.0, **kwargs)` | `str, list[str], float, ...` | `list[Source]` | Wait for multiple sources to become ready **in parallel**. Per-source timeout; `**kwargs` are forwarded to `wait_until_ready`. |
@@ -1031,8 +1031,8 @@ print(f"Keywords: {guide.keywords}")
 |--------|------------|---------|-------------|
 | `list(notebook_id, artifact_type=None)` | `str, ArtifactType \| None` | `list[Artifact]` | List artifacts |
 | `get(notebook_id, artifact_id)` | `str, str` | `Artifact \| None` | Get artifact details (returns None if not found) |
-| `delete(notebook_id, artifact_id)` | `str, str` | `bool` | Delete artifact |
-| `rename(notebook_id, artifact_id, new_title)` | `str, str, str` | `None` | Rename artifact |
+| `delete(notebook_id, artifact_id)` | `str, str` | `None` | Delete artifact (idempotent; returns `None` whether or not it existed) |
+| `rename(notebook_id, artifact_id, new_title, *, return_object=True)` | `str, str, str` | `Artifact \| None` | Rename artifact (re-fetched; raises `ArtifactNotFoundError` if missing). `return_object=False` skips the re-fetch and returns `None`. |
 | `poll_status(notebook_id, task_id)` | `str, str` | `GenerationStatus` | Check generation status |
 | `wait_for_completion(notebook_id, task_id, ...)` | `str, str, ...` | `GenerationStatus` | Wait for generation. Pass `on_status_change(status)` for sync or async progress callbacks. |
 
@@ -1544,8 +1544,8 @@ Each operation dispatches to the correct backend; you work with `MindMap` /
 | `list(notebook_id)` | `str` | `list[MindMap]` | Both kinds, as distinct `MindMap` entries |
 | `get(notebook_id, mind_map_id)` | `str, str` | `MindMap \| None` | Single mind map by id |
 | `generate(notebook_id, source_ids=None, *, kind, language="en", instructions=None, wait=True)` | … | `MindMap` | Note-backed (sync) or interactive (`CREATE_ARTIFACT` + poll) |
-| `rename(notebook_id, mind_map_id, new_title, *, kind=None)` | … | `None` | `UPDATE_NOTE` / `RENAME_ARTIFACT` by kind |
-| `delete(notebook_id, mind_map_id, *, kind=None)` | … | `bool` | `DELETE_NOTE` / `DELETE_ARTIFACT` by kind |
+| `rename(notebook_id, mind_map_id, new_title, *, kind=None, return_object=True)` | … | `MindMap \| None` | `UPDATE_NOTE` / `RENAME_ARTIFACT` by kind (re-fetched; raises `ValueError` if missing). `return_object=False` returns `None`. |
+| `delete(notebook_id, mind_map_id, *, kind=None)` | … | `None` | `DELETE_NOTE` / `DELETE_ARTIFACT` by kind (idempotent when `kind` is passed; `kind=None` raises `ValueError` for an unknown id) |
 | `get_tree(notebook_id, mind_map_id, *, kind=None)` | … | `dict \| None` | The `{"name","children"}` node tree |
 
 `MindMap` is a frozen value: `id`, `notebook_id`, `title`, `kind` (`MindMapKind.NOTE_BACKED` / `INTERACTIVE`), `created_at`, and `tree`. `generate(..., wait=True)` returns `tree` populated for **both** kinds (interactive maps are polled to completion, then their tree is fetched). For interactive *list* rows `tree` is `None` — fetch it with `get_tree`. When `kind` is omitted from `rename`/`delete`/`get_tree`, the backing is auto-detected (one extra list call).
@@ -1583,9 +1583,9 @@ In the CLI, mind maps are handled as a **type** within the existing groups (matc
 | `create_from_chat(notebook_id, ask_result, *, title=None)` | `str, AskResult, str \| None` | `Note` | **Deprecated** (emits `DeprecationWarning`) — forwards to `client.chat.save_answer_as_note(...)`, which is now the canonical owner of the saved-from-chat workflow (data ownership, ADR-013). Signature and behavior are preserved bit-for-bit; switch to the chat-owned method at your convenience. |
 | `get(notebook_id, note_id)` | `str, str` | `Optional[Note]` | Get note by ID |
 | `update(notebook_id, note_id, content, title)` | `str, str, str, str` | `None` | Update note content and title |
-| `delete(notebook_id, note_id)` | `str, str` | `bool` | Delete note |
+| `delete(notebook_id, note_id)` | `str, str` | `None` | Delete note (idempotent; returns `None` whether or not it existed) |
 | `list_mind_maps(notebook_id)` | `str` | `list[Any]` | List mind maps in the notebook |
-| `delete_mind_map(notebook_id, mind_map_id)` | `str, str` | `bool` | Delete a mind map |
+| `delete_mind_map(notebook_id, mind_map_id)` | `str, str` | `None` | Delete a mind map (idempotent; returns `None` whether or not it existed) |
 
 **Example:**
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.6.0"
+version = "0.7.0.dev0"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.7.0.dev0"
+version = "0.7.0"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -153,6 +153,28 @@ class ArtifactListingService:
                 return artifact
         return None
 
+    async def get_studio_only(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        *,
+        list_raw: ListRawCallback,
+    ) -> Artifact | None:
+        """Get a studio artifact by ID, excluding note-backed mind-map rows.
+
+        ``RENAME_ARTIFACT`` only applies to genuine studio artifacts; note-backed
+        mind maps rename via ``UPDATE_NOTE`` (see ``MindMapsAPI``). Hydrating the
+        rename result from the *merged* listing (studio + note-backed mind maps)
+        would let a note-backed mind-map id read back as a stale "success" after
+        a no-op ``RENAME_ARTIFACT``. Restricting to studio rows makes such an id
+        correctly absent here so the caller raises ``ArtifactNotFoundError``
+        and is steered to ``mind_maps.rename``.
+        """
+        for artifact in self._filter_studio_artifacts(await list_raw(notebook_id), None):
+            if artifact.id == artifact_id:
+                return artifact
+        return None
+
     def select_artifact(
         self,
         candidates: Sequence[Any],

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -46,7 +46,11 @@ from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
 from ._runtime_contracts import RpcCaller
 from ._types.research import MindMapResult
-from .exceptions import ArtifactFeatureUnavailableError, ValidationError
+from .exceptions import (
+    ArtifactFeatureUnavailableError,
+    ArtifactNotFoundError,
+    ValidationError,
+)
 
 if TYPE_CHECKING:
     from ._runtime_lifecycle import ClientLifecycle
@@ -794,15 +798,21 @@ class ArtifactsAPI:
     # Management Operations
     # =========================================================================
 
-    async def delete(self, notebook_id: str, artifact_id: str) -> bool:
+    async def delete(self, notebook_id: str, artifact_id: str) -> None:
         """Delete an artifact.
+
+        Idempotent: deleting an already-absent artifact succeeds (returns
+        ``None``) and never raises ``ArtifactNotFoundError``. Real failures
+        (``403``/``5xx``/auth/transport) still propagate.
 
         Args:
             notebook_id: The notebook ID.
             artifact_id: The artifact ID to delete.
 
-        Returns:
-            True if deletion succeeded.
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211). ``if await artifacts.delete(...):``
+            no longer enters its block.
         """
         logger.debug("Deleting artifact %s from notebook %s", artifact_id, notebook_id)
         params = [[2], artifact_id]
@@ -812,15 +822,47 @@ class ArtifactsAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return True
 
-    async def rename(self, notebook_id: str, artifact_id: str, new_title: str) -> None:
+    async def rename(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        new_title: str,
+        *,
+        return_object: bool = True,
+    ) -> Artifact | None:
         """Rename an artifact.
 
         Args:
             notebook_id: The notebook ID.
             artifact_id: The artifact ID to rename.
             new_title: The new title.
+            return_object: When ``True`` (default), re-fetch and return the
+                renamed :class:`~notebooklm.types.Artifact`. When ``False``,
+                skip the re-fetch and return ``None`` — the re-fetch is a full
+                ``LIST_ARTIFACTS`` call, so bulk renamers that ignore the
+                return should opt out to avoid N extra list calls. Opting out
+                also skips missing-target detection, so a missing artifact does
+                **not** raise — pass ``return_object=True`` (the default) if you
+                need the missing-target guarantee.
+
+        Returns:
+            The renamed :class:`~notebooklm.types.Artifact`, or ``None`` when
+            ``return_object=False``.
+
+        Raises:
+            ArtifactNotFoundError: if the artifact does not exist (the rename
+                RPC is silent on a missing target, so absence is detected via
+                a list fetch — not a transport 404). Only raised when
+                ``return_object=True``. Note-backed mind-map ids are *not*
+                renameable here (they use ``UPDATE_NOTE``); such an id is
+                treated as absent and raises — use ``mind_maps.rename`` instead.
+
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned ``None`` even on success.
+            Now re-fetches and returns the renamed ``Artifact``, raising
+            :class:`ArtifactNotFoundError` for a missing target (issue #1255).
+            Added the ``return_object`` opt-out.
         """
         params = [[artifact_id, new_title], [["title"]]]
         await self._rpc.rpc_call(
@@ -829,6 +871,20 @@ class ArtifactsAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
+        if not return_object:
+            return None
+        # Hydrate from studio artifacts only (never the public ``get()``, which
+        # warns under #1247, and never the merged listing — that would let a
+        # note-backed mind-map id, which ``RENAME_ARTIFACT`` no-ops on, read
+        # back as a stale "success"; it belongs to ``mind_maps.rename``). Only
+        # genuine absence maps to ``ArtifactNotFoundError``; transport/auth
+        # errors propagate as-is.
+        artifact = await self._listing.get_studio_only(
+            notebook_id, artifact_id, list_raw=self._list_raw
+        )
+        if artifact is None:
+            raise ArtifactNotFoundError(artifact_id, method_id=RPCMethod.RENAME_ARTIFACT.value)
+        return artifact
 
     async def poll_status(self, notebook_id: str, task_id: str) -> GenerationStatus:
         """Poll the status of a generation task.

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -57,14 +57,13 @@ class NoteBackedMindMapService:
         """
         return self._notes.extract_content(row)
 
-    async def delete_mind_map(self, notebook_id: str, note_id: str) -> bool:
+    async def delete_mind_map(self, notebook_id: str, note_id: str) -> None:
         """Soft-delete a mind-map row.
 
-        Delegates to :meth:`NoteService.delete_note`. Returns its bool
-        result so the v0.4.1 ``NotesAPI.delete_mind_map(...) -> bool``
-        public contract is preserved.
+        Delegates to :meth:`NoteService.delete_note`. Returns ``None`` as of
+        v0.7.0 (``NotesAPI.delete_mind_map(...) -> None``, issue #1211).
         """
-        return await self._notes.delete_note(notebook_id, note_id)
+        await self._notes.delete_note(notebook_id, note_id)
 
     async def rename_mind_map(self, notebook_id: str, mind_map_id: str, new_title: str) -> None:
         """Rename a note-backed mind map by retitling its backing note.

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -283,11 +283,33 @@ class MindMapsAPI:
         new_title: str,
         *,
         kind: MindMapKind | None = None,
-    ) -> None:
+        return_object: bool = True,
+    ) -> MindMap | None:
         """Rename a mind map (dispatches by kind: ``UPDATE_NOTE`` / ``RENAME_ARTIFACT``).
 
         Omitting ``kind`` triggers an extra list RPC (and possibly a second
         ``LIST_ARTIFACTS`` call) to auto-detect the backing; pass ``kind`` to skip it.
+
+        Args:
+            return_object: When ``True`` (default), re-fetch and return the
+                renamed :class:`~notebooklm.types.MindMap`. When ``False``,
+                skip the re-fetch and return ``None``.
+
+        Returns:
+            The renamed :class:`~notebooklm.types.MindMap`, or ``None`` when
+            ``return_object=False``.
+
+        Raises:
+            ValueError: if no mind map with ``mind_map_id`` exists. (Mind maps
+                have no dedicated ``*NotFoundError``; absence is detected via a
+                content/list lookup, not a transport 404. The detection is the
+                same fail-loud-on-missing policy as ``sources``/``artifacts``
+                rename — issue #1255.)
+
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned ``None`` even on success.
+            Now re-fetches and returns the renamed ``MindMap`` (issue #1255).
+            Added the ``return_object`` opt-out.
         """
         if kind is None:
             # Auto-detect inline so the note-backed list is fetched once rather
@@ -297,10 +319,15 @@ class MindMapsAPI:
             for row in await self._mind_maps.list_mind_maps(notebook_id):
                 if NoteRow(row).id == mind_map_id:
                     await self._mind_maps.rename_mind_map(notebook_id, mind_map_id, new_title)
-                    return
+                    return await self._hydrate_renamed(notebook_id, mind_map_id, return_object)
             if await self._find_interactive(notebook_id, mind_map_id) is not None:
-                await self._artifacts.rename(notebook_id, mind_map_id, new_title)
-                return
+                # ``return_object=False`` on the artifact rename: hydration (if
+                # requested) is done once below via ``self.get`` so the
+                # interactive path doesn't also re-fetch.
+                await self._artifacts.rename(
+                    notebook_id, mind_map_id, new_title, return_object=False
+                )
+                return await self._hydrate_renamed(notebook_id, mind_map_id, return_object)
             raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
         if kind == MindMapKind.NOTE_BACKED:
             await self._mind_maps.rename_mind_map(notebook_id, mind_map_id, new_title)
@@ -314,7 +341,25 @@ class MindMapsAPI:
                 raise ValueError(
                     f"Interactive mind map {mind_map_id!r} not found in notebook {notebook_id!r}"
                 )
-            await self._artifacts.rename(notebook_id, mind_map_id, new_title)
+            await self._artifacts.rename(notebook_id, mind_map_id, new_title, return_object=False)
+        return await self._hydrate_renamed(notebook_id, mind_map_id, return_object)
+
+    async def _hydrate_renamed(
+        self, notebook_id: str, mind_map_id: str, return_object: bool
+    ) -> MindMap | None:
+        """Re-fetch the renamed map (or skip when ``return_object=False``).
+
+        The dispatch paths above already proved the id exists, so a ``None``
+        from ``get`` here means the map vanished between the rename and the
+        re-fetch (a genuine race) — surface it as the same ``ValueError`` the
+        missing-target paths raise rather than returning a stale/absent object.
+        """
+        if not return_object:
+            return None
+        mind_map = await self.get(notebook_id, mind_map_id)
+        if mind_map is None:
+            raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
+        return mind_map
 
     async def delete(
         self,
@@ -322,16 +367,28 @@ class MindMapsAPI:
         mind_map_id: str,
         *,
         kind: MindMapKind | None = None,
-    ) -> bool:
+    ) -> None:
         """Delete a mind map (dispatches by kind: ``DELETE_NOTE`` / ``DELETE_ARTIFACT``).
 
         Omitting ``kind`` triggers an extra list RPC (and possibly a second
         ``LIST_ARTIFACTS`` call) to auto-detect the backing; pass ``kind`` to skip it.
+
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211).
+
+        .. note::
+            Unlike ``sources``/``artifacts``/``notes`` delete, this is **not**
+            idempotent on a missing target: when ``kind`` is omitted it routes
+            through ``_detect_kind``, which raises ``ValueError`` for an unknown
+            id (it must list to pick the right RPC family). Pass ``kind`` to
+            skip detection and delete idempotently.
         """
         kind = kind or await self._detect_kind(notebook_id, mind_map_id)
         if kind == MindMapKind.NOTE_BACKED:
-            return await self._mind_maps.delete_mind_map(notebook_id, mind_map_id)
-        return await self._artifacts.delete(notebook_id, mind_map_id)
+            await self._mind_maps.delete_mind_map(notebook_id, mind_map_id)
+        else:
+            await self._artifacts.delete(notebook_id, mind_map_id)
 
     async def get_tree(
         self,

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -349,10 +349,12 @@ class MindMapsAPI:
     ) -> MindMap | None:
         """Re-fetch the renamed map (or skip when ``return_object=False``).
 
-        The dispatch paths above already proved the id exists, so a ``None``
-        from ``get`` here means the map vanished between the rename and the
-        re-fetch (a genuine race) — surface it as the same ``ValueError`` the
-        missing-target paths raise rather than returning a stale/absent object.
+        A ``None`` from ``get`` here means the map is absent — surface it as
+        the same ``ValueError`` the missing-target dispatch paths raise rather
+        than returning a stale/absent object. For paths that pre-validate the
+        id (auto-detect and explicit-interactive) this is a vanished-between-
+        rename-and-refetch race; for the explicit ``kind=NOTE_BACKED`` path it
+        is the primary missing-target signal. Either way, absent → raise.
         """
         if not return_object:
             return None

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -363,14 +363,14 @@ class NoteService:
             allow_null=True,
         )
 
-    async def delete_note(self, notebook_id: str, note_id: str) -> bool:
+    async def delete_note(self, notebook_id: str, note_id: str) -> None:
         """Soft-delete a note row.
 
-        Returns ``True`` on success, mirroring the v0.4.1 NotesAPI
-        contract (``client.notes.delete(...) -> bool``). The bool flow
-        is preserved so the public facade can keep returning ``True``
-        unconditionally via :class:`NoteBackedMindMapService.delete_mind_map`
-        without callers seeing a behavioral change.
+        Returns ``None``. Idempotent: a missing note still succeeds
+        (``DELETE_NOTE`` is ``allow_null=True`` with no missing-signal). The
+        public facade (``client.notes.delete`` /
+        ``NoteBackedMindMapService.delete_mind_map``) returns ``None`` as of
+        v0.7.0 (issue #1211).
         """
         params = [notebook_id, None, [note_id]]
         await self._rpc.rpc_call(
@@ -379,4 +379,3 @@ class NoteService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return True

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -508,19 +508,24 @@ class NotebooksAPI:
             )
         return notebook
 
-    async def delete(self, notebook_id: str) -> bool:
+    async def delete(self, notebook_id: str) -> None:
         """Delete a notebook.
+
+        Idempotent: deleting an already-absent notebook succeeds (returns
+        ``None``) and never raises ``NotebookNotFoundError``. Real failures
+        (``403``/``5xx``/auth/transport) still propagate.
 
         Args:
             notebook_id: The notebook ID to delete.
 
-        Returns:
-            True if deletion succeeded.
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211). ``if await notebooks.delete(...):``
+            no longer enters its block.
         """
         logger.debug("Deleting notebook: %s", notebook_id)
         params = [[notebook_id], [2]]
         await self._rpc.rpc_call(RPCMethod.DELETE_NOTEBOOK, params)
-        return True
 
     async def rename(self, notebook_id: str, new_title: str) -> Notebook:
         """Rename a notebook.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -223,21 +223,27 @@ class NotesAPI:
         """
         await self._notes.update_note(notebook_id, note_id, content, title)
 
-    async def delete(self, notebook_id: str, note_id: str) -> bool:
+    async def delete(self, notebook_id: str, note_id: str) -> None:
         """Delete a note from the notebook.
 
         Note: This clears the note content/title rather than removing it
         from the list entirely. Google may garbage collect cleared notes later.
 
+        Idempotent: deleting an already-absent note succeeds (returns
+        ``None``) and never raises. Real failures (``403``/``5xx``/auth/
+        transport) still propagate.
+
         Args:
             notebook_id: The notebook ID.
             note_id: The note ID.
 
-        Returns:
-            True if deletion succeeded.
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211). ``if await notes.delete(...):``
+            no longer enters its block.
         """
         logger.debug("Deleting note %s from notebook %s", note_id, notebook_id)
-        return await self._notes.delete_note(notebook_id, note_id)
+        await self._notes.delete_note(notebook_id, note_id)
 
     async def list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """List all mind maps in the notebook.
@@ -258,17 +264,22 @@ class NotesAPI:
         """
         return await self._mind_maps.list_mind_maps(notebook_id)
 
-    async def delete_mind_map(self, notebook_id: str, mind_map_id: str) -> bool:
+    async def delete_mind_map(self, notebook_id: str, mind_map_id: str) -> None:
         """Delete a mind map from the notebook.
+
+        Idempotent: deleting an already-absent mind map succeeds (returns
+        ``None``) and never raises. Real failures (``403``/``5xx``/auth/
+        transport) still propagate.
 
         Args:
             notebook_id: The notebook ID.
             mind_map_id: The mind map ID.
 
-        Returns:
-            True if deletion succeeded.
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211).
         """
-        return await self._mind_maps.delete_mind_map(notebook_id, mind_map_id)
+        await self._mind_maps.delete_mind_map(notebook_id, mind_map_id)
 
     # =========================================================================
     # Private Helpers

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -729,7 +729,10 @@ class SourceUploadPipeline:
             try:
                 assert title is not None
                 renamed = await self.rename(notebook_id, source_id, title)
-                source = replace(source, title=renamed.title or title)
+                # ``renamed`` is ``None`` when the rename RPC echoes nothing;
+                # fall back to the requested title (the source was just
+                # uploaded, so it exists — only the echo is absent).
+                source = replace(source, title=(renamed.title if renamed else None) or title)
             except (RPCError, NetworkError):
                 module_logger.warning(
                     "Source %s uploaded but rename to %r failed",
@@ -998,8 +1001,15 @@ class SourceUploadPipeline:
             logger=module_logger,
         )
 
-    async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source:
-        """Rename an uploaded source."""
+    async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source | None:
+        """Rename a just-uploaded source, returning the ``UPDATE_SOURCE`` echo.
+
+        Internal post-upload retitle helper. Returns the echoed
+        :class:`~notebooklm.types.Source` when present, or ``None`` when the
+        RPC echoes nothing — the caller (:meth:`add_file`) falls back to the
+        requested title. Does not fabricate an unverified ``Source`` (the
+        public ``sources.rename`` policy, issue #1255).
+        """
         module_logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = build_rename_source_params(source_id, new_title)
         result = await self._rpc.rpc_call(
@@ -1008,11 +1018,9 @@ class SourceUploadPipeline:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return (
-            Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
-            if result
-            else Source(id=source_id, title=new_title)
-        )
+        if result:
+            return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
+        return None
 
     async def start_resumable_upload(
         self,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -24,6 +24,7 @@ from ._source_upload import SourceUploadPipeline
 from ._source_upload_payloads import build_rename_source_params
 from ._types.research import SourceGuide
 from ._url_utils import is_youtube_url
+from .exceptions import SourceNotFoundError
 from .rpc import RPCMethod
 from .types import (
     Source,
@@ -581,15 +582,21 @@ class SourcesAPI:
             logger=logger,
         )
 
-    async def delete(self, notebook_id: str, source_id: str) -> bool:
+    async def delete(self, notebook_id: str, source_id: str) -> None:
         """Delete a source from a notebook.
+
+        Idempotent: deleting an already-absent source succeeds (returns
+        ``None``) and never raises ``SourceNotFoundError``. Real failures
+        (``403``/``5xx``/auth/transport) still propagate.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to delete.
 
-        Returns:
-            True if deletion succeeded.
+        .. versionchanged:: 0.7.0
+            **Breaking change:** previously returned a hardcoded ``True``;
+            now returns ``None`` (issue #1211). ``if await source.delete(...):``
+            no longer enters its block.
         """
         logger.debug("Deleting source %s from notebook %s", source_id, notebook_id)
         params = [[[source_id]]]
@@ -599,18 +606,45 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return True
 
-    async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source:
+    async def rename(
+        self,
+        notebook_id: str,
+        source_id: str,
+        new_title: str,
+        *,
+        return_object: bool = True,
+    ) -> Source | None:
         """Rename a source.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to rename.
             new_title: The new title.
+            return_object: When ``True`` (default), return the renamed
+                :class:`~notebooklm.types.Source` — preferring the
+                ``UPDATE_SOURCE`` echo and falling back to a fetch only when
+                the echo is null. When ``False``, return ``None`` without
+                hydrating (cheaper for bulk renames that ignore the return);
+                this also skips missing-target detection, so a missing source
+                does **not** raise — pass ``return_object=True`` (the default)
+                if you need the missing-target guarantee.
 
         Returns:
-            Updated Source object.
+            The renamed :class:`~notebooklm.types.Source`, or ``None`` when
+            ``return_object=False``.
+
+        Raises:
+            SourceNotFoundError: if the source does not exist (the rename RPC
+                is silent on a missing target, so absence is detected via a
+                content/list fetch — not a transport 404). Only raised when
+                ``return_object=True``.
+
+        .. versionchanged:: 0.7.0
+            **Breaking change:** no longer fabricates an unverified
+            ``Source(id, title)`` when the RPC echoes nothing. It now hydrates
+            via an internal fetch and raises :class:`SourceNotFoundError` for a
+            missing target (issue #1255). Added the ``return_object`` opt-out.
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = build_rename_source_params(source_id, new_title)
@@ -620,11 +654,18 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        return (
-            Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
-            if result
-            else Source(id=source_id, title=new_title)
-        )
+        if not return_object:
+            return None
+        # Prefer the UPDATE_SOURCE echo (avoids the extra fetch).
+        if result:
+            return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
+        # Echo was null: hydrate via the internal optional-lookup (never the
+        # public ``get()``, which warns under #1247). Only genuine absence
+        # maps to ``SourceNotFoundError``; transport/auth errors propagate.
+        source = await self._get_or_none(notebook_id, source_id)
+        if source is None:
+            raise SourceNotFoundError(source_id, method_id=RPCMethod.UPDATE_SOURCE.value)
+        return source
 
     async def refresh(self, notebook_id: str, source_id: str) -> bool:
         """Refresh a source to get updated content (for URL/Drive sources).

--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -239,12 +239,18 @@ def artifact_rename(ctx, artifact_id, new_title, notebook_id, json_output, clien
             # the unified mind-map API (#1256). Regular artifacts use RENAME_ARTIFACT.
             mind_maps = await client.mind_maps.list(nb_id_resolved)
             mind_map = next((m for m in mind_maps if m.id == resolved_id), None)
+            # return_object=False: the CLI builds its confirmation from
+            # resolved_id + new_title and never uses the hydrated object, so
+            # skip the rename re-fetch (a full LIST_ARTIFACTS / get) — "no
+            # exception = success" is sufficient in this error-raising context.
             if mind_map is not None:
                 await client.mind_maps.rename(
-                    nb_id_resolved, resolved_id, new_title, kind=mind_map.kind
+                    nb_id_resolved, resolved_id, new_title, kind=mind_map.kind, return_object=False
                 )
             else:
-                await client.artifacts.rename(nb_id_resolved, resolved_id, new_title)
+                await client.artifacts.rename(
+                    nb_id_resolved, resolved_id, new_title, return_object=False
+                )
             # The rename API now returns the renamed object and raises on a
             # missing target; if no exception was raised, the operation
             # succeeded. We display the requested new_title as confirmation.

--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -241,8 +241,14 @@ def artifact_rename(ctx, artifact_id, new_title, notebook_id, json_output, clien
             mind_map = next((m for m in mind_maps if m.id == resolved_id), None)
             # return_object=False: the CLI builds its confirmation from
             # resolved_id + new_title and never uses the hydrated object, so
-            # skip the rename re-fetch (a full LIST_ARTIFACTS / get) — "no
-            # exception = success" is sufficient in this error-raising context.
+            # skip the rename re-fetch (a full LIST_ARTIFACTS / get). For
+            # partial-id input, ``resolve_artifact_id`` already listed and
+            # raised on an absent id, so existence is proven before we get
+            # here. (A canonical full-UUID input fast-paths the resolver
+            # without a list, so a UUID pointing to a since-deleted artifact
+            # would print a benign no-op "success" — a pre-existing condition,
+            # not introduced here; hydrating to catch it would re-list on every
+            # already-resolved partial-id rename, which isn't worth it.)
             if mind_map is not None:
                 await client.mind_maps.rename(
                     nb_id_resolved, resolved_id, new_title, kind=mind_map.kind, return_object=False

--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -245,8 +245,9 @@ def artifact_rename(ctx, artifact_id, new_title, notebook_id, json_output, clien
                 )
             else:
                 await client.artifacts.rename(nb_id_resolved, resolved_id, new_title)
-            # The rename API returns None; if no exception was raised, the operation succeeded.
-            # We display the requested new_title as confirmation.
+            # The rename API now returns the renamed object and raises on a
+            # missing target; if no exception was raised, the operation
+            # succeeded. We display the requested new_title as confirmation.
             if json_output:
                 json_output_response({"id": resolved_id, "renamed": True, "new_title": new_title})
             else:

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -164,9 +164,11 @@ def register_notebook_commands(cli):
                     return {"notebook_id": resolved_id, "success": False}
 
                 async def execute_delete(client, resolved):
-                    resolved["success"] = bool(
-                        await client.notebooks.delete(resolved["notebook_id"])
-                    )
+                    # delete() now returns None and raises on real failure
+                    # (issue #1211); reaching here without an exception means
+                    # success.
+                    await client.notebooks.delete(resolved["notebook_id"])
+                    resolved["success"] = True
 
                 plan = MutationPlan(
                     entity_label="notebook",

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -351,9 +351,10 @@ async def execute_source_delete(
         }
 
     async def execute_delete(client, resolved):
-        resolved["success"] = bool(
-            await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
-        )
+        # delete() now returns None and raises on real failure (issue #1211);
+        # reaching here without an exception means success.
+        await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
+        resolved["success"] = True
 
     def serialize_success(resolved):
         return {
@@ -439,9 +440,10 @@ async def execute_source_delete_by_title(
         }
 
     async def execute_delete_by_title(client, resolved):
-        resolved["success"] = bool(
-            await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
-        )
+        # delete() now returns None and raises on real failure (issue #1211);
+        # reaching here without an exception means success.
+        await client.sources.delete(resolved["notebook_id"], resolved["source_id"])
+        resolved["success"] = True
 
     def serialize_success(resolved):
         return {
@@ -507,7 +509,10 @@ async def execute_source_rename(
     resolved_id = await resolve_source_id(
         client, plan.notebook_id, plan.source_id, json_output=plan.json_output
     )
+    # return_object defaults to True, so rename returns a Source (or raises
+    # SourceNotFoundError on a missing target) — never None on this path.
     src = await client.sources.rename(plan.notebook_id, resolved_id, plan.new_title)
+    assert src is not None  # narrow Source | None for the rename-result dataclass
     return SourceRenameResult(source=src, notebook_id=plan.notebook_id)
 
 

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 from ...types import DriveMimeType, Source
 from ..resolve import resolve_source_id, validate_id
@@ -510,9 +510,13 @@ async def execute_source_rename(
         client, plan.notebook_id, plan.source_id, json_output=plan.json_output
     )
     # return_object defaults to True, so rename returns a Source (or raises
-    # SourceNotFoundError on a missing target) — never None on this path.
-    src = await client.sources.rename(plan.notebook_id, resolved_id, plan.new_title)
-    assert src is not None  # narrow Source | None for the rename-result dataclass
+    # SourceNotFoundError on a missing target) — never None on this path. Use
+    # cast (not assert, which -O strips) to narrow Source | None for the
+    # rename-result dataclass.
+    src = cast(
+        Source,
+        await client.sources.rename(plan.notebook_id, resolved_id, plan.new_title),
+    )
     return SourceRenameResult(source=src, notebook_id=plan.notebook_id)
 
 

--- a/tests/e2e/test_artifacts.py
+++ b/tests/e2e/test_artifacts.py
@@ -252,9 +252,9 @@ class TestArtifactMutations:
 
         await asyncio.sleep(2)
 
-        # Delete it
+        # Delete it (v0.7.0: returns None, idempotent — issue #1211)
         deleted = await client.artifacts.delete(temp_notebook.id, artifact_id)
-        assert deleted is True
+        assert deleted is None
 
         # Verify it's gone
         artifacts = await client.artifacts.list(temp_notebook.id)

--- a/tests/e2e/test_notebooks.py
+++ b/tests/e2e/test_notebooks.py
@@ -33,9 +33,9 @@ class TestNotebookOperations:
         # Rename
         await client.notebooks.rename(notebook.id, "E2E Test Renamed")
 
-        # Delete
+        # Delete (v0.7.0: returns None, idempotent — issue #1211)
         deleted = await client.notebooks.delete(notebook.id)
-        assert deleted is True
+        assert deleted is None
         created_notebooks.remove(notebook.id)
 
     @pytest.mark.asyncio

--- a/tests/e2e/test_notes.py
+++ b/tests/e2e/test_notes.py
@@ -66,9 +66,9 @@ class TestNotesCRUD:
         note_ids = [n.id for n in notes]
         assert note.id in note_ids
 
-        # Delete
+        # Delete (v0.7.0: returns None, idempotent — issue #1211)
         result = await client.notes.delete(temp_notebook.id, note.id)
-        assert result is True
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_update_note(self, client, temp_notebook):

--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -128,9 +128,9 @@ class TestSourceMutations:
         )
         assert source.id is not None
 
-        # Delete it
+        # Delete it (v0.7.0: returns None, idempotent — issue #1211)
         deleted = await client.sources.delete(temp_notebook.id, source.id)
-        assert deleted is True
+        assert deleted is None
 
         # Verify it's gone
         sources = await client.sources.list(temp_notebook.id)

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -11,6 +11,7 @@ Cassette-backed coverage for the same API surface lives in
 
 import csv
 import json
+import re
 import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,7 +22,11 @@ from notebooklm import NotebookLMClient
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
-from notebooklm.exceptions import UnknownRPCMethodError, ValidationError
+from notebooklm.exceptions import (
+    ArtifactNotFoundError,
+    UnknownRPCMethodError,
+    ValidationError,
+)
 from notebooklm.rpc import (
     AudioFormat,
     AudioLength,
@@ -325,7 +330,7 @@ class TestDeleteStudioContent:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.artifacts.delete("nb_123", "task_id_123")
 
-        assert result is True
+        assert result is None
 
 
 class TestMindMap:
@@ -544,15 +549,100 @@ class TestArtifactsAPI:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test renaming an artifact."""
-        response = build_rpc_response(RPCMethod.RENAME_ARTIFACT, None)
-        httpx_mock.add_response(content=response.encode())
+        """Renaming re-fetches (studio-only) and returns the server-reflected Artifact."""
+        # 1) RENAME_ARTIFACT (silent on success).
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.RENAME_ARTIFACT.value}.*"),
+            content=build_rpc_response(RPCMethod.RENAME_ARTIFACT, None).encode(),
+        )
+        # 2) LIST_ARTIFACTS hydrate — studio-only (no GET_NOTES_AND_MIND_MAPS),
+        #    the server reflects the new title.
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.LIST_ARTIFACTS.value}.*"),
+            content=build_rpc_response(
+                RPCMethod.LIST_ARTIFACTS,
+                [["art_001", "New Title", 7, None, 3]],
+            ).encode(),
+        )
 
         async with NotebookLMClient(auth_tokens) as client:
-            await client.artifacts.rename("nb_123", "art_001", "New Title")
+            artifact = await client.artifacts.rename("nb_123", "art_001", "New Title")
 
-        request = httpx_mock.get_request()
-        assert RPCMethod.RENAME_ARTIFACT.value in str(request.url)
+        assert artifact is not None
+        assert artifact.id == "art_001"
+        # Server-reflected, not echoed from the input argument.
+        assert artifact.title == "New Title"
+
+    @pytest.mark.asyncio
+    async def test_rename_artifact_missing_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Renaming an absent artifact raises ArtifactNotFoundError (list-based)."""
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.RENAME_ARTIFACT.value}.*"),
+            content=build_rpc_response(RPCMethod.RENAME_ARTIFACT, None).encode(),
+        )
+        # Studio-only hydrate list does not contain the renamed id.
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.LIST_ARTIFACTS.value}.*"),
+            content=build_rpc_response(RPCMethod.LIST_ARTIFACTS, []).encode(),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactNotFoundError):
+                await client.artifacts.rename("nb_123", "missing_art", "New Title")
+
+    @pytest.mark.asyncio
+    async def test_rename_artifact_note_backed_mind_map_id_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A note-backed mind-map id renames via UPDATE_NOTE, not RENAME_ARTIFACT.
+
+        ``artifacts.rename`` hydrates from studio artifacts only, so a
+        note-backed mind-map id (present only in the notes listing) reads as
+        absent and raises — steering the caller to ``mind_maps.rename``.
+        """
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.RENAME_ARTIFACT.value}.*"),
+            content=build_rpc_response(RPCMethod.RENAME_ARTIFACT, None).encode(),
+        )
+        # Studio listing is empty (the id lives only in the notes backing).
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.LIST_ARTIFACTS.value}.*"),
+            content=build_rpc_response(RPCMethod.LIST_ARTIFACTS, []).encode(),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactNotFoundError):
+                await client.artifacts.rename("nb_123", "note_backed_mm", "New Title")
+
+    @pytest.mark.asyncio
+    async def test_rename_artifact_transport_error_not_rewrapped(self, auth_tokens):
+        """A transport failure during hydration propagates, not ArtifactNotFoundError."""
+        async with NotebookLMClient(auth_tokens) as client:
+            rpc = AsyncMock(side_effect=[None, RPCError("boom during hydrate")])
+            client._rpc_executor.rpc_call = rpc
+            with pytest.raises(RPCError):
+                await client.artifacts.rename("nb_123", "art_001", "New Title")
+
+    @pytest.mark.asyncio
+    async def test_rename_artifact_return_object_false_skips_fetch(self, auth_tokens):
+        """return_object=False returns None and issues no LIST_ARTIFACTS hydrate."""
+        async with NotebookLMClient(auth_tokens) as client:
+            rpc = AsyncMock(return_value=None)
+            client._rpc_executor.rpc_call = rpc
+            result = await client.artifacts.rename(
+                "nb_123", "art_001", "New Title", return_object=False
+            )
+
+        assert result is None
+        rpc.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_export_artifact(
@@ -953,7 +1043,7 @@ class TestArtifactsAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.artifacts.delete("nb_123", "art_001")
 
-        assert result is True
+        assert result is None
         request = httpx_mock.get_request()
         assert RPCMethod.DELETE_ARTIFACT in str(request.url)
 

--- a/tests/integration/test_notebooks_integration.py
+++ b/tests/integration/test_notebooks_integration.py
@@ -268,7 +268,7 @@ class TestDeleteNotebook:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.notebooks.delete("nb_123")
 
-        assert result is True
+        assert result is None
 
 
 class TestSummary:

--- a/tests/integration/test_notes_integration.py
+++ b/tests/integration/test_notes_integration.py
@@ -226,7 +226,7 @@ class TestNotesAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.notes.delete("nb_123", "note_001")
 
-        assert result is True
+        assert result is None
         request = httpx_mock.get_request()
         assert RPCMethod.DELETE_NOTE in str(request.url)
 
@@ -272,6 +272,6 @@ class TestNotesAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.notes.delete_mind_map("nb_123", "mm_001")
 
-        assert result is True
+        assert result is None
         request = httpx_mock.get_request()
         assert RPCMethod.DELETE_NOTE in str(request.url)

--- a/tests/integration/test_polling_vcr.py
+++ b/tests/integration/test_polling_vcr.py
@@ -181,14 +181,16 @@ class TestPollingReplay:
             assert final_status.is_complete or final_status.is_failed
 
             # 4. Rename leg — exercises RENAME_ARTIFACT regardless of whether
-            #    the artifact ended ``completed`` or ``failed``. We don't
-            #    re-fetch + assert title here because that would require an
-            #    additional cassette interaction; the regression we care
-            #    about is "the rename RPC fires without error".
+            #    the artifact ended ``completed`` or ``failed``. We pass
+            #    ``return_object=False`` to skip the post-rename re-fetch
+            #    (issue #1255), which would otherwise require an additional
+            #    cassette interaction; the regression we care about is "the
+            #    rename RPC fires without error".
             await client.artifacts.rename(
                 MUTABLE_NOTEBOOK_ID,
                 task_id,
                 "Renamed VCR Test",
+                return_object=False,
             )
 
     def test_cassette_has_multiple_polling_interactions(self) -> None:

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -107,7 +107,7 @@ class TestDeleteSource:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.sources.delete("nb_123", "source_456")
 
-        assert result is True
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_delete_source_request_format(
@@ -676,23 +676,121 @@ class TestSourcesAPI:
         assert guide.keywords == ()
 
     @pytest.mark.asyncio
-    async def test_rename_source(
+    async def test_rename_source_uses_echo(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test renaming a source."""
-        response = build_rpc_response("b7Wfje", None)
-        httpx_mock.add_response(content=response.encode())
+        """When UPDATE_SOURCE echoes the row, rename returns it without a fetch."""
+        echo = build_rpc_response(
+            RPCMethod.UPDATE_SOURCE,
+            [["src_001"], "New Title", [None, None, None, None, 5], [None, 2]],
+        )
+        httpx_mock.add_response(content=echo.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
             source = await client.sources.rename("nb_123", "src_001", "New Title")
 
+        assert source is not None
+        assert source.id == "src_001"
         assert source.title == "New Title"
 
-        request = httpx_mock.get_request()
-        assert "b7Wfje" in str(request.url)
+        # Only the UPDATE_SOURCE RPC — the echo path issues no fetch.
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+        assert "b7Wfje" in str(requests[0].url)
+
+    @pytest.mark.asyncio
+    async def test_rename_source_falls_back_to_fetch_on_null_echo(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A null UPDATE_SOURCE echo triggers a hydrate fetch returning the server row."""
+        # 1) UPDATE_SOURCE echoes nothing.
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.UPDATE_SOURCE.value}.*"),
+            content=build_rpc_response(RPCMethod.UPDATE_SOURCE, None).encode(),
+        )
+        # 2) Hydrate via GET_NOTEBOOK — the server reflects the new title.
+        get_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [
+                        [
+                            ["src_001"],
+                            "New Title",
+                            [None, None, None, None, 5, None, None, ["https://example.com"]],
+                            [None, 2],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.GET_NOTEBOOK.value}.*"), content=get_response.encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            source = await client.sources.rename("nb_123", "src_001", "New Title")
+
+        assert source is not None
+        assert source.id == "src_001"
+        # Server-reflected, not just echoed back from the input.
+        assert source.title == "New Title"
+
+    @pytest.mark.asyncio
+    async def test_rename_source_missing_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A null echo plus an absent-from-list source raises SourceNotFoundError."""
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.UPDATE_SOURCE.value}.*"),
+            content=build_rpc_response(RPCMethod.UPDATE_SOURCE, None).encode(),
+        )
+        # Hydrate fetch: notebook exists but the source id is absent.
+        httpx_mock.add_response(
+            url=re.compile(rf".*{RPCMethod.GET_NOTEBOOK.value}.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_NOTEBOOK, [["Test Notebook", [], "nb_123"]]
+            ).encode(),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceNotFoundError):
+                await client.sources.rename("nb_123", "missing_src", "New Title")
+
+    @pytest.mark.asyncio
+    async def test_rename_source_transport_error_not_rewrapped(self, auth_tokens):
+        """A transport failure during hydration propagates, not SourceNotFoundError."""
+        async with NotebookLMClient(auth_tokens) as client:
+            # UPDATE_SOURCE echoes null, then the hydrate fetch blows up.
+            rpc = AsyncMock(side_effect=[None, RPCError("boom during hydrate")])
+            client._rpc_executor.rpc_call = rpc
+            with pytest.raises(RPCError):
+                await client.sources.rename("nb_123", "src_001", "New Title")
+
+    @pytest.mark.asyncio
+    async def test_rename_source_return_object_false_skips_fetch(self, auth_tokens):
+        """return_object=False returns None and issues no hydrate fetch on a null echo."""
+        async with NotebookLMClient(auth_tokens) as client:
+            rpc = AsyncMock(return_value=None)
+            client._rpc_executor.rpc_call = rpc
+            result = await client.sources.rename(
+                "nb_123", "src_001", "New Title", return_object=False
+            )
+
+        assert result is None
+        # Only the UPDATE_SOURCE call — no hydrate fetch.
+        rpc.assert_awaited_once()
 
 
 class TestAddFileSource:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -844,7 +844,7 @@ class TestSourcesAdditionalAPI:
             assert source is not None
             # Delete it
             result = await client.sources.delete(MUTABLE_NOTEBOOK_ID, source.id)
-        assert result is True
+        assert result is None
 
 
 # =============================================================================
@@ -878,7 +878,7 @@ class TestNotebooksAdditionalAPI:
             assert notebook is not None
             # Delete it
             result = await client.notebooks.delete(notebook.id)
-        assert result is True
+        assert result is None
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -914,7 +914,7 @@ class TestNotesAdditionalAPI:
             assert note is not None
             # Delete it
             result = await client.notes.delete(MUTABLE_NOTEBOOK_ID, note.id)
-        assert result is True
+        assert result is None
 
 
 # =============================================================================
@@ -937,10 +937,15 @@ class TestArtifactsAdditionalAPI:
                 pytest.skip("No artifacts available")
             artifact = artifacts[0]
             original_title = artifact.title
-            # Rename
-            await client.artifacts.rename(MUTABLE_NOTEBOOK_ID, artifact.id, "VCR Renamed Artifact")
+            # Rename. return_object=False skips the post-rename re-fetch so the
+            # existing cassette (rename RPC only) keeps replaying (issue #1255).
+            await client.artifacts.rename(
+                MUTABLE_NOTEBOOK_ID, artifact.id, "VCR Renamed Artifact", return_object=False
+            )
             # Restore original name
-            await client.artifacts.rename(MUTABLE_NOTEBOOK_ID, artifact.id, original_title)
+            await client.artifacts.rename(
+                MUTABLE_NOTEBOOK_ID, artifact.id, original_title, return_object=False
+            )
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -955,7 +960,7 @@ class TestArtifactsAdditionalAPI:
             # Delete the first one
             artifact_id = artifacts[0].id
             deleted = await client.artifacts.delete(MUTABLE_NOTEBOOK_ID, artifact_id)
-        assert deleted is True
+        assert deleted is None
 
     @pytest.mark.vcr
     @pytest.mark.asyncio

--- a/tests/integration/test_workflow_tracer_vcr.py
+++ b/tests/integration/test_workflow_tracer_vcr.py
@@ -223,7 +223,7 @@ class TestWorkflowTracerBullet:
                 # earlier assertion fails. Captured in the cassette so replay
                 # also drives the delete RPC.
                 deleted = await client.notebooks.delete(notebook_id)
-                assert deleted is True
+                assert deleted is None
 
     def test_cassette_size_under_budget(self) -> None:
         """Cassette stays under the 5 MB budget documented in the module docstring.

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -529,8 +529,10 @@ class TestArtifactRename:
 
             assert result.exit_code == 0
             assert "Renamed" in result.output
+            # The CLI ignores the rename return, so it passes return_object=False
+            # to skip the (unused) hydrate re-fetch.
             mock_client.mind_maps.rename.assert_awaited_once_with(
-                "nb_123", "mm_123", "New Title", kind=map_kind
+                "nb_123", "mm_123", "New Title", kind=map_kind, return_object=False
             )
             # Mind maps never fall through to the regular-artifact rename path.
             mock_client.artifacts.rename.assert_not_called()

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -574,6 +574,9 @@ class TestNotebookDelete:
             assert "Cleared current notebook context" in result.output
 
     def test_notebook_delete_failure(self, runner, mock_auth):
+        """A real delete failure now raises (v0.7.0): delete() returns None and
+        propagates RPC/transport errors instead of signalling failure via a
+        falsy return (issue #1211)."""
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             # Mock list for partial ID resolution
@@ -587,7 +590,7 @@ class TestNotebookDelete:
                     ),
                 ]
             )
-            mock_client.notebooks.delete = AsyncMock(return_value=False)
+            mock_client.notebooks.delete = AsyncMock(side_effect=RPCError("delete blew up"))
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -596,8 +599,7 @@ class TestNotebookDelete:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["delete", "-n", "nb_123", "-y"])
 
-            assert result.exit_code == 0
-            assert "Delete may have failed" in result.output
+            assert result.exit_code == 1
 
     def test_notebook_delete_json(self, runner, mock_auth):
         """--json with --yes emits a parseable success envelope (issue #1167)."""

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -686,13 +686,18 @@ class TestSourceDelete:
             mock_client.sources.delete.assert_not_called()
 
     def test_source_delete_failure(self, runner, mock_auth):
+        """A real delete failure now raises (v0.7.0): delete() returns None and
+        propagates RPC/transport errors instead of signalling failure via a
+        falsy return (issue #1211)."""
+        from notebooklm.exceptions import RPCError
+
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock sources.list for source delete resolution
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_123", title="Test Source")]
             )
-            mock_client.sources.delete = AsyncMock(return_value=False)
+            mock_client.sources.delete = AsyncMock(side_effect=RPCError("delete blew up"))
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -701,8 +706,7 @@ class TestSourceDelete:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["source", "delete", "src_123", "-n", "nb_123", "-y"])
 
-            assert result.exit_code == 0
-            assert "Delete may have failed" in result.output
+            assert result.exit_code == 1
 
     def test_source_delete_full_uuid_skips_source_list(self, runner, mock_auth):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -81,13 +81,23 @@ async def test_rename_dispatches_by_kind():
 @pytest.mark.asyncio
 async def test_rename_returns_renamed_mind_map():
     # Note-backed: the post-rename list reflects the new title; rename returns it.
+    # Current row shape carries the title in the inner envelope at row[1][4]
+    # (see NoteRow.title); extract_content reads row[1] (the JSON tree string).
     api, _, mind_maps, artifacts, _ = _make_api(
-        note_rows=[["note_mm", '{"name": "NB", "children": []}', None, None, "New Title"]]
+        note_rows=[
+            [
+                "note_mm",
+                ["note_mm", '{"name": "NB", "children": []}', None, None, "New Title"],
+            ]
+        ]
     )
     result = await api.rename("nb", "note_mm", "New Title", kind=MindMapKind.NOTE_BACKED)
     assert result is not None
     assert result.id == "note_mm"
     assert result.kind == MindMapKind.NOTE_BACKED
+    # Server-reflected title (NoteRow.title slot), not the input echoed back —
+    # guards against re-fetching a stale row with the old title.
+    assert result.title == "New Title"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -63,21 +63,47 @@ async def test_list_unions_both_backings():
 async def test_rename_dispatches_by_kind():
     # The explicit-interactive path pre-validates the id (issue #1270), so the
     # interactive artifact must exist for the rename to dispatch.
+    # return_object=False keeps this focused on dispatch (no hydrate re-fetch).
     api, _, mind_maps, artifacts, _ = _make_api(interactive=[_interactive_artifact("int_mm")])
-    await api.rename("nb", "note_mm", "X", kind=MindMapKind.NOTE_BACKED)
+    assert (
+        await api.rename("nb", "note_mm", "X", kind=MindMapKind.NOTE_BACKED, return_object=False)
+        is None
+    )
     mind_maps.rename_mind_map.assert_awaited_once_with("nb", "note_mm", "X")
     artifacts.rename.assert_not_awaited()
 
-    await api.rename("nb", "int_mm", "Y", kind=MindMapKind.INTERACTIVE)
-    artifacts.rename.assert_awaited_once_with("nb", "int_mm", "Y")
+    await api.rename("nb", "int_mm", "Y", kind=MindMapKind.INTERACTIVE, return_object=False)
+    # The interactive artifact rename is delegated with return_object=False so
+    # the unified API hydrates once (not twice) when an object is requested.
+    artifacts.rename.assert_awaited_once_with("nb", "int_mm", "Y", return_object=False)
+
+
+@pytest.mark.asyncio
+async def test_rename_returns_renamed_mind_map():
+    # Note-backed: the post-rename list reflects the new title; rename returns it.
+    api, _, mind_maps, artifacts, _ = _make_api(
+        note_rows=[["note_mm", '{"name": "NB", "children": []}', None, None, "New Title"]]
+    )
+    result = await api.rename("nb", "note_mm", "New Title", kind=MindMapKind.NOTE_BACKED)
+    assert result is not None
+    assert result.id == "note_mm"
+    assert result.kind == MindMapKind.NOTE_BACKED
+
+
+@pytest.mark.asyncio
+async def test_rename_missing_raises():
+    # Auto-detect path: the id is in neither backing → ValueError.
+    api, *_ = _make_api()
+    with pytest.raises(ValueError, match="not found"):
+        await api.rename("nb", "ghost", "X")
 
 
 @pytest.mark.asyncio
 async def test_delete_dispatches_by_kind():
     api, _, mind_maps, artifacts, _ = _make_api()
-    assert await api.delete("nb", "note_mm", kind=MindMapKind.NOTE_BACKED) is True
+    assert await api.delete("nb", "note_mm", kind=MindMapKind.NOTE_BACKED) is None
     mind_maps.delete_mind_map.assert_awaited_once_with("nb", "note_mm")
-    assert await api.delete("nb", "int_mm", kind=MindMapKind.INTERACTIVE) is True
+    assert await api.delete("nb", "int_mm", kind=MindMapKind.INTERACTIVE) is None
     artifacts.delete.assert_awaited_once_with("nb", "int_mm")
 
 
@@ -277,8 +303,10 @@ async def test_rename_interactive_bad_id_raises_not_silent_noop():
 @pytest.mark.asyncio
 async def test_rename_interactive_good_id_dispatches():
     api, _, _, artifacts, _ = _make_api(interactive=[_interactive_artifact("real_int")])
-    await api.rename("nb", "real_int", "X", kind=MindMapKind.INTERACTIVE)
-    artifacts.rename.assert_awaited_once_with("nb", "real_int", "X")
+    await api.rename("nb", "real_int", "X", kind=MindMapKind.INTERACTIVE, return_object=False)
+    # The unified API delegates with return_object=False (it hydrates once, here
+    # skipped) — the artifact rename is not asked to re-fetch.
+    artifacts.rename.assert_awaited_once_with("nb", "real_int", "X", return_object=False)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_note_backed_mind_map_service.py
+++ b/tests/unit/test_note_backed_mind_map_service.py
@@ -78,12 +78,13 @@ class TestExtractContent:
 
 class TestDeleteMindMap:
     @pytest.mark.asyncio
-    async def test_delete_mind_map_delegates_and_returns_bool(
+    async def test_delete_mind_map_delegates_and_returns_none(
         self, service: NoteBackedMindMapService, mock_notes: MagicMock
     ) -> None:
-        mock_notes.delete_note = AsyncMock(return_value=True)
+        mock_notes.delete_note = AsyncMock(return_value=None)
 
-        assert await service.delete_mind_map("nb_abc", "mm_1") is True
+        # v0.7.0: delete now returns None (issue #1211).
+        assert await service.delete_mind_map("nb_abc", "mm_1") is None
 
         mock_notes.delete_note.assert_awaited_once_with("nb_abc", "mm_1")
 

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -238,10 +238,11 @@ class TestCrud:
         )
 
     @pytest.mark.asyncio
-    async def test_delete_note_returns_true_and_sends_soft_delete(
+    async def test_delete_note_returns_none_and_sends_soft_delete(
         self, service: NoteService, mock_session: FakeSession
     ) -> None:
-        assert await service.delete_note("nb_123", "note_123") is True
+        # v0.7.0: delete_note returns None (issue #1211).
+        assert await service.delete_note("nb_123", "note_123") is None
 
         mock_session.rpc_executor.rpc_call.assert_awaited_once_with(
             RPCMethod.DELETE_NOTE,

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -589,13 +589,13 @@ class TestDeleteNote:
     """Tests for delete() method."""
 
     @pytest.mark.asyncio
-    async def test_delete_returns_true(self, notes_api, mock_core):
-        """Test that delete() always returns True."""
+    async def test_delete_returns_none(self, notes_api, mock_core):
+        """Test that delete() returns None (v0.7.0, issue #1211)."""
         mock_core.rpc_executor.rpc_call.return_value = None
 
         result = await notes_api.delete("nb_123", "note_456")
 
-        assert result is True
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_delete_calls_rpc_with_correct_params(self, notes_api, mock_core):
@@ -659,13 +659,13 @@ class TestDeleteMindMap:
     """Tests for delete_mind_map() method."""
 
     @pytest.mark.asyncio
-    async def test_delete_mind_map_returns_true(self, notes_api, mock_core):
-        """Test that delete_mind_map() always returns True."""
+    async def test_delete_mind_map_returns_none(self, notes_api, mock_core):
+        """Test that delete_mind_map() returns None (v0.7.0, issue #1211)."""
         mock_core.rpc_executor.rpc_call.return_value = None
 
         result = await notes_api.delete_mind_map("nb_123", "mm_456")
 
-        assert result is True
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_delete_mind_map_uses_same_rpc_as_delete(self, notes_api, mock_core):


### PR DESCRIPTION
## Summary

v0.7.0 rename/delete API-consistency changes. `rename()` now returns the
renamed object and fails loud on a missing target; `delete()` returns `None`
and is idempotent on a missing target. Bumps the version to `0.7.0.dev0`.

Fixes #1255
Fixes #1211
(applies the same policy to the `mind_maps` surface from #1256)

This is a deliberate **BREAKING** change (0.7.0) — and a *clean break with no
deprecation runway*, because the old returns were never usable contracts:
`artifacts.rename` returned `None` even on success, and `sources.rename`
*fabricated* an unverified `Source`. Contrast `get()`'s `None`-on-miss, which
**is** a real contract and keeps its full deprecation runway to v0.8.0 (#1247).
The coherent story: **reads/renames are missing-strict; deletes are
absence-idempotent.**

## Per-method before → after

| Method | Before | After |
|---|---|---|
| `notebooks.rename` | `-> Notebook` (re-fetch + raise) | unchanged (reference impl) |
| `notebooks.delete` | `-> bool` (always `True`) | `-> None` (idempotent) |
| `sources.rename` | `-> Source`, **fabricates** `Source(id,title)` on null echo | `-> Source \| None`; echo-or-fetch, **raises `SourceNotFoundError`** on missing; `return_object=False` opt-out |
| `sources.delete` | `-> bool` (always `True`) | `-> None` (idempotent) |
| `artifacts.rename` | `-> None` (even on success) | `-> Artifact \| None`; re-fetch (studio-only), **raises `ArtifactNotFoundError`** on missing; `return_object=False` opt-out |
| `artifacts.delete` | `-> bool` (always `True`) | `-> None` (idempotent) |
| `notes.delete` | `-> bool` (always `True`) | `-> None` (idempotent) |
| `notes.delete_mind_map` | `-> bool` (always `True`) | `-> None` (idempotent) |
| `mind_maps.rename` | `-> None` | `-> MindMap \| None`; re-fetch, raises `ValueError` on missing; `return_object=False` opt-out |
| `mind_maps.delete` | `-> bool` (always `True`) | `-> None` (idempotent when `kind=` passed) |

## Breaking-change notes

- **`True → None` flips truthy → falsy.** Code written as
  `if await client.X.delete(id): ...` no longer enters its block. The old
  `True` was a tautology (never `False`), but the flip is real and observable.
  Drop the `if`; call `delete()` for its effect. Use `get()` first to assert
  existence.
- **`delete()` is idempotent on missing:** deleting an already-absent target
  succeeds (returns `None`), it does **not** raise `*NotFoundError`. (Exception:
  `mind_maps.delete` *without* `kind=` must list to pick the RPC family, so it
  raises `ValueError` for an unknown id — pass `kind=` for idempotent delete.)
- **`delete()` still raises on real failures:** `403`/`5xx`/auth/transport
  errors propagate (`allow_null=True` tolerates only a null *result*).
- **`sources.rename` no longer fabricates** an unverified `Source`.
- **Error taxonomy:** only *genuine absence* (empty-payload / absent-from-list,
  detected via a content/list lookup — **not** a transport 404) maps to a
  `*NotFoundError`. Transport / `429` / `5xx` / auth errors propagate **as
  themselves**, never laundered into a synthetic `*NotFoundError`.
- **`return_object=False` bulk opt-out** on every `rename()` skips the hydrate
  re-fetch (artifacts' re-fetch is a full `LIST_ARTIFACTS`) — and, per that
  opt-out, also skips missing-target detection (documented on each method).
- **`artifacts.rename` hydrates studio artifacts only:** a note-backed
  mind-map id (which `RENAME_ARTIFACT` no-ops on) is treated as absent and
  raises — steering callers to `mind_maps.rename` instead of reading back a
  stale "success."

## Tests added (behavior, via public API)

- rename returns the **re-fetched** object (server-reflected title, not the
  input); `sources.rename` uses the echo when present and no longer fabricates.
- rename of a missing target raises `*NotFoundError` (content/list detection).
- a transport failure during hydration raises the **real** error, not
  `*NotFoundError`.
- `return_object=False` skips hydration and returns `None`.
- a note-backed mind-map id to `artifacts.rename` raises (studio-only hydrate).
- `delete()` returns `None`; the VCR/e2e delete tests assert `None`.
- the `mind_maps.rename`/`delete` variants across both backends.

## Verification

- `pytest`: **7839 passed, 52 skipped** (full suite, e2e excluded).
- `ruff format` + `ruff check`: clean.
- `mypy src/notebooklm --ignore-missing-imports`: clean (188 files).
- CI gates run locally: `check_deprecation_targets` (no deprecation targets
  the shipping version — none added), `audit_public_api_compat` (exit 0;
  return-type changes are call-compatible, only the new keyword-only
  `return_object` param), `check_claude_md_freshness`, `check_method_coverage`,
  `check_cassettes_clean --strict` (0 leaks) — all green.
- No new cassettes recorded; existing rename/delete cassettes replay (artifact
  rename VCR/polling tests pass `return_object=False` to keep the recorded
  interaction count).

Polish: codex review (read-only) — all Critical/Important findings addressed
(sources.rename `return_object=False` now skips hydration regardless of echo;
`return_object=False` missing-detection tradeoff documented; artifact rename
hydrates studio-only to avoid stale note-backed mind-map "success"; docs and
e2e delete assertions updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Delete operations now return None and are idempotent for missing targets.
  * Rename operations default to returning the renamed object; genuine missing targets raise NotFound while transport/HTTP errors propagate.
  * Mind-map rename/delete can require an explicit kind for ambiguous ids (ValueError if unknown).

* **New Features**
  * rename(..., return_object=False) opt-out skips re-fetch and returns None.

* **Documentation**
  * Changelog and API docs updated for v0.7.0 semantics.

* **Tests**
  * Tests adjusted to reflect new return semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->