### PR TITLE
fix(cli): emit NOT_FOUND envelope for *NotFoundError family (closes #1364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,6 +388,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CLI now emits the `NOT_FOUND` error envelope for the `*NotFoundError`
+  family from the centralized handler, instead of the generic
+  `NOTEBOOKLM_ERROR`.** Any `NotebookNotFoundError` / `SourceNotFoundError` /
+  `ArtifactNotFoundError` / `NoteNotFoundError` / `MindMapNotFoundError` that
+  reaches `cli/error_handler.py` (e.g. `notebooks.get()` on a missing notebook,
+  or a `rename` whose target was deleted mid-operation) now exits `1` with the
+  typed `{"error": true, "code": "NOT_FOUND", ...}` JSON envelope carrying the
+  missing resource id — matching the per-command `source` / `artifact` /
+  `note get` convention (the documented CLI not-found contract since v0.5.0).
+  The per-command `get` paths already used `get_or_none` and are unaffected.
+  This also makes the `NOTEBOOKLM_FUTURE_ERRORS=1` preview faithful at the CLI
+  boundary, pre-positioning it for the v0.8.0 `get()` → raise / mutate-existing
+  fail-loud flips (issues #1364, #1247, #1362).
 - **`Source.from_api_response` now reports the real processing `status`.** The
   `ADD_SOURCE` / rename parsing path previously never read the status block and
   always fell back to `SourceStatus.READY`, while `client.sources.list()` /

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     NetworkError,
     NotebookLimitError,
     NotebookLMError,
+    NotFoundError,
     RateLimitError,
     RPCError,
     ValidationError,
@@ -56,6 +57,41 @@ def current_json_output(default: bool = False) -> bool:
 def exit_with_code(exit_code: int = 1) -> NoReturn:
     """Canonical raw exit path for callers that already emitted their payload."""
     raise SystemExit(exit_code)
+
+
+# Per-``*NotFoundError`` resource-id attribute names, in MRO order. Each
+# concrete subclass stores its missing-id under exactly one of these (e.g.
+# ``SourceNotFoundError.source_id``, ``NotebookNotFoundError.notebook_id``),
+# so the central handler can surface the id in the ``NOT_FOUND`` JSON envelope
+# the same way the per-command sites do — without importing every subclass.
+_NOT_FOUND_ID_ATTRS = (
+    "notebook_id",
+    "source_id",
+    "artifact_id",
+    "note_id",
+    "mind_map_id",
+)
+
+
+def _not_found_extra(error: NotFoundError) -> dict[str, Any]:
+    """Build the JSON ``extra`` block for a ``*NotFoundError`` envelope.
+
+    Surfaces whichever resource-id attribute the concrete subclass carries
+    (``source_id`` / ``artifact_id`` / ``note_id`` / ``mind_map_id`` /
+    ``notebook_id``) under both its native key and a generic ``id`` key, so
+    automation can read the id without knowing the exact not-found subtype —
+    mirroring the per-command ``source``/``artifact``/``note get`` payloads.
+    Returns an empty dict when no known id attribute is present (e.g. a future
+    ``*NotFoundError`` subclass); the caller drops an empty ``extra``.
+    """
+    extra: dict[str, Any] = {}
+    for attr in _NOT_FOUND_ID_ATTRS:
+        value = getattr(error, attr, None)
+        if value is not None:
+            extra[attr] = value
+            extra["id"] = value
+            break
+    return extra
 
 
 def _generation_status_extra(status: Any) -> dict[str, Any]:
@@ -255,6 +291,28 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
             json_output,
             1,
             extra=extra_data,
+        )
+    except NotFoundError as e:
+        # The ``NotFoundError`` umbrella catches every concrete
+        # ``*NotFoundError`` (notebook / source / artifact / note / mind map),
+        # which all derive ``(NotFoundError, RPCError, <Domain>Error)``. Placed
+        # AFTER the more-specific branches (none of which are ancestors of a
+        # ``*NotFoundError`` — verified by the handler's exception MRO) and
+        # BEFORE the generic ``NotebookLMError`` catch-all so a missing resource
+        # emits the typed ``NOT_FOUND`` envelope (matching the per-command
+        # ``source``/``artifact``/``note get`` convention) instead of the
+        # generic ``NOTEBOOKLM_ERROR``. This makes the central handler faithful
+        # to the v0.8.0 raise-sites previewed by ``NOTEBOOKLM_FUTURE_ERRORS``
+        # (e.g. ``get()`` -> raise, ``rename``/``update`` on a missing target).
+        nf_extra = _not_found_extra(e)
+        if verbose and isinstance(e, RPCError) and e.method_id:
+            nf_extra["method_id"] = e.method_id
+        _output_error(
+            f"Error: {e}",
+            "NOT_FOUND",
+            json_output,
+            1,
+            extra=nf_extra or None,
         )
     except NotebookLMError as e:
         extra_info: dict[str, Any] | None = None

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -229,6 +229,70 @@ class TestArtifactList:
             assert result.output.count("X") < 200
             assert "…" in result.output
 
+    def test_artifact_list_json_missing_notebook_emits_not_found(self, runner, mock_auth):
+        """A ``NotebookNotFoundError`` reaching the central handler maps to NOT_FOUND.
+
+        End-to-end coverage for issue #1364 via a direct raise-site:
+        ``artifact list --json`` calls ``client.notebooks.get`` to build the
+        envelope title, and ``notebooks.get`` raises ``NotebookNotFoundError``
+        on a missing notebook (it always raises — not gated by
+        ``NOTEBOOKLM_FUTURE_ERRORS``). The central handler must emit the typed
+        ``NOT_FOUND`` envelope rather than the generic ``NOTEBOOKLM_ERROR``.
+        """
+        from notebooklm.exceptions import NotebookNotFoundError
+
+        with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(return_value=[])
+            mock_client.notes.list_mind_maps = AsyncMock(return_value=[])
+            mock_client.notebooks.get = AsyncMock(side_effect=NotebookNotFoundError("nb_123"))
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["error"] is True
+            assert data["code"] == "NOT_FOUND"
+            assert data["notebook_id"] == "nb_123"
+            assert data["id"] == "nb_123"
+
+    def test_artifact_list_future_errors_missing_notebook_emits_not_found(
+        self, runner, mock_auth, monkeypatch
+    ):
+        """The ``NOTEBOOKLM_FUTURE_ERRORS`` preview is faithful at the CLI boundary.
+
+        With the v0.8.0 error-contract preview enabled, the same missing-notebook
+        path still yields the typed ``NOT_FOUND`` envelope (code + exit 1) —
+        confirming the central handler already routes the previewed raise-sites
+        correctly so the v0.8.0 flips land with zero CLI scramble (issue #1364).
+        """
+        from notebooklm.exceptions import NotebookNotFoundError
+
+        monkeypatch.setenv("NOTEBOOKLM_FUTURE_ERRORS", "1")
+
+        with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(return_value=[])
+            mock_client.notes.list_mind_maps = AsyncMock(return_value=[])
+            mock_client.notebooks.get = AsyncMock(side_effect=NotebookNotFoundError("nb_123"))
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["code"] == "NOT_FOUND"
+            assert data["notebook_id"] == "nb_123"
+
 
 # =============================================================================
 # ARTIFACT GET TESTS
@@ -536,6 +600,46 @@ class TestArtifactRename:
             )
             # Mind maps never fall through to the regular-artifact rename path.
             mock_client.artifacts.rename.assert_not_called()
+
+    def test_artifact_rename_missing_target_emits_not_found(self, runner, mock_auth):
+        """A ``*NotFoundError`` from ``rename`` reaches the central handler as NOT_FOUND.
+
+        End-to-end coverage for issue #1364: the v0.7.0+ ``rename`` raise-site
+        (mutate-existing fail-loud, #1362) surfaces ``ArtifactNotFoundError``
+        when the target is absent — e.g. deleted between the partial-id resolve
+        and the rename. It must emit the typed ``NOT_FOUND`` envelope, not the
+        generic ``NOTEBOOKLM_ERROR``.
+        """
+        from notebooklm.exceptions import ArtifactNotFoundError
+
+        with patch("notebooklm.cli.artifact_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            # ``list`` resolves the partial id (proves it existed at resolve
+            # time); ``rename`` then races a delete and raises.
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[Artifact(id="art_123", title="Old Title", _artifact_type=4, status=3)]
+            )
+            mock_client.mind_maps.list = AsyncMock(return_value=[])
+            mock_client.artifacts.rename = AsyncMock(
+                side_effect=ArtifactNotFoundError("art_123", "audio")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["artifact", "rename", "art_123", "New Title", "-n", "nb_123", "--json"],
+                )
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["error"] is True
+            assert data["code"] == "NOT_FOUND"
+            assert data["artifact_id"] == "art_123"
+            assert data["id"] == "art_123"
 
 
 # =============================================================================

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -13,13 +13,19 @@ from notebooklm.cli.error_handler import (
     handle_errors,
 )
 from notebooklm.exceptions import (
+    ArtifactNotFoundError,
     ArtifactPendingTimeoutError,
     AuthError,
     ConfigurationError,
+    MindMapNotFoundError,
     NetworkError,
     NotebookLimitError,
+    NotebookNotFoundError,
+    NoteNotFoundError,
+    NotFoundError,
     RateLimitError,
     RPCError,
+    SourceNotFoundError,
     ValidationError,
 )
 from notebooklm.types import GenerationStatus
@@ -227,6 +233,113 @@ class TestHandleErrorsJsonOutput:
         assert data["code"] == "PATH_ERROR"
         assert data["message"] == "Bad path"
         assert data["path"] == str(Path("tmp_test_path"))
+
+
+class TestHandleErrorsNotFound:
+    """The ``*NotFoundError`` family emits the typed ``NOT_FOUND`` envelope.
+
+    Regression guard for issue #1364: before the dedicated ``except
+    NotFoundError`` branch, any ``*NotFoundError`` reaching the centralized
+    handler fell through to the generic ``NOTEBOOKLM_ERROR`` catch-all. The
+    handler now emits ``code="NOT_FOUND"`` with exit ``1`` (matching the
+    per-command ``source``/``artifact``/``note get`` convention) and surfaces
+    the missing resource id in the JSON ``extra`` block.
+    """
+
+    # (exception, native id key, id value) for each concrete subclass. All
+    # five derive ``(NotFoundError, RPCError, <Domain>Error)`` so the umbrella
+    # ``except NotFoundError`` catches every one.
+    _CASES = [
+        (NotebookNotFoundError("nb_123"), "notebook_id", "nb_123"),
+        (SourceNotFoundError("src_456"), "source_id", "src_456"),
+        (ArtifactNotFoundError("art_789", "audio"), "artifact_id", "art_789"),
+        (NoteNotFoundError("note_111"), "note_id", "note_111"),
+        (MindMapNotFoundError("mm_222"), "mind_map_id", "mm_222"),
+    ]
+
+    @pytest.mark.parametrize(
+        ("exc", "id_key", "id_value"),
+        _CASES,
+        ids=lambda v: type(v).__name__ if isinstance(v, Exception) else str(v),
+    )
+    def test_not_found_json_envelope(self, capsys, exc, id_key, id_value):
+        """Each ``*NotFoundError`` produces NOT_FOUND + exit 1 + the resource id."""
+        with pytest.raises(SystemExit) as exc_info, handle_errors(json_output=True):
+            raise exc
+
+        assert exc_info.value.code == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["error"] is True
+        assert data["code"] == "NOT_FOUND"
+        # Native attribute key plus the generic ``id`` alias are both present so
+        # automation can read the id without knowing the exact subtype.
+        assert data[id_key] == id_value
+        assert data["id"] == id_value
+
+    @pytest.mark.parametrize(
+        ("exc", "id_key", "id_value"),
+        _CASES,
+        ids=lambda v: type(v).__name__ if isinstance(v, Exception) else str(v),
+    )
+    def test_not_found_exit_code_is_1(self, exc, id_key, id_value):
+        """Not-found is a user error (exit 1), never the system-error exit 2."""
+        with pytest.raises(SystemExit) as exc_info, handle_errors():
+            raise exc
+        assert exc_info.value.code == 1
+
+    def test_not_found_text_mode(self, capsys):
+        """Text mode prints the exception message (no traceback, exit 1)."""
+        with pytest.raises(SystemExit) as exc_info, handle_errors(json_output=False):
+            raise SourceNotFoundError("src_456")
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().err
+        assert "Source not found: src_456" in output
+
+    def test_not_found_verbose_includes_method_id(self, capsys):
+        """With ``verbose``, the RPC ``method_id`` is surfaced in the envelope."""
+        with pytest.raises(SystemExit), handle_errors(json_output=True, verbose=True):
+            raise SourceNotFoundError("src_456", method_id="abc123")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["code"] == "NOT_FOUND"
+        assert data["method_id"] == "abc123"
+
+    def test_not_found_non_verbose_excludes_method_id(self, capsys):
+        """Without ``verbose``, ``method_id`` stays out of the envelope."""
+        with pytest.raises(SystemExit), handle_errors(json_output=True, verbose=False):
+            raise SourceNotFoundError("src_456", method_id="abc123")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["code"] == "NOT_FOUND"
+        assert "method_id" not in data
+
+    def test_not_found_branch_precedes_generic_rpc_error(self, capsys):
+        """A bare ``NotFoundError`` umbrella instance still maps to NOT_FOUND.
+
+        Confirms the dedicated branch sits before the generic
+        ``except NotebookLMError`` (the catch-all that would otherwise emit
+        ``NOTEBOOKLM_ERROR``). A future ``*NotFoundError`` subclass with no
+        recognized id attribute drops the (empty) ``extra`` cleanly.
+        """
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise NotFoundError("nothing here")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["code"] == "NOT_FOUND"
+        assert "id" not in data
+
+    def test_generic_rpc_error_still_emits_notebooklm_error(self, capsys):
+        """A non-not-found ``RPCError`` is unaffected — still NOTEBOOKLM_ERROR.
+
+        Guards against the new branch widening too far and swallowing ordinary
+        RPC failures.
+        """
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise RPCError("RPC failed")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["code"] == "NOTEBOOKLM_ERROR"
 
 
 class TestHandleErrorsTextOutput:


### PR DESCRIPTION
## What

Add an `except NotFoundError` branch to the centralized CLI error handler
(`cli/error_handler.py`), placed **after** the more-specific branches and
**before** the generic `except NotebookLMError` catch-all. Any
`NotebookNotFoundError` / `SourceNotFoundError` / `ArtifactNotFoundError` /
`NoteNotFoundError` / `MindMapNotFoundError` that reaches the handler now exits
`1` with the typed `{"error": true, "code": "NOT_FOUND", ...}` envelope (text
mode prints the friendly message), carrying the missing resource id under both
its native key (`notebook_id` / `source_id` / `artifact_id` / `note_id` /
`mind_map_id`) and a generic `id` alias — matching the per-command
`source` / `artifact` / `note get` convention.

A small table-driven helper (`_not_found_extra`) extracts the id from whichever
concrete subclass arrived, so the handler surfaces it without importing every
subtype. MRO-verified: the umbrella `NotFoundError` base catches all five
(each derives `(NotFoundError, RPCError, <Domain>Error)`), and none of the
earlier branches (`RateLimitError` / `AuthError` / `ValidationError` / ...) is
an ancestor of any `*NotFoundError`, so nothing swallows it first.

Tests: handler-level coverage for all five subclasses (JSON + text + verbose +
ordering, plus a guard that an ordinary `RPCError` still maps to
`NOTEBOOKLM_ERROR`), and end-to-end CLI coverage — a direct raise-site
(`artifact list --json` → `notebooks.get` raising `NotebookNotFoundError`), a
`rename`-on-missing-target raise-site (`artifacts.rename` raising
`ArtifactNotFoundError`), and a `NOTEBOOKLM_FUTURE_ERRORS=1` variant.

## Why

This is **additive and forward-compatible**, not a breaking change to a correct
contract — it aligns the central handler with the CLI's documented NOT_FOUND
contract (since v0.5.0). It corrects the *existing* 0.7.0 raise-sites that
reach the handler — e.g. `notebooks.get()` raising `NotebookNotFoundError`, and
`artifacts`/`mind_maps` `rename` raising on a missing target — which today
wrongly fall through to `NOTEBOOKLM_ERROR`.

It also makes the **`NOTEBOOKLM_FUTURE_ERRORS=1` preview faithful for CLI
users**: when `get()` → raise / mutate-existing fail-loud flip on, the CLI
already emits the right `NOT_FOUND` envelope. This pre-positions the CLI for the
v0.8.0 #1247 / #1362 flips with zero scramble. The per-command `get` paths
(`source` / `artifact` / `note get`) already use `get_or_none` and are
unaffected.

Closes #1364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CLI now consistently returns structured `NOT_FOUND` error codes with resource-specific identifiers when notebooks, artifacts, or other requested resources are missing. Error responses in JSON mode provide properly typed error envelopes across all not-found scenarios, improving clarity for automation and tooling integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->