### PR TITLE
test(cli): pin console width to fix #1332 terminal-width render flake

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -17,6 +17,54 @@ from notebooklm.types import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _pin_cli_console_width():
+    """Pin the shared Rich console to a wide, fixed width for every CLI unit test.
+
+    Under ``CliRunner`` (no TTY) Rich derives its line width from the terminal,
+    and that fallback diverges across the OS matrix and by terminal size — so an
+    exact ``"..." in result.output`` assertion flakes whenever a message reflows
+    at a different column (issue #1332; seen on ``test_login_multi_account``
+    where ``"not overwriting"`` wrapped across a newline as ``"not\noverwriting"``
+    in a narrow terminal). Forcing a wide fixed width removes the *incidental*
+    mid-line reflow, leaving only the **authored** newlines in the source strings
+    (the real render contract). The single shared ``console`` is reused by the
+    services, ``session_cmd`` and the error paths, so pinning its size once
+    covers every render site while still writing through to ``CliRunner``'s
+    captured stdout. ``Console.size`` only honours the pinned dimensions when
+    **both** ``_width`` and ``_height`` are set (otherwise it falls back to the
+    OS-divergent terminal/``COLUMNS`` detection), so both are patched.
+    """
+    from notebooklm.cli import rendering
+
+    with (
+        patch.object(rendering.console, "_width", 400),
+        patch.object(rendering.console, "_height", 100),
+    ):
+        yield
+
+
+@pytest.fixture
+def narrow_console():
+    """Override the autouse wide pin with a narrow, fixed width.
+
+    The few tests that assert *width-dependent* rendering — e.g. ``list``
+    truncating an over-wide title (``test_*_list_default_truncates_long_title``)
+    — need a deterministic *narrow* width to exercise truncation. Requesting
+    this fixture re-pins the shared console to 80 columns on top of the autouse
+    400-wide pin (pytest runs the autouse fixture first, so this inner patch
+    wins for the test body), so truncation is exercised deterministically rather
+    than relying on the OS-divergent auto-detected width (issue #1332).
+    """
+    from notebooklm.cli import rendering
+
+    with (
+        patch.object(rendering.console, "_width", 80),
+        patch.object(rendering.console, "_height", 100),
+    ):
+        yield
+
+
 def source_guide(spec: dict | None = None, **overrides: Any) -> SourceGuide:
     """Build a typed ``SourceGuide`` from a legacy guide dict spec.
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -207,7 +207,7 @@ class TestArtifactList:
             assert result.output.count("X") >= 200
             assert "…" not in result.output
 
-    def test_artifact_list_default_truncates_long_title(self, runner, mock_auth):
+    def test_artifact_list_default_truncates_long_title(self, runner, mock_auth, narrow_console):
         """Default rendering inserts an ellipsis for over-wide titles."""
         long_title = "X" * 200
         with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -216,7 +216,7 @@ class TestNotebookList:
             assert result.output.count("X") >= 200
             assert "…" not in result.output
 
-    def test_notebook_list_default_truncates_long_title(self, runner, mock_auth):
+    def test_notebook_list_default_truncates_long_title(self, runner, mock_auth, narrow_console):
         """Default rendering inserts an ellipsis for over-wide titles.
 
         Pins the existing default behavior so --no-truncate doesn't change

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -158,7 +158,7 @@ class TestSourceList:
             assert result.output.count("X") >= 200
             assert "…" not in result.output
 
-    def test_source_list_default_truncates_long_title(self, runner, mock_auth):
+    def test_source_list_default_truncates_long_title(self, runner, mock_auth, narrow_console):
         """Default rendering inserts an ellipsis for over-wide titles."""
         long_title = "X" * 200
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:


### PR DESCRIPTION
## What
Make CLI unit-test rendering **width-deterministic**, fixing the #1332 terminal-width flake (exact `"..." in result.output` asserts breaking when a phrase reflows at a different column across the OS matrix / terminal size).

## Why
Surfaced repeatedly: the nightly E2E, agy oracle runs, and the `NOTEBOOKLM_FUTURE_ERRORS=1` sweep all hit `test_login_multi_account` where `"not overwriting"` wrapped to `"not\noverwriting"` in a narrow terminal.

## How
- Autouse `_pin_cli_console_width` in `tests/unit/cli/conftest.py` (the proven #1391 pattern) pins the shared Rich console to a wide fixed width — removes incidental reflow, keeps authored newlines.
- The width-dependent trio (`test_*_list_default_truncates_long_title`) opts into a new `narrow_console` fixture that re-pins a deterministic narrow width to still exercise truncation.

## Verification
Full `tests/unit/cli` green: **1907 passed, 64 skipped** (was 3 failed under a naive global wide-pin — the truncation tests are now handled). `ruff` clean.

Fixes #1332 (the CLI-render-brittleness half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added CLI console sizing fixtures to ensure deterministic test behavior for width-dependent rendering scenarios.
  * Updated CLI tests to utilize fixed console width for reliable title truncation validation across artifact, notebook, and source list components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->