### PR TITLE
test(docs): add doc-path-freshness gate + burn down residual #1328 stale module refs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,13 @@ jobs:
     - name: Assert CLAUDE.md paths are fresh
       run: uv run python scripts/check_claude_md_freshness.py
 
+    - name: Assert doc module references are fresh
+      # Companion to the CLAUDE.md freshness gate: guards the rest of the docs
+      # against stale module paths. Every relative link into src/notebooklm/
+      # must resolve, and every inline module ref in the live docs must point at
+      # a real module (rare historical mentions are allowlisted, shrink-only).
+      run: uv run python scripts/check_docs_module_refs.py
+
     - name: Audit public API compatibility
       run: uv run python scripts/audit_public_api_compat.py
 

--- a/docs/adr/0014-feature-local-runtime-adapters.md
+++ b/docs/adr/0014-feature-local-runtime-adapters.md
@@ -212,7 +212,7 @@ After migration, `Session` owns:
   `_authed_post_chain`, `_rate_limit_max_retries`,
   `_server_error_max_retries`, `_refresh_retry_delay` — moved off `Session`
   onto `MiddlewareChainHost`
-  ([`_middleware_chain_host.py`](../../src/notebooklm/_middleware_chain_host.py))
+  ([`_middleware_chain_host.py`](../../src/notebooklm/_middleware/chain_host.py))
   in Stage B2 PR 1 (#1090). PR 2 (#1092) then split
   `wire_middleware_chain` / `build_session_transport` to take
   `chain_host: MiddlewareChainHost` directly, so the live chain reads
@@ -421,7 +421,7 @@ section of this ADR's revision history.
 Issue #1085 (deferred `MiddlewareChainHost` extraction) closed.
 
 - **#1090** introduced
-  [`_middleware_chain_host.py`](../../src/notebooklm/_middleware_chain_host.py).
+  [`_middleware_chain_host.py`](../../src/notebooklm/_middleware/chain_host.py).
   The chain's tunable storage (`_authed_post_chain_terminal`,
   `_authed_post_chain`, `_rate_limit_max_retries`,
   `_server_error_max_retries`, `_refresh_retry_delay`) moved from

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,7 +314,7 @@ needs, never a broad runtime facade. `NotebookLMClient.__init__` is the
 composition root that wires each feature with the satisfier it needs.
 
 Six Protocols live in
-[`_runtime_contracts.py`](../src/notebooklm/_runtime_contracts.py) —
+[`_runtime/contracts.py`](../src/notebooklm/_runtime/contracts.py) —
 four shared capability Protocols used by ≥2 features, plus `AuthMetadata`
 and `Kernel`, whose sole consumer today is `SourceUploadPipeline`. Per
 ADR-013 §Decision §2, those two stay in the shared contracts module
@@ -325,7 +325,7 @@ transport kernel). ADR-013 explicitly rejects anticipatory promotion —
 Protocols live next to their single consumer.
 
 **Module-level Protocols** (defined in
-[`_runtime_contracts.py`](../src/notebooklm/_runtime_contracts.py)):
+[`_runtime/contracts.py`](../src/notebooklm/_runtime/contracts.py)):
 
 | Protocol | Responsibility |
 |----------|----------------|
@@ -421,10 +421,10 @@ the executor on direct collaborator dependencies.
 | `ClientComposed` | [`_client_composed.py`](../src/notebooklm/_client_composed.py) | Write-once holder for composition state: `transport`, `executor`, `chain_host`, `chain_builder`, `middlewares`, lazy RPC semaphore, and `runtime_collaborators`. Pre-binding access raises a clear `RuntimeError`; the holder deliberately does not expose a broad `.collaborators` alias. |
 | `RpcExecutor` | [`_rpc_executor.py`](../src/notebooklm/_rpc_executor.py) | Single logical batchexecute RPC dispatch path. Owns request-id/started-metric bracketing, idempotency policy lookup, method-ID resolution, request encoding, response decode, RPC error mapping, and decode-time auth refresh retry. Takes its `Kernel`, `RuntimeTransport`, `AuthRefreshCoordinator`, and `ClientMetrics` collaborators directly via keyword-only constructor parameters (ADR-014 Rule 5). Enters transport through `RuntimeTransport.perform_authed_post`. |
 | `RuntimeTransport` | [`_runtime/transport.py`](../src/notebooklm/_runtime/transport.py) | Authed POST collaborator. Owns `perform_authed_post()` (loop guard, auth snapshot, request materialization, chain dispatch, queue-wait recording), `refresh_request_for_current_auth()`, and `terminal()` (freshness rebuild + `Kernel.post`). Called directly by `RpcExecutor` and by `chat_aware_authed_post` (ChatAPI's chat-flavoured transport call); the middleware chain leaf at `MiddlewareChainHost._authed_post_chain_terminal` continues to dispatch through `RuntimeTransport.terminal` per ADR-014 Rule 4. |
-| `MiddlewareChainHost` | [`_middleware_chain_host.py`](../src/notebooklm/_middleware_chain_host.py) | Owns the wired middleware chain (`_authed_post_chain`), the chain leaf (`_authed_post_chain_terminal`), the three retry-budget tunables (`_rate_limit_max_retries`, `_server_error_max_retries`, `_refresh_retry_delay`), and the dynamic `await_refresh` delegate that the auth-refresh middleware captures. The chain's provider lambdas and the transport's `chain_provider` closure read the host's attributes live, so post-construction mutation (e.g. tests setting `client._composed.chain_host._rate_limit_max_retries = 0`) still steers the live chain. |
-| `AuthRefreshCoordinator` | [`_runtime_auth.py`](../src/notebooklm/_runtime_auth.py) | Owns the auth-snapshot lock and refresh task. Canonical implementation for `AuthRefreshCoordinator.snapshot(auth=...)`, `update_auth_tokens(auth=..., csrf=..., session_id=...)`, and `update_auth_headers(auth=..., kernel=...)`; callers pass explicit collaborators rather than a host object. |
+| `MiddlewareChainHost` | [`_middleware/chain_host.py`](../src/notebooklm/_middleware/chain_host.py) | Owns the wired middleware chain (`_authed_post_chain`), the chain leaf (`_authed_post_chain_terminal`), the three retry-budget tunables (`_rate_limit_max_retries`, `_server_error_max_retries`, `_refresh_retry_delay`), and the dynamic `await_refresh` delegate that the auth-refresh middleware captures. The chain's provider lambdas and the transport's `chain_provider` closure read the host's attributes live, so post-construction mutation (e.g. tests setting `client._composed.chain_host._rate_limit_max_retries = 0`) still steers the live chain. |
+| `AuthRefreshCoordinator` | [`_runtime/auth.py`](../src/notebooklm/_runtime/auth.py) | Owns the auth-snapshot lock and refresh task. Canonical implementation for `AuthRefreshCoordinator.snapshot(auth=...)`, `update_auth_tokens(auth=..., csrf=..., session_id=...)`, and `update_auth_headers(auth=..., kernel=...)`; callers pass explicit collaborators rather than a host object. |
 | `ClientLifecycle` | [`_runtime/lifecycle.py`](../src/notebooklm/_runtime/lifecycle.py) | HTTP-client open/close, keepalive task, cookie save coordination. Holds `_timeout`, `_bound_loop`, `_http_client`, `_keepalive_*`. |
-| `MiddlewareChainBuilder` | [`_middleware_chain.py`](../src/notebooklm/_middleware_chain.py) | Constructs the middleware chain in the canonical ADR-009 order. |
+| `MiddlewareChainBuilder` | [`_middleware/chain.py`](../src/notebooklm/_middleware/chain.py) | Constructs the middleware chain in the canonical ADR-009 order. |
 | `TransportDrainTracker` | [`_transport_drain.py`](../src/notebooklm/_transport_drain.py) | Tracks in-flight transport operations + the drain condition variable. Gates graceful shutdown. |
 | `ClientMetrics` | [`_client_metrics.py`](../src/notebooklm/_client_metrics.py) | Per-instance counters (`ClientMetricsSnapshot`) + the `on_rpc_event` user callback. |
 | `ReqidCounter` | [`_reqid_counter.py`](../src/notebooklm/_reqid_counter.py) | Monotonic `_reqid` for the chat backend; lock-protected `next_reqid(...)`. |
@@ -433,8 +433,8 @@ the executor on direct collaborator dependencies.
 | `_request_types` | [`_request_types.py`](../src/notebooklm/_request_types.py) | Owns `AuthSnapshot`, `BuildRequest`, and request materialization shapes shared by RPC, chat, auth refresh, and the chain terminal. |
 | `_transport_errors` | [`_transport_errors.py`](../src/notebooklm/_transport_errors.py) | Owns transport-level exceptions, `Retry-After` parsing, and raw `Kernel.post` error mapping consumed by `RetryMiddleware` and `AuthRefreshMiddleware`. |
 | `_streaming_post` | [`_streaming_post.py`](../src/notebooklm/_streaming_post.py) | Low-level streaming POST helper with the response-size cap used by `Kernel.post`. |
-| `Kernel` | [`_kernel.py`](../src/notebooklm/_kernel.py) | Pure transport core. Owns the `httpx.AsyncClient` and cookie jar; exposes `post()`, the `cookies` property, and `aclose()` (the close path wraps it in `asyncio.shield` from `ClientLifecycle.close()`). Concrete class behind the `Kernel` Protocol in `_runtime_contracts.py`; constructed by `build_collaborators(...)` and called from the middleware leaf via `RuntimeTransport.terminal → Kernel.post`. |
-| `_runtime_init` | [`_runtime_init.py`](../src/notebooklm/_runtime_init.py) | Construction-time helpers for `NotebookLMClient`: `validate_constructor_args` (kwarg validation/normalization), `build_collaborators` (the seven collaborators in dependency order: `metrics`, `drain_tracker`, `reqid`, `auth_coord`, `kernel`, `lifecycle`, `cookie_persistence`), `build_runtime_transport`, `wire_middleware_chain`, and `compose_client_internals`. It binds the runtime graph into `ClientComposed` and returns `ClientInternals(collaborators, executor)`. |
+| `Kernel` | [`_kernel.py`](../src/notebooklm/_kernel.py) | Pure transport core. Owns the `httpx.AsyncClient` and cookie jar; exposes `post()`, the `cookies` property, and `aclose()` (the close path wraps it in `asyncio.shield` from `ClientLifecycle.close()`). Concrete class behind the `Kernel` Protocol in `_runtime/contracts.py`; constructed by `build_collaborators(...)` and called from the middleware leaf via `RuntimeTransport.terminal → Kernel.post`. |
+| `_runtime/init` | [`_runtime/init.py`](../src/notebooklm/_runtime/init.py) | Construction-time helpers for `NotebookLMClient`: `validate_constructor_args` (kwarg validation/normalization), `build_collaborators` (the seven collaborators in dependency order: `metrics`, `drain_tracker`, `reqid`, `auth_coord`, `kernel`, `lifecycle`, `cookie_persistence`), `build_runtime_transport`, `wire_middleware_chain`, and `compose_client_internals`. It binds the runtime graph into `ClientComposed` and returns `ClientInternals(collaborators, executor)`. |
 | `_loop_affinity` | [`_loop_affinity.py`](../src/notebooklm/_loop_affinity.py) | Tiny free-function `assert_bound_loop(bound_loop)` shared by every helper that captures a loop reference at `open()` time (`TransportDrainTracker`, `ReqidCounter`, `AuthRefreshCoordinator`, `ArtifactPollingService`, `ChatAPI`). Enforces ADR-004 without coupling those helpers to the public client. |
 
 ### Shipped runtime invariants
@@ -464,7 +464,7 @@ Beyond the client-owned runtime graph, several feature APIs are implemented via 
 | `NoteBackedMindMapService` | [`_mind_map.py`](../src/notebooklm/_mind_map.py) | Specific adapter service representing mind-maps, backed by standard notebook notes. |
 | `ArtifactDownloadService` | [`_artifact/downloads.py`](../src/notebooklm/_artifact/downloads.py) | Asynchronous download coordinator for finished artifacts. |
 | `_artifact_formatters` | [`_artifact/formatters.py`](../src/notebooklm/_artifact/formatters.py) | Markdown, HTML, and plain text formatters for artifacts. |
-| `_artifact_listing` | [`_artifact_listing.py`](../src/notebooklm/_artifact_listing.py) | Listing and filtering operations for notebook artifacts. |
+| `_artifact/listing` | [`_artifact/listing.py`](../src/notebooklm/_artifact/listing.py) | Listing and filtering operations for notebook artifacts. |
 | `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `NoteRow`, `SourceRow`) behind named accessors so downloads, polling, and listing don't open-code positional indices. Soft-degrade and strict-mode behavior is pinned in `tests/unit/test_row_adapters.py`. |
 | `_research_task_parser` | [`_research_task_parser.py`](../src/notebooklm/_research_task_parser.py) | Parses deep-research task results from raw rows. Returns dict-shaped output today; a typed-model migration is not yet complete. |
 | `_types/` | [`_types/`](../src/notebooklm/_types) | Private package holding the dataclass and `Protocol` implementations behind the public `types.py` / per-feature public schemas. Split per domain (`artifacts.py`, `chat.py`, `notebooks.py`, `notes.py`, `sharing.py`, `sources.py`, plus `common.py` for shared shapes like `ConnectionLimits`). |
@@ -624,7 +624,7 @@ The runtime chain order is pinned by
 simultaneously updating the pin tests
 (`test_chain_seeded_with_final_adr_009_ordering`) is a bug.
 
-The chain list in [`MiddlewareChainBuilder.build()`](../src/notebooklm/_middleware_chain.py)
+The chain list in [`MiddlewareChainBuilder.build()`](../src/notebooklm/_middleware/chain.py)
 reads outermost-first (index 0 wraps everything below it):
 
 ```text

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -303,7 +303,7 @@ than it sounds:
 The library uses `rookiepy` (Rust extension with a Python binding)
 rather than implementing extraction itself. `rookiepy` covers ~16
 browsers across all three platforms; `_ROOKIEPY_BROWSER_ALIASES` in
-`cli/session.py` maps user-facing names (`firefox`, `arc`, `vivaldi`,
+`cli/session_cmd.py` maps user-facing names (`firefox`, `arc`, `vivaldi`,
 …) to its functions, and `convert_rookiepy_cookies_to_storage_state`
 in `auth.py` reshapes the result into a Playwright-compatible
 `storage_state.json`. From the rest of the codebase's perspective,
@@ -1420,7 +1420,7 @@ Two stacks, in order of preference:
 > makes Chrome cookie reads admin-or-bust (see §7.5). On macOS and Linux,
 > any of the listed browsers work; Firefox just sidesteps the Keychain
 > prompt that Chrome / Brave / Edge trigger on first read. See
-> `_ROOKIEPY_BROWSER_ALIASES` in `cli/session.py` for the canonical list.
+> `_ROOKIEPY_BROWSER_ALIASES` in `cli/session_cmd.py` for the canonical list.
 > Chromium-family browsers also accept `chrome::<profile-name-or-directory>`
 > (for example `chrome::Profile 1` or `brave::Work`) to refresh from one
 > user-profile instead of relying on fan-out/account matching.

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -1420,7 +1420,7 @@ Two stacks, in order of preference:
 > makes Chrome cookie reads admin-or-bust (see §7.5). On macOS and Linux,
 > any of the listed browsers work; Firefox just sidesteps the Keychain
 > prompt that Chrome / Brave / Edge trigger on first read. See
-> `_ROOKIEPY_BROWSER_ALIASES` in `cli/session_cmd.py` for the canonical list.
+> `_ROOKIEPY_BROWSER_ALIASES` in `cli/services/login/cookie_jar.py` for the canonical list.
 > Chromium-family browsers also accept `chrome::<profile-name-or-directory>`
 > (for example `chrome::Profile 1` or `brave::Work`) to refresh from one
 > user-profile instead of relying on fan-out/account matching.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -143,7 +143,7 @@ code picks the right shape.
 |---|---|---|---|
 | `NextCall` | `_middleware/core.py` | **type alias**, not a class: `Callable[[RpcRequest], Awaitable[RpcResponse]]` | Every `Middleware.__call__` — the "call the next link" function passed into around-style middlewares |
 | `RpcCallback` | `_source/upload.py` | **Callable** Protocol: `async def __call__(method, params, ...)` | `SourceUploadPipeline.register_file_source` — RPC entrypoint passed as a **keyword argument** at call time |
-| `RpcCaller` | `_runtime_contracts.py` | **Object** Protocol: `async def rpc_call(method, params, ...)` (i.e. `obj.rpc_call(...)`) | The canonical shared capability Protocol for pure-RPC feature APIs and helper services (`NotesAPI`, `SourceLister`, `ShareManager`, etc.) |
+| `RpcCaller` | `_runtime/contracts.py` | **Object** Protocol: `async def rpc_call(method, params, ...)` (i.e. `obj.rpc_call(...)`) | The canonical shared capability Protocol for pure-RPC feature APIs and helper services (`NotesAPI`, `SourceLister`, `ShareManager`, etc.) |
 
 ### Why they diverge
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,13 +90,13 @@ src/notebooklm/
 |-------|-------|----------------|
 | **CLI** | `cli/*.py` | User commands, input validation, Rich output |
 | **Client** | `client.py`, `_*.py` | High-level Python API, returns typed dataclasses |
-| **Runtime** | `client.py`, `_client_composed.py`, `_runtime_init.py`, `_kernel.py`, runtime collaborators | `NotebookLMClient` composition root plus seam-module helpers (HTTP client lifecycle, RPC dispatch, metrics, drain bookkeeping, request-id counter, auth refresh, conversation cache, polling registry, cookie persistence) |
+| **Runtime** | `client.py`, `_client_composed.py`, `_runtime/init.py`, `_kernel.py`, runtime collaborators | `NotebookLMClient` composition root plus seam-module helpers (HTTP client lifecycle, RPC dispatch, metrics, drain bookkeeping, request-id counter, auth refresh, conversation cache, polling registry, cookie persistence) |
 | **RPC** | `rpc/*.py` | Protocol encoding/decoding, method IDs |
 
 #### Runtime seam modules
 
 The client runtime is split across `NotebookLMClient` (composition root),
-`ClientComposed` (holder), `_runtime_init.py` (construction helpers),
+`ClientComposed` (holder), `_runtime/init.py` (construction helpers),
 `_kernel.py` (HTTP client owner), and single-responsibility collaborator
 modules. (The legacy `_core.py` compatibility shim was deleted in v0.5.0;
 callers import directly from the canonical modules.) Each helper exposes
@@ -105,11 +105,11 @@ a narrow Protocol surface so it can be unit-tested against a stub:
 | Module | Class | Responsibility |
 |---|---|---|
 | `_client_composed.py` | `ClientComposed` | Client-owned holder for transport, executor, chain host, middleware metadata, and session collaborator bundle. |
-| `_runtime_init.py` | `ClientInternals` helpers | Validates constructor args, builds collaborators, wires middleware, and binds `ClientComposed`. |
+| `_runtime/init.py` | `ClientInternals` helpers | Validates constructor args, builds collaborators, wires middleware, and binds `ClientComposed`. |
 | `_client_metrics.py` | `ClientMetrics` | `ClientMetricsSnapshot` counters, queue-wait recorders, `on_rpc_event` async callback. |
 | `_transport_drain.py` | `TransportDrainTracker` | In-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. |
 | `_reqid_counter.py` | `ReqidCounter` | Monotonic `_reqid` counter for chat backend (baseline 100000, step 100000). |
-| `_runtime_auth.py` | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `AuthSnapshot` rotation. |
+| `_runtime/auth.py` | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `AuthSnapshot` rotation. |
 | `_runtime/lifecycle.py` | `ClientLifecycle` | Loop-affinity guard, `aclose` plumbing, keepalive task wiring. |
 | `_rpc_executor.py` | `RpcExecutor` | RPC dispatch executor with direct collaborator dependencies. |
 | `_request_types.py` | `AuthSnapshot`, `BuildRequest`, request materialization | Shared request construction Interface. |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -293,7 +293,7 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 
 ### `playwright install chromium` — when required, when auto-installed
 
-- **Required**: when you'll use `notebooklm login` (the interactive Playwright flow), unless the CLI auto-installs Chromium for you (it does — see `_ensure_chromium_installed()` in `cli/session.py`, which runs `python -m playwright install chromium` on first login if Chromium is missing).
+- **Required**: when you'll use `notebooklm login` (the interactive Playwright flow), unless the CLI auto-installs Chromium for you (it does — see `ensure_chromium_installed()` in `cli/services/playwright_login.py`, which runs `python -m playwright install chromium` on first login if Chromium is missing).
 - **Not required**: for headless servers (Persona D), library use (Persona C), or `--browser-cookies`-based auth (Persona A/F with `[cookies]`).
 
 ### `playwright install-deps chromium` — Linux system libraries

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -724,7 +724,7 @@ Kernel owns the `httpx.AsyncClient`; `NotebookLMClient` constructs the
 runtime graph and owns the public surface. Per the
 [ADR-010](adr/0010-session-kernel-split.md) split, `Kernel.__init__` in
 `src/notebooklm/_kernel.py` constructs the `httpx.AsyncClient` and is
-responsible for closing it on `aclose()`. `_runtime_init.py` constructs
+responsible for closing it on `aclose()`. `_runtime/init.py` constructs
 the collaborator bundle, `RuntimeTransport`, middleware chain, and
 `RpcExecutor`, then binds them into `ClientComposed`. The supporting state
 (metrics, drain bookkeeping, request-id counter, transport plumbing,

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -555,11 +555,11 @@ await page.locator(".create-artifact-button-container:has-text('Audio')").click(
 
 **All artifact types use `R7cb6c` with different content type codes and nested configs.**
 
-**Source:** `_artifacts.py` (param builders: `_artifact_payloads.py`)
+**Source:** `_artifacts.py` (param builders: `_artifact/payloads.py`)
 
 #### Audio Overview (Type 1)
 
-**Source:** `_artifacts.py::ArtifactsAPI` (param builders: `_artifact_payloads.py`)
+**Source:** `_artifacts.py::ArtifactsAPI` (param builders: `_artifact/payloads.py`)
 
 ```python
 source_ids_triple = [[[sid]] for sid in source_ids]  # [[[s1]], [[s2]], ...]

--- a/scripts/check_docs_module_refs.py
+++ b/scripts/check_docs_module_refs.py
@@ -1,0 +1,316 @@
+"""Assert doc references into ``src/notebooklm`` stay fresh.
+
+Sibling to ``scripts/check_claude_md_freshness.py`` (which guards CLAUDE.md's
+module map). This gate turns the repo's "enforce, don't document" principle onto
+the *rest* of the docs: after the #1328 refactor promoted flat ``_*.py`` modules
+into subpackages (``_chat.py`` -> ``_chat/api.py``, ``_runtime_lifecycle.py`` ->
+``_runtime/lifecycle.py``, ...), ~25 stale flat references survived across the
+live docs because a hand audit and a scoped doc-sync PR both missed them. A gate
+is the only thing that makes that class of drift un-recurrable.
+
+Two checks, both read the docs and resolve targets against the repo:
+
+**(1) Broken local-link check (strict, no allowlist).** Across ALL
+``docs/**/*.md`` + root ``*.md``, every markdown link ``[text](target)`` whose
+``target`` is a *relative path into* ``src/notebooklm/`` MUST resolve to an
+existing file. A broken link into the package is never intentional, even in an
+ADR or refactor-history doc.
+
+**(2) Inline module-ref check (LIVE docs only, allowlisted).** In the *live*
+docs (``docs/**/*.md`` MINUS ``docs/adr/**`` MINUS ``docs/refactor-history.md``,
+which intentionally name historical modules in prose), every inline code span
+```` `<ref>` ```` whose ``<ref>`` matches a ``src/notebooklm`` module shape MUST
+resolve to ``src/notebooklm/<ref>``. The rare intentional historical mention in
+a live doc is carried in :data:`_ALLOWLIST` (shrink-only). CLAUDE.md is covered
+by the sibling gate, so it is excluded here.
+
+The detector core (:func:`find_violations`) is pure and IO-free — it takes the
+already-read doc text plus a ``resolver(ref) -> bool`` — so the public test and
+these CLI self-checks exercise the same logic, exactly like
+``tests/_lint/test_v080_deprecation_coverage.py``.
+
+Usage:
+    python scripts/check_docs_module_refs.py
+    python scripts/check_docs_module_refs.py --repo-root path/to/repo
+
+Exit codes:
+    0  All doc module references are fresh.
+    1  One or more broken links or dead inline refs were found.
+    2  Argument error / repo root or docs tree not found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+# The package every reference resolves against.
+_PACKAGE_RELDIR = "src/notebooklm"
+
+# A ``src/notebooklm`` module shape: a lowercase python module (top-level name is
+# either a private ``_foo`` name or one of the known public module names), with
+# optional subdirectories, ending in ``.py``. ``test_*.py`` / ``conftest.py`` and
+# anything under ``tests/`` / ``scripts/`` are excluded by the caller, not here.
+_MODULE_REF_RE = re.compile(
+    r"^(_[a-z0-9_]+|client|auth|exceptions|config|io|log|migration|paths|research"
+    r"|types|urls|utils|artifacts)([/][a-z0-9_]+)*\.py$"
+)
+
+# Inline code spans: ``\`...\```. Non-greedy so adjacent spans on one line are
+# matched separately.
+_INLINE_SPAN_RE = re.compile(r"`([^`]+)`")
+
+# Markdown links: ``](target)``. The target may carry a ``#anchor`` we strip.
+_LINK_TARGET_RE = re.compile(r"\]\(([^)]+)\)")
+
+
+# Allowlist for the inline-ref check (check 2): live-doc inline mentions of a
+# module that no longer exists at that path but is named intentionally (a
+# historical / deliberately-deleted module, or a placeholder in a how-to). Keyed
+# by ``"<doc-relpath>:<ref>"`` -> reason. This set is SHRINK-ONLY: a test asserts
+# every entry is still genuinely needed (the doc still mentions it AND the ref
+# still does not resolve), so a stale allowlist entry fails the gate. Do NOT add
+# an entry to silence a *real* stale path — fix the path instead.
+_ALLOWLIST: dict[str, str] = {
+    # `_core.py` was the runtime compatibility shim deleted in v0.5.0. These live
+    # docs intentionally name it to explain why `CORE_LOGGER_NAME` still reads
+    # "notebooklm._core" (a logging compatibility contract), NOT to point at a
+    # live module. See docs/development.md "Logger namespace compatibility".
+    "docs/architecture.md:_core.py": "historical: deleted-in-v0.5.0 compat shim, named to explain CORE_LOGGER_NAME",
+    "docs/configuration.md:_core.py": "historical: deleted-in-v0.5.0 compat shim, named to explain CORE_LOGGER_NAME",
+    "docs/development.md:_core.py": "historical: deleted-in-v0.5.0 compat shim, named to explain CORE_LOGGER_NAME",
+    # `_newfeature.py` is a placeholder in the "adding a new API class" how-to
+    # ("Create `_newfeature.py` ..."), not a real module reference.
+    "docs/development.md:_newfeature.py": "placeholder: example module name in the add-an-API-class how-to",
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One dead doc reference, ``kind`` is ``"link"`` or ``"inline"``."""
+
+    kind: str
+    doc: str  # POSIX-relative path of the doc, for stable messages
+    line: int
+    target: str  # the dead link target or inline ref
+
+
+def _is_local_package_link(target: str) -> bool:
+    """True for a *relative* markdown link target into ``src/notebooklm/``.
+
+    Absolute URLs (``http://...``), in-page anchors (``#...``), and links that do
+    not descend into the package are out of scope — only relative paths whose
+    resolved form lands inside ``src/notebooklm/`` are checked. The substring test
+    is intentional: doc-relative targets reach the package via ``../`` prefixes
+    (``../src/notebooklm/...``, ``../../src/notebooklm/...``).
+    """
+    if target.startswith(("http://", "https://", "mailto:", "#")):
+        return False
+    return f"{_PACKAGE_RELDIR}/" in target
+
+
+def _is_module_shaped(ref: str) -> bool:
+    """True for an inline ref that looks like an in-package module path.
+
+    Excludes ``test_*.py`` / ``conftest.py`` and anything under ``tests/`` or
+    ``scripts/`` (those are not ``src/notebooklm`` modules even though they match
+    the ``.py`` shape).
+    """
+    if "/" in ref:
+        head = ref.split("/", 1)[0]
+        if head in {"tests", "scripts"}:
+            return False
+    leaf = ref.rsplit("/", 1)[-1]
+    if leaf.startswith("test_") or leaf == "conftest.py":
+        return False
+    return bool(_MODULE_REF_RE.match(ref))
+
+
+def find_violations(
+    doc_relpath: str,
+    text: str,
+    *,
+    resolver: Callable[[str], bool],
+    is_live: bool,
+    allowlist: dict[str, str],
+) -> list[Violation]:
+    """Return every dead reference in one doc. Pure: no filesystem access.
+
+    ``resolver(ref) -> bool`` answers "does ``src/notebooklm/<ref>`` exist?" for
+    the inline check, and ``resolver(target) -> bool`` answers "does this
+    doc-relative link target resolve?" for the link check — the CLI passes a
+    filesystem-backed resolver, the tests pass a dict-backed stub.
+
+    * Link check (always, every doc): a relative link into ``src/notebooklm/``
+      that does not resolve is a violation.
+    * Inline check (live docs only): a module-shaped inline span that does not
+      resolve to ``src/notebooklm/<ref>`` is a violation, unless an
+      ``"<doc>:<ref>"`` allowlist entry covers it.
+    """
+    violations: list[Violation] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for match in _LINK_TARGET_RE.finditer(line):
+            target = match.group(1).split("#", 1)[0].strip()
+            if not target or not _is_local_package_link(target):
+                continue
+            if not resolver(target):
+                violations.append(Violation("link", doc_relpath, lineno, target))
+
+        if not is_live:
+            continue
+        for match in _INLINE_SPAN_RE.finditer(line):
+            ref = match.group(1)
+            if not _is_module_shaped(ref):
+                continue
+            if resolver(ref):
+                continue
+            if f"{doc_relpath}:{ref}" in allowlist:
+                continue
+            violations.append(Violation("inline", doc_relpath, lineno, ref))
+    return violations
+
+
+# --- Filesystem helpers (I/O at the edge) -------------------------------------
+
+
+def _iter_docs(repo_root: Path):
+    """Yield ``(path, relpath, is_live)`` for every doc the gate inspects.
+
+    Docs = every ``docs/**/*.md`` plus every root-level ``*.md``. CLAUDE.md is
+    excluded (covered by the sibling gate). ``is_live`` is False for
+    ``docs/adr/**`` and ``docs/refactor-history.md`` (historical-prose docs) so
+    the inline check skips them while the link check still applies.
+    """
+    docs_dir = repo_root / "docs"
+    md_paths: list[Path] = []
+    if docs_dir.is_dir():
+        md_paths.extend(sorted(docs_dir.rglob("*.md")))
+    md_paths.extend(sorted(repo_root.glob("*.md")))
+
+    for path in md_paths:
+        rel = path.relative_to(repo_root).as_posix()
+        if rel == "CLAUDE.md":
+            continue
+        is_live = not (rel.startswith("docs/adr/") or rel == "docs/refactor-history.md")
+        yield path, rel, is_live
+
+
+def _make_resolver(repo_root: Path, doc_path: Path) -> Callable[[str], bool]:
+    """Resolver closure for one doc.
+
+    For a module-shaped inline ref it checks ``src/notebooklm/<ref>``; for a
+    doc-relative link target it resolves the target against the doc's directory.
+    Both resolve through the same callable because the link target always
+    contains ``src/notebooklm/`` (so it is never mistaken for a bare ref) and the
+    inline ref never contains a path separator prefix like ``../``.
+    """
+    package_root = repo_root / _PACKAGE_RELDIR
+
+    def resolver(ref_or_target: str) -> bool:
+        if _is_local_package_link(ref_or_target):
+            return (doc_path.parent / ref_or_target).resolve().exists()
+        return (package_root / ref_or_target).exists()
+
+    return resolver
+
+
+def _unused_allowlist_entries(
+    repo_root: Path, allowlist: dict[str, str], *, strict_missing: bool = False
+) -> list[str]:
+    """Return allowlist keys that are no longer justified (shrink-only guard).
+
+    An entry ``"<doc>:<ref>"`` is justified iff the doc still exists, still
+    mentions ``<ref>`` as a module-shaped inline span, and that ``<ref>`` still
+    does NOT resolve under ``src/notebooklm/``. The moment any of those stops
+    being true the entry is dead weight and must be removed.
+
+    ``strict_missing`` controls how a *missing* doc is treated. The default
+    (False) skips an entry whose doc does not exist under ``repo_root`` — this
+    keeps :func:`main` repo-root-agnostic, since the module-level allowlist keys
+    the *real* repo's docs and a caller may point ``--repo-root`` at a synthetic
+    tree. With ``strict_missing=True`` a missing doc IS flagged as stale; the
+    real-repo allowlist test uses this so a renamed/deleted doc can't leave a
+    dangling entry behind.
+    """
+    package_root = repo_root / _PACKAGE_RELDIR
+    unused: list[str] = []
+    for key in allowlist:
+        doc_rel, _, ref = key.partition(":")
+        doc_path = repo_root / doc_rel
+        if not doc_path.is_file():
+            if strict_missing:
+                unused.append(key)
+            continue
+        text = doc_path.read_text(encoding="utf-8")
+        mentioned = any(
+            ref == span and _is_module_shaped(span)
+            for line in text.splitlines()
+            for span in _INLINE_SPAN_RE.findall(line)
+        )
+        resolves = (package_root / ref).exists()
+        if not mentioned or resolves:
+            unused.append(key)
+    return unused
+
+
+def collect_violations(repo_root: Path) -> list[Violation]:
+    """Read every doc and return all violations (filesystem-backed)."""
+    violations: list[Violation] = []
+    for path, rel, is_live in _iter_docs(repo_root):
+        text = path.read_text(encoding="utf-8")
+        resolver = _make_resolver(repo_root, path)
+        violations.extend(
+            find_violations(
+                rel,
+                text,
+                resolver=resolver,
+                is_live=is_live,
+                allowlist=_ALLOWLIST,
+            )
+        )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=".")
+    args = ap.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    if not (repo_root / "docs").is_dir():
+        print(f"docs/ directory not found under repo root: {repo_root}", file=sys.stderr)
+        return 2
+
+    unused = _unused_allowlist_entries(repo_root, _ALLOWLIST)
+    violations = collect_violations(repo_root)
+
+    if violations or unused:
+        broken_links = [v for v in violations if v.kind == "link"]
+        dead_inline = [v for v in violations if v.kind == "inline"]
+        if broken_links:
+            print("Broken links into src/notebooklm/:", file=sys.stderr)
+            for v in broken_links:
+                print(f"  {v.doc}:{v.line} -> {v.target}", file=sys.stderr)
+        if dead_inline:
+            print("Dead inline module refs in live docs:", file=sys.stderr)
+            for v in dead_inline:
+                print(f"  {v.doc}:{v.line} -> `{v.target}`", file=sys.stderr)
+        if unused:
+            print("Stale _ALLOWLIST entries (shrink-only; remove them):", file=sys.stderr)
+            for key in unused:
+                print(f"  {key}", file=sys.stderr)
+        return 1
+
+    print(
+        "OK: all doc links into src/notebooklm resolve; "
+        "all live-doc inline module refs are fresh or allowlisted"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs_module_refs.py
+++ b/scripts/check_docs_module_refs.py
@@ -17,8 +17,9 @@ existing file. A broken link into the package is never intentional, even in an
 ADR or refactor-history doc.
 
 **(2) Inline module-ref check (LIVE docs only, allowlisted).** In the *live*
-docs (``docs/**/*.md`` MINUS ``docs/adr/**`` MINUS ``docs/refactor-history.md``,
-which intentionally name historical modules in prose), every inline code span
+docs (``docs/**/*.md`` + root ``*.md`` MINUS the historical-prose docs —
+``docs/adr/**``, ``docs/refactor-history.md``, and ``CHANGELOG.md`` — which
+intentionally name historical modules in prose), every inline code span
 ```` `<ref>` ```` whose ``<ref>`` matches a ``src/notebooklm`` module shape MUST
 resolve to ``src/notebooklm/<ref>``. The rare intentional historical mention in
 a live doc is carried in :data:`_ALLOWLIST` (shrink-only). CLAUDE.md is covered
@@ -56,15 +57,14 @@ _PACKAGE_RELDIR = "src/notebooklm"
 # optional subdirectories, ending in ``.py``. ``test_*.py`` / ``conftest.py`` and
 # anything under ``tests/`` / ``scripts/`` are excluded by the caller, not here.
 #
-# Scope: the inline-ref check intentionally covers the ``_*`` private modules plus
-# the known top-level public module names. The ``rpc/`` and ``cli/`` subpackages
-# are out of scope (they were not reorganised in #1328), so an inline ``rpc/...``
-# / ``cli/...`` ref is not resolved here — the broken-link check (which has no
-# such shape filter) still guards any ``src/notebooklm/rpc/...`` *link* target.
-# The test ``test_test_and_script_refs_are_not_module_shaped`` pins this scope.
+# Scope: covers the ``_*`` private modules, the known top-level public modules,
+# the ``notebooklm_cli`` entry point, and the ``rpc/`` + ``cli/`` subpackages
+# (broadened per review so an inline ``rpc/types.py`` / ``cli/session_cmd.py``
+# ref is resolved, not silently skipped). The test
+# ``test_test_and_script_refs_are_not_module_shaped`` pins this scope.
 _MODULE_REF_RE = re.compile(
     r"^(_[a-z0-9_]+|client|auth|exceptions|config|io|log|migration|paths|research"
-    r"|types|urls|utils|artifacts)([/][a-z0-9_]+)*\.py$"
+    r"|types|urls|utils|artifacts|notebooklm_cli|rpc|cli)([/][a-z0-9_]+)*\.py$"
 )
 
 # Inline code spans: ``\`...\```. Non-greedy so adjacent spans on one line are
@@ -184,13 +184,25 @@ def find_violations(
 # --- Filesystem helpers (I/O at the edge) -------------------------------------
 
 
+def _is_historical_prose(rel: str) -> bool:
+    """True for docs that intentionally name historical/old module paths in prose.
+
+    These are frozen-or-by-design historical records — ADRs, the refactor history,
+    and the CHANGELOG (whose entries describe edits to modules *as they were named
+    at the time*, e.g. ``cli/note.py`` for a fix that predates the ``_cmd`` rename).
+    The inline module-ref check skips them; the broken-link check still applies (a
+    dead *link* into the package is never intentional, even in history).
+    """
+    return rel.startswith("docs/adr/") or rel == "docs/refactor-history.md" or rel == "CHANGELOG.md"
+
+
 def _iter_docs(repo_root: Path):
     """Yield ``(path, relpath, is_live)`` for every doc the gate inspects.
 
     Docs = every ``docs/**/*.md`` plus every root-level ``*.md``. CLAUDE.md is
-    excluded (covered by the sibling gate). ``is_live`` is False for
-    ``docs/adr/**`` and ``docs/refactor-history.md`` (historical-prose docs) so
-    the inline check skips them while the link check still applies.
+    excluded (covered by the sibling gate). ``is_live`` is False for the
+    historical-prose docs (see :func:`_is_historical_prose`) so the inline check
+    skips them while the link check still applies.
     """
     docs_dir = repo_root / "docs"
     md_paths: list[Path] = []
@@ -202,8 +214,7 @@ def _iter_docs(repo_root: Path):
         rel = path.relative_to(repo_root).as_posix()
         if rel == "CLAUDE.md":
             continue
-        is_live = not (rel.startswith("docs/adr/") or rel == "docs/refactor-history.md")
-        yield path, rel, is_live
+        yield path, rel, not _is_historical_prose(rel)
 
 
 def _make_resolver(repo_root: Path, doc_path: Path) -> Callable[[str], bool]:

--- a/scripts/check_docs_module_refs.py
+++ b/scripts/check_docs_module_refs.py
@@ -55,6 +55,13 @@ _PACKAGE_RELDIR = "src/notebooklm"
 # either a private ``_foo`` name or one of the known public module names), with
 # optional subdirectories, ending in ``.py``. ``test_*.py`` / ``conftest.py`` and
 # anything under ``tests/`` / ``scripts/`` are excluded by the caller, not here.
+#
+# Scope: the inline-ref check intentionally covers the ``_*`` private modules plus
+# the known top-level public module names. The ``rpc/`` and ``cli/`` subpackages
+# are out of scope (they were not reorganised in #1328), so an inline ``rpc/...``
+# / ``cli/...`` ref is not resolved here — the broken-link check (which has no
+# such shape filter) still guards any ``src/notebooklm/rpc/...`` *link* target.
+# The test ``test_test_and_script_refs_are_not_module_shaped`` pins this scope.
 _MODULE_REF_RE = re.compile(
     r"^(_[a-z0-9_]+|client|auth|exceptions|config|io|log|migration|paths|research"
     r"|types|urls|utils|artifacts)([/][a-z0-9_]+)*\.py$"

--- a/tests/unit/test_docs_module_refs.py
+++ b/tests/unit/test_docs_module_refs.py
@@ -26,6 +26,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from scripts.check_docs_module_refs import (  # noqa: E402
     _ALLOWLIST,
+    _is_historical_prose,
     _is_module_shaped,
     _unused_allowlist_entries,
     collect_violations,
@@ -160,12 +161,43 @@ def test_test_and_script_refs_are_not_module_shaped() -> None:
     assert not _is_module_shaped("conftest.py")
     assert not _is_module_shaped("tests/unit/test_x.py")
     assert not _is_module_shaped("scripts/check_docs_module_refs.py")
-    # ...but real package modules (flat and subpackage) are.
+    # ...but real package modules (flat and subpackage) are, including the
+    # rpc/ + cli/ subpackages and the notebooklm_cli entry point (broadened
+    # per review so their inline refs are resolved, not silently skipped).
     assert _is_module_shaped("_runtime_lifecycle.py")
     assert _is_module_shaped("_runtime/lifecycle.py")
     assert _is_module_shaped("client.py")
-    assert _is_module_shaped("rpc/types.py") is False  # `rpc` is not a top-level name in the shape
     assert _is_module_shaped("types.py")
+    assert _is_module_shaped("rpc/types.py")
+    assert _is_module_shaped("cli/session_cmd.py")
+    assert _is_module_shaped("cli/services/generate.py")
+    assert _is_module_shaped("notebooklm_cli.py")
+
+
+def test_historical_prose_docs_are_classified() -> None:
+    # ADRs, refactor-history, and the CHANGELOG are historical-prose (inline
+    # check skipped); ordinary live docs are not.
+    assert _is_historical_prose("docs/adr/0014-x.md")
+    assert _is_historical_prose("docs/refactor-history.md")
+    assert _is_historical_prose("CHANGELOG.md")
+    assert not _is_historical_prose("docs/architecture.md")
+    assert not _is_historical_prose("README.md")
+
+
+def test_changelog_skips_inline_check_but_enforces_links(tmp_path) -> None:
+    # CHANGELOG entries name modules as they were at the time (e.g. cli/note.py
+    # pre-_cmd-rename); the inline check must skip them, but a dead LINK into the
+    # package is still reported.
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    _write(tmp_path / "src/notebooklm/cli/note_cmd.py", "")
+    (tmp_path / "docs").mkdir()  # main() requires a docs/ tree to exist
+    # Historical inline ref to a now-renamed module -> allowed.
+    _write(tmp_path / "CHANGELOG.md", "Fixed `cli/note.py` exit codes.\n")
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+    # ...but a dead link into the package in the CHANGELOG still fails.
+    _write(tmp_path / "CHANGELOG.md", "See [src](src/notebooklm/cli/note.py).\n")
+    assert main(["--repo-root", str(tmp_path)]) == 1
 
 
 def test_inline_ref_to_tests_path_is_not_flagged() -> None:

--- a/tests/unit/test_docs_module_refs.py
+++ b/tests/unit/test_docs_module_refs.py
@@ -1,0 +1,337 @@
+"""Self-tests + the real gate for ``scripts/check_docs_module_refs.py``.
+
+Mirrors the sibling ``tests/unit/test_claude_md_freshness.py`` (CLAUDE.md map)
+and the pure-detector idiom of ``tests/_lint/test_v080_deprecation_coverage.py``:
+the detector core :func:`find_violations` is IO-free, so the synthetic
+self-checks below feed crafted doc text + a dict-backed ``resolver`` while the
+real-gate test (:func:`test_real_docs_have_no_violations`) drives the same code
+over the live ``docs/`` tree.
+
+The self-checks are non-vacuous and bidirectional: a planted dead LINK is
+reported, a planted dead inline ref is reported, the correct (resolving) inline
+ref is clean, ADR/refactor-history docs skip the inline check but NOT the link
+check, an allowlisted dead inline ref is clean, and a bogus allowlist entry is
+caught by the shrink-only guard.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Add project root to sys.path so we can import scripts (matches the sibling).
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from scripts.check_docs_module_refs import (  # noqa: E402
+    _ALLOWLIST,
+    _is_module_shaped,
+    _unused_allowlist_entries,
+    collect_violations,
+    find_violations,
+    main,
+)
+
+pytestmark = pytest.mark.repo_lint
+
+
+# A resolver stub: a ref/target resolves iff it is in ``existing``. The CLI uses
+# a filesystem-backed resolver; the pure detector only needs this predicate.
+def _stub_resolver(existing: set[str]):
+    return lambda ref_or_target: ref_or_target in existing
+
+
+# --- find_violations: link check (every doc, no allowlist) --------------------
+
+
+def test_dead_link_into_package_is_reported() -> None:
+    text = "See [the helper](../src/notebooklm/_gone.py) for details.\n"
+    violations = find_violations(
+        "docs/foo.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist={},
+    )
+    assert [(v.kind, v.target) for v in violations] == [("link", "../src/notebooklm/_gone.py")]
+
+
+def test_resolving_link_into_package_is_clean() -> None:
+    target = "../src/notebooklm/_runtime/lifecycle.py"
+    text = f"See [the helper]({target}).\n"
+    violations = find_violations(
+        "docs/foo.md",
+        text,
+        resolver=_stub_resolver({target}),
+        is_live=True,
+        allowlist={},
+    )
+    assert violations == []
+
+
+def test_external_and_anchor_links_are_ignored() -> None:
+    text = (
+        "[home](https://example.com/src/notebooklm/x.py) [anchor](#section) [other](../README.md)\n"
+    )
+    violations = find_violations(
+        "docs/foo.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist={},
+    )
+    # None of these are *relative paths into src/notebooklm/*, so none are checked.
+    assert violations == []
+
+
+# --- find_violations: inline check (live docs only, allowlisted) --------------
+
+
+def test_dead_inline_flat_ref_is_reported_and_subpackage_form_is_clean() -> None:
+    dead = "The runtime lives in `_runtime_lifecycle.py` today.\n"
+    flagged = find_violations(
+        "docs/architecture.md",
+        dead,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist={},
+    )
+    assert [(v.kind, v.target) for v in flagged] == [("inline", "_runtime_lifecycle.py")]
+
+    # The correct subpackage form resolves -> clean.
+    fixed = "The runtime lives in `_runtime/lifecycle.py` today.\n"
+    clean = find_violations(
+        "docs/architecture.md",
+        fixed,
+        resolver=_stub_resolver({"_runtime/lifecycle.py"}),
+        is_live=True,
+        allowlist={},
+    )
+    assert clean == []
+
+
+def test_adr_doc_skips_inline_check_but_not_link_check() -> None:
+    # An ADR / refactor-history doc names a historical module in prose (inline)
+    # AND links to a dead target. The inline ref is NOT reported (is_live=False),
+    # but the dead LINK still is.
+    text = (
+        "Historically `_runtime_lifecycle.py` owned this "
+        "([src](../../src/notebooklm/_runtime_lifecycle.py)).\n"
+    )
+    violations = find_violations(
+        "docs/adr/0099-example.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=False,
+        allowlist={},
+    )
+    assert [(v.kind, v.target) for v in violations] == [
+        ("link", "../../src/notebooklm/_runtime_lifecycle.py")
+    ]
+
+
+def test_allowlisted_dead_inline_ref_is_clean() -> None:
+    text = "The deleted `_core.py` shim explains the logger name.\n"
+    allowlist = {"docs/development.md:_core.py": "historical: deleted compat shim"}
+    violations = find_violations(
+        "docs/development.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist=allowlist,
+    )
+    assert violations == []
+
+    # The same dead ref in a *different* doc (not keyed) is still reported.
+    elsewhere = find_violations(
+        "docs/architecture.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist=allowlist,
+    )
+    assert [(v.kind, v.target) for v in elsewhere] == [("inline", "_core.py")]
+
+
+def test_test_and_script_refs_are_not_module_shaped() -> None:
+    # The inline check excludes test_*.py / conftest.py and tests/ + scripts/.
+    assert not _is_module_shaped("test_client.py")
+    assert not _is_module_shaped("conftest.py")
+    assert not _is_module_shaped("tests/unit/test_x.py")
+    assert not _is_module_shaped("scripts/check_docs_module_refs.py")
+    # ...but real package modules (flat and subpackage) are.
+    assert _is_module_shaped("_runtime_lifecycle.py")
+    assert _is_module_shaped("_runtime/lifecycle.py")
+    assert _is_module_shaped("client.py")
+    assert _is_module_shaped("rpc/types.py") is False  # `rpc` is not a top-level name in the shape
+    assert _is_module_shaped("types.py")
+
+
+def test_inline_ref_to_tests_path_is_not_flagged() -> None:
+    # A live doc may legitimately cite a test file inline; it must not be
+    # checked against src/notebooklm/.
+    text = "Pinned in `tests/unit/test_row_adapters.py`.\n"
+    violations = find_violations(
+        "docs/architecture.md",
+        text,
+        resolver=_stub_resolver(set()),
+        is_live=True,
+        allowlist={},
+    )
+    assert violations == []
+
+
+# --- Shrink-only allowlist guard ----------------------------------------------
+
+
+def test_unused_allowlist_entry_for_missing_doc_is_flagged(tmp_path) -> None:
+    # An allowlist entry whose doc does not exist is dead weight under
+    # strict_missing (the real-repo guard); under the default it is skipped so
+    # main() stays repo-root-agnostic.
+    (tmp_path / "docs").mkdir()
+    entry = {"docs/ghost.md:_core.py": "stale entry, doc is gone"}
+    assert _unused_allowlist_entries(tmp_path, entry, strict_missing=True) == [
+        "docs/ghost.md:_core.py"
+    ]
+    assert _unused_allowlist_entries(tmp_path, entry) == []
+
+
+def test_unused_allowlist_entry_for_now_resolving_ref_is_flagged(tmp_path) -> None:
+    # If the ref now resolves under src/notebooklm/, the allowlist entry is
+    # obsolete — the gate should force its removal even though the doc still
+    # mentions it.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("We use `_now_real.py` here.\n", encoding="utf-8")
+    pkg = tmp_path / "src" / "notebooklm"
+    pkg.mkdir(parents=True)
+    (pkg / "_now_real.py").touch()
+
+    unused = _unused_allowlist_entries(
+        tmp_path, {"docs/guide.md:_now_real.py": "was missing, now exists"}
+    )
+    assert unused == ["docs/guide.md:_now_real.py"]
+
+
+def test_unused_allowlist_entry_for_unmentioned_ref_is_flagged(tmp_path) -> None:
+    # The doc no longer mentions the ref at all -> entry is dead weight.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("No module here.\n", encoding="utf-8")
+    (tmp_path / "src" / "notebooklm").mkdir(parents=True)
+
+    unused = _unused_allowlist_entries(
+        tmp_path, {"docs/guide.md:_gone.py": "doc dropped the mention"}
+    )
+    assert unused == ["docs/guide.md:_gone.py"]
+
+
+def test_genuinely_needed_allowlist_entry_is_not_flagged(tmp_path) -> None:
+    # Doc exists, mentions the ref inline, and the ref does NOT resolve -> kept.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("The deleted `_core.py` shim.\n", encoding="utf-8")
+    (tmp_path / "src" / "notebooklm").mkdir(parents=True)
+
+    unused = _unused_allowlist_entries(
+        tmp_path, {"docs/guide.md:_core.py": "historical: deleted compat shim"}
+    )
+    assert unused == []
+
+
+# --- main(): end-to-end exit codes on a synthetic repo ------------------------
+
+
+def _write(path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_main_fails_on_dead_link(tmp_path, capsys) -> None:
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    _write(
+        tmp_path / "docs/foo.md",
+        "[dead](../src/notebooklm/_gone.py)\n",
+    )
+    assert main(["--repo-root", str(tmp_path)]) == 1
+    assert "Broken links into src/notebooklm/" in capsys.readouterr().err
+
+
+def test_main_fails_on_dead_inline_ref(tmp_path, capsys) -> None:
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    _write(tmp_path / "docs/foo.md", "Runtime in `_runtime_lifecycle.py`.\n")
+    assert main(["--repo-root", str(tmp_path)]) == 1
+    assert "Dead inline module refs in live docs" in capsys.readouterr().err
+
+
+def test_main_succeeds_when_all_refs_resolve(tmp_path) -> None:
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    _write(tmp_path / "src/notebooklm/_runtime/lifecycle.py", "")
+    _write(
+        tmp_path / "docs/foo.md",
+        "Runtime in `_runtime/lifecycle.py` ([src](../src/notebooklm/_runtime/lifecycle.py)).\n",
+    )
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_main_returns_2_when_docs_dir_missing(tmp_path) -> None:
+    assert main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_main_skips_inline_check_in_adr_but_enforces_links(tmp_path) -> None:
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    # ADR names a dead flat module inline (allowed) but its link resolves.
+    _write(tmp_path / "src/notebooklm/_runtime/lifecycle.py", "")
+    _write(
+        tmp_path / "docs/adr/0099-x.md",
+        "Historically `_runtime_lifecycle.py` "
+        "([src](../../src/notebooklm/_runtime/lifecycle.py)).\n",
+    )
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+    # Now make the ADR's link dead -> must fail even though inline is skipped.
+    _write(
+        tmp_path / "docs/adr/0099-x.md",
+        "Historically `_runtime_lifecycle.py` "
+        "([src](../../src/notebooklm/_runtime_lifecycle.py)).\n",
+    )
+    assert main(["--repo-root", str(tmp_path)]) == 1
+
+
+# --- The real gate ------------------------------------------------------------
+
+
+def test_real_docs_have_no_violations() -> None:
+    """The live ``docs/`` tree has zero dead links / dead inline refs.
+
+    This is the gate that forces the #1328 stale-ref burn-down to stay done.
+    """
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+    assert main(["--repo-root", repo_root]) == 0
+
+
+def test_real_allowlist_is_not_stale() -> None:
+    """Every ``_ALLOWLIST`` entry is still genuinely needed (shrink-only).
+
+    A live entry must point at a doc that still mentions the ref inline AND a ref
+    that still does not resolve under ``src/notebooklm/``. The moment a fix lands,
+    the entry must be removed; this catches a bogus/stale entry.
+    """
+    from pathlib import Path
+
+    repo_root = Path(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+    unused = _unused_allowlist_entries(repo_root, _ALLOWLIST, strict_missing=True)
+    assert unused == [], (
+        "Stale _ALLOWLIST entries in scripts/check_docs_module_refs.py — the "
+        "allowlist is shrink-only. Remove these (the doc no longer needs the "
+        f"exemption): {unused}"
+    )
+
+
+def test_collect_violations_over_real_tree_is_empty() -> None:
+    """Direct call to the filesystem-backed collector returns no violations."""
+    from pathlib import Path
+
+    repo_root = Path(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+    assert collect_violations(repo_root) == []

--- a/tests/unit/test_docs_module_refs.py
+++ b/tests/unit/test_docs_module_refs.py
@@ -265,6 +265,20 @@ def test_main_fails_on_dead_inline_ref(tmp_path, capsys) -> None:
     assert "Dead inline module refs in live docs" in capsys.readouterr().err
 
 
+def test_main_fails_on_stale_allowlist(tmp_path, capsys, monkeypatch) -> None:
+    # Completes main()'s exit-code coverage: the third error branch fires when an
+    # _ALLOWLIST entry is no longer justified (its doc exists but no longer
+    # mentions the ref). Patch the module-level allowlist with a bogus entry.
+    import scripts.check_docs_module_refs as mod
+
+    _write(tmp_path / "src/notebooklm/__init__.py", "")
+    _write(tmp_path / "docs/foo.md", "No module mention here.\n")
+    monkeypatch.setattr(mod, "_ALLOWLIST", {"docs/foo.md:_old.py": "stale: doc dropped it"})
+
+    assert mod.main(["--repo-root", str(tmp_path)]) == 1
+    assert "Stale _ALLOWLIST entries" in capsys.readouterr().err
+
+
 def test_main_succeeds_when_all_refs_resolve(tmp_path) -> None:
     _write(tmp_path / "src/notebooklm/__init__.py", "")
     _write(tmp_path / "src/notebooklm/_runtime/lifecycle.py", "")


### PR DESCRIPTION
## What

Add `scripts/check_docs_module_refs.py` (+ self-tests in `tests/unit/test_docs_module_refs.py`), wired into the Code Quality CI job next to the CLAUDE.md freshness gate. Two checks, both resolved against the repo:

1. **Broken local-link check** (strict, no allowlist, ALL docs incl. ADRs): every markdown link `[text](target)` whose target is a relative path into `src/notebooklm/` must resolve to an existing file. A broken link into the package is never intentional, even in an ADR.
2. **Inline module-ref check** (LIVE docs only — excludes `docs/adr/**` and `docs/refactor-history.md`, which name historical modules in prose; allowlisted shrink-only): every inline code-span matching a `src/notebooklm` module shape must resolve to a real module. A module-level `_ALLOWLIST` carries the rare intentional historical mention (`_core.py` — the deleted-in-v0.5.0 compat shim named to explain `CORE_LOGGER_NAME`; the `_newfeature.py` how-to placeholder), and a test asserts the allowlist only contains still-needed entries. CLAUDE.md is excluded (covered by the sibling gate).

The detector core (`find_violations`) is **pure/IO-free** — it takes the doc text + a `resolver(ref) -> bool` — so the public test and the synthetic self-checks share the exact logic, mirroring `tests/_lint/test_v080_deprecation_coverage.py`. Self-tests are non-vacuous and bidirectional (planted dead link reported; planted dead inline ref reported; correct subpackage ref clean; ADR skips inline but not links; allowlisted ref clean; bogus allowlist entry caught by the shrink-only guard).

Burned down every residual stale flat path the gate surfaced (both inline text and markdown links, each verified against the live package):

| stale flat | current subpackage |
|---|---|
| `_runtime_contracts.py` | `_runtime/contracts.py` |
| `_runtime_auth.py` | `_runtime/auth.py` |
| `_runtime_init.py` | `_runtime/init.py` |
| `_middleware_chain.py` | `_middleware/chain.py` |
| `_middleware_chain_host.py` | `_middleware/chain_host.py` |
| `_artifact_listing.py` | `_artifact/listing.py` |
| `_artifact_payloads.py` | `_artifact/payloads.py` |

across `docs/architecture.md`, `docs/development.md`, `docs/conventions.md`, `docs/python-api.md`, `docs/rpc-reference.md`, plus the two dead links in ADR-0014 (link **target** only; the ADR's historical prose label is left intact). The gate now passes with zero violations.

## Why

Top convergent recommendation of a 3-lens architecture review: turn the repo's "enforce, don't document" principle onto its own docs. The #1328 refactor promoted flat `_*.py` modules into subpackages, and ~25 stale flat references provably survived across the live docs — a hand audit **and** a scoped doc-sync PR both missed them, which is exactly why a gate (not vigilance) is needed. Un-enforced doc/path consistency re-accretes the moment the next refactor lands; this CI gate makes that class of drift un-recurrable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture, ADRs, guides and cross-references to reflect recent internal module reorganizations.

* **Tests**
  * Added a comprehensive test suite that validates documentation module references, allowlist behavior, and CLI checks against the docs tree.

* **Chores**
  * Added a CI quality gate that scans docs for stale or broken in-repo module references and fails the build on violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->