### PR TITLE
fix(cli): enforce json validation errors

### DIFF
--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -101,7 +101,7 @@ def _output_error(
     exit_code: int,
     extra: dict[str, Any] | None = None,
     hint: str | None = None,
-) -> None:
+) -> NoReturn:
     """Output error message in text or JSON format and exit.
 
     Args:

--- a/src/notebooklm/cli/grouped.py
+++ b/src/notebooklm/cli/grouped.py
@@ -13,9 +13,36 @@ unbinned, untagged top-level command will fail the suite, surfacing the
 discoverability regression at PR review time.
 """
 
+import sys
 from collections import OrderedDict
+from collections.abc import Sequence
+from typing import Any, NoReturn
 
 import click
+
+from .error_handler import exit_with_code, output_error
+
+
+def _json_requested(args: Sequence[str] | None) -> bool:
+    """Return true when the raw command line includes the ``--json`` flag."""
+    if args is None:
+        args = sys.argv[1:]
+    for arg in args:
+        if arg == "--":
+            return False
+        if arg == "--json":
+            return True
+    return False
+
+
+def _emit_json_click_error(exc: click.ClickException) -> NoReturn:
+    """Emit a Click exception through the canonical JSON error envelope."""
+    output_error(
+        exc.format_message(),
+        "VALIDATION_ERROR",
+        json_output=True,
+        exit_code=exc.exit_code,
+    )
 
 
 class SectionedGroup(click.Group):
@@ -60,6 +87,53 @@ class SectionedGroup(click.Group):
             ("Artifact Actions (use: notebooklm <action> <type>)", ["generate", "download"]),
         ]
     )
+
+    def main(
+        self,
+        args: Sequence[str] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        """Run the CLI while honoring ``--json`` for Click validation errors.
+
+        Click renders parser and callback ``ClickException`` failures itself
+        before command bodies run, which bypasses the normal ``handle_errors``
+        JSON path. Running the superclass in non-standalone mode lets this root
+        boundary convert those failures once for every current and future
+        subcommand option.
+        """
+        try:
+            rv = super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                windows_expand_args=windows_expand_args,
+                **extra,
+            )
+        except click.ClickException as exc:
+            if not standalone_mode:
+                raise
+            if _json_requested(args):
+                _emit_json_click_error(exc)
+            else:
+                exc.show()
+                exit_with_code(exc.exit_code)
+        except click.Abort:
+            if not standalone_mode:
+                raise
+            if _json_requested(args):
+                output_error("Cancelled by user", "CANCELLED", json_output=True, exit_code=1)
+            else:
+                click.echo("Aborted!", file=sys.stderr)
+                exit_with_code(1)
+
+        if standalone_mode:
+            exit_with_code(0)
+        return rv
 
     def format_commands(self, ctx, formatter):
         """Override to display commands in sections."""

--- a/tests/unit/cli/test_json_validation_contract.py
+++ b/tests/unit/cli/test_json_validation_contract.py
@@ -1,0 +1,195 @@
+"""Root-boundary guard for ``--json`` validation errors.
+
+Click validates option values, missing arguments, and unknown options before
+command callbacks run. Those failures must still honor ``--json`` so automation
+never receives usage text when it asked for a machine-readable error.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.cli.grouped import SectionedGroup
+from notebooklm.notebooklm_cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.3 captures stdout/stderr separately by default; mix_stderr was removed.
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth_env() -> Iterator[None]:
+    with (
+        patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_load.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        mock_fetch.return_value = ("csrf", "session")
+        yield
+
+
+@pytest.mark.parametrize(
+    "case_id,argv",
+    [
+        ("invalid_limit", ["list", "--limit", "-1", "--json"]),
+        ("invalid_interval", ["research", "wait", "--interval", "0", "--json"]),
+        ("invalid_retry", ["generate", "audio", "--retry", "-1", "--json"]),
+        ("missing_argument", ["note", "get", "--json"]),
+        ("unknown_option", ["list", "--json", "--definitely-not-an-option"]),
+        ("root_callback_validation", ["--quiet", "-v", "status", "--json"]),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_json_validation_errors_emit_json(
+    case_id: str,
+    argv: list[str],
+    runner: CliRunner,
+) -> None:
+    result = runner.invoke(cli, argv, catch_exceptions=False)
+
+    assert result.exit_code != 0, result.output
+    assert result.stdout.strip(), f"{case_id}: expected JSON error on stdout"
+    assert result.stderr == "", f"{case_id}: stderr should stay empty under --json"
+    assert result.output == result.stdout, f"{case_id}: combined output should be JSON only"
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert payload["message"]
+
+
+def test_command_body_click_validation_emit_json(
+    runner: CliRunner,
+    mock_auth_env,
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["note", "create", "positional", "--content", "flag", "-n", "nb_123", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0, result.output
+    assert result.stderr == ""
+    assert result.output == result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert "Cannot use both" in payload["message"]
+
+
+def test_json_abort_emit_json(runner: CliRunner) -> None:
+    @click.group(cls=SectionedGroup)
+    def root() -> None:
+        pass
+
+    @root.command()
+    @click.option("--json", "json_output", is_flag=True)
+    def aborting(json_output: bool) -> None:  # noqa: ARG001
+        raise click.Abort()
+
+    result = runner.invoke(root, ["aborting", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert result.stderr == ""
+    assert result.output == result.stdout
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "error": True,
+        "code": "CANCELLED",
+        "message": "Cancelled by user",
+    }
+
+
+def _walk_leaf_commands(
+    command: click.BaseCommand,
+    path: tuple[str, ...] = (),
+) -> Iterator[tuple[tuple[str, ...], click.Command]]:
+    if isinstance(command, click.Group):
+        for name, child in command.commands.items():
+            yield from _walk_leaf_commands(child, path + (name,))
+        return
+    if isinstance(command, click.Command):
+        yield path, command
+
+
+def _has_json_option(command: click.Command) -> bool:
+    return any(
+        isinstance(param, click.Option) and "--json" in param.opts for param in command.params
+    )
+
+
+def _invalid_value_for_type(param_type: click.ParamType) -> str | None:
+    if isinstance(param_type, click.IntRange):
+        if param_type.min is not None:
+            return str(param_type.min - 1)
+        if param_type.max is not None:
+            return str(param_type.max + 1)
+        return "not-an-int"
+    if isinstance(param_type, click.types.IntParamType):
+        return "not-an-int"
+    if isinstance(param_type, click.Choice):
+        return "__not_a_valid_choice__"
+    return None
+
+
+def _validated_json_option_cases() -> list[pytest.ParameterSet]:
+    cases: list[pytest.ParameterSet] = []
+    for path, command in _walk_leaf_commands(cli):
+        if not _has_json_option(command):
+            continue
+        for param in command.params:
+            if (
+                not isinstance(param, click.Option)
+                or "--json" in param.opts
+                or param.is_flag
+                or param.count
+            ):
+                continue
+            value = _invalid_value_for_type(param.type)
+            if value is None:
+                continue
+            opt = next((name for name in param.opts if name.startswith("--")), param.opts[0])
+            case_id = "_".join((*path, opt.lstrip("-").replace("-", "_")))
+            cases.append(pytest.param(case_id, [*path, opt, value, "--json"], id=case_id))
+    return cases
+
+
+@pytest.mark.parametrize(
+    "case_id,argv",
+    _validated_json_option_cases(),
+)
+def test_validated_json_options_emit_json_on_bad_values(
+    case_id: str,
+    argv: list[str],
+    runner: CliRunner,
+) -> None:
+    result = runner.invoke(cli, argv, catch_exceptions=False)
+
+    assert result.exit_code != 0, result.output
+    assert result.stderr == "", f"{case_id}: stderr should stay empty under --json"
+    assert result.output == result.stdout, f"{case_id}: combined output should be JSON only"
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "VALIDATION_ERROR"
+
+
+def test_text_validation_errors_keep_click_usage_output(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["list", "--limit", "-1"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "Usage:" in result.stderr
+    assert not result.stdout.strip().startswith("{")


### PR DESCRIPTION
## Summary
- Route root Click validation failures through the canonical JSON error envelope when `--json` is present.
- Preserve text-mode Click usage output for non-JSON callers.
- Add regression coverage for parser validation, command-body Click validation, abort handling, and a dynamic guard over all validated `--json` options.

## Test plan
- `uv run --frozen ruff check src/notebooklm/cli/grouped.py tests/unit/cli/test_json_validation_contract.py`
- `uv run --frozen mypy src/notebooklm`
- `uv run --frozen pytest tests/unit/cli/test_json_validation_contract.py tests/_lint/test_error_handler_allowlist.py -q`
- `uv run --frozen pytest tests/unit/cli -q`

## Review note
This PR was opened manually at user request instead of via the full `pr-workflow` pipeline. Codex and Antigravity review passes were clean; the local Claude CLI repeatedly timed out with no output on the real diff, so the Claude polish lane did not complete before PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI validation and cancellation now emit structured JSON error responses when --json is used, covering option/value validation, missing/unknown args, and user cancellation (CANCELLED).

* **Tests**
  * Added comprehensive tests validating the JSON error contract across validation, command-body checks, invalid option values, and abort/cancel flows.

* **Refactor**
  * Clarified error-output behavior to always terminate with the appropriate exit code and consistent JSON envelope when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->