### PR TITLE
feat(research): add ResearchStatus.NOT_FOUND sentinel for pinned-but-absent poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `except NoteError` / `except MindMapError` call sites. These are the
   prerequisite for the mind-map not-found work (ADR-0019; issues #1291, #1346).
   No method raises them yet — this change only adds the types.
+- `ResearchStatus.NOT_FOUND` — a typed lifecycle sentinel for the
+  poll-observed absence of a *specific* requested research task, distinct from
+  `NO_RESEARCH` ("nothing in flight"). `research.poll(notebook_id, task_id=...)`
+  now returns `ResearchTask.not_found(task_id)` (status `NOT_FOUND`, carrying
+  the requested id) when a non-empty pinned `task_id` matches no in-flight task;
+  the unfiltered `task_id=None` empty poll still returns `NO_RESEARCH`
+  unchanged. Additive and non-breaking — the poll never raises for an absent
+  task (ADR-0019 Rule 4; issues #1344, #1346).
 
 ### Changed
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1467,9 +1467,12 @@ async def poll(notebook_id: str, task_id: str | None = None) -> ResearchTask:
     """
     Returns a ResearchTask for the selected research task. If task_id is None,
     selects the latest research task and emits an ambiguity warning if multiple
-    tasks are in-flight. Attributes:
+    tasks are in-flight. When task_id is supplied but no in-flight task matches,
+    returns ResearchTask.not_found(task_id) — status NOT_FOUND, a typed
+    poll-observed-absence sentinel (does not raise); the unfiltered empty poll
+    stays NO_RESEARCH. Attributes:
       - task_id:   str            — task/report identifier
-      - status:    ResearchStatus — COMPLETED | FAILED | IN_PROGRESS | NO_RESEARCH
+      - status:    ResearchStatus — COMPLETED | FAILED | IN_PROGRESS | NO_RESEARCH | NOT_FOUND
                                      (a str enum; == "completed" still holds)
       - query:     str            — original research query
       - sources:   tuple[ResearchSource, ...]

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -454,7 +454,11 @@ class ResearchAPI:
             await self._poll_task_models(notebook_id),
             notebook_id=notebook_id,
             task_id=task_id,
-            warn_on_ambiguous=True,
+            # The ambiguity warning only applies to the unfiltered (task_id is
+            # None) path; when a discriminator is pinned, _select_polled_tasks
+            # filters before the warn branch. Gating it here matches
+            # wait_for_completion and keeps the intent explicit.
+            warn_on_ambiguous=task_id is None,
         )
 
         if parsed_tasks:
@@ -512,8 +516,12 @@ class ResearchAPI:
             ``COMPLETED`` or ``FAILED`` statuses. ``NO_RESEARCH`` is returned
             immediately only when no task id is known; for a known/pinned task
             it can be a transient live-API state before the task appears in
-            ``POLL_RESEARCH``. Legacy ``result["status"]`` dict-subscript
-            access still works (with a ``DeprecationWarning``) until v0.8.0.
+            ``POLL_RESEARCH``. Unlike :meth:`poll`, this method never returns
+            ``NOT_FOUND`` — a pinned task that is temporarily absent from a poll
+            is treated as a transient replication-lag condition and keeps
+            polling until it appears, reaches a terminal state, or times out.
+            Legacy ``result["status"]`` dict-subscript access still works (with
+            a ``DeprecationWarning``) until v0.8.0.
 
         Raises:
             ResearchTimeoutError: If research does not reach a terminal status

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -421,9 +421,9 @@ class ResearchAPI:
             selected research task for the notebook. Use attribute access:
             - ``task.task_id``: task/report identifier for the selected task
             - ``task.status``: a :class:`~notebooklm._types.research.ResearchStatus`
-              (``IN_PROGRESS``, ``COMPLETED``, ``FAILED``, or ``NO_RESEARCH``);
-              compares equal to the historical strings (``task.status ==
-              "completed"`` still holds)
+              (``IN_PROGRESS``, ``COMPLETED``, ``FAILED``, ``NO_RESEARCH``, or
+              ``NOT_FOUND``); compares equal to the historical strings
+              (``task.status == "completed"`` still holds)
             - ``task.query``: original research query text
             - ``task.sources``: tuple of
               :class:`~notebooklm._types.research.ResearchSource` for the
@@ -441,9 +441,13 @@ class ResearchAPI:
             Legacy ``result["status"]`` dict-subscript access still works (with
             a ``DeprecationWarning``) until v0.8.0; prefer ``result.status``.
 
-            When ``task_id`` is supplied but no in-flight task matches, the
-            return is ``ResearchTask.empty()`` (status ``NO_RESEARCH``, empty
-            ``tasks``) — the same shape as the empty-poll case.
+            When a non-empty ``task_id`` is supplied but no in-flight task
+            matches, the return is ``ResearchTask.not_found(task_id)`` — status
+            ``NOT_FOUND``, carrying the requested ``task_id``, with empty
+            ``tasks``. This is the *poll-observed absence* of that specific
+            task (a typed lifecycle sentinel, not a raise; ADR-0019 Rule 4),
+            distinct from the unfiltered empty-poll case (``task_id`` ``None``
+            or empty) which stays ``NO_RESEARCH`` ("nothing in flight").
         """
         logger.debug("Polling research status for notebook %s", notebook_id)
         parsed_tasks = self._select_polled_tasks(
@@ -455,6 +459,16 @@ class ResearchAPI:
 
         if parsed_tasks:
             return self._public_poll_result(parsed_tasks[0], parsed_tasks)
+
+        # A concrete pinned ``task_id`` that matched nothing is a poll-observed
+        # absence of that specific task — a typed ``NOT_FOUND`` sentinel
+        # carrying the requested id. A falsy ``task_id`` (``None`` for the
+        # unfiltered poll, or the degenerate empty string) is not a meaningful
+        # discriminator, so it stays ``NO_RESEARCH`` ("nothing in flight") and
+        # preserves the legacy empty-poll dict shape. See ADR-0019 Rule 4
+        # (#1346).
+        if task_id:
+            return ResearchTask.not_found(task_id)
 
         return ResearchTask.empty()
 

--- a/src/notebooklm/_types/research.py
+++ b/src/notebooklm/_types/research.py
@@ -57,6 +57,12 @@ class ResearchStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     NO_RESEARCH = "no_research"
+    # ``NO_RESEARCH`` means "nothing in flight" (an unfiltered poll saw no
+    # tasks); ``NOT_FOUND`` is the poll-observed absence of a *specific*
+    # requested ``task_id`` (the task is not among the polled results). It is a
+    # typed lifecycle sentinel, not an error — distinct from looking up a
+    # resource that does not exist, which raises (ADR-0019 Rule 4, #1346).
+    NOT_FOUND = "not_found"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.value
@@ -172,6 +178,17 @@ class ResearchTask(MappingCompatMixin):
         returned when no research task is in flight.
         """
         return cls(task_id="", status=ResearchStatus.NO_RESEARCH)
+
+    @classmethod
+    def not_found(cls, task_id: str) -> ResearchTask:
+        """Return the ``not_found`` placeholder for an absent pinned task.
+
+        Used when a poll explicitly requested ``task_id`` but that task is not
+        among the polled results. Distinct from :meth:`empty` (nothing in
+        flight): this carries the requested ``task_id`` and the typed
+        :attr:`ResearchStatus.NOT_FOUND` sentinel (ADR-0019 Rule 4).
+        """
+        return cls(task_id=task_id, status=ResearchStatus.NOT_FOUND)
 
     def _to_task_dict(self) -> dict[str, Any]:
         """Return the per-task dict shape (without the sibling ``tasks`` list).

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -1453,6 +1453,7 @@ class TestResearch:
 
         assert result.status == "not_found"
         assert result.task_id == "task_missing"
+        assert result.tasks == ()
 
     @pytest.mark.asyncio
     async def test_poll_no_task_id_empty_response_stays_no_research(

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -1365,6 +1365,86 @@ class TestResearch:
         assert result.tasks == ()
 
     @pytest.mark.asyncio
+    async def test_poll_pinned_absent_task_id_returns_not_found(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """A pinned task_id absent from the poll yields the NOT_FOUND sentinel.
+
+        Distinct from the unfiltered empty-poll case (NO_RESEARCH): when the
+        caller explicitly requested a specific task that is not among the
+        polled results, the typed NOT_FOUND status carries the requested id
+        (ADR-0019 Rule 4). The poll does not raise.
+        """
+        other_task = [None, ["other query", 1], 1, [[], ""], 1]
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_other", other_task]]])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123", task_id="task_missing")
+
+        assert result.status is ResearchStatus.NOT_FOUND
+        assert result.status == "not_found"
+        assert result.task_id == "task_missing"
+        assert result.tasks == ()
+
+    @pytest.mark.asyncio
+    async def test_poll_pinned_absent_task_id_empty_response_returns_not_found(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """An empty poll with a pinned task_id is also NOT_FOUND, not NO_RESEARCH.
+
+        Requesting a specific task that the server has not surfaced (here, an
+        entirely empty envelope) is a poll-observed absence of *that* task.
+        """
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123", task_id="task_missing")
+
+        assert result.status == "not_found"
+        assert result.task_id == "task_missing"
+
+    @pytest.mark.asyncio
+    async def test_poll_no_task_id_empty_response_stays_no_research(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """The no-task-in-flight path is unchanged: empty poll → NO_RESEARCH.
+
+        Guards that adding NOT_FOUND did not perturb the existing
+        nothing-in-flight contract for the default (task_id=None) poll.
+        """
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result.status == "no_research"
+        assert result.task_id == ""
+        assert result.tasks == ()
+
+    @pytest.mark.asyncio
+    async def test_poll_empty_string_task_id_stays_no_research(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """A degenerate empty-string task_id is not a real discriminator.
+
+        It falls through to the legacy NO_RESEARCH empty-poll shape rather than
+        synthesizing a NOT_FOUND sentinel for a meaningless id, so the existing
+        dict shape is preserved exactly.
+        """
+        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        httpx_mock.add_response(content=response_body.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123", task_id="")
+
+        assert result.status == "no_research"
+        assert result.task_id == ""
+        assert result.to_public_dict() == {"status": "no_research", "tasks": []}
+
+    @pytest.mark.asyncio
     async def test_poll_unknown_string_result_type_preserved(
         self, auth_tokens, httpx_mock, build_rpc_response
     ):

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -466,6 +466,55 @@ class TestResearch:
         assert result.task_id == "task_123"
 
     @pytest.mark.asyncio
+    async def test_wait_for_completion_never_returns_not_found_for_pinned_task(
+        self, auth_tokens, httpx_mock, build_rpc_response, monkeypatch
+    ):
+        """A pinned task absent from an early poll is transient, not NOT_FOUND.
+
+        Regression guard for the insulation guarantee: wait_for_completion
+        drives _select_polled_tasks directly (never poll), so the poll-only
+        NOT_FOUND sentinel cannot leak into the wait loop — a temporarily
+        absent pinned task keeps polling until it appears.
+        """
+
+        async def no_sleep(delay: float) -> None:  # noqa: ARG001
+            return None
+
+        monkeypatch.setattr(research_module.asyncio, "sleep", no_sleep)
+
+        absent = build_rpc_response(RPCMethod.POLL_RESEARCH, [])
+        completed = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_pinned",
+                        _build_research_task_payload(
+                            "query",
+                            "https://example.com",
+                            "Result",
+                            status_code=2,
+                        ),
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=absent.encode(), method="POST")
+        httpx_mock.add_response(content=completed.encode(), method="POST")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.wait_for_completion(
+                "nb_123",
+                task_id="task_pinned",
+                timeout=10,
+                initial_interval=1,
+            )
+
+        assert result.status == "completed"
+        assert result.status != ResearchStatus.NOT_FOUND
+        assert result.task_id == "task_pinned"
+
+    @pytest.mark.asyncio
     async def test_wait_for_completion_returns_failed_terminal_status(
         self, auth_tokens, httpx_mock, build_rpc_response
     ):

--- a/tests/unit/test_typed_returns_compat.py
+++ b/tests/unit/test_typed_returns_compat.py
@@ -34,6 +34,13 @@ class TestResearchStatusEnum:
         assert ResearchStatus.COMPLETED == "completed"
         assert ResearchStatus.FAILED == "failed"
         assert ResearchStatus.NO_RESEARCH == "no_research"
+        assert ResearchStatus.NOT_FOUND == "not_found"
+
+    def test_not_found_is_distinct_from_no_research(self):
+        # The poll-observed absence of a specific task (NOT_FOUND) is a
+        # different lifecycle state from "nothing in flight" (NO_RESEARCH).
+        assert ResearchStatus.NOT_FOUND is not ResearchStatus.NO_RESEARCH
+        assert ResearchStatus.NOT_FOUND.value != ResearchStatus.NO_RESEARCH.value
 
     def test_is_a_str_subclass(self):
         assert isinstance(ResearchStatus.COMPLETED, str)
@@ -90,6 +97,24 @@ class TestTypedAttributeAccess:
         assert empty.status == ResearchStatus.NO_RESEARCH
         assert empty.tasks == ()
         assert empty.to_public_dict() == {"status": "no_research", "tasks": []}
+
+    def test_research_task_not_found_sentinel(self):
+        # The pinned-but-absent placeholder carries the requested task id and
+        # the NOT_FOUND status; its dict shape uses the per-task layout (since
+        # task_id is set), keeping it distinct from the no_research shape.
+        not_found = ResearchTask.not_found("task_missing")
+        assert not_found.status == ResearchStatus.NOT_FOUND
+        assert not_found.task_id == "task_missing"
+        assert not_found.tasks == ()
+        assert not_found.to_public_dict() == {
+            "task_id": "task_missing",
+            "status": "not_found",
+            "query": "",
+            "sources": [],
+            "summary": "",
+            "report": "",
+            "tasks": [],
+        }
 
 
 class TestDictSubscriptCompat:


### PR DESCRIPTION
## What

Adds `ResearchStatus.NOT_FOUND` — a typed lifecycle sentinel for the
**poll-observed absence of a *specific* requested research task**, distinct
from the existing `NO_RESEARCH` ("nothing in flight").

`ResearchAPI.poll(notebook_id, task_id=...)` now returns
`ResearchTask.not_found(task_id)` (status `NOT_FOUND`, carrying the requested
id, empty `tasks`) when a **non-empty** pinned `task_id` matches no in-flight
task. The unfiltered `task_id=None` empty-poll path — and the degenerate
empty-string `task_id=""` — stay `NO_RESEARCH` with the exact legacy dict shape
`{"status": "no_research", "tasks": []}`.

## Why

This is the **additive, strictly non-breaking** portion of the ADR-0019 Rule 4
not-found contract (`docs/adr/0019-error-and-return-contract.md`): a poll loop
cannot treat replication-lag as exceptional, so a poll-observed absent task is a
**typed sentinel, not a raise** — and it is categorically different from
"nothing in flight". The contract calls out a "**new** `ResearchStatus.NOT_FOUND`
member (distinct from the existing `NO_RESEARCH`)".

Implements the `research.poll` checkbox of #1344 (umbrella ADR-0019 work #1346).
The terminal-answer escalation for a task that never appears stays in
`wait_for_completion`, not here — `poll` is the stateless primitive.

## Non-breaking guarantees

- The enum is extended only; the str-enum keeps full back-compat
  (`NOT_FOUND == "not_found"`, `isinstance(..., str)`). The public-API
  compatibility audit passes with no new allowlist entry.
- The `task_id=None` empty-poll path is byte-for-byte unchanged (`NO_RESEARCH`,
  same dict shape) — guarded by tests.
- `task_id=""` (degenerate) also stays `NO_RESEARCH`, so no existing dict shape
  changes for it.
- `wait_for_completion` is untouched: it drives `_select_polled_tasks` directly
  (not `poll`), so `NOT_FOUND` never leaks into the wait loop.
- The `poll` never raises for an absent task.

## Tests

- `poll` with a pinned-but-absent `task_id` (both a populated poll with a
  non-matching task, and an empty envelope) → `NOT_FOUND` carrying the requested id.
- `poll` with no `task_id` on an empty poll → still `NO_RESEARCH`.
- `poll(task_id="")` → still `NO_RESEARCH` (legacy dict shape preserved).
- Enum-level: `NOT_FOUND == "not_found"`, distinct from `NO_RESEARCH`;
  `ResearchTask.not_found()` sentinel shape.

Full suite: 7971 passed, 95 skipped. ruff format/lint, mypy, and the
public-API compat audit all green.

Refs #1344, #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct NOT_FOUND status returned when polling a specific task_id that has no matching in-flight task.

* **Documentation**
  * Clarified API docs to describe the typed NOT_FOUND outcome, its difference from an unfiltered empty poll, and that wait-for-completion never returns NOT_FOUND for a pinned task.

* **Tests**
  * Added unit tests verifying NOT_FOUND behavior and compatibility with existing public output shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->