### PR TITLE
docs(adr): refresh stale refs, add banners, add facade + deprecation ADRs

### DIFF
--- a/docs/adr/0002-capability-protocol-pattern.md
+++ b/docs/adr/0002-capability-protocol-pattern.md
@@ -5,9 +5,13 @@
 > concrete `Session` facade class, `_session.py`, and `_core.py` have all been
 > **deleted**, and `_session_contracts.py` was renamed to `_runtime_contracts.py`
 > (see [ADR-014](0014-feature-local-runtime-adapters.md) and
-> [`docs/architecture.md`](../architecture.md) for the live shape). Read in-body
-> references to `Session`, `_core.py`, `_session_contracts.py`, and exact
-> `file.py:NNN` line numbers as historical — they do not point at live code.
+> [`docs/architecture.md`](../architecture.md) for the live shape). The
+> feature-local composite Protocols `ChatRuntime` and `ArtifactsRuntime`
+> referenced in the Status line below were also **retired** — feature APIs now
+> take their narrow collaborators by keyword-only constructor argument. Read
+> in-body references to `Session`, `_core.py`, `_session_contracts.py`,
+> `ChatRuntime`, `ArtifactsRuntime`, and exact `file.py:NNN` line numbers as
+> historical — they do not point at live code.
 
 ## Status
 

--- a/docs/adr/0010-session-kernel-split.md
+++ b/docs/adr/0010-session-kernel-split.md
@@ -1,5 +1,23 @@
 # ADR-010: Session/Kernel split
 
+> **Current state (2026-05).** This ADR is **Superseded** (by
+> [ADR-013](0013-composable-session-capabilities.md), then
+> [ADR-014](0014-feature-local-runtime-adapters.md)) and documents a transient
+> tier-13 shape for historical context only. Since it was written, the broad
+> `Session: Protocol` was **deleted**, `_session_contracts.py` was **renamed
+> to `_runtime_contracts.py`**, and the feature-local composite Protocols
+> `ChatRuntime` and `ArtifactsRuntime` were **retired** (feature APIs now take
+> their narrow collaborators by keyword-only constructor argument). The live
+> shared capability Protocols are `RpcCaller`, `LoopGuard`,
+> `OperationScopeProvider`, and `AsyncWorkRuntime` (plus `AuthMetadata` and
+> `Kernel`) in `_runtime_contracts.py`; drain-hook registration is the
+> `register_drain_hook(...)` method on `TransportDrainTracker` in
+> `_transport_drain.py`. Read in-body references to `Session`,
+> `_session_contracts.py`, `_capabilities.py`, `ChatRuntime`,
+> `ArtifactsRuntime`, the `DrainHookRegistration` Protocol, and exact
+> `file.py:NNN` line numbers as historical — consult `CLAUDE.md` and the
+> current source tree for the live shape.
+
 ## Status
 
 Superseded by [ADR-013](0013-composable-session-capabilities.md) (#866).

--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -1,5 +1,23 @@
 # ADR-013: Composable Session Capabilities and Feature-Local Runtimes
 
+> **Historical note (2026-05).** This ADR is **Accepted** and its core
+> decision — composable, per-capability Protocols instead of one fat `Session`
+> contract — remains in force. However, several *names* it cites have changed
+> since it was written, and some of the feature-local composites it proposed
+> were later retired. In particular: the contracts module
+> `_runtime_contracts.py` was **renamed to `_runtime_contracts.py`**; the
+> concrete `Session` facade was **deleted**; and the feature-local composite
+> Protocols `ChatRuntime`, `ArtifactsRuntime`, and `UploadRuntime` (Decision
+> §3) were **retired** in favour of feature constructors taking their narrow
+> collaborators by keyword-only argument (see
+> [ADR-014](0014-feature-local-runtime-adapters.md) and the
+> `_runtime_contracts.py` module docstring). Read the specific module names,
+> Protocol names, and `file.py:NNN` line numbers below as historical; the
+> `CLAUDE.md` file table and the current source tree are authoritative. The
+> live shared capability Protocols today are `RpcCaller`, `LoopGuard`,
+> `OperationScopeProvider`, and `AsyncWorkRuntime` (plus `AuthMetadata` and
+> `Kernel`) in `_runtime_contracts.py`.
+
 ## Status
 
 Accepted.
@@ -45,14 +63,14 @@ redundant protocols carrying the same single-member surface.
 `transport_post` and `next_reqid` were used by exactly one feature
 (chat), but every feature that typed against `Session` was coupled to
 them. (Post-this-ADR, Phase 7 deleted the broad `Session` Protocol
-entirely; the current `_session_contracts.py` exposes only the four
+entirely; the current `_runtime_contracts.py` exposes only the four
 shared capability Protocols below plus `AuthMetadata` and `Kernel`.)
 
 Re-reading the codebase against ADR-010's original constraint, the audit
 identified two categories of capability:
 
 - **SHARED**: a capability used by ≥2 features today, justifying
-  promotion to a module-level Protocol in `_session_contracts.py`.
+  promotion to a module-level Protocol in `_runtime_contracts.py`.
   Examples: logical RPC dispatch (`rpc_call`) is used by every feature
   API; loop-affinity assertion is used by chat plus artifact polling;
   `operation_scope(...)` is used by sources upload plus artifact
@@ -98,7 +116,7 @@ The library adopts a **composable capability model** with feature-local
 runtimes. Concretely:
 
 1. **Promote four shared capability Protocols** to
-   `_session_contracts.py`: `RpcCaller`, `LoopGuard`,
+   `_runtime_contracts.py`: `RpcCaller`, `LoopGuard`,
    `OperationScopeProvider`, and `AsyncWorkRuntime` (which composes
    `LoopGuard + OperationScopeProvider`). The promotion criterion is
    **shared by ≥2 features**. No capability is promoted on speculation.
@@ -115,7 +133,7 @@ runtimes. Concretely:
    criteria themselves do.
 
 2. **Retain `AuthMetadata` and `Kernel`** (both in
-   `_session_contracts.py`, symbols `AuthMetadata` and `Kernel`) as
+   `_runtime_contracts.py`, symbols `AuthMetadata` and `Kernel`) as
    standalone Protocols — they are **NOT** members of any
    feature-facing Session Protocol. Only `SourceUploadPipeline`
    consumes them, but the upload pipeline still depends on Session-owned
@@ -179,12 +197,12 @@ runtimes. Concretely:
   `ChatRuntime` later needs a streaming primitive, the change is local
   to `_chat.py` and the chat helpers, not to every feature that types
   against `Session`.
-- `_session_contracts.py` shrinks as Phase 7 of the migration arc
+- `_runtime_contracts.py` shrinks as Phase 7 of the migration arc
   deletes the broad `Session` Protocol. Post-cutover the module
   contains only the four shared capability Protocols plus
   `AuthMetadata` and `Kernel`.
 - The `auth/kernel/register_drain_hook` drift pattern is structurally
-  prevented: `_session_contracts.py` accepts new Protocols only when a
+  prevented: `_runtime_contracts.py` accepts new Protocols only when a
   second consumer exists in the codebase at promotion time.
 - The note/mind-map service split lets Artifacts and Notes evolve their
   internal storage paths independently. The mind-map adapter can be
@@ -200,7 +218,7 @@ runtimes. Concretely:
   test fixture update so the build stays green.
 - The `_core.py` compatibility shim was removed in Phase 4 ([#889](https://github.com/teng-lin/notebooklm-py/pull/889)); see `tests/unit/test_public_shims.py` (search for `Tier-10 PR-A re-export identity pins for ``notebooklm._core`` were deleted`) for the removal pin.
 - Two `RpcCaller` Protocols coexist briefly: the shared *object*
-  protocol in `_session_contracts.py` (symbol `RpcCaller`, used by every
+  protocol in `_runtime_contracts.py` (symbol `RpcCaller`, used by every
   feature API) and a pre-existing local *callable* protocol in
   `_source_upload.py` (symbol `RpcCallback`, used as the
   `register_file_source(rpc_call=...)` callback). They are structurally
@@ -227,15 +245,15 @@ narrative of how the cutover landed.
 - **C-X. `cookie_saver` / `cookie_rotator` late-binding seams** — introduced by PR [#879](https://github.com/teng-lin/notebooklm-py/pull/879) (`76b301d`). The cookie persistence hooks are resolved dynamically during session lifecycle setup in `_session_lifecycle.py`, decoupling persistence logic from the core HTTP client transport and ensuring clean integration with the cookie keepalive loop.
 - **C-Y. Inline `__Secure-1PSIDTS` cold-start recovery** — introduced by PR [#872](https://github.com/teng-lin/notebooklm-py/pull/872) / issue #865 (`6d8b5f4`). Production utilizes `_recover_psidts_inline` in `_auth/psidts_recovery.py` to run a preflight healing check. If preconditions are met (e.g. not bypassing credentials in environment-driven auth, and utilizing a flock-based cross-process lock), the system proactively mints a valid `__Secure-1PSIDTS` cookie before initializing the session facade to prevent cold-start failures.
 - **C-Z. AST-based delegate-surface regression guard** — introduced by PR [#885](https://github.com/teng-lin/notebooklm-py/pull/885) (`f48d4b9`). To prevent erosion of the session-facade decoupling contract, a regression test in `tests/unit/test_session_compat_delegates.py` uses AST analysis to enforce that eight legacy/compatibility methods on the `Session` facade remain simple delegate forwards (6 `RpcExecutor`-adjacent and 2 `AuthRefreshCoordinator`-adjacent methods, each restricted to a maximum of 3 statements).
-- **C-AA. Localized `DrainHookRegistration` Protocol** — The `DrainHookRegistration` protocol has been retired from the general `_session_contracts.py` surface and is now local to the `ArtifactsRuntime` in `_artifacts.py`.
-- **C-AB. Narrow executor host Protocols after bridge retirement** — The session-shrink arc narrowed `RpcOwner` after the legacy `Session` private-attribute shims were retired. `RpcOwner` no longer declares `_timeout`, `_refresh_callback`, `_refresh_retry_delay`, or `_http_client`; `RpcExecutor` receives those values through constructor-time providers or the concrete `Kernel`.
+- **C-AA. Drain-hook registration is owned by the transport drain tracker** — The standalone `DrainHookRegistration` Protocol from the Session/Kernel split was retired. *Current state (2026-05):* `DrainHookRegistration` is **not** a Protocol local to an `ArtifactsRuntime` (that composite no longer exists). It is a plain callable type alias — `DrainHookRegistration = Callable[[], Awaitable[None]]` — defined in `src/notebooklm/_transport_drain.py`; the registration surface collapsed onto `TransportDrainTracker.register_drain_hook(...)` in the same module. Feature code that owns long-running async work — artifact polling in `_artifact_polling.py` — registers its close-time hook there, and `ClientLifecycle.close` fires the registered hooks. See ADR-014.
+- **C-AB. Narrow executor host Protocols after bridge retirement** *(historical)* — The session-shrink arc narrowed the former `RpcOwner` host Protocol after the legacy `Session` private-attribute shims were retired, dropping `_timeout`, `_refresh_callback`, `_refresh_retry_delay`, and `_http_client`. *Current state (2026-05):* `RpcOwner` was deleted entirely (session-decoupling Wave 4, #1068); `RpcExecutor` (`_rpc_executor.py`) now takes its `Kernel`, `RuntimeTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters and keeps only a local `DecodeResponse` Protocol.
 - **C-AC. Retire the legacy transport Adapter** — The middleware chain terminal now calls `Kernel.post` directly through `Session._authed_post_chain_terminal`. Request construction lives in `_request_types.py`, transport exceptions and `Retry-After` parsing live in `_transport_errors.py`, and size-capped streaming lives in `_streaming_post.py`. This removed the last legacy host Protocol and the shallow Adapter seam.
 
 ## Alternatives considered
 
 1. **Keep the broad `Session` contract and let it continue to grow.**
    Rejected. At ADR-write time the drift was already visible in
-   `_session_contracts.py`'s broad `Session` Protocol: ADR-010 specified
+   `_runtime_contracts.py`'s broad `Session` Protocol: ADR-010 specified
    five members, and the contract had grown to eight. Without an
    explicit promotion criterion (shared by ≥2 features), every future
    single-consumer capability is a candidate for promotion, and the

--- a/docs/adr/0017-public-facade-private-implementation.md
+++ b/docs/adr/0017-public-facade-private-implementation.md
@@ -1,0 +1,112 @@
+# ADR-017: Public-facade / private-implementation re-export convention
+
+## Status
+
+Accepted (retroactive).
+
+## Context
+
+`notebooklm-py` exposes a public Python API that downstream callers import and
+depend on. Internally, the implementation is decomposed into many small,
+underscore-prefixed modules — the underscore-prefix privacy policy is recorded
+in [ADR-012](0012-implementation-surface-convention.md), and the runtime
+decomposition into narrow collaborators in
+[ADR-013](0013-composable-session-capabilities.md) /
+[ADR-014](0014-feature-local-runtime-adapters.md). These goals pull against
+each other:
+
+- Private modules are split, renamed, and merged frequently. The `CLAUDE.md`
+  file table records dozens of such moves (for example `_session_contracts.py`
+  → `_runtime_contracts.py`).
+- Public import paths must stay stable: a renamed module that a caller imported
+  from is a breaking change.
+
+ADR-012 establishes *that* a module is private (the leading underscore). It
+does not, on its own, say how a public symbol whose implementation lives in a
+private module is exposed. Without a paired convention, either the public
+surface ossifies the internal layout (blocking refactors) or a refactor
+silently breaks callers who imported from a private module.
+
+The codebase already resolves this with a consistent pattern, but it is
+undocumented as a decision: short public modules that re-export from one or
+more underscore-prefixed implementation modules. `auth.py` is the most
+developed example — its body is almost pure re-exports forwarding to the
+`_auth/` package (see [ADR-003](0003-auth-facade-write-through.md) and the
+`auth.py` row in `CLAUDE.md`).
+
+## Decision
+
+For each cohesive slice of the public API, a short, stable, **public** module
+re-exports the symbols whose **implementation** lives in one or more
+underscore-prefixed **private** modules. Callers import only from the public
+facade; the private modules are free to move.
+
+The established facade ↔ implementation pairs (verified against the current
+source tree) are:
+
+| Public facade | Private implementation |
+| ------------- | ---------------------- |
+| `types.py`    | `_types/` package      |
+| `config.py`   | `_env.py`              |
+| `urls.py`     | `_url_utils.py`        |
+| `io.py`       | `_atomic_io.py`        |
+| `log.py`      | `_logging.py`          |
+| `research.py` | `_research_task_parser.py` (plus public helpers) |
+| `auth.py`     | `_auth/` package       |
+
+Single-purpose public helper modules (`artifacts.py`, `utils.py`,
+`migration.py`) follow the same shape: a stable public name backed by private
+collaborators.
+
+The rules:
+
+1. **Public modules are facades.** A public module's body is re-exports (with
+   at most a thin binding, e.g. `auth.enumerate_accounts`). Logic lives in the
+   private implementation.
+2. **Callers import from the facade.** Importing from an underscore-prefixed
+   module is unsupported and may break without notice.
+3. **Private modules may move freely.** Splitting, renaming, or merging a
+   private module is *not* a breaking change as long as the facade's
+   re-exports are preserved.
+4. **The facade is the compatibility contract.** Removing or renaming a symbol
+   re-exported by a public facade *is* a breaking change; it is gated by the
+   API-compat allowlist (`scripts/audit_public_api_compat.py` /
+   `scripts/api-compat-allowlist.json`) and follows the deprecation strategy in
+   [ADR-018](0018-deprecation-strategy.md).
+
+## Consequences
+
+**Wanted**
+
+- **Refactor freedom**: internal decomposition (ADR-012/013/014) proceeds
+  without churning the public API.
+- **One obvious import path**: callers have a single stable location per
+  concept, documented in `docs/python-api.md`.
+- **Mechanical compatibility checks**: because the public surface is a small,
+  enumerable set of facades, `scripts/audit_public_api_compat.py` can diff it
+  and fail the Code Quality gate on unapproved breaking changes.
+
+**Unwanted**
+
+- **Indirection**: reading a public module rarely shows the logic; you must
+  follow the re-export into the private module.
+- **Drift risk**: a facade can fall out of sync with its implementation if a
+  symbol is added privately but not re-exported. The public-API tests and the
+  `CLAUDE.md` file table are the guardrails against this.
+- **Two names for one thing**: every facade ↔ implementation pair is a small
+  bookkeeping cost in the `CLAUDE.md` file table whenever a private module
+  moves.
+
+## Alternatives considered
+
+- **Expose the underscore modules directly and let callers import them.**
+  Rejected. It couples every caller to the internal layout; the frequent
+  private-module renames recorded in `CLAUDE.md` would each become a breaking
+  change.
+- **One flat public module that contains the implementation.** Rejected. It
+  forfeits the decomposition benefits of ADR-013/014 (narrow, testable
+  collaborators) and re-creates the god-module the runtime arc dismantled.
+- **No convention — decide ad hoc per symbol.** Rejected. Inconsistency is
+  exactly what makes the public surface hard to audit mechanically; a single
+  convention is what lets `audit_public_api_compat.py` reason about the whole
+  surface.

--- a/docs/adr/0018-deprecation-strategy.md
+++ b/docs/adr/0018-deprecation-strategy.md
@@ -1,0 +1,101 @@
+# ADR-018: Deprecation strategy (`_deprecation.py` + `MappingCompatMixin`)
+
+## Status
+
+Accepted (retroactive).
+
+## Context
+
+`notebooklm-py` evolves its public API: return shapes move from loose
+`dict[str, Any]` mappings to typed dataclasses (issue #1209), keyword
+arguments are renamed (e.g. `ResearchAPI.wait_for_completion`'s `interval` →
+`initial_interval`), and accessor semantics tighten (`get()` returning `None`
+on a miss will eventually raise a `*NotFoundError`, issue #1247). Each is a
+breaking change for some callers.
+
+Shipping breaking changes with no runway strips downstream users of any chance
+to migrate; carrying every old behavior forever ossifies the API. The project
+needs a *single, consistent* way to (a) keep old behavior working for a
+deprecation window, (b) warn callers loudly enough to migrate, and (c) stay
+silent for tests and scripts that have already opted in. Without a single home
+for this, `warnings.warn(...)` calls scatter across feature modules with
+inconsistent messages and no shared suppression switch.
+
+The mechanics already live in `src/notebooklm/_deprecation.py`; this ADR
+records the decision so the non-obvious versioning consequences are explicit.
+
+## Decision
+
+Centralize all deprecation mechanics in `src/notebooklm/_deprecation.py`, gate
+**every** deprecation warning behind the `NOTEBOOKLM_QUIET_DEPRECATIONS`
+environment variable, and name a concrete removal version (**v0.8.0** for the
+current batch) in every message. The module provides three reusable
+mechanisms:
+
+1. **`warn_get_returns_none(resource, *, removal="0.8.0")`** — the single place
+   that emits the `get()`-returns-`None` `DeprecationWarning`. Public
+   `sources/artifacts/notes.get()` warn on a miss; the private `_get_or_none()`
+   body never warns. The planned end state (issue #1247) is to raise
+   `*NotFoundError` in v0.8.0.
+
+2. **`deprecated_kwarg(...)`** — a keyword-alias helper that maps an old
+   keyword to its replacement, warns naming the removal version, and raises
+   when a caller passes both the old and new keyword. Used by
+   `ResearchAPI.wait_for_completion` (`interval` → `initial_interval`).
+
+3. **`MappingCompatMixin`** (defined at `_deprecation.py:221`) — a
+   dict-subscript backward-compat bridge for dataclasses that replaced
+   `dict[str, Any]` returns (issue #1209). Mixed into
+   `ResearchTask`/`ResearchStart`/`MindMapResult`/`SourceGuide` and the
+   mind-map value types under `_types/`, it makes `result["key"]` **warn** and
+   return the value from the dataclass's `to_public_dict()`, while the
+   mapping-style reads (`get`/`keys`/`__contains__`/`__iter__`) stay **silent**
+   so defensive callers migrate without noise.
+
+The rules:
+
+1. **One module, one switch.** All deprecation warnings live in
+   `_deprecation.py` and are silenced by `NOTEBOOKLM_QUIET_DEPRECATIONS`. No
+   ad-hoc `warnings.warn(...)` scattered through feature modules.
+2. **Name the removal version.** Every message states the version in which the
+   old behavior is removed (v0.8.0 for the current batch).
+3. **Warn at the boundary, not in the core.** Public methods warn; private
+   helpers (e.g. `_get_or_none()`) already implement the future behavior
+   without warning, so the eventual removal is a small, localized swap.
+4. **Subscript warns, mapping reads stay quiet.** `MappingCompatMixin` warns
+   only on `__getitem__`; `get`/`in`/iteration bridge silently.
+
+## Consequences
+
+**Wanted**
+
+- **Predictable runway**: callers get a named version and a consistent warning
+  shape for every deprecation.
+- **Quiet for the already-migrated**: `NOTEBOOKLM_QUIET_DEPRECATIONS` lets
+  tests and scripts opt out without monkeypatching `warnings`.
+- **Low-cost removal**: because the future behavior already lives in private
+  helpers, dropping a deprecation in v0.8.0 is a small, localized edit.
+
+**Unwanted**
+
+- **Version coupling**: the "v0.8.0" target is repeated across messages and
+  docs; bumping it requires a coordinated sweep.
+- **Two code paths during the window**: each active deprecation keeps both the
+  old and new behavior alive until removal, adding temporary surface area.
+- **Discipline required**: the single-module rule only holds if contributors
+  route new deprecations through `_deprecation.py` rather than inline warnings.
+
+## Alternatives considered
+
+- **Clean breaks with no deprecation window.** Rejected for real public
+  contracts: downstream callers need a runway, and the API-compat gate
+  (ADR-017 / `scripts/audit_public_api_compat.py`) exists precisely to stop
+  unannounced breaks. (Clean breaks remain acceptable for non-contract
+  internals and bug fixes — that is a separate policy, not a deprecation.)
+- **Per-feature `warnings.warn(...)` calls.** Rejected. It produces
+  inconsistent messages, no shared removal-version vocabulary, and no single
+  suppression switch — exactly the fragmentation this ADR prevents.
+- **Make `MappingCompatMixin` warn on every mapping access.** Rejected.
+  Warning on `get`/`in`/iteration would flood defensive callers who are
+  already forward-compatible; warning only on `__getitem__` targets the access
+  pattern that actually breaks when the dict return becomes a dataclass.


### PR DESCRIPTION
## Summary

Documentation-only refresh of `docs/adr/` per #1329. No source or test changes; `docs/adr/0007*` left untouched (owned by #1325).

### ADR-013 (live / Accepted) — stale module + class refs fixed, banner added
- Added a historical-disclaimer banner: the capability-composition decision still holds, but specific names changed.
- `_session_contracts.py` → `_runtime_contracts.py` — all 9 occurrences. Verified the module was renamed and the old name no longer exists in source.
- The retired feature-local composites `ChatRuntime` / `ArtifactsRuntime` / `UploadRuntime` are flagged as historical (feature APIs now take narrow collaborators by keyword-only ctor arg; verified against `_runtime_contracts.py` docstring + source).
- **Corrected C-AA**: `DrainHookRegistration` is a callable type alias `Callable[[], Awaitable[None]]` in `src/notebooklm/_transport_drain.py` (not a Protocol, not local to `ArtifactsRuntime` in `_artifacts.py`). Registration collapsed onto `TransportDrainTracker.register_drain_hook`; artifact polling registers its hook there.
- **Corrected C-AB**: `RpcOwner` was deleted entirely (not merely narrowed; 0 references in source); `RpcExecutor` takes its collaborators via keyword-only ctor params and keeps only a local `DecodeResponse` Protocol.

### ADR-002 / ADR-010 (Superseded) — banners
- ADR-002 already carried a banner; extended it to flag the retired `ChatRuntime` / `ArtifactsRuntime` composites cited in its Status line.
- ADR-010 had no banner; added the same historical-disclaimer banner that ADRs 0001/0002/0014 carry (deleted `Session` Protocol, `_session_contracts.py` rename, retired composites, `DrainHookRegistration` now a callable alias).

### New ADRs (repo template + append-only numbering; next numbers are 0017/0018)
- **ADR-017** — public-facade / private-impl re-export convention (`types.py`→`_types/`, `config.py`→`_env.py`, `urls.py`→`_url_utils.py`, `io.py`→`_atomic_io.py`, `log.py`→`_logging.py`, `auth.py`→`_auth/`). Every facade ↔ impl pair verified against current source; ties into the api-compat allowlist gate and ADR-012.
- **ADR-018** — deprecation strategy (`_deprecation.py`): `warn_get_returns_none`, `deprecated_kwarg`, and `MappingCompatMixin` (dict-subscript bridge at `_deprecation.py:221`), all gated by `NOTEBOOKLM_QUIET_DEPRECATIONS`, with the v0.8.0 removal runway. Verified against `_deprecation.py` and its users.

Updated the ADR index README. The row-adapter ADR (optional in the issue) was skipped to keep scope tight.

### Verification
- Every code reference verified against current source before writing.
- `uv run ruff format --check .` and `uv run ruff check src tests` pass.
- `uv run mypy src/notebooklm --ignore-missing-imports` passes (unaffected by docs).
- `uv run pytest tests/_lint -q` passes. No ADR-structure or doc-link test exists in this repo; all internal ADR links manually confirmed to resolve, and both new ADRs follow the six-section template.

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added deprecation strategy documentation with centralized warning mechanisms and versioned removal timelines for API changes
* Documented public API facade and private implementation convention to establish clear module structure and import guidelines
* Updated multiple Architecture Decision Records with historical supersession notices clarifying evolved architectural patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->