### PR TITLE
test: cover note-backed rename_mind_map + MindMapsAPI dispatch gaps (#1314)

### DIFF
--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -191,13 +191,6 @@ async def test_generate_interactive_raises_when_no_artifact_id():
         await api.generate("nb", ["s1"], kind=MindMapKind.INTERACTIVE)
 
 
-@pytest.mark.asyncio
-async def test_detect_kind_raises_when_absent():
-    api, *_ = _make_api()
-    with pytest.raises(ValueError, match="not found"):
-        await api.rename("nb", "ghost", "X")
-
-
 # --- #1270 sub-fix 1: get_tree drift vs absent-leaf ---------------------------
 
 

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -366,3 +366,143 @@ async def test_generate_note_backed_empty_name_falls_back_to_placeholder():
     )
     mm = await api.generate("nb", ["s1"], kind=MindMapKind.NOTE_BACKED)
     assert mm.title == "Mind Map"  # empty name rejected, placeholder used
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_non_interactive_mind_map_artifacts():
+    # A MIND_MAP-type artifact that is not a settled interactive map (variant
+    # not yet populated) is filtered out of the unified listing.
+    api, *_ = _make_api(
+        note_rows=[["note_mm", "{}"]],
+        interactive=[_pending_type4_artifact("settling"), _interactive_artifact("int_mm")],
+    )
+    ids = {m.id for m in await api.list("nb")}
+    assert ids == {"note_mm", "int_mm"}  # "settling" excluded
+
+
+# --- get() lookup ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_matching_mind_map():
+    api, *_ = _make_api(note_rows=[["note_mm", '{"name": "NB", "children": []}']])
+    mm = await api.get("nb", "note_mm")
+    assert mm is not None
+    assert mm.id == "note_mm"
+    assert mm.kind == MindMapKind.NOTE_BACKED
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_absent():
+    # Neither backing contains the id -> None (the v0.7.0 contract; #1247
+    # tracks the eventual flip to raise).
+    api, *_ = _make_api(note_rows=[["note_mm", "{}"]])
+    assert await api.get("nb", "ghost") is None
+
+
+# --- rename(kind=None) auto-detect dispatch ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_auto_detect_note_backed_dispatches():
+    # kind=None with the id in the note collection -> note-backed rename,
+    # interactive rename never consulted.
+    # Decoy first row exercises the loop-continue branch before the match.
+    api, _, mind_maps, artifacts, _ = _make_api(
+        note_rows=[["other_mm", "{}"], ["note_mm", '{"name": "NB", "children": []}']]
+    )
+    await api.rename("nb", "note_mm", "X", return_object=False)
+    mind_maps.rename_mind_map.assert_awaited_once_with("nb", "note_mm", "X")
+    artifacts.rename.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rename_auto_detect_interactive_dispatches():
+    # kind=None with the id absent from notes but present as an interactive
+    # artifact -> artifact rename.
+    api, _, mind_maps, artifacts, _ = _make_api(interactive=[_interactive_artifact("int_mm")])
+    await api.rename("nb", "int_mm", "Y", return_object=False)
+    artifacts.rename.assert_awaited_once_with("nb", "int_mm", "Y", return_object=False)
+    mind_maps.rename_mind_map.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rename_hydrate_raises_when_target_vanishes():
+    # Explicit note-backed rename whose post-rename refetch finds nothing
+    # (vanished-between-rename-and-refetch race) -> ValueError from
+    # _hydrate_renamed rather than a stale/None object.
+    api, _, mind_maps, _, _ = _make_api(note_rows=[])
+    with pytest.raises(ValueError, match="not found"):
+        await api.rename("nb", "note_mm", "X", kind=MindMapKind.NOTE_BACKED)
+    mind_maps.rename_mind_map.assert_awaited_once_with("nb", "note_mm", "X")
+
+
+# --- get_tree auto-detect + note-backed paths -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tree_auto_detect_note_backed_returns_tree():
+    # Decoy first row exercises the loop-continue branch before the match.
+    api, *_ = _make_api(
+        note_rows=[["other_mm", "{}"], ["note_mm", '{"name": "NB", "children": [1]}']]
+    )
+    assert await api.get_tree("nb", "note_mm") == {"name": "NB", "children": [1]}
+
+
+@pytest.mark.asyncio
+async def test_get_tree_auto_detect_interactive_falls_through_to_rpc():
+    # kind=None, id absent from notes but present as an interactive artifact ->
+    # falls through to GET_INTERACTIVE_HTML and parses the tree leaf.
+    api, rpc, *_ = _make_api(interactive=[_interactive_artifact("int_mm")])
+    row = [None] * 10
+    row[9] = [None, None, None, '{"name": "INT", "children": []}']
+    rpc.configure_mock(rpc_call=AsyncMock(return_value=[row]))
+    assert await api.get_tree("nb", "int_mm") == {"name": "INT", "children": []}
+
+
+@pytest.mark.asyncio
+async def test_get_tree_auto_detect_missing_raises():
+    api, *_ = _make_api()
+    with pytest.raises(ValueError, match="not found"):
+        await api.get_tree("nb", "ghost")
+
+
+@pytest.mark.asyncio
+async def test_get_tree_note_backed_absent_returns_none():
+    # Explicit kind=NOTE_BACKED with an unknown id returns None (does not raise).
+    api, *_ = _make_api(note_rows=[["other", "{}"]])
+    assert await api.get_tree("nb", "ghost", kind=MindMapKind.NOTE_BACKED) is None
+
+
+@pytest.mark.asyncio
+async def test_get_tree_note_backed_invalid_json_returns_none():
+    # _parse_tree swallows a JSONDecodeError on malformed content -> None.
+    api, *_ = _make_api(note_rows=[["note_mm", "not-json{"]])
+    assert await api.get_tree("nb", "note_mm", kind=MindMapKind.NOTE_BACKED) is None
+
+
+# --- _detect_kind via delete(kind=None) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_auto_detect_note_backed():
+    # Decoy first row exercises the _detect_kind loop-continue branch.
+    api, _, mind_maps, artifacts, _ = _make_api(note_rows=[["other_mm", "{}"], ["note_mm", "{}"]])
+    await api.delete("nb", "note_mm")
+    mind_maps.delete_mind_map.assert_awaited_once_with("nb", "note_mm")
+    artifacts.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_auto_detect_interactive():
+    api, _, mind_maps, artifacts, _ = _make_api(interactive=[_interactive_artifact("int_mm")])
+    await api.delete("nb", "int_mm")
+    artifacts.delete.assert_awaited_once_with("nb", "int_mm")
+    mind_maps.delete_mind_map.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_auto_detect_missing_raises():
+    api, *_ = _make_api()
+    with pytest.raises(ValueError, match="not found"):
+        await api.delete("nb", "ghost")

--- a/tests/unit/test_note_backed_mind_map_service.py
+++ b/tests/unit/test_note_backed_mind_map_service.py
@@ -89,6 +89,80 @@ class TestDeleteMindMap:
         mock_notes.delete_note.assert_awaited_once_with("nb_abc", "mm_1")
 
 
+class TestRenameMindMap:
+    """Note-backed rename retitles the backing note via ``UPDATE_NOTE``.
+
+    Unlike the interactive studio-artifact backend (which renames via
+    ``RENAME_ARTIFACT`` in ``MindMapsAPI``), the note-backed path has no
+    title-only field mask, so the rename re-sends the existing content
+    alongside the new title.
+    """
+
+    @staticmethod
+    def _stub_list(mock_notes: MagicMock, rows: list[list[object]]) -> None:
+        """Make ``list_mind_maps`` return ``rows`` (all classified MIND_MAP)."""
+        mock_notes.fetch_note_rows = AsyncMock(return_value=rows)
+        mock_notes.classify_row = MagicMock(return_value=NoteRowKind.MIND_MAP)
+
+    @pytest.mark.asyncio
+    async def test_rename_resends_content_with_new_title(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        target = ["mm_1", json.dumps({"children": []})]
+        other = ["mm_0", json.dumps({"children": []})]
+        self._stub_list(mock_notes, [other, target])
+        mock_notes.extract_content = MagicMock(return_value="existing-content")
+        mock_notes.update_note = AsyncMock()
+
+        result = await service.rename_mind_map("nb_abc", "mm_1", "New Title")
+
+        assert result is None
+        mock_notes.extract_content.assert_called_once_with(target)
+        mock_notes.update_note.assert_awaited_once_with(
+            "nb_abc", "mm_1", "existing-content", "New Title"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rename_defaults_empty_content_when_extract_returns_none(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        target = ["mm_1", None]
+        self._stub_list(mock_notes, [target])
+        # A mind-map row whose content cannot be extracted must still be
+        # renameable — the rename sends "" rather than crashing on None.
+        mock_notes.extract_content = MagicMock(return_value=None)
+        mock_notes.update_note = AsyncMock()
+
+        await service.rename_mind_map("nb_abc", "mm_1", "Renamed")
+
+        mock_notes.update_note.assert_awaited_once_with("nb_abc", "mm_1", "", "Renamed")
+
+    @pytest.mark.asyncio
+    async def test_rename_missing_raises_and_skips_update(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        self._stub_list(mock_notes, [["mm_1", "content"]])
+        mock_notes.extract_content = MagicMock(return_value="content")
+        mock_notes.update_note = AsyncMock()
+
+        with pytest.raises(ValueError, match="ghost"):
+            await service.rename_mind_map("nb_abc", "ghost", "New Title")
+
+        mock_notes.update_note.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rename_empty_notebook_raises(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        self._stub_list(mock_notes, [])
+        mock_notes.update_note = AsyncMock()
+
+        with pytest.raises(ValueError, match="mm_1"):
+            await service.rename_mind_map("nb_abc", "mm_1", "New Title")
+
+        mock_notes.update_note.assert_not_awaited()
+
+
 class TestEndToEndWithRealNoteService:
     """Integration check: NoteBackedMindMapService backed by a real
     :class:`NoteService` must still return mind-map rows correctly."""


### PR DESCRIPTION
Closes #1314.

Closes the two mind-map coverage low-water marks surfaced by the test-suite audit (2026-05-31). Tests only — **no source changes**.

## Coverage (measured per-file)

| Module | Before | After |
|---|---|---|
| `src/notebooklm/_mind_map.py` | 60% | **100%** |
| `src/notebooklm/_mind_maps_api.py` | 79% (21 missing lines) | **99% (0 missing lines)** |

The single remaining partial branch in `_mind_maps_api.py` is the trivial `_tree_title(None)` fallback — not worth a synthetic test.

## What was untested

### `_mind_map.py` — `NoteBackedMindMapService.rename_mind_map()` (lines 79–84) had no test
The existing `rename_mind_map` test in `test_mind_maps_api.py` exercises the **interactive** studio-artifact backend (`RENAME_ARTIFACT`), not this **note-backed** `UPDATE_NOTE` path (re-send existing content with the new title — notes have no title-only field mask). Added to `tests/unit/test_note_backed_mind_map_service.py`:
- happy path — asserts `update_note(nb, id, existing_content, new_title)`
- `extract_content` → `None` defaults the re-sent content to `""` rather than crashing
- not-found → `ValueError` (unknown id and empty notebook)

### `_mind_maps_api.py` — newest unified API (#1256) dispatch branches
Added to `tests/unit/test_mind_maps_api.py`:
- `get()` hit / miss
- `rename(kind=None)` auto-detect dispatch to both backends + the `_hydrate_renamed` vanished-between-rename-and-refetch race
- `get_tree` auto-detect, note-backed absent → `None`, invalid-JSON → `None`, and interactive fall-through to `GET_INTERACTIVE_HTML`
- `_detect_kind` via `delete(kind=None)` (note-backed / interactive / missing)
- `list()` excludes a non-interactive `MIND_MAP`-type artifact

## Scope / forward-compat

This PR is **tests only** and is deliberately distinct from the in-flight API-contract work on the same file:
- **#1247** — v0.8.0 flip of `mind_maps.get()` to raise `MindMapNotFoundError`
- **#1291** — routing `rename`/`get_tree` bare `ValueError` through `MindMapNotFoundError`

New tests are pinned to the **current v0.7.0 contract** (`None`/`ValueError`), so they characterize today's behavior and will be updated alongside those flips. Pinning current behavior first also de-risks both refactors.

## Verification
- `uv run pytest tests/unit/test_note_backed_mind_map_service.py tests/unit/test_mind_maps_api.py` → 47 passed
- `tests/_lint/test_no_forbidden_monkeypatches.py` → passes (mocks follow the existing `_make_api` seam convention)
- `ruff format` + `ruff check` clean
- Full non-e2e suite re-run for the coverage gate (additive, raises coverage only)

https://claude.ai/code/session_017HyLLu2R14Tqda9X9TQDrL

---
_Generated by [Claude Code](https://claude.ai/code/session_017HyLLu2R14Tqda9X9TQDrL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for mind map API dispatch to verify list/get/rename/tree/delete behaviors, including filtering of transient items and handling of unknown or malformed entries.
  * Added comprehensive tests for note-backed mind map renames, covering content preservation/defaulting and edge cases for missing records or empty notebooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->