### PR TITLE
test(lint): harden mock.patch rules against target= kwarg (#1336 follow-up)

### DIFF
--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -148,17 +148,25 @@ _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
 # ``from unittest.mock import patch``), ``mock.patch(``, and
 # ``unittest.mock.patch(`` forms all match, while ``monkeypatch(`` / ``dispatch(``
 # (where ``patch`` is preceded by a word char) and ``patch.object(`` (no ``(``
-# immediately after ``patch``) do not. Scoped to ``notebooklm\._`` so only
+# immediately after ``patch``) do not. The optional ``(?:target\s*=\s*)?``
+# catches the keyword-argument spelling ``patch(target="notebooklm._…")`` and
+# the optional ``[rRfFuUbB]*`` catches string-literal prefixes
+# (``patch(r"notebooklm._…")``), so neither can silently bypass the rule
+# (gemini-code-assist review on #1336). Scoped to ``notebooklm\._`` so only
 # *private* targets are flagged — patches at public facades are out of scope for
 # this rule (issue #1325).
-_PATTERN_MOCK_PATCH_PRIVATE = re.compile(r"(?<![\w.])(?:[\w]+\.)*patch\(\s*[\"']notebooklm\._")
+_PATTERN_MOCK_PATCH_PRIVATE = re.compile(
+    r"(?<![\w.])(?:[\w]+\.)*patch\(\s*(?:target\s*=\s*)?[rRfFuUbB]*[\"']notebooklm\._"
+)
 
 # (e) ``patch.object(notebooklm._private…, "attr", …)`` — the object-target
 #     ``unittest.mock`` form aimed at a private module reference. No occurrences
 #     exist today; the rule guards against regressions on this second
-#     ``unittest.mock`` shape.
+#     ``unittest.mock`` shape. The optional ``(?:target\s*=\s*)?`` likewise
+#     catches the ``patch.object(target=notebooklm._…)`` keyword spelling
+#     (gemini-code-assist review on #1336).
 _PATTERN_MOCK_PATCH_OBJECT_PRIVATE = re.compile(
-    r"(?<![\w.])(?:[\w]+\.)*patch\.object\(\s*[\w.]*notebooklm\._"
+    r"(?<![\w.])(?:[\w]+\.)*patch\.object\(\s*(?:target\s*=\s*)?[\w.]*notebooklm\._"
 )
 
 _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (


### PR DESCRIPTION
## Summary

Follow-up to #1336 (closed #1325), addressing the gemini-code-assist review on that PR. The new `mock.patch`-private lint rules matched only the positional spelling, so the keyword-argument form could silently bypass the lint:

```python
patch(target="notebooklm._private.thing")
patch.object(target=notebooklm._private, attribute="thing")
```

## What changed

Added an optional `(?:target\s*=\s*)?` between the opening paren and the target to both `_PATTERN_MOCK_PATCH_PRIVATE` and `_PATTERN_MOCK_PATCH_OBJECT_PRIVATE`, so the keyword form is caught too. The positional forms still match, and the word-boundary anchoring is unchanged.

Verified the hardened regexes against edge cases: positional `patch(...)` / `mock.patch(...)`, the new `patch(target=...)` / `patch.object(target=...)` kwarg forms, `monkeypatch(`/`dispatch(` (must not match), public `notebooklm.public` targets (must not match), and the string-rule-vs-object-rule separation.

## Scope

Lint-only change to `tests/_lint/test_no_forbidden_monkeypatches.py`. The shrinking allowlist is **unchanged** — no existing offender uses the keyword spelling, so the set of matched files is identical.

## Verification

- `uv run ruff format --check` — pass
- `uv run ruff check` — pass
- `uv run mypy src/notebooklm --ignore-missing-imports` — pass (188 files)
- `uv run pytest tests/_lint/test_no_forbidden_monkeypatches.py` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved lint/test rules to more reliably detect forbidden private-module mocking patterns. Detection now covers additional call shapes and keyword argument forms, reducing false negatives while remaining scoped to private/internal module targets. This strengthens test enforcement without changing public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->