### PR TITLE
feat(api)!: raise DecodingError on derived-read + lister drift (#1344)

### DIFF
--- a/src/notebooklm/_artifact/listing.py
+++ b/src/notebooklm/_artifact/listing.py
@@ -10,6 +10,7 @@ import httpx
 
 from .._row_adapters.artifacts import ArtifactRow
 from .._runtime.contracts import RpcCaller
+from ..exceptions import DecodingError
 from ..rpc import (
     FLASHCARDS_VARIANT,
     INTERACTIVE_MIND_MAP_VARIANT,
@@ -113,7 +114,14 @@ class ArtifactListingService:
                 return inner
         if isinstance(result, list):
             return result
-        return []
+        if not result:
+            return []
+        # A truthy non-list payload is schema drift, not an empty notebook —
+        # raise so callers can tell a miss from drift instead of an empty list.
+        raise DecodingError(
+            f"Unrecognized LIST_ARTIFACTS payload shape: {result!r}",
+            method_id=RPCMethod.LIST_ARTIFACTS.value,
+        )
 
     async def list_artifacts(
         self,
@@ -134,6 +142,10 @@ class ArtifactListingService:
                         artifact_type,
                     )
                 )
+            except DecodingError:
+                # Schema drift is not a transient outage: surface it (#1344)
+                # rather than masking drifted mind-map rows as "no mind maps".
+                raise
             except (RPCError, httpx.HTTPError) as e:
                 # Network/API errors - log and continue with studio artifacts.
                 # This ensures users can see audio/video/reports even if the

--- a/src/notebooklm/_artifact/listing.py
+++ b/src/notebooklm/_artifact/listing.py
@@ -119,7 +119,8 @@ class ArtifactListingService:
         # A truthy non-list payload is schema drift, not an empty notebook —
         # raise so callers can tell a miss from drift instead of an empty list.
         raise DecodingError(
-            f"Unrecognized LIST_ARTIFACTS payload shape: {result!r}",
+            "Unrecognized LIST_ARTIFACTS payload shape",
+            raw_response=repr(result),
             method_id=RPCMethod.LIST_ARTIFACTS.value,
         )
 

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -131,7 +131,8 @@ class NoteService:
             # notebook — raise so notes/mind_maps get()/get_or_none can tell a
             # miss from drift instead of silently collapsing to ``[]``.
             raise DecodingError(
-                f"Unrecognized GET_NOTES_AND_MIND_MAPS payload shape: {result!r}",
+                "Unrecognized GET_NOTES_AND_MIND_MAPS payload shape",
+                raw_response=repr(result),
                 method_id=RPCMethod.GET_NOTES_AND_MIND_MAPS.value,
             )
 

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -28,7 +28,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from ._row_adapters.notes import NoteRow
-from .exceptions import RPCError
+from .exceptions import DecodingError, RPCError
 from .rpc.types import RPCMethod
 from .types import Note
 
@@ -124,8 +124,16 @@ class NoteService:
         responses use the same first response field for rows and a second
         timestamp field, so this helper also accepts a flat row list.
         """
-        if not result or not isinstance(result, list):
+        if not result:
             return []
+        if not isinstance(result, list):
+            # A truthy non-list payload is schema drift, not a legitimately empty
+            # notebook — raise so notes/mind_maps get()/get_or_none can tell a
+            # miss from drift instead of silently collapsing to ``[]``.
+            raise DecodingError(
+                f"Unrecognized GET_NOTES_AND_MIND_MAPS payload shape: {result!r}",
+                method_id=RPCMethod.GET_NOTES_AND_MIND_MAPS.value,
+            )
 
         first = result[0]
         if self._is_note_row_like(first):

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any, ClassVar
 
 from .._types.common import _datetime_from_timestamp
+from ..exceptions import DecodingError
 from ..rpc import RPCMethod, safe_index
 from ..rpc.types import SourceStatus
 
@@ -525,3 +526,32 @@ class SourceRow:
             return SourceStatus(status_code)
         except ValueError:
             return SourceStatus.READY
+
+
+def interpret_source_freshness(result: Any) -> bool:
+    """Decode a ``CHECK_SOURCE_FRESHNESS`` payload into a freshness bool.
+
+    Shapes by source type: ``[]`` or ``[[null, true, [id]]]`` = fresh
+    (URL / Drive); bare ``True`` = fresh; bare ``False`` / ``[[null, false,
+    ...]]`` = stale. A recognized nested shape always yields a bool — including
+    the stale case, which returns ``False`` rather than falling through.
+
+    A structurally-unrecognized payload (``None``, a bare scalar, a list whose
+    first element is a non-list scalar like ``["x"]``, or a nested list too
+    short to carry the flag at index ``[1]``) is schema drift, not "stale":
+    raise ``DecodingError`` so callers can tell a miss from drift (#1344).
+    """
+    if result is True:
+        return True
+    if result is False:
+        return False
+    if isinstance(result, list):
+        if len(result) == 0:
+            return True  # empty array = fresh
+        first = result[0]
+        if isinstance(first, list) and len(first) > 1:
+            return first[1] is True
+    raise DecodingError(
+        f"Unrecognized CHECK_SOURCE_FRESHNESS payload shape: {result!r}",
+        method_id=RPCMethod.CHECK_SOURCE_FRESHNESS.value,
+    )

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -533,13 +533,16 @@ def interpret_source_freshness(result: Any) -> bool:
 
     Shapes by source type: ``[]`` or ``[[null, true, [id]]]`` = fresh
     (URL / Drive); bare ``True`` = fresh; bare ``False`` / ``[[null, false,
-    ...]]`` = stale. A recognized nested shape always yields a bool — including
-    the stale case, which returns ``False`` rather than falling through.
+    ...]]`` = stale. A recognized nested shape carries a *boolean* flag at index
+    ``[1]`` (``True`` = fresh, ``False`` = stale).
 
-    A structurally-unrecognized payload (``None``, a bare scalar, a list whose
-    first element is a non-list scalar like ``["x"]``, or a nested list too
-    short to carry the flag at index ``[1]``) is schema drift, not "stale":
-    raise ``DecodingError`` so callers can tell a miss from drift (#1344).
+    Anything else is schema drift, not "stale": ``None``, a bare scalar, a list
+    whose first element is a non-list scalar like ``["x"]``, a nested list too
+    short to carry the flag, or a nested list whose flag is *non-boolean* (e.g.
+    ``[[null, null, ...]]``). Raise ``DecodingError`` so callers can tell a miss
+    from drift (#1344). The payload is passed via ``raw_response`` so the
+    existing scrub/truncate preview applies instead of leaking it into the
+    message.
     """
     if result is True:
         return True
@@ -550,8 +553,12 @@ def interpret_source_freshness(result: Any) -> bool:
             return True  # empty array = fresh
         first = result[0]
         if isinstance(first, list) and len(first) > 1:
-            return first[1] is True
+            if first[1] is True:
+                return True
+            if first[1] is False:
+                return False
     raise DecodingError(
-        f"Unrecognized CHECK_SOURCE_FRESHNESS payload shape: {result!r}",
+        "Unrecognized CHECK_SOURCE_FRESHNESS payload shape",
+        raw_response=repr(result),
         method_id=RPCMethod.CHECK_SOURCE_FRESHNESS.value,
     )

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -13,6 +13,7 @@ import httpx
 
 from ._deprecation import future_errors_enabled
 from ._lookup import resolve_get
+from ._row_adapters.sources import interpret_source_freshness
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._runtime.contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
@@ -709,6 +710,11 @@ class SourcesAPI:
 
         Returns:
             True if source is fresh, False if it needs refresh.
+
+        Raises:
+            DecodingError: If the freshness payload has a structurally
+                unrecognized shape (schema drift) — so callers can tell a miss
+                from drift instead of a silent "stale" (#1344).
         """
         params = [None, [source_id], [2]]
         result = await self._rpc.rpc_call(
@@ -717,21 +723,7 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        # Shapes by source type: ``[]`` or ``[[null, true, [id]]]`` = fresh
-        # (URL / Drive); bare ``True`` = fresh; bare ``False`` = stale.
-        if result is True:
-            return True
-        if result is False:
-            return False
-        if isinstance(result, list):
-            # Empty array means fresh
-            if len(result) == 0:
-                return True
-            # Check for nested structure [[null, true, ...]] from Drive sources
-            first = result[0]
-            if isinstance(first, list) and len(first) > 1 and first[1] is True:
-                return True
-        return False
+        return interpret_source_freshness(result)
 
     async def get_guide(self, notebook_id: str, source_id: str) -> SourceGuide:
         """Get AI-generated summary and keywords for a specific source.

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -67,7 +67,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_artifacts.py": 1420,
     "_source/upload.py": 1236,
     "cli/session_cmd.py": 1080,
-    "_sources.py": 1023,
+    "_sources.py": 1015,
     "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,

--- a/tests/_guardrails/test_v080_deprecation_coverage.py
+++ b/tests/_guardrails/test_v080_deprecation_coverage.py
@@ -190,6 +190,11 @@ V080_BREAKING_CHANGES: tuple[BreakingChange, ...] = (
         summary="mutate-existing fail-loud (notes.update + rename(return_object=False) raise on miss)",
         exemption=_DELIBERATE_CLEAN_BREAK,
     ),
+    BreakingChange(
+        issue=1344,
+        summary="derived-read + lister drift-tightening: malformed payloads raise DecodingError",
+        exemption=_DELIBERATE_CLEAN_BREAK,
+    ),
 )
 
 
@@ -386,26 +391,30 @@ def test_issue_numbers_are_unique() -> None:
     assert dupes == [], f"duplicate issue numbers in V080_BREAKING_CHANGES: {dupes}"
 
 
-def test_three_silent_breaks_are_exempted_today() -> None:
-    """#1290 / #1342 / #1362 are the *only* exemptions and are reason-tagged.
+def test_silent_break_exemptions_match_baseline() -> None:
+    """The value-level silent breaks are exactly the reason-tagged exemptions.
 
-    Pins today's baseline: the three value-level behavioral breaks are exempted
-    (green on main), and the exemption set is *exactly* those three. If a future
-    break is exempted, this test fails and forces a review of whether it truly
-    cannot be runwayed (the set is meant to shrink, not grow). If one of the
-    three gains a runway, this also fails — a prompt to drop it from the
-    exemption baseline.
+    Pins today's baseline: the value-level behavioral breaks that cannot ship a
+    v0.7.0 warning runway are exempted (green on main), and the exemption set is
+    *exactly* this list. If a future break is exempted, this test fails and forces
+    a review of whether it truly cannot be runwayed (the set is meant to shrink,
+    not grow). If one of these gains a runway, this also fails — a prompt to drop
+    it from the exemption baseline.
+
+    #1344 (derived-read / lister drift -> DecodingError) joins the original three
+    (#1290 / #1342 / #1362): a "this future payload shape will be rejected" break
+    has no value-level warning it could emit in v0.7.0, so it is a clean break.
     """
     # Match ``_tag``'s blank-reason handling: a whitespace-only exemption is "no
     # reason" (it would already fail ``test_every_entry_is_runwayed_or_exempted``),
     # so it must not be counted toward the baseline here either.
     exempted = sorted(c.issue for c in V080_BREAKING_CHANGES if c.exemption and c.exemption.strip())
-    assert exempted == [1290, 1342, 1362], (
+    assert exempted == [1290, 1342, 1344, 1362], (
         "The v0.8.0 silent-break exemption set changed. It is meant to SHRINK as "
         "runways are added, never to grow silently. If you added a NEW exemption, "
         "confirm in review that the break genuinely cannot warn at the value level "
-        "(ADR-0019) before updating this baseline; if you RUNWAYED one of the "
-        f"three, drop it here. Current exemptions: {exempted}"
+        "(ADR-0019) before updating this baseline; if you RUNWAYED one, drop it "
+        f"here. Current exemptions: {exempted}"
     )
 
 

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -18,7 +18,7 @@ from pytest_httpx import HTTPXMock
 
 import notebooklm._sources as _sources_mod
 from notebooklm import NotebookLMClient, Source, SourceType
-from notebooklm.exceptions import RPCError
+from notebooklm.exceptions import DecodingError, RPCError
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import SourceAddError, SourceNotFoundError
 
@@ -1888,41 +1888,42 @@ class TestAddDriveWait:
 
 
 class TestCheckFreshnessEdgeCases:
-    """Tests for check_freshness() edge cases (lines 624, 657->667, 659->667)."""
+    """check_freshness() shape handling: recognized shapes yield a bool;
+    genuinely-unrecognized shapes raise DecodingError (drift, #1344)."""
 
     @pytest.mark.asyncio
-    async def test_check_freshness_none_result_returns_false(
+    async def test_check_freshness_none_result_raises_decoding_error(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test check_freshness() returns False when result is None (line 624)."""
-        # None is not True, not False, not a list - falls through to return False
+        """None is not a recognized freshness signal -> drift (#1344)."""
+        # None is not True/False/list - structurally unrecognized, so we can't
+        # tell fresh from stale: raise rather than silently report "stale".
         response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, None)
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
-
-        assert is_fresh is False
+            with pytest.raises(DecodingError):
+                await client.sources.check_freshness("nb_123", "src_001")
 
     @pytest.mark.asyncio
-    async def test_check_freshness_list_first_element_not_list(
+    async def test_check_freshness_list_first_element_not_list_raises(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test check_freshness() returns False when result list's first item is not a list (line 624)."""
-        # result is ["some_string"] - first is a string, isinstance(first, list) is False
+        """A list whose first element is a non-list scalar is drift (#1344)."""
+        # result is ["some_value"] - first is a string, not a nested freshness
+        # row: the canonical "genuinely unrecognized" shape.
         response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, ["some_value"])
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
-
-        assert is_fresh is False
+            with pytest.raises(DecodingError):
+                await client.sources.check_freshness("nb_123", "src_001")
 
     @pytest.mark.asyncio
     async def test_check_freshness_drive_nested_false_value(
@@ -1931,8 +1932,9 @@ class TestCheckFreshnessEdgeCases:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test check_freshness() returns False when nested Drive structure has first[1] != True (lines 657->667, 659->667)."""
-        # result is [[None, False, ...]] - first[1] is False, not True
+        """Recognized stale Drive shape [[None, False, ...]] still returns False."""
+        # result is [[None, False, ...]] - first[1] is False: a recognized stale
+        # shape, NOT drift. Must stay False (does not raise).
         response = build_rpc_response(
             RPCMethod.CHECK_SOURCE_FRESHNESS, [[None, False, ["src_001"]]]
         )
@@ -1944,21 +1946,21 @@ class TestCheckFreshnessEdgeCases:
         assert is_fresh is False
 
     @pytest.mark.asyncio
-    async def test_check_freshness_drive_nested_list_too_short(
+    async def test_check_freshness_drive_nested_list_too_short_raises(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test check_freshness() returns False when nested Drive list has only one element."""
-        # result is [[None]] - first has only 1 element, so len(first) > 1 check fails
+        """A nested list too short to carry the freshness flag is drift (#1344)."""
+        # result is [[None]] - first has only 1 element, so we can't read the
+        # freshness flag at first[1]: unrecognized shape -> raise.
         response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, [[None]])
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
-
-        assert is_fresh is False
+            with pytest.raises(DecodingError):
+                await client.sources.check_freshness("nb_123", "src_001")
 
 
 class TestGetFulltextEdgeCases:

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -748,6 +748,11 @@ class TestDownloadMindMap:
                 "list_mind_maps",
                 new=AsyncMock(return_value=[["other_id", [None, "{}"], None, None, "Other"]]),
             ),
+            # The studio backend is empty; the requested id is absent from the
+            # note-backed list above, so the lookup misses across both backends.
+            # (_list_raw must resolve to a real empty list, not the fixture's bare
+            # AsyncMock, which now reads as drift -> DecodingError per #1344.)
+            patch.object(api._downloads, "_list_raw", new=AsyncMock(return_value=[])),
             pytest.raises(ArtifactNotFoundError),
         ):
             await api.download_mind_map("nb_123", "/tmp/mindmap.json", artifact_id="mindmap_001")

--- a/tests/unit/test_artifact_listing.py
+++ b/tests/unit/test_artifact_listing.py
@@ -1,0 +1,90 @@
+"""Direct shape-handling tests for ``ArtifactListingService.list_raw``.
+
+The listing service collapses recognized payload shapes (a wrapped
+``[[row, ...]]`` envelope, an already-flat row list, or an empty/None payload)
+into a list of rows. A truthy *non-list* payload is schema drift, not an empty
+notebook — ``list_raw`` raises ``DecodingError`` so callers can tell a miss from
+drift instead of silently collapsing to ``[]`` (#1344).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notebooklm._artifact.listing import ArtifactListingService
+from notebooklm.exceptions import DecodingError, RPCError
+
+
+class _FakeRpc:
+    """Minimal ``RpcCaller`` returning a fixed payload from ``rpc_call``."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def rpc_call(self, *args: Any, **kwargs: Any) -> Any:
+        return self._payload
+
+
+async def _list_raw(payload: Any) -> list[Any]:
+    return await ArtifactListingService().list_raw("nb_123", rpc=_FakeRpc(payload))
+
+
+class TestListRawShapeHandling:
+    """Recognized shapes yield rows; drift raises (#1344)."""
+
+    @pytest.mark.asyncio
+    async def test_wrapped_envelope_unwraps_to_inner_rows(self) -> None:
+        rows = [["a", "Audio"], ["b", "Video"]]
+        assert await _list_raw([rows]) == rows
+
+    @pytest.mark.asyncio
+    async def test_flat_row_list_returned_as_is(self) -> None:
+        rows = [["a", "Audio"], ["b", "Video"]]
+        assert await _list_raw(rows) == rows
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [None, [], False])
+    async def test_falsy_payload_is_empty_list(self, payload: Any) -> None:
+        # An empty / missing payload is a legitimately empty notebook, not drift.
+        assert await _list_raw(payload) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", ["drift-string", {"oops": 1}, 7])
+    async def test_truthy_non_list_payload_raises(self, payload: Any) -> None:
+        with pytest.raises(DecodingError):
+            await _list_raw(payload)
+
+
+class TestListArtifactsMindMapSubFetch:
+    """The secondary mind-map fetch fails loud on drift but degrades on outage (#1344)."""
+
+    @pytest.mark.asyncio
+    async def test_mind_map_drift_propagates(self) -> None:
+        async def _empty_raw(_nb: str) -> list[Any]:
+            return []
+
+        async def _drifting_mind_maps(_nb: str) -> list[Any]:
+            raise DecodingError("drift", method_id="cFji9")
+
+        # Drift in the mind-map sub-fetch must not be masked as "no mind maps".
+        with pytest.raises(DecodingError):
+            await ArtifactListingService().list_artifacts(
+                "nb_123", None, list_raw=_empty_raw, list_mind_maps=_drifting_mind_maps
+            )
+
+    @pytest.mark.asyncio
+    async def test_transient_mind_map_outage_degrades_to_studio(self) -> None:
+        async def _empty_raw(_nb: str) -> list[Any]:
+            return []
+
+        async def _unavailable_mind_maps(_nb: str) -> list[Any]:
+            raise RPCError("mind-map endpoint temporarily unavailable")
+
+        # A transient outage in the secondary fetch still degrades gracefully:
+        # the studio artifacts (here none) are returned rather than raising.
+        result = await ArtifactListingService().list_artifacts(
+            "nb_123", None, list_raw=_empty_raw, list_mind_maps=_unavailable_mind_maps
+        )
+        assert result == []

--- a/tests/unit/test_get_returns_none_deprecation.py
+++ b/tests/unit/test_get_returns_none_deprecation.py
@@ -131,7 +131,10 @@ class TestWarnGetReturnsNone:
 def notes_api():
     from _fixtures.fake_core import make_fake_core
 
-    core = make_fake_core(rpc_call=AsyncMock())
+    # ``None`` is the empty-notebook payload (``fetch_note_rows`` resolves it to
+    # ``[]``) — the realistic miss shape. A truthy non-list payload would now
+    # raise ``DecodingError`` as drift (#1344), so it can no longer mean "empty".
+    core = make_fake_core(rpc_call=AsyncMock(return_value=None))
     note_service = NoteService(core)
     mind_maps = NoteBackedMindMapService(note_service)
     return NotesAPI(

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -22,7 +22,7 @@ import pytest
 
 from _fixtures.fake_core import FakeSession, make_fake_core
 from notebooklm._note_service import NoteRowKind, NoteService
-from notebooklm.exceptions import RPCError
+from notebooklm.exceptions import DecodingError, RPCError
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import Note
 
@@ -80,6 +80,18 @@ class TestFetchNoteRows:
     ) -> None:
         mock_session.rpc_executor.rpc_call.return_value = payload
         assert await service.fetch_note_rows("nb_123") == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", ["drift-string", {"oops": 1}, 42])
+    async def test_fetch_note_rows_raises_on_truthy_non_list_drift(
+        self, service: NoteService, mock_session: FakeSession, payload: object
+    ) -> None:
+        # A truthy non-list payload is schema drift, not an empty notebook (#1344):
+        # raise so notes/mind_maps get()/get_or_none can tell a miss from drift
+        # instead of silently collapsing to ``[]``.
+        mock_session.rpc_executor.rpc_call.return_value = payload
+        with pytest.raises(DecodingError):
+            await service.fetch_note_rows("nb_123")
 
     @pytest.mark.asyncio
     async def test_fetch_note_rows_accepts_flat_row_container(

--- a/tests/unit/test_public_api_behavior.py
+++ b/tests/unit/test_public_api_behavior.py
@@ -109,7 +109,11 @@ def _make_artifacts_api() -> ArtifactsAPI:
 def _make_notes_api() -> NotesAPI:
     from _fixtures.fake_core import make_fake_core
 
-    core = make_fake_core(rpc_call=AsyncMock())
+    # ``None`` is the empty-notebook payload (a notebook with no notes); it is
+    # the realistic miss shape that ``fetch_note_rows`` resolves to ``[]``. A
+    # truthy non-list payload would now raise ``DecodingError`` as drift (#1344),
+    # so it can no longer stand in for "empty".
+    core = make_fake_core(rpc_call=AsyncMock(return_value=None))
     note_service = NoteService(core)
     mind_maps = NoteBackedMindMapService(note_service)
     return NotesAPI(notes=note_service, mind_maps=mind_maps)
@@ -150,8 +154,8 @@ def _arrange_list_miss(api: object) -> None:
     ``_get_all_notes_and_mind_maps`` → ``fetch_note_rows``, **not** ``self.list``,
     so the assigned ``api.list`` stub is a harmless no-op for it. The notes miss
     comes from its factory (``_make_notes_api``) wiring a fake core whose
-    ``rpc_call`` returns a non-list ``MagicMock`` that ``fetch_note_rows``'
-    container-extraction treats as empty — so the ``get`` still misses. Keeping
+    ``rpc_call`` returns ``None`` — the empty-notebook payload that
+    ``fetch_note_rows`` resolves to ``[]`` — so the ``get`` still misses. Keeping
     one shared arranger across all four rows is deliberate: it stays a single
     table lever even though one namespace reaches the empty result by a different
     internal path.

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1719,9 +1719,21 @@ class TestInterpretSourceFreshness:
     def test_stale_shapes_return_false(self, payload: object) -> None:
         assert interpret_source_freshness(payload) is False
 
-    @pytest.mark.parametrize("payload", [None, "some_value", ["some_value"], [[None]]])
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            "some_value",
+            ["some_value"],
+            [[None]],
+            [[None, "unexpected", ["src"]]],
+            [[None, None, ["src"]]],
+            [[None, 1, ["src"]]],
+        ],
+    )
     def test_unrecognized_shapes_raise(self, payload: object) -> None:
         # None, a bare scalar, a list whose first element is a non-list scalar,
-        # and a too-short nested list are all drift -> raise, not a silent bool.
+        # a too-short nested list, and a nested list whose freshness flag is
+        # non-boolean are all drift -> raise, not a silent bool.
         with pytest.raises(DecodingError):
             interpret_source_freshness(payload)

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -34,8 +34,12 @@ import pytest
 
 from notebooklm._row_adapters.artifacts import ArtifactRow
 from notebooklm._row_adapters.notes import NoteRow
-from notebooklm._row_adapters.sources import SourceRow, SourceRowShape
-from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm._row_adapters.sources import (
+    SourceRow,
+    SourceRowShape,
+    interpret_source_freshness,
+)
+from notebooklm.exceptions import DecodingError, UnknownRPCMethodError
 from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode, SourceStatus
 
 # ---------------------------------------------------------------------------
@@ -1702,3 +1706,22 @@ class TestSourceRowImmutability:
         _ = row.has_id
 
         assert raw == snapshot
+
+
+class TestInterpretSourceFreshness:
+    """Decodes recognized freshness shapes; raises ``DecodingError`` on drift (#1344)."""
+
+    @pytest.mark.parametrize("payload", [True, [], [[None, True, ["src"]]]])
+    def test_fresh_shapes_return_true(self, payload: object) -> None:
+        assert interpret_source_freshness(payload) is True
+
+    @pytest.mark.parametrize("payload", [False, [[None, False, ["src"]]]])
+    def test_stale_shapes_return_false(self, payload: object) -> None:
+        assert interpret_source_freshness(payload) is False
+
+    @pytest.mark.parametrize("payload", [None, "some_value", ["some_value"], [[None]]])
+    def test_unrecognized_shapes_raise(self, payload: object) -> None:
+        # None, a bare scalar, a list whose first element is a non-list scalar,
+        # and a too-short nested list are all drift -> raise, not a silent bool.
+        with pytest.raises(DecodingError):
+            interpret_source_freshness(payload)


### PR DESCRIPTION
## What

Three RPC "derived-read / lister" sites now raise `DecodingError` on a
*structurally-unrecognized* payload shape instead of silently collapsing to
`False` / `[]`, so callers can distinguish a genuine miss from server-side
schema drift (#1344):

- **`sources.check_freshness()`** — drift raises; recognized shapes keep their
  bool (`True` / `[]` / `[[null, true, …]]` → fresh,
  `False` / `[[null, false, …]]` → stale).
- **the note lister** (`NoteService._extract_note_row_container`) — a *truthy
  non-list* payload raises; `None` / `[]` still mean an empty notebook (`[]`).
- **the artifact raw lister** (`ArtifactListingService.list_raw`) — same: a
  truthy non-list raises, a falsy payload returns `[]`.

The uniform-empty derived-read contract (`get_summary` / `get_description` /
`get_guide` → empty, `get_tree` → `None`) and the `research.poll` NOT_FOUND
sentinel are unchanged.

## Why

A malformed payload that silently becomes empty hides schema drift behind a
"not found". Raising lets `notes` / `mind_maps` `get()`/`get_or_none()` and the
freshness check tell a real miss from drift — the consistent fail-loud contract
ADR-0019 is converging the SDK toward.

## Notes

- The freshness shape-interpretation is extracted into a new module-level helper
  `interpret_source_freshness()` in `_row_adapters/sources.py` — the right layer
  for positional-RPC decoding — which also keeps the over-budget `_sources.py`
  under its module-size ratchet (ceiling lowered 1023 → 1015).
- The mind-map sub-fetch in `list_artifacts` still degrades gracefully on a
  *transient* outage (`RPCError` / `HTTPError`), but now re-raises `DecodingError`
  so drift in the secondary fetch is surfaced rather than masked as "no mind
  maps" — matching the swallow's own "temporarily unavailable" intent.
- Deliberate clean break (no value-level warning is possible for "this future
  payload shape will be rejected"), tracked as an exempted entry in the v0.8.0
  breaking-changes registry. Return types are unchanged, so the public-API compat
  audit needs no allowlist entry.

## Tests

- Direct unit coverage for `interpret_source_freshness` (recognized → bool,
  drift → raise), the note/artifact listers (truthy non-list → raise), and
  `list_artifacts` (mind-map drift propagates; transient outage still degrades).
- `check_freshness` integration tests flip the drift shapes to expect
  `DecodingError` while keeping recognized-stale → `False`.
- Full suite green; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter handling of malformed API responses for artifact listings, notes retrieval, and source-freshness checks: unexpected payload shapes now surface explicit decoding errors instead of being treated as empty results.

* **Tests**
  * Expanded unit and integration tests to cover stricter decoding behavior, freshness interpretation, and artifact-listing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->