### PR TITLE
feat(cli)!: default `generate mind-map` to interactive (#1272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ notebooklm generate quiz --difficulty hard
 notebooklm generate flashcards --quantity more
 notebooklm generate slide-deck
 notebooklm generate infographic --orientation portrait
-notebooklm generate mind-map --kind interactive   # newer studio map; note-backed JSON is the default kind
+notebooklm generate mind-map                       # interactive studio map (default); --kind note-backed for the JSON tree
 notebooklm generate data-table "compare key concepts"
 
 # 5. Download artifacts

--- a/SKILL.md
+++ b/SKILL.md
@@ -304,14 +304,14 @@ All generate commands support:
 | Slide Revision | `generate revise-slide "prompt" --artifact <id> --slide N` | `--wait`, `--notebook` | *(re-downloads parent deck)* |
 | Infographic | `generate infographic` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]` | .png |
 | Report | `generate report` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"` (¹) | .md |
-| Mind Map | `generate mind-map` | `--kind [interactive\|note-backed]` (³) *(default: note-backed; flips to interactive in v0.8.0)* | .json |
+| Mind Map | `generate mind-map` | `--kind [interactive\|note-backed]` (³) *(default: interactive)* | .json |
 | Data Table | `generate data-table` | description required | .csv |
 | Quiz | `generate quiz` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]` | .json/.md/.html |
 | Flashcards | `generate flashcards` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]` | .json/.md/.html |
 
 ¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
 
-³ **Two kinds of mind map (issue #1256).** `generate mind-map --kind note-backed` (today's default) creates the **note-backed** kind — a JSON node tree, generated synchronously. `generate mind-map --kind interactive` creates the newer **interactive** studio artifact (what the web app now makes); it is polled to completion. Both emit the same `{mind_map, note_id, kind}` JSON, list under `artifact list --type mind-map`, and export via `download mind-map`. `--instructions` applies only to the note-backed kind. **The default `--kind` switches to `interactive` in v0.8.0**; omitting `--kind` prints a one-time stderr notice (silence with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`).
+³ **Two kinds of mind map (issue #1256).** `generate mind-map --kind interactive` (the default) creates the **interactive** studio artifact (what the web app now makes); it is polled to completion. `generate mind-map --kind note-backed` creates the **note-backed** kind — a JSON node tree, generated synchronously. Both emit the same `{mind_map, note_id, kind}` JSON, list under `artifact list --type mind-map`, and export via `download mind-map`. `--instructions` applies only to the note-backed kind.
 
 ⁴ **Cinematic video (Veo 3).** `generate video --format cinematic` generates AI documentary footage via Veo 3; it **ignores `--style`**, takes ~30-40 min, and requires a Google AI Ultra subscription. Also exposed as the `generate cinematic-video` alias (which forces `--format cinematic` and a longer default timeout). Download with `download video` or the `download cinematic-video` alias.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -209,9 +209,7 @@ Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`,
 | `mind-map` | - | `--kind [interactive\|note-backed]`, `--instructions TEXT` *(no `--wait` / `--timeout` / `--interval` / `--retry` / `--prompt-file`)* | `generate mind-map --kind interactive` |
 | `report [description]` | Instructions | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append TEXT` (no effect with `--format custom`) | `generate report --format study-guide` |
 
-> **Two kinds of mind map (issue #1256).** NotebookLM has two distinct mind-map objects. `generate mind-map --kind note-backed` (today's default) builds the **note-backed** kind — a JSON node tree stored as a note, generated synchronously. `generate mind-map --kind interactive` builds the newer **interactive** kind — a studio artifact (the one the web app now creates) that is polled to completion. Both produce the same `{mind_map, note_id, kind}` output, appear in `artifact list --type mind-map`, and download via `download mind-map`. `--instructions` applies only to the note-backed kind (ignored with a warning for interactive).
->
-> **The default `--kind` switches to `interactive` in v0.8.0** (NotebookLM's web app already creates interactive maps). Until then, omitting `--kind` prints a one-time transition notice to stderr — pass `--kind` explicitly to pin your choice, or set `NOTEBOOKLM_QUIET_DEPRECATIONS=1` to silence it.
+> **Two kinds of mind map (issue #1256).** NotebookLM has two distinct mind-map objects. `generate mind-map --kind interactive` (the default) builds the **interactive** kind — a studio artifact (the one the web app now creates) that is polled to completion. `generate mind-map --kind note-backed` builds the **note-backed** kind — a JSON node tree stored as a note, generated synchronously. Both produce the same `{mind_map, note_id, kind}` output, appear in `artifact list --type mind-map`, and download via `download mind-map`. `--instructions` applies only to the note-backed kind (ignored with a warning for interactive).
 
 ### Artifact Commands (`notebooklm artifact <cmd>`)
 

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -796,12 +796,11 @@ def generate_data_table(
     "--kind",
     "map_kind",
     type=click.Choice(["interactive", "note-backed"]),
-    default="note-backed",
+    default="interactive",
     show_default=True,
     help=(
         "Which mind map to generate: 'interactive' (studio artifact, polled to "
-        "completion) or 'note-backed' (JSON tree, synchronous). The default "
-        "becomes 'interactive' in v0.8.0."
+        "completion) or 'note-backed' (JSON tree, synchronous)."
     ),
 )
 @json_option
@@ -813,14 +812,10 @@ def generate_mind_map(
 
     \b
     Two kinds (issue #1256):
-      --kind note-backed   JSON tree, synchronous (default)
-      --kind interactive   interactive studio artifact, polled to completion
+      --kind interactive   interactive studio artifact, polled to completion (default)
+      --kind note-backed   JSON tree, synchronous
     Both export the same JSON node tree via 'download mind-map'.
-
-    \b
-    Heads up: the default --kind will switch to 'interactive' in v0.8.0
-    (NotebookLM's web app already creates interactive maps). Pass --kind
-    explicitly to pin your choice. --instructions applies to note-backed only.
+    --instructions applies to note-backed only.
 
     \b
     Use --json for machine-readable output.

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -35,7 +35,6 @@ and is reused as-is).
 from __future__ import annotations
 
 import contextlib
-import os
 from collections.abc import Callable, Mapping
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
@@ -234,10 +233,9 @@ class GenerationPlan:
         params: Kind-specific keyword arguments forwarded to the
             ``client.artifacts.<method>`` call. Already enum-mapped.
         warnings: Informational stderr warnings queued during plan
-            construction (e.g. ``--append`` with ``--format custom``, or the
-            v0.8.0 mind-map default-kind transition notice). Emitted in order
-            before the API call, but **only in human (non-JSON) mode** so they
-            never pollute machine-readable output.
+            construction (e.g. ``--append`` with ``--format custom``). Emitted
+            in order before the API call, but **only in human (non-JSON) mode**
+            so they never pollute machine-readable output.
         stderr_warnings: Behavioral warnings that must surface even under
             ``--json`` because they describe an input the CLI actually dropped
             (e.g. ``--instructions`` ignored for interactive mind maps).
@@ -630,24 +628,13 @@ def _build_data_table_plan(
     )
 
 
-# Env contract mirrored from ``notebooklm._deprecation._deprecations_quiet``.
-# The CLI may not import the private ``_deprecation`` module (the CLI-boundary
-# guard in ``tests/unit/test_cli_boundary.py``), so the truthy spelling set is
-# kept in sync here. Used only to silence the v0.8.0 mind-map transition notice.
-_QUIET_DEPRECATIONS_ENV = "NOTEBOOKLM_QUIET_DEPRECATIONS"
-
-
-def _deprecations_quieted() -> bool:
-    return os.environ.get(_QUIET_DEPRECATIONS_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
 def _build_mind_map_plan(
     raw_args: Mapping[str, Any],
-    parameter_explicit: Callable[[str], bool],
+    _source: Callable[[str], bool],
     resolve_language: Callable[[str | None], str],
 ) -> GenerationPlan:
     common = _common(raw_args)
-    map_kind = raw_args.get("map_kind") or "note-backed"
+    map_kind = raw_args.get("map_kind") or "interactive"
     interactive = map_kind == "interactive"
     instructions = raw_args.get("instructions")
     # The interactive (studio-artifact) generator takes only sources — it has no
@@ -655,7 +642,6 @@ def _build_mind_map_plan(
     # *behavioral* (we actually drop the user's --instructions), so it goes to
     # stderr_warnings and surfaces even under --json — silently ignoring an
     # explicit input would be a nasty surprise for scripted callers.
-    warnings: list[str] = []
     stderr_warnings: list[str] = []
     if interactive and instructions:
         stderr_warnings.append(
@@ -663,19 +649,6 @@ def _build_mind_map_plan(
             "(the interactive generator does not accept custom instructions)."
         )
         instructions = None
-    # Managed transition (issue #1256): the default kind flips to interactive in
-    # v0.8.0. Nudge users who did not pick a kind so the switch isn't a surprise.
-    # Suppressible via NOTEBOOKLM_QUIET_DEPRECATIONS; this is an *informational*
-    # notice (no input was dropped), so it stays in ``warnings`` and the plan
-    # layer suppresses it in --json mode to keep machine-readable output clean.
-    if not parameter_explicit("map_kind") and not _deprecations_quieted():
-        warnings.append(
-            "Note: 'generate mind-map' defaults to the note-backed kind today, but "
-            "the default switches to interactive in v0.8.0 (NotebookLM's web app "
-            "already creates interactive maps). Pass --kind note-backed or "
-            "--kind interactive to pin your choice; set NOTEBOOKLM_QUIET_DEPRECATIONS=1 "
-            "to silence."
-        )
     return GenerationPlan(
         kind="mind-map",
         display_name=_DISPLAY_NAME["mind-map"],
@@ -689,7 +662,6 @@ def _build_mind_map_plan(
         max_retries=0,
         json_output=common["json_output"],
         params={"instructions": instructions, "kind": map_kind},
-        warnings=tuple(warnings),
         stderr_warnings=tuple(stderr_warnings),
     )
 

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -72,7 +72,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_artifact/downloads.py": 973,
     "client.py": 973,
     "_research.py": 969,
-    "cli/services/generate.py": 954,
+    "cli/services/generate.py": 926,
     "_chat/api.py": 948,
     "_idempotency.py": 936,
 }

--- a/tests/_guardrails/test_v080_deprecation_coverage.py
+++ b/tests/_guardrails/test_v080_deprecation_coverage.py
@@ -165,15 +165,6 @@ V080_BREAKING_CHANGES: tuple[BreakingChange, ...] = (
             symbol="deprecated_kwarg",
         ),
     ),
-    BreakingChange(
-        issue=1272,
-        summary="flip `generate mind-map` default --kind to interactive",
-        runway=Runway(
-            module="cli/services/generate.py",
-            description="omitting --kind prints a stderr transition notice about the v0.8.0 switch",
-            notice="default switches to interactive in v0.8.0",
-        ),
-    ),
     # ---- Exempted today (no clean value-level warning; shrink this set) -----
     BreakingChange(
         issue=1290,

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -4932,10 +4932,10 @@
           }
         },
         {
-          "default": "note-backed",
+          "default": "interactive",
           "envvar": null,
           "has_custom_shell_complete": false,
-          "help": "Which mind map to generate: 'interactive' (studio artifact, polled to completion) or 'note-backed' (JSON tree, synchronous). The default becomes 'interactive' in v0.8.0.",
+          "help": "Which mind map to generate: 'interactive' (studio artifact, polled to completion) or 'note-backed' (JSON tree, synchronous).",
           "is_flag": false,
           "kind": "option",
           "multiple": false,

--- a/tests/integration/cli_vcr/test_generate.py
+++ b/tests/integration/cli_vcr/test_generate.py
@@ -86,6 +86,8 @@ class TestGenerateCommands:
                 [
                     "generate",
                     "mind-map",
+                    "--kind",
+                    "note-backed",
                     "-n",
                     "bb00c9e3-656c-4fd2-b890-2b71e1cf3814",
                     "--source",

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -718,7 +718,8 @@ class TestGenerateInfographic:
 
 
 class TestGenerateMindMap:
-    def test_generate_mind_map(self, runner, mock_auth):
+    def test_generate_mind_map_note_backed(self, runner, mock_auth):
+        """--kind note-backed routes through client.artifacts.generate_mind_map."""
         with patch("notebooklm.cli.generate_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.generate_mind_map = AsyncMock(
@@ -732,9 +733,13 @@ class TestGenerateMindMap:
                 "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
             ) as mock_fetch:
                 mock_fetch.return_value = ("csrf", "session")
-                result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
+                result = runner.invoke(
+                    cli, ["generate", "mind-map", "--kind", "note-backed", "-n", "nb_123"]
+                )
 
             assert result.exit_code == 0
+            mock_client.artifacts.generate_mind_map.assert_awaited_once()
+            mock_client.mind_maps.generate.assert_not_called()
 
     def test_generate_mind_map_interactive(self, runner, mock_auth):
         """--interactive routes through client.mind_maps.generate(kind=INTERACTIVE)."""
@@ -897,13 +902,18 @@ class TestGenerateMindMap:
             mock_client.mind_maps.generate.assert_awaited_once()
             assert not mock_client.mind_maps.generate.await_args.kwargs.get("instructions")
 
-    def test_generate_mind_map_default_kind_emits_transition_notice(self, runner, mock_auth):
-        """Omitting --kind warns that the default flips to interactive in v0.8.0."""
+    def test_generate_mind_map_default_routes_interactive(self, runner, mock_auth):
+        """Omitting --kind now defaults to the interactive studio-artifact path (#1272)."""
+        from notebooklm.types import MindMap, MindMapKind
+
         with patch("notebooklm.cli.generate_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.artifacts.generate_mind_map = AsyncMock(
-                return_value=mind_map_result(
-                    {"mind_map": {"name": "Root", "children": []}, "note_id": "n1"}
+            mock_client.mind_maps.generate = AsyncMock(
+                return_value=MindMap(
+                    id="art_42",
+                    notebook_id="nb_123",
+                    title="Interactive Mind Map",
+                    kind=MindMapKind.INTERACTIVE,
                 )
             )
             mock_client_cls.return_value = mock_client
@@ -913,32 +923,16 @@ class TestGenerateMindMap:
             ) as mock_fetch:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
+
             assert result.exit_code == 0
-            assert "switches to interactive in v0.8.0" in result.output
-
-            # An explicit --kind suppresses the transition notice.
-            with patch(
-                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
-                result2 = runner.invoke(
-                    cli, ["generate", "mind-map", "--kind", "note-backed", "-n", "nb_123"]
-                )
-            assert result2.exit_code == 0
-            assert "switches to interactive in v0.8.0" not in result2.output
-
-            # The transition notice is *informational* (no input dropped), so
-            # --json suppresses it entirely — it must not leak onto stdout or
-            # stderr, keeping machine-readable output clean (design decision).
-            with patch(
-                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
-                result3 = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123", "--json"])
-            assert result3.exit_code == 0
-            assert "switches to interactive in v0.8.0" not in result3.stdout
-            assert "switches to interactive in v0.8.0" not in result3.stderr
-            json.loads(result3.stdout)  # stdout is pure, parseable JSON
+            # The bare default dispatches to the unified interactive API, not the
+            # note-backed artifacts.generate_mind_map.
+            mock_client.mind_maps.generate.assert_awaited_once()
+            assert (
+                mock_client.mind_maps.generate.await_args.kwargs["kind"] == MindMapKind.INTERACTIVE
+            )
+            mock_client.artifacts.generate_mind_map.assert_not_called()
+            assert "art_42" in result.output
 
 
 # =============================================================================
@@ -1097,8 +1091,8 @@ class TestGenerateReport:
 class TestGenerateJsonOutput:
     """JSON-output tests for commands whose envelope differs from the standard shape."""
 
-    def test_generate_mind_map_json_output(self, runner, mock_auth):
-        """Test --json for mind-map (different return structure)."""
+    def test_generate_mind_map_note_backed_json_output(self, runner, mock_auth):
+        """--kind note-backed --json emits the note-backed {mind_map, note_id} shape."""
         with patch("notebooklm.cli.generate_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.generate_mind_map = AsyncMock(
@@ -1112,7 +1106,9 @@ class TestGenerateJsonOutput:
                 "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
             ) as mock_fetch:
                 mock_fetch.return_value = ("csrf", "session")
-                result = runner.invoke(cli, ["generate", "mind-map", "--json", "-n", "nb_123"])
+                result = runner.invoke(
+                    cli, ["generate", "mind-map", "--kind", "note-backed", "--json", "-n", "nb_123"]
+                )
 
             assert result.exit_code == 0
             data = json.loads(result.output)

--- a/tests/unit/cli/test_generate_characterization.py
+++ b/tests/unit/cli/test_generate_characterization.py
@@ -179,15 +179,16 @@ def test_generate_mind_map_json_snapshot(authed_invoke: Callable[..., Result]) -
     """Mind-map JSON output is the converged {mind_map, note_id, kind} payload.
 
     The additive ``kind`` key keeps note-backed consumers reading ``mind_map`` /
-    ``note_id`` working while marking the backing (issue #1256). ``--json``
-    suppresses the v0.8.0 default-transition notice.
+    ``note_id`` working while marking the backing (issue #1256). ``--kind
+    note-backed`` pins the note-backed shape (the interactive default is covered
+    by the routing tests in ``test_generate.py``).
     """
     payload = {
         "note_id": "n1",
         "mind_map": {"name": "Root", "children": [{"a": 1}, {"b": 2}]},
     }
     result = authed_invoke(
-        ["generate", "mind-map", "--json", "-n", "nb_123"],
+        ["generate", "mind-map", "--kind", "note-backed", "--json", "-n", "nb_123"],
         configure=_attach_async_return("generate_mind_map", payload),
     )
     assert result.exit_code == 0, result.output
@@ -197,8 +198,8 @@ def test_generate_mind_map_json_snapshot(authed_invoke: Callable[..., Result]) -
 def test_generate_mind_map_text_snapshot(authed_invoke: Callable[..., Result]) -> None:
     """Mind-map text output is the kind-agnostic ``ID / Kind / Root / Children`` block.
 
-    Passing ``--kind note-backed`` explicitly pins the note-backed shape and
-    suppresses the default-transition notice (covered separately).
+    Passing ``--kind note-backed`` explicitly pins the note-backed shape (the
+    interactive default is covered by the routing tests in ``test_generate.py``).
     """
     payload = {
         "note_id": "n1",

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -206,6 +206,19 @@ _PLAN_HAPPY_CASES: list[tuple[str, dict[str, Any], dict[str, Any], dict[str, Any
         {"instructions": "summarize", "kind": "note-backed"},
     ),
     (
+        # Omitting --kind now defaults to interactive (#1272); interactive drops
+        # --instructions (none passed here), so params carry instructions=None.
+        "mind-map",
+        {"language": "en"},
+        {
+            "display_name": "mind map",
+            "wait": False,
+            "max_retries": 0,
+            "language": "en",
+        },
+        {"instructions": None, "kind": "interactive"},
+    ),
+    (
         "report",
         {
             "report_format": "study-guide",

--- a/tests/unit/test_generate_service.py
+++ b/tests/unit/test_generate_service.py
@@ -196,14 +196,14 @@ _PLAN_HAPPY_CASES: list[tuple[str, dict[str, Any], dict[str, Any], dict[str, Any
     ),
     (
         "mind-map",
-        {"instructions": "summarize", "language": "en"},
+        {"map_kind": "note-backed", "instructions": "summarize", "language": "en"},
         {
             "display_name": "mind map",
             "wait": False,
             "max_retries": 0,
             "language": "en",
         },
-        {"instructions": "summarize"},
+        {"instructions": "summarize", "kind": "note-backed"},
     ),
     (
         "report",
@@ -593,7 +593,9 @@ async def test_execute_generation_mind_map_dispatches_and_returns_typed_result(
     monkeypatch.setattr(resolve_module, "resolve_source_ids", fake_resolve_source_ids)
     plan = build_generation_plan(
         "mind-map",
-        _base_args(instructions="summarize", language="en", json_output=True),
+        _base_args(
+            map_kind="note-backed", instructions="summarize", language="en", json_output=True
+        ),
         parameter_explicit=_default_source,
         language_resolver=_identity_language,
     )


### PR DESCRIPTION
## What

`notebooklm generate mind-map` (with no `--kind`) now defaults to the
**interactive** studio-artifact kind — a `CREATE_ARTIFACT` polled to completion
— instead of the note-backed JSON tree (#1272). This matches what NotebookLM's
web app creates today.

- **Note-backed is still fully supported** via `--kind note-backed` (not
  deprecated). `--instructions` continues to apply to note-backed only.
- The one-time v0.8.0 transition notice (and its now-dead
  `NOTEBOOKLM_QUIET_DEPRECATIONS` plumbing) are removed.

CLI-only change: the Python `client.artifacts.generate_mind_map(...)` /
`client.mind_maps.generate(...)` methods are already kind-specific and are
unchanged (no public signature change).

## Tests & docs

- New `test_generate_mind_map_default_routes_interactive` pins the bare-default →
  interactive routing; the former note-backed-default tests are pinned to
  `--kind note-backed` (coverage retained).
- Regenerated the CLI-contract baseline (diff is only the `--kind` default +
  help); lowered the `cli/services/generate.py` module-size ratchet ceiling
  (954 → 927) after removing the notice plumbing.
- Updated `docs/cli-reference.md` and `SKILL.md` to describe interactive as the
  default and drop the transition notices. (Finalizing `upgrading-to-0.8.0.md`
  tense is deferred to the v0.8.0 capstone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind-map generation now defaults to the interactive studio artifact; JSON node-tree output remains available via --kind note-backed.

* **Documentation**
  * README, CLI reference, and skill docs updated to clarify interactive vs note-backed behaviors and remove obsolete transition notices.

* **Tests**
  * Test fixtures and suites updated to reflect the new default and to explicitly exercise note-backed behavior where required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->