### PR TITLE
docs(adr): fix ADR-013 banner rename typo (#1335 follow-up)

### DIFF
--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -5,7 +5,7 @@
 > contract — remains in force. However, several *names* it cites have changed
 > since it was written, and some of the feature-local composites it proposed
 > were later retired. In particular: the contracts module
-> `_runtime_contracts.py` was **renamed to `_runtime_contracts.py`**; the
+> `_session_contracts.py` was **renamed to `_runtime_contracts.py`**; the
 > concrete `Session` facade was **deleted**; and the feature-local composite
 > Protocols `ChatRuntime`, `ArtifactsRuntime`, and `UploadRuntime` (Decision
 > §3) were **retired** in favour of feature constructors taking their narrow


### PR DESCRIPTION
## Summary

Fast follow-up to #1335 (closed #1329). Both `gemini-code-assist` and `coderabbit` flagged a copy-paste typo in the ADR-013 historical-note banner *after* #1335 had already merged, so this fixes it on a new branch.

The banner said the contracts module was "`_runtime_contracts.py` was renamed to `_runtime_contracts.py`" — an artifact of the global `_session_contracts.py` → `_runtime_contracts.py` rename in #1335. Corrected to "`_session_contracts.py` was renamed to `_runtime_contracts.py`", which matches the verified source history (the module was renamed; `_session_contracts.py` no longer exists).

Docs-only, single-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Record to reflect historical naming changes in development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->