### PR TITLE
fix(scripts): close two api-compat gate coverage holes (mind_maps + return types)

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -186,6 +186,126 @@
       "code": "removed-member",
       "object": "notebooklm.client.NotebookLMClient.notes.create_from_chat",
       "reason": "Same break as notebooklm.NotebookLMClient.notes.create_from_chat above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.artifacts.generate_mind_map",
+      "reason": "v0.7.0 #1209: now returns the typed MindMapResult dataclass instead of dict[str, Any]. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.artifacts.generate_mind_map",
+      "reason": "Same break as notebooklm.NotebookLMClient.artifacts.generate_mind_map above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.research.poll",
+      "reason": "v0.7.0 #1209: now returns the typed ResearchTask dataclass instead of dict[str, Any]. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.research.poll",
+      "reason": "Same break as notebooklm.NotebookLMClient.research.poll above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.research.start",
+      "reason": "v0.7.0 #1209: now returns the typed ResearchStart | None dataclass instead of dict[str, Any] | None. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.research.start",
+      "reason": "Same break as notebooklm.NotebookLMClient.research.start above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.research.wait_for_completion",
+      "reason": "v0.7.0 #1209: now returns the typed ResearchTask dataclass instead of dict[str, Any]. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.research.wait_for_completion",
+      "reason": "Same break as notebooklm.NotebookLMClient.research.wait_for_completion above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.sources.get_guide",
+      "reason": "v0.7.0 #1209: now returns the typed SourceGuide dataclass instead of dict[str, Any]. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.sources.get_guide",
+      "reason": "Same break as notebooklm.NotebookLMClient.sources.get_guide above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.artifacts.delete",
+      "reason": "v0.7.0 #1211: delete() now returns None and is absence-idempotent (was bool). See CHANGELOG.md [Unreleased] 'delete() -> returns None, idempotent on a missing target'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.artifacts.delete",
+      "reason": "Same break as notebooklm.NotebookLMClient.artifacts.delete above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.notebooks.delete",
+      "reason": "v0.7.0 #1211: delete() now returns None and is absence-idempotent (was bool). See CHANGELOG.md [Unreleased] 'delete() -> returns None, idempotent on a missing target'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.notebooks.delete",
+      "reason": "Same break as notebooklm.NotebookLMClient.notebooks.delete above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.notes.delete",
+      "reason": "v0.7.0 #1211: delete() now returns None and is absence-idempotent (was bool). See CHANGELOG.md [Unreleased] 'delete() -> returns None, idempotent on a missing target'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.notes.delete",
+      "reason": "Same break as notebooklm.NotebookLMClient.notes.delete above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.notes.delete_mind_map",
+      "reason": "v0.7.0 #1211: delete_mind_map() now returns None and is absence-idempotent (was bool). See CHANGELOG.md [Unreleased] 'delete() -> returns None, idempotent on a missing target'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.notes.delete_mind_map",
+      "reason": "Same break as notebooklm.NotebookLMClient.notes.delete_mind_map above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.sources.delete",
+      "reason": "v0.7.0 #1211: delete() now returns None and is absence-idempotent (was bool). See CHANGELOG.md [Unreleased] 'delete() -> returns None, idempotent on a missing target'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.sources.delete",
+      "reason": "Same break as notebooklm.NotebookLMClient.sources.delete above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.artifacts.rename",
+      "reason": "v0.7.0 #1247: rename() now re-fetches and returns the renamed Artifact | None (previously returned None even on success, an unusable return). Bulk opt-out via return_object=False. See CHANGELOG.md [Unreleased] 'rename() returns the renamed object'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.artifacts.rename",
+      "reason": "Same break as notebooklm.NotebookLMClient.artifacts.rename above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.sources.rename",
+      "reason": "v0.7.0 #1247: rename() return annotation widened from Source to Source | None to match the missing-strict reads/renames contract. Bulk opt-out via return_object=False. See CHANGELOG.md [Unreleased] 'rename() returns the renamed object'."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.sources.rename",
+      "reason": "Same break as notebooklm.NotebookLMClient.sources.rename above; this entry covers the audit's dotted-module-path view of the same callable."
     }
   ]
 }

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -127,6 +127,7 @@ import inspect
 import json
 import pathlib
 import sys
+import typing
 import warnings
 
 ROOT = pathlib.Path(sys.argv[1]).resolve()
@@ -152,14 +153,33 @@ def discover_modules() -> list[str]:
     return sorted(modules)
 
 
-def annotation_repr(annotation):
+class _ReturnProbe:
+    # Tiny carrier so typing.get_type_hints can resolve a lone return string.
+    def __init__(self, annotation):
+        self.__annotations__ = {"return": annotation}
+
+
+def annotation_repr(annotation, obj=None):
     if annotation is inspect.Signature.empty:
         return None
     # `from __future__ import annotations` (PEP 563) yields string annotations
-    # already; non-postponed modules yield live objects. Normalize both to a
-    # stable, process-comparable text form.
+    # already; non-postponed modules yield live objects. Resolve string
+    # annotations against the owning module's globals so the captured form is
+    # canonical regardless of a module's PEP 563 status (a transition would
+    # otherwise flip e.g. 'MindMap' <-> 'notebooklm.types.MindMap' and surface a
+    # spurious changed-return). Fall back to the raw string when resolution
+    # fails (e.g. TYPE_CHECKING-only names).
     if isinstance(annotation, str):
-        return annotation
+        module_name = getattr(obj, "__module__", None)
+        module = sys.modules.get(module_name) if module_name else None
+        if module is None:
+            return annotation
+        try:
+            annotation = typing.get_type_hints(
+                _ReturnProbe(annotation), globalns=vars(module)
+            )["return"]
+        except Exception:
+            return annotation
     return inspect.formatannotation(annotation)
 
 
@@ -183,7 +203,7 @@ def signature_payload(obj):
     return {
         "text": str(sig),
         "parameters": params,
-        "return_annotation": annotation_repr(sig.return_annotation),
+        "return_annotation": annotation_repr(sig.return_annotation, obj),
     }
 
 

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -2,8 +2,8 @@
 
 This is a release gate, not a replacement for unit tests. It compares the
 runtime public surface in this checkout against a baseline git ref (by default
-the latest reachable tag) and reports unapproved removals or call-signature
-changes.
+the latest reachable tag) and reports unapproved removals, call-signature
+changes, or return-annotation changes.
 
 Usage:
     uv run python scripts/audit_public_api_compat.py
@@ -38,6 +38,7 @@ EXTRA_PUBLIC_PACKAGES = ("rpc",)
 CLIENT_NAMESPACE_ATTRIBUTES = (
     "artifacts",
     "chat",
+    "mind_maps",
     "notes",
     "notebooks",
     "research",
@@ -151,6 +152,17 @@ def discover_modules() -> list[str]:
     return sorted(modules)
 
 
+def annotation_repr(annotation):
+    if annotation is inspect.Signature.empty:
+        return None
+    # `from __future__ import annotations` (PEP 563) yields string annotations
+    # already; non-postponed modules yield live objects. Normalize both to a
+    # stable, process-comparable text form.
+    if isinstance(annotation, str):
+        return annotation
+    return inspect.formatannotation(annotation)
+
+
 def signature_payload(obj):
     try:
         sig = inspect.signature(obj)
@@ -168,7 +180,11 @@ def signature_payload(obj):
                 else repr(param.default),
             }
         )
-    return {"text": str(sig), "parameters": params}
+    return {
+        "text": str(sig),
+        "parameters": params,
+        "return_annotation": annotation_repr(sig.return_annotation),
+    }
 
 
 def kind_of(obj) -> str:
@@ -473,6 +489,25 @@ def _signature_breakage(old: dict[str, Any] | None, new: dict[str, Any] | None) 
     return None
 
 
+def _return_breakage(old: dict[str, Any] | None, new: dict[str, Any] | None) -> str | None:
+    """Return a reason when the return annotation changed, else ``None``.
+
+    Older baselines predate return-annotation capture, so a missing
+    ``return_annotation`` key is treated as "unknown" and never reported — only
+    an observed value-to-value change counts as a break. An annotation appearing
+    where there was none before is additive and also ignored.
+    """
+    if old is None or new is None:
+        return None
+    if "return_annotation" not in old or "return_annotation" not in new:
+        return None
+    old_return = old["return_annotation"]
+    new_return = new["return_annotation"]
+    if old_return is None or old_return == new_return:
+        return None
+    return f"return annotation changed from {old_return!r} to {new_return!r}"
+
+
 def _compare_export(
     module_name: str,
     export_name: str,
@@ -495,6 +530,9 @@ def _compare_export(
         reason = _signature_breakage(old.get("signature"), new.get("signature"))
         if reason:
             breaks.append(ApiBreak("changed-signature", path, reason))
+        return_reason = _return_breakage(old.get("signature"), new.get("signature"))
+        if return_reason:
+            breaks.append(ApiBreak("changed-return", path, return_reason))
 
     for member_name, old_member in old.get("members", {}).items():
         new_member = new.get("members", {}).get(member_name)
@@ -520,6 +558,9 @@ def _compare_export(
         reason = _signature_breakage(old_member.get("signature"), new_member.get("signature"))
         if reason:
             breaks.append(ApiBreak("changed-signature", member_path, reason))
+        return_reason = _return_breakage(old_member.get("signature"), new_member.get("signature"))
+        if return_reason:
+            breaks.append(ApiBreak("changed-return", member_path, return_reason))
 
     for enum_name, old_value in old.get("enum_members", {}).items():
         enum_members = new.get("enum_members", {})

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -515,7 +515,9 @@ def _return_breakage(old: dict[str, Any] | None, new: dict[str, Any] | None) -> 
     Older baselines predate return-annotation capture, so a missing
     ``return_annotation`` key is treated as "unknown" and never reported — only
     an observed value-to-value change counts as a break. An annotation appearing
-    where there was none before is additive and also ignored.
+    where there was none before is additive and also ignored. The mirror case —
+    an annotation disappearing (annotated -> unannotated) — *is* reported;
+    acknowledge it via the allowlist if intentional.
     """
     if old is None or new is None:
         return None

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -28,8 +28,11 @@ def script():
     return _load_module()
 
 
-def _signature(*params: dict) -> dict:
-    return {"text": "(...)", "parameters": list(params)}
+def _signature(*params: dict, return_annotation: str | None = None) -> dict:
+    payload = {"text": "(...)", "parameters": list(params)}
+    if return_annotation is not None:
+        payload["return_annotation"] = return_annotation
+    return payload
 
 
 def _param(
@@ -177,6 +180,8 @@ def test_collect_manifest_includes_representative_client_namespace_methods(scrip
     assert {
         "artifacts.download_audio",
         "chat.ask",
+        "mind_maps.generate",
+        "mind_maps.get",
         "notebooks.list",
         "notes.create",
         "research.start",
@@ -184,6 +189,19 @@ def test_collect_manifest_includes_representative_client_namespace_methods(scrip
         "sharing.set_public",
         "sources.add_url",
     } <= set(members)
+
+
+def test_mind_maps_namespace_is_audited(script):
+    assert "mind_maps" in script.CLIENT_NAMESPACE_ATTRIBUTES
+
+
+def test_collect_manifest_captures_return_annotation(script):
+    manifest = script.collect_manifest(REPO_ROOT)
+    members = manifest["modules"]["notebooklm"]["exports"]["NotebookLMClient"]["members"]
+
+    delete = members["sources.delete"]["signature"]
+    assert "return_annotation" in delete
+    assert delete["return_annotation"] == "None"
 
 
 def test_collect_manifest_preserves_defaulted_dataclass_fields(script):
@@ -266,6 +284,68 @@ def test_signature_compare_rejects_removed_kwargs(script):
         script._signature_breakage(old, new)
         == "old signature accepted **kwargs, new signature does not"
     )
+
+
+def test_return_breakage_detects_changed_return_annotation(script):
+    old = _signature(_param("self"), return_annotation="bool")
+    new = _signature(_param("self"), return_annotation="None")
+
+    assert script._return_breakage(old, new) == "return annotation changed from 'bool' to 'None'"
+
+
+def test_return_breakage_ignores_unchanged_and_additive_annotations(script):
+    same = _signature(_param("self"), return_annotation="None")
+    assert script._return_breakage(same, same) is None
+
+    # Older baselines predate return-annotation capture: a missing key on either
+    # side, or an annotation appearing where there was none, is not a break.
+    no_key = _signature(_param("self"))
+    annotated = _signature(_param("self"), return_annotation="MindMap")
+    assert script._return_breakage(no_key, annotated) is None
+    assert script._return_breakage(annotated, no_key) is None
+    none_to_value = {**no_key, "return_annotation": None}
+    assert script._return_breakage(none_to_value, annotated) is None
+
+
+def test_compare_manifests_flags_client_namespace_return_type_change(script):
+    baseline = _manifest(
+        {
+            "NotebookLMClient": _class(
+                members={
+                    "mind_maps.get": {
+                        "kind": "method",
+                        "signature": _signature(
+                            _param("self"),
+                            _param("notebook_id"),
+                            return_annotation="dict[str, Any] | None",
+                        ),
+                    },
+                },
+            )
+        }
+    )
+    current = _manifest(
+        {
+            "NotebookLMClient": _class(
+                members={
+                    "mind_maps.get": {
+                        "kind": "method",
+                        "signature": _signature(
+                            _param("self"),
+                            _param("notebook_id"),
+                            return_annotation="MindMap | None",
+                        ),
+                    },
+                },
+            )
+        }
+    )
+
+    breaks = script.compare_manifests(baseline, current)
+
+    assert [item.code for item in breaks] == ["changed-return"]
+    assert breaks[0].object == "notebooklm.NotebookLMClient.mind_maps.get"
+    assert "MindMap | None" in breaks[0].detail
 
 
 def test_compare_manifests_detects_enum_value_change(script):

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -204,6 +204,21 @@ def test_collect_manifest_captures_return_annotation(script):
     assert delete["return_annotation"] == "None"
 
 
+def test_collect_manifest_canonicalizes_pep563_return_annotation(script):
+    # ``_mind_maps_api`` uses ``from __future__ import annotations`` (PEP 563),
+    # so ``mind_maps.get -> MindMap | None`` arrives as a bare string. The
+    # collector must resolve it against the owning module's globals to the
+    # fully-qualified form, otherwise a module flipping its PEP 563 status would
+    # surface a spurious ``changed-return``.
+    manifest = script.collect_manifest(REPO_ROOT)
+    members = manifest["modules"]["notebooklm"]["exports"]["NotebookLMClient"]["members"]
+
+    assert (
+        members["mind_maps.get"]["signature"]["return_annotation"]
+        == "notebooklm.types.MindMap | None"
+    )
+
+
 def test_collect_manifest_preserves_defaulted_dataclass_fields(script):
     manifest = script.collect_manifest(REPO_ROOT)
     members = manifest["modules"]["notebooklm"]["exports"]["GenerationStatus"]["members"]

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -318,6 +318,9 @@ def test_return_breakage_ignores_unchanged_and_additive_annotations(script):
     annotated = _signature(_param("self"), return_annotation="MindMap")
     assert script._return_breakage(no_key, annotated) is None
     assert script._return_breakage(annotated, no_key) is None
+    # Key present with a null value: the function was unannotated at capture
+    # time (distinct from the missing-key/old-baseline case above), so gaining
+    # an annotation is still additive.
     none_to_value = {**no_key, "return_annotation": None}
     assert script._return_breakage(none_to_value, annotated) is None
 

--- a/tests/unit/test_public_api_contract.py
+++ b/tests/unit/test_public_api_contract.py
@@ -16,12 +16,15 @@ The allowlist exists because flipping ``get()`` to raise ``*NotFoundError`` (and
 drop its ``| None``) is deferred to issue #1247; this test passes against today's
 surface and the allowlist must *shrink* — never grow — as that flip lands.
 
-This walk is deliberately independent of ``scripts/audit_public_api_compat.py``:
-that comparator ignores return types, and its collector under-covers
-``mind_maps``. Namespaces are enumerated explicitly here (including
-``mind_maps``) so the divergence that originally occurred
-(``mind_maps.get() -> MindMap | None``, added without the deprecation warning)
-is a signature smell this catches with no backend.
+This walk is deliberately independent of ``scripts/audit_public_api_compat.py``.
+The two former coverage holes in that comparator are now closed (issue #1378:
+it audits the ``mind_maps`` namespace and flags ``changed-return`` breaks), but
+the comparator answers a different question — "did the public surface break
+*against the previous release*" — whereas this walk asserts the absolute
+return-shape *rules* against today's surface with no backend or git baseline.
+Namespaces are enumerated explicitly here (including ``mind_maps``) so the
+divergence that originally occurred (``mind_maps.get() -> MindMap | None``, added
+without the deprecation warning) is a signature smell this catches directly.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What
Closes two coverage holes in `scripts/audit_public_api_compat.py`, the CI public-API break gate:

1. **`client.mind_maps` is now audited.** It was missing from `CLIENT_NAMESPACE_ATTRIBUTES`, so the whole namespace's signatures and members went unchecked even though the client exposes it (`client.py:431`).
2. **Return annotations are now compared.** `signature_payload` captures a stable `return_annotation`, and a new `changed-return` break code flags return-type flips that the gate previously ignored.

## Why
The *automated* release gate disagreed with the ADR-0019 conformance test (`tests/unit/test_public_api_contract.py`) about what "public" means — false confidence right as the v0.8.0 breaking flips land (#1346). The conformance test's own docstring (lines 19-24) documented both holes; this PR closes them in the comparator and refreshes that docstring.

## How
- Added `"mind_maps"` to `CLIENT_NAMESPACE_ATTRIBUTES` (purely additive: v0.6.0 had no `self.mind_maps`, so no removed-member breaks surface).
- Added `annotation_repr()` to the collector — normalizes PEP 563 string annotations and live objects to a stable, process-comparable text form.
- `signature_payload` now records `return_annotation`.
- Added `_return_breakage()` and emitted `changed-return` at both the export- and member-level comparison sites. It is conservative: a missing key on either side (older baselines), an unchanged value, or an annotation appearing where there was none (`old is None`) is **not** a break.
- Surfacing return types flagged 12 pre-existing, documented v0.7.0 changes (the #1209 dict→dataclass migration, #1211 idempotent `delete()` → `None`, #1247 `rename()` returning the renamed object). Each is reconciled in `scripts/api-compat-allowlist.json` with two path-views per the existing convention — no real break is masked.
- Extended the unit test: asserts `mind_maps` is covered, that the collector captures `return_annotation`, and that a return-type change is flagged as `changed-return`.

## Verification
- `uv run python scripts/audit_public_api_compat.py` → `OK ... (36 reviewed break(s) allowlisted)`, exit 0.
- `uv run pytest tests/unit/test_public_api_compat_audit.py tests/unit/test_ci_audit_scripts.py tests/unit/test_public_api_contract.py` → 80 passed, 12 skipped.
- `uv run mypy src/notebooklm --ignore-missing-imports` → Success.
- `uv run ruff format` + `uv run ruff check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API methods now return structured typed objects instead of generic dictionaries for clearer, more reliable responses.
  * Delete operations across artifacts, notebooks, notes, mind-maps, and sources are now absence-idempotent and return None.
  * Rename operations now return the renamed object (or None) instead of a generic success value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->