### PR TITLE
feat(api)!: get() raises *NotFoundError on a miss (#1247)

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -65,7 +65,7 @@
     {
       "code": "removed-member",
       "object": "notebooklm.Note.from_api_response",
-      "reason": "Dead positional parser removed (#1389). Note rows are decoded through notebooklm._row_adapters.notes.NoteRow; the classmethod had no production callers (only test_types.py exercised it). Construct Note(...) directly from NoteRow's named properties — see NotesAPI._parse_note."
+      "reason": "Dead positional parser removed (#1389). Note rows are decoded through notebooklm._row_adapters.notes.NoteRow; the classmethod had no production callers (only test_types.py exercised it). Construct Note(...) directly from NoteRow's named properties \u2014 see NotesAPI._parse_note."
     },
     {
       "code": "removed-member",
@@ -316,6 +316,46 @@
       "code": "changed-return",
       "object": "notebooklm.client.NotebookLMClient.sources.rename",
       "reason": "Same break as notebooklm.NotebookLMClient.sources.rename above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.sources.get",
+      "reason": "v0.8.0 #1247: get() now raises SourceNotFoundError on a miss instead of returning None; the return annotation narrows from 'notebooklm.types.Source | None' to 'notebooklm.types.Source' (matches notebooks.get). Use get_or_none() for the None-on-miss lookup. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.sources.get",
+      "reason": "Same break as notebooklm.NotebookLMClient.sources.get above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.artifacts.get",
+      "reason": "v0.8.0 #1247: get() now raises ArtifactNotFoundError on a miss instead of returning None; the return annotation narrows from 'notebooklm.types.Artifact | None' to 'notebooklm.types.Artifact' (matches notebooks.get). Use get_or_none() for the None-on-miss lookup. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.artifacts.get",
+      "reason": "Same break as notebooklm.NotebookLMClient.artifacts.get above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.notes.get",
+      "reason": "v0.8.0 #1247: get() now raises NoteNotFoundError on a miss instead of returning None; the return annotation narrows from 'notebooklm.types.Note | None' to 'notebooklm.types.Note' (matches notebooks.get). Use get_or_none() for the None-on-miss lookup. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.notes.get",
+      "reason": "Same break as notebooklm.NotebookLMClient.notes.get above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.mind_maps.get",
+      "reason": "v0.8.0 #1247: get() now raises MindMapNotFoundError on a miss instead of returning None; the return annotation narrows from 'notebooklm.types.MindMap | None' to 'notebooklm.types.MindMap' (matches notebooks.get). Use get_or_none() for the None-on-miss lookup. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.mind_maps.get",
+      "reason": "Same break as notebooklm.NotebookLMClient.mind_maps.get above; this entry covers the audit's dotted-module-path view of the same callable."
     }
   ]
 }

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -224,9 +224,9 @@ class ArtifactsAPI:
         """Get an artifact by ID, returning ``None`` when it does not exist.
 
         The sanctioned ``None``-on-miss lookup (ADR-0019): unlike :meth:`get`
-        — which is slated to raise
-        :class:`~notebooklm.exceptions.ArtifactNotFoundError` on a miss in
-        v0.8.0 (issue #1247) — this returns ``None`` for a genuine absence and
+        — which now raises
+        :class:`~notebooklm.exceptions.ArtifactNotFoundError` on a miss
+        (#1247) — this returns ``None`` for a genuine absence and
         emits no deprecation warning. This method neither catches nor synthesizes
         a miss itself; it lists once and id-matches, inheriting :meth:`list`'s
         behavior unchanged. (Per ADR-0019 Rule 3, ``list`` keeps its deliberate
@@ -247,8 +247,8 @@ class ArtifactsAPI:
         logger.debug("Getting artifact %s from notebook %s", artifact_id, notebook_id)
         return await self._listing.get(notebook_id, artifact_id, list_artifacts=self.list)
 
-    # Internal optional-lookup alias: kept as a stable private name so existing
-    # internal call sites and tests can probe without the public deprecation.
+    # Internal optional-lookup alias: a stable private name so internal call
+    # sites and tests use the ``None``-on-miss lookup rather than the raising get().
     _get_or_none = get_or_none
 
     async def list_audio(self, notebook_id: str) -> builtins.list[Artifact]:

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -198,7 +198,7 @@ class ArtifactsAPI:
             list_mind_maps=self._list_mind_maps,
         )
 
-    async def get(self, notebook_id: str, artifact_id: str) -> Artifact | None:
+    async def get(self, notebook_id: str, artifact_id: str) -> Artifact:
         """Get a specific artifact by ID.
 
         Args:
@@ -206,24 +206,18 @@ class ArtifactsAPI:
             artifact_id: The artifact ID.
 
         Returns:
-            Artifact object, or None if not found.
+            The :class:`~notebooklm.types.Artifact`.
 
-        .. deprecated:: 0.7.0
-            Returning ``None`` for a missing artifact is deprecated and emits a
-            :class:`DeprecationWarning`. In **v0.8.0** this method will raise
-            :class:`~notebooklm.exceptions.ArtifactNotFoundError` instead, to
-            match ``notebooks.get`` (issue #1247). Wrap the call in
-            ``try/except ArtifactNotFoundError`` to keep handling missing
-            artifacts. Suppress with ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
-            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
+        Raises:
+            ArtifactNotFoundError: If no artifact with ``artifact_id`` exists
+                (matches ``notebooks.get``; issue #1247). Use :meth:`get_or_none`
+                for the sanctioned ``None``-on-miss lookup.
         """
-        # ``resolve_get`` single-sources the warn-runway/raise decision: warn +
-        # return ``None`` today, or raise under ``NOTEBOOKLM_FUTURE_ERRORS``
-        # (#1247). Internal callers needing the silent lookup use get_or_none.
+        # ``resolve_get`` single-sources the raise-on-miss decision (#1247).
+        # Internal callers needing the silent lookup use get_or_none.
         return resolve_get(
             await self.get_or_none(notebook_id, artifact_id),
             not_found=ArtifactNotFoundError(artifact_id),
-            resource="artifact",
         )
 
     async def get_or_none(self, notebook_id: str, artifact_id: str) -> Artifact | None:

--- a/src/notebooklm/_lookup.py
+++ b/src/notebooklm/_lookup.py
@@ -12,65 +12,41 @@ keep its fully-typed, per-arity signatures while single-sourcing the
         NoteNotFoundError(note_id),
     )
 
-(The ``get()``-raises wiring lands with the v0.8.0 flip, issue #1247; this module
-is the additive foundation it will build on — see ADR-0019 Enforcement tier-2.)
+(As of the v0.8.0 flip (#1247) every namespace ``get()`` raises its matching
+``*NotFoundError`` on a miss — see ADR-0019 Enforcement tier-2.)
 """
 
 from __future__ import annotations
 
 from typing import TypeVar
 
-from ._deprecation import future_errors_enabled, warn_get_returns_none
-
 T = TypeVar("T")
 
 
-def resolve_get(result: T | None, *, not_found: Exception, resource: str) -> T | None:
-    """Resolve a public ``get()`` miss under the v0.7.0 / v0.8.0 error contract.
+def resolve_get(result: T | None, *, not_found: Exception) -> T:
+    """Resolve a public ``get()`` lookup: return the hit, or raise on a miss.
 
-    Single-sources the warn-runway decision for every namespace ``get()``
-    (``sources`` / ``artifacts`` / ``notes`` / ``mind_maps``) so the
-    hand-duplicated ``if result is None: warn_get_returns_none(...)`` pattern
-    can no longer drift between copies (the #1358-class bug). The behavior on a
-    miss is gated:
-
-    * ``result is not None`` — a hit. Returned unchanged; no warning, no raise.
-    * miss + ``NOTEBOOKLM_FUTURE_ERRORS`` on — preview the v0.8.0 flip (#1247):
-      ``not_found`` (the matching ``*NotFoundError``) is raised. This takes
-      precedence over ``NOTEBOOKLM_QUIET_DEPRECATIONS``.
-    * miss + future errors off — the v0.7.0 runway: emit the gated
-      ``get()``-returns-``None`` ``DeprecationWarning`` and return ``None``.
-
-    ``notebooks.get()`` already raises today and does **not** route through here.
+    The single not-found entry point routed by every namespace ``get()``
+    (``sources`` / ``artifacts`` / ``notes`` / ``mind_maps``) so the contract is
+    single-sourced and can't drift between copies (the #1358-class bug). As of
+    the v0.8.0 flip (#1247) a miss raises the matching ``*NotFoundError``;
+    ``notebooks.get()`` already raises and does not route here. Delegates to
+    :func:`unwrap_or_raise`.
 
     Args:
-        result: The value returned by the namespace's ``get_or_none()`` lookup —
-            the resolved entity, or ``None`` for a genuine miss. Transport/auth/
+        result: The value from the namespace's ``get_or_none()`` lookup — the
+            resolved entity, or ``None`` for a genuine miss. Transport / auth /
             decode faults are raised by the lookup before reaching here, so
             ``None`` means "not found" and nothing else.
-        not_found: The ``*NotFoundError`` instance to raise on a miss when the
-            future-errors preview is enabled.
-        resource: Singular resource name for the warning message, e.g.
-            ``"source"`` / ``"artifact"`` / ``"note"`` / ``"mind_map"``.
+        not_found: The ``*NotFoundError`` instance to raise on a miss.
 
     Returns:
-        ``result`` when it is a hit; ``None`` on a miss in the (default) warn
-        runway.
+        ``result`` narrowed to its non-``None`` type.
 
     Raises:
-        Exception: ``not_found`` itself, on a miss, when
-            ``NOTEBOOKLM_FUTURE_ERRORS`` is enabled.
+        Exception: ``not_found`` itself, on a miss.
     """
-    if result is not None:
-        return result
-    if future_errors_enabled():
-        raise not_found
-    # stacklevel=4: warn_get_returns_none (1) -> resolve_get (2) -> the public
-    # get() (3) -> the user's call site (4). The extra bridge frame over the
-    # historical inline ``warn_get_returns_none()`` call (which used the
-    # default 3) keeps the warning pointed at the user's ``get()`` call.
-    warn_get_returns_none(resource, stacklevel=4)
-    return None
+    return unwrap_or_raise(result, not_found)
 
 
 def unwrap_or_raise(obj: T | None, exc: Exception) -> T:

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -193,28 +193,23 @@ class MindMapsAPI:
                 )
         return result
 
-    async def get(self, notebook_id: str, mind_map_id: str) -> MindMap | None:
-        """Return the mind map with ``mind_map_id``, or ``None`` if absent.
+    async def get(self, notebook_id: str, mind_map_id: str) -> MindMap:
+        """Return the mind map with ``mind_map_id``.
 
-        .. deprecated:: 0.7.0
-            Returning ``None`` for a missing mind map is deprecated and emits a
-            :class:`DeprecationWarning`. In **v0.8.0** this method will raise
-            :class:`~notebooklm.exceptions.MindMapNotFoundError` instead, to
-            match ``notebooks.get`` (issue #1247). Wrap the call in
-            ``try/except MindMapNotFoundError`` to keep handling missing mind
-            maps, or use :meth:`get_or_none` for the sanctioned optional lookup.
-            Suppress the warning with ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
-            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
+        Returns:
+            The :class:`~notebooklm.types.MindMap`.
+
+        Raises:
+            MindMapNotFoundError: If no mind map with ``mind_map_id`` exists
+                (matches ``notebooks.get``; issue #1247). Use :meth:`get_or_none`
+                for the sanctioned ``None``-on-miss lookup.
         """
-        # The warn-runway / raise decision is single-sourced in
-        # ``_lookup.resolve_get``: it warns and returns ``None`` today, or
-        # raises ``MindMapNotFoundError`` under ``NOTEBOOKLM_FUTURE_ERRORS``
-        # (the v0.8.0 flip, issue #1247). Internal callers that need the silent
-        # optional-lookup must use ``_get_or_none`` directly.
+        # ``_lookup.resolve_get`` single-sources the raise-on-miss decision
+        # (#1247). Internal callers that need the silent optional-lookup must
+        # use ``_get_or_none`` directly.
         return resolve_get(
             await self.get_or_none(notebook_id, mind_map_id),
             not_found=MindMapNotFoundError(mind_map_id),
-            resource="mind_map",
         )
 
     async def get_or_none(self, notebook_id: str, mind_map_id: str) -> MindMap | None:

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -217,9 +217,9 @@ class MindMapsAPI:
 
         The sanctioned ``None``-on-miss lookup (ADR-0019), spanning both
         backings (note-backed JSON + interactive studio-artifact). Unlike
-        :meth:`get` — which is slated to raise
-        :class:`~notebooklm.exceptions.MindMapNotFoundError` on a miss in v0.8.0
-        (issue #1247) — this returns ``None`` for an absence and emits no
+        :meth:`get` — which now raises
+        :class:`~notebooklm.exceptions.MindMapNotFoundError` on a miss
+        (#1247) — this returns ``None`` for an absence and emits no
         deprecation warning. It scans :meth:`list`, so it reflects only what
         ``list`` confirms: a just-created interactive map whose variant slot has
         not yet populated is briefly excluded from ``list`` and therefore reads
@@ -241,7 +241,7 @@ class MindMapsAPI:
 
     # Private alias for internal optional-lookup callers, mirroring
     # ``sources``/``artifacts``/``notes``: the library calls ``_get_or_none``
-    # so it never trips its own ``get()`` deprecation warning (issue #1358).
+    # for a ``None``-on-miss lookup rather than the raising ``get()`` (#1358).
     _get_or_none = get_or_none
 
     async def generate(

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -90,7 +90,7 @@ class NotesAPI:
 
         return notes
 
-    async def get(self, notebook_id: str, note_id: str) -> Note | None:
+    async def get(self, notebook_id: str, note_id: str) -> Note:
         """Get a specific note by ID.
 
         Args:
@@ -98,26 +98,19 @@ class NotesAPI:
             note_id: The note ID.
 
         Returns:
-            Note object, or None if not found.
+            The :class:`~notebooklm.types.Note`.
 
-        .. deprecated:: 0.7.0
-            Returning ``None`` for a missing note is deprecated and emits a
-            :class:`DeprecationWarning`. In **v0.8.0** this method will raise
-            ``NoteNotFoundError`` instead, to match ``notebooks.get`` (issue
-            #1247). Wrap the call in ``try/except NoteNotFoundError`` to keep
-            handling missing notes. Suppress the warning with
-            ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set
-            ``NOTEBOOKLM_FUTURE_ERRORS=1`` to preview the v0.8.0 raise now.
+        Raises:
+            NoteNotFoundError: If no note with ``note_id`` exists (matches
+                ``notebooks.get``; issue #1247). Use :meth:`get_or_none` for the
+                sanctioned ``None``-on-miss lookup.
         """
-        # The warn-runway / raise decision is single-sourced in
-        # ``_lookup.resolve_get``: it warns and returns ``None`` today, or
-        # raises ``NoteNotFoundError`` under ``NOTEBOOKLM_FUTURE_ERRORS`` (the
-        # v0.8.0 flip, issue #1247). Internal callers that need the silent
-        # optional-lookup must use ``get_or_none`` directly.
+        # ``_lookup.resolve_get`` single-sources the raise-on-miss decision
+        # (#1247). Internal callers that need the silent optional-lookup must
+        # use ``get_or_none`` directly.
         return resolve_get(
             await self.get_or_none(notebook_id, note_id),
             not_found=NoteNotFoundError(note_id),
-            resource="note",
         )
 
     async def get_or_none(self, notebook_id: str, note_id: str) -> Note | None:

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -117,8 +117,8 @@ class NotesAPI:
         """Get a note by ID, returning ``None`` when it does not exist.
 
         The sanctioned ``None``-on-miss lookup (ADR-0019): unlike :meth:`get`
-        — which is slated to raise ``NoteNotFoundError`` on a miss in v0.8.0
-        (issue #1247) — this returns ``None`` for a genuine absence and emits no
+        — which now raises ``NoteNotFoundError`` on a miss (#1247) — this
+        returns ``None`` for a genuine absence and emits no
         deprecation warning. Transport, auth, and decode faults raised by the
         underlying note listing are **not** swallowed; only a real "not found"
         yields ``None``.
@@ -136,8 +136,8 @@ class NotesAPI:
                 return self._parse_note(item, notebook_id)
         return None
 
-    # Internal optional-lookup alias: kept as a stable private name so existing
-    # internal call sites and tests can probe without the public deprecation.
+    # Internal optional-lookup alias: a stable private name so internal call
+    # sites and tests use the ``None``-on-miss lookup rather than the raising get().
     _get_or_none = get_or_none
 
     async def create(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -149,7 +149,7 @@ class SourcesAPI:
         """
         return await self._lister.list(notebook_id, strict=strict)
 
-    async def get(self, notebook_id: str, source_id: str) -> Source | None:
+    async def get(self, notebook_id: str, source_id: str) -> Source:
         """Get details of a specific source.
 
         Args:
@@ -157,23 +157,18 @@ class SourcesAPI:
             source_id: The source ID.
 
         Returns:
-            Source object with current status, or None if not found.
+            The :class:`~notebooklm.types.Source` with its current status.
 
-        .. deprecated:: 0.7.0
-            Returning ``None`` for a missing source is deprecated and emits a
-            :class:`DeprecationWarning`. In **v0.8.0** this method will raise
-            :class:`~notebooklm.exceptions.SourceNotFoundError` instead, to match
-            ``notebooks.get`` (issue #1247); wrap in ``try/except
-            SourceNotFoundError`` to keep handling missing sources. Suppress with
-            ``NOTEBOOKLM_QUIET_DEPRECATIONS``, or set ``NOTEBOOKLM_FUTURE_ERRORS=1``
-            to preview the v0.8.0 raise now.
+        Raises:
+            SourceNotFoundError: If no source with ``source_id`` exists (matches
+                ``notebooks.get``; issue #1247). Use :meth:`get_or_none` for the
+                sanctioned ``None``-on-miss lookup.
         """
-        # ``resolve_get`` single-sources the warn-vs-raise decision (#1247);
+        # ``resolve_get`` single-sources the raise-on-miss decision (#1247);
         # internal callers needing the silent lookup use ``get_or_none``.
         return resolve_get(
             await self.get_or_none(notebook_id, source_id),
             not_found=SourceNotFoundError(source_id),
-            resource="source",
         )
 
     async def get_or_none(self, notebook_id: str, source_id: str) -> Source | None:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -175,9 +175,9 @@ class SourcesAPI:
         """Get a source by ID, returning ``None`` when it does not exist.
 
         The sanctioned ``None``-on-miss lookup (ADR-0019): unlike :meth:`get`
-        — which is slated to raise :class:`~notebooklm.exceptions.SourceNotFoundError`
-        on a miss in v0.8.0 (issue #1247) — this returns ``None`` for a genuine
-        absence and emits no deprecation warning. Transport, auth, and decode
+        — which now raises :class:`~notebooklm.exceptions.SourceNotFoundError`
+        on a miss (#1247) — this returns ``None`` for a genuine absence and
+        emits no deprecation warning. Transport, auth, and decode
         faults are **not** swallowed; only a real "not found" yields ``None``.
 
         Args:

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -64,10 +64,10 @@ MODULE_SIZE_BUDGET = 900
 ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/source_cmd.py": 1498,
     "exceptions.py": 1426,
-    "_artifacts.py": 1420,
+    "_artifacts.py": 1414,
     "_source/upload.py": 1236,
     "cli/session_cmd.py": 1080,
-    "_sources.py": 1015,
+    "_sources.py": 1010,
     "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,

--- a/tests/_guardrails/test_v080_deprecation_coverage.py
+++ b/tests/_guardrails/test_v080_deprecation_coverage.py
@@ -136,18 +136,6 @@ _DELIBERATE_CLEAN_BREAK = (
 V080_BREAKING_CHANGES: tuple[BreakingChange, ...] = (
     # ---- Runwayed today (a v0.7.0 signal verified present) -----------------
     BreakingChange(
-        issue=1247,
-        summary="sources/artifacts/notes/mind_maps.get() flip None-on-miss to raise *NotFoundError",
-        runway=Runway(
-            # The warn-on-miss signal for all four namespaces is centralized in
-            # resolve_get() (issue #1406), so the symbol lives in _lookup.py —
-            # not the per-namespace _sources.py/_artifacts.py/etc. get() bodies.
-            module="_lookup.py",
-            description="public get() warns on a miss via warn_get_returns_none, centralized in resolve_get (DeprecationWarning)",
-            symbol="warn_get_returns_none",
-        ),
-    ),
-    BreakingChange(
         issue=1251,
         summary="remove dict-subscript MappingCompat from research/mind_map/guide typed returns",
         runway=Runway(

--- a/tests/e2e/test_artifacts.py
+++ b/tests/e2e/test_artifacts.py
@@ -12,7 +12,7 @@ import asyncio
 import pytest
 
 from notebooklm import Artifact, ArtifactType, ReportSuggestion
-from notebooklm.exceptions import RPCTimeoutError
+from notebooklm.exceptions import ArtifactNotFoundError, RPCTimeoutError
 
 from .conftest import assert_generation_started, requires_auth
 
@@ -45,12 +45,10 @@ class TestArtifactRetrieval:
     @pytest.mark.asyncio
     @pytest.mark.readonly
     async def test_get_artifact_not_found(self, client, read_only_notebook_id):
-        """Test getting a non-existent artifact returns None (with deprecation)."""
-        # v0.7.0: a miss still returns None but now emits a DeprecationWarning
-        # (flips to raising ArtifactNotFoundError in v0.8.0, issue #1247).
-        with pytest.warns(DeprecationWarning, match="ArtifactNotFoundError"):
-            artifact = await client.artifacts.get(read_only_notebook_id, "nonexistent_artifact_id")
-        assert artifact is None
+        """Test getting a non-existent artifact raises ArtifactNotFoundError."""
+        # v0.8.0: a miss now raises ArtifactNotFoundError (issue #1247).
+        with pytest.raises(ArtifactNotFoundError):
+            await client.artifacts.get(read_only_notebook_id, "nonexistent_artifact_id")
 
 
 @requires_auth

--- a/tests/e2e/test_notes.py
+++ b/tests/e2e/test_notes.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from notebooklm import NoteNotFoundError
+
 from .conftest import requires_auth
 
 
@@ -35,12 +37,10 @@ class TestNotesGet:
 
     @pytest.mark.asyncio
     async def test_get_note_not_found(self, client, read_only_notebook_id):
-        """Test getting a non-existent note returns None (with deprecation)."""
-        # v0.7.0: a miss still returns None but now emits a DeprecationWarning
-        # (flips to raising NoteNotFoundError in v0.8.0, issue #1247).
-        with pytest.warns(DeprecationWarning, match="NoteNotFoundError"):
-            note = await client.notes.get(read_only_notebook_id, "nonexistent_note_id")
-        assert note is None
+        """Test getting a non-existent note raises NoteNotFoundError."""
+        # v0.8.0: a miss now raises NoteNotFoundError (issue #1247).
+        with pytest.raises(NoteNotFoundError):
+            await client.notes.get(read_only_notebook_id, "nonexistent_note_id")
 
 
 @requires_auth

--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from notebooklm import Source, SourceGuide, SourceStatus
+from notebooklm import Source, SourceGuide, SourceNotFoundError, SourceStatus
 
 from .conftest import requires_auth
 
@@ -88,12 +88,10 @@ class TestSourceRetrieval:
 
     @pytest.mark.asyncio
     async def test_get_source_not_found(self, client, read_only_notebook_id):
-        """Test getting a non-existent source returns None (with deprecation)."""
-        # v0.7.0: a miss still returns None but now emits a DeprecationWarning
-        # (flips to raising SourceNotFoundError in v0.8.0, issue #1247).
-        with pytest.warns(DeprecationWarning, match="SourceNotFoundError"):
-            source = await client.sources.get(read_only_notebook_id, "nonexistent_source_id")
-        assert source is None
+        """Test getting a non-existent source raises SourceNotFoundError."""
+        # v0.8.0: a miss now raises SourceNotFoundError (issue #1247).
+        with pytest.raises(SourceNotFoundError):
+            await client.sources.get(read_only_notebook_id, "nonexistent_source_id")
 
     @pytest.mark.asyncio
     async def test_get_guide(self, client, read_only_notebook_id):

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -532,14 +532,11 @@ class TestArtifactsAPI:
             api, "list", new=AsyncMock(return_value=[other, found])
         ) as list_artifacts:
             result = await api.get("nb_123", "art_found")
-            # v0.7.0: a miss still returns None but now emits a
-            # DeprecationWarning (flips to raising ArtifactNotFoundError in
-            # v0.8.0, issue #1247).
-            with pytest.warns(DeprecationWarning, match="ArtifactNotFoundError"):
-                missing = await api.get("nb_123", "art_missing")
+            # v0.8.0: a miss now raises ArtifactNotFoundError (issue #1247).
+            with pytest.raises(ArtifactNotFoundError):
+                await api.get("nb_123", "art_missing")
 
         assert result is found
-        assert missing is None
         assert list_artifacts.await_count == 2
         list_artifacts.assert_awaited_with("nb_123")
 
@@ -903,13 +900,13 @@ class TestArtifactsAPI:
         assert result.task_id == "dt_123"
 
     @pytest.mark.asyncio
-    async def test_get_artifact_not_found(
+    async def test_get_artifact_raises_when_not_found(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test getting a non-existent artifact returns None."""
+        """Test getting a non-existent artifact raises ArtifactNotFoundError."""
         # Response for LIST_ARTIFACTS (gArtLc) - empty
         response1 = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [])
         # Response for GET_NOTES_AND_MIND_MAPS (cFji9) - empty
@@ -918,13 +915,9 @@ class TestArtifactsAPI:
         httpx_mock.add_response(content=response2.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            # v0.7.0: a miss still returns None but now emits a
-            # DeprecationWarning (flips to raising ArtifactNotFoundError in
-            # v0.8.0, issue #1247).
-            with pytest.warns(DeprecationWarning, match="ArtifactNotFoundError"):
-                result = await client.artifacts.get("nb_123", "nonexistent")
-
-        assert result is None
+            # v0.8.0: a miss now raises ArtifactNotFoundError (issue #1247).
+            with pytest.raises(ArtifactNotFoundError):
+                await client.artifacts.get("nb_123", "nonexistent")
 
     @pytest.mark.asyncio
     async def test_list_audio_artifacts(
@@ -1656,17 +1649,17 @@ class TestListMindMapErrorHandling:
         assert any(a.id == "art_002" for a in result)
 
 
-class TestGetArtifactReturnsNone:
-    """Tests for get() returning None (lines 312-313)."""
+class TestGetArtifactRaisesWhenNotFound:
+    """Tests for get() raising ArtifactNotFoundError on a miss (lines 312-313)."""
 
     @pytest.mark.asyncio
-    async def test_get_returns_none_when_not_found(
+    async def test_get_raises_when_not_found(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """get() returns None when the artifact_id is not in the list."""
+        """get() raises ArtifactNotFoundError when the artifact_id is not in the list."""
         # Return one artifact with a different ID
         artifact_data = ["art_exists", "My Report", 2, None, 3]
         list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
@@ -1675,13 +1668,9 @@ class TestGetArtifactReturnsNone:
         httpx_mock.add_response(content=notes_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            # v0.7.0: a miss still returns None but now emits a
-            # DeprecationWarning (flips to raising ArtifactNotFoundError in
-            # v0.8.0, issue #1247).
-            with pytest.warns(DeprecationWarning, match="ArtifactNotFoundError"):
-                result = await client.artifacts.get("nb_123", "art_does_not_exist")
-
-        assert result is None
+            # v0.8.0: a miss now raises ArtifactNotFoundError (issue #1247).
+            with pytest.raises(ArtifactNotFoundError):
+                await client.artifacts.get("nb_123", "art_does_not_exist")
 
     @pytest.mark.asyncio
     async def test_get_returns_artifact_when_found(

--- a/tests/integration/test_notes_integration.py
+++ b/tests/integration/test_notes_integration.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
-from notebooklm.exceptions import RPCError
+from notebooklm.exceptions import NoteNotFoundError, RPCError
 from notebooklm.rpc import RPCMethod
 
 pytestmark = pytest.mark.allow_no_vcr
@@ -126,7 +126,7 @@ class TestNotesAPI:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test getting a note that doesn't exist."""
+        """Test getting a note that doesn't exist raises NoteNotFoundError."""
         response = build_rpc_response(
             RPCMethod.GET_NOTES_AND_MIND_MAPS,
             [
@@ -138,13 +138,9 @@ class TestNotesAPI:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            # v0.7.0: a miss still returns None but now emits a
-            # DeprecationWarning (flips to raising NoteNotFoundError in v0.8.0,
-            # issue #1247).
-            with pytest.warns(DeprecationWarning, match="NoteNotFoundError"):
-                note = await client.notes.get("nb_123", "nonexistent")
-
-        assert note is None
+            # v0.8.0: a miss now raises NoteNotFoundError (issue #1247).
+            with pytest.raises(NoteNotFoundError):
+                await client.notes.get("nb_123", "nonexistent")
 
     @pytest.mark.asyncio
     async def test_create_note(

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -483,7 +483,7 @@ class TestSourcesAPI:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """Test getting a non-existent source."""
+        """Test getting a non-existent source raises SourceNotFoundError."""
         response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [
@@ -500,13 +500,9 @@ class TestSourcesAPI:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            # v0.7.0: a miss still returns None but now emits a
-            # DeprecationWarning (flips to raising SourceNotFoundError in
-            # v0.8.0, issue #1247).
-            with pytest.warns(DeprecationWarning, match="SourceNotFoundError"):
-                source = await client.sources.get("nb_123", "nonexistent")
-
-        assert source is None
+            # v0.8.0: a miss now raises SourceNotFoundError (issue #1247).
+            with pytest.raises(SourceNotFoundError):
+                await client.sources.get("nb_123", "nonexistent")
 
     @pytest.mark.asyncio
     async def test_add_drive_source(

--- a/tests/unit/test_future_errors_flag.py
+++ b/tests/unit/test_future_errors_flag.py
@@ -123,50 +123,16 @@ class _Sentinel(Exception):
 
 
 class TestResolveGet:
-    def test_hit_returns_value_no_warn_no_raise_off(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            result = resolve_get("found", not_found=_Sentinel(), resource="source")
-        assert result == "found"
+    # As of the v0.8.0 flip (#1247) resolve_get always raises on a miss and no
+    # longer consults NOTEBOOKLM_FUTURE_ERRORS — its raise-on-miss / hit contract
+    # is the flag-agnostic behavior below; the full public miss-contract lives in
+    # test_public_api_behavior.py::TestGetMissContract.
+    def test_hit_returns_value(self):
+        assert resolve_get("found", not_found=_Sentinel()) == "found"
 
-    def test_hit_returns_value_no_raise_on(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
-        # A hit never raises, even under future-errors: the flip is miss-only.
-        result = resolve_get("found", not_found=_Sentinel(), resource="source")
-        assert result == "found"
-
-    def test_miss_off_warns_and_returns_none(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        monkeypatch.delenv(_QUIET, raising=False)
-        with pytest.warns(DeprecationWarning, match="sources.get()") as record:
-            result = resolve_get(None, not_found=_Sentinel(), resource="source")
-        assert result is None
-        assert len(record) == 1
-
-    def test_miss_on_raises_the_not_found(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            with pytest.raises(_Sentinel):
-                resolve_get(None, not_found=_Sentinel(), resource="source")
-
-    def test_warning_points_at_caller_through_bridge(self, monkeypatch):
-        # stacklevel bookkeeping: resolve_get bumps warn_get_returns_none to
-        # stacklevel=4 to account for the extra bridge frame
-        # (warn (1) -> resolve_get (2) -> public get() (3) -> user (4)). The
-        # ``_fake_public_get`` wrapper stands in for the public ``get()`` frame
-        # so the warning is attributed to the *caller of get()* — this line —
-        # not to _lookup.py / _deprecation.py.
-        monkeypatch.delenv(_FLAG, raising=False)
-        monkeypatch.delenv(_QUIET, raising=False)
-
-        def _fake_public_get() -> object:
-            return resolve_get(None, not_found=_Sentinel(), resource="source")
-
-        with pytest.warns(DeprecationWarning) as record:
-            _fake_public_get()
-        assert record[0].filename == __file__
+    def test_miss_raises_the_not_found(self):
+        with pytest.raises(_Sentinel):
+            resolve_get(None, not_found=_Sentinel())
 
 
 # ---------------------------------------------------------------------------
@@ -345,12 +311,6 @@ class TestDeprecatedKwargFlip:
 
 
 class TestFutureErrorsTakesPrecedenceOverQuiet:
-    def test_resolve_get_raises_even_when_quiet(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
-        monkeypatch.setenv(_QUIET, "1")
-        with pytest.raises(_Sentinel):
-            resolve_get(None, not_found=_Sentinel(), resource="source")
-
     def test_subscript_raises_even_when_quiet(self, monkeypatch):
         monkeypatch.setenv(_FLAG, "1")
         monkeypatch.setenv(_QUIET, "1")
@@ -377,7 +337,6 @@ class TestFutureErrorsTakesPrecedenceOverQuiet:
         monkeypatch.setenv(_QUIET, "1")
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            assert resolve_get(None, not_found=_Sentinel(), resource="source") is None
             assert _CompatProbe()["status"] == "completed"
 
 

--- a/tests/unit/test_get_returns_none_deprecation.py
+++ b/tests/unit/test_get_returns_none_deprecation.py
@@ -27,6 +27,12 @@ from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
 from notebooklm._notes import NotesAPI
 from notebooklm._sources import SourcesAPI
+from notebooklm.exceptions import (
+    ArtifactNotFoundError,
+    MindMapNotFoundError,
+    NoteNotFoundError,
+    SourceNotFoundError,
+)
 from notebooklm.types import Source
 
 # ---------------------------------------------------------------------------
@@ -185,32 +191,30 @@ def mind_maps_api():
 
 
 # ---------------------------------------------------------------------------
-# Each public get() warns on a miss but still returns None
+# Each public get() raises its *NotFoundError on a miss (v0.8.0 flip, #1247)
 # ---------------------------------------------------------------------------
 #
 # Parametrised over every #1247-cohort namespace (sources / notes / artifacts /
-# mind_maps) so the missing-warning gap that #1358 closed for mind_maps cannot
-# silently recur for any of them: each get() must emit the deprecation warning
-# on a miss. All four lookups iterate ``self.list(...)``, so a mocked-empty
+# mind_maps) so the not-found contract stays uniform across all four — matching
+# notebooks.get. All four lookups iterate ``self.list(...)``, so a mocked-empty
 # ``list`` forces the miss uniformly.
 
-_GET_WARN_CASES = [
-    pytest.param("sources_api", "SourceNotFoundError", id="sources"),
-    pytest.param("notes_api", "NoteNotFoundError", id="notes"),
-    pytest.param("artifacts_api", "ArtifactNotFoundError", id="artifacts"),
-    pytest.param("mind_maps_api", "MindMapNotFoundError", id="mind_maps"),
+_GET_MISS_CASES = [
+    pytest.param("sources_api", SourceNotFoundError, id="sources"),
+    pytest.param("notes_api", NoteNotFoundError, id="notes"),
+    pytest.param("artifacts_api", ArtifactNotFoundError, id="artifacts"),
+    pytest.param("mind_maps_api", MindMapNotFoundError, id="mind_maps"),
 ]
 
 
-class TestPublicGetWarnsOnMiss:
+class TestPublicGetRaisesOnMiss:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(("api_fixture", "exc_name"), _GET_WARN_CASES)
-    async def test_get_warns_and_returns_none(self, request, api_fixture, exc_name):
+    @pytest.mark.parametrize(("api_fixture", "exc_type"), _GET_MISS_CASES)
+    async def test_get_raises_on_miss(self, request, api_fixture, exc_type):
         api = request.getfixturevalue(api_fixture)
         api.list = AsyncMock(return_value=[])
-        with pytest.warns(DeprecationWarning, match=exc_name):
-            result = await api.get("nb_1", "missing")
-        assert result is None
+        with pytest.raises(exc_type):
+            await api.get("nb_1", "missing")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_get_returns_none_deprecation.py
+++ b/tests/unit/test_get_returns_none_deprecation.py
@@ -1,14 +1,15 @@
-"""Tests for the get()-returns-``None`` deprecation layer (#1206).
+"""Tests for the get()-not-found contract (#1206, flipped to raise in #1247).
 
-The deprecation layer makes ``sources.get`` / ``artifacts.get`` / ``notes.get``
-emit a :class:`DeprecationWarning` when they are about to return ``None`` on a
-miss, while keeping the ``None``-returning *behavior* unchanged. The actual flip
-to raising ``*NotFoundError`` lands separately in v0.8.0 (issue #1247).
+As of the v0.8.0 flip (#1247) ``sources.get`` / ``artifacts.get`` / ``notes.get``
+/ ``mind_maps.get`` raise their matching ``*NotFoundError`` on a miss, matching
+``notebooks.get``; ``get_or_none`` is the unchanged ``None``-on-miss lookup. The
+``warn_get_returns_none`` helper (the retired v0.7.0 runway) still has its own
+unit coverage here until it is deleted at the v0.8.0 capstone (#1365).
 
 Covered here:
   * ``warn_get_returns_none`` message shape + ``NOTEBOOKLM_QUIET_DEPRECATIONS``
     suppression (the helper in isolation).
-  * Each public ``get()`` warns on a miss and still returns ``None``.
+  * Each public ``get()`` raises its ``*NotFoundError`` on a miss.
   * The private ``_get_or_none()`` never warns (internal optional-lookup path).
   * ``notebooks.get`` still *raises* ``NotebookNotFoundError`` (unchanged).
   * No internal CLI not-found path self-warns (warnings escalated to errors).

--- a/tests/unit/test_mind_maps_api.py
+++ b/tests/unit/test_mind_maps_api.py
@@ -435,12 +435,11 @@ async def test_get_returns_matching_mind_map():
 
 
 @pytest.mark.asyncio
-async def test_get_warns_and_returns_none_when_absent():
-    # Neither backing contains the id -> None, but with a DeprecationWarning
-    # naming the v0.8.0 MindMapNotFoundError flip (#1358 runway for #1247).
+async def test_get_raises_when_absent():
+    # Neither backing contains the id -> MindMapNotFoundError (v0.8.0 flip, #1247).
     api, *_ = _make_api(note_rows=[["note_mm", "{}"]])
-    with pytest.warns(DeprecationWarning, match="MindMapNotFoundError"):
-        assert await api.get("nb", "ghost") is None
+    with pytest.raises(MindMapNotFoundError):
+        await api.get("nb", "ghost")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -7,7 +7,7 @@ import pytest
 from notebooklm._mind_map import NoteBackedMindMapService
 from notebooklm._note_service import NoteService
 from notebooklm._notes import NotesAPI
-from notebooklm.exceptions import RPCError
+from notebooklm.exceptions import NoteNotFoundError, RPCError
 
 
 @pytest.fixture
@@ -427,16 +427,13 @@ class TestGetNote:
     """Edge case tests for get() method."""
 
     @pytest.mark.asyncio
-    async def test_get_returns_none_for_empty_list(self, notes_api, mock_core):
-        """Test get() returns None (with deprecation) when notes list is empty."""
+    async def test_get_raises_for_empty_list(self, notes_api, mock_core):
+        """Test get() raises NoteNotFoundError when notes list is empty."""
         mock_core.rpc_executor.rpc_call.return_value = [[]]
 
-        # v0.7.0: a miss still returns None but now emits a DeprecationWarning
-        # (flips to raising NoteNotFoundError in v0.8.0, issue #1247).
-        with pytest.warns(DeprecationWarning, match="NoteNotFoundError"):
-            result = await notes_api.get("nb_123", "note_1")
-
-        assert result is None
+        # v0.8.0: a miss now raises NoteNotFoundError (issue #1247).
+        with pytest.raises(NoteNotFoundError):
+            await notes_api.get("nb_123", "note_1")
 
     @pytest.mark.asyncio
     async def test_get_matches_first_element(self, notes_api, mock_core):

--- a/tests/unit/test_public_api_behavior.py
+++ b/tests/unit/test_public_api_behavior.py
@@ -16,26 +16,25 @@ This module adds the **behavioural** half of the Tier-1 floor. For each lookup
 namespace it instantiates the backing API with a fake backend (reusing the
 constructor-injection substrate under ``tests/_fixtures/`` — no network, auth, or
 event loop beyond what those provide) arranged to yield a genuine MISS, then
-asserts today's *warn-contract*:
+asserts the not-found contract:
 
-* ``await get(<missing id>)`` emits a ``DeprecationWarning`` **and** returns
-  ``None`` (the warn-runway state #1247 will flip);
+* ``await get(<missing id>)`` raises its ``*NotFoundError`` (the v0.8.0 contract,
+  #1247 — now live for all five namespaces);
 * ``await get_or_none(<missing id>)`` emits **no** ``DeprecationWarning`` **and**
   returns ``None`` (the sanctioned silent optional-lookup).
 
 **Flip-durability (the load-bearing design choice).** The per-namespace table
 :data:`LOOKUP_CASES` carries, for each namespace, its API factory, a
 miss-arranger, the ``get`` arguments, the resource name, and the
-``*NotFoundError`` type. The ``get_warns`` flag marks the warn-runway state. When
-the v0.8.0 ``get()``→raise flip lands (#1247) a namespace migrates with a
-*single table-driven edit* — flip its ``get_warns`` to ``False`` — and the
-assertion automatically swaps from ``pytest.warns(DeprecationWarning)`` to
-``pytest.raises(<*NotFoundError>)``. ``notebooks`` is the already-flipped
-exemplar (``get_warns=False`` today: it raises ``NotebookNotFoundError`` now), so
-both sides of the flip are exercised continuously and the post-flip path can
-never bit-rot before #1247 arrives. This mirrors how the static
-``GET_OPTIONAL_EXEMPTIONS`` allowlist *shrinks*: the deferred behaviours live in
-one visible, reason-tagged table, never scattered.
+``*NotFoundError`` type. The ``get_warns`` flag selects the assertion:
+``get_warns=False`` → ``pytest.raises(<*NotFoundError>)``;
+``get_warns=True`` → ``pytest.warns(DeprecationWarning)`` + ``None``. The v0.8.0
+``get()``→raise flip (#1247) landed by flipping every namespace's ``get_warns``
+to ``False`` with a *single table-driven edit*; ``test_no_namespace_remains_on_the_warn_runway``
+now pins the warn branch unused (no row may regain ``get_warns=True``). The harness
+keeps both branches so the flip is exercised by construction and the table mirrors
+how the static ``GET_OPTIONAL_EXEMPTIONS`` allowlist drained to empty: the contract
+lives in one visible, reason-tagged table, never scattered.
 """
 
 from __future__ import annotations
@@ -226,7 +225,7 @@ LOOKUP_CASES: tuple[LookupCase, ...] = (
         get_args=("nb_1", "missing"),
         resource="source",
         not_found_error=SourceNotFoundError,
-        get_warns=True,  # flip to False with #1247
+        get_warns=False,  # flipped: raises *NotFoundError on a miss (#1247)
     ),
     LookupCase(
         namespace="artifacts",
@@ -235,7 +234,7 @@ LOOKUP_CASES: tuple[LookupCase, ...] = (
         get_args=("nb_1", "missing"),
         resource="artifact",
         not_found_error=ArtifactNotFoundError,
-        get_warns=True,  # flip to False with #1247
+        get_warns=False,  # flipped: raises *NotFoundError on a miss (#1247)
     ),
     LookupCase(
         namespace="notes",
@@ -244,7 +243,7 @@ LOOKUP_CASES: tuple[LookupCase, ...] = (
         get_args=("nb_1", "missing"),
         resource="note",
         not_found_error=NoteNotFoundError,
-        get_warns=True,  # flip to False with #1247
+        get_warns=False,  # flipped: raises *NotFoundError on a miss (#1247)
     ),
     LookupCase(
         namespace="mind_maps",
@@ -253,11 +252,21 @@ LOOKUP_CASES: tuple[LookupCase, ...] = (
         get_args=("nb_1", "missing"),
         resource="mind_map",
         not_found_error=MindMapNotFoundError,
-        get_warns=True,  # flip to False with #1247
+        get_warns=False,  # flipped: raises *NotFoundError on a miss (#1247)
     ),
 )
 
 _CASES_BY_ID = [pytest.param(case, id=case.namespace) for case in LOOKUP_CASES]
+
+
+def test_no_namespace_remains_on_the_warn_runway() -> None:
+    """#1247 has landed: every namespace get() raises on a miss, so no
+    LookupCase may carry get_warns=True (flipping one back fails here)."""
+    warned = [c.namespace for c in LOOKUP_CASES if c.get_warns]
+    assert warned == [], (
+        f"These namespaces still claim the get()-warn runway (get_warns=True): "
+        f"{warned}. After #1247 every get() raises *NotFoundError on a miss."
+    )
 
 
 def _build_missing(case: LookupCase) -> object:

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -213,10 +213,7 @@ def test_collect_manifest_canonicalizes_pep563_return_annotation(script):
     manifest = script.collect_manifest(REPO_ROOT)
     members = manifest["modules"]["notebooklm"]["exports"]["NotebookLMClient"]["members"]
 
-    assert (
-        members["mind_maps.get"]["signature"]["return_annotation"]
-        == "notebooklm.types.MindMap"
-    )
+    assert members["mind_maps.get"]["signature"]["return_annotation"] == "notebooklm.types.MindMap"
 
 
 def test_collect_manifest_preserves_defaulted_dataclass_fields(script):

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -206,16 +206,16 @@ def test_collect_manifest_captures_return_annotation(script):
 
 def test_collect_manifest_canonicalizes_pep563_return_annotation(script):
     # ``_mind_maps_api`` uses ``from __future__ import annotations`` (PEP 563),
-    # so ``mind_maps.get -> MindMap | None`` arrives as a bare string. The
-    # collector must resolve it against the owning module's globals to the
-    # fully-qualified form, otherwise a module flipping its PEP 563 status would
-    # surface a spurious ``changed-return``.
+    # so ``mind_maps.get -> MindMap`` arrives as a bare string. The collector
+    # must resolve it against the owning module's globals to the fully-qualified
+    # form, otherwise a module flipping its PEP 563 status would surface a
+    # spurious ``changed-return``.
     manifest = script.collect_manifest(REPO_ROOT)
     members = manifest["modules"]["notebooklm"]["exports"]["NotebookLMClient"]["members"]
 
     assert (
         members["mind_maps.get"]["signature"]["return_annotation"]
-        == "notebooklm.types.MindMap | None"
+        == "notebooklm.types.MindMap"
     )
 
 

--- a/tests/unit/test_public_api_contract.py
+++ b/tests/unit/test_public_api_contract.py
@@ -78,12 +78,9 @@ LOOKUP_NAMESPACES = frozenset({"notebooks", "sources", "artifacts", "notes", "mi
 # Reason-tagged so every gap is visible; this set must SHRINK as #1247 lands and
 # must never gain an entry. (``notebooks.get`` already returns the non-Optional
 # ``Notebook`` and is intentionally absent.)
-GET_OPTIONAL_EXEMPTIONS: dict[str, str] = {
-    "sources": "get() still returns Source | None; flip to raise deferred to #1247",
-    "artifacts": "get() still returns Artifact | None; flip to raise deferred to #1247",
-    "notes": "get() still returns Note | None; flip to raise deferred to #1247",
-    "mind_maps": "get() still returns MindMap | None; flip to raise deferred to #1247",
-}
+# Empty as of #1247: every namespace ``get()`` now returns a non-Optional type
+# and raises its ``*NotFoundError`` on a miss. The set can never gain an entry.
+GET_OPTIONAL_EXEMPTIONS: dict[str, str] = {}
 
 
 def _method(namespace: str, name: str) -> Callable[..., object]:
@@ -240,6 +237,16 @@ def test_get_optional_exemptions_are_live(namespace: str) -> None:
     assert _is_optional(annotation), (
         f"GET_OPTIONAL_EXEMPTIONS lists {namespace}.get as Optional, but it is "
         f"now {annotation!r}; remove the stale exemption (#1247)."
+    )
+
+
+def test_get_optional_exemptions_is_empty() -> None:
+    """#1247 has landed: every namespace get() is non-Optional, so the
+    exemption set must stay empty — it can shrink to empty but never regain a
+    member (re-adding one re-introduces an Optional get())."""
+    assert GET_OPTIONAL_EXEMPTIONS == {}, (
+        "GET_OPTIONAL_EXEMPTIONS must stay empty after #1247: every namespace "
+        f"get() raises *NotFoundError and is non-Optional. Found: {GET_OPTIONAL_EXEMPTIONS}"
     )
 
 


### PR DESCRIPTION
## What

`client.{sources,artifacts,notes,mind_maps}.get(notebook_id, id)` now **raises**
its matching `*NotFoundError` on a genuine miss instead of returning `None` (with
a `DeprecationWarning`), unifying the not-found contract with `notebooks.get()`,
which already raises (#1247). Return annotations narrow `X | None` → `X`.

```python
# Before: returned None on a miss (deprecated)
src = await client.sources.get(nb, source_id)   # None if missing

# After: raises on a miss
src = await client.sources.get(nb, source_id)   # SourceNotFoundError if missing

# Unchanged escape hatch — the sanctioned None-on-miss lookup (never warns):
src = await client.sources.get_or_none(nb, source_id)
```

## Why

ADR-0019 makes resource absence an exception on `get` and reserves `None`-on-miss
for an explicit `get_or_none`. This lands the v0.8.0 flip the v0.7.0
`DeprecationWarning` runway pointed at.

## How

- **Single-sourced:** `_lookup.resolve_get` now delegates to the existing
  `unwrap_or_raise` and always raises on a miss — the `future_errors_enabled()`
  gate and the `warn_get_returns_none(...)` call are gone (so `_lookup.py` no
  longer imports either). The four namespace `get()` bodies were already routed
  through `resolve_get`; they only needed the annotation narrowing + docstring
  update + dropping the now-unused `resource=` arg.
- **The teeth:** the api-compat comparator is return-annotation-blind, so the
  flip is enforced by the conformance gates — `GET_OPTIONAL_EXEMPTIONS` empties
  (`test_public_api_contract.py`) and the four `get_warns` rows flip to `False`
  (`test_public_api_behavior.py::TestGetMissContract`, which then asserts raising
  under both flag modes). The `#1247` runway row is removed from the v0.8.0
  breaking-changes registry (its runway cited the `warn_get_returns_none` usage
  this removes). No api-compat allowlist entry is needed (a comparator-blind
  value flip).

## Tests

- Inverted `test_get_returns_none_deprecation` (warn+None → raises) and trimmed
  the now-removed flag-gated `resolve_get` cases in `test_future_errors_flag`
  (resolve_get's raise-on-miss is flag-agnostic now; the full miss-contract is in
  `test_public_api_behavior::TestGetMissContract`).
- Full suite green; mypy + ruff clean. No internal caller relied on the `None`
  return (internal code uses `get_or_none` / `_get_or_none`).

Note: `resolve_get` is now a one-line delegate to `unwrap_or_raise`; its outright
deletion (and the dead `warn_get_returns_none` def) is tracked for the v0.8.0
capstone (#1365) where the deprecation machinery is removed wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public get() calls (sources, artifacts, notes, mind_maps) now raise their matching NotFoundError on missing items instead of returning None — update callers to handle exceptions.
  * A deprecated positional-parser public member has been removed.

* **Tests**
  * Test suite updated to expect exception-on-miss behavior across unit, integration, and end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->