### PR TITLE
feat(api)!: raise on synchronous-kickoff refusal + mutate-existing miss + bool→None returns (#1342, #1362, #1290)

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -220,12 +220,32 @@
     {
       "code": "changed-return",
       "object": "notebooklm.NotebookLMClient.research.start",
-      "reason": "v0.7.0 #1209: now returns the typed ResearchStart | None dataclass instead of dict[str, Any] | None. MappingCompatMixin preserves dict-subscript access (warned, dropped in v0.8.0). See CHANGELOG.md [Unreleased] 'Added' and docs/deprecations.md."
+      "reason": "v0.7.0 #1209: now returns the typed ResearchStart dataclass instead of dict[str, Any] (MappingCompatMixin preserved dict-subscript access, dropped in v0.8.0). v0.8.0 #1342: the return type narrows from ResearchStart | None to ResearchStart — a 'couldn't-start' payload (empty/non-list or falsey task_id) now raises DecodingError instead of returning None. See CHANGELOG.md and docs/deprecations.md."
     },
     {
       "code": "changed-return",
       "object": "notebooklm.client.NotebookLMClient.research.start",
       "reason": "Same break as notebooklm.NotebookLMClient.research.start above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.sources.refresh",
+      "reason": "v0.8.0 #1290: the uninformative always-True return becomes None; the -> bool annotation is dropped. Any failure raises before the return, so the bool carried no information. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.sources.refresh",
+      "reason": "Same break as notebooklm.NotebookLMClient.sources.refresh above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.NotebookLMClient.chat.delete_conversation",
+      "reason": "v0.8.0 #1290: the uninformative always-True return becomes None; the -> bool annotation is dropped. Any failure raises before the return, so the bool carried no information. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-return",
+      "object": "notebooklm.client.NotebookLMClient.chat.delete_conversation",
+      "reason": "Same break as notebooklm.NotebookLMClient.chat.delete_conversation above; this entry covers the audit's dotted-module-path view of the same callable."
     },
     {
       "code": "changed-return",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -37,7 +37,6 @@ from ._artifact.payloads import (
     build_suggest_reports_params,
     build_video_artifact_params,
 )
-from ._deprecation import future_errors_enabled
 from ._env import get_default_language
 from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
@@ -67,7 +66,6 @@ from .rpc import (
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
-    RPCError,
     RPCMethod,
     SlideDeckFormat,
     SlideDeckLength,
@@ -549,23 +547,14 @@ class ArtifactsAPI:
             raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
 
         params = build_revise_slide_params(artifact_id, slide_index, prompt)
-        try:
-            result = await self._rpc.rpc_call(
-                RPCMethod.REVISE_SLIDE,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=True,
-            )
-        except RPCError as e:
-            # v0.8.0 preview (#1342): a refusal raises; see ``_call_generate``.
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR" and not future_errors_enabled():
-                return GenerationStatus(
-                    task_id="",
-                    status="failed",
-                    error=str(e),
-                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
-                )
-            raise
+        # v0.8.0 (#1342): a synchronous refusal (``RPCError``) propagates rather
+        # than being swallowed into a soft ``status="failed"`` return.
+        result = await self._rpc.rpc_call(
+            RPCMethod.REVISE_SLIDE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
         if result is None:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
             raise ArtifactFeatureUnavailableError(
@@ -934,9 +923,9 @@ class ArtifactsAPI:
             return_object: When ``True`` (default), re-fetch (a full
                 ``LIST_ARTIFACTS`` call) and return the renamed
                 :class:`~notebooklm.types.Artifact`; when ``False``, return
-                ``None`` without re-fetching. Under the v0.8.0 preview ``False``
-                still returns ``None`` but adds miss-detection (the flag gates
-                detection, not the return — see ``Raises``).
+                ``None`` without re-fetching. Miss-detection runs in both modes
+                (``False`` still returns ``None`` on success but raises on a
+                miss — see ``Raises``).
 
         Returns:
             The renamed :class:`~notebooklm.types.Artifact`, or ``None`` when
@@ -944,14 +933,20 @@ class ArtifactsAPI:
 
         Raises:
             ArtifactNotFoundError: if the artifact does not exist (detected via
-                a list fetch, not a 404). Always when ``return_object=True``;
-                also on ``False`` under ``NOTEBOOKLM_FUTURE_ERRORS``. Note-backed
-                mind-map ids are *not* renameable here — use ``mind_maps.rename``.
+                a list fetch, not a 404), in both ``return_object`` modes.
+                Note-backed mind-map ids are *not* renameable here — use
+                ``mind_maps.rename``.
 
         .. versionchanged:: 0.7.0
             **Breaking change:** no longer returns ``None`` on success; it
             re-fetches and raises :class:`ArtifactNotFoundError` for a missing
             target (#1255), plus the ``return_object`` opt-out.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** ``return_object=False`` now runs the existence
+            preflight too, so a missing target raises
+            :class:`ArtifactNotFoundError` instead of silently returning
+            ``None`` (#1362).
         """
         params = [[artifact_id, new_title], [["title"]]]
         await self._rpc.rpc_call(
@@ -962,10 +957,9 @@ class ArtifactsAPI:
         )
         # Resolve via studio artifacts only — never public ``get()`` (#1247) nor
         # the merged listing (a note-backed mind-map id no-ops on RENAME_ARTIFACT
-        # — use ``mind_maps.rename``). v0.7.0 ``False`` short-circuits; the v0.8.0
-        # preview (#1362) runs the lookup on ``False`` too but still returns None.
-        if not return_object and not future_errors_enabled():
-            return None
+        # — use ``mind_maps.rename``). v0.8.0 (#1362): the lookup runs on
+        # ``False`` too so a missing target is detected, but ``False`` still
+        # returns ``None`` on success.
         artifact = await self._listing.get_studio_only(
             notebook_id, artifact_id, list_raw=self._list_raw
         )
@@ -1223,27 +1217,19 @@ class ArtifactsAPI:
             descriptor[2] if isinstance(descriptor, list) and len(descriptor) > 2 else "unknown"
         )
         logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
-        try:
-            # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
-            # ``operation_variant=None`` marks this call site as the no-variant
-            # default (a future-proofing marker; the registry resolves the same).
-            result = await self._rpc.rpc_call(
-                RPCMethod.CREATE_ARTIFACT,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=True,
-                operation_variant=None,
-            )
-        except RPCError as e:
-            # v0.8.0 preview (#1342): a refusal raises (couldn't-start); default-off swallow.
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR" and not future_errors_enabled():
-                return GenerationStatus(
-                    task_id="",
-                    status="failed",
-                    error=str(e),
-                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
-                )
-            raise
+        # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
+        # ``operation_variant=None`` marks this call site as the no-variant
+        # default (a future-proofing marker; the registry resolves the same).
+        # v0.8.0 (#1342): a synchronous refusal (couldn't-start, ``RPCError``)
+        # propagates rather than being swallowed into a soft
+        # ``status="failed"`` return.
+        result = await self._rpc.rpc_call(
+            RPCMethod.CREATE_ARTIFACT,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+            operation_variant=None,
+        )
         if result is None and null_result_artifact_type is not None:
             raise ArtifactFeatureUnavailableError(
                 null_result_artifact_type,
@@ -1343,15 +1329,11 @@ class ArtifactsAPI:
             status = artifact_status_to_str(status_code) if status_code is not None else "pending"
             return GenerationStatus(task_id=artifact_id, status=status)
 
-        # v0.8.0 preview (#1342): a missing id means no task was created — raise.
+        # v0.8.0 (#1342): a missing id means no task was created — raise.
         # Null id (feature gated) -> ArtifactFeatureUnavailableError; else drift.
-        if future_errors_enabled():
-            if artifact_id is None:
-                raise ArtifactFeatureUnavailableError("artifact", method_id=method_id)
-            raise DecodingError(f"No artifact id (source={source})", method_id=method_id)
-        return GenerationStatus(
-            task_id="", status="failed", error="Generation failed - no artifact_id returned"
-        )
+        if artifact_id is None:
+            raise ArtifactFeatureUnavailableError("artifact", method_id=method_id)
+        raise DecodingError(f"No artifact id (source={source})", method_id=method_id)
 
     @staticmethod
     def _extract_artifact_error(art: builtins.list[Any]) -> str | None:

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -12,7 +12,6 @@ import weakref
 from typing import TYPE_CHECKING, Any
 
 from .._conversation_cache import ConversationCache
-from .._deprecation import future_errors_enabled
 from .._logging import get_request_id, reset_request_id, set_request_id
 from .._loop_bound import LoopBoundPrimitive
 from .._notebook_metadata import NotebookSourceIdProvider
@@ -691,7 +690,7 @@ class ChatAPI(LoopBoundPrimitive):
             for turn in cached
         ]
 
-    async def delete_conversation(self, notebook_id: str, conversation_id: str) -> bool:
+    async def delete_conversation(self, notebook_id: str, conversation_id: str) -> None:
         """Delete a conversation from the server.
 
         Mirrors the web UI's "Delete history" action. After deletion the next
@@ -703,10 +702,11 @@ class ChatAPI(LoopBoundPrimitive):
             conversation_id: The conversation to delete.
 
         Returns:
-            ``True`` on success (errors raise first, so the ``True`` is
-            uninformative). Under ``NOTEBOOKLM_FUTURE_ERRORS`` (v0.8.0 preview,
-            #1290) returns ``None``; the ``-> bool`` annotation stays until the
-            v0.8.0 flip.
+            ``None`` on success; any failure raises first.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** returns ``None`` instead of the uninformative
+            always-``True`` value; the ``-> bool`` annotation is dropped (#1290).
         """
         # Catch cross-loop misuse before acquiring the per-conversation lock
         # (like ``ask``), so a client reused from another loop fails fast rather
@@ -727,10 +727,8 @@ class ChatAPI(LoopBoundPrimitive):
             )
             # Clear the cache only after a successful RPC (failure raises above).
             self._cache.clear(conversation_id)
-        # v0.8.0 preview (#1290): uninformative ``True`` -> ``None`` (runtime-only).
-        if future_errors_enabled():
-            return None  # type: ignore[return-value]
-        return True
+        # v0.8.0 (#1290): the uninformative always-``True`` return becomes ``None``.
+        return None
 
     def clear_cache(self, conversation_id: str | None = None) -> bool:
         """Clear conversation cache.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -18,7 +18,6 @@ import builtins
 import logging
 from typing import Any
 
-from ._deprecation import future_errors_enabled
 from ._lookup import resolve_get
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteRowKind, NoteService
@@ -178,22 +177,23 @@ class NotesAPI:
             title: The new title.
 
         Raises:
-            NoteNotFoundError: When ``NOTEBOOKLM_FUTURE_ERRORS`` (the v0.8.0
-                preview, issue #1362) is enabled and ``note_id`` does not exist.
-                The ``UPDATE_NOTE`` RPC is ``allow_null=True`` and silently
-                no-ops on a missing note, so the current (v0.7.0) contract
-                silently "succeeds" on a miss; the preview adds a public-facade
-                existence preflight so a mutate-existing op fails loud per
-                ADR-0019 Class 5.
+            NoteNotFoundError: When ``note_id`` does not exist. The
+                ``UPDATE_NOTE`` RPC is ``allow_null=True`` and silently no-ops
+                on a missing note, so a public-facade existence preflight runs
+                first to make a mutate-existing op fail loud per ADR-0019
+                Class 5.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** updating a missing note now raises
+            :class:`NoteNotFoundError` instead of silently "succeeding" via the
+            ``allow_null=True`` no-op (#1362).
         """
-        if future_errors_enabled():
-            # v0.8.0 preview (issue #1362): detect a missing target at the
-            # public facade (never inside ``_note_service`` — that crosses the
-            # layer boundary). ``get_or_none`` is the silent optional-lookup;
-            # only a genuine miss yields ``None`` (transport/auth/decode faults
-            # propagate). Default-off keeps the historical silent no-op.
-            if await self.get_or_none(notebook_id, note_id) is None:
-                raise NoteNotFoundError(note_id)
+        # v0.8.0 (issue #1362): detect a missing target at the public facade
+        # (never inside ``_note_service`` — that crosses the layer boundary).
+        # ``get_or_none`` is the silent optional-lookup; only a genuine miss
+        # yields ``None`` (transport/auth/decode faults propagate).
+        if await self.get_or_none(notebook_id, note_id) is None:
+            raise NoteNotFoundError(note_id)
         await self._notes.update_note(notebook_id, note_id, content, title)
 
     async def delete(self, notebook_id: str, note_id: str) -> None:

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from . import research as _research_pub
-from ._deprecation import future_errors_enabled, warn_deprecated
+from ._deprecation import warn_deprecated
 from ._notebook_metadata import NotebookSourceLister, create_default_source_lister
 from ._research_task_parser import parse_research_task_models
 from ._runtime.contracts import RpcCaller
@@ -329,7 +329,7 @@ class ResearchAPI:
         query: str,
         source: str = "web",
         mode: str = "fast",
-    ) -> ResearchStart | None:
+    ) -> ResearchStart:
         """Start a research session.
 
         Args:
@@ -340,15 +340,18 @@ class ResearchAPI:
 
         Returns:
             A :class:`~notebooklm._types.research.ResearchStart` (``task_id`` /
-            ``report_id`` / ``notebook_id`` / ``query`` / ``mode``), or ``None``
-            when the backend returned no task. Under
-            ``NOTEBOOKLM_FUTURE_ERRORS`` (#1342) an empty/non-list payload or
-            falsey ``task_id`` raises ``DecodingError`` instead.
+            ``report_id`` / ``notebook_id`` / ``query`` / ``mode``).
 
         Raises:
             ValidationError: If source/mode combination is invalid.
-            DecodingError: Under the v0.8.0 preview, on an empty/non-list payload
-                or falsey ``task_id`` (no task created).
+            DecodingError: On a "couldn't-start" payload — an empty/non-list
+                result or a falsey ``task_id`` (no task created); #1342.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** a "couldn't-start" payload now raises
+            :class:`DecodingError` instead of returning ``None``, and the return
+            type narrows from ``ResearchStart | None`` to ``ResearchStart``
+            (#1342).
         """
         logger.debug(
             "Starting %s research in notebook %s: %s",
@@ -384,9 +387,9 @@ class ResearchAPI:
 
         if result and isinstance(result, list) and len(result) > 0:
             task_id = result[0]
-            # v0.8.0 preview (#1342): a falsey ``task_id`` means no task was
-            # created — raise (mirrors ``_parse_generation_result``'s missing id).
-            if not task_id and future_errors_enabled():
+            # v0.8.0 (#1342): a falsey ``task_id`` means no task was created —
+            # raise (mirrors ``_parse_generation_result``'s missing id).
+            if not task_id:
                 raise DecodingError(
                     f"research.start returned no task id: {result!r}", method_id=rpc_id.value
                 )
@@ -398,12 +401,10 @@ class ResearchAPI:
                 query=query,
                 mode=mode_lower,
             )
-        # v0.8.0 preview (#1342): an empty / non-list payload is couldn't-start.
-        if future_errors_enabled():
-            raise DecodingError(
-                "research.start returned an empty / non-list payload", method_id=rpc_id.value
-            )
-        return None
+        # v0.8.0 (#1342): an empty / non-list payload is couldn't-start — raise.
+        raise DecodingError(
+            "research.start returned an empty / non-list payload", method_id=rpc_id.value
+        )
 
     async def poll(
         self,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 
 import httpx
 
-from ._deprecation import future_errors_enabled
 from ._lookup import resolve_get
 from ._row_adapters.sources import interpret_source_freshness
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
@@ -634,23 +633,25 @@ class SourcesAPI:
             return_object: When ``True`` (default), return the renamed
                 :class:`~notebooklm.types.Source` (preferring the
                 ``UPDATE_SOURCE`` echo, fetching only on a null echo). When
-                ``False``, return ``None`` without hydrating. Under the v0.8.0
-                preview ``False`` still returns ``None`` but adds miss-detection
-                (the flag gates detection, not return — see ``Raises``).
+                ``False``, return ``None`` without hydrating. Miss-detection
+                runs in both modes (``False`` returns ``None`` but raises a miss).
 
         Returns:
             The renamed :class:`~notebooklm.types.Source`, or ``None`` when
             ``return_object=False``.
 
         Raises:
-            SourceNotFoundError: if the source does not exist (detected via a
-                content/list fetch, not a 404). Always when ``return_object=True``;
-                also on ``False`` under ``NOTEBOOKLM_FUTURE_ERRORS``.
+            SourceNotFoundError: if the source does not exist (a content/list
+                fetch, not a 404, detects it), in both ``return_object`` modes.
 
         .. versionchanged:: 0.7.0
             **Breaking change:** no longer fabricates an unverified
             ``Source(id, title)`` on a null echo; it hydrates and raises
             :class:`SourceNotFoundError` (#1255), plus ``return_object``.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** ``return_object=False`` now runs the existence
+            preflight on a null echo too, raising on a miss (#1362).
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = build_rename_source_params(source_id, new_title)
@@ -663,16 +664,16 @@ class SourcesAPI:
         if result and return_object:
             return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
         # Null echo: hydrate via the internal lookup (never public ``get()`` —
-        # #1247) so a miss raises. ``False`` skips it when existence is proven
-        # (echo) or flag-off; the v0.8.0 preview (#1362) runs it to detect a miss.
-        if not return_object and (result or not future_errors_enabled()):
+        # #1247) so a miss raises. ``False`` skips it only when existence is
+        # proven by the echo; v0.8.0 (#1362) runs it to detect a miss.
+        if not return_object and result:
             return None
         source = await self._get_or_none(notebook_id, source_id)
         if source is None:
             raise SourceNotFoundError(source_id, method_id=RPCMethod.UPDATE_SOURCE.value)
         return None if not return_object else source
 
-    async def refresh(self, notebook_id: str, source_id: str) -> bool:
+    async def refresh(self, notebook_id: str, source_id: str) -> None:
         """Refresh a source to get updated content (for URL/Drive sources).
 
         Args:
@@ -680,9 +681,11 @@ class SourcesAPI:
             source_id: The source ID to refresh.
 
         Returns:
-            ``True`` if refresh was initiated (failures raise first, so it is
-            uninformative). Under ``NOTEBOOKLM_FUTURE_ERRORS`` (#1290) returns
-            ``None``; ``-> bool`` stays until v0.8.0.
+            ``None`` on success; any failure raises first.
+
+        .. versionchanged:: 0.8.0
+            **Breaking change:** returns ``None`` (not always-``True``); the
+            ``-> bool`` annotation is dropped (#1290).
         """
         params = [None, [source_id], [2]]
         await self._rpc.rpc_call(
@@ -691,10 +694,7 @@ class SourcesAPI:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        # v0.8.0 preview (#1290): uninformative ``True`` -> ``None`` (runtime-only).
-        if future_errors_enabled():
-            return None  # type: ignore[return-value]
-        return True
+        return None
 
     async def check_freshness(self, notebook_id: str, source_id: str) -> bool:
         """Check if a source needs to be refreshed.

--- a/src/notebooklm/artifacts.py
+++ b/src/notebooklm/artifacts.py
@@ -1,9 +1,11 @@
 """Public artifact-generation helpers.
 
-The client methods on ``client.artifacts`` return ``GenerationStatus`` objects
-directly when Google rejects generation with a user-displayable rate-limit or
-quota error. This module provides the same retry policy used by the CLI so
-Python API callers do not need to duplicate the backoff loop.
+The client methods on ``client.artifacts`` raise
+:class:`~notebooklm.exceptions.RateLimitError` when Google rejects a
+synchronous generation kickoff with a user-displayable rate-limit or quota
+error (v0.8.0, #1342). This module provides the same retry policy used by the
+CLI — retrying on a raised ``RateLimitError`` — so Python API callers do not
+need to duplicate the backoff loop.
 """
 
 from __future__ import annotations
@@ -74,23 +76,19 @@ async def with_rate_limit_retry(
 ) -> GenerationStatus | None:
     """Run an artifact-generation callable with rate-limit retry.
 
-    The callable is always invoked at least once. A retry is scheduled when an
-    attempt signals a rate limit in **either** of these two ways:
+    The callable is always invoked at least once. A retry is scheduled only
+    when an attempt raises :class:`~notebooklm.exceptions.RateLimitError` — the
+    ADR-0019 "async kickoff" contract where a synchronous rate-limit refusal
+    propagates as an exception (v0.8.0, #1342). A *returned* ``GenerationStatus``
+    — including one whose ``is_rate_limited`` property is true — is no longer a
+    retry signal and is returned immediately.
 
-    * it returns a ``GenerationStatus`` whose ``is_rate_limited`` property is
-      true (the legacy ``generate_*`` path, which swallows a rate-limit refusal
-      into ``status="failed"`` until v0.8.0); **or**
-    * it raises :class:`~notebooklm.exceptions.RateLimitError` (the ADR-0019
-      "async kickoff" path used by ``retry_failed``, where a synchronous
-      refusal propagates as an exception rather than a returned status).
+    Successful statuses, non-rate-limit failures, returned rate-limited statuses,
+    and ``None`` return immediately. Non-``RateLimitError`` exceptions propagate
+    unchanged.
 
-    Successful statuses, non-rate-limit failures, and ``None`` return
-    immediately. Non-``RateLimitError`` exceptions propagate unchanged.
-
-    When the retry budget is exhausted, the final outcome is surfaced the same
-    way it arrived: a returned rate-limited ``GenerationStatus`` is returned,
-    and a raised ``RateLimitError`` is re-raised. (Removing the returned-status
-    path is the v0.8.0 break — not done here.)
+    When the retry budget is exhausted, the final attempt's ``RateLimitError``
+    is re-raised.
 
     Args:
         generate_fn: Async callable that starts an artifact-generation request.
@@ -100,21 +98,18 @@ async def with_rate_limit_retry(
         multiplier: Exponential backoff multiplier.
         sleep: Async sleep function. Defaults to ``asyncio.sleep``.
         on_retry: Optional callback invoked before each retry sleep. The
-            event's ``result`` is the returned rate-limited ``GenerationStatus``
-            for the returned-status path, or a synthesized
+            event's ``result`` is a synthesized
             ``GenerationStatus(status="failed", error_code="USER_DISPLAYABLE_ERROR")``
-            standing in for the raised ``RateLimitError`` so the callback shape
+            standing in for the caught ``RateLimitError`` so the callback shape
             is uniform.
 
     Returns:
-        The first non-rate-limited result, or the final rate-limited
-        ``GenerationStatus`` when the retry budget is exhausted on the
-        returned-status path.
+        The first returned result (the callable may still return ``None``).
 
     Raises:
         ValueError: If retry or delay parameters are invalid.
-        RateLimitError: When the retry budget is exhausted on the raised-error
-            path (the final attempt's ``RateLimitError`` is re-raised).
+        RateLimitError: When the retry budget is exhausted (the final attempt's
+            ``RateLimitError`` is re-raised).
     """
     if max_retries < 0:
         raise ValueError("max_retries must be non-negative")
@@ -130,10 +125,9 @@ async def with_rate_limit_retry(
     attempt = 0
     while True:
         # ``event_result`` carries the rate-limited GenerationStatus passed to
-        # ``on_retry``. For the raised-error path it is synthesized from the
-        # caught exception so the callback shape stays uniform across both
-        # rate-limit signals.
-        event_result: GenerationStatus
+        # ``on_retry``. It is synthesized from the caught ``RateLimitError`` so
+        # the callback shape is uniform — a *returned* status is never a retry
+        # signal (v0.8.0, #1342).
         try:
             result = await generate_fn()
         except RateLimitError as exc:
@@ -154,11 +148,10 @@ async def with_rate_limit_retry(
                 ),
             )
         else:
-            if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
-                return result
-            if attempt >= max_retries:
-                return result
-            event_result = result
+            # Any returned result (success, non-rate-limit failure, a returned
+            # rate-limited status, or ``None``) returns immediately — only a
+            # raised ``RateLimitError`` drives a retry (#1342).
+            return result
 
         delay = calculate_backoff_delay(
             attempt,

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -130,11 +130,11 @@ class SourceRefreshResult:
 
     source_id: str
     notebook_id: str
-    result: Source | bool | None
+    result: Source | None
 
     @property
     def payload(self) -> dict[str, Any]:
-        if self.result and self.result is not True:
+        if isinstance(self.result, Source):
             return {
                 "action": "refresh",
                 "source_id": self.result.id,
@@ -142,18 +142,13 @@ class SourceRefreshResult:
                 "title": self.result.title,
                 "status": "refreshed",
             }
-        if self.result is True:
-            return {
-                "action": "refresh",
-                "source_id": self.source_id,
-                "notebook_id": self.notebook_id,
-                "status": "refreshed",
-            }
+        # ``sources.refresh`` returns ``None`` on success (#1290); any failure
+        # raises before reaching here, so ``None`` is the refreshed-OK case.
         return {
             "action": "refresh",
             "source_id": self.source_id,
             "notebook_id": self.notebook_id,
-            "status": "no_result",
+            "status": "refreshed",
         }
 
 
@@ -543,8 +538,10 @@ async def execute_source_refresh(
         client, plan.notebook_id, plan.source_id, json_output=plan.json_output
     )
 
-    src = await client.sources.refresh(plan.notebook_id, resolved_id)
-    return SourceRefreshResult(source_id=resolved_id, notebook_id=plan.notebook_id, result=src)
+    # ``sources.refresh`` returns ``None`` on success (#1290); any failure
+    # raises before reaching here.
+    await client.sources.refresh(plan.notebook_id, resolved_id)
+    return SourceRefreshResult(source_id=resolved_id, notebook_id=plan.notebook_id, result=None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -514,13 +514,13 @@ def _render_source_refresh_result(
         return
 
     refreshed = result.result
-    if refreshed and refreshed is not True:
+    if isinstance(refreshed, Source):
         cli_print(f"[green]Source refreshed:[/green] {refreshed.id}", ctx=ctx)
         cli_print(f"[bold]Title:[/bold] {refreshed.title}", ctx=ctx)
-    elif refreshed is True:
-        cli_print(f"[green]Source refreshed:[/green] {result.source_id}", ctx=ctx)
     else:
-        cli_print("[yellow]Refresh returned no result[/yellow]", ctx=ctx)
+        # ``sources.refresh`` returns ``None`` on success (#1290); failures
+        # raise before reaching here, so ``None`` is the refreshed-OK case.
+        cli_print(f"[green]Source refreshed:[/green] {result.source_id}", ctx=ctx)
 
 
 def _render_source_add_drive_result(

--- a/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
+++ b/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
@@ -140,7 +140,7 @@ tests/integration/test_artifacts_integration.py::TestArtifactsAPI::test_list_use
 tests/integration/test_artifacts_integration.py::TestArtifactsAPI::test_list_video_artifacts # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestArtifactsAPI::test_rename_artifact # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestCallGenerateErrorHandling::test_generate_audio_other_rpc_error_reraises # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
-tests/integration/test_artifacts_integration.py::TestCallGenerateErrorHandling::test_generate_audio_user_displayable_error_returns_failed # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
+tests/integration/test_artifacts_integration.py::TestCallGenerateErrorHandling::test_generate_audio_user_displayable_error_raises # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestDeleteStudioContent::test_delete_studio_content # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestDownloadAudioErrorPaths::test_download_audio_artifact_id_not_found_raises_not_ready # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestDownloadAudioErrorPaths::test_download_audio_empty_list_raises_not_ready # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
@@ -218,7 +218,7 @@ tests/integration/test_artifacts_integration.py::TestPollStatusVariousPaths::tes
 tests/integration/test_artifacts_integration.py::TestReviseSlide::test_revise_slide_negative_index_raises_validation_error # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestReviseSlide::test_revise_slide_null_result_returns_generation_status # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestReviseSlide::test_revise_slide_other_rpc_error_reraises # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
-tests/integration/test_artifacts_integration.py::TestReviseSlide::test_revise_slide_user_displayable_error_returns_failed_status # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
+tests/integration/test_artifacts_integration.py::TestReviseSlide::test_revise_slide_user_displayable_error_raises # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestStudioContent::test_generate_audio # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestStudioContent::test_generate_audio_with_format_and_length # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py::TestStudioContent::test_generate_cinematic_video # existing mock-only integration exception; migrate per test-suite taxonomy cleanup

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -64,7 +64,7 @@ MODULE_SIZE_BUDGET = 900
 ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/source_cmd.py": 1498,
     "exceptions.py": 1426,
-    "_artifacts.py": 1412,
+    "_artifacts.py": 1394,
     "_source/upload.py": 1236,
     "cli/session_cmd.py": 1080,
     "_sources.py": 1007,
@@ -73,7 +73,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "client.py": 973,
     "_research.py": 936,
     "cli/services/generate.py": 926,
-    "_chat/api.py": 948,
+    "_chat/api.py": 946,
     "_idempotency.py": 936,
 }
 

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -71,7 +71,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,
-    "_research.py": 936,
+    "_research.py": 937,
     "cli/services/generate.py": 926,
     "_chat/api.py": 946,
     "_idempotency.py": 936,

--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -146,8 +146,8 @@ class TestSourceMutations:
         await asyncio.sleep(2)  # Wait for initial processing
 
         result = await client.sources.refresh(temp_notebook.id, source.id)
-        # refresh() always returns True if successful
-        assert result is True
+        # v0.8.0 (#1290): refresh() returns None on success
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_check_freshness(self, client, temp_notebook):

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -630,17 +630,18 @@ class TestArtifactsAPI:
                 await client.artifacts.rename("nb_123", "art_001", "New Title")
 
     @pytest.mark.asyncio
-    async def test_rename_artifact_return_object_false_skips_fetch(self, auth_tokens):
-        """return_object=False returns None and issues no LIST_ARTIFACTS hydrate."""
+    async def test_rename_artifact_return_object_false_raises_on_miss(self, auth_tokens):
+        """v0.8.0 (#1362): return_object=False runs the existence preflight too.
+
+        A null RENAME echo plus an empty LIST_ARTIFACTS hydrate means the target
+        is missing, so the False path raises ArtifactNotFoundError instead of
+        silently returning None.
+        """
         async with NotebookLMClient(auth_tokens) as client:
             rpc = AsyncMock(return_value=None)
             client._rpc_executor.rpc_call = rpc
-            result = await client.artifacts.rename(
-                "nb_123", "art_001", "New Title", return_object=False
-            )
-
-        assert result is None
-        rpc.assert_awaited_once()
+            with pytest.raises(ArtifactNotFoundError):
+                await client.artifacts.rename("nb_123", "art_001", "New Title", return_object=False)
 
     @pytest.mark.asyncio
     async def test_export_artifact(
@@ -1738,13 +1739,13 @@ class TestReviseSlide:
         assert err.method_id == RPCMethod.REVISE_SLIDE.value
 
     @pytest.mark.asyncio
-    async def test_revise_slide_user_displayable_error_returns_failed_status(
+    async def test_revise_slide_user_displayable_error_raises(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """revise_slide returns failed GenerationStatus on USER_DISPLAYABLE_ERROR."""
+        """v0.8.0 (#1342): revise_slide re-raises on a USER_DISPLAYABLE_ERROR refusal."""
         async with NotebookLMClient(auth_tokens) as client:
             err = RPCError("Rate limit exceeded")
             err.rpc_code = "USER_DISPLAYABLE_ERROR"
@@ -1752,21 +1753,20 @@ class TestReviseSlide:
             # directly; the patch goes through ``_rpc`` (the
             # ``RpcExecutor``) since that is what ``rpc_call`` resolves
             # through.
-            with patch.object(
-                client.artifacts._rpc,
-                "rpc_call",
-                AsyncMock(side_effect=err),
+            with (
+                patch.object(
+                    client.artifacts._rpc,
+                    "rpc_call",
+                    AsyncMock(side_effect=err),
+                ),
+                pytest.raises(RPCError, match="Rate limit exceeded"),
             ):
-                result = await client.artifacts.revise_slide(
+                await client.artifacts.revise_slide(
                     notebook_id="nb_123",
                     artifact_id="artifact_456",
                     slide_index=2,
                     prompt="Make it simpler",
                 )
-
-        assert result is not None
-        assert result.status == "failed"
-        assert result.error_code == "USER_DISPLAYABLE_ERROR"
 
     @pytest.mark.asyncio
     async def test_revise_slide_other_rpc_error_reraises(
@@ -2411,13 +2411,13 @@ class TestCallGenerateErrorHandling:
     """Tests for _call_generate() error handling (USER_DISPLAYABLE_ERROR path)."""
 
     @pytest.mark.asyncio
-    async def test_generate_audio_user_displayable_error_returns_failed(
+    async def test_generate_audio_user_displayable_error_raises(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """_call_generate returns failed GenerationStatus on USER_DISPLAYABLE_ERROR."""
+        """v0.8.0 (#1342): _call_generate re-raises on a USER_DISPLAYABLE_ERROR refusal."""
         async with NotebookLMClient(auth_tokens) as client:
             err = RPCError("You have exceeded your quota")
             err.rpc_code = "USER_DISPLAYABLE_ERROR"
@@ -2427,15 +2427,15 @@ class TestCallGenerateErrorHandling:
             # stores its three runtime collaborators directly, so the
             # patch target is ``_rpc`` — see the ``revise_slide``
             # siblings above for the same rationale.
-            with patch.object(
-                client.artifacts._rpc,
-                "rpc_call",
-                AsyncMock(side_effect=err),
+            with (
+                patch.object(
+                    client.artifacts._rpc,
+                    "rpc_call",
+                    AsyncMock(side_effect=err),
+                ),
+                pytest.raises(RPCError, match="exceeded your quota"),
             ):
-                result = await client.artifacts.generate_audio("nb_123", source_ids=["src_001"])
-
-        assert result.status == "failed"
-        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+                await client.artifacts.generate_audio("nb_123", source_ids=["src_001"])
 
     @pytest.mark.asyncio
     async def test_generate_audio_other_rpc_error_reraises(

--- a/tests/integration/test_chat_delete_conversation_vcr.py
+++ b/tests/integration/test_chat_delete_conversation_vcr.py
@@ -154,24 +154,26 @@ class TestDeleteConversationVCR:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     async def test_delete_conversation_round_trips(self) -> None:
-        """``delete_conversation`` returns True and produces no error envelope."""
+        """``delete_conversation`` returns None and produces no error envelope."""
         auth = await get_vcr_auth()
         async with NotebookLMClient(auth) as client:
             if _vcr_record_mode:
                 notebook_id, conversation_id = await _seed_scratch_conversation(client)
                 try:
                     with notebooklm_vcr.use_cassette(CASSETTE_NAME):
+                        # v0.8.0 (#1290): delete_conversation returns None on success.
                         assert (
                             await client.chat.delete_conversation(notebook_id, conversation_id)
-                            is True
+                            is None
                         )
                 finally:
                     await _teardown_scratch_notebook(client, notebook_id)
             else:
                 notebook_id, conversation_id = _load_cassette_inputs()
                 with notebooklm_vcr.use_cassette(CASSETTE_NAME):
+                    # v0.8.0 (#1290): delete_conversation returns None on success.
                     assert (
-                        await client.chat.delete_conversation(notebook_id, conversation_id) is True
+                        await client.chat.delete_conversation(notebook_id, conversation_id) is None
                     )
 
     def test_cassette_carries_expected_wire_shape(self) -> None:

--- a/tests/integration/test_notes_integration.py
+++ b/tests/integration/test_notes_integration.py
@@ -198,15 +198,22 @@ class TestNotesAPI:
         build_rpc_response,
     ):
         """Test updating an existing note."""
+        # v0.8.0 (#1362): update() runs a GET_NOTES_AND_MIND_MAPS existence
+        # preflight first; the note must be present so the UPDATE_NOTE RPC fires.
+        preflight = build_rpc_response(
+            RPCMethod.GET_NOTES_AND_MIND_MAPS,
+            [[["note_001", ["note_001", "Existing", None, None, "Note"]]]],
+        )
+        httpx_mock.add_response(content=preflight.encode())
         response = build_rpc_response(RPCMethod.UPDATE_NOTE, None)
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
             await client.notes.update("nb_123", "note_001", "Updated content", "Updated title")
 
-        request = httpx_mock.get_request()
-        assert RPCMethod.UPDATE_NOTE in str(request.url)
-        assert "source-path=%2Fnotebook%2Fnb_123" in str(request.url)
+        update_request = httpx_mock.get_requests()[-1]
+        assert RPCMethod.UPDATE_NOTE in str(update_request.url)
+        assert "source-path=%2Fnotebook%2Fnb_123" in str(update_request.url)
 
     @pytest.mark.asyncio
     async def test_delete_note(

--- a/tests/integration/test_polling_vcr.py
+++ b/tests/integration/test_polling_vcr.py
@@ -73,6 +73,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 import yaml
@@ -182,10 +183,13 @@ class TestPollingReplay:
 
             # 4. Rename leg — exercises RENAME_ARTIFACT regardless of whether
             #    the artifact ended ``completed`` or ``failed``. We pass
-            #    ``return_object=False`` to skip the post-rename re-fetch
-            #    (issue #1255), which would otherwise require an additional
-            #    cassette interaction; the regression we care about is "the
+            #    ``return_object=False`` so the regression we care about is "the
             #    rename RPC fires without error".
+            #    v0.8.0 (#1362): return_object=False now runs the existence
+            #    preflight too; stub it as a hit (the artifact was generated
+            #    above, so it exists) so no extra LIST_ARTIFACTS interaction is
+            #    required beyond what the cassette already captured.
+            client.artifacts._listing.get_studio_only = AsyncMock(return_value=final_status)
             await client.artifacts.rename(
                 MUTABLE_NOTEBOOK_ID,
                 task_id,

--- a/tests/integration/test_rpc_gap_backfill_vcr.py
+++ b/tests/integration/test_rpc_gap_backfill_vcr.py
@@ -81,7 +81,7 @@ async def test_refresh_source_rpc_has_cassette_coverage():
     async with vcr_client() as client:
         refreshed = await client.sources.refresh(MUTABLE_NOTEBOOK_ID, "source_backfill_001")
 
-    assert refreshed is True
+    assert refreshed is None  # v0.8.0 (#1290): returns None on success
     # Rotation-proof: assert the replayed interaction targeted REFRESH_SOURCE by
     # its constant (rpc/types.py is the single source of truth), not a literal.
     assert RPCMethod.REFRESH_SOURCE.value in _cassette_request_rpcids("sources_refresh_direct.yaml")

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -304,7 +304,7 @@ async def test_refresh_source_emits_rate_limited_warn(
         with caplog.at_level(logging.WARNING, logger="notebooklm._idempotency"):
             for _ in range(invocations):
                 ok = await client.sources.refresh("nb_x", "src_x")
-                assert ok is True
+                assert ok is None  # v0.8.0 (#1290): returns None on success
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -544,7 +544,7 @@ class TestSourcesAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.sources.refresh("nb_123", "src_001")
 
-        assert result is True
+        assert result is None  # v0.8.0 (#1290): returns None on success
         request = httpx_mock.get_request()
         assert RPCMethod.REFRESH_SOURCE in str(request.url)
 
@@ -778,18 +778,20 @@ class TestSourcesAPI:
                 await client.sources.rename("nb_123", "src_001", "New Title")
 
     @pytest.mark.asyncio
-    async def test_rename_source_return_object_false_skips_fetch(self, auth_tokens):
-        """return_object=False returns None and issues no hydrate fetch on a null echo."""
+    async def test_rename_source_return_object_false_raises_on_miss(self, auth_tokens):
+        """v0.8.0 (#1362): return_object=False runs the existence preflight too.
+
+        A null UPDATE_SOURCE echo plus an absent source means the target is
+        missing, so the False path raises SourceNotFoundError instead of
+        silently returning None.
+        """
         async with NotebookLMClient(auth_tokens) as client:
             rpc = AsyncMock(return_value=None)
             client._rpc_executor.rpc_call = rpc
-            result = await client.sources.rename(
-                "nb_123", "src_001", "New Title", return_object=False
-            )
-
-        assert result is None
-        # Only the UPDATE_SOURCE call — no hydrate fetch.
-        rpc.assert_awaited_once()
+            # The existence preflight resolves the source as a genuine miss.
+            client.sources._get_or_none = AsyncMock(return_value=None)
+            with pytest.raises(SourceNotFoundError):
+                await client.sources.rename("nb_123", "src_001", "New Title", return_object=False)
 
 
 class TestAddFileSource:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -19,6 +19,7 @@ import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -286,6 +287,11 @@ class TestNotesAPI:
                 content="Original content.",
             )
             assert note is not None
+            # v0.8.0 (#1362): update() runs an existence preflight; stub the
+            # just-created note as a hit so the cassette (recorded pre-flip,
+            # without the extra GET_NOTES_AND_MIND_MAPS round-trip) still
+            # replays the create+update interactions only.
+            client.notes.get_or_none = AsyncMock(return_value=note)
             await client.notes.update(
                 MUTABLE_NOTEBOOK_ID,
                 note.id,
@@ -818,8 +824,8 @@ class TestSourcesAdditionalAPI:
             if not url_source:
                 pytest.skip("No WEB_PAGE source available for refresh")
             result = await client.sources.refresh(MUTABLE_NOTEBOOK_ID, url_source.id)
-        # refresh() returns True if initiated successfully (no exception)
-        assert result is True, "refresh() should return True on success"
+        # v0.8.0 (#1290): refresh() returns None on success (no exception)
+        assert result is None, "refresh() should return None on success"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -948,12 +954,15 @@ class TestArtifactsAdditionalAPI:
                 pytest.skip("No artifacts available")
             artifact = artifacts[0]
             original_title = artifact.title
-            # Rename. return_object=False skips the post-rename re-fetch so the
-            # existing cassette (rename RPC only) keeps replaying (issue #1255).
+            # v0.8.0 (#1362): return_object=False now runs the existence
+            # preflight too. Stub it as a hit (the artifact came from the list
+            # above, so it exists) so no extra LIST_ARTIFACTS round-trip fires
+            # and the existing cassette (rename RPC only) keeps replaying.
+            client.artifacts._listing.get_studio_only = AsyncMock(return_value=artifact)
+            # Rename, then restore the original name.
             await client.artifacts.rename(
                 MUTABLE_NOTEBOOK_ID, artifact.id, "VCR Renamed Artifact", return_object=False
             )
-            # Restore original name
             await client.artifacts.rename(
                 MUTABLE_NOTEBOOK_ID, artifact.id, original_title, return_object=False
             )

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1249,16 +1249,19 @@ class TestGenerateWithRetry:
 
     @pytest.mark.asyncio
     async def test_retry_on_rate_limit(self):
-        """Test that rate limit triggers retry."""
+        """Test that a raised RateLimitError triggers retry (#1342)."""
+        from notebooklm.exceptions import RateLimitError
         from notebooklm.types import GenerationStatus
 
-        rate_limited = GenerationStatus(
-            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
-        )
         success_result = GenerationStatus(
             task_id="task_123", status="pending", error=None, error_code=None
         )
-        generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
+        generate_fn = AsyncMock(
+            side_effect=[
+                RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR"),
+                success_result,
+            ]
+        )
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await generate_with_retry(generate_fn, max_retries=3, artifact_type="audio")
@@ -1268,39 +1271,25 @@ class TestGenerateWithRetry:
         mock_sleep.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_retry_exhausted(self):
-        """Test that all retries being exhausted returns last result."""
-        from notebooklm.types import GenerationStatus
+    async def test_retry_exhausted_reraises(self):
+        """v0.8.0 (#1342): exhausting the budget re-raises the RateLimitError."""
+        from notebooklm.exceptions import RateLimitError
 
-        rate_limited = GenerationStatus(
-            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
-        )
-        generate_fn = AsyncMock(return_value=rate_limited)
+        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
+        generate_fn = AsyncMock(side_effect=error)
 
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await generate_with_retry(generate_fn, max_retries=2, artifact_type="audio")
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            await generate_with_retry(generate_fn, max_retries=2, artifact_type="audio")
 
-        assert result == rate_limited
+        assert exc_info.value is error
         assert generate_fn.call_count == 3  # initial + 2 retries
 
     @pytest.mark.asyncio
-    async def test_no_retry_when_max_retries_zero(self):
-        """Test that max_retries=0 means no retry attempts."""
-        from notebooklm.types import GenerationStatus
-
-        rate_limited = GenerationStatus(
-            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
-        )
-        generate_fn = AsyncMock(return_value=rate_limited)
-
-        result = await generate_with_retry(generate_fn, max_retries=0, artifact_type="audio")
-
-        assert result == rate_limited
-        assert generate_fn.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_retry_delays_increase_exponentially(self):
-        """Verify delays follow exponential backoff pattern (60s, 120s, 240s)."""
+    async def test_returned_rate_limited_status_returns_without_retry(self):
+        """v0.8.0 (#1342): a returned rate-limited status is no longer a retry signal."""
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -1309,6 +1298,37 @@ class TestGenerateWithRetry:
         generate_fn = AsyncMock(return_value=rate_limited)
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await generate_with_retry(generate_fn, max_retries=3, artifact_type="audio")
+
+        assert result == rate_limited
+        assert generate_fn.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_max_retries_zero(self):
+        """Test that max_retries=0 means no retry attempts (re-raises immediately)."""
+        from notebooklm.exceptions import RateLimitError
+
+        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
+        generate_fn = AsyncMock(side_effect=error)
+
+        with pytest.raises(RateLimitError):
+            await generate_with_retry(generate_fn, max_retries=0, artifact_type="audio")
+
+        assert generate_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_delays_increase_exponentially(self):
+        """Verify delays follow exponential backoff pattern (60s, 120s, 240s)."""
+        from notebooklm.exceptions import RateLimitError
+
+        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
+        generate_fn = AsyncMock(side_effect=error)
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            pytest.raises(RateLimitError),
+        ):
             await generate_with_retry(generate_fn, max_retries=3, artifact_type="audio")
 
         # Verify delays: 60s, 120s, 240s (3 retries = 3 sleeps)
@@ -1318,14 +1338,15 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_retry_delay_caps_at_max(self):
         """Verify delay caps at 300s even with many retries."""
-        from notebooklm.types import GenerationStatus
+        from notebooklm.exceptions import RateLimitError
 
-        rate_limited = GenerationStatus(
-            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
-        )
-        generate_fn = AsyncMock(return_value=rate_limited)
+        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
+        generate_fn = AsyncMock(side_effect=error)
 
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            pytest.raises(RateLimitError),
+        ):
             await generate_with_retry(generate_fn, max_retries=10, artifact_type="audio")
 
         # Verify no delay exceeds RETRY_MAX_DELAY (300s)
@@ -2139,17 +2160,22 @@ class TestGenerateWithRetryConsoleOutput:
 
     @pytest.mark.asyncio
     async def test_retry_shows_console_message_when_not_json(self):
-        """Line 111: console.print shown during retry when json_output=False."""
+        """Line 111: console.print shown during retry when json_output=False.
 
+        v0.8.0 (#1342): the retry is driven by a raised RateLimitError.
+        """
+        from notebooklm.exceptions import RateLimitError
         from notebooklm.types import GenerationStatus
 
-        rate_limited = GenerationStatus(
-            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
-        )
         success_result = GenerationStatus(
             task_id="task_123", status="pending", error=None, error_code=None
         )
-        generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
+        generate_fn = AsyncMock(
+            side_effect=[
+                RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR"),
+                success_result,
+            ]
+        )
 
         retry_sink = MagicMock()
         with patch("asyncio.sleep", new_callable=AsyncMock):

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -919,7 +919,9 @@ class TestSourceRefresh:
             assert result.exit_code == 0
             assert "Source refreshed" in result.output
 
-    def test_source_refresh_no_result(self, runner, mock_auth):
+    def test_source_refresh_none_prints_refreshed(self, runner, mock_auth):
+        # v0.8.0 (#1290): refresh() returns None on success; the CLI must still
+        # render "Source refreshed", not "no result".
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock sources.list for resolve_source_id
@@ -936,7 +938,8 @@ class TestSourceRefresh:
                 result = runner.invoke(cli, ["source", "refresh", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
-            assert "Refresh returned no result" in result.output
+            assert "Source refreshed" in result.output
+            assert "no result" not in result.output
 
 
 # =============================================================================
@@ -2787,29 +2790,8 @@ class TestSourceJsonOutput:
             assert data["status"] == "renamed"
 
     def test_source_refresh_json(self, runner, mock_auth):
-        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
-            mock_client = create_mock_client()
-            mock_client.sources.list = AsyncMock(
-                return_value=[Source(id="src_123", title="Original")]
-            )
-            mock_client.sources.refresh = AsyncMock(
-                return_value=Source(id="src_123", title="Refreshed")
-            )
-            mock_client_cls.return_value = mock_client
-
-            with self._patch_fetch_tokens():
-                result = runner.invoke(
-                    cli, ["source", "refresh", "src_123", "-n", "nb_123", "--json"]
-                )
-
-            assert result.exit_code == 0, result.output
-            data = json.loads(result.output)
-            assert data["action"] == "refresh"
-            assert data["source_id"] == "src_123"
-            assert data["title"] == "Refreshed"
-            assert data["status"] == "refreshed"
-
-    def test_source_refresh_json_no_result(self, runner, mock_auth):
+        # v0.8.0 (#1290): refresh() returns None on success; the --json path must
+        # render status "refreshed" (keyed on the resolved source id).
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.sources.list = AsyncMock(
@@ -2827,7 +2809,30 @@ class TestSourceJsonOutput:
             data = json.loads(result.output)
             assert data["action"] == "refresh"
             assert data["source_id"] == "src_123"
-            assert data["status"] == "no_result"
+            assert data["status"] == "refreshed"
+
+    def test_source_refresh_json_none_is_refreshed_not_no_result(self, runner, mock_auth):
+        # Regression guard for the hidden CLI bug (#1290): once refresh() returns
+        # None on success, the --json path must NOT fall through to "no_result".
+        with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Original")]
+            )
+            mock_client.sources.refresh = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with self._patch_fetch_tokens():
+                result = runner.invoke(
+                    cli, ["source", "refresh", "src_123", "-n", "nb_123", "--json"]
+                )
+
+            assert result.exit_code == 0, result.output
+            data = json.loads(result.output)
+            assert data["action"] == "refresh"
+            assert data["source_id"] == "src_123"
+            assert data["status"] == "refreshed"
+            assert data["status"] != "no_result"
 
     def test_source_add_drive_json(self, runner, mock_auth):
         with patch("notebooklm.cli.source_cmd.NotebookLMClient") as mock_client_cls:

--- a/tests/unit/cli/test_source_cmd_coverage.py
+++ b/tests/unit/cli/test_source_cmd_coverage.py
@@ -143,14 +143,16 @@ class TestRenderSourceDeleteResult:
 
 
 # ---------------------------------------------------------------------------
-# _render_source_refresh_result — result is True branch (line 519)
+# _render_source_refresh_result — None-success branch
 # ---------------------------------------------------------------------------
 
 
 class TestRenderSourceRefreshResult:
-    def test_result_is_true_prints_source_id(self, capsys):
+    def test_result_none_prints_source_id(self, capsys):
+        # v0.8.0 (#1290): refresh() returns None on success; the renderer prints
+        # "Source refreshed: <source_id>" for the non-Source success path.
         ctx = click.Context(click.Command("x"))
-        result = SourceRefreshResult(source_id="src_1", notebook_id="nb_1", result=True)
+        result = SourceRefreshResult(source_id="src_1", notebook_id="nb_1", result=None)
         source_cmd._render_source_refresh_result(result, json_output=False, ctx=ctx)
         out = capsys.readouterr().out
         assert "Source refreshed" in out

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -55,10 +55,12 @@ class TestWithRateLimitRetry:
         assert generate_fn.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_retries_rate_limited_status_then_returns_success(self) -> None:
+    async def test_returned_rate_limited_status_returns_immediately(self) -> None:
+        # v0.8.0 (#1342): a *returned* rate-limited status is no longer a retry
+        # signal — only a raised RateLimitError drives a retry. The returned
+        # status is surfaced immediately, with no sleep and no on_retry event.
         rate_limited = _rate_limited_status()
-        success = GenerationStatus(task_id="task_123", status="pending")
-        generate_fn = AsyncMock(side_effect=[rate_limited, success])
+        generate_fn = AsyncMock(return_value=rate_limited)
         events: list[RateLimitRetryEvent] = []
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
@@ -68,31 +70,10 @@ class TestWithRateLimitRetry:
                 on_retry=events.append,
             )
 
-        assert result == success
-        assert generate_fn.call_count == 2
-        mock_sleep.assert_awaited_once_with(60.0)
-        assert events == [
-            RateLimitRetryEvent(
-                result=rate_limited,
-                next_attempt_number=2,
-                total_attempts=4,
-                retry_number=1,
-                max_retries=3,
-                delay=60.0,
-            )
-        ]
-
-    @pytest.mark.asyncio
-    async def test_exhausts_retry_budget_and_returns_last_rate_limited_status(self) -> None:
-        rate_limited = _rate_limited_status()
-        generate_fn = AsyncMock(return_value=rate_limited)
-
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            result = await with_rate_limit_retry(generate_fn, max_retries=2)
-
         assert result == rate_limited
-        assert generate_fn.call_count == 3
-        assert [call.args[0] for call in mock_sleep.await_args_list] == [60.0, 120.0]
+        assert generate_fn.call_count == 1
+        mock_sleep.assert_not_awaited()
+        assert events == []
 
     @pytest.mark.asyncio
     async def test_does_not_retry_non_rate_limit_failure(self) -> None:
@@ -106,9 +87,15 @@ class TestWithRateLimitRetry:
 
     @pytest.mark.asyncio
     async def test_supports_async_retry_callback_and_custom_sleep(self) -> None:
-        rate_limited = _rate_limited_status()
+        # The retry is driven by a raised RateLimitError (#1342); a custom sleep
+        # and an async on_retry callback are both honored.
         success = GenerationStatus(task_id="task_123", status="pending")
-        generate_fn = AsyncMock(side_effect=[rate_limited, success])
+        generate_fn = AsyncMock(
+            side_effect=[
+                RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR"),
+                success,
+            ]
+        )
         on_retry = AsyncMock()
         sleep = AsyncMock()
 

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -86,6 +86,24 @@ class TestWithRateLimitRetry:
         assert generate_fn.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_exhausts_retry_budget_and_raises_rate_limit(self) -> None:
+        # v0.8.0 (#1342): when every attempt raises RateLimitError, the budget is
+        # exhausted and the final RateLimitError is RE-RAISED — it is no longer
+        # swallowed into a returned rate-limited 'failed' status.
+        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
+        generate_fn = AsyncMock(side_effect=error)
+        sleep = AsyncMock()
+
+        with pytest.raises(RateLimitError) as exc_info:
+            await with_rate_limit_retry(
+                generate_fn, max_retries=2, initial_delay=60.0, sleep=sleep
+            )
+
+        assert exc_info.value is error
+        assert generate_fn.call_count == 3  # initial attempt + 2 retries
+        assert [c.args[0] for c in sleep.await_args_list] == [60.0, 120.0]
+
+    @pytest.mark.asyncio
     async def test_supports_async_retry_callback_and_custom_sleep(self) -> None:
         # The retry is driven by a raised RateLimitError (#1342); a custom sleep
         # and an async on_retry callback are both honored.

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -95,9 +95,7 @@ class TestWithRateLimitRetry:
         sleep = AsyncMock()
 
         with pytest.raises(RateLimitError) as exc_info:
-            await with_rate_limit_retry(
-                generate_fn, max_retries=2, initial_delay=60.0, sleep=sleep
-            )
+            await with_rate_limit_retry(generate_fn, max_retries=2, initial_delay=60.0, sleep=sleep)
 
         assert exc_info.value is error
         assert generate_fn.call_count == 3  # initial attempt + 2 retries

--- a/tests/unit/test_artifact_rate_limit_retry.py
+++ b/tests/unit/test_artifact_rate_limit_retry.py
@@ -86,22 +86,6 @@ class TestWithRateLimitRetry:
         assert generate_fn.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_exhausts_retry_budget_and_raises_rate_limit(self) -> None:
-        # v0.8.0 (#1342): when every attempt raises RateLimitError, the budget is
-        # exhausted and the final RateLimitError is RE-RAISED — it is no longer
-        # swallowed into a returned rate-limited 'failed' status.
-        error = RateLimitError("Rate limited", rpc_code="USER_DISPLAYABLE_ERROR")
-        generate_fn = AsyncMock(side_effect=error)
-        sleep = AsyncMock()
-
-        with pytest.raises(RateLimitError) as exc_info:
-            await with_rate_limit_retry(generate_fn, max_retries=2, initial_delay=60.0, sleep=sleep)
-
-        assert exc_info.value is error
-        assert generate_fn.call_count == 3  # initial attempt + 2 retries
-        assert [c.args[0] for c in sleep.await_args_list] == [60.0, 120.0]
-
-    @pytest.mark.asyncio
     async def test_supports_async_retry_callback_and_custom_sleep(self) -> None:
         # The retry is driven by a raised RateLimitError (#1342); a custom sleep
         # and an async on_retry callback are both honored.

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -196,8 +196,8 @@ class TestCallGenerateRateLimit:
     """Test _call_generate handling of rate limit errors."""
 
     @pytest.mark.asyncio
-    async def test_rate_limit_returns_failed_status(self, mock_artifacts_api):
-        """Test that USER_DISPLAYABLE_ERROR returns failed status."""
+    async def test_rate_limit_refusal_raises(self, mock_artifacts_api):
+        """v0.8.0 (#1342): a USER_DISPLAYABLE_ERROR refusal re-raises the error."""
         api, mock_core = mock_artifacts_api
 
         # Simulate rate limit error from RPC
@@ -205,12 +205,8 @@ class TestCallGenerateRateLimit:
             "Rate limit exceeded", rpc_code="USER_DISPLAYABLE_ERROR"
         )
 
-        result = await api.generate_video("nb_123")
-
-        assert result.status == "failed"
-        assert result.error is not None
-        assert "Rate limit" in result.error
-        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+        with pytest.raises(RPCError, match="Rate limit"):
+            await api.generate_video("nb_123")
 
     @pytest.mark.asyncio
     async def test_other_rpc_error_propagates(self, mock_artifacts_api):

--- a/tests/unit/test_chat_delete_conversation.py
+++ b/tests/unit/test_chat_delete_conversation.py
@@ -55,7 +55,7 @@ def api(mock_rpc: MagicMock) -> ChatAPI:
 class TestDeleteConversation:
     @pytest.mark.asyncio
     async def test_sends_expected_payload(self, api: ChatAPI, mock_rpc: MagicMock) -> None:
-        assert await api.delete_conversation("nb_xyz", "conv_abc") is True
+        assert await api.delete_conversation("nb_xyz", "conv_abc") is None
 
         # Pin the load-bearing args only; the capability adapter's wiring
         # defaults (allow_null, operation_variant, etc.) are covered elsewhere.

--- a/tests/unit/test_future_errors_flag.py
+++ b/tests/unit/test_future_errors_flag.py
@@ -307,24 +307,16 @@ def _make_artifacts_api(rpc_call: AsyncMock) -> ArtifactsAPI:
 
 
 class TestBoolReturnsBecomeNone:
-    """``sources.refresh`` / ``chat.delete_conversation`` return ``None`` flag-on.
+    """``sources.refresh`` / ``chat.delete_conversation`` return ``None`` (#1290).
 
-    The ``True`` they return today carries no information (any failure raises
-    first), so under the flag they preview the v0.8.0 ``-> None`` return. The
-    ``-> bool`` annotation is intentionally preserved at runtime; only the
-    returned *value* flips. ``chat.clear_cache`` is deliberately NOT gated — its
+    The ``True`` they used to return carried no information (any failure raises
+    first), so v0.8.0 makes them return ``None`` unconditionally and drops the
+    ``-> bool`` annotation. ``chat.clear_cache`` is deliberately UNCHANGED — its
     bool is meaningful (the cache reports whether the id was present).
     """
 
     @pytest.mark.asyncio
-    async def test_sources_refresh_off_returns_true(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=None)), uploader=MagicMock())
-        assert await api.refresh("nb_1", "src_1") is True
-
-    @pytest.mark.asyncio
-    async def test_sources_refresh_on_returns_none(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_sources_refresh_returns_none(self):
         api = SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=None)), uploader=MagicMock())
         assert await api.refresh("nb_1", "src_1") is None
 
@@ -337,24 +329,15 @@ class TestBoolReturnsBecomeNone:
         )
 
     @pytest.mark.asyncio
-    async def test_delete_conversation_off_returns_true(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = self._chat_api()
-        assert await api.delete_conversation("nb_1", "conv_1") is True
-
-    @pytest.mark.asyncio
-    async def test_delete_conversation_on_returns_none(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_delete_conversation_returns_none(self):
         api = self._chat_api()
         assert await api.delete_conversation("nb_1", "conv_1") is None
 
-    def test_clear_cache_is_never_gated(self, monkeypatch):
-        # clear_cache's bool is meaningful (id present/absent), so it must NOT
-        # be touched by the flag in either mode.
-        monkeypatch.setenv(_FLAG, "1")
+    def test_clear_cache_is_unchanged(self):
+        # clear_cache's bool is meaningful (id present/absent), so it stays bool.
         api = self._chat_api()
         api._cache.cache_conversation_turn("conv_1", "Q?", "A.", turn_number=1)
-        assert api.clear_cache("conv_1") is True  # present -> True even under the flag
+        assert api.clear_cache("conv_1") is True  # present -> True
         assert api.clear_cache("conv_missing") is False  # absent -> meaningful False
 
 
@@ -364,23 +347,10 @@ class TestBoolReturnsBecomeNone:
 
 
 class TestRefusalRaises:
-    """A synchronous refusal raises under the flag instead of soft-failing."""
+    """A synchronous refusal raises instead of soft-failing (#1342)."""
 
     @pytest.mark.asyncio
-    async def test_call_generate_off_swallows_to_failed_status(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        rpc = AsyncMock(
-            side_effect=RateLimitError("Rate limit exceeded", rpc_code="USER_DISPLAYABLE_ERROR")
-        )
-        api = _make_artifacts_api(rpc)
-        result = await api.generate_video("nb_1")
-        assert result.status == "failed"
-        assert result.error_code == "USER_DISPLAYABLE_ERROR"
-        assert result.is_rate_limited is True
-
-    @pytest.mark.asyncio
-    async def test_call_generate_on_raises_rate_limit(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_call_generate_raises_rate_limit(self):
         rpc = AsyncMock(
             side_effect=RateLimitError("Rate limit exceeded", rpc_code="USER_DISPLAYABLE_ERROR")
         )
@@ -389,55 +359,29 @@ class TestRefusalRaises:
             await api.generate_video("nb_1")
 
     @pytest.mark.asyncio
-    async def test_call_generate_non_refusal_propagates_both_modes(self, monkeypatch):
-        # A non-USER_DISPLAYABLE_ERROR RPCError always propagates, flag or not.
-        for value in ("1", None):
-            if value is None:
-                monkeypatch.delenv(_FLAG, raising=False)
-            else:
-                monkeypatch.setenv(_FLAG, value)
-            rpc = AsyncMock(side_effect=RPCError("Server error", rpc_code="INTERNAL_ERROR"))
-            api = _make_artifacts_api(rpc)
-            with pytest.raises(RPCError, match="Server error"):
-                await api.generate_video("nb_1")
-
-    @pytest.mark.asyncio
-    async def test_revise_slide_off_swallows_to_failed_status(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        rpc = AsyncMock(side_effect=RPCError("Refused", rpc_code="USER_DISPLAYABLE_ERROR"))
+    async def test_call_generate_non_refusal_propagates(self):
+        # A non-USER_DISPLAYABLE_ERROR RPCError always propagates.
+        rpc = AsyncMock(side_effect=RPCError("Server error", rpc_code="INTERNAL_ERROR"))
         api = _make_artifacts_api(rpc)
-        result = await api.revise_slide("nb_1", "art_1", 0, "make it pop")
-        assert result.status == "failed"
-        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+        with pytest.raises(RPCError, match="Server error"):
+            await api.generate_video("nb_1")
 
     @pytest.mark.asyncio
-    async def test_revise_slide_on_raises(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_revise_slide_raises(self):
         rpc = AsyncMock(side_effect=RPCError("Refused", rpc_code="USER_DISPLAYABLE_ERROR"))
         api = _make_artifacts_api(rpc)
         with pytest.raises(RPCError, match="Refused"):
             await api.revise_slide("nb_1", "art_1", 0, "make it pop")
 
-    def test_parse_generation_result_null_id_off_returns_failed(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
+    def test_parse_generation_result_null_id_raises_feature_unavailable(self):
         api = _make_artifacts_api(AsyncMock())
         # A well-structured row whose artifact id (result[0][0]) is null.
-        status = api._parse_generation_result(
-            [[None, "Title", 1, None, 1]], method_id=RPCMethod.CREATE_ARTIFACT.value
-        )
-        assert status.status == "failed"
-        assert status.task_id == ""
-
-    def test_parse_generation_result_null_id_on_raises_feature_unavailable(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
-        api = _make_artifacts_api(AsyncMock())
         with pytest.raises(ArtifactFeatureUnavailableError):
             api._parse_generation_result(
                 [[None, "Title", 1, None, 1]], method_id=RPCMethod.CREATE_ARTIFACT.value
             )
 
-    def test_parse_generation_result_empty_id_on_raises_decoding(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    def test_parse_generation_result_empty_id_raises_decoding(self):
         api = _make_artifacts_api(AsyncMock())
         # A falsey-but-non-null id (``""``) is degenerate shape drift -> DecodingError.
         with pytest.raises(DecodingError):
@@ -446,43 +390,22 @@ class TestRefusalRaises:
             )
 
     @pytest.mark.asyncio
-    async def test_research_start_empty_payload_off_returns_none(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[])))
-        assert await api.start("nb_1", "query") is None
-
-    @pytest.mark.asyncio
-    async def test_research_start_empty_payload_on_raises_decoding(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_research_start_empty_payload_raises_decoding(self):
         api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[])))
         with pytest.raises(DecodingError):
             await api.start("nb_1", "query")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("falsey_id", [None, "", 0])
-    async def test_research_start_falsey_task_id_off_builds_handle(self, monkeypatch, falsey_id):
-        # A non-empty payload whose task_id is falsey still builds a (degenerate)
-        # ResearchStart on the v0.7.0 default path — byte-for-byte unchanged.
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[falsey_id, "report_1"])))
-        result = await api.start("nb_1", "query")
-        assert result is not None
-        assert result.task_id == falsey_id
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("falsey_id", [None, "", 0])
-    async def test_research_start_falsey_task_id_on_raises_decoding(self, monkeypatch, falsey_id):
-        # Under the flag a falsey task_id means no task was created — raise
+    async def test_research_start_falsey_task_id_raises_decoding(self, falsey_id):
+        # A falsey task_id means no task was created — raise
         # (mirrors _parse_generation_result's missing-id branch).
-        monkeypatch.setenv(_FLAG, "1")
         api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=[falsey_id, "report_1"])))
         with pytest.raises(DecodingError):
             await api.start("nb_1", "query")
 
     @pytest.mark.asyncio
-    async def test_research_start_real_task_id_on_returns_handle(self, monkeypatch):
-        # A truthy task_id is unaffected by the flag.
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_research_start_real_task_id_returns_handle(self):
         api = ResearchAPI(MagicMock(rpc_call=AsyncMock(return_value=["task_1", "report_1"])))
         result = await api.start("nb_1", "query")
         assert result is not None
@@ -495,7 +418,7 @@ class TestRefusalRaises:
 
 
 class TestMutateExistingFailLoud:
-    """``notes.update`` and ``rename(return_object=False)`` raise on a miss."""
+    """``notes.update`` and ``rename(return_object=False)`` raise on a miss (#1362)."""
 
     def _notes_api(self) -> NotesAPI:
         from _fixtures.fake_core import make_fake_core
@@ -506,19 +429,7 @@ class TestMutateExistingFailLoud:
         return NotesAPI(notes=note_service, mind_maps=mind_maps)
 
     @pytest.mark.asyncio
-    async def test_notes_update_off_silently_noops_on_miss(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = self._notes_api()
-        # No preflight on the off path: a missing note must NOT trigger a lookup.
-        api.get_or_none = AsyncMock(return_value=None)
-        api._notes.update_note = AsyncMock(return_value=None)
-        await api.update("nb_1", "missing", "content", "Title")
-        api.get_or_none.assert_not_awaited()
-        api._notes.update_note.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_notes_update_on_raises_on_miss(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_notes_update_raises_on_miss(self):
         api = self._notes_api()
         api.get_or_none = AsyncMock(return_value=None)
         api._notes.update_note = AsyncMock(return_value=None)
@@ -528,8 +439,7 @@ class TestMutateExistingFailLoud:
         api._notes.update_note.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_notes_update_on_succeeds_when_present(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_notes_update_succeeds_when_present(self):
         api = self._notes_api()
         api.get_or_none = AsyncMock(return_value=MagicMock())  # hit
         api._notes.update_note = AsyncMock(return_value=None)
@@ -538,58 +448,37 @@ class TestMutateExistingFailLoud:
 
     def _sources_api(self, *, echo: object) -> SourcesAPI:
         # ``echo`` is the UPDATE_SOURCE return; ``None`` forces the existence
-        # preflight on the future-errors path.
+        # preflight on the null-echo path.
         return SourcesAPI(MagicMock(rpc_call=AsyncMock(return_value=echo)), uploader=MagicMock())
 
     @pytest.mark.asyncio
-    async def test_sources_rename_no_object_off_skips_detection(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = self._sources_api(echo=None)
-        api._get_or_none = AsyncMock(return_value=None)  # would-be miss
-        # Off path short-circuits to None WITHOUT probing existence.
-        assert await api.rename("nb_1", "missing", "T", return_object=False) is None
-        api._get_or_none.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_sources_rename_no_object_on_raises_on_miss(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_sources_rename_no_object_raises_on_miss(self):
         api = self._sources_api(echo=None)
         api._get_or_none = AsyncMock(return_value=None)  # miss
         with pytest.raises(SourceNotFoundError):
             await api.rename("nb_1", "missing", "T", return_object=False)
 
     @pytest.mark.asyncio
-    async def test_sources_rename_no_object_on_returns_none_when_present(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_sources_rename_no_object_returns_none_when_present(self):
         api = self._sources_api(echo=None)
         api._get_or_none = AsyncMock(return_value=Source(id="src_1", title="T"))  # hit
-        # The flag controls miss-detection, not the return: still None on a hit.
+        # Miss-detection runs, but the return is still None on a hit.
         assert await api.rename("nb_1", "src_1", "T", return_object=False) is None
 
     def _artifacts_api_for_rename(self) -> ArtifactsAPI:
         # UPDATE/RENAME echo is None so the False path reaches the studio-only
-        # existence preflight under the flag.
+        # existence preflight.
         return _make_artifacts_api(AsyncMock(return_value=None))
 
     @pytest.mark.asyncio
-    async def test_artifacts_rename_no_object_off_skips_detection(self, monkeypatch):
-        monkeypatch.delenv(_FLAG, raising=False)
-        api = self._artifacts_api_for_rename()
-        api._listing.get_studio_only = AsyncMock(return_value=None)  # would-be miss
-        assert await api.rename("nb_1", "missing", "T", return_object=False) is None
-        api._listing.get_studio_only.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_artifacts_rename_no_object_on_raises_on_miss(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_artifacts_rename_no_object_raises_on_miss(self):
         api = self._artifacts_api_for_rename()
         api._listing.get_studio_only = AsyncMock(return_value=None)  # miss
         with pytest.raises(ArtifactNotFoundError):
             await api.rename("nb_1", "missing", "T", return_object=False)
 
     @pytest.mark.asyncio
-    async def test_artifacts_rename_no_object_on_returns_none_when_present(self, monkeypatch):
-        monkeypatch.setenv(_FLAG, "1")
+    async def test_artifacts_rename_no_object_returns_none_when_present(self):
         api = self._artifacts_api_for_rename()
         api._listing.get_studio_only = AsyncMock(return_value=MagicMock())  # hit
         assert await api.rename("nb_1", "art_1", "T", return_object=False) is None

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -1,6 +1,6 @@
 """Unit tests for NotesAPI private helpers and edge cases."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -549,6 +549,9 @@ class TestUpdateNote:
     @pytest.mark.asyncio
     async def test_update_calls_rpc_with_correct_params(self, notes_api, mock_core):
         """Test that update() passes correct parameters."""
+        # v0.8.0 (#1362): update() runs an existence preflight first; stub a hit
+        # so the UPDATE_NOTE RPC fires and we can pin its params.
+        notes_api.get_or_none = AsyncMock(return_value=MagicMock())
         mock_core.rpc_executor.rpc_call.return_value = None
 
         await notes_api.update("nb_123", "note_456", "New content", "New title")

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -705,15 +705,18 @@ class TestResearch:
                 )
 
     @pytest.mark.asyncio
-    async def test_start_research_returns_none(self, auth_tokens, httpx_mock, build_rpc_response):
-        """Test start returns None on empty response."""
+    async def test_start_research_empty_payload_raises(
+        self, auth_tokens, httpx_mock, build_rpc_response
+    ):
+        """v0.8.0 (#1342): start raises DecodingError on an empty response."""
+        from notebooklm.exceptions import DecodingError
+
         response_body = build_rpc_response(RPCMethod.START_FAST_RESEARCH, [])
         httpx_mock.add_response(content=response_body.encode(), method="POST")
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.research.start(notebook_id="nb_123", query="test", mode="fast")
-
-        assert result is None
+            with pytest.raises(DecodingError):
+                await client.research.start(notebook_id="nb_123", query="test", mode="fast")
 
     @pytest.mark.asyncio
     async def test_poll_no_research(self, auth_tokens, httpx_mock, build_rpc_response):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1436,7 +1436,7 @@ class TestGenerationStatus:
         other_failure = GenerationStatus(
             task_id="",
             status="failed",
-            error="Generation failed - no artifact_id returned",
+            error="Some unrelated generation error",
         )
         assert other_failure.is_rate_limited is False
 


### PR DESCRIPTION
Makes three FUTURE_ERRORS-gated v0.8.0 preview branches **unconditional**, replacing the historical soft-return contracts with the ADR-0019 raise/None contracts. Deletes the off-branch in each so the previewed behavior becomes the default.

## Synchronous generation-kickoff refusal now RAISES (#1342)
- `_artifacts.py` `_call_generate` / `revise_slide` no longer swallow a `USER_DISPLAYABLE_ERROR` refusal into a `GenerationStatus(status="failed")`; the underlying `RateLimitError`/`RPCError` propagates.
- `_artifacts.py` `_parse_generation_result` raises on a missing artifact id (null id → `ArtifactFeatureUnavailableError`; falsey-but-non-null id → `DecodingError`) instead of returning a synthetic failed status.
- `_research.py` `start` raises `DecodingError` on an empty/non-list payload or a falsey `task_id`; the return type narrows from `ResearchStart | None` to `ResearchStart`.
- `artifacts.py` `with_rate_limit_retry` retries **only** on a *raised* `RateLimitError` — a *returned* rate-limited `GenerationStatus` returns immediately, and budget exhaustion re-raises the `RateLimitError`.

## Mutate-existing ops fail loud on a missing target (#1362)
- `notes.update` runs a public-facade existence preflight and raises `NoteNotFoundError` before firing `UPDATE_NOTE` (the RPC is `allow_null=True` and would otherwise silently no-op).
- `sources.rename` / `artifacts.rename` run the existence preflight in **both** `return_object` modes; `return_object=False` still returns `None` on success but now raises `SourceNotFoundError` / `ArtifactNotFoundError` on a miss.

## Uninformative bool returns become None (#1290)
- `sources.refresh` and `chat.delete_conversation` return `None` (annotation dropped from `-> bool` to `-> None`); `chat.clear_cache` is deliberately unchanged (its bool is meaningful).
- Hidden CLI regression fixed: once `refresh()` returns `None` on success, `source refresh --json` and the text renderer still render status **`refreshed`**, not `no_result`.

## Mechanics
- Removes the now-unused `future_errors_enabled` import from `_artifacts.py`, `_notes.py`, `_sources.py`, `_chat/api.py`, and `_research.py` (every gated site in each file is flipped here).
- Adds four `changed-return` api-compat-allowlist entries (`sources.refresh` + `chat.delete_conversation`, both path-views) and updates the `research.start` entries to cover the v0.8.0 return-narrowing.
- Ratchets the `_artifacts.py` (1420→1402) and `_chat/api.py` (948→946) size ceilings down to their shrunk counts.
- Inverts all unit/integration/e2e test fallout to assert the new behavior (raise / `None`); VCR tests stub the new existence-preflight at the public facade so the pre-flip cassettes keep replaying unchanged.

The `#1290`/`#1342`/`#1362` rows stay in `V080_BREAKING_CHANGES` as deliberate clean-break exemptions (the table is emptied at the v0.8.0 capstone). Docs/CHANGELOG finalization is deferred to the v0.8.0 capstone (#1365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Several methods now return None on success instead of bool; one API now always returns a result or raises on failure.

* **Behavior Changes**
  * RPC-side refusals and missing IDs now raise errors rather than producing synthetic failed statuses.
  * Rename/update paths perform existence preflights and raise on missing resources.
  * Rate-limit retries trigger only on raised rate-limit errors (returned statuses do not retry).

* **Tests/CLI**
  * Tests and CLI adjusted to expect None success and to show "Source refreshed".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->