### PR TITLE
test(lint): police mock.patch string targets into privates (closes #1325)

### DIFF
--- a/docs/adr/0007-test-monkeypatch-policy.md
+++ b/docs/adr/0007-test-monkeypatch-policy.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Accepted.
+Accepted (migration in progress — allowlist non-empty).
 
-This ADR ships in the `arch-d1-fixtures-scaffolding` PR (D1 PR-1). It defines the *forbidden* test patterns going forward; the migration of the ~273 existing offenders is scheduled across D1 PR-2 (`arch-d1-auth-side`) and D1 PR-3 (`arch-d1-cli-side`), at which point the meta-lint's file-level allowlist shrinks to empty.
+This ADR shipped in the `arch-d1-fixtures-scaffolding` PR (D1 PR-1). It defines the *forbidden* test patterns going forward; the migration of the existing offenders to constructor seams is still in progress, so the meta-lint's file-level allowlist is **not yet empty**. The allowlist shrinks toward zero as offenders migrate.
+
+**Coverage update (issue #1325):** the original meta-lint policed only the three `monkeypatch.setattr` / direct-`AsyncMock`-assignment forms below and was blind to the `unittest.mock` channel — `mock.patch("notebooklm._private…")` / `patch("notebooklm._private…")` / `patch.object(notebooklm._private…, ...)` — which is where most of the recent growth happened. As of #1325 the lint also flags those string-target patches into *private* `notebooklm._*` paths (forbidden pattern 4 below), and the file-level allowlist gained the pre-existing offenders so the policy now covers both mocking channels. Because that allowlist is non-empty, this ADR is re-statused from "Accepted" to "Accepted (migration in progress — allowlist non-empty)"; the earlier text overstated completion by claiming the list shrinks to empty.
 
 ## Context
 
@@ -50,6 +52,7 @@ The following patterns are **forbidden** in new test code and enforced by `tests
 1. **String-target monkeypatches into the `notebooklm` namespace** — `monkeypatch.setattr("notebooklm.X.Y", ...)`. These rely on import-string resolution and silently no-op when storage relocates.
 2. **Object-attribute monkeypatches via the `notebooklm` module** — `monkeypatch.setattr(notebooklm.X, "attr", ...)`. Same failure mode; written slightly differently.
 3. **Direct AsyncMock attribute assignment to the transport/RPC surface** — `target.rpc_call = AsyncMock(...)`, `target._perform_authed_post = AsyncMock(...)`, `target._begin_transport_post = AsyncMock(...)`, `target._finish_transport_post = AsyncMock(...)`, `target.query_post = AsyncMock(...)`, including chained variants like `self._client._target.rpc_call = AsyncMock(...)`. These mutate a constructed instance instead of injecting a fake at construction.
+4. **`unittest.mock` string-target patches into private internals** (added in #1325) — `mock.patch("notebooklm._private…")` / `patch("notebooklm._private…")` / `patch.object(notebooklm._private…, ...)`. Same import-string failure mode as (1), routed through `unittest.mock` instead of `monkeypatch`. Scoped to *private* `notebooklm._*` paths — the implementation internals the policy forbids reaching into; patches at public facades are out of scope for this rule.
 
 `tests/_fixtures/fake_core.py` provides `make_fake_core(**overrides) -> FakeSession`. `FakeSession` is a `types.SimpleNamespace`-shaped plain class whose default fields cover every attribute the narrow Protocols in `src/notebooklm/_capabilities.py` require (`rpc_call`, `_perform_authed_post`, `_begin_transport_post`, `_finish_transport_post`, `next_reqid`, `authuser`, `account_email`, `authuser_query`, `authuser_header`, `live_cookies`, `get_upload_semaphore`, `record_upload_queue_wait`, `bound_loop`, plus the private `_route_url`/`_next_reqid` aliases tests use today). Defaults are benign `AsyncMock`s for the async surface and `MagicMock`s for the sync surface; tests override only the slice they exercise via keyword arguments.
 
@@ -57,7 +60,7 @@ The choice of `types.SimpleNamespace`-shaped attribute storage (rather than `Mag
 
 `tests/_fixtures/conftest.py` exposes exactly two thin pytest fixtures — `fake_core` (default factory call) and `make_fake_core` (the factory itself, for tests that need per-call overrides). The deliberately small fixture surface avoids the failure mode `/grill-me` Q11 flagged: a "full fixture menu" creates one parameterless pytest fixture per per-test override combination, which scales O(N tests × M overrides) and quickly becomes worse than the monkeypatch pattern it replaces.
 
-The meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) runs in `pytest` (no skip markers), scans each test file as a single string (so multi-line `monkeypatch.setattr(\n  "notebooklm.X", …)` forms are caught — `\s` already matches newlines in Python's `re` engine), and reports each violation with `(file, line, matched pattern)` for actionable failure messages. Its file-level allowlist starts at 49 files (the union of audit-flagged offenders at PR-start) and is expected to shrink to zero by D1 PR-3.
+The meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) runs in `pytest` (no skip markers), scans each test file as a single string (so multi-line `monkeypatch.setattr(\n  "notebooklm.X", …)` forms are caught — `\s` already matches newlines in Python's `re` engine), and reports each violation with `(file, line, matched pattern)` for actionable failure messages. Its file-level allowlist started at 49 files (the union of audit-flagged offenders at PR-start) and is driven toward zero as offenders migrate. **It is currently non-empty:** issue #1325 added a second batch of pre-existing offenders when the lint's coverage was extended to the `unittest.mock` channel (forbidden pattern 4) — files that patch private `notebooklm._*` paths via `mock.patch` / `patch` string targets, concentrated in `notebooklm._research`, `notebooklm._artifact_downloads`, and `notebooklm._sources`. That batch is grouped under an "issue #1325" header in the allowlist and shrinks on the same terms as the rest: a file whose offenders migrate to seams must be removed from the allowlist, and a stale entry (a file with no remaining offenders) fails the lint so the list cannot rot.
 
 ## Consequences
 

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -1,6 +1,6 @@
 """Meta-lint enforcing the test-monkeypatch policy from ADR-007.
 
-This test scans every ``.py`` file under ``tests/`` for the three
+This test scans every ``.py`` file under ``tests/`` for the four
 forbidden patterns documented in
 ``docs/adr/0007-test-monkeypatch-policy.md`` and fails if any file *not*
 on the shrinking allowlist contains a match.
@@ -30,6 +30,20 @@ Forbidden patterns
    .. code-block:: python
 
        target.rpc_call = AsyncMock(return_value=None)
+
+4. **``unittest.mock`` string-target patches into private internals** —
+   ``mock.patch("notebooklm._private…")`` / ``patch("notebooklm._private…")``
+   / ``patch.object(notebooklm._private…, ...)``. Same import-string failure
+   mode as (1), but routed through ``unittest.mock`` instead of
+   ``monkeypatch`` — the channel where the growth happened and which the lint
+   previously missed entirely (issue #1325). Scoped to private
+   ``notebooklm._*`` paths: those are the implementation internals the policy
+   forbids reaching into, and they silently no-op when the attribute relocates.
+
+   .. code-block:: python
+
+       mock.patch("notebooklm._research.ResearchAPI._poll", fake)
+       patch("notebooklm._artifact_downloads.httpx", fake)
 
 Allowlist
 ---------
@@ -126,16 +140,46 @@ _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
     r"(?<![\w.])[\w.]+\.(?:rpc_call|transport_post|_perform_authed_post|next_reqid|save_cookies)\s*=\s*(?:[\w]+\.)*AsyncMock"
 )
 
+# (d) ``mock.patch("notebooklm._private…")`` / ``patch("notebooklm._private…")``
+#     — ``unittest.mock`` string-target patch into a *private* internal path.
+#
+# The ``(?<![\w.])(?:[\w]+\.)*`` prefix anchors ``patch`` at a word boundary
+# and allows an optional dotted module qualifier, so the bare ``patch(`` (from
+# ``from unittest.mock import patch``), ``mock.patch(``, and
+# ``unittest.mock.patch(`` forms all match, while ``monkeypatch(`` / ``dispatch(``
+# (where ``patch`` is preceded by a word char) and ``patch.object(`` (no ``(``
+# immediately after ``patch``) do not. Scoped to ``notebooklm\._`` so only
+# *private* targets are flagged — patches at public facades are out of scope for
+# this rule (issue #1325).
+_PATTERN_MOCK_PATCH_PRIVATE = re.compile(r"(?<![\w.])(?:[\w]+\.)*patch\(\s*[\"']notebooklm\._")
+
+# (e) ``patch.object(notebooklm._private…, "attr", …)`` — the object-target
+#     ``unittest.mock`` form aimed at a private module reference. No occurrences
+#     exist today; the rule guards against regressions on this second
+#     ``unittest.mock`` shape.
+_PATTERN_MOCK_PATCH_OBJECT_PRIVATE = re.compile(
+    r"(?<![\w.])(?:[\w]+\.)*patch\.object\(\s*[\w.]*notebooklm\._"
+)
+
 _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("string-target monkeypatch (forbidden by ADR-007)", _PATTERN_STRING_TARGET),
     ("object-attribute monkeypatch (forbidden by ADR-007)", _PATTERN_OBJECT_ATTR),
     ("AsyncMock attribute assignment (forbidden by ADR-007)", _PATTERN_ASYNCMOCK_ASSIGN),
+    ("mock.patch string-target into private (forbidden by ADR-007)", _PATTERN_MOCK_PATCH_PRIVATE),
+    ("patch.object into private module (forbidden by ADR-007)", _PATTERN_MOCK_PATCH_OBJECT_PRIVATE),
 )
 
 
 # ---------------------------------------------------------------------------
 # File-level allowlist — baked at PR-start (2026-05-18). Shrinks across
 # D1 PR-2 and D1 PR-3; target end state is an empty set.
+#
+# A second batch (issue #1325) was added when the lint was extended to also
+# catch ``mock.patch("notebooklm._private…")`` / ``patch.object`` string targets
+# into private internals — a previously-unpoliced channel. Those entries are
+# grouped under the "issue #1325" header below and shrink toward zero on the
+# same terms: a file whose offenders are migrated to seams must be removed from
+# the allowlist (a stale entry fails the lint).
 # ---------------------------------------------------------------------------
 
 _ALLOWLIST: frozenset[str] = frozenset(
@@ -211,6 +255,59 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # module-level mapping used during request encoding — module-level data
         # seam, not a core attribute.
         "tests/unit/test_rpc_overrides.py",
+        # -------------------------------------------------------------------
+        # issue #1325: pre-existing `mock.patch("notebooklm._private…")`
+        # string-target offenders, surfaced when the lint's coverage was
+        # extended to the `unittest.mock` channel. These reach into private
+        # `notebooklm._*` modules and must migrate to constructor seams /
+        # public hooks; this list shrinks toward zero.
+        # (`tests/integration/concurrency/test_download_blocks_loop.py` also
+        # matches this rule but is already allowlisted above.)
+        # -------------------------------------------------------------------
+        # reason: patches `notebooklm._runtime_init` construction internals to
+        # assert httpx connection-pool tuning — runtime seam below the
+        # core-injection surface.
+        "tests/integration/concurrency/test_pool_tuning.py",
+        # reason: patches `notebooklm._sources` internals to assert upload
+        # timeout config — service seam, not a core attribute.
+        "tests/integration/concurrency/test_upload_timeout_config.py",
+        # reason: patches `notebooklm._artifact_downloads` download-coordinator
+        # internals (httpx-level) for the artifacts integration cassette.
+        "tests/integration/test_artifacts_integration.py",
+        # reason: patches `notebooklm._sources` source-addition internals for
+        # the sources integration cassette.
+        "tests/integration/test_sources_integration.py",
+        # reason: patches `notebooklm._artifact_downloads` download-coordinator
+        # internals to exercise the asynchronous download path.
+        "tests/unit/test_artifact_downloads.py",
+        # reason: patches `notebooklm._artifact_downloads` internals for artifact
+        # coverage edge cases.
+        "tests/unit/test_artifacts_coverage.py",
+        # reason: patches `notebooklm._artifact_downloads` internals to assert
+        # download-result shaping.
+        "tests/unit/test_download_result.py",
+        # reason: patches `notebooklm._artifact_downloads` internals to assert
+        # download-URL resolution.
+        "tests/unit/test_download_url.py",
+        # reason: patches `notebooklm._deadline` retry/backoff timing internals
+        # to assert rate-limit retry behaviour.
+        "tests/unit/test_rate_limit_retry.py",
+        # reason: patches `notebooklm._research` research-flow internals to
+        # exercise import-with-verification — the largest single concentration
+        # of private-target patches (issue #1325).
+        "tests/unit/test_research_import_with_verification.py",
+        # reason: patches `notebooklm._sources` poll-coordinator internals
+        # for the source polling service.
+        "tests/unit/test_source_polling_service.py",
+        # reason: patches `notebooklm._sources` internals to assert source
+        # status transitions.
+        "tests/unit/test_source_status.py",
+        # reason: patches `notebooklm._source_upload` internals for upload
+        # coverage edge cases.
+        "tests/unit/test_source_upload_coverage.py",
+        # reason: patches `notebooklm._types` dataclass internals exercised
+        # through the public types surface.
+        "tests/unit/test_types.py",
     }
 )
 


### PR DESCRIPTION
## Summary

Closes #1325. The ADR-0007 meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) only recognized the three `monkeypatch.setattr` / direct-`AsyncMock`-assignment forms and was blind to the dominant deep-coupling channel in this codebase — `mock.patch("notebooklm._private…")` / `patch(...)` / `patch.object(...)` string targets into private internals. Those string targets resolve at import time and silently no-op on relocation (the exact failure mode ADR-0007 forbids), so the policy was being silently out-run and the ADR overstated completion.

## What changed

- **Two new regex rules** in the existing scanner flag the `unittest.mock` patch family whose string target points at a *private* `notebooklm._*` path:
  - `_PATTERN_MOCK_PATCH_PRIVATE` — `patch("notebooklm._…")` / `<mod>.patch("notebooklm._…")` (e.g. `mock.patch(...)`), and
  - `_PATTERN_MOCK_PATCH_OBJECT_PRIVATE` — `patch.object(notebooklm._…, …)` (0 occurrences today; guards against regressions on the second shape).

  Both reuse the existing word-boundary anchoring (`(?<![\w.])(?:[\w]+\.)*`) so `monkeypatch(` / `dispatch(` and `patch.object(` don't false-match the string-target rule. Scoped to `notebooklm\._` so only **private** targets are flagged — patches at public facades are out of scope per the issue. The existing three patterns are unchanged.

- **Shrinking allowlist.** Enumerating offenders with the new rules surfaced **15 files** (concentrated in `notebooklm._sources`, `._artifact_downloads`, and `._research`; `test_download_blocks_loop.py` already was allowlisted). They're added to the existing **file-level** `_ALLOWLIST` under an "issue #1325" header with per-file reasons. The allowlist keeps its existing "no stale entries" semantics (a file whose offenders migrate to seams must be removed, or the lint fails), consistent with the ADR's deliberate choice of file-level over per-site granularity.

- **Re-statused `docs/adr/0007-test-monkeypatch-policy.md`** from "Accepted" to "Accepted (migration in progress — allowlist non-empty)", documented forbidden pattern 4, and corrected the text that claimed the allowlist shrinks to empty.

## Scope

Only `tests/_lint/test_no_forbidden_monkeypatches.py` and `docs/adr/0007-test-monkeypatch-policy.md` are touched. The offending test files are **not** modified — migrating them off deep-private patch targets is the follow-up the shrinking allowlist exists to track (out of scope per the issue).

## Verification

- `uv run ruff format --check .` — pass (605 files)
- `uv run ruff check src tests` — pass
- `uv run mypy src/notebooklm --ignore-missing-imports` — pass (188 files)
- `uv run pytest` — 7940 passed, 100 skipped
- Self-check: 15 files match the new mock.patch-private rules; all 15 are allowlisted; 0 unexpected, 0 stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture decision records regarding internal testing practices and code quality standards.

* **Tests**
  * Enhanced test enforcement policies to strengthen internal code quality and testing standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->