### PR TITLE
fix(mind_maps): route not-found through MindMapNotFoundError, idempotent delete, uniform-empty get_tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transport-level `except RPCError` call sites, and at domain-level
   `except NoteError` / `except MindMapError` call sites. These are the
   prerequisite for the mind-map not-found work (ADR-0019; issues #1291, #1346).
-  No method raises them yet — this change only adds the types.
+  `MindMapNotFoundError` is now raised by the `mind_maps` mutation paths (see
+  *Changed* below); `NoteNotFoundError` is not raised by any method yet.
 - `ResearchStatus.NOT_FOUND` — a typed lifecycle sentinel for the
   poll-observed absence of a *specific* requested research task, distinct from
   `NO_RESEARCH` ("nothing in flight"). `research.poll(notebook_id, task_id=...)`
@@ -33,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`WaitTimeoutError, ArtifactError`), matching `SourceTimeoutError` and
   `ResearchTimeoutError`. This is a cosmetic reorder with no behavior change:
   `isinstance`/`except` against either base is unaffected.
+- `client.mind_maps` mutation sites now raise `MindMapNotFoundError` instead of
+  a bare `ValueError` on a missing target, so callers can `except NotFoundError`
+  (or `except MindMapError`) uniformly across namespaces. `rename` (and the
+  underlying note-backed `rename_mind_map`) raise it; `MindMapNotFoundError`
+  multi-inherits `ValueError`'s sibling `NotFoundError`, **not** `ValueError`
+  itself, so existing `except ValueError` rename callers must switch to
+  `except NotFoundError` / `except MindMapNotFoundError`. `delete(kind=None)` is
+  now **idempotent** — deleting an already-absent mind map returns `None` rather
+  than raising (matching `sources`/`artifacts`/`notes` delete, and the
+  `kind`-supplied path). `get_tree` returns `None` for a missing mind map (it is
+  a derived read that does not police parent existence) — previously `kind=None`
+  raised on an unknown id. Shape-drift in the interactive payload still raises
+  `UnknownRPCMethodError` (ADR-0019; issues #1291, #1346).
 
 ## [0.7.0] - 2026-05-30
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -239,10 +239,11 @@ sit at the intersection — they're catchable as **any** of `NotFoundError`
 | `ArtifactTimeoutError` | `WaitTimeoutError`, `TimeoutError`, `ArtifactError`, `NotebookLMError` |
 | `ResearchTimeoutError` | `WaitTimeoutError`, `TimeoutError`, `ResearchError`, `NotebookLMError` |
 
-`NoteNotFoundError` and `MindMapNotFoundError` (with their `NoteError` /
-`MindMapError` domain bases) are defined now but **no method raises them yet** —
-they are the prerequisite types for the note / mind-map not-found work landing
-in **v0.8.0** (issues #1291, #1346).
+`MindMapNotFoundError` is raised by the `client.mind_maps` mutation paths
+(`rename`) on a missing target (issue #1291). `NoteNotFoundError` (with its
+`NoteError` domain base) is defined now but **not raised by any method yet** —
+it is the prerequisite type for the note not-found work landing in **v0.8.0**
+(issue #1346).
 
 Use the table to pick the right level of catch. `client.sources.get(...)`,
 `client.artifacts.get(...)`, and `client.notes.get(...)` currently return
@@ -921,10 +922,15 @@ async with NotebookLMClient.from_storage(rate_limit_max_retries=0) as client:
 >   (`403`/`5xx`/auth/transport) still raise. Use `get()` first to assert
 >   existence.
 > - **`rename()` returns the renamed object** and raises `*NotFoundError`
->   (`ValueError` for mind maps) on a missing target — detected via a
->   content/list lookup, never a transport 404. Pass **`return_object=False`**
->   to skip the hydrate re-fetch and return `None`; that opt-out **also skips
->   missing-target detection**, so a missing target does not raise under it.
+>   (`MindMapNotFoundError` for mind maps) on a missing target. Pass
+>   **`return_object=False`** to skip the hydrate re-fetch and return `None`.
+>   For `notebooks`/`sources`/`artifacts`, missing-target detection rides on
+>   that hydrate re-fetch, so `return_object=False` also skips it (a missing
+>   target does not raise under the opt-out). **Mind maps are the exception:**
+>   they detect absence via a content/list lookup *before* dispatching the
+>   rename RPC (never a transport 404), so `mind_maps.rename` raises
+>   `MindMapNotFoundError` on a missing target **even with**
+>   `return_object=False`.
 
 ### NotebooksAPI (`client.notebooks`)
 
@@ -1584,9 +1590,9 @@ Each operation dispatches to the correct backend; you work with `MindMap` /
 | `list(notebook_id)` | `str` | `list[MindMap]` | Both kinds, as distinct `MindMap` entries |
 | `get(notebook_id, mind_map_id)` | `str, str` | `MindMap \| None` | Single mind map by id |
 | `generate(notebook_id, source_ids=None, *, kind, language="en", instructions=None, wait=True)` | … | `MindMap` | Note-backed (sync) or interactive (`CREATE_ARTIFACT` + poll) |
-| `rename(notebook_id, mind_map_id, new_title, *, kind=None, return_object=True)` | … | `MindMap \| None` | `UPDATE_NOTE` / `RENAME_ARTIFACT` by kind (re-fetched; raises `ValueError` if missing). `return_object=False` returns `None`. |
-| `delete(notebook_id, mind_map_id, *, kind=None)` | … | `None` | `DELETE_NOTE` / `DELETE_ARTIFACT` by kind (idempotent when `kind` is passed; `kind=None` raises `ValueError` for an unknown id) |
-| `get_tree(notebook_id, mind_map_id, *, kind=None)` | … | `dict \| None` | The `{"name","children"}` node tree |
+| `rename(notebook_id, mind_map_id, new_title, *, kind=None, return_object=True)` | … | `MindMap \| None` | `UPDATE_NOTE` / `RENAME_ARTIFACT` by kind (re-fetched; raises `MindMapNotFoundError` if missing). `return_object=False` returns `None`. |
+| `delete(notebook_id, mind_map_id, *, kind=None)` | … | `None` | `DELETE_NOTE` / `DELETE_ARTIFACT` by kind (idempotent — deleting an already-absent map returns `None`, for both `kind=None` and a supplied `kind`) |
+| `get_tree(notebook_id, mind_map_id, *, kind=None)` | … | `dict \| None` | The `{"name","children"}` node tree; `None` for a missing or not-yet-populated map (derived read — does not police existence) |
 
 `MindMap` is a frozen value: `id`, `notebook_id`, `title`, `kind` (`MindMapKind.NOTE_BACKED` / `INTERACTIVE`), `created_at`, and `tree`. `generate(..., wait=True)` returns `tree` populated for **both** kinds (interactive maps are polled to completion, then their tree is fetched). For interactive *list* rows `tree` is `None` — fetch it with `get_tree`. When `kind` is omitted from `rename`/`delete`/`get_tree`, the backing is auto-detected (one extra list call).
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -97,9 +97,9 @@ NotebookError, NotebookNotFoundError
 ArtifactError, ArtifactDownloadError, ArtifactFeatureUnavailableError, ArtifactNotFoundError, ArtifactNotReadyError, ArtifactParseError
 ArtifactTimeoutError, ArtifactPendingTimeoutError, ArtifactInProgressTimeoutError
 ResearchError, ResearchTimeoutError, ResearchTaskMismatchError
-# Note: the note / mind-map *NotFoundError types are defined but not raised by
-# any method yet — they are the prerequisite for the not-found work landing in
-# v0.8.0 (issues #1291, #1346).
+# Note: MindMapNotFoundError is raised by the client.mind_maps mutation paths
+# (issue #1291). NoteNotFoundError is defined but not raised by any method yet —
+# the prerequisite for the note not-found work landing in v0.8.0 (umbrella #1346).
 NoteError, NoteNotFoundError
 MindMapError, MindMapNotFoundError
 ChatError

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from ._note_service import NoteRowKind, NoteService
 from ._row_adapters.notes import NoteRow
+from .exceptions import MindMapNotFoundError
 
 
 class NoteBackedMindMapService:
@@ -74,13 +75,12 @@ class NoteBackedMindMapService:
         ``RENAME_ARTIFACT`` instead; see ``MindMapsAPI``.)
 
         Raises:
-            ValueError: if no note-backed mind map with ``mind_map_id`` exists.
+            MindMapNotFoundError: if no note-backed mind map with
+                ``mind_map_id`` exists.
         """
         for row in await self.list_mind_maps(notebook_id):
             if NoteRow(row).id == mind_map_id:
                 content = self.extract_content(row) or ""
                 await self._notes.update_note(notebook_id, mind_map_id, content, new_title)
                 return
-        raise ValueError(
-            f"Note-backed mind map {mind_map_id!r} not found in notebook {notebook_id!r}"
-        )
+        raise MindMapNotFoundError(mind_map_id)

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -323,6 +323,14 @@ class MindMapsAPI:
                 ``except NotFoundError`` (or ``except MindMapError``) uniformly
                 across namespaces (ADR-0019; issues #1255, #1291).
 
+        .. note::
+            Unlike ``notebooks``/``sources``/``artifacts`` rename — whose
+            absence detection rides on the hydrate re-fetch and is therefore
+            skipped under ``return_object=False`` — mind maps detect absence via
+            a content/list lookup *before* dispatching the rename RPC, so this
+            raises ``MindMapNotFoundError`` on a missing target **even with**
+            ``return_object=False``.
+
         .. versionchanged:: 0.7.0
             **Breaking change:** previously returned ``None`` even on success.
             Now re-fetches and returns the renamed ``MindMap`` (issue #1255).
@@ -470,10 +478,14 @@ class MindMapsAPI:
     async def _detect_kind(self, notebook_id: str, mind_map_id: str) -> MindMapKind:
         """Resolve a bare id to its backing (note collection first, then studio).
 
-        The single-sourced absence detector (ADR-0019): raises
-        :class:`~notebooklm.exceptions.MindMapNotFoundError` for an unknown id,
-        which each caller interprets per its operation class — ``rename``
-        re-raises, ``delete`` swallows it to ``None``.
+        Used by ``delete(kind=None)``, which swallows a missing-id
+        :class:`~notebooklm.exceptions.MindMapNotFoundError` to ``None``. The
+        ``rename`` / ``get_tree`` auto-detect paths do **not** call this — they
+        inline the same note-first/interactive-second resolution to avoid a
+        second ``list_mind_maps`` RPC, but mirror its precedence and raise type
+        (ADR-0019: one resolution rule, interpreted per operation class —
+        mutate-existing re-raises, derived reads return the uniform-empty
+        value, idempotent delete swallows it).
         """
         for row in await self._mind_maps.list_mind_maps(notebook_id):
             if NoteRow(row).id == mind_map_id:

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 from ._artifact.payloads import build_interactive_mind_map_artifact_params
 from ._row_adapters.notes import NoteRow
 from ._types.mind_maps import MindMap, MindMapKind
-from .exceptions import ArtifactError, UnknownRPCMethodError
+from .exceptions import ArtifactError, MindMapNotFoundError, UnknownRPCMethodError
 from .rpc import RPCMethod, safe_index
 from .types import ArtifactType
 
@@ -317,11 +317,11 @@ class MindMapsAPI:
             ``return_object=False``.
 
         Raises:
-            ValueError: if no mind map with ``mind_map_id`` exists. (Mind maps
-                have no dedicated ``*NotFoundError``; absence is detected via a
-                content/list lookup, not a transport 404. The detection is the
-                same fail-loud-on-missing policy as ``sources``/``artifacts``
-                rename — issue #1255.)
+            MindMapNotFoundError: if no mind map with ``mind_map_id`` exists.
+                Absence is detected via a content/list lookup, not a transport
+                404, but is still surfaced as a ``*NotFoundError`` so callers can
+                ``except NotFoundError`` (or ``except MindMapError``) uniformly
+                across namespaces (ADR-0019; issues #1255, #1291).
 
         .. versionchanged:: 0.7.0
             **Breaking change:** previously returned ``None`` even on success.
@@ -332,7 +332,7 @@ class MindMapsAPI:
             # Auto-detect inline so the note-backed list is fetched once rather
             # than twice (a separate ``_detect_kind`` call would re-issue
             # ``list_mind_maps``). Error precedence matches ``_detect_kind``:
-            # note-backed first, then interactive, then ``ValueError``.
+            # note-backed first, then interactive, then ``MindMapNotFoundError``.
             for row in await self._mind_maps.list_mind_maps(notebook_id):
                 if NoteRow(row).id == mind_map_id:
                     await self._mind_maps.rename_mind_map(notebook_id, mind_map_id, new_title)
@@ -345,19 +345,18 @@ class MindMapsAPI:
                     notebook_id, mind_map_id, new_title, return_object=False
                 )
                 return await self._hydrate_renamed(notebook_id, mind_map_id, return_object)
-            raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
+            raise MindMapNotFoundError(mind_map_id)
         if kind == MindMapKind.NOTE_BACKED:
             await self._mind_maps.rename_mind_map(notebook_id, mind_map_id, new_title)
         else:
             # Pre-validate the id on the explicit-interactive path. Without this,
             # ``RENAME_ARTIFACT`` silently no-ops on a wrong id (the RPC returns
             # null), diverging from the ``kind=None`` path which raises
-            # ``ValueError`` for an unknown id. Fail loud instead (issue #1270;
-            # aligns with the "fail loud + return object" direction of #1255).
+            # ``MindMapNotFoundError`` for an unknown id. Fail loud instead
+            # (issue #1270; aligns with the "fail loud + return object" direction
+            # of #1255).
             if await self._find_interactive(notebook_id, mind_map_id) is None:
-                raise ValueError(
-                    f"Interactive mind map {mind_map_id!r} not found in notebook {notebook_id!r}"
-                )
+                raise MindMapNotFoundError(mind_map_id)
             await self._artifacts.rename(notebook_id, mind_map_id, new_title, return_object=False)
         return await self._hydrate_renamed(notebook_id, mind_map_id, return_object)
 
@@ -367,17 +366,18 @@ class MindMapsAPI:
         """Re-fetch the renamed map (or skip when ``return_object=False``).
 
         A ``None`` from ``get`` here means the map is absent — surface it as
-        the same ``ValueError`` the missing-target dispatch paths raise rather
-        than returning a stale/absent object. For paths that pre-validate the
-        id (auto-detect and explicit-interactive) this is a vanished-between-
-        rename-and-refetch race; for the explicit ``kind=NOTE_BACKED`` path it
-        is the primary missing-target signal. Either way, absent → raise.
+        the same ``MindMapNotFoundError`` the missing-target dispatch paths
+        raise rather than returning a stale/absent object. For paths that
+        pre-validate the id (auto-detect and explicit-interactive) this is a
+        vanished-between-rename-and-refetch race; for the explicit
+        ``kind=NOTE_BACKED`` path it is the primary missing-target signal.
+        Either way, absent → raise.
         """
         if not return_object:
             return None
         mind_map = await self.get(notebook_id, mind_map_id)
         if mind_map is None:
-            raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
+            raise MindMapNotFoundError(mind_map_id)
         return mind_map
 
     async def delete(
@@ -392,18 +392,25 @@ class MindMapsAPI:
         Omitting ``kind`` triggers an extra list RPC (and possibly a second
         ``LIST_ARTIFACTS`` call) to auto-detect the backing; pass ``kind`` to skip it.
 
+        Idempotent on a missing target: like ``sources``/``artifacts``/``notes``
+        delete, deleting an already-absent mind map is a no-op that returns
+        ``None`` (ADR-0019). When ``kind`` is omitted, ``_detect_kind`` lists to
+        pick the right RPC family and raises ``MindMapNotFoundError`` for an
+        unknown id; that already-absent signal is swallowed here.
+
         .. versionchanged:: 0.7.0
             **Breaking change:** previously returned a hardcoded ``True``;
-            now returns ``None`` (issue #1211).
-
-        .. note::
-            Unlike ``sources``/``artifacts``/``notes`` delete, this is **not**
-            idempotent on a missing target: when ``kind`` is omitted it routes
-            through ``_detect_kind``, which raises ``ValueError`` for an unknown
-            id (it must list to pick the right RPC family). Pass ``kind`` to
-            skip detection and delete idempotently.
+            now returns ``None`` (issue #1211). Auto-detect (``kind=None``) is
+            now idempotent on a missing target rather than raising (issue #1291).
         """
-        kind = kind or await self._detect_kind(notebook_id, mind_map_id)
+        if kind is None:
+            try:
+                kind = await self._detect_kind(notebook_id, mind_map_id)
+            except MindMapNotFoundError:
+                # Already absent — deletion is idempotent (ADR-0019), matching
+                # the kind-supplied path (whose delete RPCs are no-ops on a
+                # missing id) and the sibling sources/artifacts/notes deletes.
+                return None
         if kind == MindMapKind.NOTE_BACKED:
             await self._mind_maps.delete_mind_map(notebook_id, mind_map_id)
         else:
@@ -423,18 +430,25 @@ class MindMapsAPI:
 
         Omitting ``kind`` triggers an extra list RPC (and possibly a second
         ``LIST_ARTIFACTS`` call) to auto-detect the backing; pass ``kind`` to skip it.
+
+        As a derived read (ADR-0019), this does **not** police parent existence:
+        a missing mind map and an existing-but-unpopulated (not-ready) one both
+        return ``None``. Use :meth:`get` to distinguish absence from emptiness.
+        Shape-drift in the interactive payload still raises
+        :class:`~notebooklm.exceptions.UnknownRPCMethodError` (issue #1270).
         """
         if kind is None:
             # Auto-detect inline so the note-backed list is fetched once rather
             # than twice (a separate ``_detect_kind`` call would re-issue
-            # ``list_mind_maps``). Error precedence matches ``_detect_kind``:
-            # note-backed first (return its parsed tree), then interactive
-            # (fall through to the RPC), then ``ValueError``.
+            # ``list_mind_maps``). Precedence matches ``_detect_kind``: note-backed
+            # first (return its parsed tree), then interactive (fall through to the
+            # RPC). A miss in both backings returns ``None`` rather than raising —
+            # derived reads return the uniform-empty value on a missing parent.
             for row in await self._mind_maps.list_mind_maps(notebook_id):
                 if NoteRow(row).id == mind_map_id:
                     return _parse_tree(self._mind_maps.extract_content(row))
             if await self._find_interactive(notebook_id, mind_map_id) is None:
-                raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
+                return None
         elif kind == MindMapKind.NOTE_BACKED:
             for row in await self._mind_maps.list_mind_maps(notebook_id):
                 if NoteRow(row).id == mind_map_id:
@@ -454,13 +468,19 @@ class MindMapsAPI:
         return _parse_tree(tree_json)
 
     async def _detect_kind(self, notebook_id: str, mind_map_id: str) -> MindMapKind:
-        """Resolve a bare id to its backing (note collection first, then studio)."""
+        """Resolve a bare id to its backing (note collection first, then studio).
+
+        The single-sourced absence detector (ADR-0019): raises
+        :class:`~notebooklm.exceptions.MindMapNotFoundError` for an unknown id,
+        which each caller interprets per its operation class — ``rename``
+        re-raises, ``delete`` swallows it to ``None``.
+        """
         for row in await self._mind_maps.list_mind_maps(notebook_id):
             if NoteRow(row).id == mind_map_id:
                 return MindMapKind.NOTE_BACKED
         if await self._find_interactive(notebook_id, mind_map_id) is not None:
             return MindMapKind.INTERACTIVE
-        raise ValueError(f"Mind map {mind_map_id!r} not found in notebook {notebook_id!r}")
+        raise MindMapNotFoundError(mind_map_id)
 
     async def _find_interactive(
         self,

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -158,9 +158,9 @@ class NotFoundError(NotebookLMError):
             source = await client.sources.wait_until_ready(nb_id, src_id)
             await client.artifacts.download_audio(nb_id, dest, audio_id)
         except NotFoundError as e:
-            # Catches NotebookNotFoundError, SourceNotFoundError, and
-            # ArtifactNotFoundError uniformly (and NoteNotFoundError /
-            # MindMapNotFoundError once their not-found paths land in v0.8.0).
+            # Catches NotebookNotFoundError, SourceNotFoundError,
+            # ArtifactNotFoundError, and MindMapNotFoundError uniformly (and
+            # NoteNotFoundError once its not-found paths land in v0.8.0).
             handle_missing_resource(e)
 
     The example uses methods that *raise* a ``*NotFoundError`` on missing
@@ -168,8 +168,9 @@ class NotFoundError(NotebookLMError):
     the artifact download / content paths). :meth:`SourcesAPI.get` and
     :meth:`ArtifactsAPI.get` instead return ``None`` for missing IDs — use
     them when you want a lookup that does not trigger the umbrella.
-    :class:`NoteNotFoundError` and :class:`MindMapNotFoundError` are defined
-    but not raised by any method yet (the prerequisite for the v0.8.0 work).
+    :class:`MindMapNotFoundError` is raised by the ``client.mind_maps``
+    mutation paths (issue #1291); :class:`NoteNotFoundError` is defined but
+    not raised by any method yet (the prerequisite for the v0.8.0 work).
 
     Subclasses retain their existing type-specific bases — for example,
     :class:`SourceNotFoundError` is still a :class:`SourceError`, and
@@ -1388,17 +1389,16 @@ class MindMapError(NotebookLMError):
 class MindMapNotFoundError(NotFoundError, RPCError, MindMapError):
     """Mind map not found in notebook.
 
-    .. note::
-       This type is **defined but not raised by any method yet**. It is the
-       prerequisite for the mind-map not-found work landing in v0.8.0 (issues
-       #1291, #1346); the wording below describes the intended catchability
-       once mind-map read/mutation paths surface a missing mind map this way.
+    Raised by ``client.mind_maps`` mutation paths on a missing target —
+    ``rename`` and ``rename_mind_map`` (issue #1291). Absence is detected via a
+    content/list lookup, not a transport 404 (mind maps share storage with notes
+    / studio artifacts). The derived read ``get_tree`` and the idempotent
+    ``delete`` interpret the same absence signal differently: ``get_tree``
+    returns ``None`` and ``delete`` is a no-op (ADR-0019).
 
     Inherits from :class:`NotFoundError` (cross-domain umbrella),
     :class:`RPCError` (transport-level catchability), and :class:`MindMapError`
-    (domain base). The RPC base is what mind-map read/mutation paths will raise
-    when the server returns an empty / degenerate payload for a missing
-    mind-map ID, so ``except RPCError`` keeps working at call sites that handle
+    (domain base), so ``except RPCError`` keeps working at call sites that handle
     transport-level failures. ``except MindMapError`` works at domain-level call
     sites that don't care about the RPC layer. ``except NotFoundError`` catches
     it alongside :class:`NotebookNotFoundError` and :class:`SourceNotFoundError`.

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -1338,9 +1338,9 @@ class NoteNotFoundError(NotFoundError, RPCError, NoteError):
 
     .. note::
        This type is **defined but not raised by any method yet**. It is the
-       prerequisite for the note not-found work landing in v0.8.0 (issues
-       #1291, #1346); the wording below describes the intended catchability
-       once note read/mutation paths surface a missing note this way.
+       prerequisite for the note not-found work landing in v0.8.0 (umbrella
+       #1346); the wording below describes the intended catchability once note
+       read/mutation paths surface a missing note this way.
 
     Inherits from :class:`NotFoundError` (cross-domain umbrella),
     :class:`RPCError` (transport-level catchability), and :class:`NoteError`

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -1389,12 +1389,13 @@ class MindMapError(NotebookLMError):
 class MindMapNotFoundError(NotFoundError, RPCError, MindMapError):
     """Mind map not found in notebook.
 
-    Raised by ``client.mind_maps`` mutation paths on a missing target —
-    ``rename`` and ``rename_mind_map`` (issue #1291). Absence is detected via a
-    content/list lookup, not a transport 404 (mind maps share storage with notes
-    / studio artifacts). The derived read ``get_tree`` and the idempotent
-    ``delete`` interpret the same absence signal differently: ``get_tree``
-    returns ``None`` and ``delete`` is a no-op (ADR-0019).
+    Raised by ``client.mind_maps.rename`` (and the underlying internal
+    ``NoteBackedMindMapService.rename_mind_map``) on a missing target
+    (issue #1291). Absence is detected via a content/list lookup, not a
+    transport 404 (mind maps share storage with notes / studio artifacts). The
+    derived read ``get_tree`` and the idempotent ``delete`` interpret the same
+    absence signal differently: ``get_tree`` returns ``None`` and ``delete`` is
+    a no-op (ADR-0019).
 
     Inherits from :class:`NotFoundError` (cross-domain umbrella),
     :class:`RPCError` (transport-level catchability), and :class:`MindMapError`

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._mind_maps_api import MindMapsAPI, extract_interactive_tree_leaf
-from notebooklm.exceptions import ArtifactError, UnknownRPCMethodError
+from notebooklm.exceptions import (
+    ArtifactError,
+    MindMapNotFoundError,
+    NotFoundError,
+    UnknownRPCMethodError,
+)
 from notebooklm.rpc.types import RPCMethod
 from notebooklm.types import Artifact, MindMapKind, MindMapResult
 
@@ -102,10 +107,24 @@ async def test_rename_returns_renamed_mind_map():
 
 @pytest.mark.asyncio
 async def test_rename_missing_raises():
-    # Auto-detect path: the id is in neither backing → ValueError.
+    # Auto-detect path: the id is in neither backing → MindMapNotFoundError.
     api, *_ = _make_api()
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MindMapNotFoundError, match="not found") as excinfo:
         await api.rename("nb", "ghost", "X")
+    # Catchable via the cross-domain umbrella too (ADR-0019).
+    assert isinstance(excinfo.value, NotFoundError)
+    assert excinfo.value.mind_map_id == "ghost"
+
+
+@pytest.mark.asyncio
+async def test_rename_missing_raises_even_with_return_object_false():
+    # Unlike sources/artifacts (whose absence detection rides on the skipped
+    # hydrate re-fetch), mind maps detect absence via a list lookup *before*
+    # dispatching the rename, so return_object=False does NOT suppress the raise.
+    api, _, _, artifacts, _ = _make_api()
+    with pytest.raises(MindMapNotFoundError, match="not found"):
+        await api.rename("nb", "ghost", "X", return_object=False)
+    artifacts.rename.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -298,7 +317,7 @@ async def test_generate_interactive_unresolved_id_falls_back_to_placeholder():
 @pytest.mark.asyncio
 async def test_rename_interactive_bad_id_raises_not_silent_noop():
     api, _, _, artifacts, _ = _make_api(interactive=[_interactive_artifact("real_int")])
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MindMapNotFoundError, match="not found"):
         await api.rename("nb", "ghost", "X", kind=MindMapKind.INTERACTIVE)
     artifacts.rename.assert_not_awaited()  # never dispatched the no-op RPC
 
@@ -318,11 +337,11 @@ async def test_rename_interactive_rejects_settling_type4_variant_none():
     must NOT accept a settling (or malformed) quiz/flashcard as a mind map."""
     api, _, _, artifacts, _ = _make_api(interactive=[_pending_type4_artifact("settling")])
     # Explicit-interactive rename: the strict path rejects a variant=None row.
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MindMapNotFoundError, match="not found"):
         await api.rename("nb", "settling", "X", kind=MindMapKind.INTERACTIVE)
     artifacts.rename.assert_not_awaited()
-    # Auto-detect (kind=None) also rejects it -> ValueError, never dispatched.
-    with pytest.raises(ValueError, match="not found"):
+    # Auto-detect (kind=None) also rejects it -> MindMapNotFoundError, never dispatched.
+    with pytest.raises(MindMapNotFoundError, match="not found"):
         await api.rename("nb", "settling", "X")
     artifacts.rename.assert_not_awaited()
 
@@ -422,10 +441,10 @@ async def test_rename_auto_detect_interactive_dispatches():
 @pytest.mark.asyncio
 async def test_rename_hydrate_raises_when_target_vanishes():
     # Explicit note-backed rename whose post-rename refetch finds nothing
-    # (vanished-between-rename-and-refetch race) -> ValueError from
+    # (vanished-between-rename-and-refetch race) -> MindMapNotFoundError from
     # _hydrate_renamed rather than a stale/None object.
     api, _, mind_maps, _, _ = _make_api(note_rows=[])
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MindMapNotFoundError, match="not found"):
         await api.rename("nb", "note_mm", "X", kind=MindMapKind.NOTE_BACKED)
     mind_maps.rename_mind_map.assert_awaited_once_with("nb", "note_mm", "X")
 
@@ -454,10 +473,13 @@ async def test_get_tree_auto_detect_interactive_falls_through_to_rpc():
 
 
 @pytest.mark.asyncio
-async def test_get_tree_auto_detect_missing_raises():
-    api, *_ = _make_api()
-    with pytest.raises(ValueError, match="not found"):
-        await api.get_tree("nb", "ghost")
+async def test_get_tree_auto_detect_missing_returns_none():
+    # Derived read (ADR-0019): a missing parent yields the uniform-empty value
+    # (None), not a raise — get() is the existence check, not get_tree().
+    api, rpc, *_ = _make_api()
+    assert await api.get_tree("nb", "ghost") is None
+    # Auto-detect resolved the miss without falling through to GET_INTERACTIVE_HTML.
+    rpc.rpc_call.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -495,7 +517,11 @@ async def test_delete_auto_detect_interactive():
 
 
 @pytest.mark.asyncio
-async def test_delete_auto_detect_missing_raises():
-    api, *_ = _make_api()
-    with pytest.raises(ValueError, match="not found"):
-        await api.delete("nb", "ghost")
+async def test_delete_auto_detect_missing_is_idempotent():
+    # Auto-detect (kind=None) on an already-absent id is a no-op that returns
+    # None (ADR-0019 idempotent delete), matching sources/artifacts/notes —
+    # not a raise. Neither delete RPC family is dispatched.
+    api, _, mind_maps, artifacts, _ = _make_api()
+    assert await api.delete("nb", "ghost") is None
+    mind_maps.delete_mind_map.assert_not_awaited()
+    artifacts.delete.assert_not_awaited()

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -121,10 +121,26 @@ async def test_rename_missing_raises_even_with_return_object_false():
     # Unlike sources/artifacts (whose absence detection rides on the skipped
     # hydrate re-fetch), mind maps detect absence via a list lookup *before*
     # dispatching the rename, so return_object=False does NOT suppress the raise.
+    # Auto-detect (kind=None) path.
     api, _, _, artifacts, _ = _make_api()
     with pytest.raises(MindMapNotFoundError, match="not found"):
         await api.rename("nb", "ghost", "X", return_object=False)
     artifacts.rename.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rename_explicit_kind_missing_raises_even_with_return_object_false():
+    # The pre-dispatch guarantee holds on the explicit-kind paths too: NOTE_BACKED
+    # raises from rename_mind_map and INTERACTIVE raises from the _find_interactive
+    # pre-validation, both before _hydrate_renamed is reached.
+    api, _, mind_maps, artifacts, _ = _make_api()
+    mind_maps.rename_mind_map = AsyncMock(side_effect=MindMapNotFoundError("ghost"))
+    with pytest.raises(MindMapNotFoundError, match="ghost"):
+        await api.rename("nb", "ghost", "X", kind=MindMapKind.NOTE_BACKED, return_object=False)
+
+    with pytest.raises(MindMapNotFoundError, match="not found"):
+        await api.rename("nb", "ghost", "X", kind=MindMapKind.INTERACTIVE, return_object=False)
+    artifacts.rename.assert_not_awaited()  # never dispatched the no-op RPC
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_note_backed_mind_map_service.py
+++ b/tests/unit/test_note_backed_mind_map_service.py
@@ -16,6 +16,7 @@ import pytest
 
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteRowKind, NoteService
+from notebooklm.exceptions import MindMapNotFoundError, NotFoundError
 
 
 @pytest.fixture
@@ -145,9 +146,12 @@ class TestRenameMindMap:
         mock_notes.extract_content = MagicMock(return_value="content")
         mock_notes.update_note = AsyncMock()
 
-        with pytest.raises(ValueError, match="ghost"):
+        with pytest.raises(MindMapNotFoundError, match="ghost") as excinfo:
             await service.rename_mind_map("nb_abc", "ghost", "New Title")
 
+        # Catchable via the cross-domain umbrella too (ADR-0019), and carries the id.
+        assert isinstance(excinfo.value, NotFoundError)
+        assert excinfo.value.mind_map_id == "ghost"
         mock_notes.update_note.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -157,7 +161,7 @@ class TestRenameMindMap:
         self._stub_list(mock_notes, [])
         mock_notes.update_note = AsyncMock()
 
-        with pytest.raises(ValueError, match="mm_1"):
+        with pytest.raises(MindMapNotFoundError, match="mm_1"):
             await service.rename_mind_map("nb_abc", "mm_1", "New Title")
 
         mock_notes.update_note.assert_not_awaited()


### PR DESCRIPTION
Closes #1291 (umbrella #1346).

`client.mind_maps` raised a bare `ValueError` on a missing target, so callers could not `except NotFoundError` uniformly with the other namespaces, and `delete(kind=None)` was the lone non-idempotent delete in the library. This routes those sites through the typed `MindMapNotFoundError` per [ADR-0019](https://github.com/teng-lin/notebooklm-py/blob/main/docs/adr/0019-error-and-return-contract.md) — one absence detector, three operation-class interpretations.

## What changed

- **`_detect_kind`** is the single-sourced absence detector and now raises `MindMapNotFoundError`. The inlined auto-detect paths in `rename` / `get_tree` (kept inline to avoid a second `list_mind_maps` RPC) mirror it with the same raise type and precedence.
- **`rename`** (and the underlying note-backed `rename_mind_map`) **re-raise** it — the mutate-existing contract. Detection is pre-dispatch (a content/list lookup, never a transport 404), so `mind_maps.rename` raises even with `return_object=False` (unlike sources/artifacts, whose detection rides on the skipped hydrate re-fetch).
- **`delete(kind=None)`** swallows the detector miss to **`None`** — already-absent is now an idempotent no-op, matching the `kind`-supplied path (whose delete RPCs no-op on a missing id) and the sibling sources/artifacts/notes deletes.
- **`get_tree`** returns **`None`** on a missing map — a derived read does not police parent existence; a missing parent and a not-ready (unpopulated) map both yield the uniform-empty value. Interactive payload shape-drift still raises `UnknownRPCMethodError`.

## Compatibility

`MindMapNotFoundError` multi-inherits `NotFoundError` / `RPCError` / `MindMapError` (**not** `ValueError`), so existing `except ValueError` rename callers must switch to `except NotFoundError` / `except MindMapNotFoundError`. The CLI already routes through the `NotebookLMError` envelope, so a missing mind map now gets proper error reporting instead of falling through to the generic handler. Method signatures are unchanged, so no `api-compat-allowlist.json` entry is required (verified with `scripts/audit_public_api_compat.py`).

Docs (`docs/python-api.md`), the `NotFoundError` / `MindMapNotFoundError` docstrings, and the `[Unreleased]` CHANGELOG are updated to match.

## Tests

- `rename` / `rename_mind_map` raise `MindMapNotFoundError` (auto-detect, explicit note-backed, explicit interactive, hydrate-vanished race) and are catchable as `NotFoundError`, carrying `mind_map_id`.
- `rename(..., return_object=False)` still raises on a missing target.
- `delete(kind=None)` on an absent id is a no-op returning `None` (neither delete RPC family dispatched).
- `get_tree(kind=None)` on an absent id returns `None` without falling through to `GET_INTERACTIVE_HTML`.

Full gate green locally: `ruff format --check`, `ruff check src tests`, `mypy src/notebooklm`, full `pytest` (7988 passed, 95 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling: missing mind maps now raise `MindMapNotFoundError` instead of generic exceptions
  * Delete operations are now idempotent and return gracefully when targets are already missing

* **Documentation**
  * Updated API documentation to clarify exception behavior for mind-map operations
  * Enhanced changelog and stability guide with accurate exception-raising specifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->