### PR TITLE
docs(artifacts): complete the type-4 variant taxonomy — include interactive mind map (variant 4)

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1890,7 +1890,7 @@ class Artifact:
     status: int                     # 1=processing, 2=pending, 3=completed, 4=failed
     created_at: Optional[datetime]
     url: Optional[str]
-    _variant: int | None = None     # Internal variant for type-4 artifacts (1=flashcards, 2=quiz).
+    _variant: int | None = None     # Internal variant for type-4 artifacts (1=flashcards, 2=quiz, 4=interactive mind map).
 
     @property
     def kind(self) -> ArtifactType:

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -717,7 +717,7 @@ params = [
         [
             None,
             [
-                2,                    # Variant: 2=quiz, 1=flashcards
+                2,                    # Variant: 2=quiz, 1=flashcards, 4=interactive mind map
                 None,
                 instructions,
                 None,
@@ -752,7 +752,7 @@ params = [
         [
             None,
             [
-                1,                    # Variant: 1=flashcards (vs 2=quiz)
+                1,                    # Variant: 1=flashcards (vs 2=quiz, 4=interactive mind map)
                 None,
                 instructions,
                 None,

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -33,7 +33,7 @@ class ArtifactRow:
     7      report markdown payload (string or one-element wrapper)
     8      video metadata; nested media variants
     9      options block; ``[9][1][0]`` is the variant code (used to
-           distinguish QUIZ from FLASHCARDS from the interactive mind map
+           distinguish among QUIZ, FLASHCARDS, and the interactive mind map
            (variant 4) when type == 4)
     15     timestamp block; ``[15][0]`` is the creation timestamp
            (seconds since epoch)

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -33,7 +33,8 @@ class ArtifactRow:
     7      report markdown payload (string or one-element wrapper)
     8      video metadata; nested media variants
     9      options block; ``[9][1][0]`` is the variant code (used to
-           distinguish QUIZ from FLASHCARDS when type == 4)
+           distinguish QUIZ from FLASHCARDS from the interactive mind map
+           (variant 4) when type == 4)
     15     timestamp block; ``[15][0]`` is the creation timestamp
            (seconds since epoch)
     16     slide deck metadata; ``[16][3]`` is PDF URL and ``[16][4]``
@@ -153,7 +154,8 @@ class ArtifactRow:
 
     @property
     def variant(self) -> int | None:
-        """Variant code at ``data[9][1][0]`` — distinguishes QUIZ vs FLASHCARDS.
+        """Variant code at ``data[9][1][0]`` — distinguishes QUIZ vs FLASHCARDS
+        vs the interactive mind map (variant 4) within the type-4 family.
 
         Returns ``None`` when:
 
@@ -467,8 +469,8 @@ class ArtifactRow:
                 to pick downloadable artifacts.
 
         Note:
-            This is a *raw* type-code match. The QUIZ vs FLASHCARDS
-            variant distinction lives one layer up in
+            This is a *raw* type-code match. The QUIZ vs FLASHCARDS vs
+            interactive mind map (variant 4) distinction lives one layer up in
             ``_artifact.listing._matches_artifact_type`` because it
             operates on :class:`Artifact` objects (which know variant
             mapping), not raw rows. Keep that separation intentional —

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -69,8 +69,7 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     Returns:
         ArtifactType enum member. Returns UNKNOWN for unrecognized types.
     """
-    # Resolve the type-4 family (QUIZ / FLASHCARDS / interactive mind map)
-    # by variant; the interactive mind map (variant 4) is also returned here.
+    # Resolve the type-4 family (QUIZ / FLASHCARDS / interactive mind map) by variant.
     if artifact_type == ArtifactTypeCode.QUIZ.value:
         if variant == FLASHCARDS_VARIANT:
             return ArtifactType.FLASHCARDS

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -24,7 +24,8 @@ class ArtifactType(str, Enum):
     """User-facing artifact types.
 
     This is a str enum that hides internal variant complexity. For example,
-    quizzes and flashcards are both type 4 internally but distinguished by variant.
+    quizzes, flashcards, and interactive mind maps are all type 4 internally,
+    distinguished by variant.
 
     Comparisons work with both enum members and strings:
         artifact.kind == ArtifactType.AUDIO  # True
@@ -62,12 +63,14 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
 
     Args:
         artifact_type: ArtifactTypeCode integer value from API.
-        variant: Optional variant code (e.g., for quiz vs flashcards).
+        variant: Optional variant code (e.g., for quiz vs flashcards vs
+            interactive mind map).
 
     Returns:
         ArtifactType enum member. Returns UNKNOWN for unrecognized types.
     """
-    # Handle QUIZ/FLASHCARDS distinction.
+    # Resolve the type-4 family (QUIZ / FLASHCARDS / interactive mind map)
+    # by variant; the interactive mind map (variant 4) is also returned here.
     if artifact_type == ArtifactTypeCode.QUIZ.value:
         if variant == FLASHCARDS_VARIANT:
             return ArtifactType.FLASHCARDS
@@ -82,7 +85,7 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
             if key not in _warned_artifact_types:
                 _warned_artifact_types.add(key)
                 warnings.warn(
-                    f"Unknown QUIZ variant {variant}. "
+                    f"Unknown type-4 (quiz / flashcards / mind-map) variant {variant}. "
                     "Consider updating notebooklm-py to the latest version.",
                     UnknownTypeWarning,
                     stacklevel=3,


### PR DESCRIPTION
## What

Complete the artifact **type-4 variant taxonomy** in the describing comments / docstrings / docs. Several of these framed artifact type code 4 as the quiz/flashcard family but omitted the **interactive mind map (variant 4)**, which is also type 4. Updated, comments/docstrings/docs only:

- `src/notebooklm/_types/artifacts.py` — `ArtifactType` class docstring, `_map_artifact_kind` `variant` arg doc + the type-4 dispatch comment, and the unknown-variant warning string (`Unknown QUIZ variant {variant}.` → `Unknown type-4 (quiz / flashcards / mind-map) variant {variant}.`).
- `src/notebooklm/_row_adapters/artifacts.py` — the `[9]` options-block field comment, the `variant` property docstring, and the raw-type-match `Note:` docstring.
- `docs/python-api.md` — `_variant` field comment now `(1=flashcards, 2=quiz, 4=interactive mind map)`.
- `docs/rpc-reference.md` — the variant comments in the quiz/flashcard CREATE-payload examples now also list `4=interactive mind map` (each example keeps its own variant value).

The canonical block at `rpc/types.py:144-151` (already correct) is the source of wording and was left untouched.

## Why

Type code 4 is a **three-variant family** multiplexed via the variant at `data[9][1][0]`: `FLASHCARDS_VARIANT=1`, `QUIZ_VARIANT=2`, `INTERACTIVE_MIND_MAP_VARIANT=4`. The code already handles all three (`_map_artifact_kind`, `is_interactive_mind_map`, `is_unclassified_type4`); only the describing comments lagged, framing type 4 as just quiz/flashcard. This is a **comments-only** alignment with the canonical taxonomy — **zero behavior change**. No test asserts the old warning text. The genuinely quiz/flashcard-*specific* download/format paths (which use a separate extraction path for the mind map) were intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified artifact type documentation across API and SDK references to note that the type-4 family includes multiple variants (quizzes, flashcards, and interactive mind maps).
  * Rephrased variant explanations and inline comments so variant 4 is explicitly described as an interactive mind map option.
  * Updated notes and warnings to generically reference “type-4 (quiz / flashcards / mind-map)” for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->