### PR TITLE
fix(audit): normalize object() sentinel default reprs (unblocks main CI)

### DIFF
--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -363,22 +363,26 @@ main()
 """
 
 
-_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+_OBJECT_SENTINEL_REPR_RE = re.compile(r"<object object at 0x[0-9a-fA-F]+>")
 
 
 def normalize_default_repr(default_repr: str | None) -> str | None:
-    """Strip the memory address from a captured default repr for stable comparison.
+    """Collapse a bare object() sentinel default repr to an address-free form.
 
     A bare object() sentinel default (e.g. the wait_for_completion
     initial_interval sentinel) reprs as <object object at 0xADDR>; the hex
     address differs between the baseline collector process and the current one,
-    so identical code would otherwise read as a changed default. Normalizing the
-    address lets two same-identity sentinels compare equal, while a genuine
-    default change (which differs in more than the address) is still caught.
+    so identical code would otherwise read as a changed default. Only the bare
+    object() sentinel (matching the whole repr) is normalized, so two
+    same-identity sentinels compare equal while every other default — including
+    an address-bearing instance or function repr — is left intact and a genuine
+    change is still caught.
     """
     if default_repr is None:
         return None
-    return _ADDRESS_RE.sub(" at 0x...", default_repr)
+    if _OBJECT_SENTINEL_REPR_RE.fullmatch(default_repr):
+        return "<object object at 0x...>"
+    return default_repr
 
 
 def collect_manifest(

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -362,6 +363,24 @@ main()
 """
 
 
+_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+
+
+def normalize_default_repr(default_repr: str | None) -> str | None:
+    """Strip the memory address from a captured default repr for stable comparison.
+
+    A bare object() sentinel default (e.g. the wait_for_completion
+    initial_interval sentinel) reprs as <object object at 0xADDR>; the hex
+    address differs between the baseline collector process and the current one,
+    so identical code would otherwise read as a changed default. Normalizing the
+    address lets two same-identity sentinels compare equal, while a genuine
+    default change (which differs in more than the address) is still caught.
+    """
+    if default_repr is None:
+        return None
+    return _ADDRESS_RE.sub(" at 0x...", default_repr)
+
+
 def collect_manifest(
     source_root: Path,
     extra_public_names: dict[str, list[str]] | None = None,
@@ -459,15 +478,10 @@ def _signature_breakage(old: dict[str, Any] | None, new: dict[str, Any] | None) 
                 return f"parameter {name!r} no longer accepts keyword calls"
             if old_param["has_default"] and not new_param["has_default"]:
                 return f"optional parameter {name!r} became required"
-            if (
-                old_param["has_default"]
-                and new_param["has_default"]
-                and old_param.get("default_repr") != new_param.get("default_repr")
-            ):
-                return (
-                    f"default for parameter {name!r} changed from "
-                    f"{old_param.get('default_repr')} to {new_param.get('default_repr')}"
-                )
+            old_default = normalize_default_repr(old_param.get("default_repr"))
+            new_default = normalize_default_repr(new_param.get("default_repr"))
+            if old_param["has_default"] and new_param["has_default"] and old_default != new_default:
+                return f"default for parameter {name!r} changed from {old_default} to {new_default}"
 
     old_positional = [param for param in old_params if _accepts_positional(param)]
     new_positional = [param for param in new_params if _accepts_positional(param)]

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -257,6 +257,31 @@ def test_signature_compare_rejects_default_value_change(script):
     )
 
 
+def test_signature_compare_ignores_object_sentinel_default_address(script):
+    # A bare ``object()`` sentinel default (e.g. wait_for_completion's
+    # initial_interval) reprs as "<object object at 0xADDR>"; the hex address
+    # differs between the baseline collector process and the current one, so
+    # identical code must NOT read as a changed default (the v0.7.0 baseline
+    # regression that this normalization fixes).
+    old = _signature(
+        _param("initial_interval", default=True, default_repr="<object object at 0x7f00aaaa>")
+    )
+    new = _signature(
+        _param("initial_interval", default=True, default_repr="<object object at 0x55bbbbbb>")
+    )
+
+    assert script._signature_breakage(old, new) is None
+
+
+def test_normalize_default_repr_strips_object_addresses(script):
+    a = script.normalize_default_repr("<object object at 0x7f001234>")
+    b = script.normalize_default_repr("<object object at 0x55009999>")
+    assert a == b == "<object object at 0x...>"
+    # a genuine default differs in more than the address and is preserved verbatim
+    assert script.normalize_default_repr("5") == "5"
+    assert script.normalize_default_repr(None) is None
+
+
 def test_signature_compare_rejects_positional_parameter_reordering(script):
     old = _signature(_param("notebook_id"), _param("title"), _param("content"))
     new = _signature(_param("notebook_id"), _param("content"), _param("title"))

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -280,6 +280,16 @@ def test_normalize_default_repr_strips_object_addresses(script):
     # a genuine default differs in more than the address and is preserved verbatim
     assert script.normalize_default_repr("5") == "5"
     assert script.normalize_default_repr(None) is None
+    # ONLY the bare object() sentinel is normalized — an address-bearing instance
+    # or function default is left intact, so a real change to it is still caught.
+    assert script.normalize_default_repr("<Foo object at 0x7f00>") == "<Foo object at 0x7f00>"
+    assert (
+        script._signature_breakage(
+            _signature(_param("cb", default=True, default_repr="<function f at 0x1>")),
+            _signature(_param("cb", default=True, default_repr="<function g at 0x2>")),
+        )
+        == "default for parameter 'cb' changed from <function f at 0x1> to <function g at 0x2>"
+    )
 
 
 def test_signature_compare_rejects_positional_parameter_reordering(script):


### PR DESCRIPTION
## What

The public-API compat audit (`scripts/audit_public_api_compat.py`) **fails on every PR/main run** now that v0.7.0 is the baseline — a **false positive**:

```
[changed-signature] notebooklm...research.wait_for_completion:
  default for parameter 'initial_interval' changed from
  <object object at 0x...> to <object object at 0x...>
```

## Root cause

- The `interval → initial_interval` deprecation (#1254, additive in 0.7.0) gave `ResearchAPI.wait_for_completion` an `initial_interval` default of a **bare `object()` sentinel** (`_INITIAL_INTERVAL_UNSET`).
- `repr(object())` is `<object object at 0xADDR>` — and the **hex address differs between the baseline collector subprocess and the current one**.
- v0.7.0 **is** main HEAD (the release commit), so the audit compares **identical code** and still reports a "changed default" purely because the two sentinel instances live at different addresses.

## Fix

Strip the memory address from captured default reprs **at comparison time** (`_signature_breakage`) — covering both snapshots, which are both produced by the inline `_COLLECTOR`. Two same-identity sentinels now compare equal; a genuine default change differs in more than the address and is **still caught**.

## Tests

- `test_signature_compare_ignores_object_sentinel_default_address` — the sentinel-address case is ignored.
- `test_normalize_default_repr_strips_object_addresses` — unit test of the helper (addresses stripped; real values preserved; `None` passthrough).
- The existing `test_signature_compare_rejects_default_value_change` still passes (real changes still flagged).

Verified: the audit now reports `OK: public API is compatible with v0.7.0`; 29 audit tests pass; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public API compatibility audits by normalizing ephemeral identifiers in default parameter values, reducing false-positive change detections across runs.

* **Tests**
  * Added unit tests to validate normalization of default-value representations and ensure signature comparisons remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->