### PR TITLE
docs: replace references to the deleted Session facade class

### DIFF
--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -10,7 +10,7 @@ Google does not always answer with ``Set-Cookie: __Secure-1PSIDTS``. When that
 happens, ``storage_state.json`` is saved without PSIDTS, the Tier-1 preflight
 in :mod:`notebooklm._auth.cookie_policy` rejects the next CLI invocation, and
 the keepalive recovery path (which would heal the state in one POST) is
-unreachable because it only runs inside an opened ``Session`` — a closed loop.
+unreachable because it only runs inside an opened ``NotebookLMClient`` — a closed loop.
 
 The header comment on ``MINIMUM_REQUIRED_COOKIES`` has always described PSIDTS
 as ``directly accepted by Google's homepage check, OR recoverable via the

--- a/src/notebooklm/_auth/storage.py
+++ b/src/notebooklm/_auth/storage.py
@@ -183,7 +183,7 @@ def _file_lock_exclusive(lock_path: Path) -> Iterator[None]:
     account-metadata writes serialize on one file.
 
     The lock is per-process: threads within one process aren't serialized —
-    that's the intra-process ``threading.Lock`` in ``Session``. If the
+    that's the intra-process ``threading.Lock`` held by the client. If the
     lock can't be acquired (e.g. NFS where flock semantics vary, read-only
     parent dir, fd exhaustion), the save proceeds anyway; correctness in
     that mode is best-effort and relies on the snapshot/delta CAS guards in

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -47,7 +47,7 @@ class AuthTokens:
             accounts sign out.
         cookie_snapshot: Internal save baseline used when a pre-client token
             fetch mutates cookies but persistence fails or CAS-rejects. This
-            lets the eventual Session retry the unpersisted delta instead
+            lets the eventual client retry the unpersisted delta instead
             of snapshotting the already-mutated jar as clean state.
     """
 
@@ -201,7 +201,7 @@ class AuthTokens:
 
         # Persist any refreshed cookies from the token fetch. If the save
         # fails, carry the old baseline into the returned AuthTokens so a
-        # later Session can retry the delta instead of treating the mutated
+        # later client can retry the delta instead of treating the mutated
         # jar as clean state.
         # ``save_cookies_to_storage`` performs atomic-replace + fsync + flock
         # under a synchronous file lock; offload to a worker thread so a

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -341,7 +341,7 @@ class ChatAPI:
         # Catch cross-loop ``ask`` before any work — particularly
         # before acquiring the per-conversation lock below, which would
         # otherwise hang on a lock bound to a dead loop. The POST-path
-        # guard in ``Session._perform_authed_post`` only catches misuse on
+        # guard in ``RuntimeTransport.perform_authed_post`` only catches misuse on
         # the POST itself, which is *after* the conversation lock is
         # already held — too late.
         self._loop_guard.assert_bound_loop()

--- a/src/notebooklm/_client_composed.py
+++ b/src/notebooklm/_client_composed.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class ClientComposed:
-    """Mutable holder for composition state that is migrating off ``Session``."""
+    """Mutable holder for the client's composition state."""
 
     def __init__(
         self,

--- a/src/notebooklm/_client_metrics.py
+++ b/src/notebooklm/_client_metrics.py
@@ -11,7 +11,7 @@ and ``tests/unit/test_observability.py``):
 * ``__init__`` MUST be event-loop-agnostic — it constructs only a
   ``threading.Lock`` and a plain dataclass. Never call
   ``asyncio.get_running_loop()`` or instantiate any ``asyncio.*`` primitive
-  here. ``Session`` is routinely built outside a running loop.
+  here. ``NotebookLMClient`` is routinely built outside a running loop.
 
 * :meth:`emit_rpc_event` MUST stay ``async def`` and ``await
   maybe_await_callback(...)``. The await is the back-pressure mechanism: a
@@ -57,10 +57,8 @@ class ClientMetrics:
     * ``_on_rpc_event`` — the user-supplied telemetry callback, or ``None``.
       Read at emit time so test fixtures can swap it after construction.
 
-    Field names are deliberately the same as the legacy ``Session`` ivars
-    (``_metrics_lock``, ``_metrics``, ``_on_rpc_event``) so the compat
-    ``@property`` bridges on ``Session`` can delegate with
-    ``return self._metrics_obj._<attr>`` and stay readable.
+    Field names (``_metrics_lock``, ``_metrics``, ``_on_rpc_event``) are
+    kept stable for grep-discoverability across the test suite.
     """
 
     def __init__(

--- a/src/notebooklm/_cookie_persistence.py
+++ b/src/notebooklm/_cookie_persistence.py
@@ -21,7 +21,7 @@ from .auth import (
 
 
 class SaveCookiesToStorage(Protocol):
-    """Callable shape for the storage writer resolved by ``Session``."""
+    """Callable shape for the storage writer resolved by ``NotebookLMClient``."""
 
     def __call__(
         self,

--- a/src/notebooklm/_error_injection.py
+++ b/src/notebooklm/_error_injection.py
@@ -54,7 +54,7 @@ from ._runtime_config import CORE_LOGGER_NAME
 
 # Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
 # tests — e.g. ``caplog.at_level(..., logger=CORE_LOGGER_NAME)`` — keep
-# matching. Session collaborators and middleware seams share the same name.
+# matching. Client collaborators and middleware seams share the same name.
 logger = logging.getLogger(CORE_LOGGER_NAME)
 
 

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -15,7 +15,7 @@ from .types import ConnectionLimits
 class Kernel:
     """Own the live HTTP transport and cookie jar.
 
-    Session lifecycle code decides when to open and close. The kernel owns the
+    Client lifecycle code decides when to open and close. The kernel owns the
     concrete ``httpx.AsyncClient`` instance, its cookie jar, raw POST execution,
     and shielded teardown target.
     """

--- a/src/notebooklm/_loop_affinity.py
+++ b/src/notebooklm/_loop_affinity.py
@@ -17,7 +17,7 @@ Design constraints:
 
 * ``bound_loop is None`` is a silent no-op so callers that haven't yet
   observed an ``open()`` (most notably standalone fixtures that construct
-  the helpers directly without a :class:`Session`) keep working without
+  the helpers directly without a :class:`NotebookLMClient`) keep working without
   a special-case branch on every call site.
 
 * The error message is intentionally stable so downstream call sites can

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -17,7 +17,7 @@ This module defines:
   ``NextCall`` so the leftmost middleware in the sequence becomes the
   *outermost* wrapper (matches the ordering documented in ADR-009).
 
-Production ``Session`` wiring composes these envelopes through the current
+Production ``NotebookLMClient`` wiring composes these envelopes through the current
 middleware stack. During the request-materialization migration, the chain
 enters with populated ``RpcRequest(url, headers, body)`` fields and the
 terminal consumes that envelope directly through ``Kernel.post``. See
@@ -139,7 +139,7 @@ def materialize_rpc_request(
 ) -> RpcRequest:
     """Build a populated chain envelope from the legacy request callback.
 
-    ``Session`` uses this helper to enter the chain with populated
+    ``NotebookLMClient`` uses this helper to enter the chain with populated
     ``RpcRequest(url, headers, body)`` fields while the terminal delegates
     through the ``BuildRequest`` callback. A ``Kernel.post`` terminal can
     consume the same envelope directly.

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -31,7 +31,7 @@ that duration AFTER the successful refresh and BEFORE the retry. This
 preserves the historical transport behavior so a cassette that recorded the
 post-refresh delay replays the same timing.
 
-Request-materialization transition: ``Session`` now enters the chain with
+Request-materialization transition: ``NotebookLMClient`` now enters the chain with
 the initial ``RpcRequest.url`` / ``.headers`` / ``.body`` populated and the
 terminal consumes that envelope through ``Kernel.post``. After a successful
 refresh this middleware re-snapshots auth state and replaces the request
@@ -115,7 +115,7 @@ class AuthRefreshMiddleware:
     - ``snapshot_provider``: optional async callable returning a fresh
       :class:`AuthSnapshot` after refresh. Production wires a lambda
       that invokes :meth:`AuthRefreshCoordinator.snapshot` with the
-      explicit ``auth=session.auth`` collaborator; tests that omit
+      client's current ``auth`` tokens; tests that omit
       ``snapshot_provider``
       preserve the older "retry the same request" unit shape.
     - ``sleep``: optional sleep injection (defaults to :func:`asyncio.sleep`

--- a/src/notebooklm/_middleware_chain_host.py
+++ b/src/notebooklm/_middleware_chain_host.py
@@ -20,16 +20,16 @@ itself:
 This module is intentionally narrow:
 
 * It does NOT know about metrics, the kernel, the http client, the
-  RPC semaphore, or the auth snapshot. Those live on :class:`Session`
+  RPC semaphore, or the auth snapshot. Those live on :class:`NotebookLMClient`
   (the auth-snapshot host) and the collaborator bundle.
-* The host has no back-reference to :class:`Session` — it is reachable
-  from :class:`Session` (via ``self._chain_host``) but not the other
-  way around. This avoids a Session ↔ transport cycle, per ADR-014 Rule 4.
+* The host has no back-reference to :class:`NotebookLMClient` — it is reachable
+  from :class:`NotebookLMClient` (via ``self._chain_host``) but not the other
+  way around. This avoids a client ↔ transport cycle, per ADR-014 Rule 4.
 
 The transport / wire helpers take the host directly via the
 ``chain_host`` parameter; the chain reads ``chain_host._<attr>`` on
 every attempt. Tests that need a mid-flight mutation rebind on the
-host (``core._chain_host._<attr> = ...``); there are no Session-side
+host (``core._chain_host._<attr> = ...``); there are no client-side
 forwards in front of the host.
 """
 
@@ -49,7 +49,7 @@ class MiddlewareChainHost:
     """Owner of the middleware-chain mutable state and chain leaf.
 
     Constructed by :func:`compose_client_internals` BEFORE
-    :class:`Session`. The transport is bound write-once via
+    :class:`NotebookLMClient`. The transport is bound write-once via
     :meth:`_bind_transport` after :func:`build_runtime_transport`
     returns — this resolves the host ↔ transport construction cycle
     without giving either side a permanent back-reference to the other.
@@ -92,7 +92,7 @@ class MiddlewareChainHost:
         composition root (:func:`compose_client_internals`) is the
         single legitimate caller, and it fires this once after
         :func:`build_runtime_transport` returns. The same write-once
-        shape on :class:`Session` (:meth:`Session._bind_transport`)
+        shape on the client (:meth:`ClientComposed.bind_transport`)
         guarantees both sides of the host ↔ transport relationship are
         bound exactly once at composition time.
         """
@@ -109,9 +109,10 @@ class MiddlewareChainHost:
 
         Raises :class:`RuntimeError` if the transport is not yet bound.
         This can only happen if a caller exercised the chain before
-        the composition root finished — the fail-fast guard mirrors
-        the corresponding :meth:`Session._require_constructed` guard
-        on the Session entry points.
+        the composition root finished — this fail-fast guard raises
+        :class:`RuntimeError` when the transport is still unbound,
+        rejecting any authed POST that reaches the chain leaf before
+        :meth:`_bind_transport` has fired.
         """
         transport = self._transport
         if transport is None:

--- a/src/notebooklm/_middleware_drain.py
+++ b/src/notebooklm/_middleware_drain.py
@@ -8,7 +8,7 @@ Pure observer of the transport leg with bookkeeping side-effects: brackets
 ``next_call`` with calls to :meth:`TransportDrainTracker.begin_transport_post`
 and :meth:`TransportDrainTracker.finish_transport_post`, propagating the
 ``log_label`` from ``request.context`` as the tracker label. The chain
-caller (``Session._perform_authed_post``) always populates ``log_label``,
+caller (``RuntimeTransport.perform_authed_post``) always populates ``log_label``,
 so the middleware reads it via ``RPC_CONTEXT_LOG_LABEL`` and falls back
 to a synthetic ``"<unknown-chain-call>"`` only for malformed requests.
 
@@ -61,7 +61,7 @@ class DrainMiddleware:
     as assignable into a ``Sequence[Middleware]``.
 
     Holds a reference to the shared :class:`TransportDrainTracker` owned
-    by :class:`Session`. The middleware does not own drain state; it
+    by :class:`NotebookLMClient`. The middleware does not own drain state; it
     is a write-through into the host's counters. This keeps
     ``drain()``'s view of in-flight work authoritative even when tests
     swap a middleware out (the explicit ``_begin/_finish_transport_post``

--- a/src/notebooklm/_middleware_metrics.py
+++ b/src/notebooklm/_middleware_metrics.py
@@ -22,7 +22,7 @@ The emit fires only when ``RPC_CONTEXT_RPC_METHOD`` is present in
 ``request.context``.
 Other code paths through the chain (e.g. the chat streaming path in
 ``_chat_transport.send_authed_post``, which calls
-``Session._perform_authed_post`` directly without minting an
+``RuntimeTransport.perform_authed_post`` directly without minting an
 ``RpcExecutor`` telemetry frame) leave the key absent and skip emission —
 so chat-side requests do not appear in the RPC counters or telemetry
 stream. This invariant is pinned
@@ -72,7 +72,7 @@ class MetricsMiddleware:
     as assignable into a ``Sequence[Middleware]``.
 
     Holds a reference to the shared :class:`ClientMetrics` instance owned
-    by :class:`Session`. The middleware does not own metric state; it
+    by :class:`NotebookLMClient`. The middleware does not own metric state; it
     is purely a write-through into the host's accumulator. This keeps the
     ``client.metrics`` snapshot view authoritative — a test that swaps a
     middleware out can still observe the counters.

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -16,7 +16,7 @@ Auth-refresh-and-retry lives in :class:`AuthRefreshMiddleware`.
 Behavior:
 
 - **Same retry counts** — ``rate_limit_max_retries`` /
-  ``server_error_max_retries`` are propagated from ``Session`` so the
+  ``server_error_max_retries`` are propagated from ``NotebookLMClient`` so the
   budget matches the historical transport loop.
 - **Same backoff timing** — :func:`_backoff.compute_backoff_delay` is
   invoked with the same ``base=1.0`` / ``cap=30.0`` / ``jitter_ratio=0.2``
@@ -84,7 +84,7 @@ class RetryMiddleware:
     ``NotebookLMClient.__init__``):
 
     - ``rate_limit_max_retries`` / ``server_error_max_retries``: the same
-      budgets exposed by ``Session`` via ``_rate_limit_max_retries`` /
+      budgets exposed by ``NotebookLMClient`` via ``_rate_limit_max_retries`` /
       ``_server_error_max_retries``.
     - ``retry_timeout``: aggregate retry deadline in seconds. Production wires
       this to the existing client HTTP timeout so retry sleeps cannot exceed

--- a/src/notebooklm/_middleware_semaphore.py
+++ b/src/notebooklm/_middleware_semaphore.py
@@ -6,7 +6,7 @@ ordering is ``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection,
 Tracing]``.
 
 Placing the semaphore here (rather than around the chain dispatch in
-``Session._perform_authed_post``) keeps two contracts intact: queued tasks
+``RuntimeTransport.perform_authed_post``) keeps two contracts intact: queued tasks
 stay counted by ``DrainMiddleware`` (Drain sits outside the semaphore wait),
 and Metrics latency includes RPC queue wait:
 
@@ -44,7 +44,7 @@ from ._middleware import NextCall, RpcRequest, RpcResponse
 from ._middleware_context import RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS
 
 # ``RpcRequest.context`` key used to communicate the per-call queue-wait
-# duration from this middleware up to ``Session._perform_authed_post``
+# duration from this middleware up to ``RuntimeTransport.perform_authed_post``
 # (which forwards it to ``ClientMetrics.record_rpc_queue_wait``). Kept as a
 # compatibility alias for older internal imports; new code should use the
 # centralized ``RPC_CONTEXT_*`` vocabulary from ``_middleware_context``.

--- a/src/notebooklm/_reqid_counter.py
+++ b/src/notebooklm/_reqid_counter.py
@@ -10,7 +10,7 @@ Design constraints (load-bearing — see ``tests/unit/test_reqid_counter.py`` an
 ``tests/unit/test_reqid_counter_concurrent.py``):
 
 * ``__init__`` MUST be event-loop-agnostic — it must NOT instantiate
-  ``asyncio.Lock()`` eagerly. ``Session`` is routinely built outside a
+  ``asyncio.Lock()`` eagerly. ``NotebookLMClient`` is routinely built outside a
   running loop (sync-mode ``NotebookLMClient(...)`` before the caller's
   ``asyncio.run``), and ``asyncio.Lock()`` binds to the running loop on
   construction in some Python versions. The lock is therefore allocated
@@ -47,8 +47,7 @@ from ._loop_affinity import assert_bound_loop
 # instead of hard-coding ``100000``.
 DEFAULT_BASELINE: int = 100000
 # Default step applied by :meth:`ReqidCounter.next_reqid`. Matches the
-# historical bump that ``ChatAPI.ask`` performed under the legacy
-# ``self._core._reqid_counter += 100000`` contract.
+# historical bump that ``ChatAPI.ask`` performed.
 DEFAULT_STEP: int = 100000
 
 
@@ -76,8 +75,7 @@ class ReqidCounter:
     ) -> None:
         # Plain int; mutated only inside :meth:`next_reqid` under ``_lock`` or
         # via direct ``self._reqid._value = …`` writethrough from test fixtures
-        # that want to seed the counter without paying the deprecation-warning
-        # tax on the public ``_reqid_counter`` setter on ``Session``.
+        # that want to seed the counter to a deterministic baseline.
         self._value: int = baseline
         # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
         # Python versions, and this object is constructed at client
@@ -85,7 +83,7 @@ class ReqidCounter:
         # outside a loop.
         self._lock: asyncio.Lock | None = None
         # No-op default keeps standalone construction (unit tests) free of a
-        # ``Session``-shaped dependency. ``Session`` injects its own
+        # client-shaped dependency. ``NotebookLMClient`` injects its own
         # metrics-aware recorder so lock-wait latency continues to be tracked
         # in the cumulative ``ClientMetricsSnapshot``.
         self._on_lock_wait: Callable[[float], None] = (
@@ -118,8 +116,8 @@ class ReqidCounter:
         Returns a point-in-time read; the value can race with a concurrent
         :meth:`next_reqid` mutation. Callers that need an atomic post-
         increment value MUST use :meth:`next_reqid`, which serialises the
-        read-modify-write under :attr:`_lock`. This accessor exists so
-        ``Session._reqid_counter`` (read path) and test assertions
+        read-modify-write under :attr:`_lock`. This accessor exists so the
+        counter read path and test assertions
         (``assert core._reqid_counter == ...`` after a known sequence) stay
         lock-free.
         """
@@ -128,9 +126,8 @@ class ReqidCounter:
     def set_value(self, new_value: int) -> None:
         """Replace the counter value.
 
-        Used by the ``Session._reqid_counter`` setter (which emits a
-        ``DeprecationWarning`` before delegating here) and by test fixtures
-        that need to seed the counter to a deterministic baseline.
+        Used by test fixtures that seed the counter to a deterministic
+        baseline.
         """
         self._value = new_value
 

--- a/src/notebooklm/_runtime_auth.py
+++ b/src/notebooklm/_runtime_auth.py
@@ -36,21 +36,17 @@ tests/integration/concurrency/test_refresh_cancellation_propagation.py):
 * The ``_refresh_task`` slot is intentionally NOT cleared when a waiter is
   cancelled mid-shield — concurrency tests assert task identity across
   cancellation so siblings joined to the same single-flight refresh see the
-  same completion. Per ``_core.py`` history at the relocated comment site.
+  same completion.
 
-Collaborator surface (no Session-shaped host):
+Collaborator surface:
 
-The coordinator was historically wired through a structural
-``_AuthRefreshHost`` Protocol that re-declared three private ``Session``
-slots (``auth`` / ``_metrics_obj`` / ``_kernel``). That Protocol coupled
-the coordinator to ``Session``'s private attribute names and forced
-fake-host shims in tests. It was deleted in favor of explicit per-method
-collaborators: :meth:`snapshot` and :meth:`update_auth_tokens` take an
+The coordinator depends on explicit per-method collaborators:
+:meth:`snapshot` and :meth:`update_auth_tokens` take an
 ``auth: AuthTokens`` kwarg, :meth:`update_auth_headers` takes
 ``auth: AuthTokens`` plus ``kernel: Kernel``, and the lock-wait metric is
 recorded through ``self._metrics`` (already supplied at construction).
 This keeps every dependency on the coordinator's surface concrete and
-narrow — there is no Session shape to fake.
+narrow.
 """
 
 from __future__ import annotations
@@ -80,8 +76,7 @@ class AuthRefreshCoordinator:
     """Owns refresh single-flight, snapshot serialization, and auth-header sync.
 
     Field names (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``,
-    ``_auth_snapshot_lock``) deliberately mirror the retired legacy
-    ``Session`` ivars so bridge-retirement diffs and coordinator-specific
+    ``_auth_snapshot_lock``) are kept stable so coordinator-specific
     tests remain easy to audit.
     """
 
@@ -174,10 +169,10 @@ class AuthRefreshCoordinator:
     # inspect THIS module's source via ``inspect.getsource(...)`` + AST
     # parsing — any structural change to either method body (e.g.
     # extracting a helper, refactoring the lock dance, adding an
-    # ``await`` mid-mutation) will trip those guards. ``Session._snapshot``
-    # and ``Session.update_auth_tokens`` (`_session.py`) are now thin
-    # delegates that forward through ``self._auth_coord``; there is no
-    # longer a "second body" to keep in sync.
+    # ``await`` mid-mutation) will trip those guards. Previously a facade
+    # method mirrored each body; now ``snapshot`` and ``update_auth_tokens``
+    # here are the only implementations, so there is no second body to keep
+    # in sync.
     # ------------------------------------------------------------------
 
     async def snapshot(self, *, auth: AuthTokens) -> AuthSnapshot:
@@ -197,10 +192,8 @@ class AuthRefreshCoordinator:
         guarantees the four scalars in the snapshot are coherent with each
         other; the no-await rule keeps the cookie axis aligned with them.
 
-        ``auth`` is passed explicitly per call (the previous
-        ``_AuthRefreshHost`` Protocol re-declared the ``auth`` slot from
-        ``Session``); the lock-wait metric is recorded through
-        ``self._metrics`` (supplied at construction).
+        ``auth`` is passed explicitly per call; the lock-wait metric is
+        recorded through ``self._metrics`` (supplied at construction).
         """
         wait_start = time.perf_counter()
         async with self.get_auth_snapshot_lock():
@@ -258,9 +251,7 @@ class AuthRefreshCoordinator:
         ``accounts.google.com``.
 
         ``auth`` and ``kernel`` are passed explicitly per call so the
-        coordinator does not need a ``_AuthRefreshHost``-shaped host (the
-        Protocol that re-declared Session's ``auth`` / ``_kernel`` slots was
-        deleted alongside this signature change).
+        coordinator does not need an owner-shaped host.
 
         Raises:
             RuntimeError: If the kernel's HTTP client is not initialised (the
@@ -305,7 +296,7 @@ class AuthRefreshCoordinator:
                 "AuthRefreshCoordinator.await_refresh called without a "
                 "refresh_callback configured — wire one via "
                 "AuthRefreshCoordinator(refresh_callback=...) (or by "
-                "constructing Session with refresh_callback=...) before "
+                "constructing NotebookLMClient with refresh_callback=...) before "
                 "triggering an auth refresh."
             )
 

--- a/src/notebooklm/_runtime_contracts.py
+++ b/src/notebooklm/_runtime_contracts.py
@@ -65,7 +65,7 @@ class Kernel(Protocol):
 class RpcCaller(Protocol):
     """Narrow RPC dispatch surface consumed by pure-RPC feature APIs.
 
-    Mirrors the legacy ``Session.rpc_call`` signature exactly so feature
+    Mirrors the ``NotebookLMClient.rpc_call`` signature exactly so feature
     retypes do not change call semantics. The transitional
     ``_is_retry`` parameter and the keyword-only
     ``disable_internal_retries`` / ``operation_variant`` parameters are

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -10,7 +10,7 @@ Design constraints (load-bearing — see
 ``tests/unit/concurrency/test_close_cancellation_leak.py``,
 ``tests/unit/test_session_close.py``, and ``tests/unit/test_observability.py``):
 
-* ``__init__`` MUST be event-loop-agnostic. ``Session`` is routinely
+* ``__init__`` MUST be event-loop-agnostic. ``NotebookLMClient`` is routinely
   constructed outside a running loop (sync-mode
   ``NotebookLMClient(auth)`` before ``asyncio.run``), so this helper may
   not call ``asyncio.get_running_loop()`` or instantiate any ``asyncio.*``
@@ -108,7 +108,7 @@ class TransportDrainTracker:
         # for standalone fixtures.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
         # ADR-014 Rule 1: close-time drain hooks are owned here, not on
-        # ``Session``. Insertion order is preserved (Python 3.7+ dict
+        # the client. Insertion order is preserved (Python 3.7+ dict
         # invariant) and :meth:`run_drain_hooks` fires them in that order
         # under ``ClientLifecycle.close``.
         self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
@@ -150,7 +150,7 @@ class TransportDrainTracker:
         """Return the per-instance drain ``asyncio.Condition``, creating it lazily.
 
         Lazy construction is required because ``asyncio.Condition()`` binds
-        to the running event loop in some Python versions, and ``Session``
+        to the running event loop in some Python versions, and ``NotebookLMClient``
         is routinely instantiated outside one. The check-then-assign is
         race-free without an outer lock because asyncio is single-threaded:
         no other coroutine can execute between the ``is None`` check and

--- a/src/notebooklm/rpc/encoder.py
+++ b/src/notebooklm/rpc/encoder.py
@@ -29,7 +29,7 @@ def encode_rpc_request(
             Callers must pass the SAME string to the URL builder so the
             ``rpcids=`` query param and the ``f.req`` body stay in sync —
             mismatched IDs reach the wire as malformed requests. Used by
-            ``Session`` to thread ``NOTEBOOKLM_RPC_OVERRIDES`` through.
+            ``NotebookLMClient`` to thread ``NOTEBOOKLM_RPC_OVERRIDES`` through.
 
     Returns:
         Triple-nested array structure for batchexecute


### PR DESCRIPTION
## What

The `Session` facade class (and `_session.py`) were removed when the facade was split into `NotebookLMClient` + runtime collaborators, but **~50 comments/docstrings across 22 files still named `Session`** — confusing a contributor who greps for a `class Session` that no longer exists. This replaces each reference with the accurate current owner. Comment/docstring/error-string only.

Net: **22 files, −13 lines** (63 insertions / 76 deletions).

## Mapping applied (verified against the current code)

| `Session` reference | Replaced with |
|---|---|
| generic `Session` (client / composition root, "built outside a loop", "wiring", "enters the chain") | `NotebookLMClient` |
| `Session._perform_authed_post` | `RuntimeTransport.perform_authed_post` |
| `Session._bind_transport` | `ClientComposed.bind_transport` |
| `Session.rpc_call` | `NotebookLMClient.rpc_call` |
| `Session._snapshot` / `update_auth_tokens` | the `AuthRefreshCoordinator` methods (facade-delegate framing dropped) |
| retry budgets / intra-process lock "in `Session`" | `NotebookLMClient` / "the client" |

**Double-archaeology** — several references named methods that *also* no longer exist (the `Session._reqid_counter` setter, `Session._require_constructed`, and the `Session._snapshot` facade delegates). Those are rewritten to describe the **current** behavior (e.g. the chain leaf's own transport-bound `RuntimeError` guard) rather than a dead method name. The `AuthRefreshCoordinator.await_refresh` error hint now points callers at `NotebookLMClient(refresh_callback=...)` instead of `Session(...)`.

Also dropped two stray `_core.py` archaeology lines (another deleted module) while **keeping** the intentional `CORE_LOGGER_NAME = "notebooklm._core"` logging contract — its comment already documents that no `_core`/`Session` owner exists, which is exactly the clarification a contributor needs.

## Preserved intentionally

Generic lowercase "session" (auth session, upload session, "shared client session"), the auth **"Session ID"** token (FdrFJe), the CLI **`session`** command-group section headers, and the `CORE_LOGGER_NAME` contract.

## Verification

- **Token-level proof**: tokenizing each changed `.py` (ignoring comments/strings) yields identical code tokens for all 22 files — no executable code changed (the one error-message string edit is excluded by design).
- `ruff format` + `ruff check` clean, `mypy` clean (188 files), full suite **7895 passed**.

This closes the deliberate-out-of-scope item from #1300 — the deleted-facade references are now resolved.

https://claude.ai/code/session_017gLnLdVu3X4wrwGo2GwGwu

---
_Generated by [Claude Code](https://claude.ai/code/session_017gLnLdVu3X4wrwGo2GwGwu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and comments across multiple modules to clarify architectural references and improve code clarity.
  * Refined docstring language to better reflect current system design and component responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->