### PR TITLE
chore(cli): migrate internal _get_or_none call sites to public get_or_none

### DIFF
--- a/src/notebooklm/cli/artifact_cmd.py
+++ b/src/notebooklm/cli/artifact_cmd.py
@@ -168,7 +168,7 @@ def artifact_get(ctx, artifact_id, notebook_id, json_output, client_auth):
             resolved_id = await resolve_artifact_id(
                 client, nb_id_resolved, artifact_id, json_output=json_output
             )
-            art = await client.artifacts._get_or_none(nb_id_resolved, resolved_id)
+            art = await client.artifacts.get_or_none(nb_id_resolved, resolved_id)
 
             # BREAKING: not-found exits 1 with a typed error instead of the
             # previous exit-0 ``found: false`` placeholder. See the matching

--- a/src/notebooklm/cli/note_cmd.py
+++ b/src/notebooklm/cli/note_cmd.py
@@ -215,7 +215,7 @@ def note_get(ctx, note_id, notebook_id, json_output, client_auth):
             resolved_id = await resolve_note_id(
                 client, nb_id_resolved, note_id, json_output=json_output
             )
-            n = await client.notes._get_or_none(nb_id_resolved, resolved_id)
+            n = await client.notes.get_or_none(nb_id_resolved, resolved_id)
 
             # BREAKING: not-found exits 1 with a typed error instead of
             # the previous exit-0 ``found: false`` placeholder. The backend
@@ -362,7 +362,7 @@ def note_rename(ctx, note_id, new_title, notebook_id, json_output, client_auth):
             # mypy without forcing a ``NoReturn`` annotation onto
             # ``error_handler._output_error`` (which would change the shared
             # helper's typing contract — same trick used by ``note get``).
-            n = await client.notes._get_or_none(nb_id_resolved, resolved_id)
+            n = await client.notes.get_or_none(nb_id_resolved, resolved_id)
             if not isinstance(n, Note):
                 _output_error(
                     "Note not found",

--- a/src/notebooklm/cli/services/source_content.py
+++ b/src/notebooklm/cli/services/source_content.py
@@ -36,7 +36,7 @@ class SourceGetResult:
 
 async def execute_source_get(client: NotebookLMClient, plan: SourceGetPlan) -> SourceGetResult:
     """Fetch a single source."""
-    src = await client.sources._get_or_none(plan.notebook_id, plan.source_id)
+    src = await client.sources.get_or_none(plan.notebook_id, plan.source_id)
     return SourceGetResult(notebook_id=plan.notebook_id, source_id=plan.source_id, source=src)
 
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -245,7 +245,7 @@ class TestArtifactGet:
                     Artifact(id="art_123", title="Test Artifact", _artifact_type=4, status=3)
                 ]
             )
-            mock_client.artifacts._get_or_none = AsyncMock(
+            mock_client.artifacts.get_or_none = AsyncMock(
                 return_value=Artifact(
                     id="art_123",
                     title="Test Artifact",
@@ -271,7 +271,7 @@ class TestArtifactGet:
             mock_client = create_mock_client()
             # Mock list to return empty (no match for resolve_artifact_id)
             mock_client.artifacts.list = AsyncMock(return_value=[])
-            mock_client.artifacts._get_or_none = AsyncMock(return_value=None)
+            mock_client.artifacts.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -293,7 +293,7 @@ class TestArtifactGet:
                     Artifact(id="art_123", title="Test Artifact", _artifact_type=4, status=3)
                 ]
             )
-            mock_client.artifacts._get_or_none = AsyncMock(
+            mock_client.artifacts.get_or_none = AsyncMock(
                 return_value=Artifact(
                     id="art_123",
                     title="Test Artifact",
@@ -342,7 +342,7 @@ class TestArtifactGet:
             mock_client.artifacts.list = AsyncMock(
                 return_value=[Artifact(id="art_123", title="Doomed", _artifact_type=4, status=3)]
             )
-            mock_client.artifacts._get_or_none = AsyncMock(return_value=None)
+            mock_client.artifacts.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -375,7 +375,7 @@ class TestArtifactGet:
         with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.list = AsyncMock(return_value=[])
-            mock_client.artifacts._get_or_none = AsyncMock(return_value=None)
+            mock_client.artifacts.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -394,7 +394,7 @@ class TestArtifactGet:
         with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.list = AsyncMock(return_value=[])
-            mock_client.artifacts._get_or_none = AsyncMock(return_value=None)
+            mock_client.artifacts.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -419,7 +419,7 @@ class TestArtifactGet:
             mock_client.artifacts.list = AsyncMock(
                 return_value=[Artifact(id="art_xyz", title="Doomed", _artifact_type=4, status=3)]
             )
-            mock_client.artifacts._get_or_none = AsyncMock(return_value=None)
+            mock_client.artifacts.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -239,7 +239,7 @@ class TestNoteGet:
             mock_client.notes.list = AsyncMock(
                 return_value=[make_note("note_123", "My Note", "This is the content")]
             )
-            mock_client.notes._get_or_none = AsyncMock(
+            mock_client.notes.get_or_none = AsyncMock(
                 return_value=make_note("note_123", "My Note", "This is the content")
             )
             mock_client_cls.return_value = mock_client
@@ -260,7 +260,7 @@ class TestNoteGet:
             mock_client = create_mock_client()
             # Mock notes.list to return empty (no match for resolve_note_id)
             mock_client.notes.list = AsyncMock(return_value=[])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -287,7 +287,7 @@ class TestNoteGet:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -306,7 +306,7 @@ class TestNoteGet:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -329,7 +329,7 @@ class TestNoteGet:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_xyz", "Doomed", "")])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -425,7 +425,7 @@ class TestNoteRename:
             mock_client.notes.list = AsyncMock(
                 return_value=[make_note("note_123", "Old Title", "Original content")]
             )
-            mock_client.notes._get_or_none = AsyncMock(
+            mock_client.notes.get_or_none = AsyncMock(
                 return_value=make_note("note_123", "Old Title", "Original content")
             )
             mock_client.notes.update = AsyncMock(return_value=None)
@@ -448,7 +448,7 @@ class TestNoteRename:
             mock_client = create_mock_client()
             # Mock notes.list to return empty (no match for resolve_note_id)
             mock_client.notes.list = AsyncMock(return_value=[])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -610,7 +610,7 @@ class TestNoteGetJson:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_123", "T", "Body")])
-            mock_client.notes._get_or_none = AsyncMock(
+            mock_client.notes.get_or_none = AsyncMock(
                 return_value=make_note("note_123", "T", "Body")
             )
             mock_client_cls.return_value = mock_client
@@ -644,7 +644,7 @@ class TestNoteGetJson:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_123", "T", "B")])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -724,7 +724,7 @@ class TestNoteSaveJson:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_123", "Old", "Body")])
-            mock_client.notes._get_or_none = AsyncMock(
+            mock_client.notes.get_or_none = AsyncMock(
                 return_value=make_note("note_123", "Old", "Body")
             )
             mock_client.notes.update = AsyncMock(return_value=None)
@@ -768,7 +768,7 @@ class TestNoteSaveJson:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_123", "Old", "Body")])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client.notes.update = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
@@ -804,7 +804,7 @@ class TestNoteSaveJson:
         with patch("notebooklm.cli.note_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[make_note("note_123", "Old", "Body")])
-            mock_client.notes._get_or_none = AsyncMock(return_value=None)
+            mock_client.notes.get_or_none = AsyncMock(return_value=None)
             mock_client.notes.update = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -446,7 +446,7 @@ class TestSourceGet:
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_123", title="Test Source")]
             )
-            mock_client.sources._get_or_none = AsyncMock(
+            mock_client.sources.get_or_none = AsyncMock(
                 return_value=Source(
                     id="src_123",
                     title="Test Source",
@@ -471,7 +471,7 @@ class TestSourceGet:
             mock_client = create_mock_client()
             # Mock sources.list to return empty (no match for resolve_source_id)
             mock_client.sources.list = AsyncMock(return_value=[])
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -511,7 +511,7 @@ class TestSourceGet:
             mock_client = create_mock_client()
             # list() must NOT be called on this path; assert below.
             mock_client.sources.list = AsyncMock(return_value=[])
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -530,7 +530,7 @@ class TestSourceGet:
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.sources.list = AsyncMock(return_value=[])
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -557,7 +557,7 @@ class TestSourceGet:
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_resolved", title="Doomed")]
             )
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -576,7 +576,7 @@ class TestSourceGet:
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_resolved", title="Doomed")]
             )
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with patch(
@@ -2664,7 +2664,7 @@ class TestSourceJsonOutput:
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_123", title="My Source")]
             )
-            mock_client.sources._get_or_none = AsyncMock(
+            mock_client.sources.get_or_none = AsyncMock(
                 return_value=Source(
                     id="src_123",
                     title="My Source",
@@ -2698,7 +2698,7 @@ class TestSourceJsonOutput:
             mock_client.sources.list = AsyncMock(
                 return_value=[Source(id="src_resolved", title="Existing")]
             )
-            mock_client.sources._get_or_none = AsyncMock(return_value=None)
+            mock_client.sources.get_or_none = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
 
             with self._patch_fetch_tokens():

--- a/tests/unit/cli/test_source_characterization.py
+++ b/tests/unit/cli/test_source_characterization.py
@@ -179,7 +179,7 @@ class TestSourceGetCharacterization:
     def test_get_text_mode_prints_title_and_type(self, runner, mock_auth, patched_fetch_tokens):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
             client = create_mock_client()
-            client.sources._get_or_none = AsyncMock(
+            client.sources.get_or_none = AsyncMock(
                 return_value=Source(id="src_1", title="My Source", url=None)
             )
             cls.return_value = client
@@ -192,7 +192,7 @@ class TestSourceGetCharacterization:
     def test_get_json_mode_emits_source_envelope(self, runner, mock_auth, patched_fetch_tokens):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
             client = create_mock_client()
-            client.sources._get_or_none = AsyncMock(
+            client.sources.get_or_none = AsyncMock(
                 return_value=Source(
                     id="src_1",
                     title="My Source",
@@ -213,7 +213,7 @@ class TestSourceGetCharacterization:
     def test_get_not_found_exits_1_text_mode(self, runner, mock_auth, patched_fetch_tokens):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
             client = create_mock_client()
-            client.sources._get_or_none = AsyncMock(return_value=None)
+            client.sources.get_or_none = AsyncMock(return_value=None)
             cls.return_value = client
             result = runner.invoke(
                 cli,
@@ -230,7 +230,7 @@ class TestSourceGetCharacterization:
     def test_get_not_found_exits_1_json_mode(self, runner, mock_auth, patched_fetch_tokens):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as cls:
             client = create_mock_client()
-            client.sources._get_or_none = AsyncMock(return_value=None)
+            client.sources.get_or_none = AsyncMock(return_value=None)
             cls.return_value = client
             result = runner.invoke(
                 cli,

--- a/tests/unit/cli/test_source_content_rendering.py
+++ b/tests/unit/cli/test_source_content_rendering.py
@@ -55,7 +55,7 @@ def test_source_get_not_found_renderer_exits_one(
 ) -> None:
     source_id = "11111111-2222-3333-4444-555555555555"
     client = create_mock_client()
-    client.sources._get_or_none = AsyncMock(return_value=None)
+    client.sources.get_or_none = AsyncMock(return_value=None)
     args = ["source", "get", source_id, "-n", "nb_123"]
     if json_output:
         args.append("--json")


### PR DESCRIPTION
Follow-up from #1350. That PR promoted the private `_get_or_none` lookup to a public `get_or_none` on `sources`/`artifacts`/`notes`, keeping `_get_or_none` as a zero-churn class-level alias so internal callers needed no change in that purely-additive PR.

This migrates the four internal CLI call sites that still reached the resource through the private alias onto the public name:

- `cli/note_cmd.py` — `note get`, `note rename`
- `cli/artifact_cmd.py` — `artifact get`
- `cli/services/source_content.py` — `source get`

Plus the CLI test mocks that stub those call sites. The CLI namespace mocks are plain `MagicMock`s, so each stub must target the exact attribute the CLI calls — the test rename is load-bearing, not cosmetic.

This gets the codebase off the private alias before the v0.8.0 `get()`-raises cleanup (#1247) may remove it.

**No behavior change** — both names resolve to the same warning-free coroutine. Library tests that exercise the `_get_or_none` alias as a contract (the source poller's wiring, the get-returns-None deprecation semantics) are intentionally left untouched.

Disjoint from the mind-maps work; touches CLI files only.

Closes #1351. Refs #1346, #1350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored CLI operations to use publicly-available retrieval methods for artifacts, notes, and sources, enhancing code maintainability and consistency.

* **Tests**
  * Updated unit tests across artifact, note, and source modules to align with the refactored API calls, ensuring test coverage remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->