### PR TITLE
fix(test): deflake keepalive retry assertion

### DIFF
--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -95,7 +95,8 @@ async def _wait_for_rotate_requests(
         await asyncio.sleep(0.05)
 
     requests = _rotate_requests(httpx_mock)
-    pytest.fail(f"{failure_message}; got {len(requests)}")
+    if len(requests) < minimum:
+        pytest.fail(f"{failure_message}; got {len(requests)}")
 
 
 class TestKeepaliveDisabledByDefault:

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -76,6 +76,28 @@ async def _wait_until_storage_contains(storage_path, needle: str, failure_messag
     pytest.fail(failure_message)
 
 
+def _rotate_requests(httpx_mock: HTTPXMock) -> list[httpx.Request]:
+    return [r for r in httpx_mock.get_requests() if ROTATE_URL_RE.match(str(r.url))]
+
+
+async def _wait_for_rotate_requests(
+    httpx_mock: HTTPXMock,
+    *,
+    minimum: int,
+    failure_message: str,
+) -> None:
+    """Wait until the background keepalive task has emitted RotateCookies requests."""
+    requests: list[httpx.Request] = []
+    for _ in range(50):
+        requests = _rotate_requests(httpx_mock)
+        if len(requests) >= minimum:
+            return
+        await asyncio.sleep(0.05)
+
+    requests = _rotate_requests(httpx_mock)
+    pytest.fail(f"{failure_message}; got {len(requests)}")
+
+
 class TestKeepaliveDisabledByDefault:
     @pytest.mark.asyncio
     async def test_keepalive_off_by_default(self, mock_auth, httpx_mock: HTTPXMock):
@@ -193,12 +215,11 @@ class TestKeepalivePokes:
         )
 
         async with client:
-            await asyncio.sleep(0.5)
-
-        poke_requests = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
-        assert len(poke_requests) >= 2, (
-            f"Expected at least 2 keepalive pokes, got {len(poke_requests)}"
-        )
+            await _wait_for_rotate_requests(
+                httpx_mock,
+                minimum=2,
+                failure_message="Expected at least 2 keepalive pokes",
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.no_default_keepalive_mock
@@ -230,16 +251,19 @@ class TestKeepalivePokes:
         )
 
         async with client:
-            await asyncio.sleep(0.4)
+            await _wait_for_rotate_requests(
+                httpx_mock,
+                minimum=1,
+                failure_message="Expected first keepalive poke",
+            )
             # Task is still running after the failure
             assert client._collaborators.lifecycle._keepalive_task is not None
             assert not client._collaborators.lifecycle._keepalive_task.done()
-
-        poke_requests = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
-        # First call raised; at least one further successful call must follow.
-        assert len(poke_requests) >= 2, (
-            f"Loop should have retried after failure; got {len(poke_requests)} pokes"
-        )
+            await _wait_for_rotate_requests(
+                httpx_mock,
+                minimum=2,
+                failure_message="Loop should have retried after failure",
+            )
 
 
 class TestKeepalivePersistenceFailure:

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Replace fixed sleeps in keepalive poke tests with bounded request-count polling while the client is open.
- Keep the failure-path assertion inside the active keepalive context so CI scheduling delays do not cancel the retry before it is observed.
- Sync the editable package version in `uv.lock` with the already-committed `pyproject.toml` version (`0.7.0`) so frozen uv installs remain consistent.

## Test plan
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`
- [x] 100x loop of `tests/unit/test_client_keepalive.py::TestKeepalivePokes::test_failure_does_not_crash_loop`

## Deferred polish findings
- Polling loop constants remain inline to match the existing helper style in `tests/unit/test_client_keepalive.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved keepalive test reliability by replacing fixed waits with polling-based helpers that wait for observed rotate requests; tests now assert the loop continues and retries after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->