### PR TITLE
test(lint): scan each CLI exit-path file once per session (closes #1302)

### DIFF
--- a/tests/_fixtures/cli_exit_markers.py
+++ b/tests/_fixtures/cli_exit_markers.py
@@ -59,22 +59,29 @@ def marker_reasons(source: str, marker: str) -> dict[int, str]:
     return _reasons_from_bodies(_comment_bodies(source), marker)
 
 
-@functools.cache
 def parse_cli_file(path: Path) -> tuple[str, ast.Module]:
     """Read and ``ast.parse`` *path* once, caching ``(source, tree)`` per path.
 
     Memoized for the test session: the exit-path gate audits each CLI file
     under multiple marker families and assertions, and the source does not
     change mid-run, so each file is read + parsed exactly once (issue #1302).
+
+    Paths are canonicalized before they reach the cache so a relative and an
+    absolute reference to the same physical file share one entry.
     """
+    return _parse_cli_file_cached(path.expanduser().resolve())
+
+
+@functools.cache
+def _parse_cli_file_cached(path: Path) -> tuple[str, ast.Module]:
     source = path.read_text(encoding="utf-8")
     return source, ast.parse(source, filename=str(path))
 
 
 @functools.cache
 def _comment_bodies_for(path: Path) -> tuple[tuple[int, str], ...]:
-    """Tokenize *path* once, caching its comment ``(lineno, body)`` pairs."""
-    source, _tree = parse_cli_file(path)
+    """Tokenize *path* (canonicalized) once, caching its comment pairs."""
+    source, _tree = _parse_cli_file_cached(path)
     return _comment_bodies(source)
 
 
@@ -84,7 +91,7 @@ def marker_reasons_for(path: Path, marker: str) -> dict[int, str]:
     Byte-identical to ``marker_reasons(parse_cli_file(path)[0], marker)`` but
     reuses the cached single tokenize pass across every marker family.
     """
-    return _reasons_from_bodies(_comment_bodies_for(path), marker)
+    return _reasons_from_bodies(_comment_bodies_for(path.expanduser().resolve()), marker)
 
 
 def match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[int], set[int]]:

--- a/tests/_fixtures/cli_exit_markers.py
+++ b/tests/_fixtures/cli_exit_markers.py
@@ -6,15 +6,48 @@ calls) and ``tests/unit/cli/test_quiet_enforcement.py`` (``# quiet-ok:`` waivers
 on error-path ``cli_print`` / ``emit_status`` calls) scan inline marker comments
 and match them 1:1 to call sites. The scan + match logic lives here so a fix to
 either cannot drift between the two gates (PR #1299 review).
+
+The exit-path gate audits each CLI file under several marker families and across
+two assertions per family, so a naive helper re-reads + re-``ast.parse``s +
+re-``tokenize``s every file once per audit pass. The per-path memoized
+:func:`parse_cli_file` / :func:`marker_reasons_for` helpers collapse that to a
+single read + parse + tokenize per file per test session -- the CLI sources do
+not change mid-run, so caching on the path is sound (issue #1302).
 """
 
 from __future__ import annotations
 
+import ast
+import functools
 import io
 import tokenize
+from pathlib import Path
 
 #: ``(start_line, end_line)`` of a call, inclusive (1-based, as ``ast`` reports).
 Span = tuple[int, int]
+
+
+def _comment_bodies(source: str) -> tuple[tuple[int, str], ...]:
+    """Return ``(lineno, body)`` for every comment token in *source*.
+
+    ``body`` is the comment with its leading ``#``\\ (s) and surrounding
+    whitespace stripped. Using ``tokenize`` ensures only real comment tokens
+    are seen -- never a marker-looking substring inside a string literal.
+    """
+    bodies: list[tuple[int, str]] = []
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type == tokenize.COMMENT:
+            bodies.append((tok.start[0], tok.string.lstrip("#").strip()))
+    return tuple(bodies)
+
+
+def _reasons_from_bodies(bodies: tuple[tuple[int, str], ...], marker: str) -> dict[int, str]:
+    """Map ``lineno -> reason`` for each comment ``body`` that starts with *marker*."""
+    return {
+        lineno: body.removeprefix(marker).strip()
+        for lineno, body in bodies
+        if body.startswith(marker)
+    }
 
 
 def marker_reasons(source: str, marker: str) -> dict[int, str]:
@@ -23,14 +56,35 @@ def marker_reasons(source: str, marker: str) -> dict[int, str]:
     Uses ``tokenize`` so the marker is only recognized inside a real comment
     token, never inside a string literal that happens to contain the text.
     """
-    reasons: dict[int, str] = {}
-    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
-        if tok.type != tokenize.COMMENT:
-            continue
-        body = tok.string.lstrip("#").strip()
-        if body.startswith(marker):
-            reasons[tok.start[0]] = body.removeprefix(marker).strip()
-    return reasons
+    return _reasons_from_bodies(_comment_bodies(source), marker)
+
+
+@functools.cache
+def parse_cli_file(path: Path) -> tuple[str, ast.Module]:
+    """Read and ``ast.parse`` *path* once, caching ``(source, tree)`` per path.
+
+    Memoized for the test session: the exit-path gate audits each CLI file
+    under multiple marker families and assertions, and the source does not
+    change mid-run, so each file is read + parsed exactly once (issue #1302).
+    """
+    source = path.read_text(encoding="utf-8")
+    return source, ast.parse(source, filename=str(path))
+
+
+@functools.cache
+def _comment_bodies_for(path: Path) -> tuple[tuple[int, str], ...]:
+    """Tokenize *path* once, caching its comment ``(lineno, body)`` pairs."""
+    source, _tree = parse_cli_file(path)
+    return _comment_bodies(source)
+
+
+def marker_reasons_for(path: Path, marker: str) -> dict[int, str]:
+    """Path-keyed :func:`marker_reasons`: tokenize each file once per session.
+
+    Byte-identical to ``marker_reasons(parse_cli_file(path)[0], marker)`` but
+    reuses the cached single tokenize pass across every marker family.
+    """
+    return _reasons_from_bodies(_comment_bodies_for(path), marker)
 
 
 def match_markers(spans: list[Span], marker_lines: set[int]) -> tuple[list[int], set[int]]:

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -44,7 +44,13 @@ import ast
 from collections.abc import Callable
 from pathlib import Path
 
-from _fixtures.cli_exit_markers import Span, marker_reasons, match_markers
+from _fixtures.cli_exit_markers import (
+    Span,
+    marker_reasons,
+    marker_reasons_for,
+    match_markers,
+    parse_cli_file,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
@@ -108,10 +114,9 @@ def _audit(
     empty_reason: list[str] = []
     total = 0
     for path in _cli_files():
-        source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(path))
+        _source, tree = parse_cli_file(path)  # cached: read + parse once per session
         rel = path.relative_to(REPO_ROOT).as_posix()
-        reasons = marker_reasons(source, marker)
+        reasons = marker_reasons_for(path, marker)
         spans = spanner(tree)
         total += len(spans)
 
@@ -227,3 +232,26 @@ def test_raw_sysexit_spans_detects_bare_and_called() -> None:
     """
     tree = ast.parse("def called():\n    raise SystemExit(1)\ndef bare():\n    raise SystemExit\n")
     assert sorted(lo for lo, _hi in _raw_sysexit_spans(tree)) == [2, 4]
+
+
+def test_parse_cli_file_is_memoized_and_byte_identical() -> None:
+    """The single-pass cache must reuse one read/parse/tokenize per file.
+
+    Each audit pass calls ``parse_cli_file`` / ``marker_reasons_for`` once per
+    CLI file, and the gate runs four passes. Caching on the path collapses that
+    to one read + parse + tokenize per file per session (issue #1302) -- but
+    only if it stays behavior-identical to the source-keyed helpers it replaces.
+    """
+    path = next(iter(_cli_files()))
+
+    # Same path -> the *identical* cached (source, tree); not a re-parse.
+    source, tree = parse_cli_file(path)
+    again_source, again_tree = parse_cli_file(path)
+    assert again_tree is tree
+    assert again_source is source
+    assert source == path.read_text(encoding="utf-8")
+
+    # Path-keyed reasons are byte-identical to the source-keyed helper for
+    # every marker family the gate audits.
+    for marker in (CLICK_EXCEPTION_MARKER, RAW_SYSEXIT_MARKER):
+        assert marker_reasons_for(path, marker) == marker_reasons(source, marker)

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -242,7 +242,7 @@ def test_parse_cli_file_is_memoized_and_byte_identical() -> None:
     to one read + parse + tokenize per file per session (issue #1302) -- but
     only if it stays behavior-identical to the source-keyed helpers it replaces.
     """
-    path = next(iter(_cli_files()))
+    path = _cli_files()[0]
 
     # Same path -> the *identical* cached (source, tree); not a re-parse.
     source, tree = parse_cli_file(path)


### PR DESCRIPTION
## What

The CLI exit-path lint gate (`tests/_lint/test_error_handler_allowlist.py`) calls `_audit(spanner, marker)` **four** times — two `click.ClickException` assertions + two raw-`SystemExit` assertions — and each pass re-read, re-`ast.parse`d, and re-`tokenize`d **every** CLI file. So each CLI file was parsed/tokenized ~4× per session.

This adds two small **path-keyed memoized scanners** to the shared `tests/_fixtures/cli_exit_markers.py` and routes `_audit` through them:

- `parse_cli_file(path) -> (source, tree)` — `@functools.cache`-backed read + `ast.parse`, one per file per session.
- `marker_reasons_for(path, marker)` — reuses a once-per-file cached `tokenize` pass (`_comment_bodies_for`).

Net effect: each CLI file is read + parsed + tokenized **exactly once per test session**.

## Why it's safe

- **Byte-identical detection.** `marker_reasons` is refactored to share the single comment-token extraction (`_comment_bodies` / `_reasons_from_bodies`) with the cached path scan, so the two cannot drift. WHAT is detected (unmarked / stale / empty / total) is unchanged.
- CLI sources do not change mid-run, so caching on the path is sound.
- A new `test_parse_cli_file_is_memoized_and_byte_identical` pins the contract: same path returns the *identical* cached `(source, tree)` object, and `marker_reasons_for` equals the source-keyed `marker_reasons` across both marker families.

## Scope

The source-keyed `marker_reasons(source, marker)` is **left untouched** — it is still used by the quiet-harness gate (`tests/unit/cli/test_quiet_enforcement.py`, owned by a sibling change for #1301). Unifying both gates onto the path-keyed scanner is intentionally out of scope here to keep this PR conflict-free.

## Verification

- `uv run ruff format --check .` ✓
- `uv run ruff check src tests` ✓
- `uv run mypy src/notebooklm --ignore-missing-imports` ✓
- `uv run pytest` → 7893 passed, 100 skipped ✓

Closes #1302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that verifies cached file parsing returns identical results across repeated calls and preserves previous marker-detection results.

* **Chores**
  * Improved lint test infrastructure to cache per-file parsing and comment extraction, reducing redundant work and speeding tests while keeping behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->