### PR TITLE
docs(readme): surface the interactive mind-map variant (#1256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Use `--prompt-file PATH` with `ask`, prompt-based `generate` commands, and `sour
 
 ```python
 import asyncio
-from notebooklm import NotebookLMClient
+from notebooklm import NotebookLMClient, MindMapKind
 
 async def main():
     async with NotebookLMClient.from_storage() as client:
@@ -208,10 +208,10 @@ async def main():
         await client.artifacts.wait_for_completion(nb.id, status.task_id)
         await client.artifacts.download_quiz(nb.id, "quiz.json", output_format="json")
 
-        # Generate a mind map — two kinds (issue #1256): note-backed JSON (shown)
-        # or the newer interactive studio map, both via the unified client.mind_maps
-        # API, e.g. await client.mind_maps.generate(nb.id, kind="interactive")
-        result = await client.artifacts.generate_mind_map(nb.id)
+        # Generate a mind map via the unified client.mind_maps API (issue #1256) —
+        # two kinds: the newer MindMapKind.INTERACTIVE studio map (shown; polled to
+        # completion by default) or MindMapKind.NOTE_BACKED JSON. Both export via:
+        await client.mind_maps.generate(nb.id, kind=MindMapKind.INTERACTIVE)
         await client.artifacts.download_mind_map(nb.id, "mindmap.json")
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 | **Flashcards** | Configurable quantity and difficulty | JSON, Markdown, HTML |
 | **Report** | Briefing doc, study guide, blog post, or custom prompt | Markdown |
 | **Data Table** | Custom structure via natural language | CSV |
-| **Mind Map** | Interactive hierarchical visualization | JSON |
+| **Mind Map** | Hierarchical node tree — **two kinds**: note-backed JSON or the newer interactive studio map (`--kind` / `MindMapKind`) | JSON |
 
 ### Beyond the Web UI
 
@@ -147,7 +147,7 @@ notebooklm generate quiz --difficulty hard
 notebooklm generate flashcards --quantity more
 notebooklm generate slide-deck
 notebooklm generate infographic --orientation portrait
-notebooklm generate mind-map
+notebooklm generate mind-map --kind interactive   # newer studio map; note-backed JSON is the default kind
 notebooklm generate data-table "compare key concepts"
 
 # 5. Download artifacts
@@ -208,7 +208,9 @@ async def main():
         await client.artifacts.wait_for_completion(nb.id, status.task_id)
         await client.artifacts.download_quiz(nb.id, "quiz.json", output_format="json")
 
-        # Generate mind map and export
+        # Generate a mind map — two kinds (issue #1256): note-backed JSON (shown)
+        # or the newer interactive studio map, both via the unified client.mind_maps
+        # API, e.g. await client.mind_maps.generate(nb.id, kind="interactive")
         result = await client.artifacts.generate_mind_map(nb.id)
         await client.artifacts.download_mind_map(nb.id, "mindmap.json")
 


### PR DESCRIPTION
## What

Update the **README** to surface the newer **interactive** mind-map variant (#1256) alongside the original note-backed kind:
- **Generation Types table** — the Mind Map row now names **both kinds** (note-backed JSON / interactive studio map) instead of just "Interactive hierarchical visualization".
- **CLI quick-start** — `generate mind-map --kind interactive` (noting note-backed is today's default).
- **Python example** — points at the unified `client.mind_maps.generate(nb.id, kind="interactive")` surface, not only the note-backed `artifacts.generate_mind_map`.

## Why

The deep docs (`python-api.md`, `cli-reference.md`, `rpc-reference.md`, the upgrade guide) already document the two kinds + `MindMapKind` thoroughly — but the README front door still described mind maps as a single (note-backed) thing, so a reader landing there wouldn't know the interactive studio variant (the one the web app now creates, and the v0.8.0 `--kind` default) exists.

Docs-only; the new doc-path-freshness gate stays green (no module-path refs added), and `test_docs_examples_idioms` / `test_install_docs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the two Mind Map kinds: note-backed JSON and the newer interactive studio map (interactive is now the default).
  * Updated CLI Quick Start to show generating interactive mind maps with the --kind interactive flag.
  * Expanded Python API examples to demonstrate generating interactive mind maps via the kind parameter and added explanatory comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->