### PR TITLE
test(cli): tighten chat VCR assertions to the #1322 standard (#1324)

### DIFF
--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -30,7 +30,7 @@ import pytest
 
 from notebooklm.notebooklm_cli import cli
 
-from .conftest import notebooklm_vcr, parse_json_output, skip_no_cassettes
+from .conftest import notebooklm_vcr, skip_no_cassettes
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 
@@ -51,7 +51,9 @@ class TestAskCommand:
         result = runner.invoke(cli, ["ask", "--json", "What is this notebook about?"])
         assert result.exit_code == 0, result.output
 
-        data = parse_json_output(result.output)
+        # Parse strictly: a ``--json`` command's whole stdout must be valid
+        # JSON with no stray prefix.
+        data = json.loads(result.output)
         assert isinstance(data, dict), f"Expected JSON object, got: {result.output!r}"
         assert "answer" in data, f"Expected an 'answer' key: {data!r}"
         assert "references" in data, f"Expected a 'references' key: {data!r}"
@@ -80,10 +82,9 @@ class TestHistoryCommand:
         result = runner.invoke(cli, ["history", "--json"])
         assert result.exit_code == 0, result.output
 
-        data = parse_json_output(result.output)
+        # Parse strictly: the whole stdout must be valid JSON (no stray prefix).
+        data = json.loads(result.output)
         assert isinstance(data, dict | list), f"Expected JSON, got: {result.output!r}"
-        # Re-parse strictly: the whole stdout must be valid JSON (no stray prefix).
-        json.loads(result.output)
 
 
 class TestGetConversationTurnsCommand:

--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -1,48 +1,89 @@
-"""CLI integration tests for chat commands.
+"""CLI integration tests for the chat commands (``ask`` + ``history``).
 
-These tests exercise the full CLI → Client → RPC path using VCR cassettes.
+These tests exercise the full CLI -> Client -> RPC path using VCR cassettes,
+covering the chat happy paths flagged by issue #1316 (the sibling notebook +
+share groups landed in #1322; this file is the chat counterpart tracked by
+#1324).
+
+RPC fan-out per command
+-----------------------
+``ask`` uses the **streamed** chat backend (``_chat_wire`` / a ``_reqid``-bearing
+streaming POST), preceded by a ``GET_LAST_CONVERSATION_ID`` lookup:
+
+* ``ask``     -> ``hPTbtc`` (GET_LAST_CONVERSATION_ID) then ``rLM`` (streamed ask).
+* ``history`` -> ``hPTbtc`` (GET_LAST_CONVERSATION_ID) then ``khqZz``
+  (GET_CONVERSATION_TURNS).
+
+The cassettes were recorded against a read-only notebook
+(``mock_context`` supplies its full UUID, so ``resolve_notebook_id`` skips the
+``LIST_NOTEBOOKS`` preflight and each cassette holds only the chat RPC chain).
+
+Recording (maintainer, with a valid profile)::
+
+    NOTEBOOKLM_VCR_RECORD=1 uv run pytest \\
+        tests/integration/cli_vcr/test_chat.py -m vcr
 """
+
+import json
 
 import pytest
 
 from notebooklm.notebooklm_cli import cli
 
-from .conftest import assert_command_success, notebooklm_vcr, parse_json_output, skip_no_cassettes
+from .conftest import notebooklm_vcr, parse_json_output, skip_no_cassettes
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 
 
 class TestAskCommand:
-    """Test 'notebooklm ask' command."""
+    """Test ``notebooklm ask`` (streamed chat backend)."""
 
     @notebooklm_vcr.use_cassette("chat_ask.yaml")
     def test_ask_question(self, runner, mock_auth_for_vcr, mock_context):
-        """Ask a question shows response from real client."""
+        """``ask`` streams an answer and prints it under the Answer header."""
         result = runner.invoke(cli, ["ask", "What is this notebook about?"])
-        # allow_no_context=True: cassette may not match mock notebook ID
-        assert_command_success(result)
+        assert result.exit_code == 0, result.output
+        assert "Answer:" in result.output
 
     @notebooklm_vcr.use_cassette("chat_ask.yaml")
     def test_ask_question_json(self, runner, mock_auth_for_vcr, mock_context):
-        """Ask with --json flag returns JSON output."""
+        """``ask --json`` emits the chat-response envelope (answer + references)."""
         result = runner.invoke(cli, ["ask", "--json", "What is this notebook about?"])
-        # allow_no_context=True: cassette may not match mock notebook ID
-        assert_command_success(result)
+        assert result.exit_code == 0, result.output
 
-        if result.exit_code == 0:
-            data = parse_json_output(result.output)
-            assert data is not None, "Expected valid JSON output"
-            assert isinstance(data, list | dict)
+        data = parse_json_output(result.output)
+        assert isinstance(data, dict), f"Expected JSON object, got: {result.output!r}"
+        assert "answer" in data, f"Expected an 'answer' key: {data!r}"
+        assert "references" in data, f"Expected a 'references' key: {data!r}"
+        # ``raw_response`` is deliberately stripped from CLI output for brevity.
+        assert "raw_response" not in data
 
 
 class TestHistoryCommand:
-    """Test 'notebooklm history' command."""
+    """Test ``notebooklm history`` (GET_LAST_CONVERSATION_ID + GET_CONVERSATION_TURNS)."""
 
     @notebooklm_vcr.use_cassette("chat_get_history.yaml")
     def test_history(self, runner, mock_auth_for_vcr, mock_context):
-        """History command shows Q&A turns from last conversation."""
+        """``history`` renders the Q&A turns for the last conversation."""
         result = runner.invoke(cli, ["history"])
-        assert_command_success(result)
+        assert result.exit_code == 0, result.output
+        assert "Conversation History" in result.output
+
+    @notebooklm_vcr.use_cassette("chat_get_history.yaml")
+    def test_history_json(self, runner, mock_auth_for_vcr, mock_context):
+        """``history --json`` emits a parseable envelope carrying the turns.
+
+        Reuses ``chat_get_history.yaml`` because ``--json`` only changes
+        rendering, not the underlying ``hPTbtc`` + ``khqZz`` RPC chain, so no
+        orphan cassette is recorded for an identical request.
+        """
+        result = runner.invoke(cli, ["history", "--json"])
+        assert result.exit_code == 0, result.output
+
+        data = parse_json_output(result.output)
+        assert isinstance(data, dict | list), f"Expected JSON, got: {result.output!r}"
+        # Re-parse strictly: the whole stdout must be valid JSON (no stray prefix).
+        json.loads(result.output)
 
 
 class TestGetConversationTurnsCommand:
@@ -53,8 +94,8 @@ class TestGetConversationTurnsCommand:
     Conversation: b1556695-010e-4fe3-a841-a6efa7fe0697
 
     The cassette captures two sequential batchexecute calls:
-      1. hPTbtc (GET_LAST_CONVERSATION_ID) → returns one conversation ID
-      2. khqZz (GET_CONVERSATION_TURNS) → returns Q&A turns for that conversation
+      1. hPTbtc (GET_LAST_CONVERSATION_ID) -> returns one conversation ID
+      2. khqZz (GET_CONVERSATION_TURNS) -> returns Q&A turns for that conversation
     """
 
     @notebooklm_vcr.use_cassette("chat_get_conversation_turns.yaml")


### PR DESCRIPTION
## Summary

Closes #1324.

While picking up #1324 ("add chat CLI VCR coverage"), I found the premise was **stale**: `tests/integration/cli_vcr/test_chat.py` already covers the chat group with committed, passing cassettes (added in #1237, independent of #1322). The streamed `ask` backend (`_chat_wire` / `_reqid` streaming POST) that the issue flagged as tricky was already captured and replays fine.

The **real** weakness was assertion strength: `ask` / `history` used `assert_command_success(allow_no_context=True)`, which accepts exit code **0 or 1** and would pass even on a command error — weaker than the #1322 bar in `test_share.py` / `test_notebook.py`. This PR re-scopes #1324 to hardening those assertions.

## Changes

- **`ask`** — assert `exit_code == 0` + the Answer header renders
- **`ask --json`** — assert the chat-response envelope shape (`answer` + `references` keys; `raw_response` stripped)
- **`history`** — assert `exit_code == 0` + the history view renders
- **`history --json`** (new) — assert stdout is strictly valid JSON, reusing `chat_get_history.yaml` since `--json` only changes rendering (no orphan cassette for the identical `hPTbtc` + `khqZz` chain)
- documented per-command RPC fan-out + recording instructions in the module docstring, matching the sibling `cli_vcr` files

No production code changes; no new cassettes (existing committed cassettes cover every path).

## Coverage

| Command(s) | Cassette | RPC chain |
|---|---|---|
| `ask`, `ask --json` | `chat_ask.yaml` | `hPTbtc` → `rLM` (streamed) |
| `history`, `history --json` | `chat_get_history.yaml` | `hPTbtc` → `khqZz` |
| `history -n <uuid>` | `chat_get_conversation_turns.yaml` | `hPTbtc` → `khqZz` |

## Verification

- `tests/integration/cli_vcr/test_chat.py` — **5 passed**
- full `tests/integration/cli_vcr/` suite — **74 passed**
- `ruff check` + `ruff format --check` — clean

## Follow-up (not in this PR)

Additional chat scenarios could be covered later if desired: `ask --new`, `configure`, `history --save`.

https://claude.ai/code/session_01URPECAqVRwWkQsKDejw42y

---
_Generated by [Claude Code](https://claude.ai/code/session_01URPECAqVRwWkQsKDejw42y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened CLI chat integration tests with stricter validation of command exit codes and visible output (e.g., "Answer:" and "Conversation History").
  * JSON-mode tests now assert required keys (answer, references) and absence of raw_response; history JSON must be strict parseable JSON.
  * Clarified test descriptions for conversation-turns sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->