### PR TITLE
refactor(test): extract shared guardrail helpers to non-test modules (#1431)

### DIFF
--- a/tests/_guardrails/_ast_reach_in.py
+++ b/tests/_guardrails/_ast_reach_in.py
@@ -1,0 +1,163 @@
+"""Shared AST helpers for the reach-in / runtime-import boundary lints.
+
+This is a non-test helper module: its name does not match pytest's
+``test_*.py`` collection glob (the ``_`` prefix also marks it private), so
+pytest never collects it as a test. It holds the reusable AST visitors and
+accessor helpers that BOTH the gate test
+(:mod:`tests._guardrails.test_no_facade_reach_in`) and the
+construction-behaviour test (:mod:`tests.unit.test_init_order`) need, so the
+behaviour test no longer imports from another *test* module.
+
+Only the reusable visitors / accessors live here — the gate's ``test_*``
+functions and module-deletion asserts stay in
+``test_no_facade_reach_in.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def _self_attr_name(node: ast.AST) -> str | None:
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    ):
+        return node.attr
+    return None
+
+
+def _assigned_self_attr_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            attr_name = _self_attr_name(target)
+            if attr_name is not None:
+                return attr_name
+    if isinstance(node, ast.AnnAssign):
+        return _self_attr_name(node.target)
+    return None
+
+
+def _assignment_value(node: ast.AST) -> ast.AST | None:
+    if isinstance(node, ast.Assign):
+        return node.value
+    if isinstance(node, ast.AnnAssign):
+        return node.value
+    return None
+
+
+def _self_attr_assignment(body: list[ast.stmt], attr_name: str) -> tuple[int, ast.stmt]:
+    for index, statement in enumerate(body):
+        if _assigned_self_attr_name(statement) == attr_name:
+            return index, statement
+    raise AssertionError(f"self.{attr_name} assignment not found")
+
+
+def _method_body(tree: ast.AST, class_name: str, method_name: str) -> list[ast.stmt]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for item in node.body:
+            if (
+                isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and item.name == method_name
+            ):
+                return item.body
+    raise AssertionError(f"{class_name}.{method_name} not found")
+
+
+def _facade_call_name(node: ast.AST, facade_names: set[str]) -> str | None:
+    if isinstance(node, ast.Name) and node.id in facade_names:
+        return node.id
+    if isinstance(node, ast.Attribute):
+        if node.attr in facade_names:
+            return node.attr
+        return _facade_call_name(node.value, facade_names)
+    return None
+
+
+def _facade_construction_lines(tree: ast.AST, facade_names: set[str]) -> dict[str, list[int]]:
+    lines: dict[str, list[int]] = {facade_name: [] for facade_name in facade_names}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        facade_name = _facade_call_name(node.func, facade_names)
+        if facade_name is not None:
+            lines[facade_name].append(node.lineno)
+    return {facade_name: found for facade_name, found in lines.items() if found}
+
+
+def _call_keyword_value(call: ast.Call, keyword_name: str) -> ast.AST:
+    for keyword in call.keywords:
+        if keyword.arg == keyword_name:
+            return keyword.value
+    raise AssertionError(f"keyword argument {keyword_name!r} not found")
+
+
+def _is_type_checking_guard(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING") or (
+        isinstance(node, ast.Attribute)
+        and node.attr == "TYPE_CHECKING"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "typing"
+    )
+
+
+class _RuntimeImportVisitor(ast.NodeVisitor):
+    def __init__(
+        self,
+        *,
+        forbidden_names: set[str],
+        forbidden_modules: set[str],
+    ) -> None:
+        self._forbidden_names = forbidden_names
+        self._forbidden_modules = forbidden_modules
+        self.forbidden: list[str] = []
+
+    def visit_If(self, node: ast.If) -> None:
+        if _is_type_checking_guard(node.test):
+            for child in node.orelse:
+                self.visit(child)
+            return
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_dunder_name(name: str) -> bool:
+        return name.startswith("__") and name.endswith("__")
+
+    @classmethod
+    def _is_forbidden_module_reference(cls, name: str, forbidden_modules: set[str]) -> bool:
+        if not name:
+            return False
+
+        if any(cls._is_dunder_name(part) for part in name.split(".")):
+            return False
+
+        for forbidden_module in forbidden_modules:
+            if cls._is_dunder_name(forbidden_module):
+                continue
+            if name == forbidden_module or name.startswith(f"{forbidden_module}."):
+                return True
+
+        return False
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.forbidden.extend(
+            alias.name
+            for alias in node.names
+            if self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        if self._is_forbidden_module_reference(module, self._forbidden_modules):
+            self.forbidden.extend(f"{module}.{alias.name}" for alias in node.names)
+            return
+
+        self.forbidden.extend(
+            alias.name
+            for alias in node.names
+            if alias.name in self._forbidden_names
+            or self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
+        )

--- a/tests/_guardrails/_cassette_shape_lint.py
+++ b/tests/_guardrails/_cassette_shape_lint.py
@@ -1,0 +1,72 @@
+"""Shared cassette leak-pattern helpers for the cassette-shape lint.
+
+This is a non-test helper module: its name does not match pytest's
+``test_*.py`` collection glob (the ``_`` prefix also marks it private), so
+pytest never collects it as a test. It holds the leak-pattern detectors and the
+display-name false-positive allowlist that BOTH the gate test
+(:mod:`tests._guardrails.test_cassette_shapes`) and the registry-sync test
+(:mod:`tests.unit.test_cassette_patterns`) reference, so the registry-sync test
+no longer imports from another *test* module.
+
+The canonical scrub registry lives in :mod:`tests.cassette_patterns`; the
+detectors here are the minimal cassette-text leak patterns kept alongside the
+shape lint (assertion D in ``test_cassette_shapes.py``).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Escaped JSON display name: \"Two Capitalized Words\" inside a quoted JSON
+# string. Anchored on the escape `\"` so we don't fire on legitimate
+# capitalized prose appearing in plain text. Hyphenated tokens are *not*
+# matched (to skip HTTP header names like `Content-Type` and font families
+# like `Google-Sans-Text`). The broader scrub registry tightens this
+# further by requiring an adjacent JSON-key context.
+LEAK_DISPLAY_NAME = re.compile(r'\\"(?:[A-Z][a-z]+)(?: [A-Z][a-z]+)+\\"')
+# Two-capitalized-word strings that are legitimate UI / artifact / notebook
+# titles produced during E2E test runs — NOT human display-name leaks. Keeping
+# this allowlist explicit so future additions are intentional. Anything new
+# that matches the regex but is benign goes here with a one-line comment.
+DISPLAY_NAME_FALSE_POSITIVES = frozenset(
+    {
+        # Google Sans family (font-family CSS in HTML responses).
+        '\\"Google Sans\\"',
+        '\\"Google Sans Text\\"',
+        '\\"Google Sans Arabic\\"',
+        '\\"Google Sans Japanese\\"',
+        '\\"Google Sans Korean\\"',
+        '\\"Google Sans Simplified Chinese\\"',
+        '\\"Google Sans Traditional Chinese\\"',
+        # Browser user-agent brand surfaced in Sec-CH-UA HTML responses.
+        '\\"Microsoft Edge\\"',
+        # Account UI page title (not a person's name).
+        '\\"Account Information\\"',
+        # Artifact / notebook titles produced by the test corpus.
+        '\\"Agent Development Tutorials\\"',
+        '\\"Agent Flashcards\\"',
+        '\\"Agent Quiz\\"',
+        '\\"Slide Deck\\"',
+        '\\"Tool Use Loop\\"',
+        '\\"Claude Code\\"',
+    }
+)
+# lh3.googleusercontent.com avatar URLs — both /a/ and /ogw/ prefixes.
+LEAK_AVATAR_URL = re.compile(r"https?://lh3\.googleusercontent\.com/(?:a|ogw)/[A-Za-z0-9_\-=]+")
+# Literal IP that the audit caught leaking in example_httpbin_*.yaml.
+LEAK_HTTPBIN_IP = re.compile(r"\b108\.5\.149\.175\b")
+
+
+def _find_leaks(text: str) -> list[str]:
+    """Return human-readable leak descriptors found in `text`."""
+    leaks: list[str] = []
+    for m in LEAK_DISPLAY_NAME.finditer(text):
+        if m.group(0) in DISPLAY_NAME_FALSE_POSITIVES:
+            continue
+        leaks.append(f"escaped display-name literal {m.group(0)!r}")
+        break  # one is enough; the message is the same
+    if m := LEAK_AVATAR_URL.search(text):
+        leaks.append(f"avatar URL {m.group(0)!r}")
+    if m := LEAK_HTTPBIN_IP.search(text):
+        leaks.append(f"httpbin IP {m.group(0)!r}")
+    return leaks

--- a/tests/_guardrails/test_cassette_shapes.py
+++ b/tests/_guardrails/test_cassette_shapes.py
@@ -52,6 +52,8 @@ from urllib.parse import parse_qs, unquote, urlparse
 import pytest
 import yaml
 
+from _guardrails._cassette_shape_lint import _find_leaks
+
 pytestmark = pytest.mark.repo_lint
 
 # Prefer libyaml for the cassette-shape lint. The top-level cassette set is
@@ -130,63 +132,14 @@ def _has_bytecount_drift(cassette: Path) -> bool:
 
 # ---------------------------------------------------------------------------
 # Leak patterns (assertion D — applies to ALL interactions, including
-# non-batchexecute). Kept minimal here; the canonical scrub registry
-# lives in tests/cassette_patterns.py.
+# non-batchexecute). The minimal leak-pattern detectors and the
+# ``DISPLAY_NAME_FALSE_POSITIVES`` allowlist now live in the shared non-test
+# helper ``_guardrails._cassette_shape_lint`` (``_find_leaks`` is imported at
+# the top of this module) so that ``tests/unit/test_cassette_patterns.py``
+# (which cross-checks the allowlist against the scrub registry) can import them
+# from a non-test module instead of from this gate file (issue #1431). The
+# canonical scrub registry lives in tests/cassette_patterns.py.
 # ---------------------------------------------------------------------------
-
-# Escaped JSON display name: \"Two Capitalized Words\" inside a quoted JSON
-# string. Anchored on the escape `\"` so we don't fire on legitimate
-# capitalized prose appearing in plain text. Hyphenated tokens are *not*
-# matched (to skip HTTP header names like `Content-Type` and font families
-# like `Google-Sans-Text`). The broader scrub registry tightens this
-# further by requiring an adjacent JSON-key context.
-LEAK_DISPLAY_NAME = re.compile(r'\\"(?:[A-Z][a-z]+)(?: [A-Z][a-z]+)+\\"')
-# Two-capitalized-word strings that are legitimate UI / artifact / notebook
-# titles produced during E2E test runs — NOT human display-name leaks. Keeping
-# this allowlist explicit so future additions are intentional. Anything new
-# that matches the regex but is benign goes here with a one-line comment.
-DISPLAY_NAME_FALSE_POSITIVES = frozenset(
-    {
-        # Google Sans family (font-family CSS in HTML responses).
-        '\\"Google Sans\\"',
-        '\\"Google Sans Text\\"',
-        '\\"Google Sans Arabic\\"',
-        '\\"Google Sans Japanese\\"',
-        '\\"Google Sans Korean\\"',
-        '\\"Google Sans Simplified Chinese\\"',
-        '\\"Google Sans Traditional Chinese\\"',
-        # Browser user-agent brand surfaced in Sec-CH-UA HTML responses.
-        '\\"Microsoft Edge\\"',
-        # Account UI page title (not a person's name).
-        '\\"Account Information\\"',
-        # Artifact / notebook titles produced by the test corpus.
-        '\\"Agent Development Tutorials\\"',
-        '\\"Agent Flashcards\\"',
-        '\\"Agent Quiz\\"',
-        '\\"Slide Deck\\"',
-        '\\"Tool Use Loop\\"',
-        '\\"Claude Code\\"',
-    }
-)
-# lh3.googleusercontent.com avatar URLs — both /a/ and /ogw/ prefixes.
-LEAK_AVATAR_URL = re.compile(r"https?://lh3\.googleusercontent\.com/(?:a|ogw)/[A-Za-z0-9_\-=]+")
-# Literal IP that the audit caught leaking in example_httpbin_*.yaml.
-LEAK_HTTPBIN_IP = re.compile(r"\b108\.5\.149\.175\b")
-
-
-def _find_leaks(text: str) -> list[str]:
-    """Return human-readable leak descriptors found in `text`."""
-    leaks: list[str] = []
-    for m in LEAK_DISPLAY_NAME.finditer(text):
-        if m.group(0) in DISPLAY_NAME_FALSE_POSITIVES:
-            continue
-        leaks.append(f"escaped display-name literal {m.group(0)!r}")
-        break  # one is enough; the message is the same
-    if m := LEAK_AVATAR_URL.search(text):
-        leaks.append(f"avatar URL {m.group(0)!r}")
-    if m := LEAK_HTTPBIN_IP.search(text):
-        leaks.append(f"httpbin IP {m.group(0)!r}")
-    return leaks
 
 
 # ---------------------------------------------------------------------------

--- a/tests/_guardrails/test_cassette_shapes.py
+++ b/tests/_guardrails/test_cassette_shapes.py
@@ -130,16 +130,11 @@ def _has_bytecount_drift(cassette: Path) -> bool:
     return False
 
 
-# ---------------------------------------------------------------------------
 # Leak patterns (assertion D — applies to ALL interactions, including
-# non-batchexecute). The minimal leak-pattern detectors and the
-# ``DISPLAY_NAME_FALSE_POSITIVES`` allowlist now live in the shared non-test
-# helper ``_guardrails._cassette_shape_lint`` (``_find_leaks`` is imported at
-# the top of this module) so that ``tests/unit/test_cassette_patterns.py``
-# (which cross-checks the allowlist against the scrub registry) can import them
-# from a non-test module instead of from this gate file (issue #1431). The
-# canonical scrub registry lives in tests/cassette_patterns.py.
-# ---------------------------------------------------------------------------
+# non-batchexecute): the minimal detectors and the DISPLAY_NAME_FALSE_POSITIVES
+# allowlist live in the shared non-test helper _guardrails._cassette_shape_lint
+# (``_find_leaks`` is imported at the top of this module); the canonical scrub
+# registry lives in tests/cassette_patterns.py.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/_guardrails/test_no_facade_reach_in.py
+++ b/tests/_guardrails/test_no_facade_reach_in.py
@@ -8,8 +8,11 @@ for the artifact / source / notebook-composition service modules — plus the
 self-tests for each AST visitor and the module-deletion asserts.
 
 The construction / init-order behaviour tests that *exercise* the wired client
-stay in ``tests/unit/test_init_order.py``; the two behaviour tests that still
-need these AST visitors import them from here.
+stay in ``tests/unit/test_init_order.py``. The reusable AST visitors / accessor
+helpers both this gate and those behaviour tests need live in the shared
+non-test module ``tests/_guardrails/_ast_reach_in.py`` (issue #1431); this gate
+imports only the two its own tests exercise. The self-tests for each AST visitor
+and the module-deletion asserts stay here.
 """
 
 from __future__ import annotations
@@ -20,6 +23,12 @@ from collections import Counter
 from pathlib import Path
 
 import pytest
+
+# The AST reach-in visitors / accessor helpers now live in the shared non-test
+# helper ``_guardrails._ast_reach_in`` so that ``tests/unit/test_init_order.py``
+# can import them from a non-test module instead of from this gate file
+# (issue #1431). This gate imports only the two helpers its own tests exercise.
+from _guardrails._ast_reach_in import _facade_construction_lines, _RuntimeImportVisitor
 
 pytestmark = pytest.mark.repo_lint
 
@@ -212,83 +221,6 @@ def _collect_core_private_accesses(path: Path) -> list[tuple[str, str]]:
     visitor = _CorePrivateAccessVisitor(path.name)
     visitor.visit(tree)
     return visitor.observed
-
-
-def _self_attr_name(node: ast.AST) -> str | None:
-    if (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "self"
-    ):
-        return node.attr
-    return None
-
-
-def _assigned_self_attr_name(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Assign):
-        for target in node.targets:
-            attr_name = _self_attr_name(target)
-            if attr_name is not None:
-                return attr_name
-    if isinstance(node, ast.AnnAssign):
-        return _self_attr_name(node.target)
-    return None
-
-
-def _assignment_value(node: ast.AST) -> ast.AST | None:
-    if isinstance(node, ast.Assign):
-        return node.value
-    if isinstance(node, ast.AnnAssign):
-        return node.value
-    return None
-
-
-def _self_attr_assignment(body: list[ast.stmt], attr_name: str) -> tuple[int, ast.stmt]:
-    for index, statement in enumerate(body):
-        if _assigned_self_attr_name(statement) == attr_name:
-            return index, statement
-    raise AssertionError(f"self.{attr_name} assignment not found")
-
-
-def _method_body(tree: ast.AST, class_name: str, method_name: str) -> list[ast.stmt]:
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef) or node.name != class_name:
-            continue
-        for item in node.body:
-            if (
-                isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
-                and item.name == method_name
-            ):
-                return item.body
-    raise AssertionError(f"{class_name}.{method_name} not found")
-
-
-def _facade_call_name(node: ast.AST, facade_names: set[str]) -> str | None:
-    if isinstance(node, ast.Name) and node.id in facade_names:
-        return node.id
-    if isinstance(node, ast.Attribute):
-        if node.attr in facade_names:
-            return node.attr
-        return _facade_call_name(node.value, facade_names)
-    return None
-
-
-def _facade_construction_lines(tree: ast.AST, facade_names: set[str]) -> dict[str, list[int]]:
-    lines: dict[str, list[int]] = {facade_name: [] for facade_name in facade_names}
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        facade_name = _facade_call_name(node.func, facade_names)
-        if facade_name is not None:
-            lines[facade_name].append(node.lineno)
-    return {facade_name: found for facade_name, found in lines.items() if found}
-
-
-def _call_keyword_value(call: ast.Call, keyword_name: str) -> ast.AST:
-    for keyword in call.keywords:
-        if keyword.arg == keyword_name:
-            return keyword.value
-    raise AssertionError(f"keyword argument {keyword_name!r} not found")
 
 
 def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
@@ -557,74 +489,6 @@ def test_deleted_session_module_is_not_importable() -> None:
 
     deleted_module = "notebooklm" + "." + "_session"
     assert importlib.util.find_spec(deleted_module) is None
-
-
-def _is_type_checking_guard(node: ast.AST) -> bool:
-    return (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING") or (
-        isinstance(node, ast.Attribute)
-        and node.attr == "TYPE_CHECKING"
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "typing"
-    )
-
-
-class _RuntimeImportVisitor(ast.NodeVisitor):
-    def __init__(
-        self,
-        *,
-        forbidden_names: set[str],
-        forbidden_modules: set[str],
-    ) -> None:
-        self._forbidden_names = forbidden_names
-        self._forbidden_modules = forbidden_modules
-        self.forbidden: list[str] = []
-
-    def visit_If(self, node: ast.If) -> None:
-        if _is_type_checking_guard(node.test):
-            for child in node.orelse:
-                self.visit(child)
-            return
-        self.generic_visit(node)
-
-    @staticmethod
-    def _is_dunder_name(name: str) -> bool:
-        return name.startswith("__") and name.endswith("__")
-
-    @classmethod
-    def _is_forbidden_module_reference(cls, name: str, forbidden_modules: set[str]) -> bool:
-        if not name:
-            return False
-
-        if any(cls._is_dunder_name(part) for part in name.split(".")):
-            return False
-
-        for forbidden_module in forbidden_modules:
-            if cls._is_dunder_name(forbidden_module):
-                continue
-            if name == forbidden_module or name.startswith(f"{forbidden_module}."):
-                return True
-
-        return False
-
-    def visit_Import(self, node: ast.Import) -> None:
-        self.forbidden.extend(
-            alias.name
-            for alias in node.names
-            if self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
-        )
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        module = node.module or ""
-        if self._is_forbidden_module_reference(module, self._forbidden_modules):
-            self.forbidden.extend(f"{module}.{alias.name}" for alias in node.names)
-            return
-
-        self.forbidden.extend(
-            alias.name
-            for alias in node.names
-            if alias.name in self._forbidden_names
-            or self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
-        )
 
 
 def test_runtime_import_visitor_detects_nested_forbidden_modules() -> None:

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -1095,17 +1095,18 @@ def test_is_clean_recognizes_display_name_avatar_placeholders() -> None:
 def test_display_name_false_positives_mirror_shape_lint() -> None:
     """The scrub-registry allowlist must stay in sync with the shape-lint allowlist.
 
-    ``tests/_guardrails/test_cassette_shapes.py`` carries the same set under a
-    slightly different name (``DISPLAY_NAME_FALSE_POSITIVES``), with each
-    entry wrapped in the cassette's escape-quote form. If the two drift,
-    a real cassette could pass shape-lint but trip the scrub detector (or
-    vice versa) — this test forces both lists to be updated together.
+    The shape lint carries the same set under the same name
+    (``DISPLAY_NAME_FALSE_POSITIVES``) with each entry wrapped in the
+    cassette's escape-quote form. If the two drift, a real cassette could pass
+    shape-lint but trip the scrub detector (or vice versa) — this test forces
+    both lists to be updated together.
     """
-    # ``test_cassette_shapes`` lives in the ``tests/_guardrails`` package (it has
-    # an ``__init__.py``), so pytest imports it package-qualified as
-    # ``_guardrails.test_cassette_shapes`` with ``tests/`` on ``sys.path`` — the
-    # bare ``import test_cassette_shapes`` form no longer resolves.
-    from _guardrails.test_cassette_shapes import DISPLAY_NAME_FALSE_POSITIVES as SHAPE_LINT_FPS
+    # The shape-lint allowlist now lives in the shared non-test helper
+    # ``_guardrails._cassette_shape_lint`` (issue #1431); importing it from
+    # that ``_``-prefixed module avoids a test-imports-test dependency on
+    # ``test_cassette_shapes``. ``tests/`` is on ``sys.path`` so the
+    # ``_guardrails`` package resolves.
+    from _guardrails._cassette_shape_lint import DISPLAY_NAME_FALSE_POSITIVES as SHAPE_LINT_FPS
 
     # Shape-lint stores entries as ``\"Name\"``; the scrub registry stores
     # bare names. Strip the escape wrapping to compare apples-to-apples.
@@ -1114,5 +1115,6 @@ def test_display_name_false_positives_mirror_shape_lint() -> None:
     )
     assert shape_lint_bare == DISPLAY_NAME_FALSE_POSITIVES, (
         "Display-name false-positive allowlist drifted from shape-lint allowlist; "
-        "update BOTH tests/cassette_patterns.py and tests/_guardrails/test_cassette_shapes.py"
+        "update BOTH tests/cassette_patterns.py and "
+        "tests/_guardrails/_cassette_shape_lint.py"
     )

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -9,7 +9,9 @@ The static AST reach-in / runtime-import boundary *gates* live in
 ``tests/_guardrails/test_no_facade_reach_in.py``. What remains here are the
 tests that *exercise* the wired client (constructor-DI seams, seam wiring,
 mind-map flows). The two boundary tests that still inspect production source
-with the AST visitors import those helpers from the guardrails module.
+with the AST visitors import those helpers from the shared non-test module
+``tests/_guardrails/_ast_reach_in.py`` (issue #1431) — the same module the
+gate file imports them from — so neither test imports from the other.
 """
 
 from __future__ import annotations
@@ -23,7 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from _fixtures.fake_core import FakeSession, make_fake_core
-from _guardrails.test_no_facade_reach_in import (
+from _guardrails._ast_reach_in import (
     _assignment_value,
     _call_keyword_value,
     _facade_construction_lines,


### PR DESCRIPTION
## What

Closes #1431.

Two `tests/unit/` behavioral files imported helpers from `tests/_guardrails/` **test** modules — a test-imports-test smell (importing from another test file). This extracts the shared, reusable helpers into two new `_`-prefixed **non-test** modules that both the gate files and the behavioral files import from:

- **`tests/_guardrails/_ast_reach_in.py`** — the AST reach-in visitors / accessor helpers (`_RuntimeImportVisitor`, `_facade_construction_lines`, the `_self_attr_*` / `_method_body` / `_call_keyword_value` accessors, plus their private transitive helpers) shared with `tests/unit/test_init_order.py`.
- **`tests/_guardrails/_cassette_shape_lint.py`** — the leak-pattern detectors and the `DISPLAY_NAME_FALSE_POSITIVES` allowlist (with `_find_leaks`) shared with `tests/unit/test_cassette_patterns.py`.

After extraction:
- `test_no_facade_reach_in.py` and `test_cassette_shapes.py` (the gate files) import their helpers **from** the new `_`-prefixed modules.
- `test_init_order.py` and `test_cassette_patterns.py` import from the new `_`-prefixed modules too — so **neither behavioral test imports from another test module**.

The moved code is byte-identical and every assertion is unchanged. Only the reusable helpers/constants/visitors moved — no test functions or fixtures.

## Why it's safe

- `_`-prefixed files are **not collected by pytest** (their names don't match the `test_*.py` collection glob), so the helpers never run as tests, and the new modules contain no `test_*` functions.
- `tests/` is on `sys.path` (no `tests/__init__.py`, `tests/_guardrails/__init__.py` present), so `_guardrails._ast_reach_in` / `_guardrails._cassette_shape_lint` resolve as top-level package imports — the same mechanism the old `from _guardrails.test_no_facade_reach_in import …` relied on.

## Verification

- `uv run --frozen pytest tests/_guardrails tests/unit/test_init_order.py tests/unit/test_cassette_patterns.py -q` — green.
- **Isolated runs** (to prove the import path resolves without the gate file being collected): `pytest tests/unit/test_init_order.py -q` and `pytest tests/unit/test_cassette_patterns.py -q` individually — both green.
- Full `uv run --frozen pytest -q` — 8227 passed, 131 skipped, 1 xfailed.
- `uv run --frozen mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run --frozen ruff check tests` and `ruff format --check tests` — clean.

## Follow-up (out of scope here)

A future lint could enforce "no test module imports from another test module" (e.g. flag `from _guardrails.test_* import` and bare-name cross-imports inside `tests/`) to prevent this smell from regressing. Not built in this PR per the issue's scope guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extracted reusable AST utilities and cassette-shape leak-detection logic into shared helper modules to reduce duplication.
  * Updated guardrail and unit tests to import and validate those shared helpers instead of using local copies.
  * Adjusted test assertions and documentation to reference the new shared helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->