### PR TITLE
test(e2e): fix test_get_guide for SourceGuide dataclass return

### DIFF
--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from notebooklm import Source, SourceStatus
+from notebooklm import Source, SourceGuide, SourceStatus
 
 from .conftest import requires_auth
 
@@ -103,14 +103,14 @@ class TestSourceRetrieval:
             pytest.skip("No sources available for guide")
 
         guide = await client.sources.get_guide(read_only_notebook_id, sources[0].id)
-        # get_guide returns dict with summary and keywords
-        assert isinstance(guide, dict)
-        assert "summary" in guide
-        assert "keywords" in guide
+        # get_guide returns a SourceGuide dataclass (#1209). Use attribute access,
+        # which is forward-compatible with v0.8.0 (it removes the deprecated
+        # dict-subscript MappingCompat bridge — guide["summary"] — per #1251).
+        assert isinstance(guide, SourceGuide)
         # Verify values are actually populated (not empty due to parsing bugs)
-        assert guide["summary"], "Expected non-empty summary from source guide"
-        assert isinstance(guide["keywords"], list)
-        assert len(guide["keywords"]) > 0, "Expected non-empty keywords from source guide"
+        assert guide.summary, "Expected non-empty summary from source guide"
+        assert isinstance(guide.keywords, tuple)
+        assert len(guide.keywords) > 0, "Expected non-empty keywords from source guide"
 
 
 @requires_auth


### PR DESCRIPTION
## What
Fix `tests/e2e/test_sources.py::TestSourceRetrieval::test_get_guide`, which has been failing the **Nightly E2E** run.

## Why
`get_guide()` returns a **`SourceGuide` dataclass** (since #1209), but the test asserted `isinstance(guide, dict)` (False) and read `guide["summary"]`/`guide["keywords"]` through the **deprecated `MappingCompat` dict-subscript bridge** that v0.8.0 removes (#1251). So it's broken now and would break worse at the flip.

## How
Migrate to **attribute access** — the forward-compatible form (works on 0.7.0 *and* 0.8.0, and is exactly what `docs/upgrading-to-0.8.0.md` prescribes):
- `assert isinstance(guide, SourceGuide)`
- `guide.summary`, `guide.keywords` (a **tuple**, per the frozen dataclass)

## Verification
`ruff check`/`format` clean. The E2E test itself runs nightly (needs live auth); CI here imports/collects it. The other nightly failure — `test_add_epub_file` — is the known server-side EPUB flake (#1204) and is intentionally **not** touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to validate internal data structure formats and validate attributes correctly.

**Note:** No user-visible changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->