### PR TITLE
test(e2e): split EPUB client-contract from server processing, keep failure loud (closes #1204)

### DIFF
--- a/tests/e2e/test_file_upload.py
+++ b/tests/e2e/test_file_upload.py
@@ -710,13 +710,15 @@ class TestFileUpload:
         try:
             ready = await client.sources.wait_until_ready(temp_notebook.id, source.id, timeout=120)
         except SourceProcessingError as exc:
-            pytest.fail(
+            # Re-raise (not pytest.fail) with `from exc` so the original
+            # SourceProcessingError traceback is preserved as the cause for triage.
+            raise AssertionError(
                 f"EPUB reached terminal SourceStatus.ERROR ({exc}). Upload and "
                 "registration succeeded (asserted above), so this is NotebookLM's "
                 "server-side EPUB processing failing — the known intermittent "
                 "Google-side outage (#1204) or a content-level rejection — NOT a "
                 "client upload/registration regression. Verify EPUB ingestion is up "
                 "before treating this as a client bug."
-            )
+            ) from exc
 
         assert ready.kind == SourceType.EPUB

--- a/tests/e2e/test_file_upload.py
+++ b/tests/e2e/test_file_upload.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from notebooklm import SourceType
+from notebooklm import SourceProcessingError, SourceType
 
 from .conftest import requires_auth
 
@@ -673,19 +673,50 @@ class TestFileUpload:
 
     @pytest.mark.asyncio
     async def test_add_epub_file(self, client, temp_notebook, tmp_path):
-        """Test uploading an EPUB file."""
+        """Upload an EPUB, separating the client contract from server processing.
+
+        The terminal-``ERROR`` processing failure is deliberately left **loud**
+        (#1204): NotebookLM's server-side EPUB ingestion intermittently fails
+        Google-side, and the nightly E2E should surface that — and catch a real
+        client regression in the EPUB path — rather than silently ``xfail`` it.
+        ``xfail(raises=SourceProcessingError)`` would be wrong here because the
+        *same* terminal ``SourceStatus.ERROR`` is raised both for a Google-side
+        outage and for a client bug (bad MIME routing, corrupt upload), so it
+        would mask exactly the regression this test exists to catch.
+
+        The split below makes the two attributable:
+        - **Client contract** (``wait=False``): upload + registration must
+          succeed. A client-side regression fails here, distinctly ours.
+        - **Server processing** (``wait_until_ready``): a terminal ``ERROR``
+          fails loudly with a triage note; on success, ``kind == EPUB`` confirms
+          the server classified our upload correctly (catching a MIME/routing
+          regression as ``kind != EPUB`` rather than a processing error).
+        """
         test_epub = tmp_path / "test_book.epub"
         create_minimal_epub(test_epub)
 
-        # wait=True ensures we get the processed source type
+        # --- Client contract: registration + upload must succeed (no waiting). ---
         source = await client.sources.add_file(
             temp_notebook.id,
             test_epub,
             mime_type="application/epub+zip",
-            wait=True,
-            wait_timeout=120,
+            wait=False,
         )
         assert source is not None
         assert source.id is not None
         assert source.title == "test_book.epub"
-        assert source.kind == SourceType.EPUB
+
+        # --- Server processing: stay loud on terminal ERROR, with triage. ---
+        try:
+            ready = await client.sources.wait_until_ready(temp_notebook.id, source.id, timeout=120)
+        except SourceProcessingError as exc:
+            pytest.fail(
+                f"EPUB reached terminal SourceStatus.ERROR ({exc}). Upload and "
+                "registration succeeded (asserted above), so this is NotebookLM's "
+                "server-side EPUB processing failing — the known intermittent "
+                "Google-side outage (#1204) or a content-level rejection — NOT a "
+                "client upload/registration regression. Verify EPUB ingestion is up "
+                "before treating this as a client bug."
+            )
+
+        assert ready.kind == SourceType.EPUB


### PR DESCRIPTION
## What
Reworks `tests/e2e/test_file_upload.py::test_add_epub_file` so a client-side EPUB regression is **caught and attributable**, while a genuine server-side processing failure stays **loud**.

## Why (rejecting #1204's proposed fix)
#1204 proposed making the test tolerant of the server-side `SourceStatus.ERROR` (e.g. `xfail(raises=SourceProcessingError)`). That's the wrong instinct for an E2E suite: the **same** terminal `SourceStatus.ERROR` is raised both for NotebookLM's (Google-side) EPUB-ingestion outage *and* for a real client bug (bad MIME routing, malformed multipart/disposition, corrupt resumable upload). `xfail` would silently green-light exactly the regression this E2E exists to catch — and hide genuine service degradation. The nightly going red when EPUB ingestion is broken **is the signal**.

## How (split + attribute, no suppression)
- **Client contract** (`add_file(wait=False)`): registration + upload must succeed → a client regression fails *here*, distinctly ours.
- **Server processing** (`wait_until_ready`): terminal `ERROR` `pytest.fail`s with a triage message (server-side / known #1204 outage, verify before blaming the client); on success, `kind == SourceType.EPUB` confirms the server classified our upload correctly — a MIME/routing regression surfaces as `kind != EPUB`, not a processing error.

Honest limit: a content-level client corruption still surfaces only at processing (indistinguishable from a server outage); the split cleanly separates the upload/registration-protocol regressions, which are the common ones.

E2E-only (nightly); collection verified (`pytest tests/e2e --collect-only`), ruff clean. Can't exercise the live path locally (needs auth) — it'll prove out in the next nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved file-upload test to validate a two-phase flow: client-side registration followed by awaiting server-side processing completion.
  * Converts server-side processing failures into clearer assertion failures with a detailed triage message while preserving original error context.
  * Provides better diagnostics for intermittent EPUB ingestion errors to aid reproducible test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->