### PR TITLE
docs(adr): record ADR-0019 tier-3 resolution — sealed result types rejected (#1345)

### DIFF
--- a/docs/adr/0019-error-and-return-contract.md
+++ b/docs/adr/0019-error-and-return-contract.md
@@ -219,7 +219,7 @@ enforcement floor**:
   removed by Tier 1 (#1342 makes refusals raise), so a returned `failed` now
   means only *started-then-failed*. The residual `not_found`/`removed`/rate-limit
   juggling is poll-loop interpretation (`removed` is `wait_for_completion`'s
-  conclusion over a sustained miss run, not a result property), cause
+  conclusion over a sustained run of missed polls, not a result property), cause
   classification (`is_rate_limited` is a `Failed`/`Removed` detail, not a
   lifecycle state), and a CLI-local DTO string (`cli/services/artifact_generation.py`
   synthesizes `"rate_limited"`) — none of which a union dissolves; it relocates

--- a/docs/adr/0019-error-and-return-contract.md
+++ b/docs/adr/0019-error-and-return-contract.md
@@ -212,11 +212,22 @@ enforcement floor**:
   public-signature typing (the namespaces differ in arity) and `delete` is
   irreducibly per-namespace (`mind_maps.delete(..., kind=...)` is non-idempotent
   + kind-dispatched), so `delete` stays per-namespace.
-- **Tier 3 — sealed async result types (deferred, own ADR).** Replacing the
-  stringly-typed `GenerationStatus.status` with a sealed/discriminated result is
-  the deeper fix (it would dissolve the `failed`/`not_found`/`removed` string
-  juggling), but it is a larger redesign tracked separately; this ADR keeps the
-  typed-string states.
+- **Tier 3 — sealed async result types (resolved #1345: rejected).** Replacing
+  the stringly-typed `GenerationStatus.status` with a sealed/discriminated result
+  was evaluated and **rejected**. The load-bearing overload it targeted — a
+  synchronous *couldn't-start* masquerading as `status="failed"` — was already
+  removed by Tier 1 (#1342 makes refusals raise), so a returned `failed` now
+  means only *started-then-failed*. The residual `not_found`/`removed`/rate-limit
+  juggling is poll-loop interpretation (`removed` is `wait_for_completion`'s
+  conclusion over a sustained miss run, not a result property), cause
+  classification (`is_rate_limited` is a `Failed`/`Removed` detail, not a
+  lifecycle state), and a CLI-local DTO string (`cli/services/artifact_generation.py`
+  synthesizes `"rate_limited"`) — none of which a union dissolves; it relocates
+  them. This ADR keeps the typed-string states. The optional, *non-breaking*
+  follow-up is a `GenerationState(str, Enum)` for `GenerationStatus.status`
+  mirroring `ResearchStatus` (or a `Literal[...]` alias). If sealed types are ever
+  revisited, introduce them via parallel `poll_result()`/`wait_result()` APIs
+  rather than breaking the existing ones in place.
 
 Tier 1 + Tier 2 are required for 0.8.0; together they make this contract
 type/CI-enforced rather than review-enforced.


### PR DESCRIPTION
## What
Amends ADR-0019 Tier 3 to record the resolution of #1345: the sealed/discriminated async result type for `GenerationStatus.status` is **rejected**, not deferred.

## Why
- The load-bearing `failed`-overloading (synchronous *couldn't-start* surfacing as `status="failed"`) was already removed in v0.8.0 by #1342 (refusals raise).
- The residual `not_found`/`removed`/rate-limit handling is poll-loop interpretation (`removed` is `wait_for_completion`'s conclusion, not a result property) + cause-classification (`is_rate_limited` is a `Failed`/`Removed` detail) + a CLI-local DTO string (`cli/services/artifact_generation.py`) — a union relocates these rather than dissolving them.
- A breaking change to the public `GenerationStatus` immediately after the v0.8.0 wave is poor cost/benefit.

Records the optional, non-breaking follow-up (`GenerationState(str, Enum)` mirroring `ResearchStatus`, or a `Literal[...]` alias) and the parallel-API path (`poll_result()`/`wait_result()`) if sealed types are ever revisited. Issue #1345 has been rescoped accordingly.

Doc-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ADR: Tier 3 ("sealed async result types") marked as evaluated-and-rejected; prior masking issue resolved by earlier changes.
  * Clarified remaining async status responsibilities (e.g., interpreting not-found/removed, rate-limit classification, CLI DTO synthesis) do not justify dissolving current typed-string states.
  * Preserved a non-breaking follow-up suggestion to introduce a GenerationState representation for GenerationStatus.status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->