### PR TITLE
feat(api)!: remove the deprecated interval= kwarg on research.wait_for_completion (#1254)

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -556,6 +556,16 @@
       "code": "removed-member",
       "object": "notebooklm.types.ResearchSource.values",
       "reason": "v0.8.0 #1251: MappingCompatMixin dropped; the typed return is now attribute-only, removing the deprecated dict-style get/keys/items/values shims (warned in v0.7.0). See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "changed-signature",
+      "object": "notebooklm.NotebookLMClient.research.wait_for_completion",
+      "reason": "v0.8.0 #1254: removed the deprecated interval= alias (DeprecationWarning cycle from v0.7.0 completed). Use initial_interval= (same cadence). Passing interval= now raises TypeError. See docs/deprecations.md Removed in v0.8.0 and CHANGELOG.md."
+    },
+    {
+      "code": "changed-signature",
+      "object": "notebooklm.client.NotebookLMClient.research.wait_for_completion",
+      "reason": "Same break as above; covers the audit dotted-module-path view of the same callable."
     }
   ]
 }

--- a/src/notebooklm/_deprecation.py
+++ b/src/notebooklm/_deprecation.py
@@ -24,11 +24,12 @@ Four families live here:
   a miss as deprecated (issue #1247).
 * ``deprecated_kwarg`` — the keyword-alias pattern used when a public method
   renames a parameter but keeps the old name working for one MINOR cycle. The
-  canonical case is the wait/poll timeout standardization (issue #1208):
+  canonical case was the wait/poll timeout standardization (issue #1208):
   ``ResearchAPI.wait_for_completion`` renamed ``interval`` to
   ``initial_interval`` (matching ``SourcesAPI.wait_until_ready`` /
-  ``ArtifactsAPI.wait_for_completion``) and accepts the old name as a
-  deprecated alias removed in v0.8.0.
+  ``ArtifactsAPI.wait_for_completion``) and accepted the old name as a
+  deprecated alias; that alias was removed in v0.8.0 (issue #1254), but the
+  helper remains a generic primitive for future keyword renames.
 
 * ``MappingCompatMixin`` — the dict-subscript backward-compat bridge used when
   a public method that historically returned ``dict[str, Any]`` is upgraded to

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from . import research as _research_pub
-from ._deprecation import deprecated_kwarg, future_errors_enabled, warn_deprecated
+from ._deprecation import future_errors_enabled, warn_deprecated
 from ._notebook_metadata import NotebookSourceLister, create_default_source_lister
 from ._research_task_parser import parse_research_task_models
 from ._runtime.contracts import RpcCaller
@@ -53,16 +53,15 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 # Sentinel marking "the canonical ``initial_interval`` keyword was not passed"
-# in ``wait_for_completion``. The deprecated ``interval`` keyword keeps its
-# original default of ``5`` (so the public-API compatibility audit sees an
-# unchanged signature), while ``initial_interval`` is a newly-added keyword
-# that defaults to this sentinel. Resolution prefers ``initial_interval`` when
-# the caller supplied it and otherwise falls back to ``interval``.
+# in ``wait_for_completion``. The default stays this ``object()`` sentinel (not a
+# literal ``5.0``) so the public-API compatibility audit's default-repr check
+# sees no changed-default break; when the caller leaves it unset we resolve the
+# cadence to ``_DEFAULT_RESEARCH_POLL_INTERVAL`` below.
 _INITIAL_INTERVAL_UNSET: Any = object()
 
-# Original default cadence for the legacy ``interval`` keyword (seconds between
-# status checks). Preserved verbatim so default-shape callers keep the same
-# behavior and the API-compat audit sees no default change.
+# Default poll cadence (seconds between status checks) used when
+# ``initial_interval`` is left unset. Preserved verbatim so default-shape callers
+# keep the same behavior.
 _DEFAULT_RESEARCH_POLL_INTERVAL = 5.0
 
 
@@ -482,7 +481,6 @@ class ResearchAPI:
         task_id: str | None = None,
         *,
         timeout: float = 1800,
-        interval: float = 5,
         initial_interval: float = _INITIAL_INTERVAL_UNSET,
     ) -> ResearchTask:
         """Poll until research reaches a terminal state or times out.
@@ -501,14 +499,6 @@ class ResearchAPI:
                 is the canonical poll-interval keyword, matching
                 :meth:`SourcesAPI.wait_until_ready` and
                 :meth:`ArtifactsAPI.wait_for_completion`.
-            interval: **Deprecated** alias for ``initial_interval`` (removed in
-                v0.8.0). Passing a non-default value emits a
-                :class:`DeprecationWarning`; passing both a non-default
-                ``interval`` and an explicit ``initial_interval`` raises
-                :class:`TypeError`. Default-shape calls stay silent — note that
-                ``interval=5`` (the exact default) does *not* warn, since it is
-                indistinguishable from not passing the keyword at all; only
-                non-default ``interval`` values trigger the migration prompt.
 
         Returns:
             The final :meth:`poll` result (a
@@ -529,43 +519,23 @@ class ResearchAPI:
                 so ``except TimeoutError`` continues to catch it.
             ValueError: If ``timeout`` is negative or the poll interval is not
                 positive.
-            TypeError: If both a non-default ``interval`` and an explicit
-                ``initial_interval`` are passed, or if the resolved poll
-                interval is not a number.
+            TypeError: If the resolved poll interval is not a number.
         """
-        # ``interval`` keeps its original default of ``5`` so the public-API
-        # compatibility audit sees no signature change; we treat it as
-        # "provided" only when the caller changed it from that default. This
-        # keeps default-shape calls silent while still warning on legacy use.
-        legacy_interval: Any = (
-            interval if interval != _DEFAULT_RESEARCH_POLL_INTERVAL else _INITIAL_INTERVAL_UNSET
-        )
-        resolved_interval = deprecated_kwarg(
-            legacy_interval,
-            initial_interval,
-            old="interval",
-            new="initial_interval",
-            owner="ResearchAPI.wait_for_completion",
-            sentinel=_INITIAL_INTERVAL_UNSET,
-            stacklevel=3,
-        )
-        # Only the sentinel means "neither keyword supplied" — fall back to the
-        # default cadence. An *explicit* non-numeric value (e.g. interval=None
-        # or initial_interval="1") is a caller bug; fail fast with TypeError
-        # rather than silently coercing it back to the default, matching the
-        # old ``interval`` path which would have raised on such a value.
-        if resolved_interval is _INITIAL_INTERVAL_UNSET:
+        # The sentinel default means "``initial_interval`` was not supplied" —
+        # fall back to the default cadence. An *explicit* non-numeric value
+        # (e.g. initial_interval=None or initial_interval="1") is a caller bug;
+        # fail fast with TypeError rather than silently coercing it back to the
+        # default.
+        if initial_interval is _INITIAL_INTERVAL_UNSET:
             poll_interval = _DEFAULT_RESEARCH_POLL_INTERVAL
-        elif isinstance(resolved_interval, bool) or not isinstance(resolved_interval, (int, float)):
+        elif isinstance(initial_interval, bool) or not isinstance(initial_interval, (int, float)):
             raise TypeError("poll interval must be a number")
         else:
-            poll_interval = float(resolved_interval)
+            poll_interval = float(initial_interval)
 
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
         if poll_interval <= 0:
-            # Neutral wording: the caller may have used the deprecated
-            # ``interval`` alias rather than ``initial_interval``.
             raise ValueError("poll interval must be positive")
 
         loop = asyncio.get_running_loop()

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -71,7 +71,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,
-    "_research.py": 966,
+    "_research.py": 936,
     "cli/services/generate.py": 926,
     "_chat/api.py": 948,
     "_idempotency.py": 936,

--- a/tests/_guardrails/test_v080_deprecation_coverage.py
+++ b/tests/_guardrails/test_v080_deprecation_coverage.py
@@ -134,16 +134,6 @@ _DELIBERATE_CLEAN_BREAK = (
 # (and cite the module that wires it) or carry an explicit exemption reason.
 # The exemption set is meant to SHRINK as runways are added.
 V080_BREAKING_CHANGES: tuple[BreakingChange, ...] = (
-    # ---- Runwayed today (a v0.7.0 signal verified present) -----------------
-    BreakingChange(
-        issue=1254,
-        summary="remove deprecated 'interval' kwarg alias on research.wait_for_completion",
-        runway=Runway(
-            module="_research.py",
-            description="passing interval=... warns via deprecated_kwarg (DeprecationWarning)",
-            symbol="deprecated_kwarg",
-        ),
-    ),
     # ---- Exempted today (no clean value-level warning; shrink this set) -----
     BreakingChange(
         issue=1290,

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -590,15 +590,8 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ValueError, match="timeout must be non-negative"):
                 await client.research.wait_for_completion("nb_123", timeout=-1)
-            # Neutral "poll interval" wording so callers on the deprecated
-            # interval= alias don't see a name they never used.
             with pytest.raises(ValueError, match="poll interval must be positive"):
                 await client.research.wait_for_completion("nb_123", initial_interval=0)
-            with (
-                pytest.raises(ValueError, match="poll interval must be positive"),
-                pytest.warns(DeprecationWarning),
-            ):
-                await client.research.wait_for_completion("nb_123", interval=0)
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_rejects_non_numeric_interval(self, auth_tokens):
@@ -611,42 +604,21 @@ class TestResearch:
                 )
 
     @pytest.mark.asyncio
-    async def test_wait_for_completion_interval_alias_deprecated(
-        self, auth_tokens, httpx_mock, build_rpc_response
-    ):
-        """The legacy ``interval`` kwarg still works but emits a warning."""
-        response_body = build_rpc_response(
-            RPCMethod.POLL_RESEARCH,
-            [
-                [
-                    [
-                        "task_123",
-                        _build_research_task_payload(
-                            "query",
-                            "https://example.com",
-                            "Result",
-                            status_code=1,
-                        ),
-                    ]
-                ]
-            ],
-        )
-        httpx_mock.add_response(content=response_body.encode(), method="POST")
-
+    async def test_wait_for_completion_interval_alias_removed(self, auth_tokens):
+        """The removed ``interval`` kwarg now raises the unknown-keyword TypeError."""
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.warns(DeprecationWarning, match="initial_interval"):
-                with pytest.raises(TimeoutError):
-                    await client.research.wait_for_completion(
-                        "nb_123",
-                        timeout=0,
-                        interval=1,
-                    )
+            with pytest.raises(TypeError, match="interval"):
+                await client.research.wait_for_completion(
+                    "nb_123",
+                    timeout=0,
+                    interval=1,  # type: ignore[call-arg]
+                )
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_default_shape_is_silent(
         self, auth_tokens, httpx_mock, build_rpc_response, recwarn
     ):
-        """Default-shape calls (no interval kwarg) emit no deprecation warning."""
+        """Default-shape calls (no initial_interval kwarg) emit no deprecation warning."""
         response_body = build_rpc_response(
             RPCMethod.POLL_RESEARCH,
             [
@@ -669,17 +641,6 @@ class TestResearch:
             with pytest.raises(TimeoutError):
                 await client.research.wait_for_completion("nb_123", timeout=0)
         assert not [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
-
-    @pytest.mark.asyncio
-    async def test_wait_for_completion_both_intervals_raises(self, auth_tokens):
-        """Passing both ``interval`` and ``initial_interval`` raises TypeError."""
-        async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(TypeError, match="both 'initial_interval'"):
-                await client.research.wait_for_completion(
-                    "nb_123",
-                    interval=2,
-                    initial_interval=3,
-                )
 
     @pytest.mark.asyncio
     async def test_import_research(self, auth_tokens, httpx_mock, build_rpc_response):


### PR DESCRIPTION
## Purpose

Completes the v0.7.0 DeprecationWarning cycle for the `interval=` alias on `ResearchAPI.wait_for_completion` by removing it in v0.8.0 (closes #1254).

`wait_for_completion` now accepts only the canonical `initial_interval=` poll-cadence keyword — matching `SourcesAPI.wait_until_ready` and `ArtifactsAPI.wait_for_completion`. Passing `interval=` now raises the standard `TypeError("...unexpected keyword argument 'interval'")`; callers rename `interval=X` to `initial_interval=X`. Default-shape calls (no cadence kwarg) are unaffected.

## What changed

- **`src/notebooklm/_research.py`**: removed the `interval: float = 5` parameter; unwired the `deprecated_kwarg` alias-resolution block and now resolve cadence from `initial_interval` directly (sentinel default → `_DEFAULT_RESEARCH_POLL_INTERVAL` 5.0; explicit non-numeric → `TypeError`; the timeout/poll-interval validation is unchanged). Dropped only `deprecated_kwarg` from the `_deprecation` import (kept `future_errors_enabled` / `warn_deprecated`, still used elsewhere). Updated the docstring (dropped the `interval:` arg paragraph and the both-passed `TypeError` clause).
- **Sentinel preserved**: `_INITIAL_INTERVAL_UNSET = object()` stays as the default (audit-fix #1433) so the public-API compat audit sees no changed-default break.
- **`scripts/api-compat-allowlist.json`**: added the `changed-signature` allowlist pair for the removed keyword (both path-views).
- **`tests/_guardrails/test_v080_deprecation_coverage.py`**: dropped the #1254 runway row (its runway cited `deprecated_kwarg` in `_research.py`, now unwired).
- **`tests/_guardrails/test_module_size_ratchet.py`**: lowered the `_research.py` ceiling 969 → 939.
- **`tests/unit/test_research.py`**: inverted the alias test to assert the unknown-keyword `TypeError`; removed the `interval=0` deprecation sub-block and the both-intervals test (the alias is gone).
- `deprecated_kwarg` itself remains in `_deprecation.py` as a generic primitive (its module docstring updated to past tense).

Docs (`docs/deprecations.md`, `CHANGELOG.md`, etc.) are a deliberate single-pass at the v0.8.0 capstone (#1365) and are intentionally untouched here.

## Verification

- Full `pytest`: 8344 passed, 131 skipped, 1 xfailed
- `mypy src/notebooklm`: clean
- `ruff check` + `ruff format --check`: clean on touched files
- `scripts/audit_public_api_compat.py`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the deprecated interval alias from the polling API. Callers must use initial_interval; passing interval now raises TypeError.
  * Polling validation tightened: non-numeric interval inputs raise TypeError and zero/negative initial_interval raises a ValueError stating the poll interval must be positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->