### PR TITLE
arch(ADR-0008): make services-boundary scanner resolution-based (depth-agnostic) (closes #1400)

### DIFF
--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -1,10 +1,14 @@
 """Static AST checks enforcing the ADR-008 ``cli/services`` layering boundary.
 
 This file scans cleaned ``cli/services`` modules for forbidden imports —
-top-level ``click`` and relative imports from sibling presentation/runtime
-modules (``..rendering``, ``..error_handler``, ``..runtime``). It also
-inventories the Stage-3 transitional exceptions for workflow services still
-being migrated out of rendering/exit ownership.
+top-level ``click`` and relative imports that *resolve* to the command-layer
+presentation/runtime modules (``notebooklm.cli.rendering`` /
+``error_handler`` / ``runtime``). The relative-import check is
+resolution-based and depth-agnostic: each ``from ..X`` / ``from ...X`` /
+``from ....X`` is resolved to its absolute target module and flagged iff that
+target is one of the forbidden command modules, regardless of dot count
+(#1400). It also inventories the Stage-3 transitional exceptions for workflow
+services still being migrated out of rendering/exit ownership.
 
 Scope: every file under ``cli/services/`` (recursively, excluding
 ``__init__.py`` and ``__pycache__``) must be classified into exactly one of
@@ -53,25 +57,40 @@ import pytest
 # dependency.
 FORBIDDEN_TOP_LEVEL_MODULES = {"click"}
 
-# Relative imports from these presentation/runtime modules are forbidden
-# regardless of nesting depth. The check fires for any ``from ..<name>`` /
-# ``from ..<name>.X`` import (a sibling of ``cli/services``) AND any
-# ``from ...<name>`` / ``from ...<name>.X`` import (a sibling of ``cli``,
-# reached from a deeper subpackage like ``cli/services/login/``). Both resolve
-# to the same real command-layer module (e.g. ``cli.rendering``), so both are
-# a presentation reach-in.
+# Relative imports that *resolve* to these absolute command-layer modules are
+# forbidden, regardless of nesting depth or dot count. The check is
+# **resolution-based**: for every ``from ..X`` / ``from ...X`` / ``from ....X``
+# relative import in a scanned module, the scanner computes the import's
+# absolute target module from the importing module's package + the dot count
+# (Python's own relative-import resolution) and flags it iff the resolved
+# target is one of these presentation/runtime command modules.
 #
 # History: the scanner originally flagged only the level-2 (``..rendering``)
-# form. ``cli/services/login/*`` modules sit one directory deeper, so their
-# ``...rendering`` reach-ins resolved to the real ``cli.rendering`` while
-# slipping past the gate (#1393). The login DAG was inverted behind a
-# caller-injected ``LoginIO`` sink (``cli/services/login/io_seam.py``, concrete
-# sink in ``cli/playwright_login_io.py``) and the scanner tightened to level-3
-# so the blind spot is closed.
+# form by dot-count. ``cli/services/login/*`` modules sit one directory deeper,
+# so their ``...rendering`` reach-ins resolved to the real ``cli.rendering``
+# while slipping past the gate (#1393). #1393 tightened the bound to dot-depths
+# 2 AND 3 — but that bound was coupled to the current max directory depth: a
+# future ``cli/services/login/sub/`` module could reach ``cli.rendering`` via a
+# level-4 ``....rendering`` import and evade the gate (#1400). The check is now
+# depth-agnostic and resolution-based, so the forbidden set is expressed as the
+# absolute module names below and the dot-count no longer matters: ``....auth``
+# (→ ``notebooklm.auth``) stays allowed from any depth, while ``....rendering``
+# (→ ``notebooklm.cli.rendering``) is flagged from any depth.
 FORBIDDEN_RELATIVE_PARENTS = {"rendering", "error_handler", "runtime"}
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
 SERVICES_ROOT = REPO_ROOT / "src" / "notebooklm" / "cli" / "services"
+CLI_PACKAGE = "notebooklm.cli"
+
+# Absolute command-layer modules a ``cli/services`` module must never reach via
+# a relative import — derived from ``FORBIDDEN_RELATIVE_PARENTS`` so the two
+# stay in lockstep. A resolved relative target is forbidden iff it equals one
+# of these exactly (e.g. ``notebooklm.cli.rendering``) or is a submodule of one
+# (e.g. ``notebooklm.cli.rendering.sub``).
+FORBIDDEN_ABSOLUTE_TARGETS = frozenset(
+    f"{CLI_PACKAGE}.{name}" for name in FORBIDDEN_RELATIVE_PARENTS
+)
 
 # Fully cleaned service modules. Each must have zero ``_boundary_violations``
 # AND zero Pattern A pairs (see :func:`_pattern_a_pairs`).
@@ -229,8 +248,60 @@ def _runtime_imports(path: pathlib.Path) -> Iterator[tuple[str, int]]:
     yield from _walk(tree, inside_type_checking=False)
 
 
-def _boundary_violations(path: pathlib.Path) -> list[str]:
-    """Return human-readable violation strings (empty iff clean)."""
+def _package_for_path(path: pathlib.Path) -> str | None:
+    """Return the importing module's dotted package, or ``None`` if off-tree.
+
+    For a real module under ``src/`` (e.g.
+    ``src/notebooklm/cli/services/login/refresh.py``), the package is the
+    dotted path of its *containing directory*
+    (``notebooklm.cli.services.login``) — that is the anchor Python uses to
+    resolve relative imports. Synthetic fixtures created in ``tmp_path`` live
+    outside ``src/``; they return ``None`` and must pass an explicit
+    ``package=`` to :func:`_boundary_violations` to simulate a tree location.
+    """
+    try:
+        rel = path.resolve().relative_to(SRC_ROOT)
+    except ValueError:
+        return None
+    parts = rel.with_suffix("").parts
+    # Drop the module's own leaf name to get its containing package.
+    return ".".join(parts[:-1])
+
+
+def _resolve_relative(target: str, package: str) -> str:
+    """Resolve a dotted relative import ``target`` against ``package``.
+
+    Mirrors :func:`importlib._bootstrap._resolve_name`: ``level`` leading dots
+    strip ``level - 1`` trailing components off ``package``, then the named
+    remainder (if any) is appended. ``..rendering`` from
+    ``notebooklm.cli.services`` → ``notebooklm.cli.rendering``; ``....rendering``
+    from ``notebooklm.cli.services.login.sub`` → ``notebooklm.cli.rendering``.
+    """
+    level = len(target) - len(target.lstrip("."))
+    name = target.lstrip(".")
+    base = package.rsplit(".", level - 1)[0] if level > 1 else package
+    return f"{base}.{name}" if name else base
+
+
+def _is_forbidden_target(resolved: str) -> bool:
+    """Flag iff ``resolved`` is a forbidden command module or a submodule of one."""
+    return any(
+        resolved == forbidden or resolved.startswith(f"{forbidden}.")
+        for forbidden in FORBIDDEN_ABSOLUTE_TARGETS
+    )
+
+
+def _boundary_violations(path: pathlib.Path, *, package: str | None = None) -> list[str]:
+    """Return human-readable violation strings (empty iff clean).
+
+    Relative imports are resolved to their absolute target module (from the
+    importing module's ``package`` + the dot count) and flagged iff the target
+    is a forbidden command-layer module — independent of the dot count. The
+    ``package`` is derived from ``path`` for real on-tree modules; off-tree
+    fixtures must pass it explicitly to simulate their tree location.
+    """
+    if package is None:
+        package = _package_for_path(path)
     violations: list[str] = []
     for target, line in _runtime_imports(path):
         # Top-level import like ``import click`` or ``from click import ...``.
@@ -238,22 +309,29 @@ def _boundary_violations(path: pathlib.Path) -> list[str]:
         if not target.startswith(".") and head in FORBIDDEN_TOP_LEVEL_MODULES:
             violations.append(f"{path.name}:{line}: forbidden top-level import: {target!r}")
             continue
-        # Relative import of a presentation/runtime command module. Two forms
-        # resolve to the *same* real module (e.g. ``cli.rendering``):
-        #   * level-2 ``from ..rendering`` — from a ``cli/services/*`` module
-        #     (a sibling of ``cli/services``).
-        #   * level-3 ``from ...rendering`` — from a deeper subpackage like
-        #     ``cli/services/login/*`` (a sibling of ``cli``). #1393 tightened
-        #     the gate to cover this depth, which previously slipped through.
-        # Deeper forms (level-4 ``....rendering`` → ``notebooklm.rendering``,
-        # which does not exist) are not command-layer reach-ins, so the check
-        # is scoped to exactly levels 2 and 3.
-        dot_run = len(target) - len(target.lstrip("."))
-        if dot_run in (2, 3):
-            remainder = target.lstrip(".")
-            parent = remainder.split(".", 1)[0]
-            if parent in FORBIDDEN_RELATIVE_PARENTS:
-                violations.append(f"{path.name}:{line}: forbidden relative import: {target!r}")
+        if not target.startswith("."):
+            continue
+        # Relative import: resolve to its absolute target module and flag iff
+        # that target is a command-layer presentation/runtime module
+        # (``notebooklm.cli.rendering`` / ``error_handler`` / ``runtime``),
+        # regardless of the dot count. ``..rendering`` from
+        # ``cli/services/*``, ``...rendering`` from ``cli/services/login/*``,
+        # and a hypothetical ``....rendering`` from
+        # ``cli/services/login/sub/*`` all resolve to the same forbidden
+        # module; ``....auth`` (→ ``notebooklm.auth``) does not and stays
+        # allowed at any depth.
+        if package is None:
+            raise AssertionError(
+                f"Cannot resolve relative import {target!r} in {path}: the module "
+                "is off-tree (outside src/) so its package is unknown. Pass an "
+                "explicit package= to _boundary_violations() for synthetic fixtures."
+            )
+        resolved = _resolve_relative(target, package)
+        if _is_forbidden_target(resolved):
+            violations.append(
+                f"{path.name}:{line}: forbidden relative import: {target!r} "
+                f"(resolves to {resolved})"
+            )
     return violations
 
 
@@ -530,10 +608,27 @@ def test_guard_helper_detects_from_parent_import_sibling(tmp_path):
     alias-only form silently passes — even though it carries the same runtime
     dependency on ``cli.rendering`` as ``from ..rendering import X``. CodeRabbit
     flagged this in PR #961 review.
+
+    Simulated from a ``cli/services/*`` module: ``from .. import rendering``
+    resolves to ``notebooklm.cli.rendering``.
     """
     bad = tmp_path / "fake_service_alias_form.py"
     bad.write_text("from __future__ import annotations\nfrom .. import rendering\n")
-    violations = _boundary_violations(bad)
+    violations = _boundary_violations(bad, package="notebooklm.cli.services")
+    assert any("rendering" in v for v in violations), violations
+
+
+def test_guard_helper_detects_level_2_relative_import(tmp_path):
+    """``from ..rendering import X`` (level-2) must trip the guard.
+
+    The baseline case: a ``cli/services/*`` module reaching its presentation
+    sibling. Simulated from package ``notebooklm.cli.services`` →
+    ``notebooklm.cli.rendering``.
+    """
+    bad = tmp_path / "fake_level2_service.py"
+    with bad.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("from __future__ import annotations\nfrom ..rendering import console\n")
+    violations = _boundary_violations(bad, package="notebooklm.cli.services")
     assert any("rendering" in v for v in violations), violations
 
 
@@ -542,33 +637,65 @@ def test_guard_helper_detects_level_3_relative_import(tmp_path):
 
     Login submodules sit one directory deeper than ``cli/services``, so their
     presentation reach-ins use three leading dots and resolve to the real
-    ``cli.rendering`` module. The scanner originally flagged only the level-2
-    (``..rendering``) form, letting these slip through; this guards the
-    tightened check so a regression to level-2-only is caught.
+    ``cli.rendering`` module. Simulated from package
+    ``notebooklm.cli.services.login`` → ``notebooklm.cli.rendering``.
     """
     bad = tmp_path / "fake_level3_service.py"
     # Pin LF + UTF-8 so the fixture is byte-stable across the OS test matrix.
     with bad.open("w", encoding="utf-8", newline="\n") as f:
         f.write("from __future__ import annotations\nfrom ...rendering import console\n")
-    violations = _boundary_violations(bad)
+    violations = _boundary_violations(bad, package="notebooklm.cli.services.login")
     assert any("rendering" in v for v in violations), violations
 
 
-def test_guard_helper_allows_level_4_relative_import(tmp_path):
+def test_guard_helper_detects_level_4_relative_import_resolving_to_cli(tmp_path):
+    """``from ....rendering import X`` (level-4) must trip the guard when it
+    resolves to ``cli.rendering`` (#1400).
+
+    This is the future blind spot the old depth-2/3 bound left open: a
+    hypothetical ``cli/services/login/sub/*`` module (package
+    ``notebooklm.cli.services.login.sub``) reaching the command layer via four
+    leading dots resolves to ``notebooklm.cli.rendering`` — a presentation
+    reach-in that the depth-coupled scanner would have missed. The
+    resolution-based check flags it regardless of dot count.
+    """
+    bad = tmp_path / "fake_level4_cli_service.py"
+    with bad.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("from __future__ import annotations\nfrom ....rendering import console\n")
+    violations = _boundary_violations(bad, package="notebooklm.cli.services.login.sub")
+    assert any("rendering" in v for v in violations), violations
+
+
+def test_guard_helper_allows_level_4_relative_import_to_notebooklm(tmp_path):
     """``from ....auth import X`` (level-4) must NOT trip the guard.
 
-    From a ``cli/services/login/*`` module, four leading dots resolve to a
-    package outside ``cli`` (``notebooklm.auth``), not a presentation module,
-    so the check must stay scoped to levels 2-3.
+    From a ``cli/services/login/*`` module (package
+    ``notebooklm.cli.services.login``), four leading dots resolve to a package
+    outside ``cli`` (``notebooklm.auth``), a legitimate dependency the login
+    modules genuinely use. The resolution-based check must keep allowing it at
+    any depth.
     """
-    ok = tmp_path / "fake_level4_service.py"
+    ok = tmp_path / "fake_level4_notebooklm_auth.py"
     # Pin LF + UTF-8 so the fixture is byte-stable across the OS test matrix.
     with ok.open("w", encoding="utf-8", newline="\n") as f:
-        f.write(
-            "from __future__ import annotations\n"
-            "from ....rendering import console  # notebooklm.rendering — not cli.rendering\n"
-        )
-    assert _boundary_violations(ok) == []
+        f.write("from __future__ import annotations\nfrom ....auth import AuthTokens\n")
+    assert _boundary_violations(ok, package="notebooklm.cli.services.login") == []
+
+
+def test_guard_helper_allows_level_4_notebooklm_namesake_module(tmp_path):
+    """``from ....config import X`` (level-4) → ``notebooklm.config`` must pass.
+
+    A ``notebooklm.*`` top-level module that happens to share a *leaf* name is
+    not a ``cli.*`` reach-in. From ``notebooklm.cli.services.login``,
+    ``....config`` resolves to ``notebooklm.config`` (not
+    ``notebooklm.cli.config``), so the namesake must not be flagged. Guards
+    against a regression that keys off the leaf name instead of the resolved
+    absolute module.
+    """
+    ok = tmp_path / "fake_level4_notebooklm_config.py"
+    with ok.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("from __future__ import annotations\nfrom ....config import DEFAULT_ENDPOINT\n")
+    assert _boundary_violations(ok, package="notebooklm.cli.services.login") == []
 
 
 def test_guard_helper_allows_type_checking_imports(tmp_path):
@@ -580,7 +707,7 @@ def test_guard_helper_allows_type_checking_imports(tmp_path):
         "if TYPE_CHECKING:\n"
         "    from ..rendering import ListRender  # noqa\n"
     )
-    assert _boundary_violations(ok) == []
+    assert _boundary_violations(ok, package="notebooklm.cli.services") == []
 
 
 def test_pattern_a_helper_detects_co_occurrence(tmp_path):

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -276,10 +276,25 @@ def _resolve_relative(target: str, package: str) -> str:
     remainder (if any) is appended. ``..rendering`` from
     ``notebooklm.cli.services`` → ``notebooklm.cli.rendering``; ``....rendering``
     from ``notebooklm.cli.services.login.sub`` → ``notebooklm.cli.rendering``.
+
+    Raises :class:`ValueError` for an import that reaches past the top-level
+    package (more dots than ``package`` has components) — exactly the case
+    Python itself rejects with ``ImportError: attempted relative import beyond
+    top-level package``. Such an import can never execute, so silently clamping
+    it (``rsplit`` returning a too-short list) would mis-resolve it to a wrong
+    absolute module and could mask a real reach-in; failing loudly is correct.
     """
     level = len(target) - len(target.lstrip("."))
     name = target.lstrip(".")
-    base = package.rsplit(".", level - 1)[0] if level > 1 else package
+    if level > 1:
+        bits = package.rsplit(".", level - 1)
+        if len(bits) < level:
+            raise ValueError(
+                f"attempted relative import {target!r} beyond top-level package {package!r}"
+            )
+        base = bits[0]
+    else:
+        base = package
     return f"{base}.{name}" if name else base
 
 
@@ -696,6 +711,35 @@ def test_guard_helper_allows_level_4_notebooklm_namesake_module(tmp_path):
     with ok.open("w", encoding="utf-8", newline="\n") as f:
         f.write("from __future__ import annotations\nfrom ....config import DEFAULT_ENDPOINT\n")
     assert _boundary_violations(ok, package="notebooklm.cli.services.login") == []
+
+
+def test_guard_helper_allows_level_1_intra_package_import(tmp_path):
+    """``from .rendering import X`` (level-1) must NOT trip the guard.
+
+    A single-dot import from a ``cli/services/*`` module targets a *sibling
+    inside* ``cli.services`` (``notebooklm.cli.services.rendering``), not the
+    command-layer ``notebooklm.cli.rendering``. Guards the ``level == 1``
+    branch of ``_resolve_relative`` against a regression that would resolve
+    intra-package imports up to the ``cli`` package.
+    """
+    ok = tmp_path / "fake_level1_service.py"
+    with ok.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("from __future__ import annotations\nfrom .rendering import build_table\n")
+    assert _boundary_violations(ok, package="notebooklm.cli.services") == []
+
+
+def test_resolve_relative_rejects_import_beyond_top_level_package():
+    """``_resolve_relative`` raises when an import reaches past the root package.
+
+    Mirrors Python's own ``ImportError: attempted relative import beyond
+    top-level package``. Such an import can never execute, so silently
+    clamping it would mis-resolve to a wrong absolute module and could mask a
+    real reach-in; the helper must fail loudly instead. (gemini-code-assist /
+    claude review on #1401.)
+    """
+    # ``....rendering`` (level-4) from a 2-component package overruns the root.
+    with pytest.raises(ValueError, match="beyond top-level package"):
+        _resolve_relative("....rendering", "a.b")
 
 
 def test_guard_helper_allows_type_checking_imports(tmp_path):


### PR DESCRIPTION
## What

Rewrites the ADR-0008 `cli/services` import-boundary scanner
(`tests/unit/cli/test_services_boundary.py`) so the forbidden-relative-import
check is **resolution-based and depth-agnostic** instead of being bounded to
dot-depths 2 and 3.

## Why

#1393 tightened the scanner to flag forbidden relative imports of
`cli.rendering` / `cli.error_handler` / `cli.runtime` at dot-depths **2 AND 3**
(covering `cli/services/X.py` via `..rendering` and `cli/services/login/X.py`
via `...rendering`). But that bound is **coupled to the current max directory
depth**: a future `cli/services/login/sub/` module would reach the forbidden
`cli.rendering` via a **level-4** `....rendering` import and **evade** the gate
— silently re-opening the exact blind spot #1393 closed one level shallower
(#1400).

## How

For each relative import in a scanned `cli/services` module, the scanner now
computes the import's **absolute target module** from the importing module's
package + the dot count (Python's own relative-import resolution, mirroring
`importlib._bootstrap._resolve_name`), and flags it iff the resolved target is
`notebooklm.cli.rendering` / `error_handler` / `runtime` (or a submodule of
one), **regardless of dot count**.

- `..rendering` from `cli/services/*`, `...rendering` from
  `cli/services/login/*`, and a hypothetical `....rendering` from
  `cli/services/login/sub/*` all resolve to `notebooklm.cli.rendering` → **flagged**.
- `....auth` (→ `notebooklm.auth`), `....config` (→ `notebooklm.config`), etc.
  resolve outside `cli` → **allowed at any depth** (the legit dependencies the
  real `login/` modules use).

The importing module's package is derived from the file path for real on-tree
modules; off-tree synthetic fixtures (in `tmp_path`) pass an explicit
`package=` to simulate their tree location.

New/updated self-check tests prove:
- the existing level-2 + level-3 forbidden cases still flag;
- a synthetic **level-4** `....rendering` that resolves to `cli.rendering` **IS** flagged (the #1400 blind spot);
- `....auth` (→ `notebooklm.auth`) and a `notebooklm.config` namesake (→ `notebooklm.config`, not `notebooklm.cli.config`) are **NOT** flagged.

**Behavior-preserving:** the set of currently-flagged real modules is unchanged
— no real `cli/services` module is newly flagged. `TRANSITIONAL_GUARDED_PATHS`
stays `{}` and every `GUARDED_PATHS` entry still passes. The scanner only
becomes depth-agnostic. Only the test file changes; no `src/` module is touched.

## Verification

- `uv run pytest tests/unit/cli/test_services_boundary.py -q` → 46 passed, 1 skipped
- `uv run pytest tests/_lint/test_module_size_ratchet.py tests/_lint/test_login_package_dag.py tests/unit/test_cli_boundary.py -q` → 48 passed
- `uv run mypy src/notebooklm --ignore-missing-imports` → Success: no issues found in 197 source files
- `uv run ruff format` + `uv run ruff check` → clean

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit tests to better detect forbidden layering violations across varied relative-import patterns and depths (including deeper-level cases) and to cover guarded type-check imports.

* **Chores**
  * Improved test helpers to support synthetic/off-tree fixtures and reliable resolution of relative imports into absolute module targets for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->