### PR TITLE
refactor(settings): route language parser through safe_index per-site (closes #1395)

### DIFF
--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -89,7 +89,11 @@ def _extract_language(
     block = safe_index(data, *required_prefix, method_id=method_id, source=source)
     result: Any = block
     for idx in optional_tail:
-        if not isinstance(result, list) or idx >= len(result):
+        # Bound-check both ends: ``idx >= len`` guards the trailing-optional
+        # absence; ``idx < 0`` guards against a negative index silently
+        # wrapping to Python's from-the-end semantics for any future caller
+        # (today's tails are hardcoded non-negative tuples).
+        if not isinstance(result, list) or not 0 <= idx < len(result):
             return None
         result = result[idx]
     return result or None

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from ._runtime.contracts import RpcCaller
-from .rpc import RPCMethod
+from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, AccountTier
 
 logger = logging.getLogger(__name__)
@@ -45,23 +45,54 @@ def build_get_user_tier_params() -> list[Any]:
     ]
 
 
-def _extract_nested_value(data: list | None, path: Sequence[int]) -> str | None:
-    """Extract a value from nested lists by following an index path.
+def _extract_language(
+    data: list | None,
+    required_prefix: Sequence[int],
+    optional_tail: Sequence[int],
+    *,
+    method_id: str | int | None,
+    source: str,
+) -> str | None:
+    """Extract the output-language code from a settings RPC response.
+
+    The descent is split into two regimes, per ADR-011 (schema-validation
+    policy) and the ``_notebooks._extract_suggested_topics`` precedent for a
+    routinely-optional trailing slot:
+
+    1. ``required_prefix`` walks the *always-present* settings envelope down to
+       the settings-flags block (``result[0][2]`` for GET, ``result[2]`` for
+       SET). This block is structurally mandatory in every healthy response, so
+       it goes through :func:`safe_index`: genuine schema drift in the envelope
+       raises :class:`UnknownRPCMethodError` rather than silently degrading to
+       ``None``.
+    2. ``optional_tail`` walks the *optional* language slot inside that block
+       (index ``[4]``, then the ``[0]`` unwrap of its ``["code"]`` wrapper). A
+       user who never set a language legitimately has an empty/absent language
+       slot, and that absence is **not distinguishable from drift at that exact
+       position** — a trailing-optional element omitted when unset looks
+       identical to a block that drifted shorter. So the tail uses a plain
+       bounded guard that degrades to ``None`` on any absence/empty/non-list,
+       preserving the optional-language contract (must return ``None``, never
+       raise).
 
     Args:
         data: The nested list structure to extract from.
-        path: Sequence of indices to follow (e.g., [2, 4, 0] for data[2][4][0]).
+        required_prefix: Indices descending the mandatory settings envelope.
+        optional_tail: Indices descending the optional language slot.
+        method_id: RPC method ID, threaded into :func:`safe_index` diagnostics.
+        source: Caller label for :func:`safe_index` drift diagnostics.
 
     Returns:
-        The extracted string value, or None if the path is invalid or value is empty.
+        The language code, or ``None`` when the language is unset/empty. Raises
+        :class:`UnknownRPCMethodError` only on genuine envelope drift.
     """
-    try:
-        result = data
-        for idx in path:
-            result = result[idx]  # type: ignore[index]
-        return result or None  # type: ignore[return-value]
-    except (TypeError, IndexError):
-        return None
+    block = safe_index(data, *required_prefix, method_id=method_id, source=source)
+    result: Any = block
+    for idx in optional_tail:
+        if not isinstance(result, list) or idx >= len(result):
+            return None
+        result = result[idx]
+    return result or None
 
 
 def _extract_nested_list(data: list | None, path: Sequence[int]) -> list[Any] | None:
@@ -137,9 +168,18 @@ class SettingsAPI:
             await client.settings.set_output_language("zh_Hans")
     """
 
-    # Response paths for extracting language code from different RPC responses
-    _SET_LANGUAGE_PATH = (2, 4, 0)  # result[2][4][0]
-    _GET_SETTINGS_PATH = (0, 2, 4, 0)  # result[0][2][4][0]
+    # Response paths for extracting the language code from settings RPC
+    # responses, split into a mandatory envelope prefix (routed through
+    # ``safe_index`` — raises on drift) and an optional language tail (plain
+    # guard — degrades to ``None`` when the user has no language set). See
+    # ``_extract_language`` for the ADR-011 rationale behind the split.
+    #
+    # SET_USER_SETTINGS shape: result[2][4][0]   (flags block at result[2])
+    _SET_LANGUAGE_PREFIX = (2,)
+    _SET_LANGUAGE_TAIL = (4, 0)
+    # GET_USER_SETTINGS shape: result[0][2][4][0] (flags block at result[0][2])
+    _GET_SETTINGS_PREFIX = (0, 2)
+    _GET_SETTINGS_TAIL = (4, 0)
 
     def __init__(self, rpc: RpcCaller) -> None:
         """Initialize the settings API.
@@ -182,7 +222,13 @@ class SettingsAPI:
             source_path="/",
         )
 
-        current_language = _extract_nested_value(result, self._SET_LANGUAGE_PATH)
+        current_language = _extract_language(
+            result,
+            self._SET_LANGUAGE_PREFIX,
+            self._SET_LANGUAGE_TAIL,
+            method_id=RPCMethod.SET_USER_SETTINGS.value,
+            source="_settings.set_output_language",
+        )
         self._log_language_result(current_language, "Output language is now")
         return current_language
 
@@ -203,7 +249,13 @@ class SettingsAPI:
             source_path="/",
         )
 
-        current_language = _extract_nested_value(result, self._GET_SETTINGS_PATH)
+        current_language = _extract_language(
+            result,
+            self._GET_SETTINGS_PREFIX,
+            self._GET_SETTINGS_TAIL,
+            method_id=RPCMethod.GET_USER_SETTINGS.value,
+            source="_settings.get_output_language",
+        )
         self._log_language_result(current_language, "Current output language")
         return current_language
 

--- a/tests/integration/test_settings_integration.py
+++ b/tests/integration/test_settings_integration.py
@@ -15,6 +15,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
+from notebooklm.exceptions import UnknownRPCMethodError
 from notebooklm.rpc import RPCMethod
 
 pytestmark = pytest.mark.allow_no_vcr
@@ -114,12 +115,22 @@ class TestSettingsAPI:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_output_language_returns_none_on_malformed_response(
+    async def test_get_output_language_returns_none_when_language_slot_absent(
         self, httpx_mock: HTTPXMock, auth_tokens, build_rpc_response
     ):
-        """Test getting output language returns None on unexpected response structure."""
-        # Malformed response - missing expected structure
-        response_data = [[None, None]]  # Missing settings element
+        """An intact envelope whose flags block omits the trailing language slot.
+
+        The mandatory envelope (``result[0][2]``) is present; only the optional
+        language slot ([4]) is absent — the legitimate "user never set a
+        language" shape. This must degrade to ``None``, not raise.
+        """
+        response_data = [
+            [
+                None,
+                [100, 50, 10],
+                [True, None, None, True],  # flags block present, language slot omitted
+            ]
+        ]
         response = build_rpc_response(RPCMethod.GET_USER_SETTINGS, response_data)
         httpx_mock.add_response(content=response.encode())
 
@@ -127,6 +138,24 @@ class TestSettingsAPI:
             result = await client.settings.get_output_language()
 
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_output_language_raises_on_envelope_drift(
+        self, httpx_mock: HTTPXMock, auth_tokens, build_rpc_response
+    ):
+        """Genuine drift in the mandatory settings envelope raises (ADR-011).
+
+        ``[[None, None]]`` has no flags block at ``result[0][2]`` — the
+        structurally-mandatory envelope moved, so this is real schema drift and
+        surfaces as ``UnknownRPCMethodError`` rather than a silent ``None``.
+        """
+        response_data = [[None, None]]  # Missing settings/flags element
+        response = build_rpc_response(RPCMethod.GET_USER_SETTINGS, response_data)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(UnknownRPCMethodError):
+                await client.settings.get_output_language()
 
     @pytest.mark.asyncio
     async def test_get_account_limits(self, httpx_mock: HTTPXMock, auth_tokens, build_rpc_response):

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -6,11 +6,13 @@ import pytest
 
 from notebooklm._settings import (
     SettingsAPI,
+    _extract_language,
     build_get_user_settings_params,
     build_get_user_tier_params,
     extract_account_limits,
     extract_account_tier,
 )
+from notebooklm.exceptions import UnknownRPCMethodError
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import AccountLimits, AccountTier
 
@@ -199,3 +201,178 @@ async def test_get_account_tier_calls_user_tier_rpc():
         ],
         source_path="/",
     )
+
+
+# ---------------------------------------------------------------------------
+# Language extraction: optional-slot (None) vs envelope drift (raise).
+#
+# Wire shapes recorded against the live API (tests/cassettes/settings_*):
+#   GET_USER_SETTINGS inner: [[null,[..limits..],[true,null,null,true,["fr"]],
+#                             [[1]],[true,1,3,2]]]   -> language at [0][2][4][0]
+#   SET_USER_SETTINGS inner: [null,[..limits..],[true,null,null,true,["en"]],
+#                             [[1]],[true,1,3,2]]    -> language at [2][4][0]
+# The settings-flags block (GET [0][2] / SET [2]) is structurally mandatory;
+# the language slot ([4], then the ["code"] unwrap [0]) is routinely optional.
+# ---------------------------------------------------------------------------
+
+_GET_WIRE_PREFIX = (0, 2)
+_GET_WIRE_TAIL = (4, 0)
+_SET_WIRE_PREFIX = (2,)
+_SET_WIRE_TAIL = (4, 0)
+
+
+def _get_response(flags_block):
+    """Wrap a settings-flags block in the GET_USER_SETTINGS envelope."""
+    return [[None, [6, 500, 300, 500000], flags_block, [[1]], [True, 1, 3, 2]]]
+
+
+def _set_response(flags_block):
+    """Wrap a settings-flags block in the SET_USER_SETTINGS envelope."""
+    return [None, [6, 500, 300, 500000], flags_block, [[1]], [True, 1, 3, 2]]
+
+
+def test_extract_language_returns_code_from_get_wire_shape():
+    response = _get_response([True, None, None, True, ["fr"]])
+
+    assert (
+        _extract_language(
+            response,
+            _GET_WIRE_PREFIX,
+            _GET_WIRE_TAIL,
+            method_id="ZwVcOc",
+            source="test",
+        )
+        == "fr"
+    )
+
+
+def test_extract_language_returns_code_from_set_wire_shape():
+    response = _set_response([True, None, None, True, ["en"]])
+
+    assert (
+        _extract_language(
+            response,
+            _SET_WIRE_PREFIX,
+            _SET_WIRE_TAIL,
+            method_id="hT54vc",
+            source="test",
+        )
+        == "en"
+    )
+
+
+@pytest.mark.parametrize(
+    "flags_block",
+    [
+        [True, None, None, True, [""]],  # empty language code (user reset to default)
+        [True, None, None, True, []],  # empty language wrapper
+        [True, None, None, True],  # language slot omitted (trailing-optional absent)
+        [True],  # heavily truncated flags block
+        [],  # empty flags block
+    ],
+    ids=["empty-code", "empty-wrapper", "slot-absent", "truncated", "empty-block"],
+)
+def test_extract_language_legitimate_absent_returns_none(flags_block):
+    """A user with no language set yields ``None`` (must not raise).
+
+    The optional language slot ([4] + its [0] unwrap) lives at the tail of an
+    otherwise-intact envelope; its absence is indistinguishable from drift at
+    that exact position, so it degrades to ``None`` per the optional-language
+    contract.
+    """
+    assert (
+        _extract_language(
+            _get_response(flags_block),
+            _GET_WIRE_PREFIX,
+            _GET_WIRE_TAIL,
+            method_id="ZwVcOc",
+            source="test",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,  # no payload at all
+        [],  # empty GET envelope (no result[0])
+        [None],  # result[0] present but result[0][2] (flags block) missing
+        [[None, [6, 500, 300, 500000]]],  # envelope truncated before flags block
+        [42],  # result[0] is a non-subscriptable scalar
+    ],
+    ids=["none", "empty", "no-flags-block", "truncated-envelope", "scalar-inner"],
+)
+def test_extract_language_envelope_drift_raises(response):
+    """Genuine drift in the mandatory settings envelope raises, not silent None.
+
+    The envelope prefix (GET ``result[0][2]``) is structurally mandatory in
+    every healthy response, so descent failure there is real schema drift and
+    surfaces as :class:`UnknownRPCMethodError` rather than degrading to ``None``.
+    """
+    with pytest.raises(UnknownRPCMethodError):
+        _extract_language(
+            response,
+            _GET_WIRE_PREFIX,
+            _GET_WIRE_TAIL,
+            method_id="ZwVcOc",
+            source="test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_output_language_returns_code_from_wire_shape():
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(
+        rpc_call=AsyncMock(return_value=_get_response([True, None, None, True, ["zh_Hans"]]))
+    )
+    api = SettingsAPI(core.rpc_executor)
+
+    assert await api.get_output_language() == "zh_Hans"
+
+
+@pytest.mark.asyncio
+async def test_get_output_language_absent_language_returns_none():
+    """End-to-end: a user with no language set gets ``None`` (no raise)."""
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=_get_response([True, None, None, True])))
+    api = SettingsAPI(core.rpc_executor)
+
+    assert await api.get_output_language() is None
+
+
+@pytest.mark.asyncio
+async def test_get_output_language_envelope_drift_raises():
+    """End-to-end: mandatory-envelope drift surfaces as a typed error."""
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[None]))
+    api = SettingsAPI(core.rpc_executor)
+
+    with pytest.raises(UnknownRPCMethodError):
+        await api.get_output_language()
+
+
+@pytest.mark.asyncio
+async def test_set_output_language_returns_confirmed_code():
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(
+        rpc_call=AsyncMock(return_value=_set_response([True, None, None, True, ["en"]]))
+    )
+    api = SettingsAPI(core.rpc_executor)
+
+    assert await api.set_output_language("en") == "en"
+
+
+@pytest.mark.asyncio
+async def test_set_output_language_absent_confirmation_returns_none():
+    """If the SET response omits the language slot, return ``None`` (no raise)."""
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=_set_response([True, None, None, True])))
+    api = SettingsAPI(core.rpc_executor)
+
+    assert await api.set_output_language("en") is None

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -292,6 +292,28 @@ def test_extract_language_legitimate_absent_returns_none(flags_block):
     )
 
 
+def test_extract_language_tail_negative_index_returns_none():
+    """A negative tail index degrades to ``None`` rather than from-the-end wrapping.
+
+    The tail loop bound-checks both ends, so a hypothetical future caller
+    passing a negative index can't silently read from the end of a list.
+    """
+    # Flags block has a populated [4] slot; a negative tail index must still
+    # not wrap around to it.
+    response = _get_response([True, None, None, True, ["fr"]])
+
+    assert (
+        _extract_language(
+            response,
+            _GET_WIRE_PREFIX,
+            (-1, 0),
+            method_id="ZwVcOc",
+            source="test",
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     "response",
     [
@@ -316,6 +338,32 @@ def test_extract_language_envelope_drift_raises(response):
             _GET_WIRE_PREFIX,
             _GET_WIRE_TAIL,
             method_id="ZwVcOc",
+            source="test",
+        )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,  # no payload at all
+        [],  # empty SET envelope (no result[2])
+        [None, [6, 500, 300, 500000]],  # truncated before the flags block at [2]
+        42,  # non-subscriptable scalar payload
+    ],
+    ids=["none", "empty", "truncated-envelope", "scalar"],
+)
+def test_extract_language_set_prefix_envelope_drift_raises(response):
+    """Drift in the SET envelope prefix (``result[2]``) raises, like the GET path.
+
+    The SET response has a shorter mandatory prefix (``(2,)`` vs GET's
+    ``(0, 2)``); this pins that its drift surfaces as a typed error too.
+    """
+    with pytest.raises(UnknownRPCMethodError):
+        _extract_language(
+            response,
+            _SET_WIRE_PREFIX,
+            _SET_WIRE_TAIL,
+            method_id="hT54vc",
             source="test",
         )
 


### PR DESCRIPTION
## What

Converges `_settings.py`'s output-language parser onto `rpc/_safe_index.safe_index()` **per-site**, splitting the descent into a mandatory envelope prefix (raises on drift) and an optional language tail (degrades to `None`). Replaces the legacy `_extract_nested_value` blanket `for idx in path: result = result[idx]` + `try/except -> None` loop with a regime-aware `_extract_language` helper.

## Why

`_settings.py` was on the #1389 (positional-RPC decode burndown) checklist but the #1389 AST gate never flagged it: its parser walked a `Sequence[int]` path in a loop, not literal chained subscripts. It was deliberately left unconverted because a **blanket** `safe_index` conversion would make the legitimately-absent language slot **raise**, regressing the optional-language contract (a user who never set a language must get `None`).

The issue is an **investigate-then-decide** task. The decision: **convert per-site** (the issue's "if distinguishable" branch), because the wire evidence shows the descent is cleanly splittable.

### Wire-shape evidence (`tests/cassettes/settings_*`)

```
GET_USER_SETTINGS inner: [[null,[..limits..],[true,null,null,true,["fr"]],[[1]],[true,1,3,2]]]
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ flags block      -> language at [0][2][4][0]
SET_USER_SETTINGS inner:  [null,[..limits..],[true,null,null,true,["en"]],[[1]],[true,1,3,2]]
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ flags block      -> language at [2][4][0]
```

- The **settings-flags block** (GET `result[0][2]` / SET `result[2]`) is structurally mandatory in every healthy response — drift there is genuine schema drift and is **observable/distinguishable**.
- The **language slot** (`[4]`, then the `["code"]` unwrap `[0]`) is a **routinely-optional trailing element**. A user with no language has it empty/absent — indistinguishable from drift *at that exact position* — so it must degrade to `None`.

The original author documented exactly this: *"The API can return an empty string for the language code, which we treat as None."*

## How

`_extract_language(data, required_prefix, optional_tail, *, method_id, source)`:
1. `required_prefix` (GET `(0, 2)` / SET `(2,)`) descends the mandatory envelope via `safe_index` -> raises `UnknownRPCMethodError` on genuine drift (ADR-011).
2. `optional_tail` (`(4, 0)`) walks the optional language slot with a plain bounded guard -> degrades to `None` on absence/empty/non-list.

This mirrors the established `_notebooks._extract_suggested_topics` precedent (`safe_index` for mandatory descent + plain guard for a routinely-optional trailing slot).

**Behavior preservation:** the legitimate-absent language path returns `None` exactly as today. The *only* behavior change is that genuine envelope drift now raises instead of silently returning `None` — precisely the ADR-011 intent ("empty payload still produces an empty value; drift now produces an exception").

## Verification

- `uv run pytest tests/unit/test_user_settings_api.py` — green (41 passed); new tests prove **both** contracts: legitimate-absent (5 absence shapes) -> `None`; envelope drift (4 shapes) -> raises, plus end-to-end `get`/`set` cases.
- Integration: the pre-existing `..._returns_none_on_malformed_response` test (fed a flags-block-less envelope, asserted `None`) is split into a legitimate-trailing-absent -> `None` case and an envelope-drift -> raises case in `tests/integration/test_settings_integration.py`.
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean (196 files).
- `uv run ruff format --check` + `ruff check` — clean.
- `tests/_lint/test_module_size_ratchet.py` — `_settings.py` at 309 LOC, well under the 900 budget.
- Full `tests/unit` + `tests/integration` + `tests/_lint` suites green; all 155 language/settings-related tests pass.

Closes #1395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for extracting the configured output language and for handling missing or truncated language slots.
  * Added integration and unit tests to validate correct behavior when response envelopes are malformed or incomplete.

* **Refactor**
  * More robust handling of output-language retrieval: returns the detected language code, degrades to None when legitimately absent, and surfaces errors on unexpected response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->