### PR TITLE
fix(cli): route language get/set server sync through the error envelope (closes #1309)

### DIFF
--- a/src/notebooklm/cli/language_cmd.py
+++ b/src/notebooklm/cli/language_cmd.py
@@ -254,23 +254,25 @@ def language_get(ctx, local, json_output):
 
     # Server path: route the RPC through the standard error envelope so auth /
     # network / RPC failures hard-fail (structured envelope + non-zero exit)
-    # instead of being swallowed.
-    async def body(auth: AuthTokens) -> tuple[str | None, bool]:
+    # instead of being swallowed. The body stays pure RPC I/O -- the local
+    # config write happens outside the envelope so a (rare) disk-write error
+    # is never misreported as an RPC failure for an otherwise-successful fetch.
+    async def body(auth: AuthTokens) -> str | None:
         async with NotebookLMClient(auth) as client:
-            server_lang = await client.settings.get_output_language()
-        synced = False
-        if server_lang is not None and server_lang != get_language():
-            # Server is authoritative: persist its value locally on a change.
-            set_language(server_lang)
-            synced = True
-        return server_lang, synced
+            return await client.settings.get_output_language()
 
-    server_lang, synced = with_auth_and_errors(
+    server_lang = with_auth_and_errors(
         ctx,
         command_name="language get",
         json_output=json_output,
         body=body,
     )
+
+    # Server is authoritative: persist its value locally on a change.
+    synced = False
+    if server_lang is not None and server_lang != get_language():
+        set_language(server_lang)
+        synced = True
 
     # Server may have no value set; fall back to the local config for display.
     current = server_lang if server_lang is not None else get_language()

--- a/src/notebooklm/cli/language_cmd.py
+++ b/src/notebooklm/cli/language_cmd.py
@@ -12,14 +12,14 @@ import logging
 import click
 from rich.table import Table
 
+from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..io import atomic_update_json
 from ..paths import get_config_path, get_home_dir
-from .auth_runtime import get_auth_tokens
+from .auth_runtime import with_auth_and_errors
 from .error_handler import exit_with_code
 from .options import json_option
 from .rendering import console, json_error_response, json_output_response
-from .runtime import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -168,59 +168,6 @@ def set_language(code: str) -> None:
     atomic_update_json(config_path, _set_lang, recover_from_corrupt=True)
 
 
-def _run_language_rpc(coro):
-    """Run a language RPC coroutine and close it if the sync runner does not."""
-    try:
-        return run_async(coro)
-    finally:
-        coro.close()
-
-
-def _sync_language_to_server(code: str, ctx: click.Context) -> str | None:
-    """Sync language setting to server via RPC.
-
-    Args:
-        code: Language code to set.
-        ctx: Click context for auth.
-
-    Returns:
-        Server's response language, or None on failure.
-    """
-    try:
-        auth = get_auth_tokens(ctx)
-
-        async def _set():
-            async with NotebookLMClient(auth) as client:
-                return await client.settings.set_output_language(code)
-
-        return _run_language_rpc(_set())
-    except Exception as e:
-        logger.debug("Failed to sync language to server: %s", e)
-        return None
-
-
-def _get_language_from_server(ctx: click.Context) -> str | None:
-    """Get current language from server via RPC.
-
-    Args:
-        ctx: Click context for auth.
-
-    Returns:
-        Server's language setting, or None on failure.
-    """
-    try:
-        auth = get_auth_tokens(ctx)
-
-        async def _get():
-            async with NotebookLMClient(auth) as client:
-                return await client.settings.get_output_language()
-
-        return _run_language_rpc(_get())
-    except Exception as e:
-        logger.debug("Failed to get language from server: %s", e)
-        return None
-
-
 @click.group()
 def language():
     """Manage output language for artifact generation.
@@ -259,33 +206,8 @@ def language_list(json_output):
     console.print(f"\n[dim]Total: {len(SUPPORTED_LANGUAGES)} languages[/dim]")
 
 
-@language.command("get")
-@click.option("--local", is_flag=True, help="Show local config only (skip server sync)")
-@json_option
-@click.pass_context
-def language_get(ctx, local, json_output):
-    """Get current language setting.
-
-    Shows the currently configured output language for artifact generation.
-    By default, fetches from server and updates local config if different.
-    Use --local to skip server sync.
-    """
-    local_lang = get_language()
-    server_lang = None
-    synced = False
-
-    # Try to get from server unless --local is set
-    if not local:
-        server_lang = _get_language_from_server(ctx)
-        if server_lang is not None:
-            # Update local config if server has different value
-            if server_lang != local_lang:
-                set_language(server_lang)
-                synced = True
-            local_lang = server_lang
-
-    current = local_lang
-
+def _render_get(current: str | None, synced: bool, json_output: bool) -> None:
+    """Render the resolved ``language get`` state in JSON or text mode."""
     if json_output:
         json_output_response(
             {
@@ -308,6 +230,53 @@ def language_get(ctx, local, json_output):
         console.print("\n[dim]Use 'notebooklm language set <code>' to set a default.[/dim]")
 
 
+@language.command("get")
+@click.option("--local", is_flag=True, help="Show local config only (skip server sync)")
+@json_option
+@click.pass_context
+def language_get(ctx, local, json_output):
+    """Get current language setting.
+
+    Shows the currently configured output language for artifact generation.
+    By default, fetches from server (the source of truth) and updates local
+    config if different. Use --local to read the local config offline without
+    contacting the server (no auth required).
+
+    Without --local an auth/network/RPC failure surfaces as the structured
+    error envelope with a non-zero exit code -- it is not silently degraded to
+    the stale local value.
+    """
+    # --local is the offline escape hatch: short-circuit BEFORE any auth or
+    # client construction so it works with no credentials available.
+    if local:
+        _render_get(get_language(), synced=False, json_output=json_output)
+        return
+
+    # Server path: route the RPC through the standard error envelope so auth /
+    # network / RPC failures hard-fail (structured envelope + non-zero exit)
+    # instead of being swallowed.
+    async def body(auth: AuthTokens) -> tuple[str | None, bool]:
+        async with NotebookLMClient(auth) as client:
+            server_lang = await client.settings.get_output_language()
+        synced = False
+        if server_lang is not None and server_lang != get_language():
+            # Server is authoritative: persist its value locally on a change.
+            set_language(server_lang)
+            synced = True
+        return server_lang, synced
+
+    server_lang, synced = with_auth_and_errors(
+        ctx,
+        command_name="language get",
+        json_output=json_output,
+        body=body,
+    )
+
+    # Server may have no value set; fall back to the local config for display.
+    current = server_lang if server_lang is not None else get_language()
+    _render_get(current, synced=synced, json_output=json_output)
+
+
 @language.command("set")
 @click.argument("code")
 @click.option("--local", is_flag=True, help="Set local config only (skip server sync)")
@@ -327,7 +296,8 @@ def language_set(ctx, code, local, json_output):
       notebooklm language set ja         # Japanese
       notebooklm language set en         # English
     """
-    # Validate the language code
+    # Validate the language code BEFORE any auth/client/local write so a bad
+    # code never touches storage or the network.
     if code not in SUPPORTED_LANGUAGES:
         if json_output:
             # Match the shared JSON error schema from ``cli/rendering.py``:
@@ -343,15 +313,31 @@ def language_set(ctx, code, local, json_output):
         console.print("\nRun [cyan]notebooklm language list[/cyan] to see supported codes.")
         exit_with_code(1)
 
-    # Save locally first
-    set_language(code)
     name = SUPPORTED_LANGUAGES[code]
 
-    # Sync to server unless --local is set
-    synced = False
-    if not local:
-        server_result = _sync_language_to_server(code, ctx)
-        synced = server_result is not None
+    # --local is the offline escape hatch: persist to local config only,
+    # short-circuiting BEFORE any auth or client construction so it works with
+    # no credentials available.
+    if local:
+        set_language(code)
+        synced = False
+    else:
+        # Server-authoritative ordering: sync to the server FIRST (inside the
+        # error envelope), and only persist locally once the server confirms.
+        # This way a failed sync hard-fails (structured envelope + non-zero
+        # exit) instead of silently leaving a misleading local value behind.
+        async def body(auth: AuthTokens) -> None:
+            async with NotebookLMClient(auth) as client:
+                await client.settings.set_output_language(code)
+
+        with_auth_and_errors(
+            ctx,
+            command_name="language set",
+            json_output=json_output,
+            body=body,
+        )
+        set_language(code)
+        synced = True
 
     if json_output:
         json_output_response(
@@ -368,7 +354,5 @@ def language_set(ctx, code, local, json_output):
     console.print(f"\nLanguage set to: [cyan]{code}[/cyan] ({name})")
     if synced:
         console.print("[dim](synced to server)[/dim]")
-    elif not local:
-        console.print(
-            "[dim](saved locally, server sync failed - server may still use previous value)[/dim]"
-        )
+    elif local:
+        console.print("[dim](saved locally, server sync skipped)[/dim]")

--- a/tests/integration/cli_vcr/test_settings.py
+++ b/tests/integration/cli_vcr/test_settings.py
@@ -7,13 +7,15 @@ subcommand; see ``src/notebooklm/cli/language_cmd.py``). The task brief uses
 the conceptual name ``settings set-language``; the test exercises the
 real exposed name without touching the CLI implementation.
 
-The CLI ``language set <code>`` flow:
+The CLI ``language set <code>`` flow (server-authoritative since #1309):
 
 1. Validates ``<code>`` against the local ``SUPPORTED_LANGUAGES`` table.
-2. Writes the language to ``config.json`` (no RPC).
-3. Unless ``--local`` is passed, calls
+2. Unless ``--local`` is passed, calls
    ``client.settings.set_output_language(<code>)`` — a single
-   ``SET_USER_SETTINGS`` (rpcids ``hT54vc``) RPC.
+   ``SET_USER_SETTINGS`` (rpcids ``hT54vc``) RPC — routed through the standard
+   error envelope so a failed sync hard-fails instead of silently degrading.
+3. Writes the language to ``config.json`` only after the server confirms
+   (or immediately, with no RPC, when ``--local`` is passed).
 
 The dedicated CLI cassette ``cli_settings_set_language.yaml`` captures
 exactly that single-RPC chain (plus the bootstrap homepage GET). It is

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -1,14 +1,14 @@
 """Tests for language CLI commands (list, get, set)."""
 
-import gc
 import importlib
 import json
-import warnings
-from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
+from notebooklm.exceptions import AuthError, NetworkError
 from notebooklm.notebooklm_cli import cli
 
 # Import the module explicitly to avoid confusion with the Click group
@@ -20,6 +20,17 @@ def test_save_config_alias_removed() -> None:
     """The deprecated public ``save_config`` alias is removed in v0.5.0."""
     assert not hasattr(language_module, "save_config")
     assert hasattr(language_module, "_save_config")
+
+
+def test_swallow_helpers_removed() -> None:
+    """The broad-``except`` silent-degrade helpers are gone (issue #1309).
+
+    Server interaction now routes through the standard error envelope; the
+    old helpers that swallowed auth/network/RPC errors must not return.
+    """
+    assert not hasattr(language_module, "_get_language_from_server")
+    assert not hasattr(language_module, "_sync_language_to_server")
+    assert not hasattr(language_module, "_run_language_rpc")
 
 
 @pytest.fixture
@@ -39,13 +50,45 @@ def mock_config_file(tmp_path):
         yield config_file
 
 
-def unawaited_coroutine_warnings(caught_warnings):
-    return [
-        warning
-        for warning in caught_warnings
-        if issubclass(warning.category, RuntimeWarning)
-        and "was never awaited" in str(warning.message)
-    ]
+@contextmanager
+def mock_server(*, get_returns="en", set_returns="en", get_error=None, set_error=None):
+    """Patch the auth bootstrap + ``NotebookLMClient`` for the server path.
+
+    ``language get``/``set`` (without ``--local``) now route through
+    ``with_auth_and_errors`` → ``NotebookLMClient`` → ``client.settings``.
+    This stubs that whole stack so a unit test can drive the server response
+    (or inject an auth/network error to exercise the hard-fail envelope).
+    """
+    settings = MagicMock()
+    if get_error is not None:
+        settings.get_output_language = AsyncMock(side_effect=get_error)
+    else:
+        settings.get_output_language = AsyncMock(return_value=get_returns)
+    if set_error is not None:
+        settings.set_output_language = AsyncMock(side_effect=set_error)
+    else:
+        settings.set_output_language = AsyncMock(return_value=set_returns)
+
+    client = MagicMock()
+    client.settings = settings
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+        patch.object(language_module, "NotebookLMClient", return_value=client),
+    ):
+        mock_load.return_value = {
+            "SID": "test",
+            "__Secure-1PSIDTS": "test_1psidts",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        mock_fetch.return_value = ("csrf", "session")
+        yield settings
 
 
 # =============================================================================
@@ -136,41 +179,96 @@ class TestLanguageGetCommand:
 
 class TestLanguageSetCommand:
     def test_language_set_valid_code(self, runner, mock_config_file):
-        """Test 'language set' with valid language code."""
-        result = runner.invoke(cli, ["language", "set", "zh_Hans"])
+        """Test 'language set' with valid language code (server-authoritative)."""
+        with mock_server(set_returns="zh_Hans") as settings:
+            result = runner.invoke(cli, ["language", "set", "zh_Hans"])
 
         assert result.exit_code == 0
         assert "zh_Hans" in result.output
         assert "中文" in result.output or "GLOBAL" in result.output
+        # Server sync happened before the local write.
+        settings.set_output_language.assert_awaited_once_with("zh_Hans")
 
-        # Verify config was written
+        # Verify config was written (only after the server confirmed).
         config = json.loads(mock_config_file.read_text())
         assert config["language"] == "zh_Hans"
 
     def test_language_set_shows_global_warning(self, runner, mock_config_file):
         """Test 'language set' shows global setting warning."""
-        result = runner.invoke(cli, ["language", "set", "ko"])
+        with mock_server(set_returns="ko"):
+            result = runner.invoke(cli, ["language", "set", "ko"])
 
         assert result.exit_code == 0
         assert "GLOBAL" in result.output or "global" in result.output.lower()
         assert "all notebooks" in result.output.lower()
 
     def test_language_set_invalid_code(self, runner, mock_config_file):
-        """Test 'language set' with invalid language code."""
+        """Test 'language set' with invalid language code.
+
+        Validation runs before any auth/client, so no server fixture is needed
+        and storage is never touched.
+        """
         result = runner.invoke(cli, ["language", "set", "invalid_code"])
 
         assert result.exit_code == 1
         assert "Unknown language code" in result.output
         assert "language list" in result.output.lower()
+        assert not mock_config_file.exists()
 
     def test_language_set_json_output(self, runner, mock_config_file):
         """Test 'language set --json' outputs JSON format."""
-        result = runner.invoke(cli, ["language", "set", "fr", "--json"])
+        with mock_server(set_returns="fr"):
+            result = runner.invoke(cli, ["language", "set", "fr", "--json"])
 
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["language"] == "fr"
         assert data["name"] == "Français"
+        assert data["synced_to_server"] is True
+
+    def test_language_set_local_skips_server(self, runner, mock_config_file):
+        """``language set --local`` persists locally with NO auth/client (offline)."""
+        # No mock_server fixture: if --local touched auth/client this would fail.
+        result = runner.invoke(cli, ["language", "set", "ja", "--local"])
+
+        assert result.exit_code == 0
+        assert "ja" in result.output
+        assert "server sync skipped" in result.output
+        config = json.loads(mock_config_file.read_text())
+        assert config["language"] == "ja"
+
+    def test_language_set_local_json(self, runner, mock_config_file):
+        """``language set --local --json`` reports ``synced_to_server`` False offline."""
+        result = runner.invoke(cli, ["language", "set", "ko", "--local", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["language"] == "ko"
+        assert data["synced_to_server"] is False
+
+    def test_language_set_server_error_hard_fails(self, runner, mock_config_file):
+        """A server RPC failure surfaces the envelope + non-zero exit (NOT swallowed)."""
+        with mock_server(set_error=NetworkError("connection refused")):
+            result = runner.invoke(cli, ["language", "set", "fr"])
+
+        assert result.exit_code != 0
+        assert "Network error" in result.output or "error" in result.output.lower()
+        # Server-authoritative ordering: the failed sync must NOT leave a
+        # misleading local value behind.
+        assert not mock_config_file.exists()
+
+    def test_language_set_server_error_json_envelope(self, runner, mock_config_file):
+        """``language set --json`` on a server failure emits the typed error envelope."""
+        with mock_server(set_error=AuthError("expired session")):
+            result = runner.invoke(cli, ["language", "set", "fr", "--json"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["error"] is True
+        assert data["code"] == "AUTH_ERROR"
+        assert "synced_to_server" not in data
+        # Local value never written when the server rejected the change.
+        assert not mock_config_file.exists()
 
     def test_language_set_invalid_json_output(self, runner, mock_config_file):
         """``language set --json`` with invalid code emits the shared JSON error schema.
@@ -242,161 +340,41 @@ class TestGetConfigErrorPaths:
 
 
 # =============================================================================
-# _SYNC_LANGUAGE_TO_SERVER AND _GET_LANGUAGE_FROM_SERVER (lines 162-164, 176-186)
+# LANGUAGE GET SERVER PATH (issue #1309: hard-fail via the error envelope)
 # =============================================================================
 
 
-class TestSyncLanguageToServer:
-    def test_sync_language_to_server_success(self):
-        """Test _sync_language_to_server returns run_async result on success."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {"auth": {"SID": "test", "HSID": "test", "SSID": "test"}}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", return_value="en") as mock_run,
-        ):
-            result = language_module._sync_language_to_server("en", mock_ctx)
-
-        assert result == "en"
-        mock_run.assert_called_once()
-
-    def test_sync_language_to_server_exception_returns_none(self):
-        """Test _sync_language_to_server returns None when exception occurs."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with patch.object(language_module, "get_auth_tokens", side_effect=Exception("no auth")):
-            result = language_module._sync_language_to_server("en", mock_ctx)
-
-        assert result is None
-
-    def test_sync_language_to_server_run_async_exception(self):
-        """Test _sync_language_to_server returns None when run_async raises."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", side_effect=Exception("connection error")),
-        ):
-            result = language_module._sync_language_to_server("en", mock_ctx)
-
-        assert result is None
-
-    def test_sync_language_to_server_closes_coroutine_when_run_async_raises(self):
-        """Test run_async failures do not leak an unawaited coroutine warning."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", side_effect=Exception("connection error")),
-            warnings.catch_warnings(record=True) as caught_warnings,
-        ):
-            warnings.simplefilter("always", RuntimeWarning)
-
-            result = language_module._sync_language_to_server("en", mock_ctx)
-            gc.collect()
-
-        assert result is None
-        assert unawaited_coroutine_warnings(caught_warnings) == []
-
-
-class TestGetLanguageFromServer:
-    def test_get_language_from_server_success(self):
-        """Test _get_language_from_server returns the server language on success."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {"auth": {"SID": "test"}}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", return_value="fr") as mock_run,
-        ):
-            result = language_module._get_language_from_server(mock_ctx)
-
-        assert result == "fr"
-        mock_run.assert_called_once()
-
-    def test_get_language_from_server_exception_returns_none(self):
-        """Test _get_language_from_server returns None when exception occurs."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with patch.object(language_module, "get_auth_tokens", side_effect=Exception("no auth")):
-            result = language_module._get_language_from_server(mock_ctx)
-
-        assert result is None
-
-    def test_get_language_from_server_run_async_exception(self):
-        """Test _get_language_from_server returns None when run_async raises."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", side_effect=Exception("rpc error")),
-        ):
-            result = language_module._get_language_from_server(mock_ctx)
-
-        assert result is None
-
-    def test_get_language_from_server_closes_coroutine_when_run_async_raises(self):
-        """Test run_async failures do not leak an unawaited coroutine warning."""
-        mock_ctx = MagicMock()
-        mock_ctx.obj = {}
-
-        with (
-            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
-            patch.object(language_module, "run_async", side_effect=Exception("rpc error")),
-            warnings.catch_warnings(record=True) as caught_warnings,
-        ):
-            warnings.simplefilter("always", RuntimeWarning)
-
-            result = language_module._get_language_from_server(mock_ctx)
-            gc.collect()
-
-        assert result is None
-        assert unawaited_coroutine_warnings(caught_warnings) == []
-
-
-# =============================================================================
-# LANGUAGE GET SERVER SYNC PATHS (lines 244-250, 270)
-# =============================================================================
-
-
-class TestLanguageGetServerSyncPaths:
-    def test_language_get_server_has_different_value_updates_local(self, runner, mock_config_file):
-        """Test 'language get' updates local config when server has a different value."""
-        # Local is "en", server returns "fr" → local should be updated to "fr"
+class TestLanguageGetServerPath:
+    def test_server_different_value_updates_local(self, runner, mock_config_file):
+        """'language get' updates local config when the server has a different value."""
+        # Local is "en", server returns "fr" → local should be updated to "fr".
         mock_config_file.write_text(json.dumps({"language": "en"}))
 
-        with patch.object(language_module, "_get_language_from_server", return_value="fr"):
+        with mock_server(get_returns="fr") as settings:
             result = runner.invoke(cli, ["language", "get"])
 
         assert result.exit_code == 0
-        # Local config should be updated to "fr"
+        settings.get_output_language.assert_awaited_once()
         config = json.loads(mock_config_file.read_text())
         assert config["language"] == "fr"
-        # Output should show "fr" (the server value)
         assert "fr" in result.output
 
-    def test_language_get_server_different_shows_synced(self, runner, mock_config_file):
-        """Test 'language get' shows synced message when server differs from local."""
+    def test_server_different_shows_synced(self, runner, mock_config_file):
+        """'language get' shows the synced message when the server differs from local."""
         mock_config_file.write_text(json.dumps({"language": "en"}))
 
-        with patch.object(language_module, "_get_language_from_server", return_value="ja"):
+        with mock_server(get_returns="ja"):
             result = runner.invoke(cli, ["language", "get"])
 
         assert result.exit_code == 0
         assert "synced" in result.output.lower()
 
-    def test_language_get_server_same_value_no_update(self, runner, mock_config_file):
-        """Test 'language get' does not update local when server value matches."""
+    def test_server_same_value_no_update(self, runner, mock_config_file):
+        """'language get' does not rewrite local config when the server value matches."""
         mock_config_file.write_text(json.dumps({"language": "en"}))
 
         with (
-            patch.object(language_module, "_get_language_from_server", return_value="en"),
+            mock_server(get_returns="en"),
             patch.object(language_module, "set_language") as mock_set,
         ):
             result = runner.invoke(cli, ["language", "get"])
@@ -404,20 +382,29 @@ class TestLanguageGetServerSyncPaths:
         assert result.exit_code == 0
         mock_set.assert_not_called()
 
-    def test_language_get_no_language_shows_not_set(self, runner, mock_config_file):
-        """Test 'language get' shows 'not set' when no language is configured and server returns None."""
-        # No language configured locally
-        with patch.object(language_module, "_get_language_from_server", return_value=None):
+    def test_server_returns_none_falls_back_to_local(self, runner, mock_config_file):
+        """When the server has no value set, fall back to local for display."""
+        mock_config_file.write_text(json.dumps({"language": "de"}))
+
+        with mock_server(get_returns=None):
+            result = runner.invoke(cli, ["language", "get"])
+
+        assert result.exit_code == 0
+        assert "de" in result.output
+
+    def test_server_and_local_unset_shows_not_set(self, runner, mock_config_file):
+        """'language get' shows 'not set' when neither server nor local has a value."""
+        with mock_server(get_returns=None):
             result = runner.invoke(cli, ["language", "get"])
 
         assert result.exit_code == 0
         assert "not set" in result.output
 
-    def test_language_get_server_sync_json_output(self, runner, mock_config_file):
-        """Test 'language get --json' reflects synced_from_server when values differ."""
+    def test_server_sync_json_output(self, runner, mock_config_file):
+        """'language get --json' reflects synced_from_server when values differ."""
         mock_config_file.write_text(json.dumps({"language": "en"}))
 
-        with patch.object(language_module, "_get_language_from_server", return_value="de"):
+        with mock_server(get_returns="de"):
             result = runner.invoke(cli, ["language", "get", "--json"])
 
         assert result.exit_code == 0
@@ -425,50 +412,27 @@ class TestLanguageGetServerSyncPaths:
         assert data["language"] == "de"
         assert data["synced_from_server"] is True
 
+    def test_server_error_hard_fails(self, runner, mock_config_file):
+        """A server RPC failure surfaces the envelope + non-zero exit (NOT swallowed)."""
+        mock_config_file.write_text(json.dumps({"language": "en"}))
 
-# =============================================================================
-# LANGUAGE SET SYNC FAILED AND JSON PATHS (lines 316-320, 335-336)
-# =============================================================================
+        with mock_server(get_error=NetworkError("connection refused")):
+            result = runner.invoke(cli, ["language", "get"])
 
+        assert result.exit_code != 0
+        assert "Network error" in result.output or "error" in result.output.lower()
+        # Local config must be left untouched on a failed fetch.
+        config = json.loads(mock_config_file.read_text())
+        assert config["language"] == "en"
 
-class TestLanguageSetSyncFailedAndJsonPaths:
-    def test_language_set_sync_failed_shows_local_only_message(self, runner, mock_config_file):
-        """Test 'language set' shows local-only message when server sync fails."""
-        with patch.object(language_module, "_sync_language_to_server", return_value=None):
-            result = runner.invoke(cli, ["language", "set", "en"])
+    def test_server_error_json_envelope(self, runner, mock_config_file):
+        """'language get --json' on a server failure emits the typed error envelope."""
+        with mock_server(get_error=AuthError("expired session")):
+            result = runner.invoke(cli, ["language", "get", "--json"])
 
-        assert result.exit_code == 0
-        assert "saved locally" in result.output or "server sync failed" in result.output
-
-    def test_language_set_sync_success_shows_synced_message(self, runner, mock_config_file):
-        """Test 'language set' shows synced message when server sync succeeds."""
-        with patch.object(language_module, "_sync_language_to_server", return_value="en"):
-            result = runner.invoke(cli, ["language", "set", "en"])
-
-        assert result.exit_code == 0
-        assert "synced" in result.output.lower()
-        # Should NOT show "server sync failed"
-        assert "server sync failed" not in result.output
-
-    def test_language_set_json_output_with_server_sync(self, runner, mock_config_file):
-        """Test 'language set --json' includes synced_to_server field."""
-        with patch.object(language_module, "_sync_language_to_server", return_value="fr"):
-            result = runner.invoke(cli, ["language", "set", "fr", "--json"])
-
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         data = json.loads(result.output)
-        assert data["language"] == "fr"
-        assert data["name"] == "Français"
-        assert "synced_to_server" in data
-        assert data["synced_to_server"] is True
-
-    def test_language_set_json_output_sync_failed(self, runner, mock_config_file):
-        """Test 'language set --json' shows synced_to_server=False when sync fails."""
-        with patch.object(language_module, "_sync_language_to_server", return_value=None):
-            result = runner.invoke(cli, ["language", "set", "ko", "--json"])
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["language"] == "ko"
-        assert "synced_to_server" in data
-        assert data["synced_to_server"] is False
+        assert data["error"] is True
+        assert data["code"] == "AUTH_ERROR"
+        # The success payload keys must not leak into the error envelope.
+        assert "synced_from_server" not in data

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -50,6 +50,22 @@ def mock_config_file(tmp_path):
         yield config_file
 
 
+def write_config(path, config):
+    """Write a config dict to ``path`` with explicit UTF-8 + LF semantics.
+
+    Centralizes the cross-platform file-write contract (utf-8 encoding, ``\n``
+    newlines, ``ensure_ascii=False``) so individual tests stay terse and no
+    test relies on the platform default of ``Path.write_text``.
+    """
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(config, ensure_ascii=False))
+
+
+def read_config(path):
+    """Read a config dict from ``path`` with explicit UTF-8 decoding."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 @contextmanager
 def mock_server(*, get_returns="en", set_returns="en", get_error=None, set_error=None):
     """Patch the auth bootstrap + ``NotebookLMClient`` for the server path.
@@ -139,7 +155,7 @@ class TestLanguageGetCommand:
     def test_language_get_when_set(self, runner, mock_config_file):
         """Test 'language get --local' when language is configured."""
         # Write config file with language
-        mock_config_file.write_text(json.dumps({"language": "zh_Hans"}))
+        write_config(mock_config_file, {"language": "zh_Hans"})
 
         # Use --local to test local config only
         result = runner.invoke(cli, ["language", "get", "--local"])
@@ -150,7 +166,7 @@ class TestLanguageGetCommand:
 
     def test_language_get_json_output(self, runner, mock_config_file):
         """Test 'language get --local --json' outputs JSON format."""
-        mock_config_file.write_text(json.dumps({"language": "ja"}))
+        write_config(mock_config_file, {"language": "ja"})
 
         # Use --local to test local config only
         result = runner.invoke(cli, ["language", "get", "--local", "--json"])
@@ -160,6 +176,8 @@ class TestLanguageGetCommand:
         assert data["language"] == "ja"
         assert data["name"] == "日本語"
         assert data["is_default"] is False
+        # --local never contacts the server, so the sync flag is always False.
+        assert data["synced_from_server"] is False
 
     def test_language_get_json_when_not_set(self, runner, mock_config_file):
         """Test 'language get --local --json' when not configured."""
@@ -190,7 +208,7 @@ class TestLanguageSetCommand:
         settings.set_output_language.assert_awaited_once_with("zh_Hans")
 
         # Verify config was written (only after the server confirmed).
-        config = json.loads(mock_config_file.read_text())
+        config = read_config(mock_config_file)
         assert config["language"] == "zh_Hans"
 
     def test_language_set_shows_global_warning(self, runner, mock_config_file):
@@ -234,7 +252,7 @@ class TestLanguageSetCommand:
         assert result.exit_code == 0
         assert "ja" in result.output
         assert "server sync skipped" in result.output
-        config = json.loads(mock_config_file.read_text())
+        config = read_config(mock_config_file)
         assert config["language"] == "ja"
 
     def test_language_set_local_json(self, runner, mock_config_file):
@@ -296,7 +314,7 @@ class TestLanguageSetCommand:
 class TestGenerateUsesConfigLanguage:
     def test_generate_audio_uses_config_language(self, runner, mock_config_file):
         """Test that generate audio uses config language when not specified."""
-        mock_config_file.write_text(json.dumps({"language": "zh_Hans"}))
+        write_config(mock_config_file, {"language": "zh_Hans"})
 
         # Just verify the help shows the default behavior
         result = runner.invoke(cli, ["generate", "audio", "--help"])
@@ -315,7 +333,7 @@ class TestGetConfigErrorPaths:
     def test_get_config_json_decode_error(self, tmp_path):
         """Test get_config() returns {} when config file has invalid JSON."""
         config_file = tmp_path / "config.json"
-        config_file.write_text("this is not valid json{{{")
+        config_file.write_text("this is not valid json{{{", encoding="utf-8")
 
         with patch.object(language_module, "get_config_path", return_value=config_file):
             result = language_module.get_config()
@@ -326,7 +344,7 @@ class TestGetConfigErrorPaths:
         """Test get_config() returns {} when config file can't be read (OSError)."""
         config_file = tmp_path / "config.json"
         # Create the file so exists() returns True, then mock read_text to raise OSError
-        config_file.write_text('{"language": "en"}')
+        config_file.write_text('{"language": "en"}', encoding="utf-8")
 
         with (
             patch.object(language_module, "get_config_path", return_value=config_file),
@@ -348,20 +366,20 @@ class TestLanguageGetServerPath:
     def test_server_different_value_updates_local(self, runner, mock_config_file):
         """'language get' updates local config when the server has a different value."""
         # Local is "en", server returns "fr" → local should be updated to "fr".
-        mock_config_file.write_text(json.dumps({"language": "en"}))
+        write_config(mock_config_file, {"language": "en"})
 
         with mock_server(get_returns="fr") as settings:
             result = runner.invoke(cli, ["language", "get"])
 
         assert result.exit_code == 0
         settings.get_output_language.assert_awaited_once()
-        config = json.loads(mock_config_file.read_text())
+        config = read_config(mock_config_file)
         assert config["language"] == "fr"
         assert "fr" in result.output
 
     def test_server_different_shows_synced(self, runner, mock_config_file):
         """'language get' shows the synced message when the server differs from local."""
-        mock_config_file.write_text(json.dumps({"language": "en"}))
+        write_config(mock_config_file, {"language": "en"})
 
         with mock_server(get_returns="ja"):
             result = runner.invoke(cli, ["language", "get"])
@@ -371,7 +389,7 @@ class TestLanguageGetServerPath:
 
     def test_server_same_value_no_update(self, runner, mock_config_file):
         """'language get' does not rewrite local config when the server value matches."""
-        mock_config_file.write_text(json.dumps({"language": "en"}))
+        write_config(mock_config_file, {"language": "en"})
 
         with (
             mock_server(get_returns="en"),
@@ -384,7 +402,7 @@ class TestLanguageGetServerPath:
 
     def test_server_returns_none_falls_back_to_local(self, runner, mock_config_file):
         """When the server has no value set, fall back to local for display."""
-        mock_config_file.write_text(json.dumps({"language": "de"}))
+        write_config(mock_config_file, {"language": "de"})
 
         with mock_server(get_returns=None):
             result = runner.invoke(cli, ["language", "get"])
@@ -402,7 +420,7 @@ class TestLanguageGetServerPath:
 
     def test_server_sync_json_output(self, runner, mock_config_file):
         """'language get --json' reflects synced_from_server when values differ."""
-        mock_config_file.write_text(json.dumps({"language": "en"}))
+        write_config(mock_config_file, {"language": "en"})
 
         with mock_server(get_returns="de"):
             result = runner.invoke(cli, ["language", "get", "--json"])
@@ -414,7 +432,7 @@ class TestLanguageGetServerPath:
 
     def test_server_error_hard_fails(self, runner, mock_config_file):
         """A server RPC failure surfaces the envelope + non-zero exit (NOT swallowed)."""
-        mock_config_file.write_text(json.dumps({"language": "en"}))
+        write_config(mock_config_file, {"language": "en"})
 
         with mock_server(get_error=NetworkError("connection refused")):
             result = runner.invoke(cli, ["language", "get"])
@@ -422,7 +440,7 @@ class TestLanguageGetServerPath:
         assert result.exit_code != 0
         assert "Network error" in result.output or "error" in result.output.lower()
         # Local config must be left untouched on a failed fetch.
-        config = json.loads(mock_config_file.read_text())
+        config = read_config(mock_config_file)
         assert config["language"] == "en"
 
     def test_server_error_json_envelope(self, runner, mock_config_file):


### PR DESCRIPTION
## Summary

`notebooklm language get`/`set` (without `--local`) previously wrapped their server RPC in a broad `except Exception: return None`, **silently swallowing** auth/network/RPC failures and degrading to a stale local value. A `--json` consumer running `language set zh_Hans` against an expired session got `{"synced_to_server": false}` with **no error, no code, no hint** — bypassing the typed `{"error": true, ...}` envelope every other network command provides.

This routes the server interaction through the standard error envelope with **hard-fail** semantics, per the decision in #1309.

## ⚠️ Behavior change (prominent)

- **`language get`/`set` now ERROR** (structured `{"error": true, "code": ...}` envelope + **non-zero exit**) when the server can't be reached — auth, network, and RPC failures are no longer silently swallowed and no longer degrade to the local value.
- **`--local` is the offline path**: it works with no auth and no client available. The `--local` branch short-circuits **before** any auth/client construction (pure local config).
- `language list` is truly local and is **unchanged**.

## What changed

- The non-`--local` branch now calls `with_auth_and_errors(ctx, command_name=..., json_output=..., body=...)` from `cli/auth_runtime.py` — the same machinery `@with_client` wraps (auth-load + client lifecycle + `handle_errors` envelope + hard-fail). `@with_client` itself isn't usable here because it loads auth + opens the client eagerly, which conflicts with the offline `--local` flag.
- Removed the silent-degrade helpers `_get_language_from_server`, `_sync_language_to_server`, and `_run_language_rpc` — errors now propagate into the envelope.
- **`language set` uses server-authoritative ordering**: sync to the server first (inside the envelope), then persist the local value only after the server confirms. This way a failed sync doesn't silently leave a misleading local value behind. (Documented in a comment in `language_cmd.py`.)
- `language set` validation now runs **before** any auth/client/local write, so an invalid code never touches storage or the network.

## Tests

- Server error (auth/network/RPC) on non-`--local` get/set → structured envelope + non-zero exit (NOT swallowed, NOT exit 0), both text and `--json`.
- `--local` get/set work with NO auth/client available (offline; no server fixture, so any auth/RPC attempt would fail loudly).
- Success path: get reads from the server + syncs local on change; set syncs to server then persists local + reports `synced_to_server: true`.
- Updated existing language tests that assumed the old silent-degrade behavior (the `_sync/_get_language_from_server` helper tests are replaced; success-path `set` tests now drive a mock server).
- Added a guard asserting the swallow helpers are gone.
- Refreshed the CLI-VCR settings test docstring to the new server-authoritative ordering.

## Verification

- `ruff format --check .` ✅
- `ruff check src tests` ✅
- `mypy src/notebooklm --ignore-missing-imports` ✅
- `pytest` (full suite) ✅ — 7890 passed, 100 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `language get` and `language set` short-circuit immediately for --local and validate language codes up front.
* **Bug Fixes**
  * Commands now hard-fail on auth/network/RPC errors (no silent fallback to stale local state).
  * `language set` only writes local config after successful server sync when not --local.
* **Refactor**
  * CLI flows consolidated for consistent error handling and output formatting.
* **Tests & Docs**
  * Updated tests and module docs to verify server-sync semantics and error-envelope behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->