### PR TITLE
test(cassettes): add generic high-entropy / unknown-field credential scan (closes #1382)

### DIFF
--- a/tests/_lint/test_cassettes_clean.py
+++ b/tests/_lint/test_cassettes_clean.py
@@ -102,9 +102,9 @@ def test_guard_detects_a_known_bad_cassette() -> None:
 def test_guard_detects_credential_shapes(tmp_path: Path) -> None:
     """Positive control for the ``--secrets-only`` path, across every shape.
 
-    Covers all four credential-shape detectors (the Google API key plus the
-    ``g.a000-`` / ``sidts-`` / ``ya29.`` auth-token shapes), so a single dead
-    detector is caught. Shapes are assembled at runtime so this source file
+    Covers all four known credential-shape detectors (the Google API key plus
+    the ``g.a000-`` / ``sidts-`` / ``ya29.`` auth-token shapes), so a single
+    dead detector is caught. Shapes are assembled at runtime so this source file
     carries no static credential-shaped literal that the repo-wide secrets scan
     would flag. Asserting one reported leak *per shape* (not merely a non-zero
     exit, which a scanner crash also produces) keeps the control robust.
@@ -126,4 +126,27 @@ def test_guard_detects_credential_shapes(tmp_path: Path) -> None:
     assert len(reported) >= len(shapes), (
         f"expected >= {len(shapes)} reported leaks (one per shape), got {len(reported)} — "
         f"a shape detector may be dead or the guard crashed:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_guard_detects_novel_high_entropy_token(tmp_path: Path) -> None:
+    """Positive control for the generic high-entropy scan (issue #1382).
+
+    A NOVEL credential shape — one matching none of the known prefixes above —
+    riding in an unknown quoted JSON field must still be flagged by the
+    field-agnostic entropy backstop. The token is assembled at runtime (a mixed
+    base64 run, 40+ chars, high entropy) so it matches no static secret pattern
+    in this source file. Asserting the detector fires here is what proves the
+    entropy scan is live in the ``--secrets-only`` path, not merely defined.
+    """
+    novel = "kJ8sLm2NpQr5" + "TvWxYz0AbCdEf" + "GhIjKlMnOpQrSt" + "UvWxYz12345678"
+    leaky = tmp_path / "novel.json"
+    leaky.write_text(f'{{"unknownField":"{novel}"}}\n', encoding="utf-8")
+    result = _run_guard("--secrets-only", str(leaky))
+    assert result.returncode == 1, (
+        f"entropy scan missed a planted novel high-entropy token:\n{result.stdout}"
+    )
+    assert "high-entropy token" in result.stdout, (
+        f"exit 1 but no high-entropy leak reported — the entropy detector may be "
+        f"dead or the guard crashed:\n{result.stdout}\n{result.stderr}"
     )

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -53,7 +53,20 @@ Exports
 - :data:`SENSITIVE_PATTERNS`  ordered (regex, replacement) registry
 - :func:`scrub_string`        single sanitization entry point
 - :func:`is_clean`            validator returning ``(ok, leaks)``
+- :func:`find_credential_leaks`   high-severity-shape-only subset (fixture-safe)
+- :func:`find_high_entropy_leaks` field-agnostic novel-token entropy backstop
 - :func:`recompute_chunk_prefix`  XSSI byte-count re-derivation
+
+Necessary-not-sufficient boundary (issue #1382)
+-----------------------------------------------
+The name-anchored / known-shape detectors below are NECESSARY but not
+SUFFICIENT: a novel credential prefix, or a known secret in an un-targeted
+field, passes them silently (this has bitten the guard twice — ``LSID`` and
+``JrWMbf``). :func:`find_high_entropy_leaks` is the deliberate field-agnostic
+complement that catches a long high-entropy base64/hex token in ANY quoted
+JSON scalar. See its KNOWN-SHAPE BOUNDARY block for the residual-risk decision
+this draws (it is scoped to quoted scalars on purpose; non-quoted high-entropy
+text remains GitHub-secret-scanning's job). Relates to ADR-006.
 
 Upload + Drive token coverage
 -----------------------------
@@ -112,7 +125,9 @@ which field carried it.
 
 from __future__ import annotations
 
+import math
 import re
+from collections import Counter
 
 # =============================================================================
 # Chunked-response byte-count re-derivation
@@ -919,19 +934,154 @@ _CREDENTIAL_DETECTORS: list[tuple[str, re.Pattern[str]]] = [
 ]
 
 
+# =============================================================================
+# Generic high-entropy / unknown-field credential scan
+# =============================================================================
+#
+# THE KNOWN-SHAPE BOUNDARY (residual-risk decision; ADR-006, issue #1382).
+# ---------------------------------------------------------------------------
+# Everything ABOVE this point is *name-anchored* (cookie names, WIZ field IDs)
+# or *known-shape* (``g.a000-`` / ``sidts-`` / ``ya29.`` / ``AIza`` prefixes).
+# That makes the guard NECESSARY-but-not-SUFFICIENT: a credential family the
+# registry does not yet know about — a NOVEL token prefix, or a known secret
+# riding in an un-targeted JSON field — passes the targeted detectors silently.
+# This is not hypothetical: the guard has missed two such shapes historically
+# (the ``LSID`` cookie whose name was off the allowlist, and the ``JrWMbf`` WIZ
+# field whose API key the name-anchored scrubbers skipped), and #1372 fixed a
+# double-encoded-email shape that leaked the maintainer's address. Each fix
+# extended the known-shape set by ONE entry — reactive, after-the-leak.
+#
+# This scanner is the deliberate, field-agnostic complement: it flags a quoted
+# JSON string scalar whose ENTIRE value is one long, high-entropy
+# base64url/hex run, regardless of the field name carrying it. It is the
+# "would have caught it generically" backstop the targeted detectors lack.
+#
+# Why it is SCOPED to a *quoted scalar value* rather than scanning every token:
+# committed cassettes are dense with legitimate high-entropy text — minified
+# CSS class names, ``fonts.gstatic.com`` / ``googleusercontent.com`` URLs,
+# 1.5 KB hex mind-map blobs, and 600-char ``context=eJw…`` zlib-base64 query
+# params. A raw per-token entropy scan would drown in thousands of those false
+# positives. But NONE of that legitimate content appears as a *clean quoted
+# JSON scalar* (``"field":"<one-pure-token>"``) — which is exactly the shape a
+# leaked credential takes when it rides in an unknown field. Anchoring on that
+# shape is what makes ZERO false positives across every committed cassette
+# achievable while still catching a planted novel token. This residual-risk
+# property is therefore a DECISION, not an accident: anything that is NOT a
+# quoted high-entropy scalar (a credential split across structural punctuation,
+# a token in a non-JSON encoding) remains the backstop's blind spot, covered by
+# GitHub secret-scanning and the name-anchored detectors above.
+#
+# Thresholds (calibrated against every committed cassette — see the unit tests
+# ``test_entropy_scan_*`` and ``test_all_committed_cassettes_pass_entropy_scan``):
+#
+#   * base64url / mixed-alphabet tokens: length >= 40 AND Shannon entropy
+#     >= 4.0 bits/char. A 40+ char run drawn from a ~64-symbol alphabet with
+#     >=4.0 entropy is a random secret by construction; legitimate quoted
+#     scalars in cassettes (UUIDs, opaque IDs) never reach both bars at once.
+#   * pure-hex tokens (``[0-9a-fA-F]`` only): a separate length floor of 64,
+#     because a 16-symbol alphabet CAPS Shannon entropy at log2(16) = 4.0
+#     bits/char — a hex secret can never reliably clear the 4.0 bar, so length
+#     alone gates it. 64 hex chars = 256 bits, comfortably above any incidental
+#     hex literal (a 32-hex MD5 or a 36-char UUID stays well under the floor).
+#
+# Allowlist (known-benign long tokens that must NOT be flagged):
+#
+#   * the canonical ``SCRUB_PLACEHOLDERS`` sentinels (idempotent validation);
+#   * the canonical UUID shape (``8-4-4-4-12`` hex-with-dashes) — these are
+#     NotebookLM-internal artifact / source / conversation IDs that the
+#     surrounding scrubbers deliberately preserve. The base64 length+entropy
+#     gate already excludes them (36 chars < 40, dashes depress entropy), but
+#     the explicit shape skip documents the intent and guards against a future
+#     threshold change re-flagging them.
+_ENTROPY_MIN_LEN_BASE64 = 40
+_ENTROPY_MIN_BITS = 4.0
+_ENTROPY_MIN_LEN_HEX = 64
+
+# A quoted JSON string scalar whose entire content is a single base64url / hex
+# token. ``\A``/``\Z`` inside the captured group are unnecessary because the
+# surrounding quotes already anchor the run to the FULL value — a token split
+# by any non-``[A-Za-z0-9_\-+/=]`` byte simply won't match.
+_DETECT_QUOTED_TOKEN = re.compile(r'"([A-Za-z0-9_\-+/=]+)"')
+
+# Canonical UUID shape (``8-4-4-4-12``). Internal NotebookLM IDs, never secrets.
+_UUID_SHAPE = re.compile(
+    r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z"
+)
+
+# Pure-hex run (no base64-only symbols). Used to route a token onto the hex
+# length floor instead of the entropy bar (hex entropy caps at 4.0).
+_HEX_ONLY = re.compile(r"\A[0-9a-fA-F]+\Z")
+
+
+def _shannon_entropy(token: str) -> float:
+    """Shannon entropy of ``token`` in bits per character.
+
+    A measure of per-character randomness: a token drawn uniformly from an
+    ``N``-symbol alphabet approaches ``log2(N)`` bits/char, while repetitive or
+    small-alphabet content scores lower. Returns ``0.0`` for the empty string.
+    """
+    if not token:
+        return 0.0
+    length = len(token)
+    return -sum((count / length) * math.log2(count / length) for count in Counter(token).values())
+
+
+def _is_high_entropy_token(token: str) -> bool:
+    """Return ``True`` if ``token`` looks like a novel high-entropy credential.
+
+    See the KNOWN-SHAPE BOUNDARY block above for the full rationale and the
+    threshold calibration. In brief: a pure base64url/hex run that is long
+    AND random enough that no legitimate quoted-scalar cassette value reaches
+    both bars, with the placeholder + UUID allowlist applied first.
+    """
+    if token in SCRUB_PLACEHOLDERS:
+        return False
+    if _UUID_SHAPE.match(token):
+        return False
+    if _HEX_ONLY.match(token):
+        # Hex entropy caps at log2(16) == 4.0 bits/char, so length alone gates
+        # a hex secret; the entropy bar below would never reliably fire on it.
+        return len(token) >= _ENTROPY_MIN_LEN_HEX
+    if len(token) < _ENTROPY_MIN_LEN_BASE64:
+        return False
+    return _shannon_entropy(token) >= _ENTROPY_MIN_BITS
+
+
+def find_high_entropy_leaks(text: str) -> list[str]:
+    """Flag quoted high-entropy base64/hex scalars in ANY field (issue #1382).
+
+    The field-agnostic complement to the name-anchored / known-shape detectors:
+    catches a novel credential shape — or a known secret riding in an
+    un-targeted JSON field — that the targeted scrubbers miss. Scoped to a
+    *quoted JSON string scalar* so it never fires on the legitimate high-entropy
+    text (CSS, URLs, compressed-query blobs) that pervades real cassettes. See
+    the KNOWN-SHAPE BOUNDARY block above for the boundary this deliberately
+    draws. Each returned string is a human-readable ``"Leak (...): '...'"``.
+    """
+    leaks: list[str] = []
+    for match in _DETECT_QUOTED_TOKEN.finditer(text):
+        token = match.group(1)
+        if _is_high_entropy_token(token):
+            leaks.append(f"Leak (high-entropy token): {token!r}")
+    return leaks
+
+
 def find_credential_leaks(text: str) -> list[str]:
     """Return high-severity credential leaks (auth tokens + Google API keys).
 
     A focused subset of :func:`is_clean` that runs ONLY the credential-shape
-    detectors in :data:`_CREDENTIAL_DETECTORS`. These shapes have no legitimate
-    occurrence anywhere in the repo, so unlike :func:`is_clean` this is safe to
-    point at fixture directories full of intentional placeholder content. Each
-    returned string is a human-readable ``"Leak (...): '...'"`` description.
+    detectors in :data:`_CREDENTIAL_DETECTORS` PLUS the field-agnostic
+    high-entropy scan (:func:`find_high_entropy_leaks`). These shapes have no
+    legitimate occurrence anywhere in the repo, so unlike :func:`is_clean` this
+    is safe to point at fixture directories full of intentional placeholder
+    content. Each returned string is a human-readable ``"Leak (...): '...'"``
+    description.
     """
     leaks: list[str] = []
     for label, regex in _CREDENTIAL_DETECTORS:
         for match in regex.finditer(text):
             leaks.append(f"Leak ({label}): {match.group(0)!r}")
+    leaks.extend(find_high_entropy_leaks(text))
     return leaks
 
 
@@ -1052,6 +1202,15 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
     # ``JrWMbf`` gap the name-anchored field detectors missed.
     for match in _DETECT_GOOGLE_API_KEY.finditer(text):
         leaks.append(f"Leak (Google API key): {match.group(0)!r}")
+
+    # --- 10. Generic high-entropy / unknown-field credential scan ----------
+    # Field-agnostic backstop for a NOVEL credential shape — or a known secret
+    # in an un-targeted JSON field — that the name-anchored / known-shape
+    # detectors above miss (issue #1382). Scoped to a quoted high-entropy
+    # base64/hex scalar so it never fires on the legitimate high-entropy text
+    # (CSS, URLs, compressed-query blobs) that pervades real cassettes. See the
+    # KNOWN-SHAPE BOUNDARY block near :func:`find_high_entropy_leaks`.
+    leaks.extend(find_high_entropy_leaks(text))
 
     return (not leaks, leaks)
 

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -997,6 +997,15 @@ _ENTROPY_MIN_LEN_BASE64 = 40
 _ENTROPY_MIN_BITS = 4.0
 _ENTROPY_MIN_LEN_HEX = 64
 
+# Cap the substring fed to the entropy computation. A cassette can carry a
+# multi-megabyte base64-encoded asset as one quoted scalar (an inline image /
+# PDF / audio blob), and computing Shannon entropy over the whole run would be a
+# needless O(n) hot loop per scanned line. A random credential is high-entropy
+# throughout, so a 512-char prefix is a faithful representative — the entropy of
+# the prefix and the whole token converge well before this bound (gemini review
+# on #1387). Length gating still uses the FULL token length, not the cap.
+_ENTROPY_SAMPLE_CHARS = 512
+
 # A quoted JSON string scalar whose entire content is a single base64url / hex
 # token. ``\A``/``\Z`` inside the captured group are unnecessary because the
 # surrounding quotes already anchor the run to the FULL value — a token split
@@ -1019,11 +1028,17 @@ def _shannon_entropy(token: str) -> float:
     A measure of per-character randomness: a token drawn uniformly from an
     ``N``-symbol alphabet approaches ``log2(N)`` bits/char, while repetitive or
     small-alphabet content scores lower. Returns ``0.0`` for the empty string.
+
+    Only the first :data:`_ENTROPY_SAMPLE_CHARS` characters are analyzed so a
+    multi-megabyte base64 asset scalar does not turn this into a per-line hot
+    loop; a random credential is high-entropy throughout, so the prefix is
+    representative.
     """
     if not token:
         return 0.0
-    length = len(token)
-    return -sum((count / length) * math.log2(count / length) for count in Counter(token).values())
+    sample = token[:_ENTROPY_SAMPLE_CHARS]
+    length = len(sample)
+    return -sum((count / length) * math.log2(count / length) for count in Counter(sample).values())
 
 
 def _is_high_entropy_token(token: str) -> bool:

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -450,13 +450,18 @@ def test_find_credential_leaks_ignores_placeholder_fixture_content() -> None:
 # pin the field-agnostic backstop: it WOULD catch a planted novel token, yet
 # produces ZERO false positives on every committed cassette.
 
-# Synthetic novel credentials assembled at runtime so this source file carries
-# no static credential-shaped literal (which would itself trip secret scanning)
-# and so the shapes are distinct from the known g.a000-/sidts-/ya29./AIza
-# prefixes. ``random``-free deterministic mixes keep the entropy well above the
-# 4.0 bits/char floor.
-NOVEL_BASE64_TOKEN = "kJ8sLm2NpQr5TvWxYz0AbCdEfGhIjKlMnOpQrStUvWxYz12345678AbCdEf"
-NOVEL_HEX_TOKEN = "9f8e7d6c5b4a392817065fe4d3c2b1a09f8e7d6c5b4a392817065fe4d3c2b1a0"
+# Synthetic novel credentials assembled at runtime from shorter chunks so this
+# source file carries NO contiguous static credential-shaped literal — a 64-char
+# hex or 40+ char base64 string written inline would itself trip secret scanning
+# (Betterleaks flags it as a generic API key). The shapes are also distinct from
+# the known g.a000-/sidts-/ya29./AIza prefixes, and the deterministic mixes keep
+# the base64 entropy well above the 4.0 bits/char floor.
+NOVEL_BASE64_TOKEN = "".join(
+    ("kJ8sLm2NpQr5TvWx", "Yz0AbCdEfGhIjKlM", "nOpQrStUvWxYz123", "45678AbCdEf")
+)
+NOVEL_HEX_TOKEN = "".join(
+    ("9f8e7d6c5b4a3928", "17065fe4d3c2b1a0", "9f8e7d6c5b4a3928", "17065fe4d3c2b1a0")
+)
 assert len(NOVEL_BASE64_TOKEN) >= 40
 assert len(NOVEL_HEX_TOKEN) >= 64
 

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -41,6 +41,7 @@ from cassette_patterns import (  # noqa: E402
     SECURE_COOKIES,
     SESSION_COOKIES,
     find_credential_leaks,
+    find_high_entropy_leaks,
     is_clean,
     scrub_string,
 )
@@ -437,6 +438,119 @@ def test_find_credential_leaks_ignores_placeholder_fixture_content() -> None:
     assert not is_clean(fixture_like)[0]
     # ... but the credential-only scanner stays silent.
     assert find_credential_leaks(fixture_like) == []
+
+
+# ---------------------------------------------------------------------------
+# Generic high-entropy / unknown-field credential scan (issue #1382)
+# ---------------------------------------------------------------------------
+#
+# The targeted detectors above are name-anchored or known-shape, making the
+# guard necessary-but-not-sufficient: a NOVEL token shape, or a known secret in
+# an un-targeted field, passes silently (the LSID / JrWMbf leaks). These tests
+# pin the field-agnostic backstop: it WOULD catch a planted novel token, yet
+# produces ZERO false positives on every committed cassette.
+
+# Synthetic novel credentials assembled at runtime so this source file carries
+# no static credential-shaped literal (which would itself trip secret scanning)
+# and so the shapes are distinct from the known g.a000-/sidts-/ya29./AIza
+# prefixes. ``random``-free deterministic mixes keep the entropy well above the
+# 4.0 bits/char floor.
+NOVEL_BASE64_TOKEN = "kJ8sLm2NpQr5TvWxYz0AbCdEfGhIjKlMnOpQrStUvWxYz12345678AbCdEf"
+NOVEL_HEX_TOKEN = "9f8e7d6c5b4a392817065fe4d3c2b1a09f8e7d6c5b4a392817065fe4d3c2b1a0"
+assert len(NOVEL_BASE64_TOKEN) >= 40
+assert len(NOVEL_HEX_TOKEN) >= 64
+
+
+def test_entropy_scan_flags_novel_base64_token_in_unknown_field() -> None:
+    """A long high-entropy base64 token in an UNKNOWN field is flagged.
+
+    This is the residual-risk shape the name-anchored detectors miss: a credential
+    family the registry does not yet know about, riding in a field that is not on
+    any allowlist. The generic entropy scan catches it by shape alone.
+    """
+    payload = f'{{"sessionBlob":"{NOVEL_BASE64_TOKEN}"}}'
+    leaks = find_high_entropy_leaks(payload)
+    assert any("high-entropy token" in leak for leak in leaks), leaks
+    # It also surfaces through both public entry points.
+    assert any("high-entropy token" in leak for leak in find_credential_leaks(payload))
+    assert not is_clean(payload)[0]
+
+
+def test_entropy_scan_flags_novel_hex_token_in_unknown_field() -> None:
+    """A long pure-hex token (64+ chars) in an unknown field is flagged.
+
+    Hex entropy caps at log2(16) == 4.0 bits/char, so the base64 entropy bar can
+    never reliably fire on it — the scan routes pure-hex tokens onto a dedicated
+    64-char length floor instead.
+    """
+    payload = f'{{"legacyToken":"{NOVEL_HEX_TOKEN}"}}'
+    assert any("high-entropy token" in leak for leak in find_high_entropy_leaks(payload))
+    assert not is_clean(payload)[0]
+
+
+def test_entropy_scan_ignores_internal_uuid() -> None:
+    """A 36-char UUID (artifact / source / conversation ID) is NOT flagged.
+
+    UUIDs are NotebookLM-internal identifiers the scrubbers deliberately
+    preserve. They fall under both the 40-char base64 length floor and the
+    explicit UUID-shape allowlist, so the scan must stay silent.
+    """
+    payload = '{"artifactId":"06f0c5bd-108f-4c8b-8911-34b2acc656de"}'
+    assert find_high_entropy_leaks(payload) == []
+    assert is_clean(payload)[0]
+
+
+def test_entropy_scan_ignores_scrub_placeholders() -> None:
+    """Canonical scrub placeholders are never flagged (idempotent validation)."""
+    for placeholder in SCRUB_PLACEHOLDERS:
+        payload = f'{{"field":"{placeholder}"}}'
+        assert find_high_entropy_leaks(payload) == [], placeholder
+
+
+def test_entropy_scan_ignores_short_token() -> None:
+    """A token below the 40-char base64 length floor is not flagged."""
+    payload = '{"x":"abcdef1234567890ABCDEF"}'  # 22 chars, high entropy
+    assert find_high_entropy_leaks(payload) == []
+
+
+def test_entropy_scan_ignores_unquoted_high_entropy_content() -> None:
+    """High-entropy content that is NOT a quoted scalar is out of scope.
+
+    The scan deliberately anchors on a quoted JSON string scalar — the shape a
+    leaked credential takes in an unknown field — so the legitimate high-entropy
+    text that pervades real cassettes (CSS class runs, base64 query blobs split
+    by ``=``/``&``, hex mind-map data) stays out of scope. This documents that
+    blind spot as a deliberate decision, not an accident.
+    """
+    # Mirrors a real cassette ``context=eJw...`` zlib-base64 query param: the
+    # token is preceded by ``context=`` and is NOT inside quotes.
+    blob = "kJ8sLm2NpQr5TvWxYz0AbCdEfGhIjKlMnOpQrStUvWxYz12345678AbCdEf"
+    assert find_high_entropy_leaks(f"context={blob}&next=1") == []
+
+
+def test_all_committed_cassettes_pass_entropy_scan() -> None:
+    """ZERO false positives: every committed cassette passes the entropy scan.
+
+    Calibration guard. The thresholds are tuned against the real corpus; if a
+    future cassette legitimately carries a quoted high-entropy scalar this test
+    fails loudly so the threshold/allowlist is revisited deliberately rather
+    than the scan silently regressing into noise.
+    """
+    cassette_dir = REPO_ROOT / "tests" / "cassettes"
+    offenders: list[str] = []
+    for cassette in sorted(cassette_dir.rglob("*.yaml")):
+        # ``examples/`` holds illustrative fixtures with hand-edited placeholder
+        # content, excluded from the real-recording guard for the same reason
+        # the checker excludes them.
+        if "examples" in cassette.parts:
+            continue
+        text = cassette.read_text(encoding="utf-8", errors="replace")
+        leaks = find_high_entropy_leaks(text)
+        if leaks:
+            offenders.append(f"{cassette.name}: {leaks[:3]}")
+    assert not offenders, "entropy scan false-positives on committed cassettes:\n" + "\n".join(
+        offenders
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add `find_high_entropy_leaks()` to `tests/cassette_patterns.py`: a generic, field-agnostic credential scan that flags a quoted JSON string scalar whose entire value is one long, high-entropy base64url/hex token — regardless of the field name carrying it. Wired into both `is_clean` (full cassette scan) and the `--secrets-only` `find_credential_leaks` path (fixture scan). Plus a `KNOWN-SHAPE BOUNDARY` comment block that documents the residual-risk decision, and unit + lint positive-control tests.

## Why

The cassette guard's existing detectors are **name-anchored** (cookie names, WIZ field IDs) or **known-shape** (`g.a000-` / `sidts-` / `ya29.` / `AIza` prefixes). That makes it **necessary-but-not-sufficient**: a NOVEL credential shape, or a known secret riding in an un-targeted JSON field, passes the targeted detectors silently. This is not hypothetical — the guard has missed two such shapes historically (the `LSID` cookie whose name was off the allowlist, and the `JrWMbf` WIZ field whose API key the name-anchored scrubbers skipped); #1372 fixed a double-encoded-email shape after it leaked the maintainer's address. Each prior fix extended the known-shape set by exactly one entry — reactive, after-the-leak. This adds the generic "would have caught it" backstop the targeted detectors lack. Relates to ADR-0006.

## How

- **Scoped to a quoted JSON string scalar** on purpose. Committed cassettes are dense with legitimate high-entropy text — minified CSS class names, `fonts.gstatic.com` / `googleusercontent.com` URLs, 1.5 KB hex mind-map blobs, 600-char `context=eJw…` zlib-base64 query params. A raw per-token entropy scan would drown in thousands of those false positives. But NONE of that legitimate content appears as a clean quoted JSON scalar (`"field":"<one-pure-token>"`) — which is exactly the shape a leaked credential takes when it rides in an unknown field. Anchoring on that shape is what makes ZERO false positives across every committed cassette achievable while still catching a planted novel token. The blind spot (non-quoted high-entropy text) is therefore a documented, deliberate decision, covered by GitHub secret-scanning + the name-anchored detectors.
- **Thresholds** (calibrated against the real corpus): base64/mixed-alphabet tokens need `len >= 40` AND Shannon entropy `>= 4.0` bits/char; pure-hex tokens use a dedicated `len >= 64` floor because a 16-symbol alphabet caps Shannon entropy at `log2(16) = 4.0`, so a hex secret can never reliably clear the 4.0 bar.
- **Allowlist**: canonical `SCRUB_PLACEHOLDERS` sentinels (idempotent validation) and the UUID shape (`8-4-4-4-12`) — internal NotebookLM artifact/source/conversation IDs the scrubbers deliberately preserve.

## Verification

- ZERO false positives: `--strict --recursive` over all 103 committed cassettes is clean; `--secrets-only --recursive` over the entire `tests/` tree (161 files incl. golden JSON/HTML fixtures) is clean.
- A planted novel base64 token AND a planted 64-char hex token in an unknown field ARE caught (unit tests + a new lint positive control `test_guard_detects_novel_high_entropy_token`).
- Negative controls pinned: UUIDs, scrub placeholders, short tokens, and unquoted high-entropy blobs are NOT flagged.
- `ruff format` + `ruff check` clean; `mypy src/notebooklm` clean; full `tests/unit/` + `tests/_lint/` green (7395 passed).

Closes #1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection expanded to flag novel high-entropy tokens (base64-like and long hex) found in unknown JSON fields, reducing missed secret shapes.

* **Tests**
  * Added positive-control and unit tests to validate entropy-based detection and ensure existing cassette files produce zero false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->