### PR TITLE
docs: amend ADR-0015 + cli-exit-codes for parse-time JSON envelope (closes #1370)

### DIFF
--- a/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
+++ b/docs/adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md
@@ -2,7 +2,68 @@
 
 ## Status
 
-Accepted.
+Accepted. **Amended 2026-06-02** — see the amendment note below; it supersedes
+the original "no JSON emitted at parse time" stance recorded in Decision rule 1.
+
+## Amendment note (2026-06-02): parse-time `ClickException` is JSON-wrapped under `--json`
+
+The original Decision rule 1 stated that parse-time `ClickException` is
+*unchanged* and that "no JSON envelope is emitted in this case, because
+`handle_errors` has not yet been entered when the parser fires." That premise
+was correct about `handle_errors` — the per-command context manager genuinely
+never sees parse-time errors — but the conclusion no longer holds, because the
+CLI grew a **second, higher** boundary above `handle_errors`.
+
+The root group (`SectionedGroup.main` in
+[`src/notebooklm/cli/grouped.py`](../../src/notebooklm/cli/grouped.py)) runs
+Click's superclass `main` in **non-standalone mode** specifically so it can
+catch the parse-time parser/callback `click.ClickException` that Click would
+otherwise render itself. Its docstring records the intent: catching the failure
+at "this root boundary [lets it] convert those failures once for every current
+and future subcommand option." When the raw argv contains `--json`
+(`_json_requested(args)`), the root group routes the exception through
+`_emit_json_click_error(exc)`, which calls `output_error(exc.format_message(),
+"VALIDATION_ERROR", json_output=True, exit_code=exc.exit_code)`. Concretely,
+under `--json`:
+
+- The typed JSON envelope is emitted on stdout — `{ "error": true, "code":
+  "VALIDATION_ERROR", "message": "<Click's formatted message>" }` — and nothing
+  is written to stderr.
+- **Exit codes are preserved**, not normalised. The envelope passes
+  `exit_code=exc.exit_code`, so a `UsageError` / `BadParameter` still exits `2`
+  and a base `ClickException` still exits `1`. (This differs from the
+  *post-parse* envelope path, which standardises on exit `1` per Decision rules
+  2 and 4. The parse-time wrapper changes the *channel* — JSON instead of
+  stderr — but not the exit code.)
+
+Without `--json`, behavior is exactly as the original ADR described: the root
+group calls `exc.show()` (Click's native `Usage: ... / Error: ...` text on
+stderr) and exits with `exc.exit_code` (`2` for `UsageError` / `BadParameter`,
+`1` for the base `ClickException`). The `click.Abort` path is handled the same
+way at this boundary — `CANCELLED` envelope + exit `1` under `--json`, or
+`Aborted!` on stderr + exit `1` in text mode.
+
+**Why the change.** The motivation is the same one that drove the original
+contract for post-parse errors: a JSON consumer that passes `--json` should
+never receive usage prose on stderr instead of a parseable envelope, even when
+the failure is an argv-level one (an invalid `--limit`, an unknown option, a
+missing required argument). Converting once at the root boundary gives every
+current and future subcommand a consistent envelope without per-command
+plumbing, and is strictly more useful to automation than the original
+"argv-level failures are structurally impossible to wrap" stance — which was
+true *inside Click's parser* but not at a boundary that runs the parser in
+non-standalone mode and catches what it raises.
+
+**Source of truth.** This behavior is pinned by
+[`tests/unit/cli/test_json_validation_contract.py`](../../tests/unit/cli/test_json_validation_contract.py):
+`test_json_validation_errors_emit_json` asserts the `VALIDATION_ERROR` envelope
+on stdout (empty stderr, non-zero exit) for invalid limits/intervals/retries, a
+missing argument, an unknown option, and a root-callback validation failure;
+`test_text_validation_errors_keep_click_usage_output` asserts the unchanged
+text-mode path (exit `2`, `Usage:` on stderr, empty stdout); and
+`test_json_abort_emit_json` pins the `CANCELLED` envelope. The original
+Decision rule 1 below is retained for history; treat this note and the contract
+tests as authoritative wherever they diverge.
 
 ## Context
 
@@ -99,15 +160,21 @@ corresponding standard code, and writes no usage text to stderr.
 
 Concretely:
 
-1. **Parse-time `ClickException` is unchanged.** Click's parser keeps raising
+1. **Parse-time `ClickException` is unchanged.** *(Superseded — see the
+   "Amendment note (2026-06-02)" above. The root group now JSON-wraps
+   parse-time `ClickException` under `--json`, preserving Click's exit code.
+   The text below is retained for history and remains accurate only for the
+   non-`--json` path.)* Click's parser keeps raising
    `UsageError` / `BadParameter` / `ClickException` for argv-level
    validation failures; Click keeps rendering its own
    `Usage: ... / Error: ...` text on stderr and exiting `2`
    (`UsageError` / `BadParameter`) or `1` (base `ClickException`). The
    re-raise in
    [`src/notebooklm/cli/error_handler.py`](../../src/notebooklm/cli/error_handler.py)
-   stays. No JSON envelope is emitted in this case, because `handle_errors`
-   has not yet been entered when the parser fires.
+   stays. No JSON envelope is emitted *by `handle_errors`* in this case,
+   because `handle_errors` has not yet been entered when the parser fires —
+   but the root group (`SectionedGroup.main`) sits *above* `handle_errors`
+   and does emit the envelope under `--json`; see the amendment note.
 2. **Post-parse `ClickException` flows through the typed envelope.**
    Command bodies and service-layer code that wish to signal a validation
    failure under the JSON contract MUST NOT raise
@@ -226,12 +293,20 @@ Concretely:
   short-term patch is "service calls `output_error` directly". Both
   satisfy this ADR.
 - **Have `handle_errors` catch `ClickException` and convert to the
-  envelope unconditionally.** Rejected. This would absorb parse-time
-  `ClickException` too — but `handle_errors` is entered *inside* the
-  command body, so the parse-time path never reaches it (Click renders
-  parser errors via `BaseCommand.main` before invoking the command).
-  Attempting to intercept parse-time errors would require subclassing
-  Click's command/group machinery, which is outside the scope of an
+  envelope unconditionally.** Rejected *for `handle_errors`*. This would
+  absorb parse-time `ClickException` too — but `handle_errors` is entered
+  *inside* the command body, so the parse-time path never reaches it (Click
+  renders parser errors via `BaseCommand.main` before invoking the command).
+  Intercepting parse-time errors requires subclassing Click's command/group
+  machinery, which was originally judged outside the scope of an
   error-handling contract change. The post-parse path is the only one
   `handle_errors` can address, and rule 2 already covers it via
   `output_error(...)`.
+
+  *(Update 2026-06-02: the "subclass Click's group machinery" approach was
+  subsequently adopted — but at the root group, not in `handle_errors`.
+  `SectionedGroup.main` runs Click's superclass in non-standalone mode and
+  converts the parse-time `ClickException` to the JSON envelope under
+  `--json`. This is a separate boundary from `handle_errors`, so the
+  reasoning above — that `handle_errors` itself cannot see parse-time errors
+  — still stands; see the amendment note.)*

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -1,7 +1,7 @@
 # CLI Exit-Code Convention
 
 **Status:** Active
-**Last Updated:** 2026-05-27
+**Last Updated:** 2026-06-02
 
 This document defines the exit-code policy for the `notebooklm` CLI. Shell
 scripts, CI pipelines, and AI-agent automations should rely on these codes for
@@ -55,7 +55,7 @@ mapping in `error_handler.py`:
 | `KeyboardInterrupt`     | `CANCELLED`         | `130` |
 | Anything else (`Exception`) | `UNEXPECTED_ERROR` | `2` |
 | Parse-time `click.UsageError` / `click.BadParameter` (Click's parser, before command body runs) | `VALIDATION_ERROR` under `--json`; — in text mode | `2` (under `--json`: typed JSON envelope on stdout, **exit code preserved**; text mode: Click's `Usage:/Error:` on stderr) |
-| Parse-time `click.ClickException` (other subclasses raised by Click's parser) | `VALIDATION_ERROR` under `--json`; — in text mode | `1` (same: JSON envelope under `--json` with the code preserved; native text otherwise) |
+| Parse-time `click.ClickException` (other subclasses raised by Click's parser) | `VALIDATION_ERROR` under `--json`; — in text mode | `1` (same: JSON envelope under `--json` with the exit code preserved; native text otherwise) |
 | Post-parse `ClickException` raised from a command body or service module | `VALIDATION_ERROR` (or another standard code, per the raise site) | `1` (typed JSON envelope under `--json`; see ADR-015) |
 
 `click.ClickException` raised by **Click's own parser** is the *parse-time*

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -54,19 +54,34 @@ mapping in `error_handler.py`:
 | `NotebookLMError` (other) | `NOTEBOOKLM_ERROR` | `1` |
 | `KeyboardInterrupt`     | `CANCELLED`         | `130` |
 | Anything else (`Exception`) | `UNEXPECTED_ERROR` | `2` |
-| Parse-time `click.UsageError` / `click.BadParameter` (Click's parser, before command body runs) | — | re-raised; Click exits `2` |
-| Parse-time `click.ClickException` (other subclasses raised by Click's parser) | — | re-raised; Click exits `1` |
+| Parse-time `click.UsageError` / `click.BadParameter` (Click's parser, before command body runs) | `VALIDATION_ERROR` under `--json`; — in text mode | `2` (under `--json`: typed JSON envelope on stdout, **exit code preserved**; text mode: Click's `Usage:/Error:` on stderr) |
+| Parse-time `click.ClickException` (other subclasses raised by Click's parser) | `VALIDATION_ERROR` under `--json`; — in text mode | `1` (same: JSON envelope under `--json` with the code preserved; native text otherwise) |
 | Post-parse `ClickException` raised from a command body or service module | `VALIDATION_ERROR` (or another standard code, per the raise site) | `1` (typed JSON envelope under `--json`; see ADR-015) |
 
-`click.ClickException` raised by **Click's own parser** is intentionally
-re-raised so Click can render its own `Usage: ... / Error: ...` message.
-This is the *parse-time* path: argv parsing decides the command body
-should not run at all (unknown flag, type-validation failure, missing
-required argument), so `handle_errors(...)` is not yet on the stack and
-no JSON envelope is emitted. The exit code is whatever Click's own
-`exit_code` class attribute provides — `2` for `UsageError` (and
-`BadParameter`, which subclasses it), `1` for the base `ClickException`
-and other non-usage subclasses.
+`click.ClickException` raised by **Click's own parser** is the *parse-time*
+path: argv parsing decides the command body should not run at all (unknown
+flag, type-validation failure, missing required argument), so `handle_errors(...)`
+— the per-command context manager — is never on the stack. But the **root
+group** (`SectionedGroup.main` in
+[`src/notebooklm/cli/grouped.py`](../src/notebooklm/cli/grouped.py)) sits
+*above* `handle_errors`: it runs Click's superclass in non-standalone mode and
+catches the parse-time `ClickException` itself.
+
+- **Under `--json`**, the root group emits the typed JSON error envelope on
+  stdout (`{ "error": true, "code": "VALIDATION_ERROR", "message": ... }`,
+  empty stderr), so automation that passed `--json` still gets a parseable
+  document for argv-level failures. The **exit code is preserved** from Click —
+  `2` for `UsageError` / `BadParameter`, `1` for the base `ClickException` and
+  other non-usage subclasses. (Note the envelope `code` is `VALIDATION_ERROR`
+  regardless of which Click subclass fired; only the exit code carries the
+  `2`-vs-`1` distinction.)
+- **In text mode** (no `--json`), behavior is unchanged: Click renders its own
+  `Usage: ... / Error: ...` message on stderr and exits with that same
+  `exc.exit_code` (`2` / `1`).
+
+This supersedes the original ADR-015 §1 stance that "no JSON envelope is
+emitted at parse time"; see the amendment note in
+[ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md).
 
 `ClickException`-subclass failures raised from inside a **command body or
 its service-layer code** are *post-parse*: argv parsing succeeded, the
@@ -111,11 +126,21 @@ succeeds) are routed through this same envelope under `--json` and exit
 the raise site). The contract decision and its enumerated raise sites
 are recorded in
 [ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md).
-**Parse-time** `ClickException` raised by Click's own parser (before the
-command body runs) is unchanged — Click still renders its
-`Usage: ... / Error: ...` text on stderr and exits with its
-class-default code, because `handle_errors(...)` is not yet on the stack
-when the parser fires.
+
+**Parse-time `ClickException` is also covered under `--json`.**
+`ClickException` raised by Click's own parser (before the command body runs)
+is JSON-wrapped at the root group (`SectionedGroup.main`), not by the
+per-command `handle_errors(...)`: under `--json` it emits the same envelope on
+stdout with `code: "VALIDATION_ERROR"` and an **exit code preserved** from
+Click (`2` for `UsageError` / `BadParameter`, `1` for the base
+`ClickException`). In text mode it is unchanged — Click renders its
+`Usage: ... / Error: ...` text on stderr and exits with that class-default
+code. This is the more consistent behavior for JSON consumers: argv-level
+failures no longer fall back to usage prose just because they fired before the
+command body. The behavior is pinned by
+[`tests/unit/cli/test_json_validation_contract.py`](../tests/unit/cli/test_json_validation_contract.py)
+(`test_json_validation_errors_emit_json`, `test_text_validation_errors_keep_click_usage_output`)
+and amended into ADR-015 (amendment note, 2026-06-02).
 
 ## Intentional exceptions to the standard convention
 
@@ -376,7 +401,7 @@ section above.
 |------|------------------|
 | `0`  | The command succeeded as documented — the requested effect was carried out and any reported result is authoritative. |
 | `1`  | The command failed, **or** the queried target was not found. Both share exit `1` because automation typically wants the same control-flow branch (`if !` / `case 1)`); JSON mode (`--json`) distinguishes them via the typed `code` field (`NOT_FOUND` vs. `AUTH_ERROR` vs. `VALIDATION_ERROR`, etc.). |
-| `2`  | Click parser-time error — argv could not be parsed into a valid command invocation (unknown flag, type-validation failure, missing required argument). See the [parser-time row in the Exception → exit-code mapping](#exception--exit-code-mapping) for the full Click behavior; this entry exists to call out that `2` is **not** a post-parse code in the default case. Post-parse `ClickException` is contracted by [ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md) to route through the typed JSON envelope and exit `1`, not `2`. The same code is also raised when `handle_errors` catches an unhandled non-`NotebookLMError` exception (likely a bug — see the [Standard exit codes](#standard-exit-codes) table). |
+| `2`  | Click parser-time error — argv could not be parsed into a valid command invocation (unknown flag, type-validation failure, missing required argument). Under `--json` the root group still emits the typed JSON envelope on stdout (`code: "VALIDATION_ERROR"`) but **preserves** this exit `2`; in text mode Click renders its `Usage:/Error:` prose on stderr. See the [parser-time row in the Exception → exit-code mapping](#exception--exit-code-mapping) for the full behavior; this entry exists to call out that `2` is **not** a post-parse code in the default case. Post-parse `ClickException` is contracted by [ADR-015](adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md) to route through the typed JSON envelope and exit `1`, not `2`. The same code is also raised when `handle_errors` catches an unhandled non-`NotebookLMError` exception (likely a bug — see the [Standard exit codes](#standard-exit-codes) table). |
 
 Two commands deliberately deviate from this baseline because their primary
 use case is shell control flow:


### PR DESCRIPTION
## What

Doc-only amendment fixing the ADR-0015 drift in #1370. The CLI deliberately evolved past ADR-0015 §1, but the ADR (and `docs/cli-exit-codes.md`) still claimed *"No JSON envelope is emitted [at parse time]"* — contradicting the shipped, tested behavior. No code changes.

## Why (code + test evidence the docs now match)

`SectionedGroup.main` ([`src/notebooklm/cli/grouped.py`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/cli/grouped.py)) runs Click's superclass in **non-standalone mode** specifically to catch parse-time parser/callback `click.ClickException`:

```python
except click.ClickException as exc:
    if not standalone_mode:
        raise
    if _json_requested(args):
        _emit_json_click_error(exc)   # parse-time errors DO get JSON under --json
    else:
        exc.show(); exit_with_code(exc.exit_code)
```

`_emit_json_click_error` calls `output_error(exc.format_message(), "VALIDATION_ERROR", json_output=True, exit_code=exc.exit_code)` — so under `--json`:
- the typed JSON envelope is emitted on stdout (`code: "VALIDATION_ERROR"`, empty stderr), and
- **the exit code is preserved** (`exc.exit_code`: `2` for `UsageError`/`BadParameter`, `1` for base `ClickException`) — it is *not* normalised to `1`. This is the key nuance the docs now state precisely.

Without `--json`, Click's native `Usage:/Error:` text + exit code is unchanged.

Pinned by [`tests/unit/cli/test_json_validation_contract.py`](https://github.com/teng-lin/notebooklm-py/blob/main/tests/unit/cli/test_json_validation_contract.py):
- `test_json_validation_errors_emit_json` — `VALIDATION_ERROR` envelope on stdout (empty stderr, non-zero exit) for invalid limit/interval/retry, missing argument, unknown option, root-callback validation.
- `test_text_validation_errors_keep_click_usage_output` — text mode unchanged: exit `2`, `Usage:` on stderr, empty stdout.
- `test_json_abort_emit_json` — `CANCELLED` envelope for `click.Abort`.

Verified locally: `git diff` touches only the two docs; **85/85** contract tests pass.

## Doc sections changed

**`docs/adr/0015-...md`**
- New dated **amendment note (2026-06-02)** documenting the actual root-group contract, superseding §1's "no JSON at parse time" stance. Original rationale retained for history (per the issue's guidance — mark what changed and why, don't rewrite wholesale).
- Decision rule 1 and the relevant "Alternatives considered" entry annotated as superseded, cross-referencing the note.
- Contract tests cited as source of truth.

**`docs/cli-exit-codes.md`**
- Exception→exit-code mapping rows for parse-time `UsageError`/`BadParameter`/`ClickException` updated (JSON envelope under `--json`, exit code preserved).
- Parse-time prose paragraph, the "JSON output mode" section, and the "Exit code semantics" summary all updated so JSON consumers get the envelope for parse-time errors too, with exit codes unchanged.

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Amended ADR to reflect root-level JSON error envelope for parse-time CLI exceptions when using --json
  * Expanded CLI docs to clarify parse-time vs post-parse error output, channel differences (stdout vs stderr), and preserved exit codes
  * Updated exit-code semantics table and clarified JSON consumer behavior and related test coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->