### PR TITLE
arch(ADR-0008): tighten boundary scanner to level-3 + invert login DAG reach-ins (closes #1393)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,7 @@ src/notebooklm/
         │   ├── cookie_writes.py
         │   ├── exceptions.py
         │   ├── firefox_accounts.py
+        │   ├── io_seam.py        # Caller-injected LoginIO Protocol + resolver (#1393)
         │   ├── outcomes.py
         │   ├── profile_targets.py
         │   ├── refresh.py

--- a/src/notebooklm/cli/playwright_login_io.py
+++ b/src/notebooklm/cli/playwright_login_io.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from .error_handler import exit_with_code
 from .rendering import console
 from .runtime import run_async
+from .services.login.io_seam import set_default_login_io_factory
 from .services.playwright_login import (
     PathError,
     PlaywrightLoginPlan,
@@ -76,6 +77,17 @@ class PlaywrightLoginIO:
 def make_login_io() -> LoginIO:
     """Build the concrete :class:`PlaywrightLoginIO` sink for the login flow."""
     return PlaywrightLoginIO()
+
+
+# Register this concrete sink as the browser-cookie login service's default at
+# import time (#1393). The login DAG (``services/login/*``) inverts its
+# presentation / exit / async reach-ins behind a ``LoginIO`` Protocol and
+# resolves an explicit injected sink first; when none is injected (direct
+# callers, and tests that exercise the service through the command layer) it
+# falls back to this factory so behavior is byte-for-byte identical. Importing
+# this command-layer module is what wires the default — the service never
+# imports across the ADR-0008 boundary itself.
+set_default_login_io_factory(make_login_io)
 
 
 def validate_flags_or_exit(

--- a/src/notebooklm/cli/services/login/browser_accounts.py
+++ b/src/notebooklm/cli/services/login/browser_accounts.py
@@ -37,6 +37,7 @@ from .firefox_accounts import (
     _maybe_warn_firefox_containers_in_use,
     _read_firefox_container_cookies,
 )
+from .io_seam import resolve_login_io
 from .outcomes import (
     BrowserCookieOutcome,
     CookieValidationFailure,
@@ -47,28 +48,18 @@ from .rookiepy_errors import _handle_rookiepy_error
 
 if TYPE_CHECKING:
     from ....auth import Account
+    from .io_seam import LoginIO
 
 
-def _emit_progress(message: str) -> None:
-    """Emit a verbose-mode progress line.
+def _emit_progress(io: LoginIO, message: str) -> None:
+    """Emit a verbose-mode progress line through the caller-injected sink.
 
-    Routed through a module-level seam so the boundary test
-    (:func:`_pattern_a_pairs`) does not see a literal ``console.print``
-    call inside the dispatcher's function body. The seam imports
-    ``rendering.console`` lazily — the rendering module is still a
-    level-3 reach-in from this services-package subdirectory, which the
-    boundary test explicitly does not flag — and forwards the call so
-    text-mode UX is preserved (the "Reading cookies from ..." status
-    line that callers like ``login --browser-cookies chrome`` rely on).
-
-    Future PRs that lift rendering reach-in entirely will replace this
-    with an injected progress callback owned by the command layer; the
-    seam is the minimum change that keeps text-mode behavior identical
-    while moving this module into :data:`GUARDED_PATHS`.
+    Routes the "Reading cookies from ..." status line (byte-for-byte
+    unchanged) through ``io.emit`` so this dispatcher never imports the
+    command layer's ``...rendering`` module (ADR-0008 level-3 boundary,
+    #1393). The command layer supplies the concrete ``console.print`` sink.
     """
-    from ...rendering import console
-
-    console.print(message)
+    io.emit(message)
 
 
 def _enumerate_browser_accounts(
@@ -76,6 +67,7 @@ def _enumerate_browser_accounts(
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
+    io: LoginIO | None = None,
 ) -> tuple[dict[str | None, list[dict[str, Any]]], list[Account]] | BrowserCookieOutcome:
     """Read cookies from ``browser_name`` and discover signed-in accounts.
 
@@ -95,6 +87,9 @@ def _enumerate_browser_accounts(
         include_domains: Forwarded to :func:`_read_browser_cookies` to
             broaden the extraction set with sibling-product cookies. See
             :func:`_parse_include_domains`.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink (resolved
+            to the command-layer default when ``None``) threaded to the
+            chromium / firefox readers for their verbose progress lines.
 
     Returns:
         On success — ``(per_profile_cookies, accounts)``:
@@ -113,12 +108,14 @@ def _enumerate_browser_accounts(
         the unknown-browser dispatch); the command layer — or
         ``refresh._exit_on_outcome`` — renders ``outcome.message`` and exits.
     """
+    io = resolve_login_io(io)
     chromium_profiles = _chromium_profiles_module()
 
     scoped_chromium = _split_chromium_profile_browser_spec(browser_name)
     if scoped_chromium is not None:
         scoped_browser, profile_selector = scoped_chromium
         scoped_result = _read_chromium_profile_cookies_from_selector(
+            io,
             scoped_browser,
             profile_selector,
             verbose=verbose,
@@ -131,6 +128,7 @@ def _enumerate_browser_accounts(
             raw_cookies,
             profile.browser,
             browser_profile=profile.directory_name,
+            io=io,
         )
         if isinstance(result, BrowserCookieOutcome):
             return result
@@ -143,6 +141,7 @@ def _enumerate_browser_accounts(
         profiles = chromium_profiles.discover_chromium_profiles(browser_name)
         if len(profiles) > 1:
             return _enumerate_chromium_profiles_fanout(
+                io,
                 browser_name,
                 profiles,
                 verbose=verbose,
@@ -150,11 +149,11 @@ def _enumerate_browser_accounts(
             )
 
     cookies_result = _read_browser_cookies(
-        browser_name, verbose=verbose, include_domains=include_domains
+        browser_name, verbose=verbose, include_domains=include_domains, io=io
     )
     if isinstance(cookies_result, BrowserCookieOutcome):
         return cookies_result
-    enum_result = _enumerate_one_jar(cookies_result, browser_name, browser_profile=None)
+    enum_result = _enumerate_one_jar(cookies_result, browser_name, browser_profile=None, io=io)
     if isinstance(enum_result, BrowserCookieOutcome):
         return enum_result
     return {None: cookies_result}, enum_result
@@ -165,6 +164,7 @@ def _read_browser_cookies(
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
+    io: LoginIO | None = None,
 ) -> list[dict[str, Any]] | BrowserCookieOutcome:
     """Load Google cookies from an installed browser via rookiepy.
 
@@ -186,6 +186,9 @@ def _read_browser_cookies(
             extraction set with sibling-product cookies. ``None`` (the
             default) keeps the extraction tight to
             :data:`REQUIRED_COOKIE_DOMAINS`.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink (resolved
+            to the command-layer default when ``None``) threaded to the
+            firefox / chromium readers and used for the verbose progress line.
 
     Returns:
         On success — raw cookie dicts as returned by rookiepy (or by the
@@ -198,6 +201,7 @@ def _read_browser_cookies(
         (rookiepy not installed, empty Firefox container spec, or read
         failure surfaced by :func:`_handle_rookiepy_error`).
     """
+    io = resolve_login_io(io)
     # Firefox container syntax: ``firefox::<name>`` or ``firefox::none``.
     # Routed to a direct sqlite3 reader because rookiepy does not honor
     # ``originAttributes`` — see issue #367.
@@ -215,13 +219,14 @@ def _read_browser_cookies(
                 ),
             )
         return _read_firefox_container_cookies(
-            container_spec, verbose=verbose, include_domains=include_domains
+            io, container_spec, verbose=verbose, include_domains=include_domains
         )
 
     scoped_chromium = _split_chromium_profile_browser_spec(browser_name)
     if scoped_chromium is not None:
         scoped_browser, profile_selector = scoped_chromium
         scoped_result = _read_chromium_profile_cookies_from_selector(
+            io,
             scoped_browser,
             profile_selector,
             verbose=verbose,
@@ -266,7 +271,8 @@ def _read_browser_cookies(
     if browser_name == "auto":
         if verbose:
             _emit_progress(
-                "[yellow]Reading cookies from installed browser (auto-detect)...[/yellow]"
+                io,
+                "[yellow]Reading cookies from installed browser (auto-detect)...[/yellow]",
             )
         try:
             return rookiepy.load(domains=domains)
@@ -278,7 +284,7 @@ def _read_browser_cookies(
 
     assert canonical is not None
     if verbose:
-        _emit_progress(f"[yellow]Reading cookies from {browser_name}...[/yellow]")
+        _emit_progress(io, f"[yellow]Reading cookies from {browser_name}...[/yellow]")
     browser_fn = getattr(rookiepy, canonical, None)
     if browser_fn is None or not callable(browser_fn):
         return UnsupportedBrowser(
@@ -301,6 +307,6 @@ def _read_browser_cookies(
     # every Multi-Account Container. Skip when ``verbose=False`` so callers
     # like ``auth inspect --json`` don't pollute stdout before their JSON.
     if canonical == "firefox" and verbose:
-        _maybe_warn_firefox_containers_in_use()
+        _maybe_warn_firefox_containers_in_use(io)
 
     return cookies

--- a/src/notebooklm/cli/services/login/chromium_accounts.py
+++ b/src/notebooklm/cli/services/login/chromium_accounts.py
@@ -20,6 +20,7 @@ from .rookiepy_errors import _handle_rookiepy_error
 
 if TYPE_CHECKING:
     from ....auth import Account
+    from .io_seam import LoginIO
 
 # Shared rookiepy-not-installed message — kept identical to the single-jar
 # path (``browser_accounts._read_browser_cookies``) so the user sees the
@@ -33,20 +34,15 @@ _ROOKIEPY_NOT_INSTALLED_MESSAGE = (
 )
 
 
-def _emit_progress(message: str) -> None:
-    """Emit a verbose-mode progress line.
+def _emit_progress(io: LoginIO, message: str) -> None:
+    """Emit a verbose-mode progress line through the caller-injected sink.
 
-    Routed through a module-level seam so the boundary test
-    (:func:`_pattern_a_pairs`) does not see a literal ``console.print``
-    call inside the reader bodies. The seam imports ``rendering.console``
-    lazily — the rendering module is a level-3 reach-in from this
-    services-package subdirectory, which the boundary test explicitly
-    does not flag — and forwards the call so text-mode UX (the "Reading
-    cookies from ..." status lines) is preserved byte-for-byte.
+    Routes the text-mode "Reading cookies from ..." status lines
+    (byte-for-byte unchanged) through ``io.emit`` so this service never
+    imports the command layer's ``...rendering`` module (ADR-0008 level-3
+    boundary, #1393).
     """
-    from ...rendering import console
-
-    console.print(message)
+    io.emit(message)
 
 
 def _chromium_profiles_module() -> Any:
@@ -71,6 +67,7 @@ def _split_chromium_profile_browser_spec(browser_name: str) -> tuple[str, str] |
 
 
 def _read_chromium_profile_cookies_from_selector(
+    io: LoginIO,
     browser_name: str,
     profile_selector: str,
     *,
@@ -83,6 +80,7 @@ def _read_chromium_profile_cookies_from_selector(
     :class:`.outcomes.BrowserCookieOutcome` on failure. The command layer
     (or :func:`refresh._exit_on_outcome`) renders ``outcome.message`` and
     exits; this keeps presentation + exit policy out of ``cli/services``.
+    The ``io`` sink carries the verbose progress line.
     """
     chromium_profiles = _chromium_profiles_module()
 
@@ -94,8 +92,9 @@ def _read_chromium_profile_cookies_from_selector(
     domains = _build_google_cookie_domains(include_domains=include_domains)
     if verbose:
         _emit_progress(
+            io,
             f"[yellow]Reading cookies from {profile.browser} profile "
-            f"'{profile.human_name}' (directory: {profile.directory_name})...[/yellow]"
+            f"'{profile.human_name}' (directory: {profile.directory_name})...[/yellow]",
         )
 
     try:
@@ -114,6 +113,7 @@ def _read_chromium_profile_cookies_from_selector(
 
 
 def _enumerate_chromium_profiles_fanout(
+    io: LoginIO,
     browser_name: str,
     profiles: list[Any],
     *,
@@ -131,7 +131,8 @@ def _enumerate_chromium_profiles_fanout(
     Returns ``(per_profile_cookies, accounts)`` on success, or a
     :class:`.outcomes.BrowserCookieOutcome` on failure. The command layer
     renders ``outcome.message`` and exits — presentation + exit policy stay
-    out of ``cli/services``.
+    out of ``cli/services``. The ``io`` sink carries the verbose progress and
+    per-profile skip/dedupe lines.
     """
     chromium_profiles = _chromium_profiles_module()
 
@@ -140,8 +141,9 @@ def _enumerate_chromium_profiles_fanout(
     if verbose:
         names = ", ".join(f"'{p.human_name}'" for p in profiles)
         _emit_progress(
+            io,
             f"[yellow]Reading cookies from {len(profiles)} {browser_name} "
-            f"user-profiles: {names}[/yellow]"
+            f"user-profiles: {names}[/yellow]",
         )
 
     from ....auth import Account
@@ -169,8 +171,9 @@ def _enumerate_chromium_profiles_fanout(
             read_failures.append((profile.human_name, e))
             if verbose:
                 _emit_progress(
+                    io,
                     f"  [yellow]skipping {browser_name} profile "
-                    f"'{profile.human_name}': {e}[/yellow]"
+                    f"'{profile.human_name}': {e}[/yellow]",
                 )
             continue
 
@@ -181,6 +184,7 @@ def _enumerate_chromium_profiles_fanout(
                 browser_name,
                 browser_profile=profile.directory_name,
                 quiet=True,
+                io=io,
             )
         except httpx.RequestError as e:
             # Network failure — every subsequent profile probe will hit the
@@ -199,7 +203,8 @@ def _enumerate_chromium_profiles_fanout(
             # normal — continue to the next one.
             if verbose:
                 _emit_progress(
-                    f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]"
+                    io,
+                    f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]",
                 )
             continue
         accounts = jar_result
@@ -209,9 +214,10 @@ def _enumerate_chromium_profiles_fanout(
             if account.email in seen_emails:
                 if verbose:
                     _emit_progress(
+                        io,
                         f"  [yellow]warning: {account.email} also appears in "
                         f"'{profile.human_name}'; using cookies from "
-                        f"'{seen_emails[account.email]}'[/yellow]"
+                        f"'{seen_emails[account.email]}'[/yellow]",
                     )
                 continue
             seen_emails[account.email] = profile.directory_name

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -35,7 +35,7 @@ from ....auth import (
     missing_cookies_hint,
     validate_with_recovery,
 )
-from ...runtime import run_async
+from .io_seam import resolve_login_io
 from .outcomes import (
     BrowserCookieOutcome,
     CookieValidationFailure,
@@ -45,6 +45,7 @@ from .outcomes import (
 
 if TYPE_CHECKING:
     from ....auth import Account
+    from .io_seam import LoginIO
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ def _enumerate_one_jar(
     browser_profile: str | None,
     *,
     quiet: bool = False,
+    io: LoginIO | None = None,
 ) -> list[Account] | BrowserCookieOutcome:
     """Probe ``?authuser=N`` against one cookie set and return tagged Accounts.
 
@@ -87,6 +89,10 @@ def _enumerate_one_jar(
         browser_name: The browser the cookies came from (for error messages).
         browser_profile: Tag attached to each Account (``"Default"``,
             ``"Profile 1"``, ...) or ``None`` for the legacy single-jar path.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink (resolved
+            to the command-layer default when ``None``) whose ``run_async``
+            drives the synchronous account-enumeration probe. This module owns
+            no presentation/exit — only the async bridge.
         quiet: Suppress the loud multi-line user-facing message body in the
             returned outcome (the fan-out caller prints its own per-profile
             soft note for signed-out / stale-cookie profiles and would
@@ -122,6 +128,7 @@ def _enumerate_one_jar(
         extract_cookies_with_domains,
     )
 
+    io = resolve_login_io(io)
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
         if quiet:
@@ -143,7 +150,7 @@ def _enumerate_one_jar(
     cookie_map = extract_cookies_with_domains(storage_state)
     jar = build_cookie_jar(cookies=cookie_map)
     try:
-        accounts = run_async(enumerate_accounts(jar))
+        accounts = io.run_async(enumerate_accounts(jar))
     except ValueError:
         # Cookies are present but Google rejected them (passive sign-in
         # redirected to the account chooser, or RotateCookies returned 401).

--- a/src/notebooklm/cli/services/login/cookie_writes.py
+++ b/src/notebooklm/cli/services/login/cookie_writes.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -41,17 +41,24 @@ from .outcomes import (
     CookieValidationFailure,
 )
 
+if TYPE_CHECKING:
+    from .io_seam import LoginIO
+
 logger = logging.getLogger(__name__)
 
 
-def _emit_warning(message: str) -> None:
-    """Render a nonfatal text-mode warning while keeping failure paths typed."""
-    from ...rendering import console
+def _emit_warning(io: LoginIO, message: str) -> None:
+    """Render a nonfatal text-mode warning through the caller-injected sink.
 
-    console.print(message)
+    Routes the warning line through ``io.emit`` so this service never imports
+    the command layer's ``...rendering`` module (ADR-0008 level-3 boundary,
+    #1393), while keeping the failure paths typed (outcomes, not exits).
+    """
+    io.emit(message)
 
 
 def _select_account(
+    io: LoginIO,
     accounts: list[Any],
     *,
     account_email: str | None,
@@ -65,7 +72,8 @@ def _select_account(
     :class:`.outcomes.CookieValidationFailure` outcome with a
     human-readable message when no accounts were discovered or the
     requested email is absent. The default-account fallback still emits
-    the legacy nonfatal warning and then returns the first account.
+    the legacy nonfatal warning (via the injected ``io`` sink) and then
+    returns the first account.
     """
     if not accounts:
         return CookieValidationFailure(
@@ -96,8 +104,9 @@ def _select_account(
     # No default marker — fall back to the first account. This is a
     # nonfatal success-path warning, so keep the previous text-mode output.
     _emit_warning(
+        io,
         "[yellow]Warning: Browser account list did not mark a default account; "
-        f"using {accounts[0].email}.[/yellow]"
+        f"using {accounts[0].email}.[/yellow]",
     )
     logger.warning(
         "Browser account list did not mark a default account; using %s.",
@@ -170,6 +179,7 @@ def _select_refresh_account(
 
 
 def _write_extracted_cookies(
+    io: LoginIO,
     raw_cookies: list[dict[str, Any]],
     *,
     storage_path: Path,
@@ -188,11 +198,10 @@ def _write_extracted_cookies(
     :class:`.outcomes.BrowserCookieOutcome` subclass on failure
     (validation failure or disk-write failure). The success-path
     confirmation print is emitted by the caller; nonfatal metadata and
-    verification warnings are still rendered here to preserve the
-    historical text-mode behavior.
+    verification warnings are routed through the injected ``io`` sink to
+    preserve the historical text-mode behavior, and ``io.run_async`` drives
+    the cookie-verification probe.
     """
-    from ...runtime import run_async
-
     storage_state, validation_error = validate_with_recovery(raw_cookies)
     if validation_error is not None:
         cookie_names = cookie_names_from_storage(storage_state)
@@ -232,8 +241,9 @@ def _write_extracted_cookies(
         # but preserve the previous user-facing warning text.
         logger.warning("Failed to save account metadata for %s: %s", storage_path, type(e).__name__)
         _emit_warning(
+            io,
             f"[yellow]Warning: cookies saved but account metadata write failed.[/yellow]\n"
-            f"Details: {e}"
+            f"Details: {e}",
         )
 
     # Success-path confirmation print is the caller's job. We log a
@@ -246,13 +256,14 @@ def _write_extracted_cookies(
     # not fatal (the existing behavior warned but did not exit), so we
     # log a WARNING and return None.
     try:
-        run_async(fetch_tokens_with_domains(storage_path, profile))
+        io.run_async(fetch_tokens_with_domains(storage_path, profile))
     except ValueError as e:
         logger.warning("Extracted cookies for %s failed verification: %s", email, e)
-        _emit_warning(f"    [yellow]Warning: cookies for {email} failed verification.[/yellow]")
+        _emit_warning(io, f"    [yellow]Warning: cookies for {email} failed verification.[/yellow]")
     except httpx.RequestError as e:
         logger.warning("Could not verify cookies for %s: %s", email, e)
         _emit_warning(
-            f"    [yellow]Warning: could not verify cookies for {email} (network).[/yellow]"
+            io,
+            f"    [yellow]Warning: could not verify cookies for {email} (network).[/yellow]",
         )
     return None

--- a/src/notebooklm/cli/services/login/firefox_accounts.py
+++ b/src/notebooklm/cli/services/login/firefox_accounts.py
@@ -15,26 +15,26 @@ error printer), and :mod:`.cookie_domains` (domain-list builder).
 from __future__ import annotations
 
 import sqlite3
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .cookie_domains import _build_google_cookie_domains
 from .outcomes import BrowserCookieOutcome, CookieValidationFailure
 from .rookiepy_errors import _handle_rookiepy_error
 
+if TYPE_CHECKING:
+    from .io_seam import LoginIO
 
-def _emit_progress(message: str) -> None:
-    """Emit a verbose-mode progress line through a lazy ``console`` seam.
 
-    Keeps the literal ``console.print`` call out of the reader body (the
-    boundary :func:`_pattern_a_pairs` scanner only flags ``console.print``
-    co-occurring with ``exit_with_code`` in the same function) while
-    preserving the text-mode "Reading cookies from Firefox ..." status
-    lines byte-for-byte. ``rendering`` is a level-3 reach-in the boundary
-    test explicitly does not flag.
+def _emit_progress(io: LoginIO, message: str) -> None:
+    """Emit a verbose-mode progress line through the caller-injected sink.
+
+    Routes the text-mode "Reading cookies from Firefox ..." status lines
+    (byte-for-byte unchanged) through ``io.emit`` so this service never
+    imports the command layer's ``...rendering`` module (ADR-0008 level-3
+    boundary, #1393). The split-helper shape also keeps the literal print
+    call out of any function body that owns exit policy.
     """
-    from ...rendering import console
-
-    console.print(message)
+    io.emit(message)
 
 
 def _firefox_containers_module() -> Any:
@@ -44,6 +44,7 @@ def _firefox_containers_module() -> Any:
 
 
 def _read_firefox_container_cookies(
+    io: LoginIO,
     container_spec: str,
     *,
     verbose: bool = True,
@@ -57,6 +58,8 @@ def _read_firefox_container_cookies(
     helpers in :mod:`notebooklm.cli._firefox_containers`.
 
     Args:
+        io: Caller-injected :class:`.io_seam.LoginIO` sink for the verbose
+            progress line.
         container_spec: The part after ``firefox::`` (e.g. ``"Work"`` or
             ``"none"`` for the no-container default).
         verbose: When False, suppress the progress line; used by
@@ -94,11 +97,12 @@ def _read_firefox_container_cookies(
 
     if verbose:
         if container_id == "none":
-            _emit_progress("[yellow]Reading cookies from Firefox (no container)...[/yellow]")
+            _emit_progress(io, "[yellow]Reading cookies from Firefox (no container)...[/yellow]")
         else:
             _emit_progress(
+                io,
                 f"[yellow]Reading cookies from Firefox container "
-                f"'{container_spec}' (userContextId={container_id})...[/yellow]"
+                f"'{container_spec}' (userContextId={container_id})...[/yellow]",
             )
 
     domains = _build_google_cookie_domains(include_domains=include_domains)
@@ -119,7 +123,7 @@ def _read_firefox_container_cookies(
         )
 
 
-def _maybe_warn_firefox_containers_in_use() -> None:
+def _maybe_warn_firefox_containers_in_use(io: LoginIO) -> None:
     """Emit a one-line warning when unscoped ``firefox`` is risky.
 
     Triggers when ``cookies.sqlite`` has at least one row whose
@@ -138,11 +142,12 @@ def _maybe_warn_firefox_containers_in_use() -> None:
         return
     if firefox_containers.has_container_cookies_in_use(profile_path):
         _emit_progress(
+            io,
             "[yellow]Warning: this Firefox profile has cookies stored inside "
             "a Multi-Account Container, but '--browser-cookies firefox' "
             "merges every container into one jar. If your Google session "
             "lives inside a container, re-run with "
             "[cyan]--browser-cookies 'firefox::<container-name>'[/cyan] "
             "(or [cyan]'firefox::none'[/cyan] for the no-container "
-            "default).[/yellow]"
+            "default).[/yellow]",
         )

--- a/src/notebooklm/cli/services/login/io_seam.py
+++ b/src/notebooklm/cli/services/login/io_seam.py
@@ -1,0 +1,105 @@
+"""Caller-injected IO seam for the browser-cookie login service (#1393).
+
+The browser-cookie login DAG (``refresh`` → ``browser_accounts`` →
+``chromium_accounts`` / ``firefox_accounts`` / ``cookie_writes``) used to
+reach the command layer's presentation (``...rendering``), exit-policy
+(``...error_handler``), and async-runner (``...runtime``) modules directly
+through *level-3* relative imports. Those imports slipped past the ADR-0008
+services-boundary scanner, which only flagged *level-2* (``..rendering``)
+reach-ins (#1391 closed the level-2 gap for ``playwright_login.py``; the
+scanner was tightened to level-3 in #1393).
+
+To stay on the service side of the boundary, the login DAG inverts those side
+effects behind the :class:`LoginIO` Protocol — the *same* structural shape
+#1391 introduced for the Playwright flow (``emit`` / ``fail`` /
+``run_async``). The command layer (:mod:`notebooklm.cli.playwright_login_io`)
+supplies the concrete sink and registers it here as the default factory at
+import time, so:
+
+* Production code (and tests that import the command layer, directly or via the
+  ``cli`` package) gets the real ``console.print`` / ``exit_with_code`` /
+  ``run_async`` sink with byte-for-byte-identical behavior.
+* Service entry points call :func:`resolve_login_io` to accept an explicit
+  injected sink (preferred) or fall back to the registered default factory.
+
+No forbidden ``...rendering`` / ``...error_handler`` / ``...runtime`` import
+lives in this module or any of its peers — the concrete sink that *does* import
+them lives in the (unscanned) command layer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class LoginIO(Protocol):
+    """Caller-injected sink for the browser-cookie login flow's side effects.
+
+    Structurally identical to the Playwright flow's ``LoginIO`` (#1391) so the
+    one concrete command-layer sink
+    (:class:`notebooklm.cli.playwright_login_io.PlaywrightLoginIO`) satisfies
+    both. ``emit`` forwards to ``console.print`` (``*args, **kwargs`` pass
+    through verbatim, incl. ``markup=False``); ``fail`` forwards to
+    ``exit_with_code`` (raises ``SystemExit``); ``run_async`` forwards to
+    ``run_async``.
+    """
+
+    def emit(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def fail(self, code: int) -> NoReturn: ...
+
+    def run_async(self, coro: Awaitable[Any]) -> Any: ...
+
+
+# Default sink factory, registered by the command layer
+# (:mod:`notebooklm.cli.playwright_login_io`) at import time so service entry
+# points that are *not* handed an explicit sink still resolve the real
+# ``console`` / ``exit_with_code`` / ``run_async`` behavior. Kept here (not as a
+# direct import of the command-layer sink) so this services module never
+# reaches across the ADR-0008 boundary.
+_default_io_factory: Callable[[], LoginIO] | None = None
+
+
+def set_default_login_io_factory(factory: Callable[[], LoginIO]) -> None:
+    """Register the command-layer default :class:`LoginIO` sink factory.
+
+    Called once by :mod:`notebooklm.cli.playwright_login_io` at import time.
+    Idempotent: re-registering simply replaces the factory (the command layer
+    only ever registers its single concrete sink).
+    """
+    global _default_io_factory
+    _default_io_factory = factory
+
+
+def resolve_login_io(io: LoginIO | None) -> LoginIO:
+    """Return ``io`` if given, else build one from the registered default factory.
+
+    Service entry points call this so callers may inject a sink explicitly
+    (the preferred shape) while direct callers — and tests that exercise the
+    service through the command layer — still get the real console/exit/async
+    behavior via the factory the command layer registered.
+
+    Raises:
+        RuntimeError: when no sink was injected and no default factory has been
+            registered (i.e. the command layer was never imported). This is a
+            wiring bug, not a user-facing error.
+    """
+    if io is not None:
+        return io
+    if _default_io_factory is None:  # pragma: no cover - defensive wiring guard
+        raise RuntimeError(
+            "No LoginIO sink injected and no default factory registered. "
+            "Import notebooklm.cli.playwright_login_io (the command layer "
+            "registers the default sink) or pass an explicit io= sink."
+        )
+    return _default_io_factory()
+
+
+__all__ = [
+    "LoginIO",
+    "resolve_login_io",
+    "set_default_login_io_factory",
+]

--- a/src/notebooklm/cli/services/login/io_seam.py
+++ b/src/notebooklm/cli/services/login/io_seam.py
@@ -20,11 +20,18 @@ import time, so:
   ``cli`` package) gets the real ``console.print`` / ``exit_with_code`` /
   ``run_async`` sink with byte-for-byte-identical behavior.
 * Service entry points call :func:`resolve_login_io` to accept an explicit
-  injected sink (preferred) or fall back to the registered default factory.
+  injected sink (preferred) or fall back to the default factory. When no sink is
+  injected and no factory has been registered yet (a sink-resolving entry point
+  reached on a path that never imported the command layer — e.g. a bare
+  ``_sync_server_language_to_config()`` call, or a library consumer that
+  imported only ``cli.services.login``), the resolver registers the
+  command-layer default lazily so it never raises and behavior stays the
+  historical default (#1393).
 
 No forbidden ``...rendering`` / ``...error_handler`` / ``...runtime`` import
 lives in this module or any of its peers — the concrete sink that *does* import
-them lives in the (unscanned) command layer.
+them lives in the (unscanned) command layer, which this module pulls in only
+lazily, on the fallback path.
 """
 
 from __future__ import annotations
@@ -74,26 +81,52 @@ def set_default_login_io_factory(factory: Callable[[], LoginIO]) -> None:
     _default_io_factory = factory
 
 
+def _ensure_default_factory_registered() -> None:
+    """Lazily trigger the command-layer default-sink registration.
+
+    Importing :mod:`notebooklm.cli.playwright_login_io` registers the concrete
+    default factory as an import side effect (it calls
+    :func:`set_default_login_io_factory`). Some login flows resolve the sink
+    without going through a driver that already forced that import (e.g. a
+    direct ``_sync_server_language_to_config()`` call, or a library consumer
+    that imported only ``cli.services.login``). Triggering the import here makes
+    :func:`resolve_login_io` robust on every path while keeping the *static*
+    dependency direction clean: this module never imports the command layer at
+    module scope, and the only thing it pulls in is the ADR-0008 sink module
+    (not a presentation / exit / runtime module). Idempotent — once registered,
+    the re-import is a no-op.
+    """
+    # ``...playwright_login_io`` is the command-layer sink module (the ADR-0008
+    # seam), not ``...rendering`` / ``...error_handler`` / ``...runtime``; the
+    # services-boundary scanner permits it. Kept lazy + local so it only fires
+    # on the fallback path. Register ``make_login_io`` explicitly rather than
+    # relying solely on the import side effect, so this self-heals even when the
+    # module was already imported (its import-time registration won't re-run).
+    from ...playwright_login_io import make_login_io
+
+    set_default_login_io_factory(make_login_io)
+
+
 def resolve_login_io(io: LoginIO | None) -> LoginIO:
-    """Return ``io`` if given, else build one from the registered default factory.
+    """Return ``io`` if given, else build one from the default factory.
 
     Service entry points call this so callers may inject a sink explicitly
-    (the preferred shape) while direct callers — and tests that exercise the
-    service through the command layer — still get the real console/exit/async
-    behavior via the factory the command layer registered.
-
-    Raises:
-        RuntimeError: when no sink was injected and no default factory has been
-            registered (i.e. the command layer was never imported). This is a
-            wiring bug, not a user-facing error.
+    (the preferred shape) while direct callers — and tests / library consumers
+    that exercise the service without injecting a sink — still get the real
+    console/exit/async behavior. When no factory has been registered yet (the
+    command layer was never imported on this path), the command-layer default
+    is registered lazily via :func:`_ensure_default_factory_registered` so the
+    resolver never raises and behavior is byte-for-byte the historical default.
     """
     if io is not None:
         return io
+    if _default_io_factory is None:
+        _ensure_default_factory_registered()
     if _default_io_factory is None:  # pragma: no cover - defensive wiring guard
         raise RuntimeError(
-            "No LoginIO sink injected and no default factory registered. "
-            "Import notebooklm.cli.playwright_login_io (the command layer "
-            "registers the default sink) or pass an explicit io= sink."
+            "No LoginIO sink injected and the command-layer default sink could "
+            "not be registered (notebooklm.cli.playwright_login_io import had no "
+            "effect). Pass an explicit io= sink."
         )
     return _default_io_factory()
 

--- a/src/notebooklm/cli/services/login/refresh.py
+++ b/src/notebooklm/cli/services/login/refresh.py
@@ -35,12 +35,10 @@ from ....auth import (
 from ....client import NotebookLMClient
 from ....io import atomic_write_json
 from ....paths import get_storage_path
-from ...error_handler import exit_with_code
 from ...language_cmd import set_language
-from ...rendering import console
-from ...runtime import run_async
 from .browser_accounts import _enumerate_browser_accounts, _read_browser_cookies
 from .cookie_writes import _select_account, _select_refresh_account, _write_extracted_cookies
+from .io_seam import LoginIO, resolve_login_io
 from .outcomes import BrowserCookieOutcome
 from .profile_targets import (
     _profiles_by_account_email,
@@ -59,33 +57,26 @@ ConfirmCallback = Callable[[str], bool]
 logger = logging.getLogger(__name__)
 
 
-def _emit(message: str) -> None:
-    """Emit one Rich-markup line through the ``console`` seam.
+def _emit(io: LoginIO, message: str) -> None:
+    """Emit one Rich-markup line through the caller-injected sink.
 
-    Routing every refresh-driver ``console.print`` through this one-line
-    helper keeps the literal ``console.print`` call out of any function
-    body that also calls ``exit_with_code`` — the ADR-008 boundary scanner
-    (:mod:`tests.unit.cli.test_services_boundary`) flags a service module
-    only when both co-occur inside the *same* function. The split-helper
-    shape is the preferred form the scanner explicitly allows
-    (``test_pattern_a_helper_ignores_split_helpers``) and mirrors the
-    ``_emit_progress`` seam already used by the sibling ``*_accounts``
-    readers. Text-mode UX is byte-for-byte unchanged. ``rendering`` is a
-    level-3 reach-in the boundary import scanner does not flag.
+    Routes every refresh-driver line through ``io.emit`` so this service
+    never imports the command layer's ``...rendering`` module (ADR-0008
+    level-3 boundary, #1393). Text-mode UX is byte-for-byte unchanged.
     """
-    console.print(message)
+    io.emit(message)
 
 
-def _exit_on_outcome(outcome: BrowserCookieOutcome) -> NoReturn:
+def _exit_on_outcome(io: LoginIO, outcome: BrowserCookieOutcome) -> NoReturn:
     """Render a helper-chain failure outcome and exit with code 1.
 
     Implements the text-mode behavior for refresh.py-driven paths: the
-    Rich-markup message is emitted (via the :func:`_emit` seam) and the
-    process exits. The shared rendering boundary for the browser-cookie
-    helper chain's typed outcomes.
+    Rich-markup message is emitted through the injected ``io`` sink and the
+    process exits (``io.fail`` → ``exit_with_code``). The shared rendering
+    boundary for the browser-cookie helper chain's typed outcomes.
     """
-    _emit(outcome.message)
-    exit_with_code(1)
+    _emit(io, outcome.message)
+    io.fail(1)
 
 
 def _login_browser_cookies_single(
@@ -97,6 +88,7 @@ def _login_browser_cookies_single(
     active_profile: str | None,
     include_domains: set[str] | None = None,
     confirm: ConfirmCallback | None = None,
+    io: LoginIO | None = None,
 ) -> None:
     """Extract one account from ``--browser-cookies`` into a profile.
 
@@ -116,7 +108,11 @@ def _login_browser_cookies_single(
             callers. The Click command layer injects ``click.confirm`` at
             the boundary so interactive ``notebooklm login`` runs still
             prompt.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink. When
+            ``None`` (direct callers) the command-layer default factory is
+            resolved so console / exit / async behavior is unchanged.
     """
+    io = resolve_login_io(io)
     explicit_storage = Path(storage) if storage else None
 
     if account_email is None and profile_name is None:
@@ -127,18 +123,21 @@ def _login_browser_cookies_single(
             browser_cookies,
             active_profile,
             include_domains=include_domains,
+            io=io,
         )
         return
 
     # Path 2: targeted extraction. Select the requested browser account, then
     # write it to an explicit destination or to the active profile.
-    enum_result = _enumerate_browser_accounts(browser_cookies, include_domains=include_domains)
+    enum_result = _enumerate_browser_accounts(
+        browser_cookies, include_domains=include_domains, io=io
+    )
     if isinstance(enum_result, BrowserCookieOutcome):
-        _exit_on_outcome(enum_result)
+        _exit_on_outcome(io, enum_result)
     per_profile_cookies, accounts = enum_result
-    selected_or_outcome = _select_account(accounts, account_email=account_email)
+    selected_or_outcome = _select_account(io, accounts, account_email=account_email)
     if isinstance(selected_or_outcome, BrowserCookieOutcome):
-        _exit_on_outcome(selected_or_outcome)
+        _exit_on_outcome(io, selected_or_outcome)
     selected = selected_or_outcome
 
     target_profile: str | None
@@ -155,9 +154,11 @@ def _login_browser_cookies_single(
             profile=storage_profile,
             selected_email=selected.email,
             confirm=confirm,
+            io=io,
         )
 
     write_outcome = _write_extracted_cookies(
+        io,
         per_profile_cookies[selected.browser_profile],
         storage_path=target_storage,
         profile=storage_profile,
@@ -165,8 +166,8 @@ def _login_browser_cookies_single(
         email=selected.email,
     )
     if isinstance(write_outcome, BrowserCookieOutcome):
-        _exit_on_outcome(write_outcome)
-    console.print(f"  [green]✓[/green] {storage_profile or target_storage}  →  {selected.email}")
+        _exit_on_outcome(io, write_outcome)
+    io.emit(f"  [green]✓[/green] {storage_profile or target_storage}  →  {selected.email}")
     _sync_server_language_to_config(storage_path=target_storage, profile=storage_profile)
 
 
@@ -176,6 +177,7 @@ def _confirm_profile_account_overwrite(
     profile: str | None,
     selected_email: str,
     confirm: ConfirmCallback | None = None,
+    io: LoginIO | None = None,
 ) -> None:
     """Prompt before replacing a profile bound to a different Google account.
 
@@ -184,11 +186,14 @@ def _confirm_profile_account_overwrite(
             command layer. Receives the confirmation prompt string and
             returns ``True`` to proceed with overwrite, ``False`` to
             abort (which renders via the :func:`_emit` seam and
-            ``exit_with_code(1)``). When ``None``, the confirmation is
+            ``io.fail(1)``). When ``None``, the confirmation is
             skipped (treated as auto-accept) — used by non-interactive
             callers; production Click commands always inject
             ``click.confirm`` at the boundary so interactive runs prompt.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink; resolved
+            to the command-layer default when ``None``.
     """
+    io = resolve_login_io(io)
     metadata = read_account_metadata(storage_path)
     existing_email = metadata.get("email")
     if isinstance(existing_email, str) and existing_email.strip():
@@ -212,9 +217,10 @@ def _confirm_profile_account_overwrite(
         return
 
     _emit(
-        f"[red]Aborted:[/red] {target} still has {conflict}; not overwriting with {selected_email}."
+        io,
+        f"[red]Aborted:[/red] {target} still has {conflict}; not overwriting with {selected_email}.",
     )
-    exit_with_code(1)
+    io.fail(1)
 
 
 def _login_all_accounts_from_browser(
@@ -222,6 +228,7 @@ def _login_all_accounts_from_browser(
     *,
     update: bool = False,
     include_domains: set[str] | None = None,
+    io: LoginIO | None = None,
 ) -> None:
     """Extract every signed-in Google account into its own profile.
 
@@ -237,18 +244,23 @@ def _login_all_accounts_from_browser(
             for users who hand-created profiles via plain ``notebooklm
             login --profile NAME`` before extending to ``--all-accounts``.
         include_domains: Forwarded to :func:`_enumerate_browser_accounts`.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink; resolved
+            to the command-layer default when ``None``.
     """
     from ....paths import list_profiles
 
-    enum_result = _enumerate_browser_accounts(browser_cookies, include_domains=include_domains)
+    io = resolve_login_io(io)
+    enum_result = _enumerate_browser_accounts(
+        browser_cookies, include_domains=include_domains, io=io
+    )
     if isinstance(enum_result, BrowserCookieOutcome):
-        _exit_on_outcome(enum_result)
+        _exit_on_outcome(io, enum_result)
     per_profile_cookies, accounts = enum_result
     if not accounts:
-        console.print("[yellow]No accounts discovered.[/yellow]")
+        io.emit("[yellow]No accounts discovered.[/yellow]")
         return
 
-    console.print(f"\n[bold]Found {len(accounts)} accounts.[/bold] Saving profiles:")
+    io.emit(f"\n[bold]Found {len(accounts)} accounts.[/bold] Saving profiles:")
     # Reuse a profile when its account metadata already points at the same
     # email. This makes repeated --all-accounts runs idempotent and lets a
     # later run update authuser if Google's account indices shifted. Only
@@ -279,6 +291,7 @@ def _login_all_accounts_from_browser(
 
         target_storage = get_storage_path(profile=target_profile)
         write_outcome = _write_extracted_cookies(
+            io,
             per_profile_cookies[account.browser_profile],
             storage_path=target_storage,
             profile=target_profile,
@@ -286,8 +299,8 @@ def _login_all_accounts_from_browser(
             email=account.email,
         )
         if isinstance(write_outcome, BrowserCookieOutcome):
-            _exit_on_outcome(write_outcome)
-        console.print(f"  [green]✓[/green] {target_profile or target_storage}  →  {account.email}")
+            _exit_on_outcome(io, write_outcome)
+        io.emit(f"  [green]✓[/green] {target_profile or target_storage}  →  {account.email}")
         language_sync_target = (target_storage, target_profile)
 
     if language_sync_target is not None:
@@ -302,24 +315,31 @@ def _refresh_from_browser_cookies(
     profile: str | None,
     quiet: bool,
     include_domains: set[str] | None = None,
+    io: LoginIO | None = None,
 ) -> None:
-    """Refresh the active profile from browser cookies, repairing account drift."""
+    """Refresh the active profile from browser cookies, repairing account drift.
+
+    ``io`` is an optional caller-injected :class:`.io_seam.LoginIO` sink,
+    resolved to the command-layer default when ``None``.
+    """
+    io = resolve_login_io(io)
     enum_result = _enumerate_browser_accounts(
-        browser_name, verbose=not quiet, include_domains=include_domains
+        browser_name, verbose=not quiet, include_domains=include_domains, io=io
     )
     if isinstance(enum_result, BrowserCookieOutcome):
-        _exit_on_outcome(enum_result)
+        _exit_on_outcome(io, enum_result)
     per_profile_cookies, accounts = enum_result
     if not accounts:
-        _emit(f"[red]No signed-in Google accounts found in {browser_name}.[/red]")
-        exit_with_code(1)
+        _emit(io, f"[red]No signed-in Google accounts found in {browser_name}.[/red]")
+        io.fail(1)
 
     metadata = read_account_metadata(storage_path)
     selected_or_outcome = _select_refresh_account(accounts, metadata, browser_name)
     if isinstance(selected_or_outcome, BrowserCookieOutcome):
-        _exit_on_outcome(selected_or_outcome)
+        _exit_on_outcome(io, selected_or_outcome)
     selected = selected_or_outcome
     write_outcome = _write_extracted_cookies(
+        io,
         per_profile_cookies[selected.browser_profile],
         storage_path=storage_path,
         profile=profile,
@@ -328,13 +348,14 @@ def _refresh_from_browser_cookies(
         quiet=True,
     )
     if isinstance(write_outcome, BrowserCookieOutcome):
-        _exit_on_outcome(write_outcome)
+        _exit_on_outcome(io, write_outcome)
     _sync_server_language_to_config(storage_path=storage_path, profile=profile)
 
     if not quiet:
         _emit(
+            io,
             f"[green]ok[/green] refreshed from {browser_name}: {storage_path}\n"
-            f"[green]account[/green] {selected.email}"
+            f"[green]account[/green] {selected.email}",
         )
 
 
@@ -346,6 +367,7 @@ def _login_with_browser_cookies(
     authuser: int = 0,
     email: str | None = None,
     include_domains: set[str] | None = None,
+    io: LoginIO | None = None,
 ) -> None:
     """Extract Google cookies from an installed browser via rookiepy.
 
@@ -357,10 +379,13 @@ def _login_with_browser_cookies(
         email: Optional account email to record for stable routing.
         include_domains: Optional ``--include-domains`` label set forwarded
             to :func:`_read_browser_cookies`.
+        io: Optional caller-injected :class:`.io_seam.LoginIO` sink; resolved
+            to the command-layer default when ``None``.
     """
-    cookies_result = _read_browser_cookies(browser_name, include_domains=include_domains)
+    io = resolve_login_io(io)
+    cookies_result = _read_browser_cookies(browser_name, include_domains=include_domains, io=io)
     if isinstance(cookies_result, BrowserCookieOutcome):
-        _exit_on_outcome(cookies_result)
+        _exit_on_outcome(io, cookies_result)
     raw_cookies = cookies_result
 
     # ``validate_with_recovery`` mutates ``raw_cookies`` in place if the
@@ -371,11 +396,12 @@ def _login_with_browser_cookies(
         cookie_names = cookie_names_from_storage(storage_state)
         hint = missing_cookies_hint(cookie_names, browser_label=browser_name)
         _emit(
+            io,
             "[red]No valid Google authentication cookies found.[/red]\n"
             f"{validation_error}\n\n"
-            f"{hint}"
+            f"{hint}",
         )
-        exit_with_code(1)
+        io.fail(1)
 
     # Create parent directory (avoid mode= on Windows to prevent ACL issues)
     try:
@@ -389,8 +415,8 @@ def _login_with_browser_cookies(
             storage_path.parent.chmod(0o700)
     except OSError as e:
         logger.error("Failed to save authentication to %s: %s", storage_path, e)
-        _emit(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
-        exit_with_code(1)
+        _emit(io, f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
+        io.fail(1)
 
     # Record account metadata so future calls target the same Google account.
     # Even on a default-account login (authuser=0, no email), remove stale
@@ -403,8 +429,9 @@ def _login_with_browser_cookies(
         except OSError as e:
             logger.error("Failed to save account metadata for %s: %s", storage_path, e)
             _emit(
+                io,
                 f"[yellow]Warning: cookies saved but account metadata write failed.[/yellow]\n"
-                f"Details: {e}"
+                f"Details: {e}",
             )
     else:
         from ....auth import clear_account_metadata
@@ -417,36 +444,39 @@ def _login_with_browser_cookies(
     saved_msg = f"\n[green]Authentication saved to:[/green] {storage_path}"
     if email:
         saved_msg += f"\n[green]Account:[/green] {email}"
-    _emit(saved_msg)
+    _emit(io, saved_msg)
 
     # Verify that cookies work.
     try:
-        run_async(fetch_tokens_with_domains(storage_path, profile))
+        io.run_async(fetch_tokens_with_domains(storage_path, profile))
         logger.info("Cookies verified successfully")
-        _emit("[green]Cookies verified successfully.[/green]")
+        _emit(io, "[green]Cookies verified successfully.[/green]")
     except ValueError as e:
         # Cookie validation failed - the extracted cookies are invalid
         logger.error("Extracted cookies are invalid: %s", e)
         _emit(
+            io,
             "[red]Warning: Extracted cookies failed validation.[/red]\n"
             "The cookies may be expired or malformed.\n"
             f"Error: {e}\n\n"
-            "Saved anyway, but you may need to re-run login if these are invalid."
+            "Saved anyway, but you may need to re-run login if these are invalid.",
         )
     except httpx.RequestError as e:
         # Network error - can't verify but cookies might be OK
         logger.warning("Could not verify cookies due to network error: %s", e)
         _emit(
+            io,
             "[yellow]Warning: Could not verify cookies (network issue).[/yellow]\n"
             "Cookies saved but may not be working.\n"
-            "Try running 'notebooklm ask' to test authentication."
+            "Try running 'notebooklm ask' to test authentication.",
         )
     except Exception as e:
         # Unexpected error - log it fully
         logger.exception("Unexpected error verifying cookies: %s: %s", type(e).__name__, e)
         _emit(
+            io,
             f"[yellow]Warning: Unexpected error during verification: {e}[/yellow]\n"
-            "Cookies saved but please verify with 'notebooklm auth check --test'"
+            "Cookies saved but please verify with 'notebooklm auth check --test'",
         )
 
     _sync_server_language_to_config(storage_path=storage_path, profile=profile)
@@ -456,6 +486,7 @@ def _sync_server_language_to_config(
     *,
     storage_path: Path | None = None,
     profile: str | None = None,
+    io: LoginIO | None = None,
 ) -> None:
     """Fetch server language setting and persist to local config.
 
@@ -463,8 +494,12 @@ def _sync_server_language_to_config(
     global language setting. This prevents generate commands from defaulting
     to 'en' when the user has configured a different language on the server.
 
-    Non-critical: logs errors at debug level to avoid blocking login.
+    Non-critical: logs errors at debug level to avoid blocking login. ``io``
+    is an optional caller-injected :class:`.io_seam.LoginIO` sink (resolved to
+    the command-layer default when ``None``) used both to drive the async
+    settings fetch and to emit the rare manual-sync warning.
     """
+    io = resolve_login_io(io)
 
     async def _fetch() -> Any:
         kwargs: dict[str, Any] = {}
@@ -476,12 +511,12 @@ def _sync_server_language_to_config(
             return await client.settings.get_output_language()
 
     try:
-        server_lang = run_async(_fetch())
+        server_lang = io.run_async(_fetch())
         if server_lang:
             set_language(server_lang)
     except Exception as e:
         logger.debug("Failed to sync server language to config: %s", e)
-        console.print(
+        io.emit(
             "[dim]Warning: Could not sync language setting. "
             "Run 'notebooklm language get' to sync manually.[/dim]"
         )

--- a/tests/_fixtures/login_io.py
+++ b/tests/_fixtures/login_io.py
@@ -1,0 +1,67 @@
+"""Test sinks satisfying the browser-cookie login ``LoginIO`` Protocol (#1393).
+
+The browser-cookie login DAG (``cli/services/login/*``) inverts its
+presentation / exit / async side effects behind a caller-injected ``LoginIO``
+sink (Protocol + resolver in
+:mod:`notebooklm.cli.services.login.io_seam`). These helpers let direct unit
+tests inject a controllable sink instead of relying on the command-layer
+default factory:
+
+* :class:`RecordingLoginIO` — captures every ``emit`` line, raises ``SystemExit``
+  on ``fail`` (mirroring ``exit_with_code``), and runs the supplied coroutine /
+  awaitable through a real event loop on ``run_async`` (overridable).
+* :func:`make_recording_io` — convenience constructor.
+
+Behavior parity note: the production default sink
+(:class:`notebooklm.cli.playwright_login_io.PlaywrightLoginIO`) forwards ``emit``
+→ ``console.print``, ``fail`` → ``exit_with_code`` (``SystemExit``), and
+``run_async`` → ``cli.runtime.run_async``. :class:`RecordingLoginIO` matches
+``fail``'s ``SystemExit`` contract exactly so exit-code assertions are
+unchanged; ``emit`` lines are captured rather than rendered, and ``run_async``
+is a stub by default (tests that need real async drive supply ``run_async``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, NoReturn
+
+
+def _default_run_async(coro: Awaitable[Any]) -> Any:
+    """Drive an awaitable to completion on a throwaway event loop."""
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+@dataclass
+class RecordingLoginIO:
+    """Controllable ``LoginIO`` sink that records emitted lines.
+
+    Attributes:
+        emitted: Every positional first-arg passed to :meth:`emit`, in order.
+        run_async: Callable used by :meth:`run_async`. Defaults to
+            :func:`_default_run_async` (real event loop); tests that stub the
+            async bridge pass their own (e.g. ``MagicMock(return_value=...)``).
+    """
+
+    emitted: list[str] = field(default_factory=list)
+    run_async: Callable[[Awaitable[Any]], Any] = _default_run_async
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        # Mirror ``console.print`` 's first-arg-is-the-message convention so
+        # tests can assert on ``io.emitted`` the same way they asserted on
+        # ``capsys`` / ``console.print`` call args.
+        self.emitted.append(args[0] if args else "")
+
+    def fail(self, code: int) -> NoReturn:
+        raise SystemExit(code)
+
+
+def make_recording_io(
+    run_async: Callable[[Awaitable[Any]], Any] | None = None,
+) -> RecordingLoginIO:
+    """Build a :class:`RecordingLoginIO`, optionally overriding ``run_async``."""
+    if run_async is None:
+        return RecordingLoginIO()
+    return RecordingLoginIO(run_async=run_async)

--- a/tests/_lint/test_login_package_dag.py
+++ b/tests/_lint/test_login_package_dag.py
@@ -26,18 +26,32 @@ PKG_PATH = Path("src/notebooklm/cli/services/login")
 # but you also remove the documented design intent that says "this edge is
 # legitimate when needed". Keep the entry; add a comment when you start
 # using it.
+# ``io_seam`` (the caller-injected ``LoginIO`` Protocol + resolver, #1393) is a
+# leaf: it imports no siblings. Every helper that emits / exits / runs async now
+# threads a ``LoginIO`` sink and imports ``io_seam`` (the resolver and/or the
+# Protocol under TYPE_CHECKING), so it is an allowed edge from the whole DAG.
 ALLOWED_EDGES: dict[str, set[str]] = {
     "exceptions": set(),
     "outcomes": set(),
     "cookie_domains": set(),
     "rookiepy_errors": set(),
+    "io_seam": set(),
     "cookie_jar": {
         "outcomes",
         # allowed but currently unused — _enumerate_one_jar formats its own
         # rookiepy error messages and does not call _handle_rookiepy_error.
         "rookiepy_errors",
+        # io_seam: _enumerate_one_jar drives the account probe via io.run_async.
+        "io_seam",
     },
-    "chromium_accounts": {"cookie_jar", "rookiepy_errors", "cookie_domains", "outcomes"},
+    "chromium_accounts": {
+        "cookie_jar",
+        "rookiepy_errors",
+        "cookie_domains",
+        "outcomes",
+        # io_seam: the chromium readers emit verbose progress via io.emit.
+        "io_seam",
+    },
     "firefox_accounts": {
         # _read_firefox_container_cookies returns a CookieValidationFailure
         # (a BrowserCookieOutcome) on every extractor failure instead of
@@ -49,6 +63,8 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         # back to the caller (browser_accounts) which then routes through
         # _enumerate_one_jar; this module does not import it directly.
         "cookie_jar",
+        # io_seam: the firefox readers emit verbose progress via io.emit.
+        "io_seam",
     },
     "browser_accounts": {
         "chromium_accounts",
@@ -63,6 +79,8 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         # browser-family subordinates. Adding the edge here keeps the dispatch
         # logic colocated; the DAG stays acyclic (cookie_domains is a leaf).
         "cookie_domains",
+        # io_seam: the dispatcher resolves + threads the LoginIO sink.
+        "io_seam",
     },
     "profile_targets": {
         # ADR-015 Pattern B decoupling — _validate_profile_name raises
@@ -75,8 +93,19 @@ ALLOWED_EDGES: dict[str, set[str]] = {
         "browser_accounts",
         "cookie_domains",
         "outcomes",
+        # io_seam: _write_extracted_cookies / _select_account emit warnings and
+        # run the verification probe through the injected sink.
+        "io_seam",
     },
-    "refresh": {"browser_accounts", "cookie_writes", "outcomes", "profile_targets"},
+    "refresh": {
+        "browser_accounts",
+        "cookie_writes",
+        "outcomes",
+        "profile_targets",
+        # io_seam: refresh drivers own success messaging + exit policy via the
+        # injected sink (io.emit / io.fail / io.run_async).
+        "io_seam",
+    },
 }
 
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -92,6 +92,21 @@ def mind_map_result(spec: dict | None = None, **overrides: Any) -> MindMapResult
     return MindMapResult(mind_map=data.get("mind_map"), note_id=data.get("note_id"))
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _register_default_login_io():
+    """Ensure the browser-cookie login default ``LoginIO`` sink is registered.
+
+    The login DAG (``cli/services/login/*``) resolves its presentation / exit /
+    async sink via ``io_seam.resolve_login_io`` (#1393); the concrete default
+    factory is registered as a side effect of importing the command-layer
+    ``cli/playwright_login_io.py``. Direct-service unit tests import only the
+    service module, so without this they'd race on collection order to have the
+    factory wired. Importing it here once per session makes ``resolve_login_io``
+    deterministic for tests that call a driver without injecting ``io``.
+    """
+    import notebooklm.cli.playwright_login_io  # noqa: F401  (registration side effect)
+
+
 @pytest.fixture(autouse=True)
 def _disable_chromium_profile_fanout():
     """Default: Chromium multi-user-profile discovery returns nothing in tests.

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -6,7 +6,6 @@ helpers live in ``_session_helpers.py``; the proxy-block-aware
 ``patch_session_login_dual`` lives in ``tests/_fixtures``.
 """
 
-import asyncio
 import json
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1414,7 +1413,14 @@ class TestAuthRefreshCommand:
 
 
 class TestAuthInspect:
-    def test_session_run_async_patch_reaches_login_service_helper(self):
+    def test_injected_io_run_async_reaches_login_service_helper(self):
+        """The injected ``LoginIO`` sink's ``run_async`` drives the probe (#1393).
+
+        Previously ``_enumerate_one_jar`` bound a module-level ``run_async``;
+        the async bridge is now the injected sink's ``run_async``. This pins
+        that the helper routes the account-enumeration probe through the sink.
+        """
+        from _fixtures.login_io import make_recording_io
         from notebooklm.auth import Account
         from notebooklm.cli.services.login import _enumerate_one_jar
 
@@ -1425,14 +1431,12 @@ class TestAuthInspect:
             awaitable.close()
             return accounts
 
-        with (
-            patch("notebooklm.auth.enumerate_accounts", return_value=object()),
-            patch_session_login_dual("run_async", side_effect=fake_run_async) as mock_run_async,
-        ):
-            result = _enumerate_one_jar(raw_cookies, "chrome", browser_profile=None)
+        io = make_recording_io(run_async=MagicMock(side_effect=fake_run_async))
+        with patch("notebooklm.auth.enumerate_accounts", return_value=object()):
+            result = _enumerate_one_jar(raw_cookies, "chrome", browser_profile=None, io=io)
 
         assert result == accounts
-        mock_run_async.assert_called_once()
+        io.run_async.assert_called_once()
 
     def test_enumerate_one_jar_network_error_non_quiet_exits_without_reraising(self):
         from notebooklm.cli.services.login import _enumerate_one_jar
@@ -1452,6 +1456,7 @@ class TestAuthInspect:
         assert "offline" in message
 
     def test_select_account_without_marked_default_uses_first_account(self, caplog):
+        from _fixtures.login_io import RecordingLoginIO
         from notebooklm.auth import Account
         from notebooklm.cli.services.login import _select_account
 
@@ -1460,24 +1465,26 @@ class TestAuthInspect:
             Account(authuser=1, email="bob@gmail.com", is_default=False),
         ]
 
-        with (
-            caplog.at_level("WARNING", logger="notebooklm.cli.services.login.cookie_writes"),
-            patch("notebooklm.cli.rendering.console") as mock_console,
-        ):
-            selected = _select_account(accounts, account_email=None)
+        # The no-default warning is now emitted through the injected ``LoginIO``
+        # sink (#1393); capture it on a ``RecordingLoginIO`` instead of the
+        # module-level console.
+        io = RecordingLoginIO()
+        with caplog.at_level("WARNING", logger="notebooklm.cli.services.login.cookie_writes"):
+            selected = _select_account(io, accounts, account_email=None)
 
         assert selected == accounts[0]
-        warning_text = mock_console.print.call_args[0][0]
+        warning_text = io.emitted[0]
         assert "default account" in warning_text
         assert "alice@example.com" in warning_text
         assert "default account" in caplog.text
         assert "alice@example.com" in caplog.text
 
     def test_select_account_empty_accounts_returns_user_message(self):
+        from _fixtures.login_io import make_recording_io
         from notebooklm.cli.services.login.cookie_writes import _select_account
         from notebooklm.cli.services.login.outcomes import CookieValidationFailure
 
-        result = _select_account([], account_email=None)
+        result = _select_account(make_recording_io(), [], account_email=None)
 
         assert isinstance(result, CookieValidationFailure)
         message = result.message
@@ -1505,9 +1512,12 @@ class TestAuthInspect:
                 Account(authuser=2, email="carol@ws.com", is_default=False),
             ]
 
+        # The account-enumeration probe now runs through the injected ``LoginIO``
+        # sink's ``run_async`` (the default ``PlaywrightLoginIO`` →
+        # ``cli.runtime.run_async``, #1393); mocking ``enumerate_accounts`` is
+        # enough — the real ``run_async`` drives the (already-async) stub.
         with (
             patch.dict("sys.modules", {"rookiepy": mock_rk}),
-            patch_session_login_dual("run_async", side_effect=asyncio.run),
             patch("notebooklm.auth.enumerate_accounts", new=_enum),
         ):
             result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome"])

--- a/tests/unit/cli/test_cookie_jar_enumerate.py
+++ b/tests/unit/cli/test_cookie_jar_enumerate.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from _fixtures.login_io import RecordingLoginIO
 from notebooklm.cli.services.login import cookie_jar
 from notebooklm.cli.services.login.outcomes import (
     CookieValidationFailure,
@@ -35,14 +36,21 @@ class _FakeAccount:
 def _enumerate_env(*, validate_return, run_async_side_effect=None, run_async_return=None):
     """Patch the collaborators ``_enumerate_one_jar`` reaches at call time.
 
-    ``validate_with_recovery`` and ``run_async`` are module-level imports in
-    ``cookie_jar`` (patched via ``patch.object``); ``build_cookie_jar`` /
+    ``validate_with_recovery`` is a module-level import in ``cookie_jar``
+    (patched via ``patch.object``); ``build_cookie_jar`` /
     ``extract_cookies_with_domains`` / ``enumerate_accounts`` are *function-local*
     ``from ....auth import ...`` lookups, so they're patched on ``notebooklm.auth``.
     ``enumerate_accounts`` is async, so an auto-specced ``patch`` would hand back
-    an un-awaited coroutine (``run_async`` is stubbed and never awaits it); an
+    an un-awaited coroutine (the ``io.run_async`` stub never awaits it); an
     explicit sync ``MagicMock`` returns a plain sentinel instead.
+
+    The async bridge is no longer a module-level ``run_async`` (#1393 inverted
+    it behind the injected ``LoginIO`` sink). This helper yields a
+    :class:`RecordingLoginIO` whose ``run_async`` is the configured stub; tests
+    pass it as ``io=`` so the probe result / side-effect is controlled exactly
+    as before.
     """
+    run_async = MagicMock(side_effect=run_async_side_effect, return_value=run_async_return)
     with ExitStack() as stack:
         stack.enter_context(
             patch.object(cookie_jar, "validate_with_recovery", return_value=validate_return)
@@ -52,21 +60,13 @@ def _enumerate_env(*, validate_return, run_async_side_effect=None, run_async_ret
         stack.enter_context(
             patch("notebooklm.auth.enumerate_accounts", MagicMock(return_value=object()))
         )
-        if run_async_side_effect is not None:
-            stack.enter_context(
-                patch.object(cookie_jar, "run_async", side_effect=run_async_side_effect)
-            )
-        else:
-            stack.enter_context(
-                patch.object(cookie_jar, "run_async", return_value=run_async_return)
-            )
-        yield
+        yield RecordingLoginIO(run_async=run_async)
 
 
 class TestValidationFailure:
     def test_quiet_returns_collapsed_validation_failure(self):
-        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))):
-            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=True)
+        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))) as io:
+            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=True, io=io)
 
         assert isinstance(out, CookieValidationFailure)
         assert out.code == "COOKIE_VALIDATION_FAILED"
@@ -75,8 +75,8 @@ class TestValidationFailure:
         assert "\n" not in out.message
 
     def test_loud_returns_validation_failure_with_hint(self):
-        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))):
-            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=False)
+        with _enumerate_env(validate_return=({"cookies": []}, ValueError("missing SID"))) as io:
+            out = cookie_jar._enumerate_one_jar([], "chrome", None, quiet=False, io=io)
 
         assert isinstance(out, CookieValidationFailure)
         assert out.code == "COOKIE_VALIDATION_FAILED"
@@ -90,8 +90,8 @@ class TestStaleCookies:
         with _enumerate_env(
             validate_return=({"cookies": [1]}, None),
             run_async_side_effect=ValueError("rejected"),
-        ):
-            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=True)
+        ) as io:
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=True, io=io)
 
         assert isinstance(out, StaleCookies)
         assert out.code == "STALE_COOKIES"
@@ -102,8 +102,8 @@ class TestStaleCookies:
         with _enumerate_env(
             validate_return=({"cookies": [1]}, None),
             run_async_side_effect=ValueError("rejected"),
-        ):
-            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=False)
+        ) as io:
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "firefox", None, quiet=False, io=io)
 
         assert isinstance(out, StaleCookies)
         assert out.code == "STALE_COOKIES"
@@ -117,17 +117,17 @@ class TestNetworkFailure:
             _enumerate_env(
                 validate_return=({"cookies": [1]}, None),
                 run_async_side_effect=httpx.ConnectError("no route"),
-            ),
+            ) as io,
             pytest.raises(httpx.RequestError),
         ):
-            cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=True)
+            cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=True, io=io)
 
     def test_loud_returns_network_failure_outcome(self):
         with _enumerate_env(
             validate_return=({"cookies": [1]}, None),
             run_async_side_effect=httpx.ConnectError("no route"),
-        ):
-            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=False)
+        ) as io:
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, quiet=False, io=io)
 
         assert isinstance(out, NetworkFailure)
         assert out.code == "NETWORK_ERROR"
@@ -136,8 +136,10 @@ class TestNetworkFailure:
 class TestSuccessPath:
     def test_legacy_single_jar_returns_accounts_unchanged(self):
         accounts = [_FakeAccount(0, "a@gmail.com", True)]
-        with _enumerate_env(validate_return=({"cookies": [1]}, None), run_async_return=accounts):
-            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None)
+        with _enumerate_env(
+            validate_return=({"cookies": [1]}, None), run_async_return=accounts
+        ) as io:
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", None, io=io)
 
         assert out == accounts
 
@@ -145,8 +147,10 @@ class TestSuccessPath:
         # Account is reconstructed inside the function from notebooklm.auth, so
         # leave the real class in place here (only the probe is stubbed).
         accounts = [_FakeAccount(0, "a@gmail.com", True)]
-        with _enumerate_env(validate_return=({"cookies": [1]}, None), run_async_return=accounts):
-            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", "Profile 1")
+        with _enumerate_env(
+            validate_return=({"cookies": [1]}, None), run_async_return=accounts
+        ) as io:
+            out = cookie_jar._enumerate_one_jar([{"x": 1}], "chrome", "Profile 1", io=io)
 
         assert len(out) == 1
         assert out[0].browser_profile == "Profile 1"

--- a/tests/unit/cli/test_cookie_writes.py
+++ b/tests/unit/cli/test_cookie_writes.py
@@ -12,15 +12,16 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 
+from _fixtures.login_io import RecordingLoginIO, make_recording_io
 from notebooklm.cli.services.login import cookie_writes
 from notebooklm.cli.services.login.outcomes import CookieValidationFailure
 
 
-def test_emit_warning_prints_through_console():
-    """``_emit_warning`` renders the message via the rendering console."""
-    with patch("notebooklm.cli.rendering.console") as console:
-        cookie_writes._emit_warning("[yellow]heads up[/yellow]")
-    console.print.assert_called_once_with("[yellow]heads up[/yellow]")
+def test_emit_warning_emits_through_injected_sink():
+    """``_emit_warning`` routes the message through the injected ``io`` sink."""
+    io = RecordingLoginIO()
+    cookie_writes._emit_warning(io, "[yellow]heads up[/yellow]")
+    assert io.emitted == ["[yellow]heads up[/yellow]"]
 
 
 class _Acct:
@@ -37,18 +38,22 @@ class _Acct:
 
 class TestSelectAccount:
     def test_no_accounts_returns_failure(self):
-        out = cookie_writes._select_account([], account_email=None)
+        out = cookie_writes._select_account(make_recording_io(), [], account_email=None)
         assert isinstance(out, CookieValidationFailure)
         assert out.code == "NO_ACCOUNTS_FOUND"
 
     def test_email_match_returns_account(self):
         acct = _Acct(0, "Match@Gmail.com", True)
-        out = cookie_writes._select_account([acct], account_email="match@gmail.com")
+        out = cookie_writes._select_account(
+            make_recording_io(), [acct], account_email="match@gmail.com"
+        )
         assert out is acct
 
     def test_email_not_found_returns_failure_listing_available(self):
         acct = _Acct(0, "other@gmail.com", True)
-        out = cookie_writes._select_account([acct], account_email="missing@gmail.com")
+        out = cookie_writes._select_account(
+            make_recording_io(), [acct], account_email="missing@gmail.com"
+        )
         assert isinstance(out, CookieValidationFailure)
         assert out.code == "ACCOUNT_NOT_FOUND"
         assert "other@gmail.com" in out.message
@@ -56,17 +61,22 @@ class TestSelectAccount:
     def test_default_account_returned_without_email(self):
         first = _Acct(0, "a@gmail.com", False)
         default = _Acct(1, "b@gmail.com", True)
-        out = cookie_writes._select_account([first, default], account_email=None)
+        out = cookie_writes._select_account(
+            make_recording_io(), [first, default], account_email=None
+        )
         assert out is default
 
     def test_no_default_marker_warns_and_returns_first(self):
         first = _Acct(0, "a@gmail.com", False)
         second = _Acct(1, "b@gmail.com", False)
         with patch.object(cookie_writes, "_emit_warning") as emit:
-            out = cookie_writes._select_account([first, second], account_email=None)
+            out = cookie_writes._select_account(
+                make_recording_io(), [first, second], account_email=None
+            )
         assert out is first
         emit.assert_called_once()
-        assert "did not mark a default" in emit.call_args[0][0]
+        # ``_emit_warning`` now takes ``(io, message)`` — message is arg index 1.
+        assert "did not mark a default" in emit.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +138,11 @@ def _ok_storage():
 
 
 class TestWriteExtractedCookies:
+    # The cookie-verification probe now runs through the injected ``io``
+    # sink's ``run_async`` (#1393), so each test supplies a ``RecordingLoginIO``
+    # whose ``run_async`` is the stub that previously patched
+    # ``notebooklm.cli.runtime.run_async``. The ``_emit_warning`` helper now
+    # takes ``(io, message)``, so warning assertions read ``c.args[1]``.
     def test_validation_failure_returns_outcome(self, tmp_path):
         storage_path = tmp_path / "storage_state.json"
         with patch.object(
@@ -136,7 +151,12 @@ class TestWriteExtractedCookies:
             return_value=({"cookies": []}, ValueError("missing SID")),
         ):
             out = cookie_writes._write_extracted_cookies(
-                [], storage_path=storage_path, profile=None, authuser=0, email="a@gmail.com"
+                make_recording_io(),
+                [],
+                storage_path=storage_path,
+                profile=None,
+                authuser=0,
+                email="a@gmail.com",
             )
         assert isinstance(out, CookieValidationFailure)
         assert out.code == "COOKIE_VALIDATION_FAILED"
@@ -151,6 +171,7 @@ class TestWriteExtractedCookies:
             patch.object(cookie_writes, "atomic_write_json", side_effect=OSError("disk full")),
         ):
             out = cookie_writes._write_extracted_cookies(
+                make_recording_io(),
                 [{"name": "SID"}],
                 storage_path=storage_path,
                 profile=None,
@@ -163,17 +184,18 @@ class TestWriteExtractedCookies:
 
     def test_metadata_write_failure_is_nonfatal(self, tmp_path):
         storage_path = tmp_path / "storage_state.json"
+        io = make_recording_io(run_async=MagicMock())
         with (
             patch.object(
                 cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
             ),
             patch.object(cookie_writes, "atomic_write_json"),
             patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
-            patch("notebooklm.cli.runtime.run_async"),
             patch("notebooklm.auth.write_account_metadata", side_effect=OSError("ro fs")),
             patch.object(cookie_writes, "_emit_warning") as emit,
         ):
             out = cookie_writes._write_extracted_cookies(
+                io,
                 [{"name": "SID"}],
                 storage_path=storage_path,
                 profile=None,
@@ -182,21 +204,22 @@ class TestWriteExtractedCookies:
             )
         # Cookies were written; metadata failure only warns.
         assert out is None
-        assert any("metadata write failed" in c.args[0] for c in emit.call_args_list)
+        assert any("metadata write failed" in c.args[1] for c in emit.call_args_list)
 
     def test_verification_value_error_warns(self, tmp_path):
         storage_path = tmp_path / "storage_state.json"
+        io = make_recording_io(run_async=MagicMock(side_effect=ValueError("bad token")))
         with (
             patch.object(
                 cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
             ),
             patch.object(cookie_writes, "atomic_write_json"),
             patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
-            patch("notebooklm.cli.runtime.run_async", side_effect=ValueError("bad token")),
             patch("notebooklm.auth.write_account_metadata"),
             patch.object(cookie_writes, "_emit_warning") as emit,
         ):
             out = cookie_writes._write_extracted_cookies(
+                io,
                 [{"name": "SID"}],
                 storage_path=storage_path,
                 profile=None,
@@ -204,24 +227,22 @@ class TestWriteExtractedCookies:
                 email="a@gmail.com",
             )
         assert out is None
-        assert any("failed verification" in c.args[0] for c in emit.call_args_list)
+        assert any("failed verification" in c.args[1] for c in emit.call_args_list)
 
     def test_verification_network_error_warns(self, tmp_path):
         storage_path = tmp_path / "storage_state.json"
+        io = make_recording_io(run_async=MagicMock(side_effect=httpx.ConnectError("offline")))
         with (
             patch.object(
                 cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
             ),
             patch.object(cookie_writes, "atomic_write_json"),
             patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
-            patch(
-                "notebooklm.cli.runtime.run_async",
-                side_effect=httpx.ConnectError("offline"),
-            ),
             patch("notebooklm.auth.write_account_metadata"),
             patch.object(cookie_writes, "_emit_warning") as emit,
         ):
             out = cookie_writes._write_extracted_cookies(
+                io,
                 [{"name": "SID"}],
                 storage_path=storage_path,
                 profile=None,
@@ -229,21 +250,22 @@ class TestWriteExtractedCookies:
                 email="a@gmail.com",
             )
         assert out is None
-        assert any("could not verify" in c.args[0] for c in emit.call_args_list)
+        assert any("could not verify" in c.args[1] for c in emit.call_args_list)
 
     def test_happy_path_returns_none(self, tmp_path):
         storage_path = tmp_path / "storage_state.json"
+        io = make_recording_io(run_async=MagicMock())
         with (
             patch.object(
                 cookie_writes, "validate_with_recovery", return_value=(_ok_storage(), None)
             ),
             patch.object(cookie_writes, "atomic_write_json"),
             patch.object(cookie_writes, "fetch_tokens_with_domains", MagicMock()),
-            patch("notebooklm.cli.runtime.run_async"),
             patch("notebooklm.auth.write_account_metadata"),
             patch.object(cookie_writes, "_emit_warning") as emit,
         ):
             out = cookie_writes._write_extracted_cookies(
+                io,
                 [{"name": "SID"}],
                 storage_path=storage_path,
                 profile=None,

--- a/tests/unit/cli/test_firefox_accounts.py
+++ b/tests/unit/cli/test_firefox_accounts.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import sqlite3
 from unittest.mock import MagicMock, patch
 
+from _fixtures.login_io import make_recording_io
 from notebooklm.cli.services.login import firefox_accounts
 from notebooklm.cli.services.login.outcomes import BrowserCookieOutcome
 
@@ -34,14 +35,18 @@ class TestReadFirefoxContainerCookiesErrors:
             tmp_path, extract_side_effect=FileNotFoundError("no cookies.sqlite")
         )
         with patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod):
-            result = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+            result = firefox_accounts._read_firefox_container_cookies(
+                make_recording_io(), "none", verbose=False
+            )
         assert isinstance(result, BrowserCookieOutcome)
         assert "no cookies.sqlite" in result.message
 
     def test_oserror_routes_through_rookiepy_handler(self, tmp_path):
         mod = _fake_containers_module(tmp_path, extract_side_effect=OSError("database is locked"))
         with patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod):
-            result = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+            result = firefox_accounts._read_firefox_container_cookies(
+                make_recording_io(), "none", verbose=False
+            )
         assert isinstance(result, BrowserCookieOutcome)
         # The locked-DB message from _handle_rookiepy_error is surfaced.
         assert "database is locked" in result.message
@@ -51,7 +56,9 @@ class TestReadFirefoxContainerCookiesErrors:
             tmp_path, extract_side_effect=RuntimeError("totally unexpected")
         )
         with patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod):
-            result = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+            result = firefox_accounts._read_firefox_container_cookies(
+                make_recording_io(), "none", verbose=False
+            )
         assert isinstance(result, BrowserCookieOutcome)
 
     def test_sqlite_database_error_returns_outcome(self, tmp_path):
@@ -59,7 +66,9 @@ class TestReadFirefoxContainerCookiesErrors:
             tmp_path, extract_side_effect=sqlite3.DatabaseError("malformed db")
         )
         with patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod):
-            result = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+            result = firefox_accounts._read_firefox_container_cookies(
+                make_recording_io(), "none", verbose=False
+            )
         assert isinstance(result, BrowserCookieOutcome)
         assert "malformed db" in result.message
 
@@ -72,7 +81,9 @@ class TestReadFirefoxContainerCookiesErrors:
                 firefox_accounts, "_build_google_cookie_domains", return_value=[".google.com"]
             ),
         ):
-            cookies = firefox_accounts._read_firefox_container_cookies("none", verbose=False)
+            cookies = firefox_accounts._read_firefox_container_cookies(
+                make_recording_io(), "none", verbose=False
+            )
         assert cookies == [{"name": "SID"}]
 
 
@@ -84,7 +95,7 @@ class TestMaybeWarnFirefoxContainersInUse:
             patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
             patch.object(firefox_accounts, "_emit_progress") as emit,
         ):
-            firefox_accounts._maybe_warn_firefox_containers_in_use()
+            firefox_accounts._maybe_warn_firefox_containers_in_use(make_recording_io())
         mod.has_container_cookies_in_use.assert_not_called()
         emit.assert_not_called()
 
@@ -96,6 +107,8 @@ class TestMaybeWarnFirefoxContainersInUse:
             patch.object(firefox_accounts, "_firefox_containers_module", return_value=mod),
             patch.object(firefox_accounts, "_emit_progress") as emit,
         ):
-            firefox_accounts._maybe_warn_firefox_containers_in_use()
+            firefox_accounts._maybe_warn_firefox_containers_in_use(make_recording_io())
         emit.assert_called_once()
-        assert "Multi-Account Container" in emit.call_args[0][0]
+        # ``_emit_progress`` now takes ``(io, message)`` — the message is the
+        # second positional arg.
+        assert "Multi-Account Container" in emit.call_args[0][1]

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -1579,7 +1579,10 @@ class TestLoginLanguageSync:
 
         with (
             patch_session_login_dual("NotebookLMClient") as mock_client_cls,
-            patch_session_login_dual("console") as mock_console,
+            # The warning is now emitted through the injected ``LoginIO`` sink
+            # (#1393); with no sink passed, the default ``PlaywrightLoginIO``
+            # resolves and forwards ``emit`` to ``playwright_login_io.console``.
+            patch("notebooklm.cli.playwright_login_io.console") as mock_console,
         ):
             # Raise from the sync `from_storage` call itself.
             mock_client_cls.from_storage = MagicMock(side_effect=Exception("Network error"))

--- a/tests/unit/cli/test_login_io_seam.py
+++ b/tests/unit/cli/test_login_io_seam.py
@@ -1,0 +1,88 @@
+"""Regression tests for the browser-cookie login ``LoginIO`` resolver (#1393).
+
+The login DAG inverts its presentation / exit / async side effects behind a
+caller-injected ``LoginIO`` sink (``cli/services/login/io_seam.py``). Service
+entry points that are reached *without* an explicit ``io`` — most notably a bare
+``_sync_server_language_to_config()`` call, or a library consumer that imported
+only ``cli.services.login`` — must still resolve the real console / exit / async
+behavior instead of raising. ``resolve_login_io`` therefore lazily registers the
+command-layer default sink the first time it is needed.
+
+These tests pin:
+
+* ``resolve_login_io`` returns an injected sink unchanged.
+* ``resolve_login_io`` self-heals when no factory is registered (so it never
+  raises ``RuntimeError`` on the fallback path).
+* A bare ``_sync_server_language_to_config()`` does not raise even from a
+  *cold* interpreter where the command layer was never imported (run in a
+  subprocess so the import side effect cannot mask the regression).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+from _fixtures.login_io import RecordingLoginIO
+from notebooklm.cli.services.login import io_seam
+
+
+def test_resolve_returns_injected_sink_unchanged():
+    io = RecordingLoginIO()
+    assert io_seam.resolve_login_io(io) is io
+
+
+def test_resolve_self_heals_when_no_factory_registered(monkeypatch):
+    """With the factory cleared, ``resolve_login_io`` re-registers the default.
+
+    Mirrors the #1393 cubic finding: a sink-resolving entry point reached
+    without an injected ``io`` (and without the command layer pre-imported on
+    that path) must not raise — the resolver registers the command-layer
+    default lazily and returns a working sink.
+    """
+    monkeypatch.setattr(io_seam, "_default_io_factory", None)
+    sink = io_seam.resolve_login_io(None)
+    # The concrete command-layer sink satisfies the LoginIO Protocol.
+    assert hasattr(sink, "emit")
+    assert hasattr(sink, "fail")
+    assert hasattr(sink, "run_async")
+    # And the factory is now registered for subsequent resolves.
+    assert io_seam._default_io_factory is not None
+
+
+def test_bare_sync_language_does_not_raise_from_cold_start():
+    """``_sync_server_language_to_config()`` survives a cold interpreter (#1393).
+
+    Run in a subprocess so the command-layer registration cannot already be
+    cached from this test session — the regression (a ``RuntimeError`` from the
+    sink resolver) would only surface when ``cli.playwright_login_io`` was never
+    imported on the call path.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        # The command layer (which registers the default sink) must NOT have
+        # been imported yet — otherwise the cold-start path isn't exercised.
+        assert "notebooklm.cli.playwright_login_io" not in sys.modules
+
+        import notebooklm.cli.services.login.refresh as r
+
+        with patch.object(r, "NotebookLMClient") as cls:
+            # Force the language fetch to fail so the warning-emitting branch
+            # runs; that branch resolves the sink and calls io.emit / io.run_async.
+            cls.from_storage = MagicMock(side_effect=Exception("boom"))
+            r._sync_server_language_to_config()  # must NOT raise RuntimeError
+
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/unit/cli/test_login_refresh_coverage.py
+++ b/tests/unit/cli/test_login_refresh_coverage.py
@@ -32,6 +32,13 @@ from notebooklm.cli.services.login import refresh
 from notebooklm.cli.services.login.outcomes import BrowserCookieOutcome
 
 REFRESH = "notebooklm.cli.services.login.refresh"
+# The async bridge is no longer ``refresh.run_async`` (#1393 inverted it behind
+# the injected ``LoginIO`` sink). With no ``io`` injected these drivers resolve
+# the command-layer default sink (``PlaywrightLoginIO``), whose ``run_async``
+# binds ``cli.playwright_login_io.run_async``. Patching it here intercepts the
+# async probe while leaving ``emit`` → ``console.print`` intact so ``capsys``
+# still captures the rendered warning lines.
+IO_RUN_ASYNC = "notebooklm.cli.playwright_login_io.run_async"
 
 
 def _account(email: str, *, authuser: int = 0, browser_profile: str = "Default") -> Any:
@@ -308,7 +315,7 @@ def test_login_with_cookies_write_metadata_oserror_warns(tmp_path, capsys) -> No
                 side_effect=OSError("metadata write fail"),
             )
         )
-        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        stack.enter_context(patch(IO_RUN_ASYNC))
         refresh._login_with_browser_cookies(
             tmp_path / "storage.json", "chrome", authuser=1, email="x@example.com"
         )
@@ -326,7 +333,7 @@ def test_login_with_cookies_clear_metadata_oserror_logged(tmp_path, caplog) -> N
         stack.enter_context(
             patch("notebooklm.auth.clear_account_metadata", side_effect=OSError("clear fail"))
         )
-        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        stack.enter_context(patch(IO_RUN_ASYNC))
         stack.enter_context(caplog.at_level(logging.WARNING, logger=REFRESH))
         refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
     assert any(
@@ -340,7 +347,7 @@ def test_login_with_cookies_account_line_printed(tmp_path, capsys) -> None:
         _enter_login_base(stack)
         stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
         stack.enter_context(patch("notebooklm.auth.write_account_metadata"))
-        stack.enter_context(patch(f"{REFRESH}.run_async"))
+        stack.enter_context(patch(IO_RUN_ASYNC))
         refresh._login_with_browser_cookies(
             tmp_path / "storage.json", "chrome", authuser=2, email="dave@example.com"
         )
@@ -354,9 +361,7 @@ def test_login_with_cookies_verify_valueerror_warns(tmp_path, capsys) -> None:
         _enter_login_base(stack)
         stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
         stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
-        stack.enter_context(
-            patch(f"{REFRESH}.run_async", side_effect=ValueError("invalid cookies"))
-        )
+        stack.enter_context(patch(IO_RUN_ASYNC, side_effect=ValueError("invalid cookies")))
         refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
     out = capsys.readouterr().out
     assert "failed validation" in out
@@ -368,9 +373,7 @@ def test_login_with_cookies_verify_network_error_warns(tmp_path, capsys) -> None
         _enter_login_base(stack)
         stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
         stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
-        stack.enter_context(
-            patch(f"{REFRESH}.run_async", side_effect=httpx.RequestError("connect failed"))
-        )
+        stack.enter_context(patch(IO_RUN_ASYNC, side_effect=httpx.RequestError("connect failed")))
         refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
     out = capsys.readouterr().out
     assert "network issue" in out
@@ -382,7 +385,7 @@ def test_login_with_cookies_verify_unexpected_error_warns(tmp_path, capsys) -> N
         _enter_login_base(stack)
         stack.enter_context(patch(f"{REFRESH}.atomic_write_json"))
         stack.enter_context(patch("notebooklm.auth.clear_account_metadata"))
-        stack.enter_context(patch(f"{REFRESH}.run_async", side_effect=RuntimeError("boom")))
+        stack.enter_context(patch(IO_RUN_ASYNC, side_effect=RuntimeError("boom")))
         refresh._login_with_browser_cookies(tmp_path / "storage.json", "chrome")
     out = capsys.readouterr().out
     assert "Unexpected error during verification" in out

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -53,17 +53,21 @@ import pytest
 # dependency.
 FORBIDDEN_TOP_LEVEL_MODULES = {"click"}
 
-# Relative imports from these sibling packages of ``cli/services`` are
-# forbidden. The check fires for any ``from ..<name>`` or ``from ..<name>.X``
-# import — i.e. ``..rendering`` and ``..rendering.something`` both count.
+# Relative imports from these presentation/runtime modules are forbidden
+# regardless of nesting depth. The check fires for any ``from ..<name>`` /
+# ``from ..<name>.X`` import (a sibling of ``cli/services``) AND any
+# ``from ...<name>`` / ``from ...<name>.X`` import (a sibling of ``cli``,
+# reached from a deeper subpackage like ``cli/services/login/``). Both resolve
+# to the same real command-layer module (e.g. ``cli.rendering``), so both are
+# a presentation reach-in.
 #
-# Note: level-3 imports (``...rendering``, from a deeper subpackage like
-# ``cli/services/login/``) are NOT flagged here. Login submodules currently
-# rely on that path; tracking their reach-in is done via the
-# ``pattern_a_violations`` inventory inside ``TRANSITIONAL_GUARDED_PATHS``
-# (e.g. ``cli/services/login/browser_accounts.py``). Broadening the import
-# scanner to level-3 would surface those automatically; that's a deliberate
-# follow-up, not a gap to plug here.
+# History: the scanner originally flagged only the level-2 (``..rendering``)
+# form. ``cli/services/login/*`` modules sit one directory deeper, so their
+# ``...rendering`` reach-ins resolved to the real ``cli.rendering`` while
+# slipping past the gate (#1393). The login DAG was inverted behind a
+# caller-injected ``LoginIO`` sink (``cli/services/login/io_seam.py``, concrete
+# sink in ``cli/playwright_login_io.py``) and the scanner tightened to level-3
+# so the blind spot is closed.
 FORBIDDEN_RELATIVE_PARENTS = {"rendering", "error_handler", "runtime"}
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
@@ -72,16 +76,17 @@ SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
 # Fully cleaned service modules. Each must have zero ``_boundary_violations``
 # AND zero Pattern A pairs (see :func:`_pattern_a_pairs`).
 #
-# Several login submodules (``browser_accounts.py``, ``cookie_writes.py``,
-# ``chromium_accounts.py``, ``firefox_accounts.py``, ``refresh.py``) still
-# emit progress/warning output (and ``refresh.py`` owns success messaging +
-# the shared ``_exit_on_outcome`` rendering boundary) through a narrow lazy
-# LEVEL-3 ``console`` seam (``_emit`` / ``_emit_progress``). The boundary
-# scanner intentionally does not flag those level-3 imports; the load-bearing
-# invariant is zero Pattern A pairs — no single function body co-locates
-# ``console.print`` with ``exit_with_code``, because the print is routed
-# through a split helper the scanner treats as the preferred shape. The
-# remaining seams can be inverted into caller-provided callbacks later.
+# The login submodules (``browser_accounts.py``, ``cookie_writes.py``,
+# ``chromium_accounts.py``, ``firefox_accounts.py``, ``refresh.py``) used to
+# reach the command layer's ``console`` / ``exit_with_code`` / ``run_async``
+# through narrow LEVEL-3 (``...rendering`` / ``...error_handler`` /
+# ``...runtime``) seams that slipped past this scanner. #1393 tightened the
+# import check to level-3 and inverted those reach-ins behind a caller-injected
+# ``LoginIO`` sink (Protocol + resolver in ``cli/services/login/io_seam.py``;
+# concrete sink registered by the command layer in
+# ``cli/playwright_login_io.py``). The ``_emit`` / ``_emit_progress`` /
+# ``_emit_warning`` helpers now forward to ``io.emit`` — no presentation import
+# remains in any of these modules, so they are genuinely GUARDED.
 # Login ``cookie_domains.py`` is pure service code: the command layer hosts
 # Click ``BadParameter`` translation and optional-domain warning rendering.
 GUARDED_PATHS = {
@@ -99,6 +104,7 @@ GUARDED_PATHS = {
     "cli/services/login/cookie_writes.py": SERVICES_ROOT / "login" / "cookie_writes.py",
     "cli/services/login/exceptions.py": SERVICES_ROOT / "login" / "exceptions.py",
     "cli/services/login/firefox_accounts.py": SERVICES_ROOT / "login" / "firefox_accounts.py",
+    "cli/services/login/io_seam.py": SERVICES_ROOT / "login" / "io_seam.py",
     "cli/services/login/outcomes.py": SERVICES_ROOT / "login" / "outcomes.py",
     "cli/services/login/profile_targets.py": SERVICES_ROOT / "login" / "profile_targets.py",
     "cli/services/login/refresh.py": SERVICES_ROOT / "login" / "refresh.py",
@@ -232,9 +238,18 @@ def _boundary_violations(path: pathlib.Path) -> list[str]:
         if not target.startswith(".") and head in FORBIDDEN_TOP_LEVEL_MODULES:
             violations.append(f"{path.name}:{line}: forbidden top-level import: {target!r}")
             continue
-        # Relative import ``from ..rendering ...`` etc. (exactly two leading dots
-        # because that targets a sibling of ``cli/services``).
-        if target.startswith("..") and not target.startswith("..."):
+        # Relative import of a presentation/runtime command module. Two forms
+        # resolve to the *same* real module (e.g. ``cli.rendering``):
+        #   * level-2 ``from ..rendering`` — from a ``cli/services/*`` module
+        #     (a sibling of ``cli/services``).
+        #   * level-3 ``from ...rendering`` — from a deeper subpackage like
+        #     ``cli/services/login/*`` (a sibling of ``cli``). #1393 tightened
+        #     the gate to cover this depth, which previously slipped through.
+        # Deeper forms (level-4 ``....rendering`` → ``notebooklm.rendering``,
+        # which does not exist) are not command-layer reach-ins, so the check
+        # is scoped to exactly levels 2 and 3.
+        dot_run = len(target) - len(target.lstrip("."))
+        if dot_run in (2, 3):
             remainder = target.lstrip(".")
             parent = remainder.split(".", 1)[0]
             if parent in FORBIDDEN_RELATIVE_PARENTS:
@@ -520,6 +535,36 @@ def test_guard_helper_detects_from_parent_import_sibling(tmp_path):
     bad.write_text("from __future__ import annotations\nfrom .. import rendering\n")
     violations = _boundary_violations(bad)
     assert any("rendering" in v for v in violations), violations
+
+
+def test_guard_helper_detects_level_3_relative_import(tmp_path):
+    """``from ...rendering import X`` (level-3) must trip the guard (#1393).
+
+    Login submodules sit one directory deeper than ``cli/services``, so their
+    presentation reach-ins use three leading dots and resolve to the real
+    ``cli.rendering`` module. The scanner originally flagged only the level-2
+    (``..rendering``) form, letting these slip through; this guards the
+    tightened check so a regression to level-2-only is caught.
+    """
+    bad = tmp_path / "fake_level3_service.py"
+    bad.write_text("from __future__ import annotations\nfrom ...rendering import console\n")
+    violations = _boundary_violations(bad)
+    assert any("rendering" in v for v in violations), violations
+
+
+def test_guard_helper_allows_level_4_relative_import(tmp_path):
+    """``from ....auth import X`` (level-4) must NOT trip the guard.
+
+    From a ``cli/services/login/*`` module, four leading dots resolve to a
+    package outside ``cli`` (``notebooklm.auth``), not a presentation module,
+    so the check must stay scoped to levels 2-3.
+    """
+    ok = tmp_path / "fake_level4_service.py"
+    ok.write_text(
+        "from __future__ import annotations\n"
+        "from ....rendering import console  # notebooklm.rendering — not cli.rendering\n"
+    )
+    assert _boundary_violations(ok) == []
 
 
 def test_guard_helper_allows_type_checking_imports(tmp_path):

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -547,7 +547,9 @@ def test_guard_helper_detects_level_3_relative_import(tmp_path):
     tightened check so a regression to level-2-only is caught.
     """
     bad = tmp_path / "fake_level3_service.py"
-    bad.write_text("from __future__ import annotations\nfrom ...rendering import console\n")
+    # Pin LF + UTF-8 so the fixture is byte-stable across the OS test matrix.
+    with bad.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("from __future__ import annotations\nfrom ...rendering import console\n")
     violations = _boundary_violations(bad)
     assert any("rendering" in v for v in violations), violations
 
@@ -560,10 +562,12 @@ def test_guard_helper_allows_level_4_relative_import(tmp_path):
     so the check must stay scoped to levels 2-3.
     """
     ok = tmp_path / "fake_level4_service.py"
-    ok.write_text(
-        "from __future__ import annotations\n"
-        "from ....rendering import console  # notebooklm.rendering — not cli.rendering\n"
-    )
+    # Pin LF + UTF-8 so the fixture is byte-stable across the OS test matrix.
+    with ok.open("w", encoding="utf-8", newline="\n") as f:
+        f.write(
+            "from __future__ import annotations\n"
+            "from ....rendering import console  # notebooklm.rendering — not cli.rendering\n"
+        )
     assert _boundary_violations(ok) == []
 
 


### PR DESCRIPTION
## What

Closes the final ADR-0008 enforcement gap: the services-boundary scanner only flagged **level-2** relative imports (`..rendering`), so the `cli/services/login/*` modules — one directory deeper — reached `rendering` / `error_handler` / `runtime` through **level-3** `...` imports that slipped past the gate while still calling `console.print` / `exit_with_code` / `run_async`. This PR tightens the scanner to cover level-3 **and** inverts every reach-in it exposes so `main` stays green.

- **Tighten the scanner** (`tests/unit/cli/test_services_boundary.py`): `_boundary_violations` now flags level-2 **and** level-3 forbidden relative imports (scoped to dot-depths 2-3 so `....auth` → `notebooklm.auth` stays allowed). Added self-checks for the level-3 (flagged) and level-4 (allowed) shapes; updated the `GUARDED_PATHS` rationale and classified the new `io_seam.py`.
- **Invert the login DAG** behind a caller-injected `LoginIO` sink, reusing the #1391 pattern across `refresh.py`, `browser_accounts.py`, `chromium_accounts.py`, `firefox_accounts.py`, `cookie_writes.py`, and `cookie_jar.py`. New `cli/services/login/io_seam.py` holds the service-local `LoginIO` Protocol + a default-sink resolver; the command layer (`cli/playwright_login_io.py`) registers the concrete `PlaywrightLoginIO` sink as the default at import time. `_emit*` helpers forward to `io.emit`, exit policy goes through `io.fail`, and the async account probe runs through `io.run_async`. No `...rendering` / `...error_handler` / `...runtime` import remains in any scanned login module.

## Why

After #1391 drained `playwright_login.py`, ADR-0008 *looked* fully enforced — but the level-3 blind spot meant ~6 `login/` modules still owned presentation/exit policy invisibly. The boundary is only genuinely enforced once the scanner sees level-3 and those reach-ins are inverted. This is a real burndown (it re-flags the modules #1383 "drained"), not a one-liner.

## How (behavior-preserving)

These are login/auth flows, so rendered output + exit codes must be identical:
- Public driver entry points take `io: LoginIO | None = None` and resolve the command-layer default sink, so `session_cmd.py` call sites are **unchanged** (`session_cmd.py` stays at its pinned 1080-line ceiling) and the ~40 direct-call unit tests keep their signatures or inject a tiny recording sink.
- The concrete default sink forwards `emit` → `console.print`, `fail` → `exit_with_code` (`SystemExit`), `run_async` → `cli.runtime.run_async`, so text-mode UX is byte-for-byte identical.
- A session-autouse conftest fixture imports `playwright_login_io` so direct service unit tests get the default sink deterministically regardless of collection order.
- New `tests/_fixtures/login_io.py` provides a `RecordingLoginIO` for tests that previously patched module-level `run_async` / `console`.

## Verification

All green:
- `test_services_boundary.py` with the tightened scanner (+ level-3/level-4 guards); `TRANSITIONAL_GUARDED_PATHS` stays empty; `io_seam.py` classified `GUARDED`.
- `test_login_package_dag.py` (`io_seam` added as a leaf edge), `test_login_init_is_reexport_only.py`, `test_module_size_ratchet.py`, `test_claude_md_freshness.py`.
- `uv run mypy src/notebooklm --ignore-missing-imports` clean; ruff check + format clean.
- Full `tests/unit` + `tests/integration` suite: **8031 passed, 66 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI login and cookie-import flows now route progress, warnings, async probes, and exit behavior through a caller-injectable LoginIO interface with a default factory, centralizing presentation and async wiring.

* **Tests**
  * Added test fixtures and updated unit tests to exercise the injectable IO bridge and stabilize CLI test ordering.

* **Documentation**
  * Updated docs and lint/boundary rules to document and allow the new IO seam.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1393