### PR TITLE
feat: NOTEBOOKLM_FUTURE_ERRORS opt-in v0.8.0 error-contract preview flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `NOTEBOOKLM_FUTURE_ERRORS` opt-in preview flag — run the **v0.8.0 error
+  contract** early to test forward-compatibility before the breaking flips ship
+  (ADR-0019 / umbrella #1346). Default-off and **byte-identical** to current
+  v0.7.0 behavior; when truthy (`1`/`true`/`yes`/`on`) the three warn-runways
+  adopt their v0.8.0 raise-target: `sources.get` / `artifacts.get` /
+  `notes.get` / `mind_maps.get` raise the matching `*NotFoundError` on a miss
+  (#1247), `MappingCompatMixin` dict-subscript raises `TypeError` (#1251), and
+  the deprecated `ResearchAPI.wait_for_completion(interval=...)` alias raises
+  `TypeError` (#1254). Takes precedence over `NOTEBOOKLM_QUIET_DEPRECATIONS`
+  (a runway raises regardless of quiet). The four `get()` methods are now routed
+  through a single `_lookup.resolve_get` bridge, eliminating the hand-duplicated
+  warn-on-miss pattern. Helper: `notebooklm._deprecation.future_errors_enabled`.
+  The purely-behavioral v0.8.0 changes that lack a warn-runway (`delete()`
+  returning `None`, refusal-suppression, fail-loud listing) are not gated yet;
+  they will be folded in as their behavior is defined. Does **not** close
+  #1247/#1251/#1254 — the runways remain until the v0.8.0 flip. See
+  `docs/deprecations.md`. Additive (issue #1346).
 - `client.artifacts.retry_failed(notebook_id, artifact_id)` — retry a failed
   Studio artifact in place (the web UI "Retry" action), via the new
   `RETRY_ARTIFACT` (`Rytqqe`) RPC. The artifact is not deleted first and the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_REFRESH_STORAGE_PATH` | Child-process hint set for `NOTEBOOKLM_REFRESH_CMD`; path to the `storage_state.json` file the command must rewrite | resolved storage path |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the project's public-API `DeprecationWarning`s: the `get()`-returns-`None` warning (`sources.get` / `artifacts.get` / `notes.get` on a miss) and deprecated keyword aliases (e.g. `ResearchAPI.wait_for_completion(interval=...)`). Set to a truthy value (`1` / `true` / `yes` / `on`, case-insensitive) to silence them; see `docs/deprecations.md`. | (warnings emitted) |
+| `NOTEBOOKLM_FUTURE_ERRORS` | Opt in to the **v0.8.0 error contract** early (forward-compat preview). When truthy (`1` / `true` / `yes` / `on`), the warn-runways adopt their v0.8.0 raise-target: `*.get()` raises `*NotFoundError` on a miss, `MappingCompatMixin` dict-subscript raises `TypeError`, and the deprecated `interval=` keyword raises `TypeError`. Takes precedence over `NOTEBOOKLM_QUIET_DEPRECATIONS`. Off by default (byte-identical to v0.7.0); see `docs/deprecations.md`. | (off — warn) |
 | `NOTEBOOKLM_VCR_RECORD_ERRORS` | Synthetic-error injection mode for VCR test cassettes (`429`, `5xx`, `expired_csrf`) | - |
 
 ### Public config API vs internal resolvers
@@ -175,6 +176,7 @@ be audited from one location.
 | `NOTEBOOKLM_NOTEBOOK` | Default notebook ID when no `-n/--notebook` flag is passed. Composes with `notebooklm use <id>` so per-shell overrides do not clobber the persisted active-notebook context. | `-n/--notebook` flag → `NOTEBOOKLM_NOTEBOOK` → active context (from `notebooklm use`) → error | `cli.helpers.require_notebook` (Click also reads it natively via `cli/options.py:notebook_option`'s `envvar=`) |
 | `NOTEBOOKLM_RPC_OVERRIDES` | **JSON object** mapping `RPCMethod` enum names to RPC ID strings (e.g. `{"LIST_NOTEBOOKS": "AbC123"}`). Overrides runtime RPC IDs — community self-patch when Google rotates a method ID. Empty string / unset disables the mechanism; invalid JSON or non-object payloads emit a `WARNING` and are ignored. | Process env, evaluated per RPC resolve (cached on the raw env string). | `notebooklm.rpc.overrides._parse_rpc_overrides` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the project's public-API `DeprecationWarning`s. Two families are gated: (1) the `get()`-returns-`None` warning, emitted when `sources.get` / `artifacts.get` / `notes.get` are about to return `None` for a missing entity (these will raise `*NotFoundError` instead in v0.8.0); and (2) deprecated keyword aliases (e.g. `ResearchAPI.wait_for_completion(interval=...)` → `initial_interval=...`) — the keyword still works, only its warning is silenced. Set to a truthy value (`1` / `true` / `yes` / `on`) to silence them. See `docs/deprecations.md`. | (warnings emitted) | `_deprecation._deprecations_quiet` / `deprecations_quiet` |
+| `NOTEBOOKLM_FUTURE_ERRORS` | Opt in to the **v0.8.0 error contract** early so you can test forward-compatibility before the breaking flips ship (ADR-0019 / umbrella [#1346](https://github.com/teng-lin/notebooklm-py/issues/1346)). When truthy (`1` / `true` / `yes` / `on`), the warn-runways adopt their v0.8.0 raise-target: `sources.get` / `artifacts.get` / `notes.get` / `mind_maps.get` raise the matching `*NotFoundError` on a miss (#1247); `MappingCompatMixin` dict-subscript raises `TypeError` (#1251); the deprecated `interval=` alias raises `TypeError` (#1254). **Takes precedence over `NOTEBOOKLM_QUIET_DEPRECATIONS`** (a runway raises regardless of quiet). Off by default and byte-identical to v0.7.0. Run `NOTEBOOKLM_FUTURE_ERRORS=1 pytest` in CI to gate forward-compat. See `docs/deprecations.md`. | (off — warn) | `_deprecation._future_errors_enabled` / `future_errors_enabled` |
 | `NOTEBOOKLM_STRICT_DECODE` | **Retired (ignored since v0.7.0).** Strict decoding is the only mode — `safe_index` always raises `UnknownRPCMethodError` on schema drift. The former `0` warn-and-fallback opt-out was removed; setting the variable has no effect. | (ignored) | — |
 | `NOTEBOOKLM_BASE_URL` | NotebookLM base URL. Constrained to `https://notebooklm.google.com` (personal) or `https://notebooklm.cloud.google.com` (enterprise); other schemes/hosts/paths raise `ValueError`. | Process env on every base-URL lookup. | `_env.get_base_url` |
 | `NOTEBOOKLM_BL` | `bl` (build label) URL parameter sent on the chat streaming endpoint (`ChatAPI.ask`). Pins the frontend build the request is attributed to. | Process env on every chat stream call; whitespace-only falls back to `_env.DEFAULT_BL`. | `_env.get_default_bl` |
@@ -343,6 +345,50 @@ export NOTEBOOKLM_QUIET_DEPRECATIONS=1
 > `client.sources.add_file(mime_type=...)` — `mime_type` is a supported
 > parameter and emits no warning. (It was previously a no-op that once gated a
 > since-removed `--mime-type` notice; it is now wired to the deprecations above.)
+
+### NOTEBOOKLM_FUTURE_ERRORS
+
+Opt in to the **v0.8.0 error contract** early so you can verify forward-
+compatibility before the breaking flips ship (ADR-0019 / umbrella
+[#1346](https://github.com/teng-lin/notebooklm-py/issues/1346)). Set it to a
+truthy value (`1`, `true`, `yes`, or `on`, case-insensitive); any other value
+(including unset) keeps current v0.7.0 behavior. Default-off is **byte-identical**
+to v0.7.0.
+
+When on, the three warn-runways adopt their v0.8.0 raise-target:
+
+1. **`*.get()` on a miss raises.** `client.sources.get()` /
+   `client.artifacts.get()` / `client.notes.get()` / `client.mind_maps.get()`
+   raise the matching `*NotFoundError` instead of warning-and-returning `None`
+   ([#1247](https://github.com/teng-lin/notebooklm-py/issues/1247)).
+   `get_or_none()` is unaffected — it stays the silent `None`-on-miss path.
+2. **Dict-subscript raises.** `result["key"]` on the typed research / mind-map /
+   source-guide returns (`MappingCompatMixin`) raises
+   `TypeError: '<Type>' object is not subscriptable` — the same error a plain
+   dataclass raises once the mixin is removed
+   ([#1251](https://github.com/teng-lin/notebooklm-py/issues/1251)). Attribute
+   access (`result.status`) and the silent shape-probes are unaffected.
+3. **Deprecated keyword raises.** Passing
+   `ResearchAPI.wait_for_completion(interval=...)` raises `TypeError` instead of
+   aliasing to `initial_interval=`
+   ([#1254](https://github.com/teng-lin/notebooklm-py/issues/1254)).
+
+**Precedence.** `NOTEBOOKLM_FUTURE_ERRORS` takes precedence over
+`NOTEBOOKLM_QUIET_DEPRECATIONS`: under future mode a runway **raises regardless**
+of the quiet setting (quiet only silences the *warning*, which future mode
+replaces with an exception). The helper that reads this variable is
+`notebooklm._deprecation._future_errors_enabled` (public alias
+`future_errors_enabled`).
+
+```bash
+# Gate forward-compatibility in CI: run your suite under the v0.8.0 contract.
+NOTEBOOKLM_FUTURE_ERRORS=1 pytest
+```
+
+The purely-behavioral v0.8.0 changes that lack a clean warn-runway (`delete()`
+returning `None`, refusal-suppression, fail-loud listing) are **not** gated by
+this flag yet; they will be folded in as their v0.8.0 behavior is defined. See
+[`deprecations.md`](deprecations.md) for the full table.
 
 ### Timeouts
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -42,9 +42,16 @@ When the flag is on, these three runways adopt their v0.8.0 behavior:
 | Deprecated keyword alias `ResearchAPI.wait_for_completion(interval=...)` | Warns, aliases to `initial_interval` | Raises `TypeError` (the deprecated keyword is gone) | [#1254](https://github.com/teng-lin/notebooklm-py/issues/1254) |
 
 The flag does **not** close those issues — the runways stay until the v0.8.0 flip
-actually ships; it only lets you preview the target behavior. `get_or_none()` and
-every silent shape-probe (`result.get(...)` / `keys()` / `in` / `iter(...)`) are
-the sanctioned post-flip paths and are **unaffected** by the flag in both modes.
+actually ships; it only lets you preview the target behavior. The flag changes
+only the *deprecated* paths in the table; the sanctioned replacements are
+**unaffected** in both modes: `get_or_none()` stays the silent `None`-on-miss
+lookup, and attribute access (`result.status`, `result.sources`, …) stays the
+warning-free read on the typed dataclasses. Note that the *other*
+`MappingCompatMixin` accessors (`result.get(...)` / `keys()` / `in` / `iter(...)`)
+stay silent **under this flag** — it gates only `__getitem__` — but they are part
+of the mixin and are removed wholesale in v0.8.0 along with subscript; the only
+post-flip read is attribute access. Use them as a temporary migration aid, not a
+target shape.
 
 **Precedence over `NOTEBOOKLM_QUIET_DEPRECATIONS`.** When `NOTEBOOKLM_FUTURE_ERRORS`
 is on, a runway **raises regardless of the quiet setting** — quiet only silences

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -20,6 +20,63 @@ the broader stability policy (semver promise, supported Python versions, the
 | `ResearchAPI.wait_for_completion(interval=...)` | `initial_interval=...` — same cadence, name now matches `SourcesAPI.wait_until_ready` / `ArtifactsAPI.wait_for_completion` | v0.7.0 | v0.8.0 | Additive: `interval` keeps its default of `5` and still works; passing a non-default value emits a `DeprecationWarning`, passing both `interval` and `initial_interval` raises `TypeError`. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py` |
 | Dict-subscript access (`result["status"]`) on `research.poll` / `research.start` / `research.wait_for_completion`, `artifacts.generate_mind_map`, and `sources.get_guide` return values | Attribute access (`result.status`, `result.sources`, `result.note_id`, `guide.summary`, …) | v0.7.0 | v0.8.0 | These methods now return typed dataclasses (`ResearchTask` / `ResearchStart` / `MindMapResult` / `SourceGuide`) with a new `ResearchStatus` str-enum, instead of `dict[str, Any]`. The dataclasses mix in `MappingCompatMixin` so the legacy dict shape keeps working for one MINOR cycle: `result["key"]` warns and returns the historical value (from `to_public_dict()`), while `result.get(...)` / `result.keys()` / `"x" in result` / `iter(result)` stay silent. In v0.8.0 the mixin is dropped and the returns become attribute-only. `ResearchStatus` is a `str` enum, so `status == "completed"` keeps working in v0.8.0. Suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`. Helper: `src/notebooklm/_deprecation.py::MappingCompatMixin`. Tracked by [#1209](https://github.com/teng-lin/notebooklm-py/issues/1209) |
 
+## Preview the v0.8.0 error contract early: `NOTEBOOKLM_FUTURE_ERRORS`
+
+The deprecations in the **Scheduled for removal** table above are *warn-runways*:
+in v0.7.0 they still behave the old way and only emit a `DeprecationWarning`. In
+v0.8.0 three of them flip to a hard error (the breaking error-contract work,
+[ADR-0019](adr/0019-error-and-return-contract.md) / umbrella
+[#1346](https://github.com/teng-lin/notebooklm-py/issues/1346)). Setting
+`NOTEBOOKLM_FUTURE_ERRORS=1` (any of `1` / `true` / `yes` / `on`,
+case-insensitive) opts a process — or a CI job — into that **v0.8.0 target
+behavior today**, so you can verify your code is forward-compatible before the
+flip ships. It is **off by default**, and default-off is byte-identical to
+current v0.7.0 behavior.
+
+When the flag is on, these three runways adopt their v0.8.0 behavior:
+
+| Runway | v0.7.0 (default / flag off) | With `NOTEBOOKLM_FUTURE_ERRORS=1` | Tracked by |
+|--------|-----------------------------|-----------------------------------|------------|
+| `sources.get()` / `artifacts.get()` / `notes.get()` / `mind_maps.get()` on a miss | Warns, returns `None` | Raises the matching `*NotFoundError` (`SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError` / `MindMapNotFoundError`) | [#1247](https://github.com/teng-lin/notebooklm-py/issues/1247) |
+| Dict-subscript `result["key"]` on the typed research / mind-map / source-guide returns (`MappingCompatMixin`) | Warns, returns the legacy dict value | Raises `TypeError: '<Type>' object is not subscriptable` (the same error a plain dataclass raises once the mixin is removed) | [#1251](https://github.com/teng-lin/notebooklm-py/issues/1251) |
+| Deprecated keyword alias `ResearchAPI.wait_for_completion(interval=...)` | Warns, aliases to `initial_interval` | Raises `TypeError` (the deprecated keyword is gone) | [#1254](https://github.com/teng-lin/notebooklm-py/issues/1254) |
+
+The flag does **not** close those issues — the runways stay until the v0.8.0 flip
+actually ships; it only lets you preview the target behavior. `get_or_none()` and
+every silent shape-probe (`result.get(...)` / `keys()` / `in` / `iter(...)`) are
+the sanctioned post-flip paths and are **unaffected** by the flag in both modes.
+
+**Precedence over `NOTEBOOKLM_QUIET_DEPRECATIONS`.** When `NOTEBOOKLM_FUTURE_ERRORS`
+is on, a runway **raises regardless of the quiet setting** — quiet only silences
+the *warning* on the warn path, which future mode replaces with an exception, so
+there is nothing left to silence. Setting both is well-defined: future mode wins.
+
+**Not yet covered.** The purely-behavioral v0.8.0 changes that lack a clean
+warn-runway — `delete()` returning `None`
+([#1290](https://github.com/teng-lin/notebooklm-py/issues/1290)),
+refusal-suppression
+([#1342](https://github.com/teng-lin/notebooklm-py/issues/1342)), and the
+fail-loud listing change
+([#1362](https://github.com/teng-lin/notebooklm-py/issues/1362)) — are **not**
+gated by this flag yet. They will be folded in as their v0.8.0 behavior is
+defined (tracked as a follow-up). The flag is implemented in
+`src/notebooklm/_deprecation.py::future_errors_enabled` and routed through
+`src/notebooklm/_lookup.py::resolve_get` for the `get()` flip.
+
+```python
+# Verify forward-compatibility in CI: run your suite with the v0.8.0 contract on.
+#   NOTEBOOKLM_FUTURE_ERRORS=1 pytest
+
+import os
+os.environ["NOTEBOOKLM_FUTURE_ERRORS"] = "1"   # before constructing the client
+
+# Now a missing-source lookup RAISES instead of returning None:
+try:
+    source = await client.sources.get(nb_id, "missing")
+except SourceNotFoundError:
+    ...   # the v0.8.0 shape — code that handles this is forward-compatible
+```
+
 ### Migration: typed research / mind-map / source-guide returns
 
 ```python
@@ -122,6 +179,11 @@ inference), so both are now supported parameters. The earlier
   a **`RuntimeWarning`** safety advisory about the stale-overwrite-fresh race —
   outside ADR-018's scope and intentionally **not** silenced by
   `NOTEBOOKLM_QUIET_DEPRECATIONS`.
+* `NOTEBOOKLM_FUTURE_ERRORS=1` is the opposite gate: instead of *silencing* a
+  warn-runway it makes the runway adopt its v0.8.0 *target* behavior (raise)
+  early, for forward-compat testing. It takes precedence over
+  `NOTEBOOKLM_QUIET_DEPRECATIONS` — a runway under future mode raises regardless
+  of quiet. See the "Preview the v0.8.0 error contract early" section above.
 * See `docs/stability.md` "Deprecation Policy" for the broader timeline
   contract (one MINOR cycle of warnings before removal during 0.x).
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -37,8 +37,8 @@ from ._artifact.payloads import (
     build_suggest_reports_params,
     build_video_artifact_params,
 )
-from ._deprecation import warn_get_returns_none
 from ._env import get_default_language
+from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteService
 from ._notebook_metadata import NotebookSourceIdProvider
@@ -212,17 +212,17 @@ class ArtifactsAPI:
             :class:`~notebooklm.exceptions.ArtifactNotFoundError` instead, to
             match ``notebooks.get`` (issue #1247). Wrap the call in
             ``try/except ArtifactNotFoundError`` to keep handling missing
-            artifacts. Suppress the warning with
-            ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
+            artifacts. Suppress with ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
+            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
         """
-        # v0.8.0: replace the warn-and-return-None below with
-        # ``raise ArtifactNotFoundError(artifact_id)`` (issue #1247). Internal
-        # callers that need the silent optional-lookup must use
-        # ``get_or_none`` directly so the library never self-warns.
-        result = await self.get_or_none(notebook_id, artifact_id)
-        if result is None:
-            warn_get_returns_none("artifact")
-        return result
+        # ``resolve_get`` single-sources the warn-runway/raise decision: warn +
+        # return ``None`` today, or raise under ``NOTEBOOKLM_FUTURE_ERRORS``
+        # (#1247). Internal callers needing the silent lookup use get_or_none.
+        return resolve_get(
+            await self.get_or_none(notebook_id, artifact_id),
+            not_found=ArtifactNotFoundError(artifact_id),
+            resource="artifact",
+        )
 
     async def get_or_none(self, notebook_id: str, artifact_id: str) -> Artifact | None:
         """Get an artifact by ID, returning ``None`` when it does not exist.

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -45,6 +45,15 @@ message always names the removal version (so ``scripts/check_deprecation_targets
 can verify the shipping release never names *itself* as the removal target), and
 passing BOTH the old and new keyword raises :class:`TypeError` rather than
 silently preferring one.
+
+A second, orthogonal gate lives here too: ``NOTEBOOKLM_FUTURE_ERRORS``
+(:func:`future_errors_enabled`). When on, the three runways above adopt their
+v0.8.0 *target* behavior early — ``deprecated_kwarg`` and the
+:class:`MappingCompatMixin` subscript raise instead of warn (the
+``<resource>.get()`` runway is routed through ``_lookup.resolve_get``). It is an
+opt-in forward-compat preview, default-off, and takes precedence over the quiet
+gate (a runway raises regardless of quiet; quiet only silences the warn path
+that future mode replaces). See ``docs/deprecations.md``.
 """
 
 from __future__ import annotations
@@ -60,6 +69,18 @@ from typing import Any, ClassVar, TypeVar
 # get()-returns-None deprecation; it is intentionally read live (not cached) so
 # tests and callers can toggle it per call.
 _QUIET_ENV_VAR = "NOTEBOOKLM_QUIET_DEPRECATIONS"
+
+# Forward-compat preview gate. Setting ``NOTEBOOKLM_FUTURE_ERRORS`` to a truthy
+# value makes the v0.7.0 deprecation *runways* adopt their v0.8.0 *target*
+# behavior early, so callers and CI can test forward-compatibility against the
+# breaking error contract (ADR-0019, umbrella #1346) before it ships. It is
+# read live (not cached) so tests and callers can toggle it per call, exactly
+# like the quiet gate. Default-off behavior is byte-identical to current
+# v0.7.0 behavior. ``FUTURE_ERRORS`` takes precedence over
+# ``QUIET_DEPRECATIONS``: when future errors are on, the runway raises
+# regardless of the quiet gate (quiet only silences the warn path that future
+# mode replaces). See ``docs/deprecations.md``.
+_FUTURE_ERRORS_ENV_VAR = "NOTEBOOKLM_FUTURE_ERRORS"
 
 # Follow-up issue tracking the actual breaking flip in v0.8.0, where these
 # ``get()`` methods stop returning ``None`` and start raising the relevant
@@ -91,6 +112,37 @@ def deprecations_quiet() -> bool:
     leaves the warning enabled.
     """
     return _deprecations_quiet()
+
+
+def _future_errors_enabled() -> bool:
+    """Return ``True`` when the v0.8.0 error-contract preview is opted in."""
+    raw = os.environ.get(_FUTURE_ERRORS_ENV_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def future_errors_enabled() -> bool:
+    """Public alias for :func:`_future_errors_enabled`.
+
+    ``NOTEBOOKLM_FUTURE_ERRORS=1`` (or any truthy ``1``/``true``/``yes``/``on``
+    spelling, case-insensitive) opts a process into the **v0.8.0 error contract**
+    early. When on, the v0.7.0 deprecation *runways* that still warn today adopt
+    their v0.8.0 *target* behavior instead — ``<resource>.get()`` raises the
+    matching ``*NotFoundError`` on a miss (#1247), the
+    :class:`MappingCompatMixin` dict-subscript bridge raises instead of
+    warning-and-returning (#1251), and :func:`deprecated_kwarg` raises on the
+    deprecated keyword instead of aliasing it (#1254). Any other value —
+    including unset — keeps the current (warn) behavior, so default-off is
+    byte-identical to v0.7.0.
+
+    This gate takes precedence over :func:`deprecations_quiet`: when future
+    errors are enabled the runway *raises* regardless of the quiet setting,
+    because the quiet gate only silences the warning that future mode replaces
+    with an exception. The purely-behavioral v0.8.0 changes that lack a clean
+    warn-runway (bool returns, refusal-suppression, fail-loud listing) are
+    **not** covered by this flag yet; they will be folded in as their v0.8.0
+    behavior is defined (tracked as a follow-up).
+    """
+    return _future_errors_enabled()
 
 
 def warn_deprecated(message: str, *, removal: str | None = None, stacklevel: int = 3) -> None:
@@ -157,7 +209,7 @@ def _not_found_error_exists(exc_name: str) -> bool:
     return hasattr(exceptions, exc_name)
 
 
-def warn_get_returns_none(resource: str, *, removal: str = "0.8.0") -> None:
+def warn_get_returns_none(resource: str, *, removal: str = "0.8.0", stacklevel: int = 3) -> None:
     """Warn that ``<resource>.get()`` returning ``None`` on a miss is deprecated.
 
     ``sources.get`` / ``artifacts.get`` / ``notes.get`` currently return
@@ -179,6 +231,11 @@ def warn_get_returns_none(resource: str, *, removal: str = "0.8.0") -> None:
             parameter so the message and the release-gate
             (``scripts/check_deprecation_targets.py``) share one source of
             truth.
+        stacklevel: ``warnings.warn`` stacklevel. The default of ``3`` is correct
+            when this helper is called *directly* from the public ``get()``
+            (helper → ``get()`` → user). Callers that route through an extra
+            wrapper frame — the shared ``_lookup.resolve_get`` bridge — pass
+            ``4`` so the warning still points at the user's ``get()`` call site.
     """
     if _deprecations_quiet():
         return
@@ -202,10 +259,12 @@ def warn_get_returns_none(resource: str, *, removal: str = "0.8.0") -> None:
         f"#{GET_RETURNS_NONE_FLIP_ISSUE}). To keep handling missing "
         f"{resource}s, wrap the call in try/except {exc_hint}."
     )
-    # stacklevel=3: warn_get_returns_none (1) -> the public get() (2) ->
-    # the user's call site (3). Points the warning's filename/lineno at the
-    # caller that wrote ``await client.<resource>s.get(...)``.
-    warnings.warn(message, DeprecationWarning, stacklevel=3)
+    # stacklevel=3 (default): warn_get_returns_none (1) -> the public get() (2)
+    # -> the user's call site (3). Points the warning's filename/lineno at the
+    # caller that wrote ``await client.<resource>s.get(...)``. Callers reaching
+    # this helper through ``_lookup.resolve_get`` pass stacklevel=4 to account
+    # for the extra bridge frame.
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
 def deprecated_kwarg(
@@ -254,7 +313,10 @@ def deprecated_kwarg(
 
     Raises:
         TypeError: If the caller passed BOTH the deprecated and the canonical
-            keyword. They name the same concept, so two values is ambiguous.
+            keyword (they name the same concept, so two values is ambiguous);
+            or, when ``NOTEBOOKLM_FUTURE_ERRORS`` is on, if the caller passed
+            the deprecated keyword at all (previewing the v0.8.0 removal —
+            issue #1254).
     """
     new_provided = new_value is not sentinel
     old_provided = old_value is not sentinel
@@ -265,6 +327,15 @@ def deprecated_kwarg(
         )
 
     if old_provided:
+        if _future_errors_enabled():
+            # v0.8.0 preview: the deprecated keyword is removed, so passing it
+            # is a TypeError (the same shape an unknown keyword raises once the
+            # alias is gone). Precedence over the quiet gate is deliberate —
+            # quiet only silences the warning that future mode replaces.
+            raise TypeError(
+                f"{owner}() got an unexpected keyword argument {old!r}; "
+                f"use {new!r} instead (the {old!r} alias was removed in v{removal})."
+            )
         if not _deprecations_quiet():
             warnings.warn(
                 (
@@ -323,7 +394,16 @@ class MappingCompatMixin:
         raise NotImplementedError
 
     def __getitem__(self, key: str) -> Any:
-        """Deprecated dict-style read; warns and returns the legacy dict value."""
+        """Deprecated dict-style read; warns and returns the legacy dict value.
+
+        When ``NOTEBOOKLM_FUTURE_ERRORS`` is on, this previews the v0.8.0 state
+        in which the mixin is dropped and the return is an attribute-only
+        dataclass: any subscript raises :class:`TypeError` (the exact error a
+        plain dataclass raises — ``'<Type>' object is not subscriptable``),
+        regardless of the quiet gate (issue #1251).
+        """
+        if _future_errors_enabled():
+            raise TypeError(f"{type(self).__name__!r} object is not subscriptable")
         legacy = self.to_public_dict()
         if key not in legacy:
             raise KeyError(key)

--- a/src/notebooklm/_lookup.py
+++ b/src/notebooklm/_lookup.py
@@ -20,7 +20,57 @@ from __future__ import annotations
 
 from typing import TypeVar
 
+from ._deprecation import future_errors_enabled, warn_get_returns_none
+
 T = TypeVar("T")
+
+
+def resolve_get(result: T | None, *, not_found: Exception, resource: str) -> T | None:
+    """Resolve a public ``get()`` miss under the v0.7.0 / v0.8.0 error contract.
+
+    Single-sources the warn-runway decision for every namespace ``get()``
+    (``sources`` / ``artifacts`` / ``notes`` / ``mind_maps``) so the
+    hand-duplicated ``if result is None: warn_get_returns_none(...)`` pattern
+    can no longer drift between copies (the #1358-class bug). The behavior on a
+    miss is gated:
+
+    * ``result is not None`` — a hit. Returned unchanged; no warning, no raise.
+    * miss + ``NOTEBOOKLM_FUTURE_ERRORS`` on — preview the v0.8.0 flip (#1247):
+      ``not_found`` (the matching ``*NotFoundError``) is raised. This takes
+      precedence over ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
+    * miss + future errors off — the v0.7.0 runway: emit the gated
+      ``get()``-returns-``None`` ``DeprecationWarning`` and return ``None``.
+
+    ``notebooks.get()`` already raises today and does **not** route through here.
+
+    Args:
+        result: The value returned by the namespace's ``get_or_none()`` lookup —
+            the resolved entity, or ``None`` for a genuine miss. Transport/auth/
+            decode faults are raised by the lookup before reaching here, so
+            ``None`` means "not found" and nothing else.
+        not_found: The ``*NotFoundError`` instance to raise on a miss when the
+            future-errors preview is enabled.
+        resource: Singular resource name for the warning message, e.g.
+            ``"source"`` / ``"artifact"`` / ``"note"`` / ``"mind_map"``.
+
+    Returns:
+        ``result`` when it is a hit; ``None`` on a miss in the (default) warn
+        runway.
+
+    Raises:
+        Exception: ``not_found`` itself, on a miss, when
+            ``NOTEBOOKLM_FUTURE_ERRORS`` is enabled.
+    """
+    if result is not None:
+        return result
+    if future_errors_enabled():
+        raise not_found
+    # stacklevel=4: warn_get_returns_none (1) -> resolve_get (2) -> the public
+    # get() (3) -> the user's call site (4). The extra bridge frame over the
+    # historical inline ``warn_get_returns_none()`` call (which used the
+    # default 3) keeps the warning pointed at the user's ``get()`` call.
+    warn_get_returns_none(resource, stacklevel=4)
+    return None
 
 
 def unwrap_or_raise(obj: T | None, exc: Exception) -> T:

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -17,7 +17,7 @@ import reprlib
 from typing import TYPE_CHECKING, Any
 
 from ._artifact.payloads import build_interactive_mind_map_artifact_params
-from ._deprecation import warn_get_returns_none
+from ._lookup import resolve_get
 from ._row_adapters.notes import NoteRow
 from ._types.mind_maps import MindMap, MindMapKind
 from .exceptions import (
@@ -203,16 +203,19 @@ class MindMapsAPI:
             match ``notebooks.get`` (issue #1247). Wrap the call in
             ``try/except MindMapNotFoundError`` to keep handling missing mind
             maps, or use :meth:`get_or_none` for the sanctioned optional lookup.
-            Suppress the warning with ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
+            Suppress the warning with ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
+            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
         """
-        # v0.8.0: replace the warn-and-return-None below with
-        # ``raise MindMapNotFoundError(mind_map_id)`` (issue #1247). Internal
-        # callers that need the silent optional-lookup must use ``_get_or_none``
-        # directly so the library never self-warns.
-        result = await self.get_or_none(notebook_id, mind_map_id)
-        if result is None:
-            warn_get_returns_none("mind_map")
-        return result
+        # The warn-runway / raise decision is single-sourced in
+        # ``_lookup.resolve_get``: it warns and returns ``None`` today, or
+        # raises ``MindMapNotFoundError`` under ``NOTEBOOKLM_FUTURE_ERRORS``
+        # (the v0.8.0 flip, issue #1247). Internal callers that need the silent
+        # optional-lookup must use ``_get_or_none`` directly.
+        return resolve_get(
+            await self.get_or_none(notebook_id, mind_map_id),
+            not_found=MindMapNotFoundError(mind_map_id),
+            resource="mind_map",
+        )
 
     async def get_or_none(self, notebook_id: str, mind_map_id: str) -> MindMap | None:
         """Get a mind map by ID, returning ``None`` when it does not exist.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -18,10 +18,11 @@ import builtins
 import logging
 from typing import Any
 
-from ._deprecation import warn_get_returns_none
+from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteRowKind, NoteService
 from ._row_adapters.notes import NoteRow
+from .exceptions import NoteNotFoundError
 from .types import Note
 
 logger = logging.getLogger(__name__)
@@ -104,16 +105,19 @@ class NotesAPI:
             ``NoteNotFoundError`` instead, to match ``notebooks.get`` (issue
             #1247). Wrap the call in ``try/except NoteNotFoundError`` to keep
             handling missing notes. Suppress the warning with
-            ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
+            ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
+            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
         """
-        # v0.8.0: replace the warn-and-return-None below with
-        # ``raise NoteNotFoundError(note_id)`` (issue #1247). Internal callers
-        # that need the silent optional-lookup must use ``get_or_none``
-        # directly so the library never self-warns.
-        result = await self.get_or_none(notebook_id, note_id)
-        if result is None:
-            warn_get_returns_none("note")
-        return result
+        # The warn-runway / raise decision is single-sourced in
+        # ``_lookup.resolve_get``: it warns and returns ``None`` today, or
+        # raises ``NoteNotFoundError`` under ``NOTEBOOKLM_FUTURE_ERRORS`` (the
+        # v0.8.0 flip, issue #1247). Internal callers that need the silent
+        # optional-lookup must use ``get_or_none`` directly.
+        return resolve_get(
+            await self.get_or_none(notebook_id, note_id),
+            not_found=NoteNotFoundError(note_id),
+            resource="note",
+        )
 
     async def get_or_none(self, notebook_id: str, note_id: str) -> Note | None:
         """Get a note by ID, returning ``None`` when it does not exist.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from ._deprecation import warn_get_returns_none
+from ._lookup import resolve_get
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._runtime.contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
@@ -160,19 +160,19 @@ class SourcesAPI:
         .. deprecated:: 0.7.0
             Returning ``None`` for a missing source is deprecated and emits a
             :class:`DeprecationWarning`. In **v0.8.0** this method will raise
-            :class:`~notebooklm.exceptions.SourceNotFoundError` instead, to
-            match ``notebooks.get`` (issue #1247). Wrap the call in
-            ``try/except SourceNotFoundError`` to keep handling missing
-            sources. Suppress the warning with ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
+            :class:`~notebooklm.exceptions.SourceNotFoundError` instead, to match
+            ``notebooks.get`` (issue #1247); wrap in ``try/except
+            SourceNotFoundError`` to keep handling missing sources. Suppress with
+            ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set ``NOTEBOOKLM_FUTURE_ERRORS=1``
+            to preview the v0.8.0 raise now.
         """
-        # v0.8.0: replace the warn-and-return-None below with
-        # ``raise SourceNotFoundError(source_id)`` (issue #1247). Internal
-        # callers that need the silent optional-lookup must use
-        # ``get_or_none`` directly so the library never self-warns.
-        result = await self.get_or_none(notebook_id, source_id)
-        if result is None:
-            warn_get_returns_none("source")
-        return result
+        # ``resolve_get`` single-sources the warn-vs-raise decision (#1247);
+        # internal callers needing the silent lookup use ``get_or_none``.
+        return resolve_get(
+            await self.get_or_none(notebook_id, source_id),
+            not_found=SourceNotFoundError(source_id),
+            resource="source",
+        )
 
     async def get_or_none(self, notebook_id: str, source_id: str) -> Source | None:
         """Get a source by ID, returning ``None`` when it does not exist.

--- a/tests/unit/test_future_errors_flag.py
+++ b/tests/unit/test_future_errors_flag.py
@@ -1,0 +1,329 @@
+"""Unit tests for the ``NOTEBOOKLM_FUTURE_ERRORS`` opt-in preview flag.
+
+The flag lets a process (or a CI job) run the **v0.8.0 error contract** early so
+forward-compatibility can be tested before the breaking flips ship (ADR-0019,
+umbrella #1346). When on, the three v0.7.0 deprecation *runways* that still warn
+today adopt their v0.8.0 *target* behavior:
+
+1. ``<resource>.get()`` raises the matching ``*NotFoundError`` on a miss instead
+   of warning-and-returning ``None`` (#1247), routed through
+   :func:`notebooklm._lookup.resolve_get`;
+2. :class:`~notebooklm._deprecation.MappingCompatMixin` dict-subscript raises
+   :class:`TypeError` instead of warning-and-returning the legacy dict value
+   (#1251);
+3. :func:`~notebooklm._deprecation.deprecated_kwarg` raises :class:`TypeError`
+   on the deprecated keyword instead of warning-and-aliasing it (#1254).
+
+Default-off must be byte-identical to current v0.7.0 behavior, and the flag
+takes precedence over ``NOTEBOOKLM_QUIET_DEPRECATIONS`` (a runway raises
+regardless of quiet; quiet only silences the warn path future mode replaces).
+The behavioral conformance for the ``get()`` flip across all five namespaces
+lives in ``test_public_api_behavior.py`` (run under both modes); this module
+covers the resolver, the two non-``get`` flips, and the precedence rule.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from notebooklm import _deprecation
+from notebooklm._deprecation import (
+    MappingCompatMixin,
+    deprecated_kwarg,
+    future_errors_enabled,
+)
+from notebooklm._lookup import resolve_get
+
+_FLAG = "NOTEBOOKLM_FUTURE_ERRORS"
+_QUIET = "NOTEBOOKLM_QUIET_DEPRECATIONS"
+_UNSET = object()
+
+
+# ---------------------------------------------------------------------------
+# future_errors_enabled() — the resolver (mirrors the quiet resolver)
+# ---------------------------------------------------------------------------
+
+
+class TestFutureErrorsResolver:
+    def test_unset_is_off(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert future_errors_enabled() is False
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "Yes", "on", "ON"])
+    def test_truthy_values_enable(self, monkeypatch, truthy):
+        monkeypatch.setenv(_FLAG, truthy)
+        assert future_errors_enabled() is True
+
+    @pytest.mark.parametrize("falsy", ["", "0", "false", "no", "off", "  "])
+    def test_falsy_values_stay_off(self, monkeypatch, falsy):
+        monkeypatch.setenv(_FLAG, falsy)
+        assert future_errors_enabled() is False
+
+    def test_surrounding_whitespace_is_stripped(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "  on  ")
+        assert future_errors_enabled() is True
+
+    def test_read_live_not_cached(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert future_errors_enabled() is False
+        monkeypatch.setenv(_FLAG, "1")
+        assert future_errors_enabled() is True
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert future_errors_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_get() — the shared get()-miss bridge (#1247)
+# ---------------------------------------------------------------------------
+
+
+class _Sentinel(Exception):
+    """A distinct exception type so ``pytest.raises`` cannot match by accident."""
+
+
+class TestResolveGet:
+    def test_hit_returns_value_no_warn_no_raise_off(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = resolve_get("found", not_found=_Sentinel(), resource="source")
+        assert result == "found"
+
+    def test_hit_returns_value_no_raise_on(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        # A hit never raises, even under future-errors: the flip is miss-only.
+        result = resolve_get("found", not_found=_Sentinel(), resource="source")
+        assert result == "found"
+
+    def test_miss_off_warns_and_returns_none(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.delenv(_QUIET, raising=False)
+        with pytest.warns(DeprecationWarning, match="sources.get()") as record:
+            result = resolve_get(None, not_found=_Sentinel(), resource="source")
+        assert result is None
+        assert len(record) == 1
+
+    def test_miss_on_raises_the_not_found(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(_Sentinel):
+                resolve_get(None, not_found=_Sentinel(), resource="source")
+
+    def test_warning_points_at_caller_through_bridge(self, monkeypatch):
+        # stacklevel bookkeeping: resolve_get bumps warn_get_returns_none to
+        # stacklevel=4 to account for the extra bridge frame
+        # (warn (1) -> resolve_get (2) -> public get() (3) -> user (4)). The
+        # ``_fake_public_get`` wrapper stands in for the public ``get()`` frame
+        # so the warning is attributed to the *caller of get()* — this line —
+        # not to _lookup.py / _deprecation.py.
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.delenv(_QUIET, raising=False)
+
+        def _fake_public_get() -> object:
+            return resolve_get(None, not_found=_Sentinel(), resource="source")
+
+        with pytest.warns(DeprecationWarning) as record:
+            _fake_public_get()
+        assert record[0].filename == __file__
+
+
+# ---------------------------------------------------------------------------
+# MappingCompatMixin.__getitem__ — dict-subscript flip (#1251)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CompatProbe(MappingCompatMixin):
+    """Minimal mixin subclass mirroring the real typed-dataclass returns."""
+
+    status: str = "completed"
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {"status": self.status}
+
+
+class TestMappingCompatSubscriptFlip:
+    def test_off_warns_and_returns_legacy_value(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.delenv(_QUIET, raising=False)
+        probe = _CompatProbe()
+        with pytest.warns(DeprecationWarning, match="dict-style access"):
+            value = probe["status"]
+        assert value == "completed"
+
+    def test_on_raises_typeerror_not_subscriptable(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        probe = _CompatProbe()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(TypeError, match="not subscriptable"):
+                probe["status"]
+
+    def test_on_message_matches_plain_dataclass(self, monkeypatch):
+        # The previewed error must read like the real v0.8.0 one: a plain
+        # dataclass with no __getitem__ raises "'X' object is not subscriptable".
+        @dataclass(frozen=True)
+        class _Plain:
+            status: str = "completed"
+
+        plain_msg = ""
+        try:
+            _Plain()["status"]  # type: ignore[index]
+        except TypeError as exc:
+            plain_msg = str(exc)
+
+        monkeypatch.setenv(_FLAG, "1")
+        with pytest.raises(TypeError) as caught:
+            _CompatProbe()["status"]
+        # Same shape: "'<Type>' object is not subscriptable" (only the type name
+        # differs between the plain dataclass and the mixin subclass).
+        assert "object is not subscriptable" in plain_msg
+        assert "object is not subscriptable" in str(caught.value)
+
+    def test_on_silent_surface_unaffected(self, monkeypatch):
+        # Only __getitem__ flips; get/keys/in/iter stay the silent legacy shape.
+        monkeypatch.setenv(_FLAG, "1")
+        probe = _CompatProbe()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert probe.get("status") == "completed"
+            assert "status" in probe
+            assert list(probe.keys()) == ["status"]
+
+
+# ---------------------------------------------------------------------------
+# deprecated_kwarg — renamed-keyword flip (#1254)
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedKwargFlip:
+    def test_off_old_only_warns_and_aliases(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.delenv(_QUIET, raising=False)
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            result = deprecated_kwarg(
+                2.0,
+                _UNSET,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+                sentinel=_UNSET,
+            )
+        assert result == 2.0
+
+    def test_on_old_passed_raises_typeerror(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(TypeError, match="unexpected keyword argument 'interval'"):
+                deprecated_kwarg(
+                    2.0,
+                    _UNSET,
+                    old="interval",
+                    new="initial_interval",
+                    owner="X.m",
+                    sentinel=_UNSET,
+                )
+
+    def test_on_new_only_still_works(self, monkeypatch):
+        # The canonical keyword is unaffected by the flag.
+        monkeypatch.setenv(_FLAG, "1")
+        result = deprecated_kwarg(
+            _UNSET,
+            3.0,
+            old="interval",
+            new="initial_interval",
+            owner="X.m",
+            sentinel=_UNSET,
+        )
+        assert result == 3.0
+
+    def test_on_neither_passed_returns_sentinel(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        result = deprecated_kwarg(
+            _UNSET,
+            _UNSET,
+            old="interval",
+            new="initial_interval",
+            owner="X.m",
+            sentinel=_UNSET,
+        )
+        assert result is _UNSET
+
+    def test_both_passed_still_raises_under_both_modes(self, monkeypatch):
+        # The pre-existing both-passed ambiguity TypeError is independent of the
+        # flag — it must keep raising whether the preview is on or off.
+        for flag in ("1", None):
+            if flag is None:
+                monkeypatch.delenv(_FLAG, raising=False)
+            else:
+                monkeypatch.setenv(_FLAG, flag)
+            with pytest.raises(TypeError, match="both"):
+                deprecated_kwarg(
+                    2.0,
+                    3.0,
+                    old="interval",
+                    new="initial_interval",
+                    owner="X.m",
+                    sentinel=_UNSET,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Precedence: FUTURE_ERRORS overrides QUIET_DEPRECATIONS for all three flips
+# ---------------------------------------------------------------------------
+
+
+class TestFutureErrorsTakesPrecedenceOverQuiet:
+    def test_resolve_get_raises_even_when_quiet(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.setenv(_QUIET, "1")
+        with pytest.raises(_Sentinel):
+            resolve_get(None, not_found=_Sentinel(), resource="source")
+
+    def test_subscript_raises_even_when_quiet(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.setenv(_QUIET, "1")
+        with pytest.raises(TypeError, match="not subscriptable"):
+            _CompatProbe()["status"]
+
+    def test_deprecated_kwarg_raises_even_when_quiet(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.setenv(_QUIET, "1")
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            deprecated_kwarg(
+                2.0,
+                _UNSET,
+                old="interval",
+                new="initial_interval",
+                owner="X.m",
+                sentinel=_UNSET,
+            )
+
+    def test_quiet_alone_silences_warn_path_off(self, monkeypatch):
+        # Sanity: with the flag OFF, quiet still just silences (no raise),
+        # proving the precedence is specifically the flag's doing.
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.setenv(_QUIET, "1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert resolve_get(None, not_found=_Sentinel(), resource="source") is None
+            assert _CompatProbe()["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Default-off is byte-identical: the public alias matches the private resolver
+# ---------------------------------------------------------------------------
+
+
+def test_public_alias_matches_private_resolver(monkeypatch):
+    for value in ("1", "0", "", "yes", "off"):
+        monkeypatch.setenv(_FLAG, value)
+        assert future_errors_enabled() == _deprecation._future_errors_enabled()
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert future_errors_enabled() == _deprecation._future_errors_enabled()

--- a/tests/unit/test_public_api_behavior.py
+++ b/tests/unit/test_public_api_behavior.py
@@ -140,11 +140,21 @@ def _make_notebooks_api() -> NotebooksAPI:
 
 
 def _arrange_list_miss(api: object) -> None:
-    """Force a miss for the four ``list``-scanning namespaces.
+    """Force a miss for the four non-``notebooks`` namespaces.
 
-    ``sources`` / ``artifacts`` / ``notes`` / ``mind_maps`` all resolve a single
-    ``get`` by scanning ``self.list(...)``, so an empty ``list`` is a uniform,
+    ``sources`` / ``artifacts`` / ``mind_maps`` resolve a single ``get`` by
+    scanning ``self.list(...)``, so stubbing ``list`` to ``[]`` is a uniform,
     backend-agnostic miss (the same lever the existing per-namespace tests pull).
+
+    ``notes`` is the exception: ``NotesAPI.get_or_none`` resolves through
+    ``_get_all_notes_and_mind_maps`` → ``fetch_note_rows``, **not** ``self.list``,
+    so the assigned ``api.list`` stub is a harmless no-op for it. The notes miss
+    comes from its factory (``_make_notes_api``) wiring a fake core whose
+    ``rpc_call`` returns a non-list ``MagicMock`` that ``fetch_note_rows``'
+    container-extraction treats as empty — so the ``get`` still misses. Keeping
+    one shared arranger across all four rows is deliberate: it stays a single
+    table lever even though one namespace reaches the empty result by a different
+    internal path.
     """
     api.list = AsyncMock(return_value=[])  # type: ignore[attr-defined]
 
@@ -278,6 +288,11 @@ def _apply_future_errors(request: pytest.FixtureRequest, monkeypatch: pytest.Mon
     *raises* (future-on, or already-flipped) or *warns* (the warn-runway under
     future-off).
     """
+    # Hermetic both ways: the future-off branch asserts a DeprecationWarning
+    # fires, so a parent process exporting NOTEBOOKLM_QUIET_DEPRECATIONS=1 would
+    # otherwise silence the warn path and fail the warn-runway rows. Clear it so
+    # the matrix is independent of the ambient environment.
+    monkeypatch.delenv("NOTEBOOKLM_QUIET_DEPRECATIONS", raising=False)
     future_on: bool = request.param
     if future_on:
         monkeypatch.setenv("NOTEBOOKLM_FUTURE_ERRORS", "1")

--- a/tests/unit/test_public_api_behavior.py
+++ b/tests/unit/test_public_api_behavior.py
@@ -254,6 +254,39 @@ def _build_missing(case: LookupCase) -> object:
 
 
 # ---------------------------------------------------------------------------
+# The two error-contract modes the miss path is exercised under
+#
+# ``NOTEBOOKLM_FUTURE_ERRORS`` (v0.7.0 opt-in preview, default off) makes the
+# warn-runway namespaces adopt their v0.8.0 raise-target early (#1247). Both
+# ``get`` test methods run under both modes so the warn path (today's default)
+# and the raise path (the previewed flip, and v0.8.0's eventual default) are
+# pinned in lock-step — and the #1247 flip becomes a one-field edit
+# (``get_warns=False``) that keeps passing under both modes by construction.
+# ---------------------------------------------------------------------------
+
+_FUTURE_MODES = [
+    pytest.param(False, id="future-off"),
+    pytest.param(True, id="future-on"),
+]
+
+
+@pytest.fixture
+def _apply_future_errors(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> bool:
+    """Set/clear ``NOTEBOOKLM_FUTURE_ERRORS`` per the parametrized mode.
+
+    Returns the boolean mode so a test can compute whether a given ``get`` row
+    *raises* (future-on, or already-flipped) or *warns* (the warn-runway under
+    future-off).
+    """
+    future_on: bool = request.param
+    if future_on:
+        monkeypatch.setenv("NOTEBOOKLM_FUTURE_ERRORS", "1")
+    else:
+        monkeypatch.delenv("NOTEBOOKLM_FUTURE_ERRORS", raising=False)
+    return future_on
+
+
+# ---------------------------------------------------------------------------
 # The table is pinned to the static gate's lookup set
 # ---------------------------------------------------------------------------
 
@@ -282,15 +315,30 @@ def test_table_covers_all_lookup_namespaces() -> None:
 
 class TestGetMissContract:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("_apply_future_errors", _FUTURE_MODES, indirect=True)
     @pytest.mark.parametrize("case", _CASES_BY_ID)
-    async def test_get_on_miss_warns_or_raises(self, case: LookupCase) -> None:
+    async def test_get_on_miss_warns_or_raises(
+        self, case: LookupCase, _apply_future_errors: bool
+    ) -> None:
         """``get(<missing>)`` warns + returns ``None`` today; raises post-#1247-flip.
 
-        The single ``get_warns`` field selects the branch, so flipping a
-        namespace with #1247 is one table edit, not a rewrite of this test.
+        Run under both error-contract modes. The effective branch is "warns"
+        only when the namespace is still on its warn-runway (``get_warns``) AND
+        the future-errors preview is off; otherwise the miss must raise the
+        namespace's ``*NotFoundError``. So:
+
+        * future-off + ``get_warns`` → warn + return ``None`` (today's default);
+        * future-on + ``get_warns`` → raise (the ``NOTEBOOKLM_FUTURE_ERRORS``
+          preview of the v0.8.0 flip, #1247);
+        * ``get_warns=False`` (``notebooks``, and any namespace after the #1247
+          flip) → raise under both modes.
+
+        Flipping a namespace with #1247 is one table edit (``get_warns=False``)
+        and this test keeps passing under both modes by construction.
         """
+        future_on = _apply_future_errors
         api = _build_missing(case)
-        if case.get_warns:
+        if case.get_warns and not future_on:
             # Warn-runway: a DeprecationWarning fires AND None comes back.
             with pytest.warns(DeprecationWarning) as record:
                 result = await api.get(*case.get_args)  # type: ignore[attr-defined]
@@ -328,13 +376,20 @@ class TestGetMissContract:
 
 class TestGetOrNoneMissContract:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("_apply_future_errors", _FUTURE_MODES, indirect=True)
     @pytest.mark.parametrize("case", _CASES_BY_ID)
-    async def test_get_or_none_on_miss_is_silent_and_none(self, case: LookupCase) -> None:
+    async def test_get_or_none_on_miss_is_silent_and_none(
+        self, case: LookupCase, _apply_future_errors: bool
+    ) -> None:
         """Public ``get_or_none(<missing>)`` returns ``None`` with NO DeprecationWarning.
 
         This contract is invariant across the #1247 flip — ``get_or_none`` is the
         sanctioned ``None``-on-miss path for every namespace, before and after
         ``get`` starts raising — so it is asserted unconditionally for all rows.
+        It is also invariant under ``NOTEBOOKLM_FUTURE_ERRORS``: the preview flag
+        only changes the *deprecated* ``get`` runway, never the sanctioned
+        optional-lookup, so ``get_or_none`` must stay silent-and-``None`` in both
+        modes (asserted by running under both ``_FUTURE_MODES``).
         """
         api = _build_missing(case)
         with warnings.catch_warnings():


### PR DESCRIPTION
## What

Adds a default-off opt-in preview flag, **`NOTEBOOKLM_FUTURE_ERRORS`**, that lets users (and CI) run the breaking **v0.8.0 error contract** early to test forward-compatibility. When truthy (`1`/`true`/`yes`/`on`, case-insensitive) the v0.7.0 deprecation *warn-runways* adopt their v0.8.0 *raise-target*:

| Runway | v0.7.0 (flag off, default) | `NOTEBOOKLM_FUTURE_ERRORS=1` | Issue |
|--------|----------------------------|------------------------------|-------|
| `sources`/`artifacts`/`notes`/`mind_maps`.`get()` on a miss | warn + return `None` | raise the matching `*NotFoundError` | #1247 |
| `MappingCompatMixin` dict-subscript `result["key"]` | warn + legacy dict value | raise `TypeError` (`'<Type>' object is not subscriptable`) | #1251 |
| `ResearchAPI.wait_for_completion(interval=...)` | warn + alias to `initial_interval` | raise `TypeError` | #1254 |

The flag is a deliberate transition-smoothing feature for the breaking v0.8.0 work (ADR-0019 / umbrella #1346). It does **not** close #1247/#1251/#1254 — the runways remain until the v0.8.0 flip actually ships; the flag only previews the target.

## Why

The v0.8.0 error-contract convergence is breaking. Giving users a default-off switch to run their suite under the future behavior (`NOTEBOOKLM_FUTURE_ERRORS=1 pytest`) lets them gate forward-compat *before* the flip lands, smoothing the migration instead of discovering breakage on upgrade day.

## How

- New resolver `future_errors_enabled()` in `_deprecation.py`, mirroring the existing `deprecations_quiet()` (read live, never cached; same truthy spellings).
- New shared bridge `_lookup.resolve_get(result, *, not_found, resource)` — every namespace `get()` (sources/artifacts/notes/mind_maps) now routes through it. This **eliminates the hand-duplicated** `if result is None: warn_get_returns_none(...)` pattern across four modules, so the divergence that caused the #1358-class mind_maps bug becomes impossible by construction. `notebooks.get()` already raises and is untouched.
- `MappingCompatMixin.__getitem__` and `deprecated_kwarg` gain a future-mode raise branch.
- **Precedence:** `FUTURE_ERRORS` takes precedence over `QUIET_DEPRECATIONS` — a runway raises regardless of quiet (quiet only silenced the warning, which future mode replaces with an exception). Documented in both docs and the helper docstrings.
- **Stacklevel:** `resolve_get` bumps `warn_get_returns_none` to `stacklevel=4` for the extra bridge frame, so the warning still points at the user's `get()` call (verified).
- **Module-size ratchet:** routing through the helper is net line-neutral (`_sources.py` / `_artifacts.py` stay at their ceilings; ratchet green).
- **Out of scope (follow-up #1405):** the purely-behavioral v0.8.0 changes that lack a clean warn-runway — #1290 (bool returns), #1342 (refusal-suppression), #1362 (fail-loud listing) — are not gated yet; they'll be folded in as their target behavior is defined.

## Verification

- `tests/unit/test_future_errors_flag.py` (new): resolver truthy/falsy/live-read; `resolve_get` hit/miss in both modes + stacklevel-through-bridge; the dict-subscript and `deprecated_kwarg` flips in both modes; and the **precedence** rule (future raises even with quiet set) for all three.
- `tests/unit/test_public_api_behavior.py` (extended): the behavioral conformance table now runs every `get()`/`get_or_none` case under **both** `future-off` (warns) and `future-on` (raises); `get_or_none` proven silent-and-`None` in both modes.
- Full `uv run pytest tests/unit -q` → **7345 passed, 128 skipped, 1 xfailed**.
- `mypy src/notebooklm` clean (197 files); `ruff check` + `ruff format --check` clean.
- `scripts/audit_public_api_compat.py` → exit 0 (flag is additive, no public break); `scripts/check_deprecation_targets.py` clean; module-size ratchet + inline-deprecation lints green.

Refs #1346, #1247, #1251, #1254. Follow-up: #1405. Does not close the flip issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in env var NOTEBOOKLM_FUTURE_ERRORS (default off) to preview v0.8.0 error behavior.
  * When enabled, missing-resource lookups raise NotFound errors and deprecated keyword usage raises TypeError.
  * Legacy dict-style access now raises TypeError when the flag is on; non-deprecated access remains unchanged.

* **Documentation**
  * Added configuration and deprecation guides, precedence rules, and CI usage examples.

* **Tests**
  * Added tests exercising the opt-in flag and its precedence over quiet deprecations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->