### PR TITLE
feat: extend NOTEBOOKLM_FUTURE_ERRORS to behavioral v0.8.0 previews (closes #1405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,11 +180,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a runway raises regardless of quiet). The four `get()` methods are now routed
   through a single `_lookup.resolve_get` bridge, eliminating the hand-duplicated
   warn-on-miss pattern. Helper: `notebooklm._deprecation.future_errors_enabled`.
-  The purely-behavioral v0.8.0 changes that lack a warn-runway (`delete()`
-  returning `None`, refusal-suppression, fail-loud listing) are not gated yet;
-  they will be folded in as their behavior is defined. Does **not** close
-  #1247/#1251/#1254 — the runways remain until the v0.8.0 flip. See
-  `docs/deprecations.md`. Additive (issue #1346).
+  The flag now **also** previews the purely-behavioral v0.8.0 changes that have
+  no warn-runway (#1405): the uninformative `bool` returns of `sources.refresh`
+  and `chat.delete_conversation` become `None` (#1290); a synchronous generation
+  refusal **raises** the decoder's `RateLimitError` / `RPCError` /
+  `DecodingError` / `ArtifactFeatureUnavailableError` instead of being swallowed
+  into `GenerationStatus(status="failed")` / returned `None` — across
+  `_call_generate`, `revise_slide`, `_parse_generation_result`, and
+  `research.start` (#1342); and the mutate-existing ops `notes.update` and
+  `sources`/`artifacts` `rename(return_object=False)` fail loud with a
+  `*NotFoundError` on a missing target (#1362). These previews are runtime-only —
+  **no public return annotation changes** until the v0.8.0 flip — so default-off
+  stays byte-identical. Does **not** close #1247/#1251/#1254/#1290/#1342/#1362 —
+  the runways and current behavior remain until the v0.8.0 flip. See
+  `docs/deprecations.md`. Additive (issues #1346, #1405).
 - `client.artifacts.retry_failed(notebook_id, artifact_id)` — retry a failed
   Studio artifact in place (the web UI "Retry" action), via the new
   `RETRY_ARTIFACT` (`Rytqqe`) RPC. The artifact is not deleted first and the

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -39,13 +39,18 @@ behavior today**, so you can verify your code is forward-compatible before the
 flip ships. It is **off by default**, and default-off is byte-identical to
 current v0.7.0 behavior.
 
-When the flag is on, these three runways adopt their v0.8.0 behavior:
+When the flag is on, these runways adopt their v0.8.0 behavior. The first three
+are deprecation *warn-runways* (the warning becomes a raise); the last three are
+purely-behavioral previews with no warning today (#1405):
 
 | Runway | v0.7.0 (default / flag off) | With `NOTEBOOKLM_FUTURE_ERRORS=1` | Tracked by |
 |--------|-----------------------------|-----------------------------------|------------|
 | `sources.get()` / `artifacts.get()` / `notes.get()` / `mind_maps.get()` on a miss | Warns, returns `None` | Raises the matching `*NotFoundError` (`SourceNotFoundError` / `ArtifactNotFoundError` / `NoteNotFoundError` / `MindMapNotFoundError`) | [#1247](https://github.com/teng-lin/notebooklm-py/issues/1247) |
 | Dict-subscript `result["key"]` on the typed research / mind-map / source-guide returns (`MappingCompatMixin`) | Warns, returns the legacy dict value | Raises `TypeError: '<Type>' object is not subscriptable` (the same error a plain dataclass raises once the mixin is removed) | [#1251](https://github.com/teng-lin/notebooklm-py/issues/1251) |
 | Deprecated keyword alias `ResearchAPI.wait_for_completion(interval=...)` | Warns, aliases to `initial_interval` | Raises `TypeError` (the deprecated keyword is gone) | [#1254](https://github.com/teng-lin/notebooklm-py/issues/1254) |
+| `sources.refresh()` / `chat.delete_conversation()` return value | Returns `True` (uninformative — failures raise first) | Returns `None` (the `-> bool` annotation is preserved until the v0.8.0 flip) | [#1290](https://github.com/teng-lin/notebooklm-py/issues/1290) |
+| Synchronous generation refusal (`generate_*` / `revise_slide` / `research.start`) | Swallowed into `GenerationStatus(status="failed")` / returned `None` | Raises the decoder's `RateLimitError` / `RPCError` / `DecodingError` / `ArtifactFeatureUnavailableError` ("couldn't-start" is an error, not data) | [#1342](https://github.com/teng-lin/notebooklm-py/issues/1342) |
+| `notes.update()` / `sources.rename(return_object=False)` / `artifacts.rename(return_object=False)` on a missing target | Silent no-op / returns `None` | Raises the matching `*NotFoundError` (the `return_object=False` path still returns `None` on success — the flag gates miss-detection, not the return) | [#1362](https://github.com/teng-lin/notebooklm-py/issues/1362) |
 
 The flag does **not** close those issues — the runways stay until the v0.8.0 flip
 actually ships; it only lets you preview the target behavior. The flag changes
@@ -64,17 +69,17 @@ is on, a runway **raises regardless of the quiet setting** — quiet only silenc
 the *warning* on the warn path, which future mode replaces with an exception, so
 there is nothing left to silence. Setting both is well-defined: future mode wins.
 
-**Not yet covered.** The purely-behavioral v0.8.0 changes that lack a clean
-warn-runway — `delete()` returning `None`
-([#1290](https://github.com/teng-lin/notebooklm-py/issues/1290)),
-refusal-suppression
-([#1342](https://github.com/teng-lin/notebooklm-py/issues/1342)), and the
-fail-loud listing change
-([#1362](https://github.com/teng-lin/notebooklm-py/issues/1362)) — are **not**
-gated by this flag yet. They will be folded in as their v0.8.0 behavior is
-defined (tracked as a follow-up). The flag is implemented in
-`src/notebooklm/_deprecation.py::future_errors_enabled` and routed through
-`src/notebooklm/_lookup.py::resolve_get` for the `get()` flip.
+**Scope.** Both the warn-runway flips and the purely-behavioral previews above
+are gated by the same flag. The behavioral previews are **runtime-only** — no
+public return annotation changes until the v0.8.0 flip — so the default-off path
+is byte-identical to v0.7.0 and the api-compat / conformance gates stay green.
+The flag does **not** close #1290 / #1342 / #1362 — the default behavior remains
+until the v0.8.0 flip ships ([#1405](https://github.com/teng-lin/notebooklm-py/issues/1405)).
+The flag is implemented in
+`src/notebooklm/_deprecation.py::future_errors_enabled`, routed through
+`src/notebooklm/_lookup.py::resolve_get` for the `get()` flip, and consumed at
+each behavioral preview's call site via `if future_errors_enabled(): ... else:
+...`.
 
 ```python
 # Verify forward-compatibility in CI: run your suite with the v0.8.0 contract on.

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -37,6 +37,7 @@ from ._artifact.payloads import (
     build_suggest_reports_params,
     build_video_artifact_params,
 )
+from ._deprecation import future_errors_enabled
 from ._env import get_default_language
 from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
@@ -48,6 +49,7 @@ from ._types.research import MindMapResult
 from .exceptions import (
     ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
+    DecodingError,
     ValidationError,
 )
 
@@ -561,7 +563,8 @@ class ArtifactsAPI:
                 allow_null=True,
             )
         except RPCError as e:
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
+            # v0.8.0 preview (#1342): a refusal raises; see ``_call_generate``.
+            if e.rpc_code == "USER_DISPLAYABLE_ERROR" and not future_errors_enabled():
                 return GenerationStatus(
                     task_id="",
                     status="failed",
@@ -936,32 +939,27 @@ class ArtifactsAPI:
             notebook_id: The notebook ID.
             artifact_id: The artifact ID to rename.
             new_title: The new title.
-            return_object: When ``True`` (default), re-fetch and return the
-                renamed :class:`~notebooklm.types.Artifact`. When ``False``,
-                skip the re-fetch and return ``None`` — the re-fetch is a full
-                ``LIST_ARTIFACTS`` call, so bulk renamers that ignore the
-                return should opt out to avoid N extra list calls. Opting out
-                also skips missing-target detection, so a missing artifact does
-                **not** raise — pass ``return_object=True`` (the default) if you
-                need the missing-target guarantee.
+            return_object: When ``True`` (default), re-fetch (a full
+                ``LIST_ARTIFACTS`` call) and return the renamed
+                :class:`~notebooklm.types.Artifact`; when ``False``, return
+                ``None`` without re-fetching. Under the v0.8.0 preview ``False``
+                still returns ``None`` but adds miss-detection (the flag gates
+                detection, not the return — see ``Raises``).
 
         Returns:
             The renamed :class:`~notebooklm.types.Artifact`, or ``None`` when
             ``return_object=False``.
 
         Raises:
-            ArtifactNotFoundError: if the artifact does not exist (the rename
-                RPC is silent on a missing target, so absence is detected via
-                a list fetch — not a transport 404). Only raised when
-                ``return_object=True``. Note-backed mind-map ids are *not*
-                renameable here (they use ``UPDATE_NOTE``); such an id is
-                treated as absent and raises — use ``mind_maps.rename`` instead.
+            ArtifactNotFoundError: if the artifact does not exist (detected via
+                a list fetch, not a 404). Always when ``return_object=True``;
+                also on ``False`` under ``NOTEBOOKLM_FUTURE_ERRORS``. Note-backed
+                mind-map ids are *not* renameable here — use ``mind_maps.rename``.
 
         .. versionchanged:: 0.7.0
-            **Breaking change:** previously returned ``None`` even on success.
-            Now re-fetches and returns the renamed ``Artifact``, raising
-            :class:`ArtifactNotFoundError` for a missing target (issue #1255).
-            Added the ``return_object`` opt-out.
+            **Breaking change:** no longer returns ``None`` on success; it
+            re-fetches and raises :class:`ArtifactNotFoundError` for a missing
+            target (#1255), plus the ``return_object`` opt-out.
         """
         params = [[artifact_id, new_title], [["title"]]]
         await self._rpc.rpc_call(
@@ -970,20 +968,18 @@ class ArtifactsAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if not return_object:
+        # Resolve via studio artifacts only — never public ``get()`` (#1247) nor
+        # the merged listing (a note-backed mind-map id no-ops on RENAME_ARTIFACT
+        # — use ``mind_maps.rename``). v0.7.0 ``False`` short-circuits; the v0.8.0
+        # preview (#1362) runs the lookup on ``False`` too but still returns None.
+        if not return_object and not future_errors_enabled():
             return None
-        # Hydrate from studio artifacts only (never the public ``get()``, which
-        # warns under #1247, and never the merged listing — that would let a
-        # note-backed mind-map id, which ``RENAME_ARTIFACT`` no-ops on, read
-        # back as a stale "success"; it belongs to ``mind_maps.rename``). Only
-        # genuine absence maps to ``ArtifactNotFoundError``; transport/auth
-        # errors propagate as-is.
         artifact = await self._listing.get_studio_only(
             notebook_id, artifact_id, list_raw=self._list_raw
         )
         if artifact is None:
             raise ArtifactNotFoundError(artifact_id, method_id=RPCMethod.RENAME_ARTIFACT.value)
-        return artifact
+        return None if not return_object else artifact
 
     async def poll_status(self, notebook_id: str, task_id: str) -> GenerationStatus:
         """Poll the status of a generation task.
@@ -1236,12 +1232,9 @@ class ArtifactsAPI:
         )
         logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
         try:
-            # CREATE_ARTIFACT is classified PROBE_THEN_CREATE in
-            # ``_idempotency.py``. ``operation_variant=None`` is
-            # passed explicitly to document this call site as the
-            # no-variant default (the registry resolves the same entry
-            # either way; the explicit kwarg is a future-proofing marker
-            # for a possible variant table).
+            # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
+            # ``operation_variant=None`` marks this call site as the no-variant
+            # default (a future-proofing marker; the registry resolves the same).
             result = await self._rpc.rpc_call(
                 RPCMethod.CREATE_ARTIFACT,
                 params,
@@ -1250,7 +1243,8 @@ class ArtifactsAPI:
                 operation_variant=None,
             )
         except RPCError as e:
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
+            # v0.8.0 preview (#1342): a refusal raises (couldn't-start); default-off swallow.
+            if e.rpc_code == "USER_DISPLAYABLE_ERROR" and not future_errors_enabled():
                 return GenerationStatus(
                     task_id="",
                     status="failed",
@@ -1357,6 +1351,12 @@ class ArtifactsAPI:
             status = artifact_status_to_str(status_code) if status_code is not None else "pending"
             return GenerationStatus(task_id=artifact_id, status=status)
 
+        # v0.8.0 preview (#1342): a missing id means no task was created — raise.
+        # Null id (feature gated) -> ArtifactFeatureUnavailableError; else drift.
+        if future_errors_enabled():
+            if artifact_id is None:
+                raise ArtifactFeatureUnavailableError("artifact", method_id=method_id)
+            raise DecodingError(f"No artifact id (source={source})", method_id=method_id)
         return GenerationStatus(
             task_id="", status="failed", error="Generation failed - no artifact_id returned"
         )

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -12,6 +12,7 @@ import weakref
 from typing import TYPE_CHECKING, Any
 
 from .._conversation_cache import ConversationCache
+from .._deprecation import future_errors_enabled
 from .._logging import get_request_id, reset_request_id, set_request_id
 from .._notebook_metadata import NotebookSourceIdProvider
 from .._request_types import AuthSnapshot
@@ -698,43 +699,42 @@ class ChatAPI:
     async def delete_conversation(self, notebook_id: str, conversation_id: str) -> bool:
         """Delete a conversation from the server.
 
-        Mirrors the web UI's "Delete history" action. After deletion the
-        next ``ask()`` with no ``conversation_id`` starts a fresh
-        server-side conversation rather than extending the deleted one.
+        Mirrors the web UI's "Delete history" action. After deletion the next
+        ``ask()`` with no ``conversation_id`` starts a fresh server-side
+        conversation rather than extending the deleted one.
 
         Args:
             notebook_id: The notebook that owns the conversation.
             conversation_id: The conversation to delete.
 
         Returns:
-            True on success. The server returns an empty body; any
-            RPC-level error raises before this returns.
+            ``True`` on success (errors raise first, so the ``True`` is
+            uninformative). Under ``NOTEBOOKLM_FUTURE_ERRORS`` (v0.8.0 preview,
+            #1290) returns ``None``; the ``-> bool`` annotation stays until the
+            v0.8.0 flip.
         """
         # Catch cross-loop misuse before acquiring the per-conversation lock
-        # below — like ``ask`` does — so a client reused from a different loop
-        # fails fast at the call site instead of hanging on (or rebuilding) a
-        # lock bound to a dead loop. The owner-level ``set_bound_loop`` /
-        # ``reset_after_open`` protocol (#1225) only resets the locks on a
-        # *reopen*; an already-open client driven cross-loop is still rejected
-        # here by the injected guard.
+        # (like ``ask``), so a client reused from another loop fails fast rather
+        # than hang on a dead-loop lock. ``set_bound_loop`` / ``reset_after_open``
+        # (#1225) only reset locks on *reopen*; an open cross-loop client raises.
         self._loop_guard.assert_bound_loop()
         logger.debug("Deleting conversation %s in notebook %s", conversation_id, notebook_id)
-        # Hold the per-``conversation_id`` lock the same way ``ask`` does
-        # for follow-ups, so a concurrent follow-up ``ask`` can't read
-        # pre-delete history, then POST it after the delete has cleared
-        # both server-side state and the local cache.
+        # Hold the per-``conversation_id`` lock like ``ask`` does for follow-ups,
+        # so a concurrent follow-up can't read pre-delete history then POST it
+        # after the delete cleared both server-side state and the local cache.
         async with self._get_conversation_lock(conversation_id):
-            # Param shape captured from web-UI traffic. The trailing 1 is
-            # always observed; its meaning is uncharted — treated as a fixed flag.
+            # Param shape from web-UI traffic; trailing 1 is a fixed flag.
             params: list[Any] = [[], conversation_id, None, 1]
             await self._rpc.rpc_call(
                 RPCMethod.DELETE_CONVERSATION,
                 params,
                 source_path=f"/notebook/{notebook_id}",
             )
-            # Clear the cache only after a successful RPC; on failure the
-            # rpc_call above raises and we leave the cache intact for retry.
+            # Clear the cache only after a successful RPC (failure raises above).
             self._cache.clear(conversation_id)
+        # v0.8.0 preview (#1290): uninformative ``True`` -> ``None`` (runtime-only).
+        if future_errors_enabled():
+            return None  # type: ignore[return-value]
         return True
 
     def clear_cache(self, conversation_id: str | None = None) -> bool:

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -50,10 +50,16 @@ A second, orthogonal gate lives here too: ``NOTEBOOKLM_FUTURE_ERRORS``
 (:func:`future_errors_enabled`). When on, the three runways above adopt their
 v0.8.0 *target* behavior early — ``deprecated_kwarg`` and the
 :class:`MappingCompatMixin` subscript raise instead of warn (the
-``<resource>.get()`` runway is routed through ``_lookup.resolve_get``). It is an
-opt-in forward-compat preview, default-off, and takes precedence over the quiet
-gate (a runway raises regardless of quiet; quiet only silences the warn path
-that future mode replaces). See ``docs/deprecations.md``.
+``<resource>.get()`` runway is routed through ``_lookup.resolve_get``). The same
+gate also previews the purely-behavioral v0.8.0 changes that have no warn-runway
+(issue #1405): the uninformative ``bool`` returns become ``None`` (#1290), a
+synchronous generation refusal raises instead of soft-failing (#1342), and the
+mutate-existing ops fail loud on a missing target (#1362). Those previews live in
+the feature modules (each gated ``if future_errors_enabled(): ... else: ...``),
+not here; :func:`future_errors_enabled` enumerates them. It is an opt-in
+forward-compat preview, default-off, and takes precedence over the quiet gate
+(a runway raises regardless of quiet; quiet only silences the warn path that
+future mode replaces). See ``docs/deprecations.md``.
 """
 
 from __future__ import annotations
@@ -137,10 +143,20 @@ def future_errors_enabled() -> bool:
     This gate takes precedence over :func:`deprecations_quiet`: when future
     errors are enabled the runway *raises* regardless of the quiet setting,
     because the quiet gate only silences the warning that future mode replaces
-    with an exception. The purely-behavioral v0.8.0 changes that lack a clean
-    warn-runway (bool returns, refusal-suppression, fail-loud listing) are
-    **not** covered by this flag yet; they will be folded in as their v0.8.0
-    behavior is defined (tracked as a follow-up).
+    with an exception. The flag **also** previews the purely-behavioral v0.8.0
+    changes that have no warn-runway (issue #1405), each gated the same way:
+    the uninformative ``bool`` returns of ``sources.refresh`` /
+    ``chat.delete_conversation`` become ``None`` (#1290); a synchronous
+    generation refusal **raises** the decoder's ``RateLimitError`` / ``RPCError``
+    / ``DecodingError`` / ``ArtifactFeatureUnavailableError`` instead of being
+    swallowed into ``GenerationStatus(status="failed")`` / returned ``None``
+    (#1342, across ``_call_generate`` / ``revise_slide`` /
+    ``_parse_generation_result`` / ``research.start``); and the mutate-existing
+    ops ``notes.update`` and ``sources``/``artifacts``
+    ``rename(return_object=False)`` fail loud with a ``*NotFoundError`` on a
+    missing target (#1362). These previews are **runtime-only** — no public
+    return annotation changes until the v0.8.0 flip — so default-off stays
+    byte-identical to v0.7.0.
     """
     return _future_errors_enabled()
 

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -18,6 +18,7 @@ import builtins
 import logging
 from typing import Any
 
+from ._deprecation import future_errors_enabled
 from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteRowKind, NoteService
@@ -182,7 +183,24 @@ class NotesAPI:
             note_id: The note ID.
             content: The new content.
             title: The new title.
+
+        Raises:
+            NoteNotFoundError: When ``NOTEBOOKLM_FUTURE_ERRORS`` (the v0.8.0
+                preview, issue #1362) is enabled and ``note_id`` does not exist.
+                The ``UPDATE_NOTE`` RPC is ``allow_null=True`` and silently
+                no-ops on a missing note, so the current (v0.7.0) contract
+                silently "succeeds" on a miss; the preview adds a public-facade
+                existence preflight so a mutate-existing op fails loud per
+                ADR-019 Class 5.
         """
+        if future_errors_enabled():
+            # v0.8.0 preview (issue #1362): detect a missing target at the
+            # public facade (never inside ``_note_service`` — that crosses the
+            # layer boundary). ``get_or_none`` is the silent optional-lookup;
+            # only a genuine miss yields ``None`` (transport/auth/decode faults
+            # propagate). Default-off keeps the historical silent no-op.
+            if await self.get_or_none(notebook_id, note_id) is None:
+                raise NoteNotFoundError(note_id)
         await self._notes.update_note(notebook_id, note_id, content, title)
 
     async def delete(self, notebook_id: str, note_id: str) -> None:

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from . import research as _research_pub
-from ._deprecation import deprecated_kwarg, warn_deprecated
+from ._deprecation import deprecated_kwarg, future_errors_enabled, warn_deprecated
 from ._notebook_metadata import NotebookSourceLister, create_default_source_lister
 from ._research_task_parser import parse_research_task_models
 from ._runtime.contracts import RpcCaller
@@ -27,6 +27,7 @@ from ._types.research import (
     ResearchTask,
 )
 from .exceptions import (
+    DecodingError,
     NetworkError,
     ResearchTaskMismatchError,
     ResearchTimeoutError,
@@ -336,17 +337,20 @@ class ResearchAPI:
             notebook_id: The notebook ID.
             query: The research query.
             source: "web" or "drive".
-            mode: "fast" or "deep" (deep only available for web).
+            mode: "fast" or "deep" (deep is web-only).
 
         Returns:
-            A :class:`~notebooklm._types.research.ResearchStart` with
-            ``task_id``, ``report_id``, ``notebook_id``, ``query``, and
-            ``mode``, or ``None`` when the backend returned no task. Legacy
-            ``result["task_id"]`` dict-subscript access still works (with a
-            ``DeprecationWarning``) until v0.8.0; prefer ``result.task_id``.
+            A :class:`~notebooklm._types.research.ResearchStart` (``task_id`` /
+            ``report_id`` / ``notebook_id`` / ``query`` / ``mode``), or ``None``
+            when the backend returned no task (legacy ``result["task_id"]`` dict
+            access still works with a warning until v0.8.0). Under
+            ``NOTEBOOKLM_FUTURE_ERRORS`` (#1342) an empty/non-list payload or
+            falsey ``task_id`` raises ``DecodingError`` instead.
 
         Raises:
             ValidationError: If source/mode combination is invalid.
+            DecodingError: Under the v0.8.0 preview, on an empty/non-list payload
+                or falsey ``task_id`` (no task created).
         """
         logger.debug(
             "Starting %s research in notebook %s: %s",
@@ -382,6 +386,12 @@ class ResearchAPI:
 
         if result and isinstance(result, list) and len(result) > 0:
             task_id = result[0]
+            # v0.8.0 preview (#1342): a falsey ``task_id`` means no task was
+            # created — raise (mirrors ``_parse_generation_result``'s missing id).
+            if not task_id and future_errors_enabled():
+                raise DecodingError(
+                    f"research.start returned no task id: {result!r}", method_id=rpc_id.value
+                )
             report_id = result[1] if len(result) > 1 else None
             return ResearchStart(
                 task_id=task_id,
@@ -389,6 +399,11 @@ class ResearchAPI:
                 notebook_id=notebook_id,
                 query=query,
                 mode=mode_lower,
+            )
+        # v0.8.0 preview (#1342): an empty / non-list payload is couldn't-start.
+        if future_errors_enabled():
+            raise DecodingError(
+                "research.start returned an empty / non-list payload", method_id=rpc_id.value
             )
         return None
 
@@ -407,49 +422,34 @@ class ResearchAPI:
                 ``sources`` / ``summary`` / ``report`` fields describe the
                 matched task, and ``tasks`` contains only that task. When
                 ``None`` and multiple tasks are in flight, a
-                :class:`DeprecationWarning` is emitted and the *latest* task
-                is returned (preserving legacy behavior). When ``None`` and a
-                single task is in flight, behavior is unchanged and no
-                warning fires.
-
-                Migration: callers that started research via
-                :meth:`start` and held onto the returned ``task_id`` should
-                pass it here on every subsequent ``poll`` to remove
-                ambiguity. The ``None`` default will be removed in a future
-                major release.
+                :class:`DeprecationWarning` is emitted and the *latest* task is
+                returned (legacy behavior); a single in-flight task is silent.
+                Migration: pass the ``task_id`` from :meth:`start` on every
+                ``poll`` — the ``None`` default is removed in a future major.
 
         Returns:
-            A :class:`~notebooklm._types.research.ResearchTask` describing the
-            selected research task for the notebook. Use attribute access:
+            A :class:`~notebooklm._types.research.ResearchTask` for the selected
+            task. Use attribute access:
             - ``task.task_id``: task/report identifier for the selected task
             - ``task.status``: a :class:`~notebooklm._types.research.ResearchStatus`
-              (``IN_PROGRESS``, ``COMPLETED``, ``FAILED``, ``NO_RESEARCH``, or
-              ``NOT_FOUND``); compares equal to the historical strings
-              (``task.status == "completed"`` still holds)
+              (``IN_PROGRESS`` / ``COMPLETED`` / ``FAILED`` / ``NO_RESEARCH`` /
+              ``NOT_FOUND``); equals the historical strings
             - ``task.query``: original research query text
-            - ``task.sources``: tuple of
-              :class:`~notebooklm._types.research.ResearchSource` for the
-              selected task
+            - ``task.sources``: tuple of ``ResearchSource`` (each exposes ``url``,
+              ``title``, ``result_type``, ``research_task_id``, ``report_markdown``)
             - ``task.summary``: summary text when present
-            - ``task.report``: extracted deep-research report markdown when present
-            - ``task.tasks``: tuple of all parsed research tasks visible at this
-              poll (filtered to the matched task when ``task_id`` is set)
+            - ``task.report``: extracted deep-research report markdown, if present
+            - ``task.tasks``: all parsed research tasks visible at this poll
+              (filtered to the matched task when ``task_id`` is set)
 
-            Each :class:`ResearchSource` exposes ``url``, ``title``,
-            ``result_type``, ``research_task_id`` (the task/report id that
-            produced the source), and ``report_markdown`` (for deep-research
-            report entries).
-
-            Legacy ``result["status"]`` dict-subscript access still works (with
-            a ``DeprecationWarning``) until v0.8.0; prefer ``result.status``.
+            Legacy ``result["status"]`` dict access still works (with a warning)
+            until v0.8.0; prefer ``result.status``.
 
             When a non-empty ``task_id`` is supplied but no in-flight task
-            matches, the return is ``ResearchTask.not_found(task_id)`` — status
-            ``NOT_FOUND``, carrying the requested ``task_id``, with empty
-            ``tasks``. This is the *poll-observed absence* of that specific
+            matches, the return is ``ResearchTask.not_found(task_id)`` (status
+            ``NOT_FOUND``, empty ``tasks``) — the *poll-observed absence* of that
             task (a typed lifecycle sentinel, not a raise; ADR-019 Rule 4),
-            distinct from the unfiltered empty-poll case (``task_id`` ``None``
-            or empty) which stays ``NO_RESEARCH`` ("nothing in flight").
+            distinct from the unfiltered empty poll, which stays ``NO_RESEARCH``.
         """
         logger.debug("Polling research status for notebook %s", notebook_id)
         parsed_tasks = self._select_polled_tasks(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -640,7 +640,7 @@ class SourcesAPI:
                 ``UPDATE_SOURCE`` echo, fetching only on a null echo). When
                 ``False``, return ``None`` without hydrating. Under the v0.8.0
                 preview ``False`` still returns ``None`` but adds miss-detection
-                (the flag gates detection, not the return — see ``Raises``).
+                (the flag gates detection, not return — see ``Raises``).
 
         Returns:
             The renamed :class:`~notebooklm.types.Source`, or ``None`` when
@@ -654,7 +654,7 @@ class SourcesAPI:
         .. versionchanged:: 0.7.0
             **Breaking change:** no longer fabricates an unverified
             ``Source(id, title)`` on a null echo; it hydrates and raises
-            :class:`SourceNotFoundError` (#1255). Added ``return_object``.
+            :class:`SourceNotFoundError` (#1255), plus ``return_object``.
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = build_rename_source_params(source_id, new_title)
@@ -664,11 +664,11 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if result and return_object:  # truthy echo proves existence
+        if result and return_object:
             return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
-        # Null echo: hydrate via the internal optional-lookup (never public
-        # ``get()`` — #1247) so a miss raises. v0.7.0 ``False`` skips this; the
-        # v0.8.0 preview (#1362) runs it to detect a miss but returns ``None``.
+        # Null echo: hydrate via the internal lookup (never public ``get()`` —
+        # #1247) so a miss raises. ``False`` skips it when existence is proven
+        # (echo) or flag-off; the v0.8.0 preview (#1362) runs it to detect a miss.
         if not return_object and (result or not future_errors_enabled()):
             return None
         source = await self._get_or_none(notebook_id, source_id)
@@ -686,7 +686,7 @@ class SourcesAPI:
         Returns:
             ``True`` if refresh was initiated (failures raise first, so it is
             uninformative). Under ``NOTEBOOKLM_FUTURE_ERRORS`` (#1290) returns
-            ``None`` (``-> bool`` stays until the v0.8.0 flip).
+            ``None``; ``-> bool`` stays until v0.8.0.
         """
         params = [None, [source_id], [2]]
         await self._rpc.rpc_call(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ._deprecation import future_errors_enabled
 from ._lookup import resolve_get
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._runtime.contracts import RpcCaller
@@ -635,29 +636,25 @@ class SourcesAPI:
             source_id: The source ID to rename.
             new_title: The new title.
             return_object: When ``True`` (default), return the renamed
-                :class:`~notebooklm.types.Source` — preferring the
-                ``UPDATE_SOURCE`` echo and falling back to a fetch only when
-                the echo is null. When ``False``, return ``None`` without
-                hydrating (cheaper for bulk renames that ignore the return);
-                this also skips missing-target detection, so a missing source
-                does **not** raise — pass ``return_object=True`` (the default)
-                if you need the missing-target guarantee.
+                :class:`~notebooklm.types.Source` (preferring the
+                ``UPDATE_SOURCE`` echo, fetching only on a null echo). When
+                ``False``, return ``None`` without hydrating. Under the v0.8.0
+                preview ``False`` still returns ``None`` but adds miss-detection
+                (the flag gates detection, not the return — see ``Raises``).
 
         Returns:
             The renamed :class:`~notebooklm.types.Source`, or ``None`` when
             ``return_object=False``.
 
         Raises:
-            SourceNotFoundError: if the source does not exist (the rename RPC
-                is silent on a missing target, so absence is detected via a
-                content/list fetch — not a transport 404). Only raised when
-                ``return_object=True``.
+            SourceNotFoundError: if the source does not exist (detected via a
+                content/list fetch, not a 404). Always when ``return_object=True``;
+                also on ``False`` under ``NOTEBOOKLM_FUTURE_ERRORS``.
 
         .. versionchanged:: 0.7.0
             **Breaking change:** no longer fabricates an unverified
-            ``Source(id, title)`` when the RPC echoes nothing. It now hydrates
-            via an internal fetch and raises :class:`SourceNotFoundError` for a
-            missing target (issue #1255). Added the ``return_object`` opt-out.
+            ``Source(id, title)`` on a null echo; it hydrates and raises
+            :class:`SourceNotFoundError` (#1255). Added ``return_object``.
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = build_rename_source_params(source_id, new_title)
@@ -667,18 +664,17 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if not return_object:
-            return None
-        # Prefer the UPDATE_SOURCE echo (avoids the extra fetch).
-        if result:
+        if result and return_object:  # truthy echo proves existence
             return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
-        # Echo was null: hydrate via the internal optional-lookup (never the
-        # public ``get()``, which warns under #1247). Only genuine absence
-        # maps to ``SourceNotFoundError``; transport/auth errors propagate.
+        # Null echo: hydrate via the internal optional-lookup (never public
+        # ``get()`` — #1247) so a miss raises. v0.7.0 ``False`` skips this; the
+        # v0.8.0 preview (#1362) runs it to detect a miss but returns ``None``.
+        if not return_object and (result or not future_errors_enabled()):
+            return None
         source = await self._get_or_none(notebook_id, source_id)
         if source is None:
             raise SourceNotFoundError(source_id, method_id=RPCMethod.UPDATE_SOURCE.value)
-        return source
+        return None if not return_object else source
 
     async def refresh(self, notebook_id: str, source_id: str) -> bool:
         """Refresh a source to get updated content (for URL/Drive sources).
@@ -688,7 +684,9 @@ class SourcesAPI:
             source_id: The source ID to refresh.
 
         Returns:
-            True if refresh was initiated.
+            ``True`` if refresh was initiated (failures raise first, so it is
+            uninformative). Under ``NOTEBOOKLM_FUTURE_ERRORS`` (#1290) returns
+            ``None`` (``-> bool`` stays until the v0.8.0 flip).
         """
         params = [None, [source_id], [2]]
         await self._rpc.rpc_call(
@@ -697,6 +695,9 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
+        # v0.8.0 preview (#1290): uninformative ``True`` -> ``None`` (runtime-only).
+        if future_errors_enabled():
+            return None  # type: ignore[return-value]
         return True
 
     async def check_freshness(self, notebook_id: str, source_id: str) -> bool:
@@ -716,11 +717,8 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        # API returns different structures depending on source type:
-        #   - [] (empty array): source is fresh (URL sources)
-        #   - [[null, true, [source_id]]]: source is fresh (Drive sources)
-        #   - True: source is fresh
-        #   - False: source is stale
+        # Shapes by source type: ``[]`` or ``[[null, true, [id]]]`` = fresh
+        # (URL / Drive); bare ``True`` = fresh; bare ``False`` = stale.
         if result is True:
             return True
         if result is False:

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -1337,10 +1337,10 @@ class NoteNotFoundError(NotFoundError, RPCError, NoteError):
     """Note not found in notebook.
 
     .. note::
-       This type is **defined but not raised by any method yet**. It is the
-       prerequisite for the note not-found work landing in v0.8.0 (umbrella
-       #1346); the wording below describes the intended catchability once note
-       read/mutation paths surface a missing note this way.
+       Under v0.7.0 this type is raised only when the ``NOTEBOOKLM_FUTURE_ERRORS``
+       preview is on — ``notes.update`` then fails loud on a missing note (#1362).
+       It becomes the unconditional not-found signal for note read/mutation paths
+       in v0.8.0 (umbrella #1346); the wording below describes that catchability.
 
     Inherits from :class:`NotFoundError` (cross-domain umbrella),
     :class:`RPCError` (transport-level catchability), and :class:`NoteError`

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -1337,10 +1337,10 @@ class NoteNotFoundError(NotFoundError, RPCError, NoteError):
     """Note not found in notebook.
 
     .. note::
-       Under v0.7.0 this type is raised only when the ``NOTEBOOKLM_FUTURE_ERRORS``
-       preview is on — ``notes.update`` then fails loud on a missing note (#1362).
-       It becomes the unconditional not-found signal for note read/mutation paths
-       in v0.8.0 (umbrella #1346); the wording below describes that catchability.
+       Under v0.7.0 this type is raised only when ``NOTEBOOKLM_FUTURE_ERRORS``
+       is on — ``notes.get`` (via ``resolve_get``, #1247) and ``notes.update``
+       (#1362) then fail loud on a missing note. It is the unconditional
+       not-found signal for note paths in v0.8.0 (#1346); see below.
 
     Inherits from :class:`NotFoundError` (cross-domain umbrella),
     :class:`RPCError` (transport-level catchability), and :class:`NoteError`

--- a/tests/_lint/test_module_size_ratchet.py
+++ b/tests/_lint/test_module_size_ratchet.py
@@ -67,7 +67,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_artifacts.py": 1420,
     "_source/upload.py": 1239,
     "cli/session_cmd.py": 1080,
-    "_sources.py": 1025,
+    "_sources.py": 1023,
     "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,

--- a/tests/unit/test_future_errors_flag.py
+++ b/tests/unit/test_future_errors_flag.py
@@ -2,8 +2,8 @@
 
 The flag lets a process (or a CI job) run the **v0.8.0 error contract** early so
 forward-compatibility can be tested before the breaking flips ship (ADR-0019,
-umbrella #1346). When on, the three v0.7.0 deprecation *runways* that still warn
-today adopt their v0.8.0 *target* behavior:
+umbrella #1346). When on, the v0.7.0 deprecation *runways* that still warn today
+adopt their v0.8.0 *target* behavior:
 
 1. ``<resource>.get()`` raises the matching ``*NotFoundError`` on a miss instead
    of warning-and-returning ``None`` (#1247), routed through
@@ -14,12 +14,29 @@ today adopt their v0.8.0 *target* behavior:
 3. :func:`~notebooklm._deprecation.deprecated_kwarg` raises :class:`TypeError`
    on the deprecated keyword instead of warning-and-aliasing it (#1254).
 
+The flag also previews the three **purely-behavioral** v0.8.0 changes (#1405),
+each gated the same way (``if future_errors_enabled(): <v0.8.0> else: <v0.7.0>``):
+
+4. uninformative ``bool`` returns become ``None`` — ``sources.refresh`` and
+   ``chat.delete_conversation`` (#1290; ``chat.clear_cache`` is *not* gated, its
+   bool is meaningful);
+5. a synchronous generation refusal **raises** the decoder's
+   ``RateLimitError`` / ``RPCError`` / ``DecodingError`` /
+   ``ArtifactFeatureUnavailableError`` instead of being swallowed into
+   ``GenerationStatus(status="failed")`` / returned ``None`` — ``_call_generate``,
+   ``revise_slide``, ``_parse_generation_result``'s missing-id branch, and
+   ``research.start``'s empty-payload branch (#1342);
+6. mutate-existing ops fail loud on a missing target — ``notes.update`` and
+   ``sources``/``artifacts`` ``rename(return_object=False)`` raise
+   ``*NotFoundError`` (#1362).
+
 Default-off must be byte-identical to current v0.7.0 behavior, and the flag
 takes precedence over ``NOTEBOOKLM_QUIET_DEPRECATIONS`` (a runway raises
 regardless of quiet; quiet only silences the warn path future mode replaces).
 The behavioral conformance for the ``get()`` flip across all five namespaces
 lives in ``test_public_api_behavior.py`` (run under both modes); this module
-covers the resolver, the two non-``get`` flips, and the precedence rule.
+covers the resolver, the two non-``get`` flips, the precedence rule, and the
+six behavioral previews above (one new test class per gated behavior).
 """
 
 from __future__ import annotations
@@ -27,16 +44,36 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from notebooklm import _deprecation
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._chat import ChatAPI
 from notebooklm._deprecation import (
     MappingCompatMixin,
     deprecated_kwarg,
     future_errors_enabled,
 )
 from notebooklm._lookup import resolve_get
+from notebooklm._mind_map import NoteBackedMindMapService
+from notebooklm._note_service import NoteService
+from notebooklm._notes import NotesAPI
+from notebooklm._research import ResearchAPI
+from notebooklm._runtime.contracts import LoopGuard, RpcCaller
+from notebooklm._sources import SourcesAPI
+from notebooklm.exceptions import (
+    ArtifactFeatureUnavailableError,
+    ArtifactNotFoundError,
+    DecodingError,
+    NoteNotFoundError,
+    RateLimitError,
+    RPCError,
+    SourceNotFoundError,
+)
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Source
 
 _FLAG = "NOTEBOOKLM_FUTURE_ERRORS"
 _QUIET = "NOTEBOOKLM_QUIET_DEPRECATIONS"
@@ -327,3 +364,328 @@ def test_public_alias_matches_private_resolver(monkeypatch):
         assert future_errors_enabled() == _deprecation._future_errors_enabled()
     monkeypatch.delenv(_FLAG, raising=False)
     assert future_errors_enabled() == _deprecation._future_errors_enabled()
+
+
+# ===========================================================================
+# Behavioral previews (#1405): one new test class per gated behavior. Each
+# asserts flag-OFF = current v0.7.0 behavior AND flag-ON = the v0.8.0 target,
+# using the same setenv/delenv(_FLAG) idiom as the classes above.
+# ===========================================================================
+
+
+def _make_artifacts_api(rpc_call: AsyncMock) -> ArtifactsAPI:
+    """Build a minimal ``ArtifactsAPI`` over a single ``rpc_call`` seam.
+
+    ADR-007: the ``rpc_call`` seam is injected via ``make_fake_core`` rather
+    than dotted attribute assignment so the forbidden-monkeypatch lint stays
+    clean.
+    """
+    from _fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=rpc_call, get_source_ids=AsyncMock(return_value=[]))
+    mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    mind_maps.list_mind_maps = AsyncMock(return_value=[])
+    notebooks = MagicMock()
+    notebooks.get_source_ids = AsyncMock(return_value=[])
+    return ArtifactsAPI(
+        rpc=core,
+        drain=core,
+        lifecycle=core,
+        notebooks=notebooks,
+        mind_maps=mind_maps,
+        note_service=MagicMock(spec=NoteService),
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1290 — uninformative bool returns become None
+# ---------------------------------------------------------------------------
+
+
+class TestBoolReturnsBecomeNone:
+    """``sources.refresh`` / ``chat.delete_conversation`` return ``None`` flag-on.
+
+    The ``True`` they return today carries no information (any failure raises
+    first), so under the flag they preview the v0.8.0 ``-> None`` return. The
+    ``-> bool`` annotation is intentionally preserved at runtime; only the
+    returned *value* flips. ``chat.clear_cache`` is deliberately NOT gated — its
+    bool is meaningful (the cache reports whether the id was present).
+    """
+
+    @pytest.mark.asyncio
+    async def test_sources_refresh_off_returns_true(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=None)), uploader=MagicMock())
+        assert await api.refresh("nb_1", "src_1") is True
+
+    @pytest.mark.asyncio
+    async def test_sources_refresh_on_returns_none(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=None)), uploader=MagicMock())
+        assert await api.refresh("nb_1", "src_1") is None
+
+    def _chat_api(self) -> ChatAPI:
+        return ChatAPI(
+            rpc=MagicMock(spec=RpcCaller, rpc_call=AsyncMock(return_value=None)),
+            transport=MagicMock(),
+            reqid=MagicMock(),
+            loop_guard=MagicMock(spec=LoopGuard),
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_conversation_off_returns_true(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = self._chat_api()
+        assert await api.delete_conversation("nb_1", "conv_1") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_conversation_on_returns_none(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._chat_api()
+        assert await api.delete_conversation("nb_1", "conv_1") is None
+
+    def test_clear_cache_is_never_gated(self, monkeypatch):
+        # clear_cache's bool is meaningful (id present/absent), so it must NOT
+        # be touched by the flag in either mode.
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._chat_api()
+        api._cache.cache_conversation_turn("conv_1", "Q?", "A.", turn_number=1)
+        assert api.clear_cache("conv_1") is True  # present -> True even under the flag
+        assert api.clear_cache("conv_missing") is False  # absent -> meaningful False
+
+
+# ---------------------------------------------------------------------------
+# #1342 — synchronous generation refusal raises (drops status="failed")
+# ---------------------------------------------------------------------------
+
+
+class TestRefusalRaises:
+    """A synchronous refusal raises under the flag instead of soft-failing."""
+
+    @pytest.mark.asyncio
+    async def test_call_generate_off_swallows_to_failed_status(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        rpc = AsyncMock(
+            side_effect=RateLimitError("Rate limit exceeded", rpc_code="USER_DISPLAYABLE_ERROR")
+        )
+        api = _make_artifacts_api(rpc)
+        result = await api.generate_video("nb_1")
+        assert result.status == "failed"
+        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+        assert result.is_rate_limited is True
+
+    @pytest.mark.asyncio
+    async def test_call_generate_on_raises_rate_limit(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        rpc = AsyncMock(
+            side_effect=RateLimitError("Rate limit exceeded", rpc_code="USER_DISPLAYABLE_ERROR")
+        )
+        api = _make_artifacts_api(rpc)
+        with pytest.raises(RateLimitError, match="Rate limit"):
+            await api.generate_video("nb_1")
+
+    @pytest.mark.asyncio
+    async def test_call_generate_non_refusal_propagates_both_modes(self, monkeypatch):
+        # A non-USER_DISPLAYABLE_ERROR RPCError always propagates, flag or not.
+        for value in ("1", None):
+            if value is None:
+                monkeypatch.delenv(_FLAG, raising=False)
+            else:
+                monkeypatch.setenv(_FLAG, value)
+            rpc = AsyncMock(side_effect=RPCError("Server error", rpc_code="INTERNAL_ERROR"))
+            api = _make_artifacts_api(rpc)
+            with pytest.raises(RPCError, match="Server error"):
+                await api.generate_video("nb_1")
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_off_swallows_to_failed_status(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        rpc = AsyncMock(side_effect=RPCError("Refused", rpc_code="USER_DISPLAYABLE_ERROR"))
+        api = _make_artifacts_api(rpc)
+        result = await api.revise_slide("nb_1", "art_1", 0, "make it pop")
+        assert result.status == "failed"
+        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_on_raises(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        rpc = AsyncMock(side_effect=RPCError("Refused", rpc_code="USER_DISPLAYABLE_ERROR"))
+        api = _make_artifacts_api(rpc)
+        with pytest.raises(RPCError, match="Refused"):
+            await api.revise_slide("nb_1", "art_1", 0, "make it pop")
+
+    def test_parse_generation_result_null_id_off_returns_failed(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = _make_artifacts_api(AsyncMock())
+        # A well-structured row whose artifact id (result[0][0]) is null.
+        status = api._parse_generation_result(
+            [[None, "Title", 1, None, 1]], method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
+        assert status.status == "failed"
+        assert status.task_id == ""
+
+    def test_parse_generation_result_null_id_on_raises_feature_unavailable(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = _make_artifacts_api(AsyncMock())
+        with pytest.raises(ArtifactFeatureUnavailableError):
+            api._parse_generation_result(
+                [[None, "Title", 1, None, 1]], method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
+
+    def test_parse_generation_result_empty_id_on_raises_decoding(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = _make_artifacts_api(AsyncMock())
+        # A falsey-but-non-null id (``""``) is degenerate shape drift -> DecodingError.
+        with pytest.raises(DecodingError):
+            api._parse_generation_result(
+                [["", "Title", 1, None, 1]], method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
+
+    @pytest.mark.asyncio
+    async def test_research_start_empty_payload_off_returns_none(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[])))
+        assert await api.start("nb_1", "query") is None
+
+    @pytest.mark.asyncio
+    async def test_research_start_empty_payload_on_raises_decoding(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[])))
+        with pytest.raises(DecodingError):
+            await api.start("nb_1", "query")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("falsey_id", [None, "", 0])
+    async def test_research_start_falsey_task_id_off_builds_handle(self, monkeypatch, falsey_id):
+        # A non-empty payload whose task_id is falsey still builds a (degenerate)
+        # ResearchStart on the v0.7.0 default path — byte-for-byte unchanged.
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[falsey_id, "report_1"])))
+        result = await api.start("nb_1", "query")
+        assert result is not None
+        assert result.task_id == falsey_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("falsey_id", [None, "", 0])
+    async def test_research_start_falsey_task_id_on_raises_decoding(self, monkeypatch, falsey_id):
+        # Under the flag a falsey task_id means no task was created — raise
+        # (mirrors _parse_generation_result's missing-id branch).
+        monkeypatch.setenv(_FLAG, "1")
+        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[falsey_id, "report_1"])))
+        with pytest.raises(DecodingError):
+            await api.start("nb_1", "query")
+
+    @pytest.mark.asyncio
+    async def test_research_start_real_task_id_on_returns_handle(self, monkeypatch):
+        # A truthy task_id is unaffected by the flag.
+        monkeypatch.setenv(_FLAG, "1")
+        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=["task_1", "report_1"])))
+        result = await api.start("nb_1", "query")
+        assert result is not None
+        assert result.task_id == "task_1"
+
+
+# ---------------------------------------------------------------------------
+# #1362 — mutate-existing fail-loud on a missing target
+# ---------------------------------------------------------------------------
+
+
+class TestMutateExistingFailLoud:
+    """``notes.update`` and ``rename(return_object=False)`` raise on a miss."""
+
+    def _notes_api(self) -> NotesAPI:
+        from _fixtures.fake_core import make_fake_core
+
+        core = make_fake_core(rpc_call=AsyncMock())
+        note_service = NoteService(core)
+        mind_maps = NoteBackedMindMapService(note_service)
+        return NotesAPI(notes=note_service, mind_maps=mind_maps)
+
+    @pytest.mark.asyncio
+    async def test_notes_update_off_silently_noops_on_miss(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = self._notes_api()
+        # No preflight on the off path: a missing note must NOT trigger a lookup.
+        api.get_or_none = AsyncMock(return_value=None)
+        api._notes.update_note = AsyncMock(return_value=None)
+        await api.update("nb_1", "missing", "content", "Title")
+        api.get_or_none.assert_not_awaited()
+        api._notes.update_note.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_notes_update_on_raises_on_miss(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._notes_api()
+        api.get_or_none = AsyncMock(return_value=None)
+        api._notes.update_note = AsyncMock(return_value=None)
+        with pytest.raises(NoteNotFoundError):
+            await api.update("nb_1", "missing", "content", "Title")
+        # Fail-loud: the underlying update RPC must not fire on a miss.
+        api._notes.update_note.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_notes_update_on_succeeds_when_present(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._notes_api()
+        api.get_or_none = AsyncMock(return_value=MagicMock())  # hit
+        api._notes.update_note = AsyncMock(return_value=None)
+        await api.update("nb_1", "note_1", "content", "Title")
+        api._notes.update_note.assert_awaited_once()
+
+    def _sources_api(self, *, echo: object) -> SourcesAPI:
+        # ``echo`` is the UPDATE_SOURCE return; ``None`` forces the existence
+        # preflight on the future-errors path.
+        return SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=echo)), uploader=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_sources_rename_no_object_off_skips_detection(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = self._sources_api(echo=None)
+        api._get_or_none = AsyncMock(return_value=None)  # would-be miss
+        # Off path short-circuits to None WITHOUT probing existence.
+        assert await api.rename("nb_1", "missing", "T", return_object=False) is None
+        api._get_or_none.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sources_rename_no_object_on_raises_on_miss(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._sources_api(echo=None)
+        api._get_or_none = AsyncMock(return_value=None)  # miss
+        with pytest.raises(SourceNotFoundError):
+            await api.rename("nb_1", "missing", "T", return_object=False)
+
+    @pytest.mark.asyncio
+    async def test_sources_rename_no_object_on_returns_none_when_present(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._sources_api(echo=None)
+        api._get_or_none = AsyncMock(return_value=Source(id="src_1", title="T"))  # hit
+        # The flag controls miss-detection, not the return: still None on a hit.
+        assert await api.rename("nb_1", "src_1", "T", return_object=False) is None
+
+    def _artifacts_api_for_rename(self) -> ArtifactsAPI:
+        # UPDATE/RENAME echo is None so the False path reaches the studio-only
+        # existence preflight under the flag.
+        return _make_artifacts_api(AsyncMock(return_value=None))
+
+    @pytest.mark.asyncio
+    async def test_artifacts_rename_no_object_off_skips_detection(self, monkeypatch):
+        monkeypatch.delenv(_FLAG, raising=False)
+        api = self._artifacts_api_for_rename()
+        api._listing.get_studio_only = AsyncMock(return_value=None)  # would-be miss
+        assert await api.rename("nb_1", "missing", "T", return_object=False) is None
+        api._listing.get_studio_only.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_artifacts_rename_no_object_on_raises_on_miss(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._artifacts_api_for_rename()
+        api._listing.get_studio_only = AsyncMock(return_value=None)  # miss
+        with pytest.raises(ArtifactNotFoundError):
+            await api.rename("nb_1", "missing", "T", return_object=False)
+
+    @pytest.mark.asyncio
+    async def test_artifacts_rename_no_object_on_returns_none_when_present(self, monkeypatch):
+        monkeypatch.setenv(_FLAG, "1")
+        api = self._artifacts_api_for_rename()
+        api._listing.get_studio_only = AsyncMock(return_value=MagicMock())  # hit
+        assert await api.rename("nb_1", "art_1", "T", return_object=False) is None


### PR DESCRIPTION
## What

Extends the existing `NOTEBOOKLM_FUTURE_ERRORS` opt-in preview flag to the three **purely-behavioral** v0.8.0 changes that lack a deprecation warn-runway: #1290 (bool→None returns), #1342 (synchronous refusal raises), and #1362 (mutate-existing fail-loud). Each is gated `if future_errors_enabled(): <v0.8.0 behavior> else: <v0.7.0 behavior>`.

- **#1290** — `SourcesAPI.refresh` and `ChatAPI.delete_conversation` return `None` under the flag (the `True` they return today is uninformative — any failure raises first). The `-> bool` annotation is preserved; it flips to `-> None` at v0.8.0. `ChatAPI.clear_cache` is **not** gated — its bool is meaningful (`_ConversationCache.clear()` returns `False` when the id is absent).
- **#1342** — a synchronous generation refusal **raises** the decoder's `RateLimitError` / `RPCError` / `DecodingError` / `ArtifactFeatureUnavailableError` instead of being swallowed into `GenerationStatus(status="failed")` / returned `None`. Gated in `_call_generate`, `revise_slide`, `_parse_generation_result` (null id → `ArtifactFeatureUnavailableError`, falsey id → `DecodingError`), and `research.start` (empty/non-list payload **or falsey `task_id`** → `DecodingError`). `with_rate_limit_retry` already retries on both a returned rate-limited `GenerationStatus` (flag-off) and a raised `RateLimitError` (#1319), so the flag-on retry path is preserved in both modes.
- **#1362** — `NotesAPI.update` preflights at the public facade (`get_or_none`) and raises `NoteNotFoundError` on a miss; `sources`/`artifacts` `rename(return_object=False)` detect a missing target and raise `*NotFoundError` under the flag while still returning `None`. The flag gates **miss-detection**, not the return.

New both-modes test classes in `tests/unit/test_future_errors_flag.py` (one per gated behavior, each asserting flag-OFF = v0.7.0 and flag-ON = v0.8.0). `future_errors_enabled()` docstring, the `_deprecation`/`exceptions` notes, `CHANGELOG.md`, and `docs/deprecations.md` updated.

## Why

ADR-0019 (umbrella #1346) converges the public error/return contract in v0.8.0. The preview flag lets callers and CI test forward-compatibility **today**. Previously it covered only the three warn-runway flips (#1247/#1251/#1254); the three behavioral changes were deliberately left out pending their target behavior being pinned down (#1405).

**Preview-only invariant (load-bearing):** these are runtime-only previews. **No public return annotation changes** (which would trip the api-compat-allowlist + conformance gates), no default is flipped, and the default (flag-off) path is **byte-identical** to current v0.7.0. This PR does **not** close #1290/#1342/#1362 — their default flips ship in v0.8.0; it closes the tracking issue #1405.

Verified: `mypy` clean, full `pytest` green flag-off, the api-compat audit + conformance + v0.8.0-coverage gates pass, and the artifact/research/notes/source/chat suites exercised with `NOTEBOOKLM_FUTURE_ERRORS=1` to prove the flag-on paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded docs to clarify the NOTEBOOKLM_FUTURE_ERRORS preview, enumerating runtime-only v0.8.0 behavior changes.

* **New Features**
  * With the flag enabled: some boolean-returning ops now yield None; generation refusals raise underlying errors; mutate-existing ops raise NotFoundError on missing targets.

* **Tests**
  * Added extensive tests covering the behavioral previews gated by the future-errors flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->