### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-06-03
+## [0.7.0] - 2026-06-04
 
 ### Highlights
 


### PR DESCRIPTION
Release **v0.7.0**.

This PR finalizes the release: the `[0.7.0]` CHANGELOG section is dated to the tag day (`2026-06-04`). The version (`0.7.0`) and the full release notes were already on `main`; this is the 1-line date finalization that the release goes out on.

See [CHANGELOG.md](../CHANGELOG.md) `[0.7.0]` for the full notes — headline is the v0.8.0 error-contract **additive runway** (`get_or_none()`, `NOTEBOOKLM_FUTURE_ERRORS` forward-test flag, typed not-found exceptions, `ResearchStatus.NOT_FOUND`, `retry_failed`) plus the completed deprecation removals (`notes.create_from_chat`, `Note.from_api_response`).

Pre-release gates (run locally on this branch): public-API compat audit exit 0 (only allowlisted intentional breaks), drift gates pass, mypy clean (198 files), ruff clean, full `pytest` 8389 passed / 66 skipped / 1 xfailed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release date documentation for v0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->