### PR TITLE
refactor(cli): extract playwright redaction to playwright_redaction.py (#1331)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,7 @@ src/notebooklm/
         │   ├── refresh.py
         │   └── rookiepy_errors.py
         ├── playwright_login.py  # Playwright-driven Google login service
+        ├── playwright_redaction.py # Subprocess-output redaction helpers for the Playwright login service
         ├── polling.py           # Shared polling helpers for CLI wait commands
         ├── research.py          # Service layer for `research wait`
         ├── session_context.py   # Notebook-context services for `use`/`status`/`auth logout`

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -19,15 +19,12 @@ wrappers render + exit. Entry points: :class:`PlaywrightLoginPlan`,
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import os
-import re
 import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Awaitable, Iterator, Mapping
+from collections.abc import Awaitable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +36,7 @@ import httpx
 from ...config import get_base_host, get_base_url
 from ...io import atomic_write_json
 from ...paths import get_browser_profile_dir, get_storage_path
+from .playwright_redaction import redact_subprocess_output
 
 if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page
@@ -100,150 +98,6 @@ CHANNEL_BROWSERS: dict[str, tuple[str, str]] = {
     "msedge": ("Microsoft Edge", "https://www.microsoft.com/edge"),
     "chrome": ("Google Chrome", "https://www.google.com/chrome"),
 }
-
-
-# ---------------------------------------------------------------------------
-# Subprocess output sanitisation
-# ---------------------------------------------------------------------------
-#
-# Captured stderr/stdout from a Playwright subprocess (e.g. the install-failure
-# path below) can leak two classes of noise into the console:
-#   1. Environment-variable VALUES — Playwright forwards the parent env, so a
-#      secret (PSIDTS, API tokens, auth-source / SAPISID cookie material)
-#      interpolated into a traceback lands verbatim in ``result.stderr``.
-#   2. ANSI control sequences — pip/playwright progress bars + colour codes.
-# ``redact_subprocess_output`` strips both. Env-var redaction is conservative:
-# empty / single-char / boolean-ish / path-separator constants are skipped to
-# avoid false positives across normal stderr lines.
-
-# CSI: ESC '[' parameter-bytes intermediate-bytes final-byte
-# OSC: ESC ']' ... (BEL | ESC '\\')
-# Plus a catch-all for any remaining two-byte C1 Fe sequence (the
-# 0x40-0x5F final-byte range). CSI and OSC are stripped first so this
-# only fires on leftovers (PM ``ESC ^``, APC ``ESC _``, ST ``ESC \``,
-# etc.).
-_ANSI_CSI_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
-_ANSI_OSC_PATTERN = re.compile(r"\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)")
-_ANSI_OTHER_PATTERN = re.compile(r"\x1B[@-_]")
-
-# Env-var values we never redact even if they happen to be set (they would
-# produce noisy false positives on every line that mentions a path / boolean).
-# Single-character values (``/``, ``.``, ``*``, ``0``, ``1``, ``y``, ``n``)
-# don't appear here — they are already excluded by ``_REDACTION_MIN_VALUE_LEN``.
-_REDACTION_SAFE_VALUES = frozenset(
-    {
-        "",
-        "..",
-        "true",
-        "false",
-        "True",
-        "False",
-        "TRUE",
-        "FALSE",
-        "yes",
-        "no",
-        "on",
-        "off",
-    }
-)
-
-# Skip env values shorter than this — substring matches on 2-char strings
-# false-positive across the bytes Playwright prints.
-_REDACTION_MIN_VALUE_LEN = 3
-
-
-def _strip_ansi(text: str) -> str:
-    """Remove ANSI CSI / OSC / two-byte escape sequences from ``text``."""
-    text = _ANSI_CSI_PATTERN.sub("", text)
-    text = _ANSI_OSC_PATTERN.sub("", text)
-    text = _ANSI_OTHER_PATTERN.sub("", text)
-    return text
-
-
-def _expand_nested_secret_values(value: str) -> Iterator[str]:
-    """Yield ``value`` plus any nested string leaves if it parses as JSON.
-
-    Env values supplied as inline JSON (the auth-source env var being
-    the canonical example) carry serialised dicts whose leaf strings
-    (cookie tokens, refresh tokens) are the actual secrets. If a
-    subprocess re-emits the parsed nested value rather than the whole
-    JSON blob, exact-string matching against the original env value
-    would miss the leak. Walk JSON objects/arrays here to add every
-    leaf string to the redaction candidate set.
-
-    Non-JSON values yield just themselves (and only if they pass the
-    caller's length / safe-value filter).
-    """
-    yield value
-    stripped = value.strip()
-    if not stripped or stripped[0] not in "{[":
-        return
-    try:
-        parsed = json.loads(stripped)
-    except (ValueError, TypeError):
-        return
-
-    stack: list[Any] = [parsed]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, str):
-            yield node
-        elif isinstance(node, dict):
-            stack.extend(node.values())
-        elif isinstance(node, list):
-            stack.extend(node)
-
-
-def redact_subprocess_output(text: str, env: Mapping[str, str] | None = None) -> str:
-    """Sanitise captured subprocess ``stdout`` / ``stderr`` before printing.
-
-    Runs in two passes (detail in the inline comments + module header):
-
-    1. **Strip ANSI control sequences** FIRST so a secret split by an inert
-       reset (``"abc\\x1b[0m123"`` → ``"abc123"``) is reassembled before the
-       exact-match redactor runs — otherwise it would miss it.
-    2. **Replace each non-trivial env-var value** (plus any JSON-nested leaf
-       strings) with ``<redacted>``. The env is snapshotted from ``os.environ``
-       unless ``env`` is supplied. Values under
-       :data:`_REDACTION_MIN_VALUE_LEN` and the :data:`_REDACTION_SAFE_VALUES`
-       constants are skipped; candidates are tried longest-first so a longer
-       secret containing a shorter one is redacted as one token.
-
-    Returns the sanitised string; the input is not mutated.
-    """
-    if not text:
-        return text
-
-    # Pass 1: strip ANSI BEFORE redaction so a secret broken up by reset
-    # codes (``"abc\x1b[0m123"`` → ``"abc123"``) is reassembled and
-    # redactable by the exact-match pass below.
-    text = _strip_ansi(text)
-
-    # ``dict(os.environ)`` defends against another thread mutating the process
-    # environment mid-iteration (rare).
-    source_env: Mapping[str, str] = dict(os.environ) if env is None else env
-
-    # Candidate set: every env value + any JSON-nested leaf strings, plus the
-    # ansi-stripped form of each (the env value may carry embedded control
-    # bytes; ``text`` is already stripped). Sorted longest-first below so a
-    # longer secret is redacted before any shorter prefix.
-    candidates: set[str] = set()
-    for raw_value in source_env.values():
-        if not isinstance(raw_value, str):
-            continue
-        for nested in _expand_nested_secret_values(raw_value):
-            for variant in (nested, _strip_ansi(nested)):
-                if (
-                    len(variant) >= _REDACTION_MIN_VALUE_LEN
-                    and variant not in _REDACTION_SAFE_VALUES
-                ):
-                    candidates.add(variant)
-
-    for value in sorted(candidates, key=len, reverse=True):
-        if value in text:
-            text = text.replace(value, "<redacted>")
-
-    return text
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/cli/services/playwright_redaction.py
+++ b/src/notebooklm/cli/services/playwright_redaction.py
@@ -1,0 +1,150 @@
+"""Subprocess output sanitisation for the Playwright login service.
+
+Captured stderr/stdout from a Playwright subprocess (e.g. the install-failure
+path in :mod:`notebooklm.cli.services.playwright_login`) can leak two classes of
+noise into the console:
+  1. Environment-variable VALUES — Playwright forwards the parent env, so a
+     secret (PSIDTS, API tokens, auth-source / SAPISID cookie material)
+     interpolated into a traceback lands verbatim in ``result.stderr``.
+  2. ANSI control sequences — pip/playwright progress bars + colour codes.
+``redact_subprocess_output`` strips both. Env-var redaction is conservative:
+empty / single-char / boolean-ish / path-separator constants are skipped to
+avoid false positives across normal stderr lines.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+# CSI: ESC '[' parameter-bytes intermediate-bytes final-byte
+# OSC: ESC ']' ... (BEL | ESC '\\')
+# Plus a catch-all for any remaining two-byte C1 Fe sequence (the
+# 0x40-0x5F final-byte range). CSI and OSC are stripped first so this
+# only fires on leftovers (PM ``ESC ^``, APC ``ESC _``, ST ``ESC \``,
+# etc.).
+_ANSI_CSI_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+_ANSI_OSC_PATTERN = re.compile(r"\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)")
+_ANSI_OTHER_PATTERN = re.compile(r"\x1B[@-_]")
+
+# Env-var values we never redact even if they happen to be set (they would
+# produce noisy false positives on every line that mentions a path / boolean).
+# Single-character values (``/``, ``.``, ``*``, ``0``, ``1``, ``y``, ``n``)
+# don't appear here — they are already excluded by ``_REDACTION_MIN_VALUE_LEN``.
+_REDACTION_SAFE_VALUES = frozenset(
+    {
+        "",
+        "..",
+        "true",
+        "false",
+        "True",
+        "False",
+        "TRUE",
+        "FALSE",
+        "yes",
+        "no",
+        "on",
+        "off",
+    }
+)
+
+# Skip env values shorter than this — substring matches on 2-char strings
+# false-positive across the bytes Playwright prints.
+_REDACTION_MIN_VALUE_LEN = 3
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI CSI / OSC / two-byte escape sequences from ``text``."""
+    text = _ANSI_CSI_PATTERN.sub("", text)
+    text = _ANSI_OSC_PATTERN.sub("", text)
+    text = _ANSI_OTHER_PATTERN.sub("", text)
+    return text
+
+
+def _expand_nested_secret_values(value: str) -> Iterator[str]:
+    """Yield ``value`` plus any nested string leaves if it parses as JSON.
+
+    Env values supplied as inline JSON (the auth-source env var being
+    the canonical example) carry serialised dicts whose leaf strings
+    (cookie tokens, refresh tokens) are the actual secrets. If a
+    subprocess re-emits the parsed nested value rather than the whole
+    JSON blob, exact-string matching against the original env value
+    would miss the leak. Walk JSON objects/arrays here to add every
+    leaf string to the redaction candidate set.
+
+    Non-JSON values yield just themselves (and only if they pass the
+    caller's length / safe-value filter).
+    """
+    yield value
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "{[":
+        return
+    try:
+        parsed = json.loads(stripped)
+    except (ValueError, TypeError):
+        return
+
+    stack: list[Any] = [parsed]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            yield node
+        elif isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def redact_subprocess_output(text: str, env: Mapping[str, str] | None = None) -> str:
+    """Sanitise captured subprocess ``stdout`` / ``stderr`` before printing.
+
+    Runs in two passes (detail in the inline comments + module header):
+
+    1. **Strip ANSI control sequences** FIRST so a secret split by an inert
+       reset (``"abc\\x1b[0m123"`` → ``"abc123"``) is reassembled before the
+       exact-match redactor runs — otherwise it would miss it.
+    2. **Replace each non-trivial env-var value** (plus any JSON-nested leaf
+       strings) with ``<redacted>``. The env is snapshotted from ``os.environ``
+       unless ``env`` is supplied. Values under
+       :data:`_REDACTION_MIN_VALUE_LEN` and the :data:`_REDACTION_SAFE_VALUES`
+       constants are skipped; candidates are tried longest-first so a longer
+       secret containing a shorter one is redacted as one token.
+
+    Returns the sanitised string; the input is not mutated.
+    """
+    if not text:
+        return text
+
+    # Pass 1: strip ANSI BEFORE redaction so a secret broken up by reset
+    # codes (``"abc\x1b[0m123"`` → ``"abc123"``) is reassembled and
+    # redactable by the exact-match pass below.
+    text = _strip_ansi(text)
+
+    # ``dict(os.environ)`` defends against another thread mutating the process
+    # environment mid-iteration (rare).
+    source_env: Mapping[str, str] = dict(os.environ) if env is None else env
+
+    # Candidate set: every env value + any JSON-nested leaf strings, plus the
+    # ansi-stripped form of each (the env value may carry embedded control
+    # bytes; ``text`` is already stripped). Sorted longest-first below so a
+    # longer secret is redacted before any shorter prefix.
+    candidates: set[str] = set()
+    for raw_value in source_env.values():
+        if not isinstance(raw_value, str):
+            continue
+        for nested in _expand_nested_secret_values(raw_value):
+            for variant in (nested, _strip_ansi(nested)):
+                if (
+                    len(variant) >= _REDACTION_MIN_VALUE_LEN
+                    and variant not in _REDACTION_SAFE_VALUES
+                ):
+                    candidates.add(variant)
+
+    for value in sorted(candidates, key=len, reverse=True):
+        if value in text:
+            text = text.replace(value, "<redacted>")
+
+    return text

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -68,7 +68,6 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_source/upload.py": 1236,
     "cli/session_cmd.py": 1080,
     "_sources.py": 1007,
-    "cli/services/playwright_login.py": 988,
     "_artifact/downloads.py": 973,
     "client.py": 973,
     "_research.py": 936,

--- a/tests/unit/cli/test_services_boundary.py
+++ b/tests/unit/cli/test_services_boundary.py
@@ -129,6 +129,7 @@ GUARDED_PATHS = {
     "cli/services/login/refresh.py": SERVICES_ROOT / "login" / "refresh.py",
     "cli/services/login/rookiepy_errors.py": SERVICES_ROOT / "login" / "rookiepy_errors.py",
     "cli/services/playwright_login.py": SERVICES_ROOT / "playwright_login.py",
+    "cli/services/playwright_redaction.py": SERVICES_ROOT / "playwright_redaction.py",
     "cli/services/polling.py": SERVICES_ROOT / "polling.py",
     "cli/services/research.py": SERVICES_ROOT / "research.py",
     "cli/services/session_context.py": SERVICES_ROOT / "session_context.py",


### PR DESCRIPTION
## Summary

Wave-1 module shrink (Section 3 of the plan): extract the subprocess-output redaction cluster out of `cli/services/playwright_login.py` into a new `cli/services/playwright_redaction.py`. Pure relocation, no behavior change.

Moved (verbatim, with the leading "Subprocess output sanitisation" section comment):
- `_ANSI_CSI_PATTERN` / `_ANSI_OSC_PATTERN` / `_ANSI_OTHER_PATTERN` regexes
- `_REDACTION_SAFE_VALUES`, `_REDACTION_MIN_VALUE_LEN`
- `_strip_ansi`, `_expand_nested_secret_values`, `redact_subprocess_output`

The retained cookie-domain filter section comment and `filter_storage_state_cookies_by_domain_policy` stay in `playwright_login.py`.

## Surface preservation

`playwright_login.py` re-imports `redact_subprocess_output` near the top so:
- its `__all__` (which lists `redact_subprocess_output`) keeps working,
- `run_playwright_login` / `ensure_chromium_installed` still call it via the module-level name,
- `mock.patch("...playwright_login.redact_subprocess_output")` keeps resolving.

Grep over all `playwright_login` test files confirmed `redact_subprocess_output` is the only externally-imported/patched moved name (`_strip_ansi` references in `test_research_characterization.py` are a local test helper, unrelated). The private `_strip_ansi` / `_expand_nested_secret_values` are only called by `redact_subprocess_output`, so they moved with it.

## Sizes

- `playwright_login.py`: 988 → 842 LOC → removed from `test_module_size_ratchet.py` allowlist.
- `playwright_redaction.py`: 150 LOC (new, under the 900 budget).

## Shared-file edits

- `tests/_guardrails/test_module_size_ratchet.py`: removed `"cli/services/playwright_login.py": 988`.
- `tests/unit/cli/test_services_boundary.py`: added `playwright_redaction.py` to `GUARDED_PATHS` (pure string funcs, Click-free).
- `CLAUDE.md`: added `playwright_redaction.py` to the Repository Structure tree under `cli/services/`.

## Verification (all green)

- `ruff format --check` + `ruff check`
- `mypy src/notebooklm --ignore-missing-imports`
- full `pytest`: 8363 passed, 67 skipped, 1 xfailed
- `audit_public_api_compat.py`: OK, exit 0, **0 new allowlist entries**
- guardrails: `test_module_size_ratchet`, `test_claude_md_freshness`, `test_no_cross_test_imports`, `test_services_boundary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted subprocess output redaction logic into a dedicated module for improved code organization.

* **Tests**
  * Updated test configurations to reflect the restructured module layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->