### PR TITLE
test(adr-0019): no-orphans v0.8.0 release gate + document the unwarned clean breaks

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -156,6 +156,27 @@ the resumable-upload content-type header (overriding filename-extension
 inference), so both are now supported parameters. The earlier
 `DeprecationWarning` was removed.
 
+## v0.8.0 breaking changes without a deprecation warning
+
+A few v0.8.0 breaks are **return-value or behavioral** changes that cannot emit a
+clean `DeprecationWarning` (you cannot warn on "this returns `True` today but
+`None` tomorrow" without firing on every call). They are **silent** in v0.7.0 and
+surface only under `NOTEBOOKLM_FUTURE_ERRORS=1` — that flag is the *only* v0.7.0
+signal for them. Full before/after migrations are in
+[`docs/upgrading-to-0.8.0.md`](upgrading-to-0.8.0.md). They ship **together** with
+the rest of the break-set (one release; #1344 is not split to 0.9.0).
+
+| Change | v0.7.0 (default) | v0.8.0 | v0.7.0 preview | Tracked by |
+|--------|------------------|--------|----------------|------------|
+| `sources.refresh()` / `chat.delete_conversation()` return value | `True` (uninformative — failures raise first) | `None` | `NOTEBOOKLM_FUTURE_ERRORS=1` | [#1290](https://github.com/teng-lin/notebooklm-py/issues/1290) |
+| Synchronous generation refusal (`generate_*` / `revise_slide` / `research.start`) | swallowed into `GenerationStatus(status="failed")` / returns `None` | raises `RateLimitError` / `RPCError` / `DecodingError` / `ArtifactFeatureUnavailableError` | `NOTEBOOKLM_FUTURE_ERRORS=1` | [#1342](https://github.com/teng-lin/notebooklm-py/issues/1342) |
+| `notes.update()` / `sources.rename(return_object=False)` / `artifacts.rename(return_object=False)` on a missing target | silent no-op / returns `None` | raises the matching `*NotFoundError` | `NOTEBOOKLM_FUTURE_ERRORS=1` | [#1362](https://github.com/teng-lin/notebooklm-py/issues/1362) |
+| Derived-read drift + lister drift-tightening | malformed / unknown payloads collapse to empty / `None` | raise `DecodingError` | _(no flag preview yet)_ | [#1344](https://github.com/teng-lin/notebooklm-py/issues/1344) |
+
+The flip happens in lockstep at the version bump, enforced by the
+`tests/_lint/test_v080_release_gate.py` no-orphans gate (umbrella
+[#1346](https://github.com/teng-lin/notebooklm-py/issues/1346)).
+
 ## Removed in v0.7.0
 
 | Removed | Replacement | Deprecated since | Removed in | Notes |

--- a/docs/upgrading-to-0.8.0.md
+++ b/docs/upgrading-to-0.8.0.md
@@ -63,6 +63,19 @@ tests, fix what breaks using the migrations below, and you're ready for 0.8.0.
 > it; the second silences the *warnings* the current behavior emits while you
 > migrate. They can be set together.
 
+> **Surfacing the warnings.** Python **hides `DeprecationWarning` by default**
+> outside `__main__`, so the per-change runways may be invisible in a normal run.
+> To see them, enable them explicitly:
+> ```bash
+> python -W error::DeprecationWarning -m pytest          # turn them into errors
+> PYTHONWARNINGS=default::DeprecationWarning python app.py  # just print them
+> ```
+> But `NOTEBOOKLM_FUTURE_ERRORS=1` is the more reliable forward-test: it
+> **raises** (not warns), so it surfaces regardless of your warning filters — and
+> it is the **only** 0.7.0 signal for the silent behavioral breaks (return-value
+> flips, refusal-raises, mutate-existing fail-loud) that emit no
+> `DeprecationWarning` at all.
+
 ---
 
 ## Summary table

--- a/tests/_lint/test_v080_release_gate.py
+++ b/tests/_lint/test_v080_release_gate.py
@@ -31,7 +31,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from tests._lint.test_v080_deprecation_coverage import (
+# Relative import: ``tests/_lint`` is a package (has ``__init__.py``), so pytest
+# imports this module as ``_lint.test_v080_release_gate`` with ``tests/`` — not
+# the repo root — on ``sys.path``. ``from tests._lint...`` therefore fails to
+# resolve under CI's prepend import mode; the sibling-relative form is correct.
+from .test_v080_deprecation_coverage import (
     PROJECT_ROOT,
     SRC_ROOT,
     V080_BREAKING_CHANGES,
@@ -134,10 +138,13 @@ def test_no_orphaned_v080_breaks_at_release() -> None:
 
 # --- Self-checks: the detector must be non-vacuous in BOTH directions ----------
 # A crafted "runway live" source (all four machinery markers present) and a
-# non-empty stand-in table, so the self-checks never depend on the real tree's
-# current state.
+# static non-empty stand-in table. The dummy is deliberately *decoupled* from the
+# real ``V080_BREAKING_CHANGES`` (it is NOT ``[:1]`` of it): at the 0.8.0 flip the
+# real table is emptied, which would otherwise make these self-checks vacuous /
+# spuriously fail. ``_orphans`` reads only truthiness + ``.issue`` (via getattr
+# fallback), so a bare sentinel string is a valid stand-in entry.
 _LIVE_SRC = "\n".join(_MACHINERY)
-_NONEMPTY_TABLE: tuple[object, ...] = V080_BREAKING_CHANGES[:1]
+_NONEMPTY_TABLE: tuple[object, ...] = ("dummy-break-sentinel",)
 
 
 def test_selfcheck_pre_flip_healthy_when_runway_intact() -> None:

--- a/tests/_lint/test_v080_release_gate.py
+++ b/tests/_lint/test_v080_release_gate.py
@@ -1,0 +1,164 @@
+"""Release gate: at the v0.8.0 flip, every deferred break must be flipped — no orphans.
+
+``scripts/check_deprecation_targets.py`` forces only the *warning-message*
+removals (a warn whose stated removal target equals the shipping version is
+incoherent — issue #1214). This gate adds the **behavioral** half: when
+``pyproject.toml`` reaches 0.8.0, the ``NOTEBOOKLM_FUTURE_ERRORS`` preview
+machinery and the deprecation shims must be **gone** (every preview-gated branch
+flipped to its default), and the :data:`V080_BREAKING_CHANGES` break table must
+be **empty**. Otherwise a behavioral break (#1290 / #1342 / #1362 / #1344) —
+which carries no warning message and so is invisible to the deprecation-targets
+gate — could ship un-flipped and silently un-enforced.
+
+The gate is **bidirectional** around the 0.8.0 bump (its pivot is the
+``pyproject.toml`` version, so it is dormant during 0.7.x and *activates*
+automatically at the bump):
+
+* **Below 0.8.0** — the runway is live: the preview/deprecation machinery and a
+  non-empty break table MUST be present. You cannot remove the runway (or empty
+  the table) before the flip ships.
+* **At/after 0.8.0** — the flip shipped: the machinery MUST be gone and the table
+  MUST be empty. Every break flipped, no orphans.
+
+This turns "remember to flip everything in lockstep" into a CI invariant
+(umbrella #1346; ADR-0019). It is intentionally distinct from — and complementary
+to — the deprecation-coverage gate (which verifies *prep-time* runways exist) and
+``check_deprecation_targets.py`` (which catches self-referential warn versions).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests._lint.test_v080_deprecation_coverage import (
+    PROJECT_ROOT,
+    SRC_ROOT,
+    V080_BREAKING_CHANGES,
+)
+
+# The release that flips the breaking half of ADR-0019. The gate's behavior
+# pivots here: < this version is "runway live", >= is "flip shipped".
+_FLIP_VERSION = (0, 8, 0)
+
+# The v0.8.0 preview/deprecation machinery, as code-level markers (a call site or
+# a ``def``/``class`` definition). Each exists while the runway is live and must
+# be deleted at the flip (#1365). Mapped to a human reason for legible failures.
+# NOTE: ``future_errors_enabled()`` (with parens) matches both the resolver
+# ``def`` and every gate call site; the ``def``/``class`` prefixes anchor the
+# others to their definitions so a passing mention in a docstring/name doesn't
+# count. Comments are stripped before scanning (see :func:`_src_code`).
+_MACHINERY: dict[str, str] = {
+    "future_errors_enabled()": (
+        "the NOTEBOOKLM_FUTURE_ERRORS preview-gate (resolver + every "
+        "#1247/#1251/#1254/#1290/#1342/#1362 gate site)"
+    ),
+    "class MappingCompatMixin": "the dict-style compat bridge (#1251)",
+    "def warn_get_returns_none": "the get()-returns-None warn runway (#1247)",
+    "def deprecated_kwarg": "the kwarg-alias warn runway (#1254)",
+}
+
+
+def _version_tuple(pyproject: Path) -> tuple[int, int, int]:
+    """Parse ``(major, minor, patch)`` from ``pyproject.toml``'s ``version``."""
+    text = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version\s*=\s*"(\d+)\.(\d+)\.(\d+)', text)
+    if match is None:  # pragma: no cover - guard; pyproject always has a version
+        raise AssertionError('could not parse version = "X.Y.Z" from pyproject.toml')
+    return (int(match[1]), int(match[2]), int(match[3]))
+
+
+def _strip_comments(text: str) -> str:
+    """Drop ``#`` line-comments so a marker named only in a comment doesn't count."""
+    return re.sub(r"#.*$", "", text, flags=re.MULTILINE)
+
+
+def _src_code() -> str:
+    """Comment-stripped concatenation of every ``src/notebooklm`` module."""
+    return "\n".join(
+        _strip_comments(path.read_text(encoding="utf-8")) for path in sorted(SRC_ROOT.rglob("*.py"))
+    )
+
+
+# --- Pure detector (no I/O) — the real gate and the self-checks share it -------
+def _orphans(
+    version: tuple[int, int, int],
+    src_code: str,
+    breaks: tuple[object, ...],
+) -> list[str]:
+    """Return no-orphan violations for ``(version, src, table)``; empty == healthy.
+
+    The version pivots the direction: below :data:`_FLIP_VERSION` the machinery
+    and a non-empty table must be PRESENT (runway live); at/after it they must be
+    ABSENT / empty (flip complete).
+    """
+    present = sorted(marker for marker in _MACHINERY if marker in src_code)
+    violations: list[str] = []
+    if version < _FLIP_VERSION:
+        missing = sorted(set(_MACHINERY) - set(present))
+        if missing:
+            violations.append(
+                "v0.8.0 runway machinery removed before the flip (pyproject is "
+                f"still pre-0.8.0): {missing}. Re-add it, or bump pyproject to 0.8.0 "
+                "if the flip is shipping."
+            )
+        if not breaks:
+            violations.append(
+                "V080_BREAKING_CHANGES is empty before the 0.8.0 flip — the break "
+                "table must stay populated until each break actually ships."
+            )
+    else:
+        if present:
+            detail = {marker: _MACHINERY[marker] for marker in present}
+            violations.append(
+                f"pyproject is at v{'.'.join(map(str, version))} (>= 0.8.0) but the "
+                f"preview/deprecation machinery is still in src/: {detail}. Flip every "
+                "gate to its v0.8.0 default and delete the shims (#1365)."
+            )
+        if breaks:
+            issues = [getattr(change, "issue", change) for change in breaks]
+            violations.append(
+                f"pyproject is at v{'.'.join(map(str, version))} (>= 0.8.0) but "
+                f"V080_BREAKING_CHANGES still lists {issues} — these breaks were not "
+                "flipped (orphans). Remove each from the table as its flip ships."
+            )
+    return violations
+
+
+def test_no_orphaned_v080_breaks_at_release() -> None:
+    """Every v0.8.0 break is handled in lockstep with the version bump (no orphans)."""
+    version = _version_tuple(PROJECT_ROOT / "pyproject.toml")
+    violations = _orphans(version, _src_code(), V080_BREAKING_CHANGES)
+    assert not violations, "v0.8.0 release-gate violation(s):\n  - " + "\n  - ".join(violations)
+
+
+# --- Self-checks: the detector must be non-vacuous in BOTH directions ----------
+# A crafted "runway live" source (all four machinery markers present) and a
+# non-empty stand-in table, so the self-checks never depend on the real tree's
+# current state.
+_LIVE_SRC = "\n".join(_MACHINERY)
+_NONEMPTY_TABLE: tuple[object, ...] = V080_BREAKING_CHANGES[:1]
+
+
+def test_selfcheck_pre_flip_healthy_when_runway_intact() -> None:
+    assert _orphans((0, 7, 0), _LIVE_SRC, _NONEMPTY_TABLE) == []
+
+
+def test_selfcheck_pre_flip_flags_early_machinery_removal() -> None:
+    assert _orphans((0, 7, 0), "", _NONEMPTY_TABLE)
+
+
+def test_selfcheck_pre_flip_flags_early_table_emptying() -> None:
+    assert _orphans((0, 7, 0), _LIVE_SRC, ())
+
+
+def test_selfcheck_post_flip_healthy_when_fully_flipped() -> None:
+    assert _orphans((0, 8, 0), "", ()) == []
+
+
+def test_selfcheck_post_flip_flags_leftover_machinery() -> None:
+    assert _orphans((0, 8, 0), _LIVE_SRC, ())
+
+
+def test_selfcheck_post_flip_flags_unflipped_breaks() -> None:
+    assert _orphans((0, 8, 0), "", _NONEMPTY_TABLE)


### PR DESCRIPTION
## What

0.8.0-transition hardening (umbrella #1346), two pieces:

1. **No-orphans release gate** — `tests/_lint/test_v080_release_gate.py`.
2. **Removal-set doc coverage** — the unwarned clean breaks in `docs/deprecations.md` + a DeprecationWarning-visibility note in the upgrade guide.

## Why

**The gap (#2):** `scripts/check_deprecation_targets.py` only forces the **warning-message** removals at the version bump (#1247/#1251/#1254). The **behavioral** breaks (#1290 bool→None, #1342 refusal-raises, #1362 fail-loud, #1344 drift) emit no `DeprecationWarning`, so nothing failed CI if one were forgotten at the flip — a silent orphan. The new gate is **bidirectional**, pivoting on the `pyproject.toml` version:

- **< 0.8.0** (runway live): the `NOTEBOOKLM_FUTURE_ERRORS` machinery *and* a non-empty `V080_BREAKING_CHANGES` table must be **present** — you can't remove the runway or empty the table early.
- **≥ 0.8.0** (flip shipped): the machinery must be **gone** and the table **empty** — every break flipped, no orphans.

It's **dormant during 0.7.x** and activates automatically at the bump, turning "remember to flip everything in lockstep" into a CI invariant. Pure detector + **6 self-checks** prove it's non-vacuous in both directions.

**The doc gap (#3):** the silent clean breaks never appeared in `docs/deprecations.md` (they have no warn-runway). Added a section listing them with their flag-preview + tracking issues. The guide now also notes that `DeprecationWarning` is **hidden by default** in Python — so `NOTEBOOKLM_FUTURE_ERRORS=1` (which *raises*) is the more reliable forward-test, and the only signal for the silent breaks.

**Staging decision (your call, recorded in #1346):** all v0.8.0 breaks ship in **one go**; #1344 is **not** split to 0.9.0.

## Verification

- `test_v080_release_gate.py` → **7 passed** (real gate green at 0.7.0; 6 self-checks); full `tests/_lint/` → **192 passed**; ruff clean.
- Internal gate + docs only — no `src/` or public-API change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a deprecations section enumerating v0.8.0 silent behavioral/return-value changes and guidance for surfacing DeprecationWarnings; clarified using NOTEBOOKLM_FUTURE_ERRORS for stricter migration checks.
* **Tests**
  * Added a release-gate test suite that enforces coordination between the package version and the v0.8.0 migration/deprecation machinery, validating pre- and post-flip states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->