### PR TITLE
refactor(runtime): remove dead/single-consumer Protocol indirection

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -6,7 +6,8 @@ import asyncio
 import builtins
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from contextlib import AbstractAsyncContextManager
+from typing import Any, Protocol
 
 from ._artifact_listing import find_artifact_row_by_id
 from ._backoff import compute_backoff_delay
@@ -14,7 +15,7 @@ from ._callbacks import maybe_await_callback
 from ._deadline import Monotonic, RuntimeDeadline, Sleep
 from ._polling_registry import PollRegistry
 from ._row_adapters_artifacts import ArtifactRow
-from ._runtime_contracts import LoopGuard, OperationScopeProvider
+from ._runtime_contracts import LoopGuard
 from .exceptions import ArtifactInProgressTimeoutError, ArtifactPendingTimeoutError
 from .rpc import (
     ArtifactStatus,
@@ -38,6 +39,17 @@ MediaReadyCallback = Callable[[builtins.list[Any], int], bool]
 ArtifactTypeNameCallback = Callable[[int], str]
 ArtifactErrorCallback = Callable[[builtins.list[Any]], str | None]
 StatusChangeCallback = Callable[[GenerationStatus], object]
+
+
+class OperationScopeProvider(Protocol):
+    """``operation_scope`` async-context-manager surface for feature APIs.
+
+    Inlined from ``_runtime_contracts`` in issue #1327: artifact polling
+    is the only consumer, so this single-consumer Protocol lives local to
+    its owner per the ADR-013 ≥2-feature promotion bar.
+    """
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]: ...
 
 
 class ArtifactPollingService:

--- a/src/notebooklm/_client_seams.py
+++ b/src/notebooklm/_client_seams.py
@@ -3,6 +3,19 @@
 The callable seams in this module are intentionally separate from construction
 seams such as ``async_client_factory``. ``ClientSeams`` owns only callables that
 runtime closures may re-read after construction.
+
+**TEST-ONLY injection points.** The three ``ClientSeams`` callables
+(``decode_response`` / ``sleep`` / ``is_auth_error``) — along with the
+construction-only ``async_client_factory`` resolved in ``_runtime_init`` —
+are never varied in production: ``NotebookLMClient.__init__`` hardcodes
+all four to ``None`` (``resolve_client_seams(decode_response=None,
+sleep=None, is_auth_error=None)``), so they always resolve to the
+canonical module bindings (:func:`_default_decode_response` /
+:func:`_default_sleep` / :func:`_default_is_auth_error` /
+:class:`httpx.AsyncClient`). The non-``None`` paths exist solely so tests
+can inject deterministic substitutes via ``compose_client_internals`` or
+the client-shell test helper. Do not wire a public ``NotebookLMClient``
+kwarg to any of them without a production caller that varies them.
 """
 
 from __future__ import annotations

--- a/src/notebooklm/_runtime_contracts.py
+++ b/src/notebooklm/_runtime_contracts.py
@@ -2,15 +2,18 @@
 
 This module defines the narrow structural Protocols feature APIs depend
 on. Per ADR-013, a Protocol lives here only when **shared by ≥2
-features**; single-consumer capabilities (e.g. artifact polling's
-``register_drain_hook``) stay local to their owning feature module.
+features**; single-consumer capabilities stay local to their owning
+feature module (e.g. ``AuthMetadata`` lives in ``_source_upload.py`` and
+``OperationScopeProvider`` lives in ``_artifact_polling.py``, each with a
+single consumer).
 
 Contents:
 
-* :class:`AuthMetadata` and :class:`Kernel` — selected-account routing
-  metadata + pure transport surface consumed by the upload pipeline.
-* :class:`RpcCaller`, :class:`LoopGuard`, :class:`OperationScopeProvider`,
-  :class:`AsyncWorkRuntime` — the four shared capability Protocols.
+* :class:`Kernel` — pure transport surface consumed by the upload
+  pipeline (and structurally satisfied by the concrete ``Kernel``).
+* :class:`RpcCaller` (~17 consumers) and :class:`LoopGuard` (2
+  consumers) — the surviving shared capability Protocols that meet the
+  ADR-013 ≥2-feature bar.
 
 Feature APIs that need more than one capability take their direct
 collaborators by keyword-only constructor argument (``ChatAPI`` in
@@ -19,31 +22,21 @@ collaborators by keyword-only constructor argument (``ChatAPI`` in
 composite Protocols ``ArtifactsRuntime`` and ``UploadRuntime`` (and
 their corresponding adapter dataclasses) that previously bundled three
 capability Protocols apiece were retired once it was clear they only
-hid three stable collaborators with exactly one production satisfier;
-the surviving narrow Protocols (``RpcCaller``, ``LoopGuard``,
-``OperationScopeProvider``, ``AsyncWorkRuntime``) here continue to
-describe the per-capability shapes feature constructors consume.
+hid three stable collaborators with exactly one production satisfier.
+The single-consumer ``AuthMetadata`` / ``OperationScopeProvider`` and
+the unused ``AsyncWorkRuntime`` composite were inlined / deleted in
+issue #1327 for the same reason — a Protocol with fewer than two
+production consumers is indirection that no production code varies.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from contextlib import AbstractAsyncContextManager
 from typing import Any, Protocol
 
 import httpx
 
 from .rpc.types import RPCMethod
-
-
-class AuthMetadata(Protocol):
-    """Selected-account routing metadata required by upload flows."""
-
-    @property
-    def authuser(self) -> int: ...
-
-    @property
-    def account_email(self) -> str | None: ...
 
 
 class Kernel(Protocol):
@@ -96,21 +89,8 @@ class LoopGuard(Protocol):
     def assert_bound_loop(self) -> None: ...
 
 
-class OperationScopeProvider(Protocol):
-    """``operation_scope`` async-context-manager surface for feature APIs."""
-
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]: ...
-
-
-class AsyncWorkRuntime(LoopGuard, OperationScopeProvider, Protocol):
-    """Runtime support for feature-owned async work."""
-
-
 __all__ = [
-    "AsyncWorkRuntime",
-    "AuthMetadata",
     "Kernel",
     "LoopGuard",
-    "OperationScopeProvider",
     "RpcCaller",
 ]

--- a/src/notebooklm/_runtime_init.py
+++ b/src/notebooklm/_runtime_init.py
@@ -142,27 +142,6 @@ def _resolve_async_client_factory(
     return httpx.AsyncClient
 
 
-def resolve_seam_defaults(
-    *,
-    sleep: Callable[[float], Awaitable[Any]] | None,
-    async_client_factory: Callable[..., httpx.AsyncClient] | None,
-    is_auth_error: Callable[[Exception], bool] | None,
-    decode_response: Callable[..., Any] | None,
-) -> dict[str, Callable[..., Any]]:
-    """Resolve legacy seam-default shape while keeping ``ClientSeams`` separate."""
-    seams = resolve_client_seams(
-        sleep=sleep,
-        is_auth_error=is_auth_error,
-        decode_response=decode_response,
-    )
-    return {
-        "sleep": seams.sleep,
-        "async_client_factory": _resolve_async_client_factory(async_client_factory),
-        "is_auth_error": seams.is_auth_error,
-        "decode_response": seams.decode_response,
-    }
-
-
 def validate_constructor_args(
     *,
     timeout: float,
@@ -623,7 +602,6 @@ __all__ = [
     "build_collaborators",
     "build_runtime_transport",
     "compose_client_internals",
-    "resolve_seam_defaults",
     "validate_constructor_args",
     "wire_middleware_chain",
 ]

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -24,7 +24,6 @@ from ._runtime_config import (
     normalize_max_concurrent_uploads,
 )
 from ._runtime_contracts import (
-    AuthMetadata,
     Kernel,
     RpcCaller,
 )
@@ -60,6 +59,22 @@ _SOURCE_NAME_FIELD_NAMES = frozenset(
     {"SOURCE_NAME", "source_name", "sourceName", "filename", "fileName", "name", "title"}
 )
 _SOURCE_ID_ENVELOPE_MAX_DEPTH = 8
+
+
+class AuthMetadata(Protocol):
+    """Selected-account routing metadata required by upload flows.
+
+    Inlined from ``_runtime_contracts`` in issue #1327: the upload
+    pipeline is the only consumer, so this single-consumer Protocol lives
+    local to its owner per the ADR-013 ≥2-feature promotion bar.
+    ``AuthTokens`` structurally satisfies it.
+    """
+
+    @property
+    def authuser(self) -> int: ...
+
+    @property
+    def account_email(self) -> str | None: ...
 
 
 class RpcCallback(Protocol):

--- a/src/notebooklm/_transport_drain.py
+++ b/src/notebooklm/_transport_drain.py
@@ -249,8 +249,9 @@ class TransportDrainTracker:
 
         Wraps :meth:`begin_transport_post` / :meth:`finish_transport_post`
         so feature code can write ``async with tracker.operation_scope("upload"):``
-        without managing the token by hand. Satisfies ``OperationScopeProvider``
-        directly.
+        without managing the token by hand. Satisfies the
+        ``_artifact_polling.OperationScopeProvider`` Protocol directly
+        (inlined into that module in issue #1327).
         """
         token = await self.begin_transport_post(label)
         try:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -298,6 +298,14 @@ class NotebookLMClient:
         # ``is_auth_error`` / ``async_client_factory``) live on
         # ``compose_client_internals`` and the client-shell test helper
         # only.
+        #
+        # TEST-ONLY injection points: production passes ``None`` for all
+        # three runtime seams here (and never supplies an
+        # ``async_client_factory``), so they always resolve to the
+        # canonical module bindings. The non-``None`` paths exist solely
+        # for deterministic test injection — see ``_client_seams`` module
+        # docstring. Do not promote any of them to a public kwarg without
+        # a production caller that varies them.
         self._seams = resolve_client_seams(
             decode_response=None,
             sleep=None,

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -3,8 +3,10 @@
 This module provides a single entry point — :func:`make_fake_core` — that
 returns a ``FakeSession`` instance shaped to satisfy the **shared
 capability Protocols** in :mod:`notebooklm._runtime_contracts`
-(``RpcCaller``, ``LoopGuard``, ``OperationScopeProvider``,
-``AsyncWorkRuntime``, ``AuthMetadata``, ``Kernel``). Feature APIs that
+(``RpcCaller``, ``LoopGuard``, ``Kernel``) plus the single-consumer
+Protocols inlined into their owning feature modules in issue #1327
+(``AuthMetadata`` in ``_source_upload``, ``OperationScopeProvider`` in
+``_artifact_polling``). Feature APIs that
 need more than one capability take their direct collaborators by
 keyword-only constructor argument (``ChatAPI`` in ``_chat.py``,
 ``ArtifactsAPI`` in ``_artifacts.py``, ``SourceUploadPipeline`` in
@@ -149,8 +151,9 @@ def make_fake_core(**overrides: Any) -> FakeSession:
         # bag-of-attributes.
         "rpc_call": rpc_call_mock,
         "rpc_executor": SimpleNamespace(rpc_call=rpc_call_mock),
-        # AsyncWorkRuntime (LoopGuard + OperationScopeProvider) — used by
-        # ArtifactsAPI polling and SourceUploadPipeline.
+        # LoopGuard + OperationScopeProvider (the latter inlined into
+        # ``_artifact_polling`` in #1327) — used by ArtifactsAPI polling
+        # and SourceUploadPipeline.
         "assert_bound_loop": MagicMock(return_value=None),
         "operation_scope": MagicMock(side_effect=_operation_scope),
         # DrainHookRegistration (local in ``_artifacts.py``) — close-time

--- a/tests/_lint/test_session_runtime_boundaries.py
+++ b/tests/_lint/test_session_runtime_boundaries.py
@@ -133,10 +133,12 @@ MOVED_SESSION_SYMBOL_NAMES: frozenset[str] = frozenset(
     # Only symbols that used to be reachable through the deleted session module
     # aliases belong here. Moves between other modules, such as default sleep
     # resolution moving onto `ClientSeams`, are outside this guard's scope.
+    # ``resolve_seam_defaults`` was deleted in issue #1327 (redundant
+    # alongside ``resolve_client_seams``); dropped from this set since the
+    # symbol no longer exists to be reached through any alias.
     {
         "compose_session_internals",
         "ComposedSession",
-        "resolve_seam_defaults",
         "_default_decode_response",
         "_default_is_auth_error",
     }

--- a/tests/unit/test_composition_primitives.py
+++ b/tests/unit/test_composition_primitives.py
@@ -5,10 +5,14 @@ PR 2 of the post-refactoring plan
 (``docs/post-refactoring-plan-2026-05-27.md``):
 
 - :class:`notebooklm._runtime_init.ClientInternals` dataclass
-- :func:`notebooklm._runtime_init.resolve_seam_defaults`
 - :func:`notebooklm._runtime_init.compose_client_internals`
 - ``ClientComposed.bind_*`` write-once setters
 - ``ClientComposed`` required-property guards
+
+The redundant ``resolve_seam_defaults`` resolver was removed in issue
+#1327 — ``compose_client_internals`` resolves seams directly via
+``resolve_client_seams`` + ``_resolve_async_client_factory``, so the
+parallel dict-shaped resolver had no production caller.
 
 Session-elimination Phase 3 leaves ``NotebookLMClient`` as both composition
 root and public surface; all composition runtime state belongs to
@@ -21,7 +25,6 @@ import asyncio
 import logging
 from typing import Any
 
-import httpx
 import pytest
 
 from _helpers.client_factory import build_client_shell_for_tests
@@ -30,7 +33,6 @@ from notebooklm._client_seams import ClientSeams
 from notebooklm._runtime_init import (
     ClientInternals,
     compose_client_internals,
-    resolve_seam_defaults,
 )
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -48,71 +50,6 @@ def _make_auth() -> AuthTokens:
         csrf_token="csrf",
         session_id="sid",
     )
-
-
-# ---------------------------------------------------------------------------
-# resolve_seam_defaults
-# ---------------------------------------------------------------------------
-
-
-def test_resolve_seam_defaults_returns_module_bindings_when_none() -> None:
-    """All four seams default to the canonical module bindings."""
-    resolved = resolve_seam_defaults(
-        sleep=None,
-        async_client_factory=None,
-        is_auth_error=None,
-        decode_response=None,
-    )
-
-    # ``sleep`` resolves to ``asyncio.sleep`` via the client seam defaults.
-    assert resolved["sleep"] is asyncio.sleep
-
-    # ``async_client_factory`` resolves to :class:`httpx.AsyncClient`.
-    assert resolved["async_client_factory"] is httpx.AsyncClient
-
-    # ``is_auth_error`` resolves to :func:`notebooklm._runtime_helpers.is_auth_error`
-    # via the lazy import inside :func:`_default_is_auth_error`.
-    from notebooklm._runtime_helpers import is_auth_error as canonical_is_auth_error
-
-    assert resolved["is_auth_error"] is canonical_is_auth_error
-
-    # ``decode_response`` resolves to :func:`notebooklm.rpc.decode_response`
-    # via the lazy import inside :func:`_default_decode_response`.
-    from notebooklm.rpc import decode_response as canonical_decode_response
-
-    assert resolved["decode_response"] is canonical_decode_response
-
-
-def test_resolve_seam_defaults_passes_through_explicit_callables() -> None:
-    """Explicit callables override the module-binding defaults."""
-
-    async def fake_sleep(_d: float) -> None:
-        """Sentinel callable — identity-checked, never invoked."""
-        return None
-
-    def fake_factory(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - identity check
-        """Sentinel callable — identity-checked, never invoked."""
-        raise AssertionError
-
-    def fake_is_auth_error(_exc: Exception) -> bool:  # pragma: no cover
-        """Sentinel callable — identity-checked, never invoked."""
-        return False
-
-    def fake_decode(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover
-        """Sentinel callable — identity-checked, never invoked."""
-        return None
-
-    resolved = resolve_seam_defaults(
-        sleep=fake_sleep,
-        async_client_factory=fake_factory,
-        is_auth_error=fake_is_auth_error,
-        decode_response=fake_decode,
-    )
-
-    assert resolved["sleep"] is fake_sleep
-    assert resolved["async_client_factory"] is fake_factory
-    assert resolved["is_auth_error"] is fake_is_auth_error
-    assert resolved["decode_response"] is fake_decode
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runtime_contracts.py
+++ b/tests/unit/test_runtime_contracts.py
@@ -7,9 +7,11 @@ shared Protocols are ``RpcCaller`` (~17 consumers), ``LoopGuard`` (2
 consumers), and the pure-transport ``Kernel``. The single-consumer
 ``AuthMetadata`` / ``OperationScopeProvider`` Protocols and the unused
 ``AsyncWorkRuntime`` composite were inlined into their owning feature
-modules / deleted in issue #1327 — see ``test_source_upload`` for the
-upload pipeline's local ``AuthMetadata`` and ``test_artifact_polling``
-for the local ``OperationScopeProvider``. The standalone
+modules / deleted in issue #1327 — ``AuthMetadata`` now lives in
+``_source_upload`` (used by ``SourceUploadPipeline``) and
+``OperationScopeProvider`` in ``_artifact_polling`` (used by
+``ArtifactPollingService``); mypy enforces their structural conformance
+at the consuming call sites. The standalone
 ``DrainHookRegistration`` Protocol previously kept here was deleted in
 Phase 7 — the canonical ``DrainHookRegistration`` is now local to
 ``_artifacts.py`` since artifact polling is its only consumer.

--- a/tests/unit/test_runtime_contracts.py
+++ b/tests/unit/test_runtime_contracts.py
@@ -2,47 +2,33 @@
 ``notebooklm._runtime_contracts``.
 
 Phase 7 (refactor-history.md §Migration Plan step 10) replaced the broad
-``Session`` Protocol with four shared capability Protocols
-(``RpcCaller``, ``LoopGuard``, ``OperationScopeProvider``,
-``AsyncWorkRuntime``). ``AuthMetadata`` and ``Kernel`` are preserved
-as standalone Protocols for the upload pipeline. The standalone
+``Session`` Protocol with shared capability Protocols. The surviving
+shared Protocols are ``RpcCaller`` (~17 consumers), ``LoopGuard`` (2
+consumers), and the pure-transport ``Kernel``. The single-consumer
+``AuthMetadata`` / ``OperationScopeProvider`` Protocols and the unused
+``AsyncWorkRuntime`` composite were inlined into their owning feature
+modules / deleted in issue #1327 — see ``test_source_upload`` for the
+upload pipeline's local ``AuthMetadata`` and ``test_artifact_polling``
+for the local ``OperationScopeProvider``. The standalone
 ``DrainHookRegistration`` Protocol previously kept here was deleted in
-the same step — the canonical ``DrainHookRegistration`` is now local
-to ``_artifacts.py`` since artifact polling is its only consumer.
+Phase 7 — the canonical ``DrainHookRegistration`` is now local to
+``_artifacts.py`` since artifact polling is its only consumer.
 """
 
 from __future__ import annotations
 
 import inspect
 from collections.abc import Mapping
-from contextlib import AbstractAsyncContextManager
-from types import TracebackType
 from typing import Any
 
 import httpx
 
 from notebooklm._runtime_contracts import (
-    AsyncWorkRuntime,
-    AuthMetadata,
     Kernel,
     LoopGuard,
-    OperationScopeProvider,
     RpcCaller,
 )
 from notebooklm.rpc.types import RPCMethod
-
-
-class _NoopOperationScope:
-    async def __aenter__(self) -> None:
-        return None
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> bool | None:
-        return False
 
 
 class _RpcCallerImpl:
@@ -62,29 +48,6 @@ class _RpcCallerImpl:
 
 class _LoopGuardImpl:
     def assert_bound_loop(self) -> None:
-        return None
-
-
-class _OperationScopeProviderImpl:
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
-        return _NoopOperationScope()
-
-
-class _AsyncWorkRuntimeImpl:
-    def assert_bound_loop(self) -> None:
-        return None
-
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
-        return _NoopOperationScope()
-
-
-class _AuthMetadataImpl:
-    @property
-    def authuser(self) -> int:
-        return 0
-
-    @property
-    def account_email(self) -> str | None:
         return None
 
 
@@ -114,10 +77,6 @@ def _public_contract_members(protocol: type[Any]) -> set[str]:
 # ----------------------------------------------------------------------
 
 
-def test_auth_metadata_protocol_has_exactly_two_members() -> None:
-    assert _public_contract_members(AuthMetadata) == {"authuser", "account_email"}
-
-
 def test_kernel_protocol_has_exactly_three_members() -> None:
     assert _public_contract_members(Kernel) == {"post", "cookies", "aclose"}
 
@@ -128,23 +87,6 @@ def test_rpc_caller_protocol_has_exactly_one_member() -> None:
 
 def test_loop_guard_protocol_has_exactly_one_member() -> None:
     assert _public_contract_members(LoopGuard) == {"assert_bound_loop"}
-
-
-def test_operation_scope_provider_protocol_has_exactly_one_member() -> None:
-    assert _public_contract_members(OperationScopeProvider) == {"operation_scope"}
-
-
-def test_async_work_runtime_protocol_extends_loop_guard_and_operation_scope_provider() -> None:
-    # ``AsyncWorkRuntime`` inherits both members through Protocol composition.
-    # The union of inherited public members across its MRO must match.
-    mro_members: set[str] = set()
-    for parent in AsyncWorkRuntime.__mro__:
-        mro_members.update(name for name in parent.__dict__ if not name.startswith("_"))
-    assert {"assert_bound_loop", "operation_scope"} <= mro_members
-    assert AsyncWorkRuntime.__mro__[1:3] in (
-        (LoopGuard, OperationScopeProvider),
-        (OperationScopeProvider, LoopGuard),
-    )
 
 
 # ----------------------------------------------------------------------
@@ -173,14 +115,6 @@ def test_rpc_caller_signature_matches_legacy_session_rpc_call() -> None:
     assert sig.parameters["operation_variant"].default is None
 
 
-def test_auth_metadata_protocol_signatures_are_pinned() -> None:
-    authuser = inspect.signature(AuthMetadata.authuser.fget)
-    assert authuser.return_annotation == "int"
-
-    account_email = inspect.signature(AuthMetadata.account_email.fget)
-    assert account_email.return_annotation == "str | None"
-
-
 def test_kernel_protocol_signatures_are_pinned() -> None:
     post = inspect.signature(Kernel.post)
     assert list(post.parameters) == ["self", "url", "headers", "body"]
@@ -202,29 +136,16 @@ def test_loop_guard_signature_is_pinned() -> None:
     assert sig.return_annotation == "None"
 
 
-def test_operation_scope_provider_signature_is_pinned() -> None:
-    sig = inspect.signature(OperationScopeProvider.operation_scope)
-    assert list(sig.parameters) == ["self", "label"]
-    assert sig.parameters["label"].annotation == "str"
-    assert sig.return_annotation == "AbstractAsyncContextManager[None]"
-
-
 # ----------------------------------------------------------------------
 # Structural conformance — mypy verifies these assignments
 # ----------------------------------------------------------------------
 
 
 def test_structural_implementations_satisfy_protocols() -> None:
-    auth: AuthMetadata = _AuthMetadataImpl()
     kernel: Kernel = _KernelImpl()
     rpc: RpcCaller = _RpcCallerImpl()
     loop_guard: LoopGuard = _LoopGuardImpl()
-    op_scope: OperationScopeProvider = _OperationScopeProviderImpl()
-    async_work: AsyncWorkRuntime = _AsyncWorkRuntimeImpl()
 
-    assert auth is not None
     assert kernel is not None
     assert rpc is not None
     assert loop_guard is not None
-    assert op_scope is not None
-    assert async_work is not None

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -149,9 +149,10 @@ def mock_core():
     core = SimpleNamespace(
         rpc_executor=SimpleNamespace(rpc_call=rpc_call),
         # ``rpc_call`` mirrors ``rpc_executor.rpc_call`` so the SimpleNamespace
-        # also satisfies the composite ``ArtifactsRuntime`` Protocol
-        # (``RpcCaller`` + ``AsyncWorkRuntime`` + ``DrainHookRegistration``)
-        # when threaded into ``ArtifactsAPI`` as the runtime adapter.
+        # also satisfies the composite ``ArtifactsRuntime`` shape
+        # (``RpcCaller`` + ``LoopGuard`` + ``OperationScopeProvider`` +
+        # ``DrainHookRegistration``) when threaded into ``ArtifactsAPI`` as
+        # the runtime adapter.
         rpc_call=rpc_call,
         auth=auth,
         next_reqid=AsyncMock(return_value=100000),


### PR DESCRIPTION
Closes #1327.

Subtractive, low-risk cleanup of runtime contracts that no production code varies, per the module's own ADR-013 "≥2 features" rule. **Production behavior is unchanged** — every removed symbol was either dead code, a single-consumer type-only Protocol inlined into its owner, or a test-only injection seam.

Each item was verified against current code with a repo-wide grep before removal.

## Removals
- **Delete the unused `AsyncWorkRuntime` Protocol** from `_runtime_contracts.py`. Repo-wide grep confirmed zero consumers (only its own definition, `__all__`, and a now-deleted test pin).
- **Inline `AuthMetadata`** into `_source_upload.py` (its sole consumer, `SourceUploadPipeline`) and **`OperationScopeProvider`** into `_artifact_polling.py` (its sole consumer, `ArtifactPollingService`); remove both Protocols from `_runtime_contracts.py`. The shared `Kernel`, `RpcCaller` (~17 consumers), and `LoopGuard` (2 consumers) remain in `_runtime_contracts.py`.
- **Remove the redundant `resolve_seam_defaults` resolver** in `_runtime_init.py`. `compose_client_internals` already resolves seams directly via `resolve_client_seams` + `_resolve_async_client_factory`; the parallel dict-shaped resolver had no production caller (only tests referenced it).

## Documentation
- **Document the 4 constructor seams** (`decode_response` / `sleep` / `is_auth_error` / `async_client_factory`) as **TEST-ONLY injection points** in the `_client_seams.py` module docstring and at the `resolve_client_seams` call site in `client.py`. `NotebookLMClient.__init__` hardcodes all four to `None` in production, so they always resolve to the canonical module bindings; the non-`None` paths exist solely for deterministic test injection.

## Tests
- Dropped the membership / signature / structural pins for the removed Protocols in `test_runtime_contracts.py`.
- Dropped the two `resolve_seam_defaults` tests + import in `test_composition_primitives.py`.
- Removed `resolve_seam_defaults` from the `_session`-boundary lint set in `test_session_runtime_boundaries.py` (the symbol no longer exists to be reached through any alias; the guard remains a no-op since the `_session` module is gone).
- Updated comment-only references in `fake_core.py` and `test_source_selection.py` to point at the new local Protocol locations.

## Verification
- `uv run ruff format --check .` — clean
- `uv run ruff check src tests` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — Success, no issues in 188 files (removing/changing Protocols kept mypy green)
- `uv run pytest` — 7941 passed, 100 skipped

Stays out of scope of the held #1328 subpackage move — no files relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized runtime protocol boundaries: several shared protocols were consolidated or inlined into their consuming modules and a legacy seam helper was removed to simplify internals.
* **Documentation**
  * Clarified runtime “seams” as test-only injection points in client docs.
* **Tests**
  * Updated test suites and fixtures to match the narrowed protocol surface and removed tests for retired contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->