### PR TITLE
fix(test): re-point #1247 deprecation runway to _lookup.py (fix red main) + #1411 changelog MindMapKind refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a derived read that does not police parent existence) — previously `kind=None`
   raised on an unknown id. Shape-drift in the interactive payload still raises
   `UnknownRPCMethodError` (ADR-019; issues #1291, #1346).
-- `client.mind_maps.generate(kind=INTERACTIVE)` now raises
+- `client.mind_maps.generate(kind=MindMapKind.INTERACTIVE)` now raises
   `ArtifactFeatureUnavailableError` (instead of a bare `ArtifactError`) when the
   `CREATE_ARTIFACT` call returns no artifact id — no generation task was
   created. **Non-breaking for `except ArtifactError`**:
@@ -305,8 +305,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented two pre-existing `client.mind_maps` read semantics (docs-only, no
   behavior change): `list()` populates `MindMap.tree` only for note-backed
   entries — interactive entries carry `tree=None` ("not fetched", not "empty";
-  call `get_tree(..., kind=INTERACTIVE)` to fetch one); and the explicit
-  `get_tree(..., kind=INTERACTIVE)` path delegates absence detection to the RPC,
+  call `get_tree(..., kind=MindMapKind.INTERACTIVE)` to fetch one); and the explicit
+  `get_tree(..., kind=MindMapKind.INTERACTIVE)` path delegates absence detection to the RPC,
   so a missing id's value is server-dependent (returns `None` today) rather than
   enforced client-side (issues #1355, #1359).
 - **`ResearchAPI.wait_for_completion(interval=...)` → `initial_interval=...`.**

--- a/tests/_lint/test_v080_deprecation_coverage.py
+++ b/tests/_lint/test_v080_deprecation_coverage.py
@@ -139,8 +139,11 @@ V080_BREAKING_CHANGES: tuple[BreakingChange, ...] = (
         issue=1247,
         summary="sources/artifacts/notes/mind_maps.get() flip None-on-miss to raise *NotFoundError",
         runway=Runway(
-            module="_sources.py",
-            description="public get() warns on a miss via warn_get_returns_none (DeprecationWarning)",
+            # The warn-on-miss signal for all four namespaces is centralized in
+            # resolve_get() (issue #1406), so the symbol lives in _lookup.py —
+            # not the per-namespace _sources.py/_artifacts.py/etc. get() bodies.
+            module="_lookup.py",
+            description="public get() warns on a miss via warn_get_returns_none, centralized in resolve_get (DeprecationWarning)",
             symbol="warn_get_returns_none",
         ),
     ),


### PR DESCRIPTION
## What

Two post-0.7.0-changelog cleanups:

1. **Fix red `main`** — re-point the `#1247` runway in `tests/_lint/test_v080_deprecation_coverage.py` from `_sources.py` to `_lookup.py`.
2. **Address the `gemini-code-assist` review on #1411** — replace the bare `kind=INTERACTIVE` references in `CHANGELOG.md` (×3) with the publicly-exported `kind=MindMapKind.INTERACTIVE`.

## Why

**(1)** The deprecation-coverage gate's `test_claimed_runways_actually_exist` verifies each claimed v0.8.0 runway's warn-signal is wired in its *cited module*. The `#1247` entry claimed `warn_get_returns_none` lives in `_sources.py`, but the `resolve_get()` centralization (#1406) moved that signal into `_lookup.py` — all four namespace `get()` methods (`sources`/`artifacts`/`notes`/`mind_maps`) now route their warn-on-miss through the shared helper. The stale citation failed the gate **across the entire CI matrix** (every OS × Python), reddening `main` after the #1410/#1411 merges. The code is correct; the table was stale → re-point it to the signal's true home. Gate now passes locally (`20 passed`).

**(2)** `MindMapKind` is a top-level export (`from notebooklm import MindMapKind`) and a `str` enum (`INTERACTIVE = "interactive"`). The bare `INTERACTIVE` would `NameError` if copy-pasted. `MindMapKind.INTERACTIVE` is the idiomatic, importable form.

## Verification

- `pytest tests/_lint/test_v080_deprecation_coverage.py` → `20 passed`
- No bare `kind=INTERACTIVE` remains in `CHANGELOG.md`; the runway needle `warn_get_returns_none` is confirmed present in `_lookup.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Mind Maps documentation references for consistency.

* **Tests**
  * Updated deprecation coverage test registry entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->