### PR TITLE
test: complete forward-compat migration of typed-return dict access + pin stderr_console (audit follow-up to #1409/#1410)

### DIFF
--- a/tests/e2e/test_generation.py
+++ b/tests/e2e/test_generation.py
@@ -380,10 +380,9 @@ class TestMindMapGeneration:
 
         result = await client.artifacts.generate_mind_map(generation_notebook_id)
         assert result is not None
-        assert "mind_map" in result
-        assert "note_id" in result
+        assert result.note_id is not None
         # Verify mind map structure
-        mind_map = result["mind_map"]
+        mind_map = result.mind_map
         assert isinstance(mind_map, dict)
         assert "name" in mind_map
         assert "children" in mind_map

--- a/tests/e2e/test_research.py
+++ b/tests/e2e/test_research.py
@@ -27,7 +27,6 @@ class TestResearchStart:
         )
 
         assert result is not None, "Research start should return a result"
-        assert "task_id" in result, "Result should contain task_id"
         assert result.task_id is not None, "task_id should not be None"
         assert result.notebook_id == temp_notebook.id
         assert result.query == "artificial intelligence basics"
@@ -45,7 +44,6 @@ class TestResearchStart:
         )
 
         assert result is not None, "Deep research start should return a result"
-        assert "task_id" in result, "Result should contain task_id"
         assert result.task_id is not None, "task_id should not be None"
         assert result.mode == "deep"
 
@@ -97,7 +95,7 @@ class TestResearchPoll:
         result = await client.research.poll(temp_notebook.id)
 
         assert result is not None
-        status = result.get("status")
+        status = result.status
         assert status == "no_research", f"Expected 'no_research', got {status}"
 
     @pytest.mark.asyncio
@@ -119,14 +117,14 @@ class TestResearchPoll:
         poll_result = await client.research.poll(temp_notebook.id)
 
         assert poll_result is not None
-        status = poll_result.get("status")
+        status = poll_result.status
         assert status is not None, f"Invalid poll response: {poll_result}"
         # Should be either in_progress or completed
         assert status in ("in_progress", "completed", "no_research")
 
         if status != "no_research":
-            assert "task_id" in poll_result
-            assert "query" in poll_result
+            assert poll_result.task_id
+            assert poll_result.query
 
     @pytest.mark.asyncio
     async def test_poll_until_complete(self, client, temp_notebook):
@@ -144,19 +142,18 @@ class TestResearchPoll:
         max_attempts = int(POLL_TIMEOUT / POLL_INTERVAL)
         for _ in range(max_attempts):
             poll_result = await client.research.poll(temp_notebook.id)
-            status = poll_result.get("status")
+            status = poll_result.status
 
             if status is None:
                 pytest.fail(f"Invalid poll response (missing status): {poll_result}")
 
             if status == "completed":
                 # Verify completed result structure
-                assert "sources" in poll_result
-                assert isinstance(poll_result.get("sources"), list)
+                assert isinstance(poll_result.sources, tuple)
                 # Research may or may not find sources
-                sources = poll_result.get("sources", [])
+                sources = poll_result.sources
                 if sources:
-                    assert "url" in sources[0] or "title" in sources[0]
+                    assert sources[0].url or sources[0].title
                 return  # Test passed
 
             if status == "no_research":
@@ -204,7 +201,7 @@ class TestResearchImport:
             mode="fast",
         )
         assert start_result is not None, "Failed to start research"
-        task_id = start_result.get("task_id")
+        task_id = start_result.task_id
         assert task_id is not None, "start_result missing task_id"
 
         # Step 2: Poll until complete
@@ -212,7 +209,7 @@ class TestResearchImport:
         max_attempts = int(POLL_TIMEOUT / POLL_INTERVAL)
         for _ in range(max_attempts):
             poll_result = await client.research.poll(temp_notebook.id)
-            status = poll_result.get("status")
+            status = poll_result.status
 
             if status is None:
                 pytest.fail(f"Invalid poll response: {poll_result}")
@@ -226,11 +223,11 @@ class TestResearchImport:
 
             await asyncio.sleep(POLL_INTERVAL)
 
-        if poll_result is None or poll_result.get("status") != "completed":
+        if poll_result is None or poll_result.status != "completed":
             pytest.skip(f"Research did not complete within {POLL_TIMEOUT}s")
 
         # Step 3: Import sources (if any found)
-        sources = poll_result.get("sources", [])
+        sources = poll_result.sources
         if not sources:
             pytest.skip("No sources found by research - cannot test import")
 
@@ -280,5 +277,5 @@ class TestResearchDriveSource:
         if result is None:
             pytest.skip("Drive research returned no results - may need Drive access")
 
-        assert "task_id" in result
+        assert result.task_id is not None
         assert result.mode == "fast"

--- a/tests/e2e/test_research_import_verification.py
+++ b/tests/e2e/test_research_import_verification.py
@@ -182,10 +182,10 @@ class TestResearchImportVerification:
         if not sources:
             pytest.skip("Deep research returned no sources — cannot test import")
 
-        # Count importable entries: report rows (result_type=5 with markdown) +
+        # Count importable entries: report rows (is_report with markdown) +
         # web rows with non-empty URLs. ``import_sources`` skips everything
         # else, so this is the upper bound we expect to land in sources.list.
-        report_entries = [src for src in sources if src.result_type == 5 and src.report_markdown]
+        report_entries = [src for src in sources if src.is_report and src.report_markdown]
         web_entries = [src for src in sources if src.url]
         expected_import_count = len(report_entries) + len(web_entries)
         if expected_import_count == 0:

--- a/tests/e2e/test_research_import_verification.py
+++ b/tests/e2e/test_research_import_verification.py
@@ -47,7 +47,7 @@ class TestResearchImportVerification:
             mode="fast",
         )
         assert start_result is not None, "Failed to start research"
-        task_id = start_result.get("task_id")
+        task_id = start_result.task_id
         assert task_id is not None, "start_result missing task_id"
 
         # Wait for research to register before polling
@@ -59,7 +59,7 @@ class TestResearchImportVerification:
         max_attempts = int(research_timeout / POLL_INTERVAL)
         for _ in range(max_attempts):
             poll_result = await client.research.poll(temp_notebook.id)
-            status = poll_result.get("status")
+            status = poll_result.status
 
             if status == "completed":
                 break
@@ -68,16 +68,16 @@ class TestResearchImportVerification:
 
             await asyncio.sleep(POLL_INTERVAL)
 
-        if poll_result is None or poll_result.get("status") != "completed":
+        if poll_result is None or poll_result.status != "completed":
             pytest.skip(f"Research did not complete within {research_timeout}s")
 
         # Step 3: Get sources to import
-        sources = poll_result.get("sources", [])
+        sources = poll_result.sources
         if not sources:
             pytest.skip("No sources found by research - cannot test import")
 
         # Filter to sources with URLs (required for import)
-        sources_with_urls = [s for s in sources if s.get("url")]
+        sources_with_urls = [s for s in sources if s.url]
         if not sources_with_urls:
             pytest.skip("All sources lack URLs - cannot test import")
 
@@ -148,7 +148,7 @@ class TestResearchImportVerification:
         except RateLimitError as e:
             pytest.skip(f"START_DEEP_RESEARCH rate limited by NotebookLM: {e}")
         assert start_result is not None, "Failed to start deep research"
-        start_task_id = start_result.get("task_id")
+        start_task_id = start_result.task_id
         assert start_task_id is not None, "start_result missing task_id"
 
         await asyncio.sleep(3)
@@ -163,10 +163,10 @@ class TestResearchImportVerification:
         max_attempts = int(research_timeout / POLL_INTERVAL)
         for _ in range(max_attempts):
             poll_result = await client.research.poll(temp_notebook.id, task_id=polled_task_id)
-            status = poll_result.get("status")
+            status = poll_result.status
 
             if polled_task_id is None:
-                polled_task_id = poll_result.get("task_id")
+                polled_task_id = poll_result.task_id
 
             if status == "completed":
                 break
@@ -175,20 +175,18 @@ class TestResearchImportVerification:
 
             await asyncio.sleep(POLL_INTERVAL)
 
-        if poll_result is None or poll_result.get("status") != "completed":
+        if poll_result is None or poll_result.status != "completed":
             pytest.skip(f"Deep research did not complete within {research_timeout}s")
 
-        sources = poll_result.get("sources", [])
+        sources = poll_result.sources
         if not sources:
             pytest.skip("Deep research returned no sources — cannot test import")
 
         # Count importable entries: report rows (result_type=5 with markdown) +
         # web rows with non-empty URLs. ``import_sources`` skips everything
         # else, so this is the upper bound we expect to land in sources.list.
-        report_entries = [
-            src for src in sources if src.get("result_type") == 5 and src.get("report_markdown")
-        ]
-        web_entries = [src for src in sources if src.get("url")]
+        report_entries = [src for src in sources if src.result_type == 5 and src.report_markdown]
+        web_entries = [src for src in sources if src.url]
         expected_import_count = len(report_entries) + len(web_entries)
         if expected_import_count == 0:
             pytest.skip("Deep research returned sources but none are importable")

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -34,12 +34,20 @@ def _pin_cli_console_width():
     captured stdout. ``Console.size`` only honours the pinned dimensions when
     **both** ``_width`` and ``_height`` are set (otherwise it falls back to the
     OS-divergent terminal/``COLUMNS`` detection), so both are patched.
+
+    ``rendering`` exposes a *second* console — ``stderr_console`` (a
+    ``Console(stderr=True)`` for diagnostic/status output in ``--json`` mode) —
+    and the ~15 CLI tests that assert on ``result.stderr`` reflow on its width
+    the same way (#1410). Pin both consoles to the same wide, fixed dimensions
+    so stderr assertions are as deterministic as stdout ones.
     """
     from notebooklm.cli import rendering
 
     with (
         patch.object(rendering.console, "_width", 400),
         patch.object(rendering.console, "_height", 100),
+        patch.object(rendering.stderr_console, "_width", 400),
+        patch.object(rendering.stderr_console, "_height", 100),
     ):
         yield
 
@@ -55,12 +63,18 @@ def narrow_console():
     400-wide pin (pytest runs the autouse fixture first, so this inner patch
     wins for the test body), so truncation is exercised deterministically rather
     than relying on the OS-divergent auto-detected width (issue #1332).
+
+    ``stderr_console`` is re-pinned to the same narrow width so any
+    width-dependent stderr rendering exercised by these tests stays
+    deterministic too (#1410).
     """
     from notebooklm.cli import rendering
 
     with (
         patch.object(rendering.console, "_width", 80),
         patch.object(rendering.console, "_height", 100),
+        patch.object(rendering.stderr_console, "_width", 80),
+        patch.object(rendering.stderr_console, "_height", 100),
     ):
         yield
 


### PR DESCRIPTION
## What

Two test-only fixes from a merged-PR audit:

1. **Complete the forward-compat dict-access migration** on the typed `MappingCompat` return dataclasses. Convert the remaining `.get("k")` / `"k" in obj` / dict-subscript residues to attribute access in:
   - `tests/e2e/test_research.py` — `research.start()` → `ResearchStart`; `research.poll()` → `ResearchTask`; `ResearchTask.sources[i]` → `ResearchSource`
   - `tests/e2e/test_research_import_verification.py` — same `ResearchStart` / `ResearchTask` / `ResearchSource` receivers (fast + deep flows)
   - `tests/e2e/test_generation.py` — `artifacts.generate_mind_map()` → `MindMapResult`

   Each receiver's assignment was traced to confirm it is genuinely one of the four dataclasses. Plain dicts/lists are left untouched: the `json.loads` CLI `--json` output, the `list[dict[str, str]]` return of `import_sources`, the parsed `mind_map` node tree (`result.mind_map` is `Any`, asserted `isinstance(..., dict)`), and the hand-built `sources_mixed` filter fixture.

   `poll_result.sources` is a `tuple`, so the completed-result assertion now checks `isinstance(poll_result.sources, tuple)` — the declared field type — rather than the compat shim's coincidental `list` output. None-guards are preserved (e.g. `if poll_result is None or poll_result.status != "completed"`).

2. **Pin `rendering.stderr_console`** alongside `rendering.console` in both CLI unit conftest fixtures (`_pin_cli_console_width` at width 400, `narrow_console` at width 80), patching both `_width` and `_height` (#1410).

## Why

#1408/#1409 migrated the `__getitem__` residues (`obj["k"]`) but left the **silent** `MappingCompatMixin` shims — `get` / `__contains__` / `keys` / `__iter__` — in place. The `NOTEBOOKLM_FUTURE_ERRORS` preview flag only makes `__getitem__` raise, so those silent shims slipped past it, and they **all break at the v0.8.0 #1251 removal of `MappingCompatMixin`**. This finishes the #1408/#1409 forward-compat goal so the research/generation e2e tests are v0.8.0-#1251-clean.

For #1410 (gemini-flagged, previously unaddressed): both fixtures pinned only `rendering.console`, leaving the separate `Console(stderr=True)` at `rendering.py:41` at its OS-divergent auto-detected width. The ~15 CLI tests asserting on `result.stderr` reflow on that width exactly as stdout assertions do, so pinning `stderr_console` to the matching dimensions makes those stderr assertions deterministic across the OS matrix.

## Verification

- `uv run pytest tests/unit -q` → 7394 passed, 128 skipped, 1 xfailed (the conftest change is the only one touching default CI)
- `uv run pytest tests/e2e --collect-only -q` → 159 tests collect cleanly (e2e is auth-gated/excluded from default CI)
- `uv run mypy` on the three e2e files introduces **zero** new errors (the only mypy diagnostics pre-exist on the untouched `sources_mixed` plain-dict literal and e2e conftest)
- `ruff check` + `ruff format` clean

No assertions weakened: presence-only `"k" in obj` checks (always true under the compat shim) became truthiness/`is not None` attribute checks of equal-or-greater strength, and the `tuple` assertion tracks the real declared return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests to read API responses as typed objects (attribute access) across mind-map generation, research workflows, polling, and import-verification flows; improved validations for status, sources, and completed results.
  * Enhanced unit/e2e fixtures to enforce deterministic CLI rendering (stdout/stderr), stabilizing width/height for consistent test output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->