### PR TITLE
test(e2e): ResearchStart attribute access in test_research (forward-compat #1251)

### DIFF
--- a/tests/e2e/test_research.py
+++ b/tests/e2e/test_research.py
@@ -28,10 +28,10 @@ class TestResearchStart:
 
         assert result is not None, "Research start should return a result"
         assert "task_id" in result, "Result should contain task_id"
-        assert result["task_id"] is not None, "task_id should not be None"
-        assert result["notebook_id"] == temp_notebook.id
-        assert result["query"] == "artificial intelligence basics"
-        assert result["mode"] == "fast"
+        assert result.task_id is not None, "task_id should not be None"
+        assert result.notebook_id == temp_notebook.id
+        assert result.query == "artificial intelligence basics"
+        assert result.mode == "fast"
 
     @pytest.mark.xfail(reason="Deep research frequently hits rate limits in CI")
     @pytest.mark.asyncio
@@ -46,8 +46,8 @@ class TestResearchStart:
 
         assert result is not None, "Deep research start should return a result"
         assert "task_id" in result, "Result should contain task_id"
-        assert result["task_id"] is not None, "task_id should not be None"
-        assert result["mode"] == "deep"
+        assert result.task_id is not None, "task_id should not be None"
+        assert result.mode == "deep"
 
     @pytest.mark.asyncio
     async def test_start_research_invalid_source(self, client, temp_notebook):
@@ -281,4 +281,4 @@ class TestResearchDriveSource:
             pytest.skip("Drive research returned no results - may need Drive access")
 
         assert "task_id" in result
-        assert result["mode"] == "fast"
+        assert result.mode == "fast"


### PR DESCRIPTION
## What
Migrate `tests/e2e/test_research.py` off the deprecated `result["x"]` dict-subscript (the `MappingCompat` bridge v0.8.0 removes per #1251) to `ResearchStart` **attribute access** (`result.task_id`, `.notebook_id`, `.query`, `.mode`).

## Why
Surfaced by running the suite under `NOTEBOOKLM_FUTURE_ERRORS=1`: these were the only genuine forward-incompat *means*-usages outside the deprecation runway tests. Attribute access is correct today and forward-compatible with v0.8.0 (same migration as #1408 did for `test_get_guide`).

## Verification
`ruff` clean; E2E runs nightly (needs auth) — CI imports/collects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Research API end-to-end test assertions to improve test code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->