### PR TITLE
test(cli): widen quiet-enforcement gate to all cli/**/*.py (closes #1301)

### DIFF
--- a/tests/unit/cli/test_quiet_enforcement.py
+++ b/tests/unit/cli/test_quiet_enforcement.py
@@ -16,7 +16,12 @@ The contract therefore is:
   emit a structured JSON envelope) so the failure is always observable.
 
 This module enforces that contract structurally via an AST walk over every
-``src/notebooklm/cli/*_cmd.py`` file.
+``src/notebooklm/cli/**/*.py`` file except ``error_handler.py`` (which owns
+the quiet-bypassing error helpers themselves). The scan mirrors ``_cli_files()``
+in the sibling gate ``tests/_lint/test_error_handler_allowlist.py`` so the two
+CLI exit-path gates cover an identical file set -- including everything under
+``cli/services/`` -- and a quiet-bypassing error-path call cannot hide in a
+non-``*_cmd.py`` module (issue #1301).
 
 Error-path heuristic
 --------------------
@@ -164,8 +169,18 @@ def _walk_with_ancestors(tree: ast.AST) -> Iterator[tuple[ast.AST, list[ast.AST]
 # ---------------------------------------------------------------------------
 
 
+def _cli_files() -> list[Path]:
+    """Every ``cli/**/*.py`` except ``error_handler.py`` (which owns the helpers).
+
+    Identical file set to ``_cli_files()`` in the sibling gate
+    ``tests/_lint/test_error_handler_allowlist.py`` so both CLI exit-path gates
+    audit the same modules (issue #1301).
+    """
+    return [p for p in sorted(CLI_ROOT.rglob("*.py")) if p.name != "error_handler.py"]
+
+
 def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
-    """Return ``(unmarked, stale, empty_reason)`` across every ``*_cmd.py``.
+    """Return ``(unmarked, stale, empty_reason)`` across every CLI module.
 
     * ``unmarked`` -- error-path quiet-bypass calls with no ``# quiet-ok:``
       marker (formatted ``module::func:line``).
@@ -175,7 +190,7 @@ def _audit_quiet_markers() -> tuple[list[str], list[str], list[str]]:
     unmarked: list[str] = []
     stale: list[str] = []
     empty_reason: list[str] = []
-    for path in sorted(CLI_ROOT.glob("*_cmd.py")):
+    for path in _cli_files():
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
         rel = path.relative_to(REPO_ROOT).as_posix()


### PR DESCRIPTION
## Summary

Fixes #1301. The CLI quiet-enforcement lint gate
(`tests/unit/cli/test_quiet_enforcement.py`) scanned only top-level
`cli/*_cmd.py` files, so a quiet-bypassing error-path `cli_print` /
`emit_status` call in any non-`*_cmd.py` CLI module — `cli/helpers.py`,
`cli/polling_ui.py`, `cli/rendering.py`, or anything under `cli/services/` —
would not be caught. The sibling exit-path gate
(`tests/_lint/test_error_handler_allowlist.py`) already scans the full
`cli/**/*.py` set; this brings the two gates to parity.

## Change

- Add a `_cli_files()` helper that returns every `cli/**/*.py` except
  `error_handler.py` (`rglob("*.py")`), mirroring the identically-named helper
  in the sibling gate.
- Widen `_audit_quiet_markers()` to iterate `_cli_files()` instead of
  `CLI_ROOT.glob("*_cmd.py")`.
- Update the module + function docstrings to document the widened scope and the
  decision to include `cli/services/` (for full parity with the sibling gate).

## Newly surfaced sites

**Zero.** The widened scan now covers all 67 CLI files (33 under `services/`).
The only qualifying error-path quiet-aware site remains the already-annotated
`chat_cmd.py::_run` `# quiet-ok:` waiver — so no conversions to `output_error` /
`json_error_response` and no new `# quiet-ok:` markers were required. This
matches the issue's prediction ("Most likely there are few or zero").

## Verification

- `uv run ruff format --check .` — clean
- `uv run ruff check src tests` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run pytest` — 7892 passed, 100 skipped

The marker-scanning helpers in `tests/_fixtures/cli_exit_markers.py`
(`marker_reasons`, `match_markers`, `Span`) are imported and used as-is;
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for CLI error handling to ensure consistent quiet-mode behavior across additional modules. This strengthens validation of error-path contracts throughout the CLI interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->