### PR TITLE
test(lint): gate ClickException subclasses on CLI exit paths (closes #1307)

### DIFF
--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -227,7 +227,9 @@ def register_chat_commands(cli):
                     json_output,
                     1,
                 )
-            raise click.UsageError(mutual_exclusion_message)
+            raise click.UsageError(  # cli-input-validation: --new and --conversation-id are mutually exclusive
+                mutual_exclusion_message
+            )
         question = resolve_prompt(question, prompt_file, "question", required=True)
         nb_id = require_notebook(notebook_id)
 

--- a/src/notebooklm/cli/download_cmd.py
+++ b/src/notebooklm/cli/download_cmd.py
@@ -136,7 +136,9 @@ def _run_artifact_download(ctx: click.Context, spec: DownloadTypeSpec, **kwargs:
     except DownloadPlanValidationError as exc:
         if json_output:
             output_error(exc.message, exc.code, True, 1)
-        raise click.UsageError(exc.message) from exc
+        raise click.UsageError(  # cli-input-validation: download plan flag/argument validation
+            exc.message
+        ) from exc
 
     for warning in plan.warnings:
         click.echo(warning, err=True)

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -69,7 +69,7 @@ def resolve_prompt(
         click.ClickException: Prompt file is unreadable or not valid UTF-8.
     """
     if argument_value and prompt_file:
-        raise click.UsageError(
+        raise click.UsageError(  # cli-input-validation: argument and --prompt-file are mutually exclusive
             f"Cannot use both the {param_name} argument and --prompt-file. Choose one."
         )
 
@@ -96,5 +96,7 @@ def resolve_prompt(
         text = argument_value or ""
 
     if required and not text:
-        raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")
+        raise click.UsageError(  # cli-input-validation: required prompt missing from argument and --prompt-file
+            f"Provide a {param_name} argument or --prompt-file."
+        )
     return text

--- a/src/notebooklm/cli/note_cmd.py
+++ b/src/notebooklm/cli/note_cmd.py
@@ -142,7 +142,7 @@ def note_create(ctx, content, content_flag, notebook_id, title, json_output, cli
     # distinguish "user passed empty" from "user passed nothing"; the explicit
     # ``content_flag is not None`` check means ``--content ""`` still wins.
     if content and content_flag is not None:
-        raise click.UsageError(
+        raise click.UsageError(  # cli-input-validation: positional CONTENT and --content are mutually exclusive
             "Cannot use both the positional CONTENT argument and --content. Choose one."
         )
     if content_flag is not None:

--- a/src/notebooklm/cli/research_cmd.py
+++ b/src/notebooklm/cli/research_cmd.py
@@ -170,7 +170,9 @@ def research_wait(
                 json_output,
                 1,
             )
-        raise click.UsageError("--cited-only requires --import-all")
+        raise click.UsageError(  # cli-input-validation: --cited-only requires --import-all
+            "--cited-only requires --import-all"
+        )
 
     nb_id = require_notebook(notebook_id)
     plan = ResearchWaitPlan(

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -203,7 +203,9 @@ def _parse_include_domains(values: tuple[str, ...]) -> set[str]:
     try:
         return _cookie_domains._parse_include_domains(values)
     except _cookie_domains.IncludeDomainsParseError as exc:
-        raise click.BadParameter(str(exc)) from None
+        raise click.BadParameter(  # cli-input-validation: --include-domains value parse failure
+            str(exc)
+        ) from None
 
 
 def _warn_missing_optional_domains(include_domains: set[str]) -> None:

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -202,7 +202,9 @@ def _emit_source_fulltext_flag_conflict(message: str, *, json_output: bool) -> N
     if json_output:
         _output_error(message, "VALIDATION_ERROR", json_output, 1)
         raise AssertionError("unreachable")  # pragma: no cover
-    raise click.UsageError(message)
+    raise click.UsageError(  # cli-input-validation: source fulltext flag conflict
+        message
+    )
 
 
 def _resolve_source_fulltext_output_path(
@@ -677,7 +679,9 @@ def source_add(
             if json_output:
                 _output_error(message, "VALIDATION_ERROR", json_output, 1)
                 raise AssertionError("unreachable") from None  # pragma: no cover
-            raise click.UsageError(message)
+            raise click.UsageError(  # cli-input-validation: stdin '-' incompatible with non-text --type
+                message
+            )
         content = read_stdin_text(source_label="source content")
         source_type = "text"
 
@@ -910,7 +914,9 @@ def _emit_add_research_flag_conflict(message: str, *, json_output: bool) -> NoRe
     if json_output:
         _output_error(message, "VALIDATION_ERROR", json_output, 1)
         raise AssertionError("unreachable")  # pragma: no cover
-    raise click.UsageError(message)
+    raise click.UsageError(  # cli-input-validation: source add-research flag conflict
+        message
+    )
 
 
 def _print_add_research_task_ids(result: SourceAddResearchResult) -> None:

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -102,22 +102,25 @@ def _cli_files() -> list[Path]:
 
 
 def _is_envelope_bypassing_click_exception(func: ast.AST) -> bool:
-    """True for ``click.<Name>`` or bare ``<Name>`` in the bypassing family.
+    """True for a ``click``-rooted or bare call in the bypassing family.
 
-    Matches both the qualified ``click.UsageError`` attribute form and the bare
-    ``UsageError`` name form (``from click import UsageError``), while rejecting
-    unrelated identifiers and any deeper / differently-rooted attribute chain
-    (e.g. ``foo.UsageError`` or ``click.exceptions.Exit``).
+    Resolves the dotted call path via :func:`_call_name` and accepts:
+
+    * a bare ``<Name>`` (``from click import UsageError``), and
+    * any ``click``-rooted chain whose leaf is in the family --
+      ``click.UsageError`` *and* the canonical ``click.exceptions.UsageError``.
+
+    Rejects a differently-rooted chain (``other.UsageError``) and any leaf
+    outside the family, so the deliberately-excluded control-flow exits
+    ``click.Abort`` / ``click.exceptions.Exit`` never match (issue #1307).
     """
-    if isinstance(func, ast.Attribute):
-        return (
-            isinstance(func.value, ast.Name)
-            and func.value.id == "click"
-            and func.attr in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
-        )
-    if isinstance(func, ast.Name):
-        return func.id in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
-    return False
+    name = _call_name(func)
+    if not name:
+        return False
+    parts = name.split(".")
+    if len(parts) == 1:
+        return parts[0] in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
+    return parts[0] == "click" and parts[-1] in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
 
 
 def _click_exception_spans(tree: ast.AST) -> list[Span]:
@@ -281,10 +284,11 @@ def test_click_exception_spans_detects_subclasses_and_bare_import() -> None:
     """Envelope-bypassing subclasses are detected in both attribute + bare form.
 
     The gate widened from literal ``click.ClickException`` to the whole
-    envelope-bypassing family, in both the ``click.<Name>`` attribute form and
-    the bare ``<Name>`` form (``from click import UsageError``) (issue #1307).
-    An unrelated attribute chain (``click.exceptions.Exit``) and a same-named
-    attribute on a different root (``other.UsageError``) must NOT match.
+    envelope-bypassing family, in the ``click.<Name>`` attribute form, the
+    canonical ``click.exceptions.<Name>`` chain, and the bare ``<Name>`` form
+    (``from click import UsageError``) (issue #1307). The control-flow exit
+    ``click.exceptions.Exit`` and a same-named attribute on a different root
+    (``other.UsageError``) must NOT match.
     """
     tree = ast.parse(
         "import click\n"
@@ -294,8 +298,9 @@ def test_click_exception_spans_detects_subclasses_and_bare_import() -> None:
         "raise UsageError('x')\n"
         "raise click.exceptions.Exit(0)\n"
         "raise other.UsageError('x')\n"
+        "raise click.exceptions.UsageError('x')\n"
     )
-    assert sorted(lo for lo, _hi in _click_exception_spans(tree)) == [3, 4, 5]
+    assert sorted(lo for lo, _hi in _click_exception_spans(tree)) == [3, 4, 5, 8]
 
 
 def test_parse_cli_file_is_memoized_and_byte_identical() -> None:

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -101,32 +101,53 @@ def _cli_files() -> list[Path]:
     return [p for p in sorted(CLI_ROOT.rglob("*.py")) if p.name != "error_handler.py"]
 
 
-def _is_envelope_bypassing_click_exception(func: ast.AST) -> bool:
-    """True for a ``click``-rooted or bare call in the bypassing family.
+def _click_bare_exception_bindings(tree: ast.AST) -> set[str]:
+    """Local names bound to a family member via ``from click import ...``.
+
+    Only these may match the bare ``<Name>`` form -- a locally defined class or
+    a same-named import from another module must NOT be linted as a Click exit
+    (the gate's "reject unrelated identifiers" goal). Honors ``as`` aliases.
+    """
+    bindings: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "click":
+            for alias in node.names:
+                if alias.name in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS:
+                    bindings.add(alias.asname or alias.name)
+    return bindings
+
+
+def _is_envelope_bypassing_click_exception(func: ast.AST, *, bare_bindings: set[str]) -> bool:
+    """True for a ``click``-rooted or click-bound bare call in the family.
 
     Resolves the dotted call path via :func:`_call_name` and accepts:
 
-    * a bare ``<Name>`` (``from click import UsageError``), and
+    * a bare ``<Name>`` *only* when it was bound by ``from click import <Name>``
+      in this module (see :func:`_click_bare_exception_bindings`), and
     * any ``click``-rooted chain whose leaf is in the family --
       ``click.UsageError`` *and* the canonical ``click.exceptions.UsageError``.
 
-    Rejects a differently-rooted chain (``other.UsageError``) and any leaf
-    outside the family, so the deliberately-excluded control-flow exits
-    ``click.Abort`` / ``click.exceptions.Exit`` never match (issue #1307).
+    Rejects a differently-rooted chain (``other.UsageError``), a bare name not
+    imported from ``click``, and any leaf outside the family, so the
+    deliberately-excluded control-flow exits ``click.Abort`` /
+    ``click.exceptions.Exit`` never match (issue #1307).
     """
     name = _call_name(func)
     if not name:
         return False
     parts = name.split(".")
     if len(parts) == 1:
-        return parts[0] in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
+        return parts[0] in bare_bindings
     return parts[0] == "click" and parts[-1] in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
 
 
 def _click_exception_spans(tree: ast.AST) -> list[Span]:
     spans: list[Span] = []
+    bare_bindings = _click_bare_exception_bindings(tree)
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and _is_envelope_bypassing_click_exception(node.func):
+        if isinstance(node, ast.Call) and _is_envelope_bypassing_click_exception(
+            node.func, bare_bindings=bare_bindings
+        ):
             spans.append((node.lineno, node.end_lineno or node.lineno))
     return spans
 
@@ -285,10 +306,11 @@ def test_click_exception_spans_detects_subclasses_and_bare_import() -> None:
 
     The gate widened from literal ``click.ClickException`` to the whole
     envelope-bypassing family, in the ``click.<Name>`` attribute form, the
-    canonical ``click.exceptions.<Name>`` chain, and the bare ``<Name>`` form
-    (``from click import UsageError``) (issue #1307). The control-flow exit
-    ``click.exceptions.Exit`` and a same-named attribute on a different root
-    (``other.UsageError``) must NOT match.
+    canonical ``click.exceptions.<Name>`` chain, and the bare ``<Name>`` form --
+    but only when bound by ``from click import <Name>`` (issue #1307). The
+    control-flow exit ``click.exceptions.Exit``, a same-named attribute on a
+    different root (``other.UsageError``), and a bare name not imported from
+    ``click`` (``BadParameter`` here, never imported) must NOT match.
     """
     tree = ast.parse(
         "import click\n"
@@ -299,6 +321,7 @@ def test_click_exception_spans_detects_subclasses_and_bare_import() -> None:
         "raise click.exceptions.Exit(0)\n"
         "raise other.UsageError('x')\n"
         "raise click.exceptions.UsageError('x')\n"
+        "raise BadParameter('x')\n"
     )
     assert sorted(lo for lo, _hi in _click_exception_spans(tree)) == [3, 4, 5, 8]
 

--- a/tests/_lint/test_error_handler_allowlist.py
+++ b/tests/_lint/test_error_handler_allowlist.py
@@ -1,18 +1,25 @@
 """CLI exit-path marker enforcement.
 
-``click.ClickException`` and raw ``raise SystemExit`` bypass the typed
-``{"error": true, "code": ...}`` JSON envelope owned by ``error_handler.py``.
-Every such site OUTSIDE ``error_handler.py`` must carry an inline marker
-comment naming why, so each one stays a conscious, documented choice that
-cannot silently break ``--json`` consumers.
+``ClickException`` and its envelope-bypassing subclasses (``UsageError``,
+``BadParameter``, ``MissingParameter``, ``NoSuchOption``, ``BadArgumentUsage``,
+``FileError``) and raw ``raise SystemExit`` bypass the typed
+``{"error": true, "code": ...}`` JSON envelope owned by ``error_handler.py``:
+Click prints ``Error:`` / ``Usage:`` to stderr and exits the process. Every such
+site OUTSIDE ``error_handler.py`` must carry an inline marker comment naming why,
+so each one stays a conscious, documented choice that cannot silently break
+``--json`` consumers.
+
+``click.Abort`` and ``click.exceptions.Exit`` are deliberately EXCLUDED: they
+are control-flow (user-abort / explicit exit code), not error-message exits, so
+the gate neither detects nor requires a marker on them (issue #1307).
 
 The markers follow the ``# noqa`` / ``# type: ignore`` convention -- the
 reason lives at the call site, so (unlike the previous ``(file, line)``
 allowlist) they are immune to line shifts in unrelated code and need no central
 list to regenerate (issue #1298):
 
-* ``click.ClickException(...)``  ->  ``# cli-input-validation: <reason>``
-* ``raise SystemExit(...)``      ->  ``# cli-raw-exit: <reason>``
+* ``ClickException(...)`` and subclasses  ->  ``# cli-input-validation: <reason>``
+* ``raise SystemExit(...)``               ->  ``# cli-raw-exit: <reason>``
 
 A marker may sit on any physical line spanned by its call, so multi-line calls
 can carry it on the opening or the closing line.
@@ -58,6 +65,23 @@ CLI_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli"
 CLICK_EXCEPTION_MARKER = "cli-input-validation:"
 RAW_SYSEXIT_MARKER = "cli-raw-exit:"
 
+#: ``ClickException`` and the subclasses that bypass the JSON error envelope
+#: identically (Click prints ``Error:`` / ``Usage:`` to stderr and exits). Each
+#: requires a ``# cli-input-validation:`` marker. ``Abort`` / ``exceptions.Exit``
+#: are control-flow, not error-message exits, and are intentionally absent
+#: (issue #1307).
+ENVELOPE_BYPASSING_CLICK_EXCEPTIONS = frozenset(
+    {
+        "ClickException",
+        "UsageError",
+        "BadParameter",
+        "MissingParameter",
+        "NoSuchOption",
+        "BadArgumentUsage",
+        "FileError",
+    }
+)
+
 # Defense-in-depth ceiling: raw ``SystemExit`` outside ``error_handler.py``
 # must stay rare even when individually marked.
 MAX_RAW_SYSEXIT_SITES = 5
@@ -77,10 +101,29 @@ def _cli_files() -> list[Path]:
     return [p for p in sorted(CLI_ROOT.rglob("*.py")) if p.name != "error_handler.py"]
 
 
+def _is_envelope_bypassing_click_exception(func: ast.AST) -> bool:
+    """True for ``click.<Name>`` or bare ``<Name>`` in the bypassing family.
+
+    Matches both the qualified ``click.UsageError`` attribute form and the bare
+    ``UsageError`` name form (``from click import UsageError``), while rejecting
+    unrelated identifiers and any deeper / differently-rooted attribute chain
+    (e.g. ``foo.UsageError`` or ``click.exceptions.Exit``).
+    """
+    if isinstance(func, ast.Attribute):
+        return (
+            isinstance(func.value, ast.Name)
+            and func.value.id == "click"
+            and func.attr in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
+        )
+    if isinstance(func, ast.Name):
+        return func.id in ENVELOPE_BYPASSING_CLICK_EXCEPTIONS
+    return False
+
+
 def _click_exception_spans(tree: ast.AST) -> list[Span]:
     spans: list[Span] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and _call_name(node.func) == "click.ClickException":
+        if isinstance(node, ast.Call) and _is_envelope_bypassing_click_exception(node.func):
             spans.append((node.lineno, node.end_lineno or node.lineno))
     return spans
 
@@ -136,12 +179,12 @@ def _format(sites: list[str]) -> str:
 
 
 def test_click_exception_sites_are_marked() -> None:
-    """Every ``click.ClickException`` call must carry an input-validation marker."""
+    """Every ``ClickException`` (and envelope-bypassing subclass) call is marked."""
     unmarked, _stale, _empty, _total = _audit(_click_exception_spans, CLICK_EXCEPTION_MARKER)
     assert not unmarked, (
-        "Unmarked click.ClickException call sites. Each bypasses the JSON error "
-        "envelope (see error_handler.py) and must carry an inline "
-        f"`# {CLICK_EXCEPTION_MARKER} <reason>` comment:\n" + _format(unmarked)
+        "Unmarked ClickException (or envelope-bypassing subclass) call sites. Each "
+        "bypasses the JSON error envelope (see error_handler.py) and must carry an "
+        f"inline `# {CLICK_EXCEPTION_MARKER} <reason>` comment:\n" + _format(unmarked)
     )
 
 
@@ -149,8 +192,8 @@ def test_no_stale_or_empty_click_exception_markers() -> None:
     """``# cli-input-validation:`` markers must sit on a call and name a reason."""
     _unmarked, stale, empty, _total = _audit(_click_exception_spans, CLICK_EXCEPTION_MARKER)
     assert not stale, (
-        f"Stale `# {CLICK_EXCEPTION_MARKER}` markers (not on a click.ClickException "
-        "call) -- delete them:\n" + _format(stale)
+        f"Stale `# {CLICK_EXCEPTION_MARKER}` markers (not on a ClickException or "
+        "envelope-bypassing subclass call) -- delete them:\n" + _format(stale)
     )
     assert not empty, (
         f"`# {CLICK_EXCEPTION_MARKER}` markers with no reason -- add one:\n" + _format(empty)
@@ -232,6 +275,27 @@ def test_raw_sysexit_spans_detects_bare_and_called() -> None:
     """
     tree = ast.parse("def called():\n    raise SystemExit(1)\ndef bare():\n    raise SystemExit\n")
     assert sorted(lo for lo, _hi in _raw_sysexit_spans(tree)) == [2, 4]
+
+
+def test_click_exception_spans_detects_subclasses_and_bare_import() -> None:
+    """Envelope-bypassing subclasses are detected in both attribute + bare form.
+
+    The gate widened from literal ``click.ClickException`` to the whole
+    envelope-bypassing family, in both the ``click.<Name>`` attribute form and
+    the bare ``<Name>`` form (``from click import UsageError``) (issue #1307).
+    An unrelated attribute chain (``click.exceptions.Exit``) and a same-named
+    attribute on a different root (``other.UsageError``) must NOT match.
+    """
+    tree = ast.parse(
+        "import click\n"
+        "from click import UsageError\n"
+        "raise click.UsageError('x')\n"
+        "raise click.BadParameter('x')\n"
+        "raise UsageError('x')\n"
+        "raise click.exceptions.Exit(0)\n"
+        "raise other.UsageError('x')\n"
+    )
+    assert sorted(lo for lo, _hi in _click_exception_spans(tree)) == [3, 4, 5]
 
 
 def test_parse_cli_file_is_memoized_and_byte_identical() -> None:


### PR DESCRIPTION
## Summary

Closes #1307. The CLI exit-path marker gate (`tests/_lint/test_error_handler_allowlist.py`) detected only the literal `click.ClickException`. Its envelope-bypassing subclasses bypass the typed `{"error": true, "code": ...}` JSON envelope identically — Click prints `Error:`/`Usage:` to stderr and exits the process — but were invisible to the gate, leaving 10 unmarked sites that could silently break `--json` consumers.

## What changed

**Test harness (`tests/_lint/test_error_handler_allowlist.py`)**
- Widened `_click_exception_spans` to the full envelope-bypassing family via a named constant `ENVELOPE_BYPASSING_CLICK_EXCEPTIONS = {ClickException, UsageError, BadParameter, MissingParameter, NoSuchOption, BadArgumentUsage, FileError}`.
- New `_is_envelope_bypassing_click_exception` matches both the `click.<Name>` attribute form and the bare `<Name>` form (`from click import UsageError`), while rejecting unrelated identifiers, a different attribute root (`other.UsageError`), and the deeper `click.exceptions.Exit` chain.
- Updated the module docstring + test names/messages to say "ClickException and its envelope-bypassing subclasses", and documented the deliberate exclusion of `click.Abort` / `click.exceptions.Exit` (control-flow, not error-message exits).
- Added `test_click_exception_spans_detects_subclasses_and_bare_import` mirroring the existing bare/called SystemExit regression test.

**CLI sites (comments only — no runtime behavior change)**
Annotated all 10 flagged subclass raises with inline `# cli-input-validation: <reason>` markers:
- `chat_cmd.py` (UsageError), `download_cmd.py` (UsageError), `input.py` (2× UsageError), `note_cmd.py` (UsageError), `research_cmd.py` (UsageError), `session_cmd.py` (BadParameter), `source_cmd.py` (3× UsageError).

No `UsageError`→`ClickException` conversions, no message changes, no type-error suppression.

## Out of scope
`click.Abort` and `click.exceptions.Exit` are control-flow (user-abort / explicit exit code), not error-message exits — excluded by design and documented in the docstring rather than marked.

## Verification
- `uv run ruff format --check .` — clean
- `uv run ruff check src tests` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — no issues
- `uv run pytest` — 7894 passed, 100 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized formatting and added inline CLI input-validation annotations for several command-line validation paths, preserving existing messages and behavior.

* **Tests**
  * Broadened lint/test coverage to detect a wider family of Click exception patterns (including specific subclasses and bare-import forms) and updated related test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->