### PR TITLE
test(cli): make exit-path allowlists robust to line shifts (closes #1298)

### DIFF
--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -360,7 +360,12 @@ def register_chat_commands(cli):
                             )
                         except Exception as e:
                             note_save_error = str(e)
-                            emit_status(
+                            # Note-save is a secondary `--save-as-note` action;
+                            # emit_status keeps the warning non-fatal so the chat
+                            # response payload still prints. output_error would
+                            # SystemExit(1) and abort that payload. Revisit when
+                            # save-as-note gains a structured non-fatal error channel.
+                            emit_status(  # quiet-ok: non-fatal warning for a secondary --save-as-note action
                                 f"[yellow]Warning: Failed to save note: {e}[/yellow]",
                                 json_output=json_output,
                             )

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -27,36 +27,12 @@ from ._encoding import safe_echo
 
 logger = logging.getLogger(__name__)
 
-# Sites where direct Click exceptions remain appropriate because they are
-# input-validation boundaries before command output is committed. The lint in
-# ``tests/_lint/test_error_handler_allowlist.py`` keeps this list exact.
-ALLOWED_CLICK_EXCEPTION_SITES: list[tuple[str, int, str]] = [
-    ("src/notebooklm/cli/input.py", 31, "stdin must decode as UTF-8 before command body runs"),
-    ("src/notebooklm/cli/input.py", 80, "prompt-file path validation"),
-    ("src/notebooklm/cli/input.py", 84, "prompt-file read validation"),
-    ("src/notebooklm/cli/input.py", 86, "prompt-file UTF-8 validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 52, "profile name validation translation"),
-    ("src/notebooklm/cli/profile_cmd.py", 53, "profile name validation translation"),
-    ("src/notebooklm/cli/profile_cmd.py", 176, "profile path/name validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 178, "profile create duplicate validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 198, "profile path/name validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 202, "profile switch target validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 216, "profile config write validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 255, "profile path/name validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 261, "profile delete active/default validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 267, "profile delete target validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 294, "profile path/name validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 297, "profile rename source validation"),
-    ("src/notebooklm/cli/profile_cmd.py", 299, "profile rename destination validation"),
-    ("src/notebooklm/cli/resolve.py", 58, "entity ID argument validation"),
-    ("src/notebooklm/cli/session_cmd.py", 161, "login profile-name validation translation"),
-    ("src/notebooklm/cli/session_cmd.py", 162, "login profile-name validation translation"),
-]
-
-# Raw ``raise SystemExit`` should live in this module. If a future path truly
-# cannot route through ``exit_with_code``/``_output_error``, it must be listed
-# here with a reason.
-ALLOWED_RAW_SYSEXIT_SITES: list[tuple[str, int, str]] = []
+# NOTE: ``click.ClickException`` / raw ``raise SystemExit`` sites outside this
+# module are governed by inline marker comments
+# (``# cli-input-validation: <reason>`` / ``# cli-raw-exit: <reason>``), checked
+# by ``tests/_lint/test_error_handler_allowlist.py``. The previous
+# ``ALLOWED_*_SITES`` line-number allowlists were removed in issue #1298 because
+# any edit above a site shifted its line and failed CI with no behavior change.
 
 
 def current_json_output(default: bool = False) -> bool:

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -28,7 +28,9 @@ def read_stdin_text(*, source_label: str = "stdin") -> str:
     try:
         text = click.get_text_stream("stdin").read()
     except UnicodeDecodeError as e:
-        raise click.ClickException(f"{source_label} (stdin) is not valid UTF-8: {e}") from e
+        raise click.ClickException(  # cli-input-validation: stdin must decode as UTF-8 before command body runs
+            f"{source_label} (stdin) is not valid UTF-8: {e}"
+        ) from e
     return text.strip()
 
 
@@ -77,13 +79,17 @@ def resolve_prompt(
     elif prompt_file:
         path = Path(prompt_file)
         if not path.is_file():
-            raise click.ClickException(f"Prompt file '{prompt_file}' is not a regular file.")
+            raise click.ClickException(  # cli-input-validation: prompt-file path validation
+                f"Prompt file '{prompt_file}' is not a regular file."
+            )
         try:
             text = path.read_text(encoding="utf-8").strip()
         except OSError as e:
-            raise click.ClickException(f"Failed to read prompt file '{prompt_file}': {e}") from e
+            raise click.ClickException(  # cli-input-validation: prompt-file read validation
+                f"Failed to read prompt file '{prompt_file}': {e}"
+            ) from e
         except UnicodeDecodeError as e:
-            raise click.ClickException(
+            raise click.ClickException(  # cli-input-validation: prompt-file UTF-8 validation
                 f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
             ) from e
     else:

--- a/src/notebooklm/cli/profile_cmd.py
+++ b/src/notebooklm/cli/profile_cmd.py
@@ -49,8 +49,12 @@ def _validate_profile_name_or_click(name: str) -> str:
         return _validate_profile_name(name)
     except LoginConfigurationError as exc:
         if exc.hint:
-            raise click.ClickException(f"{exc.message} {exc.hint}") from None
-        raise click.ClickException(exc.message) from None
+            raise click.ClickException(  # cli-input-validation: profile name validation translation
+                f"{exc.message} {exc.hint}"
+            ) from None
+        raise click.ClickException(  # cli-input-validation: profile name validation translation
+            exc.message
+        ) from None
 
 
 def _read_config(config_path: Path, *, suppress_errors: bool = True) -> dict:
@@ -173,9 +177,13 @@ def create_cmd(name):
     try:
         profile_dir = get_profile_dir(name)
     except ValueError as e:
-        raise click.ClickException(str(e)) from None
+        raise click.ClickException(  # cli-input-validation: profile path/name validation
+            str(e)
+        ) from None
     if profile_dir.exists():
-        raise click.ClickException(f"Profile '{name}' already exists.")
+        raise click.ClickException(  # cli-input-validation: profile create duplicate validation
+            f"Profile '{name}' already exists."
+        )
 
     get_profile_dir(name, create=True)
     console.print(f"[green]Profile '{name}' created.[/green]")
@@ -195,11 +203,15 @@ def switch_cmd(name):
     try:
         profile_dir = get_profile_dir(name)
     except ValueError as e:
-        raise click.ClickException(str(e)) from None
+        raise click.ClickException(  # cli-input-validation: profile path/name validation
+            str(e)
+        ) from None
     if not profile_dir.exists():
         available = list_profiles()
         hint = f" Available: {', '.join(available)}" if available else ""
-        raise click.ClickException(f"Profile '{name}' not found.{hint}")
+        raise click.ClickException(  # cli-input-validation: profile switch target validation
+            f"Profile '{name}' not found.{hint}"
+        )
 
     config_path = get_config_path()
     # Capture the previous value for the status message before mutating.
@@ -213,7 +225,9 @@ def switch_cmd(name):
     try:
         _atomic_write_config(config_path, _set_default)
     except OSError as e:
-        raise click.ClickException(f"Failed to update config.json: {e}") from None
+        raise click.ClickException(  # cli-input-validation: profile config write validation
+            f"Failed to update config.json: {e}"
+        ) from None
 
     console.print(f"[green]Switched default profile: {old_profile} → {name}[/green]")
 
@@ -252,19 +266,23 @@ def delete_cmd(name, yes, confirm):
     try:
         profile_dir = get_profile_dir(name)
     except ValueError as e:
-        raise click.ClickException(str(e)) from None
+        raise click.ClickException(  # cli-input-validation: profile path/name validation
+            str(e)
+        ) from None
 
     # Block deletion of active or configured default profile
     configured_default = read_default_profile() or "default"
     effective_active = resolve_profile()
     if name in (configured_default, effective_active):
-        raise click.ClickException(
+        raise click.ClickException(  # cli-input-validation: profile delete active/default validation
             f"Cannot delete active/default profile '{name}'. "
             f"Switch to another profile first with 'notebooklm profile switch <name>'."
         )
 
     if not profile_dir.exists():
-        raise click.ClickException(f"Profile '{name}' not found.")
+        raise click.ClickException(  # cli-input-validation: profile delete target validation
+            f"Profile '{name}' not found."
+        )
 
     if not yes:
         if not click.confirm(f"Delete profile '{name}' and all its data?"):
@@ -291,12 +309,18 @@ def rename_cmd(old_name, new_name):
         old_dir = get_profile_dir(old_name)
         new_dir = get_profile_dir(new_name)
     except ValueError as e:
-        raise click.ClickException(str(e)) from None
+        raise click.ClickException(  # cli-input-validation: profile path/name validation
+            str(e)
+        ) from None
 
     if not old_dir.exists():
-        raise click.ClickException(f"Profile '{old_name}' not found.")
+        raise click.ClickException(  # cli-input-validation: profile rename source validation
+            f"Profile '{old_name}' not found."
+        )
     if new_dir.exists():
-        raise click.ClickException(f"Profile '{new_name}' already exists.")
+        raise click.ClickException(  # cli-input-validation: profile rename destination validation
+            f"Profile '{new_name}' already exists."
+        )
 
     os.rename(old_dir, new_dir)
 

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -55,7 +55,9 @@ def validate_id(entity_id: str, entity_name: str = "ID") -> str:
         click.ClickException: If ID is empty or whitespace-only.
     """
     if not entity_id or not entity_id.strip():
-        raise click.ClickException(f"{entity_name} ID cannot be empty")
+        raise click.ClickException(  # cli-input-validation: entity ID argument validation
+            f"{entity_name} ID cannot be empty"
+        )
     return entity_id.strip()
 
 

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -158,8 +158,12 @@ def _click_exception_from(exc: LoginConfigurationError) -> click.ClickException:
     final ``Error: ...`` line carries the remediation advice.
     """
     if exc.hint:
-        return click.ClickException(f"{exc.message} {exc.hint}")
-    return click.ClickException(exc.message)
+        return click.ClickException(
+            f"{exc.message} {exc.hint}"
+        )  # cli-input-validation: login profile-name validation translation
+    return click.ClickException(
+        exc.message
+    )  # cli-input-validation: login profile-name validation translation
 
 
 def _is_valid_account_metadata(metadata: dict[str, Any]) -> bool:

--- a/tests/_fixtures/cli_exit_markers.py
+++ b/tests/_fixtures/cli_exit_markers.py
@@ -1,0 +1,68 @@
+"""Shared marker-scanning helpers for the CLI exit-path lint gates.
+
+Both ``tests/_lint/test_error_handler_allowlist.py`` (``# cli-input-validation:``
+/ ``# cli-raw-exit:`` markers on ``click.ClickException`` / raw ``SystemExit``
+calls) and ``tests/unit/cli/test_quiet_enforcement.py`` (``# quiet-ok:`` waivers
+on error-path ``cli_print`` / ``emit_status`` calls) scan inline marker comments
+and match them 1:1 to call sites. The scan + match logic lives here so a fix to
+either cannot drift between the two gates (PR #1299 review).
+"""
+
+from __future__ import annotations
+
+import io
+import tokenize
+
+#: ``(start_line, end_line)`` of a call, inclusive (1-based, as ``ast`` reports).
+Span = tuple[int, int]
+
+
+def marker_reasons(source: str, marker: str) -> dict[int, str]:
+    """Map ``lineno -> reason`` for each ``# <marker> <reason>`` comment.
+
+    Uses ``tokenize`` so the marker is only recognized inside a real comment
+    token, never inside a string literal that happens to contain the text.
+    """
+    reasons: dict[int, str] = {}
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type != tokenize.COMMENT:
+            continue
+        body = tok.string.lstrip("#").strip()
+        if body.startswith(marker):
+            reasons[tok.start[0]] = body.removeprefix(marker).strip()
+    return reasons
+
+
+def match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[int], set[int]]:
+    """Greedily assign each marker line to at most one call span.
+
+    Returns ``(unmarked_indices, orphan_lines)``: indices into ``spans`` for
+    calls with no dedicated marker, and marker lines no span could claim (the
+    source moved, the call was deleted, or a call carries a redundant second
+    marker -- the stale-marker signal that keeps the annotations from rotting).
+
+    Indices (not the span tuples) are returned so a caller can map an unmarked
+    call back to its OWN label via a parallel list even when two distinct calls
+    share an identical span.
+
+    Each marker satisfies a single span (claimed, then removed from the pool),
+    so a lone marker on a line shared by two overlapping call spans leaves the
+    second span unmarked -- every audited call needs its own marker, matching
+    the per-site strength of the removed 1:1 allowlist.
+
+    Spans are processed by ascending end line (then start) and claim the lowest
+    available marker: the textbook optimal greedy for assigning each interval a
+    distinct point. A naive left-endpoint sort could let an outer span steal the
+    only marker an overlapping inner span needs and red CI on validly-marked
+    code -- the exact false-positive class these gates exist to remove.
+    """
+    unclaimed = set(marker_lines)
+    unmarked: list[int] = []
+    for idx in sorted(range(len(spans)), key=lambda i: (spans[i][1], spans[i][0])):
+        lo, hi = spans[idx]
+        claim = next((line for line in range(lo, hi + 1) if line in unclaimed), None)
+        if claim is None:
+            unmarked.append(idx)
+        else:
+            unclaimed.discard(claim)
+    return unmarked, unclaimed

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -1,19 +1,62 @@
-"""CLI exit-path allowlist enforcement."""
+"""CLI exit-path marker enforcement.
+
+``click.ClickException`` and raw ``raise SystemExit`` bypass the typed
+``{"error": true, "code": ...}`` JSON envelope owned by ``error_handler.py``.
+Every such site OUTSIDE ``error_handler.py`` must carry an inline marker
+comment naming why, so each one stays a conscious, documented choice that
+cannot silently break ``--json`` consumers.
+
+The markers follow the ``# noqa`` / ``# type: ignore`` convention -- the
+reason lives at the call site, so (unlike the previous ``(file, line)``
+allowlist) they are immune to line shifts in unrelated code and need no central
+list to regenerate (issue #1298):
+
+* ``click.ClickException(...)``  ->  ``# cli-input-validation: <reason>``
+* ``raise SystemExit(...)``      ->  ``# cli-raw-exit: <reason>``
+
+A marker may sit on any physical line spanned by its call, so multi-line calls
+can carry it on the opening or the closing line.
+
+The gate keeps its full original strength:
+
+* a NEW unmarked site fails ``test_*_sites_are_marked`` -- you cannot add an
+  un-audited exit path;
+* markers are matched 1:1 to call sites (see :func:`_match_markers`), so a
+  single marker cannot satisfy two calls that share a physical line -- each
+  audited call needs its own reason, exactly as the old per-row allowlist did;
+* a STALE marker (one no call can claim) fails
+  ``test_no_stale_or_empty_*_markers`` -- the annotations cannot rot, which is
+  the guarantee the old "no stale allowlist entries" half provided;
+* every marker must carry a non-empty reason.
+
+Raw ``SystemExit`` is governed the same way as ``click.ClickException`` -- it is
+allowed where a ``# cli-raw-exit:`` marker documents it -- and additionally
+stays bounded by ``MAX_RAW_SYSEXIT_SITES``. This is a deliberate, conscious
+relaxation of the previous gate, where ``ALLOWED_RAW_SYSEXIT_SITES = []`` made
+*any* raw ``SystemExit`` outside ``error_handler.py`` an unconditional failure.
+The canonical raw exits still live in ``error_handler.py``; the marker + ceiling
+keep new ones rare and individually justified rather than forbidden outright.
+"""
 
 from __future__ import annotations
 
 import ast
+import io
+import tokenize
+from collections.abc import Callable
 from pathlib import Path
-
-from notebooklm.cli.error_handler import (
-    ALLOWED_CLICK_EXCEPTION_SITES,
-    ALLOWED_RAW_SYSEXIT_SITES,
-)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
 
-AllowedSite = tuple[str, int]
+CLICK_EXCEPTION_MARKER = "cli-input-validation:"
+RAW_SYSEXIT_MARKER = "cli-raw-exit:"
+
+# Defense-in-depth ceiling: raw ``SystemExit`` outside ``error_handler.py``
+# must stay rare even when individually marked.
+MAX_RAW_SYSEXIT_SITES = 5
+
+Span = tuple[int, int]
 
 
 def _call_name(node: ast.AST) -> str:
@@ -25,64 +68,190 @@ def _call_name(node: ast.AST) -> str:
     return ""
 
 
-def _allowed_sites(entries: list[tuple[str, int, str]]) -> set[AllowedSite]:
-    return {(path, line) for path, line, _reason in entries}
+def _cli_files() -> list[Path]:
+    """Every ``cli/*.py`` except ``error_handler.py`` (which owns the exits)."""
+    return [p for p in sorted(CLI_ROOT.rglob("*.py")) if p.name != "error_handler.py"]
 
 
-def _format_sites(sites: set[AllowedSite]) -> str:
-    return "\n".join(f"{path}:{line}" for path, line in sorted(sites))
+def _marker_reasons(source: str, marker: str) -> dict[int, str]:
+    """Map ``lineno -> reason`` for each ``# <marker> <reason>`` comment.
 
-
-def _raw_system_exit_sites() -> set[AllowedSite]:
-    sites: set[AllowedSite] = set()
-    for path in sorted(CLI_ROOT.rglob("*.py")):
-        if path.name == "error_handler.py":
+    Uses ``tokenize`` so the marker is only recognized inside a real comment
+    token, never inside a string literal that happens to contain the text.
+    """
+    reasons: dict[int, str] = {}
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type != tokenize.COMMENT:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        rel_path = path.relative_to(REPO_ROOT).as_posix()
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
-                continue
-            if _call_name(node.exc.func) == "SystemExit":
-                sites.add((rel_path, node.lineno))
-    return sites
+        body = tok.string.lstrip("#").strip()
+        if body.startswith(marker):
+            reasons[tok.start[0]] = body.removeprefix(marker).strip()
+    return reasons
 
 
-def _click_exception_call_sites() -> set[AllowedSite]:
-    sites: set[AllowedSite] = set()
-    for path in sorted(CLI_ROOT.rglob("*.py")):
-        if path.name == "error_handler.py":
-            continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        rel_path = path.relative_to(REPO_ROOT).as_posix()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and _call_name(node.func) == "click.ClickException":
-                sites.add((rel_path, node.lineno))
-    return sites
+def _click_exception_spans(tree: ast.AST) -> list[Span]:
+    spans: list[Span] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _call_name(node.func) == "click.ClickException":
+            spans.append((node.lineno, node.end_lineno or node.lineno))
+    return spans
 
 
-def test_raw_system_exit_sites_are_error_handler_owned_or_allowlisted() -> None:
-    """Raw ``SystemExit`` outside ``error_handler.py`` must stay exceptional."""
-    actual = _raw_system_exit_sites()
-    allowed = _allowed_sites(ALLOWED_RAW_SYSEXIT_SITES)
+def _raw_sysexit_spans(tree: ast.AST) -> list[Span]:
+    spans: list[Span] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Raise)
+            and isinstance(node.exc, ast.Call)
+            and _call_name(node.exc.func) == "SystemExit"
+        ):
+            # Anchor to the ``SystemExit(...)`` call node, not the enclosing
+            # ``Raise``: a marker on a multi-line ``raise ... from <cause>`` tail
+            # (outside the call) must not count (symmetric with click below).
+            call = node.exc
+            spans.append((call.lineno, call.end_lineno or call.lineno))
+    return spans
 
-    assert len(actual) <= 5
-    assert actual <= allowed, "Unallowlisted raw SystemExit sites:\n" + _format_sites(
-        actual - allowed
+
+def _match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[Span], set[int]]:
+    """Greedily assign each marker line to at most one call span.
+
+    Returns ``(unmarked_spans, orphan_lines)``. Each marker satisfies a single
+    span (claimed, then removed from the pool), so a lone marker on a line shared
+    by two overlapping call spans leaves the second span unmarked -- every
+    audited call needs its OWN marker, matching the per-site strength of the
+    removed 1:1 allowlist. ``orphan_lines`` are markers no span could claim
+    (the source moved, the call was deleted, or a call carries a redundant
+    second marker) -- the stale-marker signal that keeps the annotations from
+    rotting.
+    """
+    # Process spans by ascending end line (then start) and claim the lowest
+    # available marker in each: the textbook optimal greedy for assigning each
+    # interval a distinct point. A naive left-endpoint sort could let an outer
+    # span steal the only marker an overlapping inner span needs and red CI on
+    # validly-marked code -- the exact false-positive class this gate exists to
+    # remove.
+    unclaimed = set(marker_lines)
+    unmarked: list[Span] = []
+    for lo, hi in sorted(spans, key=lambda span: (span[1], span[0])):
+        claim = next((line for line in range(lo, hi + 1) if line in unclaimed), None)
+        if claim is None:
+            unmarked.append((lo, hi))
+        else:
+            unclaimed.discard(claim)
+    return unmarked, unclaimed
+
+
+def _audit(
+    spanner: Callable[[ast.AST], list[Span]],
+    marker: str,
+) -> tuple[list[str], list[str], list[str], int]:
+    """Return ``(unmarked, stale, empty_reason, total)`` across all CLI files."""
+    unmarked: list[str] = []
+    stale: list[str] = []
+    empty_reason: list[str] = []
+    total = 0
+    for path in _cli_files():
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        reasons = _marker_reasons(source, marker)
+        spans = spanner(tree)
+        total += len(spans)
+
+        unmarked_spans, orphan_lines = _match_markers(spans, set(reasons))
+        unmarked.extend(f"{rel}:{lo}" for lo, _hi in unmarked_spans)
+        stale.extend(f"{rel}:{line}" for line in sorted(orphan_lines))
+        # Empty-reason is checked on CLAIMED markers only; an empty orphan is
+        # already reported (more actionably) as stale.
+        for line in sorted(set(reasons) - orphan_lines):
+            if not reasons[line]:
+                empty_reason.append(f"{rel}:{line}")
+    return unmarked, stale, empty_reason, total
+
+
+def _format(sites: list[str]) -> str:
+    return "\n".join(f"  {site}" for site in sorted(sites))
+
+
+def test_click_exception_sites_are_marked() -> None:
+    """Every ``click.ClickException`` call must carry an input-validation marker."""
+    unmarked, _stale, _empty, _total = _audit(_click_exception_spans, CLICK_EXCEPTION_MARKER)
+    assert not unmarked, (
+        "Unmarked click.ClickException call sites. Each bypasses the JSON error "
+        "envelope (see error_handler.py) and must carry an inline "
+        f"`# {CLICK_EXCEPTION_MARKER} <reason>` comment:\n" + _format(unmarked)
     )
-    assert allowed <= actual, "Stale raw SystemExit allowlist entries:\n" + _format_sites(
-        allowed - actual
+
+
+def test_no_stale_or_empty_click_exception_markers() -> None:
+    """``# cli-input-validation:`` markers must sit on a call and name a reason."""
+    _unmarked, stale, empty, _total = _audit(_click_exception_spans, CLICK_EXCEPTION_MARKER)
+    assert not stale, (
+        f"Stale `# {CLICK_EXCEPTION_MARKER}` markers (not on a click.ClickException "
+        "call) -- delete them:\n" + _format(stale)
+    )
+    assert not empty, (
+        f"`# {CLICK_EXCEPTION_MARKER}` markers with no reason -- add one:\n" + _format(empty)
     )
 
 
-def test_click_exception_sites_match_input_validation_allowlist() -> None:
-    """``click.ClickException`` is limited to documented input-validation sites."""
-    actual = _click_exception_call_sites()
-    allowed = _allowed_sites(ALLOWED_CLICK_EXCEPTION_SITES)
+def test_raw_system_exit_sites_are_marked_and_bounded() -> None:
+    """Raw ``SystemExit`` outside ``error_handler.py`` stays bounded and marked."""
+    unmarked, _stale, _empty, total = _audit(_raw_sysexit_spans, RAW_SYSEXIT_MARKER)
+    assert total <= MAX_RAW_SYSEXIT_SITES, (
+        f"Too many raw SystemExit sites outside error_handler.py ({total} > "
+        f"{MAX_RAW_SYSEXIT_SITES}); route new exits through "
+        "exit_with_code()/_output_error()."
+    )
+    assert not unmarked, (
+        "Unmarked raw SystemExit call sites. Each must carry an inline "
+        f"`# {RAW_SYSEXIT_MARKER} <reason>` comment:\n" + _format(unmarked)
+    )
 
-    assert actual <= allowed, "Unallowlisted click.ClickException sites:\n" + _format_sites(
-        actual - allowed
+
+def test_no_stale_or_empty_raw_system_exit_markers() -> None:
+    """``# cli-raw-exit:`` markers must sit on a call and name a reason."""
+    _unmarked, stale, empty, _total = _audit(_raw_sysexit_spans, RAW_SYSEXIT_MARKER)
+    assert not stale, (
+        f"Stale `# {RAW_SYSEXIT_MARKER}` markers (not on a raise SystemExit "
+        "call) -- delete them:\n" + _format(stale)
     )
-    assert allowed <= actual, "Stale click.ClickException allowlist entries:\n" + _format_sites(
-        allowed - actual
+    assert not empty, f"`# {RAW_SYSEXIT_MARKER}` markers with no reason -- add one:\n" + _format(
+        empty
     )
+
+
+def test_match_markers_is_per_site_one_to_one() -> None:
+    """A single marker cannot satisfy two calls (the per-site 1:1 guarantee).
+
+    Guards the regression both reviewers flagged: union-coverage would let one
+    marker on a shared line green-light two un-audited overlapping calls.
+    """
+    # Two calls sharing one line + one marker -> exactly one stays unmarked.
+    unmarked, orphan = _match_markers([(1, 1), (1, 1)], {1})
+    assert len(unmarked) == 1
+    assert orphan == set()
+
+    # One marker inside an outer span but "stolen" by an overlapping inner call
+    # leaves the outer call unmarked rather than silently satisfied.
+    unmarked, orphan = _match_markers([(1, 3), (2, 2)], {2})
+    assert len(unmarked) == 1
+    assert orphan == set()
+
+    # Distinct marker per call -> all satisfied, nothing orphaned.
+    unmarked, orphan = _match_markers([(1, 2), (4, 5)], {1, 4})
+    assert unmarked == []
+    assert orphan == set()
+
+    # Optimal assignment: an outer span must NOT steal the inner span's only
+    # marker when an alternative exists (would false-positive under a naive
+    # left-endpoint sort). Both are satisfiable -> neither flagged.
+    unmarked, orphan = _match_markers([(1, 5), (2, 2)], {2, 3})
+    assert unmarked == []
+    assert orphan == set()
+
+    # A marker no call can claim is reported as stale.
+    unmarked, orphan = _match_markers([(1, 1)], {1, 9})
+    assert unmarked == []
+    assert orphan == {9}

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -212,6 +212,12 @@ def test_match_markers_is_per_site_one_to_one() -> None:
     assert unmarked == []
     assert orphan == {9}
 
+    # Degenerate inputs: nothing to check; a marker with no call is orphaned;
+    # a call with no marker is unmarked.
+    assert match_markers([], set()) == ([], set())
+    assert match_markers([], {5}) == ([], {5})
+    assert match_markers([(1, 1)], set()) == ([0], set())
+
 
 def test_raw_sysexit_spans_detects_bare_and_called() -> None:
     """Both ``raise SystemExit(1)`` and bare ``raise SystemExit`` are detected.

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -100,16 +100,19 @@ def _click_exception_spans(tree: ast.AST) -> list[Span]:
 def _raw_sysexit_spans(tree: ast.AST) -> list[Span]:
     spans: list[Span] = []
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Raise)
-            and isinstance(node.exc, ast.Call)
-            and _call_name(node.exc.func) == "SystemExit"
-        ):
+        if not isinstance(node, ast.Raise) or node.exc is None:
+            continue
+        exc = node.exc
+        if isinstance(exc, ast.Call) and _call_name(exc.func) == "SystemExit":
             # Anchor to the ``SystemExit(...)`` call node, not the enclosing
             # ``Raise``: a marker on a multi-line ``raise ... from <cause>`` tail
             # (outside the call) must not count (symmetric with click below).
-            call = node.exc
-            spans.append((call.lineno, call.end_lineno or call.lineno))
+            spans.append((exc.lineno, exc.end_lineno or exc.lineno))
+        elif isinstance(exc, ast.Name) and exc.id == "SystemExit":
+            # Bare ``raise SystemExit`` (no parens) is an ``ast.Name``, not a
+            # ``Call``; it would otherwise bypass the gate entirely. The marker
+            # sits on the raise statement, so anchor to the ``Raise`` span.
+            spans.append((node.lineno, node.end_lineno or node.lineno))
     return spans
 
 
@@ -255,3 +258,13 @@ def test_match_markers_is_per_site_one_to_one() -> None:
     unmarked, orphan = _match_markers([(1, 1)], {1, 9})
     assert unmarked == []
     assert orphan == {9}
+
+
+def test_raw_sysexit_spans_detects_bare_and_called() -> None:
+    """Both ``raise SystemExit(1)`` and bare ``raise SystemExit`` are detected.
+
+    Bare ``raise SystemExit`` is an ``ast.Name`` (not a ``Call``); missing it
+    would let a raw exit bypass the gate (gemini-code-assist, PR #1299).
+    """
+    tree = ast.parse("def called():\n    raise SystemExit(1)\ndef bare():\n    raise SystemExit\n")
+    assert sorted(lo for lo, _hi in _raw_sysexit_spans(tree)) == [2, 4]

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -41,10 +41,10 @@ keep new ones rare and individually justified rather than forbidden outright.
 from __future__ import annotations
 
 import ast
-import io
-import tokenize
 from collections.abc import Callable
 from pathlib import Path
+
+from _fixtures.cli_exit_markers import Span, marker_reasons, match_markers
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
@@ -55,8 +55,6 @@ RAW_SYSEXIT_MARKER = "cli-raw-exit:"
 # Defense-in-depth ceiling: raw ``SystemExit`` outside ``error_handler.py``
 # must stay rare even when individually marked.
 MAX_RAW_SYSEXIT_SITES = 5
-
-Span = tuple[int, int]
 
 
 def _call_name(node: ast.AST) -> str:
@@ -71,22 +69,6 @@ def _call_name(node: ast.AST) -> str:
 def _cli_files() -> list[Path]:
     """Every ``cli/*.py`` except ``error_handler.py`` (which owns the exits)."""
     return [p for p in sorted(CLI_ROOT.rglob("*.py")) if p.name != "error_handler.py"]
-
-
-def _marker_reasons(source: str, marker: str) -> dict[int, str]:
-    """Map ``lineno -> reason`` for each ``# <marker> <reason>`` comment.
-
-    Uses ``tokenize`` so the marker is only recognized inside a real comment
-    token, never inside a string literal that happens to contain the text.
-    """
-    reasons: dict[int, str] = {}
-    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
-        if tok.type != tokenize.COMMENT:
-            continue
-        body = tok.string.lstrip("#").strip()
-        if body.startswith(marker):
-            reasons[tok.start[0]] = body.removeprefix(marker).strip()
-    return reasons
 
 
 def _click_exception_spans(tree: ast.AST) -> list[Span]:
@@ -116,35 +98,6 @@ def _raw_sysexit_spans(tree: ast.AST) -> list[Span]:
     return spans
 
 
-def _match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[Span], set[int]]:
-    """Greedily assign each marker line to at most one call span.
-
-    Returns ``(unmarked_spans, orphan_lines)``. Each marker satisfies a single
-    span (claimed, then removed from the pool), so a lone marker on a line shared
-    by two overlapping call spans leaves the second span unmarked -- every
-    audited call needs its OWN marker, matching the per-site strength of the
-    removed 1:1 allowlist. ``orphan_lines`` are markers no span could claim
-    (the source moved, the call was deleted, or a call carries a redundant
-    second marker) -- the stale-marker signal that keeps the annotations from
-    rotting.
-    """
-    # Process spans by ascending end line (then start) and claim the lowest
-    # available marker in each: the textbook optimal greedy for assigning each
-    # interval a distinct point. A naive left-endpoint sort could let an outer
-    # span steal the only marker an overlapping inner span needs and red CI on
-    # validly-marked code -- the exact false-positive class this gate exists to
-    # remove.
-    unclaimed = set(marker_lines)
-    unmarked: list[Span] = []
-    for lo, hi in sorted(spans, key=lambda span: (span[1], span[0])):
-        claim = next((line for line in range(lo, hi + 1) if line in unclaimed), None)
-        if claim is None:
-            unmarked.append((lo, hi))
-        else:
-            unclaimed.discard(claim)
-    return unmarked, unclaimed
-
-
 def _audit(
     spanner: Callable[[ast.AST], list[Span]],
     marker: str,
@@ -158,12 +111,12 @@ def _audit(
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
         rel = path.relative_to(REPO_ROOT).as_posix()
-        reasons = _marker_reasons(source, marker)
+        reasons = marker_reasons(source, marker)
         spans = spanner(tree)
         total += len(spans)
 
-        unmarked_spans, orphan_lines = _match_markers(spans, set(reasons))
-        unmarked.extend(f"{rel}:{lo}" for lo, _hi in unmarked_spans)
+        unmarked_idx, orphan_lines = match_markers(spans, set(reasons))
+        unmarked.extend(f"{rel}:{spans[i][0]}" for i in unmarked_idx)
         stale.extend(f"{rel}:{line}" for line in sorted(orphan_lines))
         # Empty-reason is checked on CLAIMED markers only; an empty orphan is
         # already reported (more actionably) as stale.
@@ -232,30 +185,30 @@ def test_match_markers_is_per_site_one_to_one() -> None:
     marker on a shared line green-light two un-audited overlapping calls.
     """
     # Two calls sharing one line + one marker -> exactly one stays unmarked.
-    unmarked, orphan = _match_markers([(1, 1), (1, 1)], {1})
+    unmarked, orphan = match_markers([(1, 1), (1, 1)], {1})
     assert len(unmarked) == 1
     assert orphan == set()
 
     # One marker inside an outer span but "stolen" by an overlapping inner call
     # leaves the outer call unmarked rather than silently satisfied.
-    unmarked, orphan = _match_markers([(1, 3), (2, 2)], {2})
+    unmarked, orphan = match_markers([(1, 3), (2, 2)], {2})
     assert len(unmarked) == 1
     assert orphan == set()
 
     # Distinct marker per call -> all satisfied, nothing orphaned.
-    unmarked, orphan = _match_markers([(1, 2), (4, 5)], {1, 4})
+    unmarked, orphan = match_markers([(1, 2), (4, 5)], {1, 4})
     assert unmarked == []
     assert orphan == set()
 
     # Optimal assignment: an outer span must NOT steal the inner span's only
     # marker when an alternative exists (would false-positive under a naive
     # left-endpoint sort). Both are satisfiable -> neither flagged.
-    unmarked, orphan = _match_markers([(1, 5), (2, 2)], {2, 3})
+    unmarked, orphan = match_markers([(1, 5), (2, 2)], {2, 3})
     assert unmarked == []
     assert orphan == set()
 
     # A marker no call can claim is reported as stale.
-    unmarked, orphan = _match_markers([(1, 1)], {1, 9})
+    unmarked, orphan = match_markers([(1, 1)], {1, 9})
     assert unmarked == []
     assert orphan == {9}
 

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -7,8 +7,6 @@ import pytest
 
 import notebooklm.cli._encoding as encoding_module
 from notebooklm.cli.error_handler import (
-    ALLOWED_CLICK_EXCEPTION_SITES,
-    ALLOWED_RAW_SYSEXIT_SITES,
     _output_error,
     emit_cancelled_and_exit,
     exit_with_code,
@@ -72,24 +70,6 @@ class TestHandleErrorsExitCodes:
             exit_with_code(75)
 
         assert exc_info.value.code == 75
-
-
-class TestErrorHandlerAllowlists:
-    """The allowlists are intentionally structured for lint enforcement."""
-
-    def test_raw_system_exit_allowlist_entries_have_reasons(self):
-        for rel_path, line_number, reason in ALLOWED_RAW_SYSEXIT_SITES:
-            assert rel_path.startswith("src/notebooklm/cli/")
-            assert isinstance(line_number, int)
-            assert line_number > 0
-            assert reason
-
-    def test_click_exception_allowlist_entries_have_reasons(self):
-        for rel_path, line_number, reason in ALLOWED_CLICK_EXCEPTION_SITES:
-            assert rel_path.startswith("src/notebooklm/cli/")
-            assert isinstance(line_number, int)
-            assert line_number > 0
-            assert reason
 
 
 class TestHandleErrorsJsonOutput:

--- a/tests/unit/cli/test_quiet_enforcement.py
+++ b/tests/unit/cli/test_quiet_enforcement.py
@@ -22,7 +22,7 @@ Error-path heuristic
 --------------------
 A call site is considered to live on an *error path* when ANY of the
 following hold (the test fails on a quiet-bypassing helper at that site
-unless the site is explicitly waived):
+unless the site carries a waiver marker):
 
 1. **Inside a ``Try`` ``ExceptHandler`` body** -- by definition the program
    is currently handling an exception.
@@ -43,20 +43,28 @@ exception/error.
 
 Waiver mechanism
 ----------------
-Each pre-existing violation is listed in :data:`QUIET_WAIVED_SITES` with a
-rationale. The test fails on:
+A genuinely-intended quiet-aware call on an error path is waived with an
+inline ``# quiet-ok: <reason>`` marker comment on any physical line spanned
+by the call (the ``# noqa`` convention). This replaces the old
+``QUIET_WAIVED_SITES`` ``(module, function, line)`` table, which failed CI
+whenever an unrelated edit shifted a waived line (issue #1298). The test
+fails on:
 
 - a new (un-waived) error-path site using ``cli_print`` / ``emit_status``,
-- drift -- a waived ``(module, function, line)`` tuple that no longer maps
-  to a quiet-bypassing call.
+- a stale ``# quiet-ok:`` marker that no longer sits on a quiet-bypassing
+  error-path call (the source moved or the call was fixed), and
+- a ``# quiet-ok:`` marker with no reason text.
 
-This guarantees that the waiver list shrinks toward zero over time and
-cannot silently rot.
+This keeps the waivers minimal and prevents them from rotting, the same
+guarantees the old drift check provided.
 """
 
 from __future__ import annotations
 
 import ast
+import io
+import tokenize
+from collections.abc import Iterator
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -66,31 +74,10 @@ CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
 # eats the diagnostic, which is the bug this test prevents.
 QUIET_AWARE_HELPERS = frozenset({"cli_print", "emit_status"})
 
-# Pre-existing error-path violations grandfathered in at the time this test
-# was introduced. Keys are ``(module, function, line)`` -- the file path is
-# repo-relative POSIX; the function is the innermost enclosing
-# ``def``/``async def`` name; the line is the call site's ``lineno``.
-#
-# Drift detection: each entry MUST still resolve to a quiet-bypassing call
-# at the recorded line, in the recorded function, in the recorded module.
-# If the source moves or the call is fixed, delete the waiver.
-QUIET_WAIVED_SITES: dict[tuple[str, str, int], str] = {
-    (
-        "src/notebooklm/cli/chat_cmd.py",
-        "_run",
-        363,
-    ): (
-        "TODO(quiet-policy): note-save failure inside `ask` reports the "
-        "underlying exception via `emit_status` so the warning is colored "
-        "and routed alongside other chat status text. Switching to "
-        "`output_error` here would also `SystemExit(1)`, aborting the "
-        "outer chat response payload; the user explicitly opted into "
-        "`--save-as-note` as a *secondary* action, so we surface the "
-        "note-save failure without killing the chat output. Revisit when "
-        "the chat-cmd save-as-note path gains a structured non-fatal "
-        "error channel."
-    ),
-}
+# Inline marker that waives an intentional quiet-aware error-path call.
+QUIET_OK_MARKER = "quiet-ok:"
+
+Span = tuple[int, int]
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +150,7 @@ def _is_error_path(ancestors: list[ast.AST]) -> bool:
     return False
 
 
-def _walk_with_ancestors(tree: ast.AST):
+def _walk_with_ancestors(tree: ast.AST) -> Iterator[tuple[ast.AST, list[ast.AST]]]:
     """Yield ``(node, ancestors)`` for every node in *tree*."""
     stack: list[tuple[ast.AST, list[ast.AST]]] = [(tree, [])]
     while stack:
@@ -174,13 +161,73 @@ def _walk_with_ancestors(tree: ast.AST):
             stack.append((child, next_ancestors))
 
 
-def _collect_quiet_bypass_error_sites() -> set[tuple[str, str, int]]:
-    """Walk every ``cli/*_cmd.py`` and return error-path quiet-aware calls."""
-    sites: set[tuple[str, str, int]] = set()
+# ---------------------------------------------------------------------------
+# Marker scanning
+# ---------------------------------------------------------------------------
+
+
+def _marker_reasons(source: str, marker: str) -> dict[int, str]:
+    """Map ``lineno -> reason`` for each ``# <marker> <reason>`` comment.
+
+    Uses ``tokenize`` so the marker is only recognized inside a real comment
+    token, never inside a string literal that happens to contain the text.
+    """
+    reasons: dict[int, str] = {}
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type != tokenize.COMMENT:
+            continue
+        body = tok.string.lstrip("#").strip()
+        if body.startswith(marker):
+            reasons[tok.start[0]] = body.removeprefix(marker).strip()
+    return reasons
+
+
+def _match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[Span], set[int]]:
+    """Greedily assign each marker line to at most one call span.
+
+    Returns ``(unmarked_spans, orphan_lines)``. Each marker satisfies a single
+    span (claimed, then removed from the pool), so a lone marker on a line shared
+    by two overlapping error-path calls leaves the second unmarked -- every
+    waived call needs its OWN ``# quiet-ok:`` reason. ``orphan_lines`` are
+    markers no span could claim (the source moved or the call was fixed) -- the
+    stale signal that replaces the old drift check.
+    """
+    # Process spans by ascending end line (then start) and claim the lowest
+    # available marker in each: the textbook optimal greedy for assigning each
+    # interval a distinct point. A naive left-endpoint sort could let an outer
+    # span steal the only marker an overlapping inner span needs and red CI on
+    # validly-marked code -- the exact false-positive class this gate exists to
+    # remove.
+    unclaimed = set(marker_lines)
+    unmarked: list[Span] = []
+    for lo, hi in sorted(spans, key=lambda span: (span[1], span[0])):
+        claim = next((line for line in range(lo, hi + 1) if line in unclaimed), None)
+        if claim is None:
+            unmarked.append((lo, hi))
+        else:
+            unclaimed.discard(claim)
+    return unmarked, unclaimed
+
+
+def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
+    """Return ``(unmarked, stale, empty_reason)`` across every ``*_cmd.py``.
+
+    * ``unmarked`` -- error-path quiet-bypass calls with no ``# quiet-ok:``
+      marker (formatted ``module::func:line``).
+    * ``stale`` -- ``# quiet-ok:`` markers no such call can claim.
+    * ``empty_reason`` -- claimed ``# quiet-ok:`` markers with no reason text.
+    """
+    unmarked: list[str] = []
+    stale: list[str] = []
+    empty_reason: list[str] = []
     for path in sorted(CLI_ROOT.glob("*_cmd.py")):
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
-        rel_path = path.relative_to(REPO_ROOT).as_posix()
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        reasons = _marker_reasons(source, QUIET_OK_MARKER)
+
+        spans: list[Span] = []
+        labels: dict[int, str] = {}
         for node, ancestors in _walk_with_ancestors(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -189,12 +236,20 @@ def _collect_quiet_bypass_error_sites() -> set[tuple[str, str, int]]:
                 continue
             if not _is_error_path(ancestors):
                 continue
-            sites.add((rel_path, _enclosing_function_name(ancestors), node.lineno))
-    return sites
+            spans.append((node.lineno, node.end_lineno or node.lineno))
+            labels[node.lineno] = f"{rel}::{_enclosing_function_name(ancestors)}:{node.lineno}"
+
+        unmarked_spans, orphan_lines = _match_markers(spans, set(reasons))
+        unmarked.extend(labels[lo] for lo, _hi in unmarked_spans)
+        stale.extend(f"{rel}:{line}" for line in sorted(orphan_lines))
+        for line in sorted(set(reasons) - orphan_lines):
+            if not reasons[line]:
+                empty_reason.append(f"{rel}:{line}")
+    return unmarked, stale, empty_reason
 
 
-def _format_sites(sites: set[tuple[str, str, int]]) -> str:
-    return "\n".join(f"  {module}::{func}:{line}" for module, func, line in sorted(sites))
+def _format(sites: list[str]) -> str:
+    return "\n".join(f"  {site}" for site in sorted(sites))
 
 
 # ---------------------------------------------------------------------------
@@ -207,32 +262,28 @@ def test_no_new_quiet_bypassing_error_sites() -> None:
 
     Errors must use ``output_error(...)`` (or ``json_error_response(...)``)
     which bypass ``--quiet`` and route to stderr. Quiet-aware helpers
-    silently swallow the diagnostic and are forbidden on error paths.
+    silently swallow the diagnostic and are forbidden on error paths unless
+    waived with an inline ``# quiet-ok: <reason>`` marker.
     """
-    actual = _collect_quiet_bypass_error_sites()
-    waived = set(QUIET_WAIVED_SITES.keys())
-    unwaived = actual - waived
-    assert not unwaived, (
+    unmarked, _stale, _empty = _audit_quiet_markers()
+    assert not unmarked, (
         "New error-path uses of cli_print/emit_status detected.\n"
         "Errors must use output_error(...) (cli.error_handler) or "
         "json_error_response(...) (cli.rendering); both bypass --quiet.\n"
-        "Sites:\n" + _format_sites(unwaived)
+        "If the quiet-aware call is intentional, waive it with an inline "
+        f"`# {QUIET_OK_MARKER} <reason>` comment.\nSites:\n" + _format(unmarked)
     )
 
 
-def test_waiver_list_has_no_drift() -> None:
-    """Every waived site must still exist in source at the recorded line.
+def test_no_stale_or_empty_quiet_markers() -> None:
+    """``# quiet-ok:`` markers must sit on a quiet-bypass call and name a reason.
 
-    Drift means a waived ``(module, function, line)`` tuple no longer maps
-    to a quiet-bypassing helper in source -- either the source moved or
-    someone already fixed the violation. Either way, the waiver must be
-    deleted so the list stays minimal and trustworthy.
+    A stale marker means the source moved or the violation was fixed -- the
+    waiver must be deleted so the list stays minimal and trustworthy.
     """
-    actual = _collect_quiet_bypass_error_sites()
-    waived = set(QUIET_WAIVED_SITES.keys())
-    stale = waived - actual
+    _unmarked, stale, empty = _audit_quiet_markers()
     assert not stale, (
-        "Stale QUIET_WAIVED_SITES entries (no longer match source):\n"
-        + _format_sites(stale)
-        + "\nDelete these waivers from QUIET_WAIVED_SITES."
+        f"Stale `# {QUIET_OK_MARKER}` markers (no longer on an error-path "
+        "quiet-bypass call) -- delete them:\n" + _format(stale)
     )
+    assert not empty, f"`# {QUIET_OK_MARKER}` markers with no reason -- add one:\n" + _format(empty)

--- a/tests/unit/cli/test_quiet_enforcement.py
+++ b/tests/unit/cli/test_quiet_enforcement.py
@@ -62,10 +62,10 @@ guarantees the old drift check provided.
 from __future__ import annotations
 
 import ast
-import io
-import tokenize
 from collections.abc import Iterator
 from pathlib import Path
+
+from _fixtures.cli_exit_markers import Span, marker_reasons, match_markers
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
@@ -76,8 +76,6 @@ QUIET_AWARE_HELPERS = frozenset({"cli_print", "emit_status"})
 
 # Inline marker that waives an intentional quiet-aware error-path call.
 QUIET_OK_MARKER = "quiet-ok:"
-
-Span = tuple[int, int]
 
 
 # ---------------------------------------------------------------------------
@@ -166,49 +164,6 @@ def _walk_with_ancestors(tree: ast.AST) -> Iterator[tuple[ast.AST, list[ast.AST]
 # ---------------------------------------------------------------------------
 
 
-def _marker_reasons(source: str, marker: str) -> dict[int, str]:
-    """Map ``lineno -> reason`` for each ``# <marker> <reason>`` comment.
-
-    Uses ``tokenize`` so the marker is only recognized inside a real comment
-    token, never inside a string literal that happens to contain the text.
-    """
-    reasons: dict[int, str] = {}
-    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
-        if tok.type != tokenize.COMMENT:
-            continue
-        body = tok.string.lstrip("#").strip()
-        if body.startswith(marker):
-            reasons[tok.start[0]] = body.removeprefix(marker).strip()
-    return reasons
-
-
-def _match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[Span], set[int]]:
-    """Greedily assign each marker line to at most one call span.
-
-    Returns ``(unmarked_spans, orphan_lines)``. Each marker satisfies a single
-    span (claimed, then removed from the pool), so a lone marker on a line shared
-    by two overlapping error-path calls leaves the second unmarked -- every
-    waived call needs its OWN ``# quiet-ok:`` reason. ``orphan_lines`` are
-    markers no span could claim (the source moved or the call was fixed) -- the
-    stale signal that replaces the old drift check.
-    """
-    # Process spans by ascending end line (then start) and claim the lowest
-    # available marker in each: the textbook optimal greedy for assigning each
-    # interval a distinct point. A naive left-endpoint sort could let an outer
-    # span steal the only marker an overlapping inner span needs and red CI on
-    # validly-marked code -- the exact false-positive class this gate exists to
-    # remove.
-    unclaimed = set(marker_lines)
-    unmarked: list[Span] = []
-    for lo, hi in sorted(spans, key=lambda span: (span[1], span[0])):
-        claim = next((line for line in range(lo, hi + 1) if line in unclaimed), None)
-        if claim is None:
-            unmarked.append((lo, hi))
-        else:
-            unclaimed.discard(claim)
-    return unmarked, unclaimed
-
-
 def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
     """Return ``(unmarked, stale, empty_reason)`` across every ``*_cmd.py``.
 
@@ -224,10 +179,13 @@ def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
         rel = path.relative_to(REPO_ROOT).as_posix()
-        reasons = _marker_reasons(source, QUIET_OK_MARKER)
+        reasons = marker_reasons(source, QUIET_OK_MARKER)
 
+        # ``spans`` and ``labels`` are index-aligned so an unmarked call maps
+        # back to its OWN label even if two qualifying calls share a start line
+        # (a dict keyed by lineno would collapse them and mislabel — PR #1299).
         spans: list[Span] = []
-        labels: dict[int, str] = {}
+        labels: list[str] = []
         for node, ancestors in _walk_with_ancestors(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -237,10 +195,10 @@ def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
             if not _is_error_path(ancestors):
                 continue
             spans.append((node.lineno, node.end_lineno or node.lineno))
-            labels[node.lineno] = f"{rel}::{_enclosing_function_name(ancestors)}:{node.lineno}"
+            labels.append(f"{rel}::{_enclosing_function_name(ancestors)}:{node.lineno}")
 
-        unmarked_spans, orphan_lines = _match_markers(spans, set(reasons))
-        unmarked.extend(labels[lo] for lo, _hi in unmarked_spans)
+        unmarked_idx, orphan_lines = match_markers(spans, set(reasons))
+        unmarked.extend(labels[i] for i in unmarked_idx)
         stale.extend(f"{rel}:{line}" for line in sorted(orphan_lines))
         for line in sorted(set(reasons) - orphan_lines):
             if not reasons[line]:


### PR DESCRIPTION
## Summary

- Replaces the line-number-pinned CLI exit-path lint gates (`ALLOWED_CLICK_EXCEPTION_SITES`, `ALLOWED_RAW_SYSEXIT_SITES`, `QUIET_WAIVED_SITES`) with **inline marker comments** (the `# noqa` convention), so the reason lives at the call site and is immune to line shifts in unrelated code (#1298).
  - `click.ClickException(...)` → `# cli-input-validation: <reason>`
  - `raise SystemExit(...)` → `# cli-raw-exit: <reason>`
  - error-path `cli_print`/`emit_status` waiver → `# quiet-ok: <reason>`
- Markers are matched via **AST** (find the call, anchored to the call node) + **`tokenize`** (find the comment in the call's line span), and assigned to calls **1:1** via an optimal interval-point greedy (`_match_markers`) — so one marker can't satisfy two calls sharing a line, and the gate keeps its full per-site strength.
- Deletes the now-dead allowlists + the obsolete `TestErrorHandlerAllowlists`; adds a `_match_markers` regression test.

## Motivation

#1297 shifted six `ClickException` sites and the quiet waiver, reding CI with **no behavior change** — exactly the fragility this removes. The gate still:
- fails on a **new unmarked** exit path,
- fails on a **stale marker** no call can claim (annotations can't rot),
- requires every marker to carry a **non-empty reason**,
- bounds raw `SystemExit` by `MAX_RAW_SYSEXIT_SITES`.

**Deliberate relaxation:** raw `SystemExit` is now governed like `ClickException` (allowed where a `# cli-raw-exit:` marker documents it, up to the ceiling) instead of the old `ALLOWED_RAW_SYSEXIT_SITES = []` hard-zero. Canonical raw exits still live in `error_handler.py`; no raw `SystemExit` sites exist outside it today.

## Test plan

- [x] `uv run pytest` — 7891 passed, 100 skipped
- [x] `uv run ruff format --check .` + `uv run ruff check src tests` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] Line-shift robustness verified: injected a line above all 13 `profile_cmd.py` sites — both harnesses stayed green.

## Deferred polish findings

- `session_cmd.py` `_click_exception_from` places its markers on the closing-paren line rather than the opening-call line used elsewhere. Both are valid per the documented "any line in the call span" rule and ruff-stable; left as-is to avoid churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more consistent CLI error and validation messages across profile commands; improved guidance when profiles are missing and safeguards to prevent deleting active/default profiles.
  * Note-save failures are now non-fatal warnings so chat and JSON output continue uninterrupted.

* **Chores**
  * Test/lint tooling now requires inline source markers to document intentional CLI error/quiet bypasses and raw exits, with stricter auditing and new shared test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->