### PR TITLE
test(guardrails): re-record-safety lint + cli_vcr group-coverage gate (Phase 4, #1452)

### DIFF
--- a/tests/_guardrails/test_cli_vcr_coverage.py
+++ b/tests/_guardrails/test_cli_vcr_coverage.py
@@ -1,0 +1,205 @@
+"""Guard: every CLI command GROUP has cli_vcr coverage or a reasoned exemption.
+
+The ``cli_vcr`` suite (``tests/integration/cli_vcr/``) is the project's
+behaviour net over the full CLI → Client → RPC path. A whole command *group*
+landing with no cli_vcr coverage — and no recorded reason — is how the net
+silently develops holes. This gate enumerates the top-level command groups of
+``notebooklm.notebooklm_cli.cli`` and asserts each one is EITHER:
+
+1. **Covered** — listed in :data:`GROUP_COVERAGE`, mapped to the
+   ``tests/integration/cli_vcr/`` test file that exercises it (the file must
+   exist), OR
+2. **Exempt** — listed in :data:`COVERAGE_EXEMPT` with a one-line reason.
+
+This is group-level, not leaf-command-level: 77 leaf commands across 12 groups
+would be noise. A group is the right granularity — when a group is exercised at
+all, the per-command depth is the job of the re-record-safe assertion tiers
+(issue #1452), not this gate.
+
+Mapping is **explicit** rather than ``test_<group>*.py`` filename inference,
+because the file names do not all match the group (``language`` → ``test_settings.py``,
+``note`` → ``test_notes.py``). An explicit ``group → file`` map is honest and
+survives a rename better than a glob.
+
+The exempt set is a **shrink-only ratchet** (mirrors
+``test_module_size_ratchet.py``): a group may only leave the exempt set by
+gaining real coverage — never by being added to dodge the gate. The two
+self-draining checks enforce this:
+
+* :func:`test_exempt_groups_have_no_cli_vcr_coverage` fails if an exempt group
+  *does* have a ``GROUP_COVERAGE`` entry whose file exists — that group is now
+  covered and MUST be removed from :data:`COVERAGE_EXEMPT` (the "newly-covered
+  group must be removed" contract).
+* :func:`test_every_cli_group_is_classified` fails if a brand-new group appears
+  that is in neither map — new groups start gated.
+
+Two exemption *reasons* exist, chosen by REALITY (verified by reading each
+command module for a ``NotebookLMClient`` / ``run_client_workflow`` RPC path):
+
+* ``"Phase-3: needs maintainer recording (#1452)"`` — the group hits the RPC API
+  but has no cassettes yet; it flips on when a maintainer records (issue #1452
+  Phase 3). These are the only entries expected to drain.
+* ``"local-only, no RPC path"`` — the group never builds a client (filesystem /
+  package-data only), so a VCR cassette would record nothing. These are
+  permanent by design.
+
+The gate is GREEN on ``main`` today.
+
+Modelled on the ratchet lints in ``tests/_guardrails/`` (e.g.
+``test_module_size_ratchet.py`` / ``test_no_module_shadowing.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from notebooklm.notebooklm_cli import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_VCR_DIR = REPO_ROOT / "tests" / "integration" / "cli_vcr"
+
+# Exemption reason strings (kept as named constants so the two reasons are
+# spelled identically everywhere and a typo can't fork them).
+_REASON_NEEDS_RECORDING = "Phase-3: needs maintainer recording (#1452)"
+_REASON_LOCAL_ONLY = "local-only, no RPC path"
+
+# Covered groups → the cli_vcr test file that exercises them. The file name does
+# not always match the group (the matcher keys on RPC shape, not the group
+# name), so the mapping is explicit. Each path is relative to ``CLI_VCR_DIR``.
+GROUP_COVERAGE: dict[str, str] = {
+    "artifact": "test_artifacts.py",
+    "download": "test_downloads.py",
+    "generate": "test_generate.py",
+    "language": "test_settings.py",  # `language` commands live in test_settings.py
+    "note": "test_notes.py",
+    "profile": "test_profile.py",
+    "share": "test_share.py",
+    "source": "test_sources.py",
+}
+
+# Groups with no cli_vcr coverage today → reason. Shrink-only: a group leaves
+# this map ONLY by gaining real coverage (move it to GROUP_COVERAGE). Verified
+# by reading each command module:
+#   * ``research``/``auth`` build a NotebookLMClient (RPC path) but have no
+#     cassettes yet — they flip on when a maintainer records (#1452 Phase 3).
+#   * ``agent``/``skill`` never touch the RPC API (``agent show`` prints packaged
+#     prompt templates; ``skill`` reads/writes skill files on disk), so a VCR
+#     cassette would capture nothing — permanently local-only.
+COVERAGE_EXEMPT: dict[str, str] = {
+    "research": _REASON_NEEDS_RECORDING,
+    "auth": _REASON_NEEDS_RECORDING,
+    "agent": _REASON_LOCAL_ONLY,
+    "skill": _REASON_LOCAL_ONLY,
+}
+
+_VALID_REASONS = frozenset({_REASON_NEEDS_RECORDING, _REASON_LOCAL_ONLY})
+
+
+def _cli_groups() -> set[str]:
+    """The names of every top-level ``click.Group`` under ``cli``.
+
+    Walks the live command tree so a newly-registered group is picked up
+    automatically (and then fails :func:`test_every_cli_group_is_classified`
+    until it is classified).
+    """
+    return {name for name, cmd in cli.commands.items() if isinstance(cmd, click.Group)}
+
+
+def _covered_file_exists(group: str) -> bool:
+    """True if ``group`` maps to a cli_vcr test file that exists on disk."""
+    rel = GROUP_COVERAGE.get(group)
+    return rel is not None and (CLI_VCR_DIR / rel).is_file()
+
+
+def test_every_cli_group_is_classified() -> None:
+    """Every CLI group must be covered OR exempt — a new group starts gated.
+
+    A group in neither :data:`GROUP_COVERAGE` nor :data:`COVERAGE_EXEMPT` is an
+    unclassified hole in the cli_vcr net. Add a cli_vcr test and map it in
+    ``GROUP_COVERAGE``, or (only if it is RPC-less or genuinely needs recording)
+    add it to ``COVERAGE_EXEMPT`` with a reason.
+    """
+    classified = set(GROUP_COVERAGE) | set(COVERAGE_EXEMPT)
+    unclassified = sorted(_cli_groups() - classified)
+    assert unclassified == [], (
+        "CLI command group(s) have no cli_vcr coverage and no exemption "
+        "(issue #1452 coverage gate). Add a cli_vcr test (and map it in "
+        "GROUP_COVERAGE) or add a reasoned COVERAGE_EXEMPT entry:\n"
+        + "\n".join(f"  {g}" for g in unclassified)
+    )
+
+
+def test_covered_groups_have_an_existing_test_file() -> None:
+    """Every :data:`GROUP_COVERAGE` entry must point at a real, existing group + file.
+
+    A dangling mapping (the group was renamed/removed, or the test file was
+    deleted) would silently claim coverage that no longer exists.
+    """
+    groups = _cli_groups()
+    broken = {
+        group: rel
+        for group, rel in GROUP_COVERAGE.items()
+        if group not in groups or not (CLI_VCR_DIR / rel).is_file()
+    }
+    assert broken == {}, (
+        "GROUP_COVERAGE has entries whose group no longer exists or whose test "
+        f"file is missing — fix or remove them {{group: file}}: {broken}"
+    )
+
+
+def test_exempt_groups_have_no_cli_vcr_coverage() -> None:
+    """A newly-covered group must be REMOVED from :data:`COVERAGE_EXEMPT` (shrink-only).
+
+    This is the ratchet: the moment an exempt group gains a real cli_vcr test
+    (a ``GROUP_COVERAGE`` mapping to an existing file), it is no longer exempt
+    and must move out of ``COVERAGE_EXEMPT``. Keeping a covered group in the
+    exempt set would let coverage silently regress behind a stale exemption.
+    """
+    regressed = sorted(g for g in COVERAGE_EXEMPT if _covered_file_exists(g))
+    assert regressed == [], (
+        "Group(s) now have cli_vcr coverage but are still in COVERAGE_EXEMPT "
+        "(issue #1452 shrink-only ratchet). The exempt set may only shrink — "
+        "remove each newly-covered group from COVERAGE_EXEMPT:\n"
+        + "\n".join(f"  {g}" for g in regressed)
+    )
+
+
+def test_exempt_and_covered_sets_are_disjoint() -> None:
+    """No group may be both covered and exempt.
+
+    Belt-and-braces against the two maps drifting out of sync — a group in both
+    is contradictory (and would defeat the shrink-only check above).
+    """
+    overlap = sorted(set(GROUP_COVERAGE) & set(COVERAGE_EXEMPT))
+    assert overlap == [], (
+        f"Group(s) appear in BOTH GROUP_COVERAGE and COVERAGE_EXEMPT: {overlap}. "
+        "A covered group must not also be exempt."
+    )
+
+
+def test_every_exemption_has_a_known_reason() -> None:
+    """Each :data:`COVERAGE_EXEMPT` reason must be one of the sanctioned strings.
+
+    Forces every exemption into one of the two audited buckets (needs-recording
+    vs local-only) so a free-text reason can't smuggle in an un-triaged hole.
+    """
+    bad = {g: r for g, r in COVERAGE_EXEMPT.items() if r not in _VALID_REASONS}
+    assert bad == {}, (
+        "COVERAGE_EXEMPT entries with an unrecognised reason — use one of "
+        f"{sorted(_VALID_REASONS)} {{group: reason}}: {bad}"
+    )
+
+
+def test_exempt_groups_still_exist() -> None:
+    """Every exempt group must still be a real CLI group (no stale entries).
+
+    A removed/renamed group left in :data:`COVERAGE_EXEMPT` is dead weight that
+    would mask a future re-introduction under the same name.
+    """
+    stale = sorted(g for g in COVERAGE_EXEMPT if g not in _cli_groups())
+    assert stale == [], (
+        "COVERAGE_EXEMPT references group(s) that no longer exist on the CLI — "
+        f"remove the stale entries: {stale}"
+    )

--- a/tests/_guardrails/test_cli_vcr_coverage.py
+++ b/tests/_guardrails/test_cli_vcr_coverage.py
@@ -145,7 +145,7 @@ def test_covered_groups_have_an_existing_test_file() -> None:
     }
     assert broken == {}, (
         "GROUP_COVERAGE has entries whose group no longer exists or whose test "
-        f"file is missing — fix or remove them {{group: file}}: {broken}"
+        f"file is missing — fix or remove them (group -> file): {broken}"
     )
 
 
@@ -188,7 +188,7 @@ def test_every_exemption_has_a_known_reason() -> None:
     bad = {g: r for g, r in COVERAGE_EXEMPT.items() if r not in _VALID_REASONS}
     assert bad == {}, (
         "COVERAGE_EXEMPT entries with an unrecognised reason — use one of "
-        f"{sorted(_VALID_REASONS)} {{group: reason}}: {bad}"
+        f"{sorted(_VALID_REASONS)} (group -> reason): {bad}"
     )
 
 

--- a/tests/_guardrails/test_no_pinned_cassette_values.py
+++ b/tests/_guardrails/test_no_pinned_cassette_values.py
@@ -24,8 +24,10 @@ literal — the CLI is echoing the test's input back, not the recording.
 
 So the lint's rule is narrow and unambiguous:
 
-    FAIL if an ``assert`` comparison (or an ``assertEqual``-style call) has an
-    operand that is an **inline UUID-shaped string literal**.
+    FAIL if an ``assert`` statement (or a value-comparing ``assert*`` unittest
+    call — ``assertEqual`` / ``assertIn`` / ``assertDictEqual`` / …, but not the
+    ``assertRaises``-style context managers) contains an **inline UUID-shaped
+    string literal**.
 
 A UUID literal is the concrete, notebook-tied, re-record-fragile shape. The
 input-echo case never trips this because it compares to a ``_fixtures``
@@ -51,6 +53,7 @@ from __future__ import annotations
 import ast
 import re
 from pathlib import Path
+from typing import TypeGuard
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_VCR_DIR = REPO_ROOT / "tests" / "integration" / "cli_vcr"
@@ -63,9 +66,24 @@ _UUID_RE = re.compile(
     re.IGNORECASE,
 )
 
-# ``assertEqual``-style unittest methods whose first two positional args are
-# compared for equality (so a UUID literal in either is a pinned value too).
-_ASSERT_EQ_METHODS = frozenset({"assertEqual", "assertEquals", "assertNotEqual"})
+# ``unittest`` ``assert*`` methods that do NOT compare values for equality:
+# context managers (``assertRaises`` / ``assertWarns`` / ``assertLogs`` and
+# their ``*Regex`` variants). Every *other* ``assert*`` method
+# (``assertEqual``, ``assertIn``, ``assertDictEqual``, …) takes the asserted
+# value as a positional arg, so a UUID literal in any of those is a pinned
+# value and must be flagged. Excluding by this small denylist (rather than
+# allow-listing the comparison methods) keeps the gate robust as new
+# ``assert*`` helpers appear.
+_NON_COMPARISON_ASSERT_METHODS = frozenset(
+    {
+        "assertRaises",
+        "assertRaisesRegex",
+        "assertWarns",
+        "assertWarnsRegex",
+        "assertLogs",
+        "assertNoLogs",
+    }
+)
 
 # Inline UUID literals that are legitimately pinned (NOT recorded-response
 # values). Empty today: Phase 1 (#1458) removed every inline UUID, and the
@@ -74,8 +92,12 @@ _ASSERT_EQ_METHODS = frozenset({"assertEqual", "assertEquals", "assertNotEqual"}
 ALLOWLIST: frozenset[str] = frozenset()
 
 
-def _is_uuid_literal(node: ast.expr) -> bool:
-    """True if ``node`` is a string constant whose value is UUID-shaped."""
+def _is_uuid_literal(node: ast.AST) -> TypeGuard[ast.Constant]:
+    """True if ``node`` is a string constant whose value is UUID-shaped.
+
+    A ``TypeGuard`` so callers can read ``node.lineno`` after a positive check
+    (it narrows ``ast.AST`` -> ``ast.Constant``, which carries position info).
+    """
     return (
         isinstance(node, ast.Constant)
         and isinstance(node.value, str)
@@ -83,36 +105,72 @@ def _is_uuid_literal(node: ast.expr) -> bool:
     )
 
 
+def _is_assert_call(node: ast.Call) -> bool:
+    """True if ``node`` is a value-comparing ``unittest`` ``assert*`` call.
+
+    Any method whose name starts with ``assert`` (called as ``self.assertX`` or
+    a bare ``assertX``) counts, except the context-manager forms in
+    :data:`_NON_COMPARISON_ASSERT_METHODS`, which take no asserted *value*.
+    """
+    func = node.func
+    name = (
+        func.attr
+        if isinstance(func, ast.Attribute)
+        else func.id
+        if isinstance(func, ast.Name)
+        else None
+    )
+    return (
+        name is not None
+        and name.startswith("assert")
+        and name not in _NON_COMPARISON_ASSERT_METHODS
+    )
+
+
+class _UUIDAssertVisitor(ast.NodeVisitor):
+    """Collect line numbers of inline UUID literals that sit inside an assertion.
+
+    Single-pass over the tree: a depth counter (``_depth``) tracks whether the
+    current node is nested inside an ``assert`` statement or an ``assert*``
+    call. Any UUID-shaped string constant seen while ``_depth > 0`` is a value
+    pinned from a specific recording, wherever in the asserted expression it
+    sits (a comparison operand, a set/list member, a call arg). Visiting once
+    avoids the nested-``ast.walk`` re-scan of every subtree.
+    """
+
+    def __init__(self) -> None:
+        self.lines: set[int] = set()
+        self._depth = 0
+
+    def visit_Assert(self, node: ast.Assert) -> None:
+        self._depth += 1
+        self.generic_visit(node)
+        self._depth -= 1
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _is_assert_call(node):
+            self._depth += 1
+            self.generic_visit(node)
+            self._depth -= 1
+        else:
+            self.generic_visit(node)
+
+    def generic_visit(self, node: ast.AST) -> None:
+        if self._depth > 0 and _is_uuid_literal(node):
+            self.lines.add(node.lineno)
+        super().generic_visit(node)
+
+
 def _uuid_literal_lines(tree: ast.AST) -> list[int]:
     """Return sorted line numbers of inline UUID literals inside assertions.
 
-    An "assertion" is either an ``assert`` statement or a call to an
-    ``assertEqual``-style unittest method. A UUID literal *anywhere* in the
-    asserted expression (a comparison operand, a set/list member, a call arg)
-    counts — it is a value pinned from a specific recording regardless of where
-    in the expression it sits. Pure on its input so a planted fixture can
-    exercise it without touching the filesystem.
+    An "assertion" is an ``assert`` statement or a value-comparing ``assert*``
+    unittest call (see :func:`_is_assert_call`). Pure on its input so a planted
+    fixture can exercise it without touching the filesystem.
     """
-    lines: set[int] = set()
-    for node in ast.walk(tree):
-        asserted: ast.AST | None = None
-        if isinstance(node, ast.Assert):
-            asserted = node.test
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr in _ASSERT_EQ_METHODS
-        ):
-            # Only the compared operands (positional args), not the optional msg.
-            asserted = ast.Module(
-                body=[ast.Expr(value=arg) for arg in node.args[:2]], type_ignores=[]
-            )
-        if asserted is None:
-            continue
-        for inner in ast.walk(asserted):
-            if isinstance(inner, ast.expr) and _is_uuid_literal(inner):
-                lines.add(inner.lineno)
-    return sorted(lines)
+    visitor = _UUIDAssertVisitor()
+    visitor.visit(tree)
+    return sorted(visitor.lines)
 
 
 def _cli_vcr_test_files() -> list[Path]:
@@ -177,11 +235,11 @@ def test_allowlist_entries_are_well_formed() -> None:
 
 
 def test_detector_flags_pinned_uuid_in_assert() -> None:
-    """The detector flags an inline UUID literal in an ``assert`` comparison.
+    """The detector flags an inline UUID literal in any value-comparing assertion.
 
-    Covers both a bare ``assert ==`` and an ``assertEqual`` call, and a UUID on
-    either side of the comparison — the recorded value is just as pinned whether
-    it is the left or right operand.
+    Covers a bare ``assert ==`` (UUID on either side), and the ``assert*``
+    unittest helpers beyond ``assertEqual`` — ``assertIn`` / ``assertDictEqual``
+    must NOT bypass the gate (the broadened-method case from PR #1460 review).
     """
     src = "\n".join(
         [
@@ -189,9 +247,11 @@ def test_detector_flags_pinned_uuid_in_assert() -> None:
             "assert 'C3F6285F-1709-44C4-9CD6-E95CF0EA4F5E' == data['id']",  # 2 (uppercase)
             "self.assertEqual(out['id'], 'fdfc8ac4-3237-4f2a-8a79-3e24297a7040')",  # 3
             "assert src['id'] in {'00000000-0000-0000-0000-000000000000'}",  # 4 (set member)
+            "self.assertIn('11111111-1111-1111-1111-111111111111', ids)",  # 5 (assertIn)
+            "self.assertDictEqual(d, {'id': '22222222-2222-2222-2222-222222222222'})",  # 6
         ]
     )
-    assert _uuid_literal_lines(ast.parse(src)) == [1, 2, 3, 4]
+    assert _uuid_literal_lines(ast.parse(src)) == [1, 2, 3, 4, 5, 6]
 
 
 def test_detector_ignores_re_record_safe_assertions() -> None:
@@ -215,6 +275,10 @@ def test_detector_ignores_re_record_safe_assertions() -> None:
             "assert data.get('added_user') == VCR_SHARE_EMAIL",  # input-echo (Name)
             "result = runner.invoke(cli, ['source', 'get', 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'])",
             "PLACEHOLDER_NOTEBOOK_ID = 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",
+            # A context-manager assert takes no asserted *value* — a UUID inside
+            # the managed block is a command arg, not a pinned comparison.
+            "with self.assertRaises(ValueError):\n"
+            "    runner.invoke(cli, ['source', 'get', 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'])",
         ]
     )
     assert _uuid_literal_lines(ast.parse(benign)) == []

--- a/tests/_guardrails/test_no_pinned_cassette_values.py
+++ b/tests/_guardrails/test_no_pinned_cassette_values.py
@@ -1,0 +1,220 @@
+"""Guard: no pinned recorded values in ``cli_vcr`` assertions (issue #1452).
+
+The ``cli_vcr`` suite (``tests/integration/cli_vcr/``) runs the real CLI →
+Client → RPC path against VCR cassettes, but the cassette matcher
+(``tests/vcr_config.py`` — ``_rpcids_matcher`` + ``_freq_body_matcher``) keys on
+the RPC method id and the decoded body *shape*, **never** on the notebook/source
+id in the request. The 105 cassettes were recorded against 15 distinct
+notebooks, and ``mock_context`` injects one placeholder id regardless of which
+notebook a cassette was recorded against (see ``cli_vcr/_fixtures.py``).
+
+The design contract (issue #1452): **every assertion must survive a re-record
+that uses a DIFFERENT notebook with different data.** An assertion that pins a
+value which came out of the recorded *response* — a server-returned id, a
+recorded title — would break the moment the cassette is re-recorded against
+another notebook, even though nothing about the client behaviour changed. That
+is exactly the brittle coupling this gate forbids.
+
+The one legitimate equality-against-a-concrete-id is the **input-echo** case: a
+mutation command threads the id the test *passed* into its own ``--json`` output,
+so ``data["notebook_id"] == MUTATION_NOTEBOOK_ID`` holds for any cassette and
+survives any re-record. That comparison is fine because its operand is a
+``_fixtures`` placeholder *constant* (a ``Name``/attribute), not an inline
+literal — the CLI is echoing the test's input back, not the recording.
+
+So the lint's rule is narrow and unambiguous:
+
+    FAIL if an ``assert`` comparison (or an ``assertEqual``-style call) has an
+    operand that is an **inline UUID-shaped string literal**.
+
+A UUID literal is the concrete, notebook-tied, re-record-fragile shape. The
+input-echo case never trips this because it compares to a ``_fixtures``
+placeholder *name*, not an inline literal — so there is nothing to allow-list in
+practice. Schema/enum literals (``"pass"``, ``"RATE_LIMITED"``, ``"delete"``)
+and input-echo string literals (a language code, an email the test passed) are
+**not** UUIDs and are intentionally out of scope: pinning a server-returned UUID
+is the unambiguous violation worth gating, and widening to "any literal" would
+fire on every legitimate schema/enum assertion.
+
+This is a forward ratchet: Phase 1 (#1458) already migrated every inline UUID in
+the ``cli_vcr`` tests onto ``_fixtures`` placeholder names, so the gate is GREEN
+on ``main`` today and stays green unless someone re-introduces a pinned recorded
+value. If a genuinely-legitimate inline UUID literal ever appears (none is known
+today), add it to :data:`ALLOWLIST` with a one-line justification.
+
+Modelled on the AST/path lints in ``tests/_guardrails/`` (e.g.
+``test_no_raw_positional_rpc_indexing.py``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_VCR_DIR = REPO_ROOT / "tests" / "integration" / "cli_vcr"
+
+# 8-4-4-4-12 hex UUID, anchored to the whole string. A re-record yields a
+# different UUID, so any *inline* UUID literal in an assertion is a value pinned
+# from a specific recording.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# ``assertEqual``-style unittest methods whose first two positional args are
+# compared for equality (so a UUID literal in either is a pinned value too).
+_ASSERT_EQ_METHODS = frozenset({"assertEqual", "assertEquals", "assertNotEqual"})
+
+# Inline UUID literals that are legitimately pinned (NOT recorded-response
+# values). Empty today: Phase 1 (#1458) removed every inline UUID, and the
+# input-echo case compares to a ``_fixtures`` placeholder *name*, never an inline
+# literal. Add an entry as ``"relpath:lineno"`` only with a justifying comment.
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _is_uuid_literal(node: ast.expr) -> bool:
+    """True if ``node`` is a string constant whose value is UUID-shaped."""
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and bool(_UUID_RE.match(node.value))
+    )
+
+
+def _uuid_literal_lines(tree: ast.AST) -> list[int]:
+    """Return sorted line numbers of inline UUID literals inside assertions.
+
+    An "assertion" is either an ``assert`` statement or a call to an
+    ``assertEqual``-style unittest method. A UUID literal *anywhere* in the
+    asserted expression (a comparison operand, a set/list member, a call arg)
+    counts — it is a value pinned from a specific recording regardless of where
+    in the expression it sits. Pure on its input so a planted fixture can
+    exercise it without touching the filesystem.
+    """
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        asserted: ast.AST | None = None
+        if isinstance(node, ast.Assert):
+            asserted = node.test
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _ASSERT_EQ_METHODS
+        ):
+            # Only the compared operands (positional args), not the optional msg.
+            asserted = ast.Module(
+                body=[ast.Expr(value=arg) for arg in node.args[:2]], type_ignores=[]
+            )
+        if asserted is None:
+            continue
+        for inner in ast.walk(asserted):
+            if isinstance(inner, ast.expr) and _is_uuid_literal(inner):
+                lines.add(inner.lineno)
+    return sorted(lines)
+
+
+def _cli_vcr_test_files() -> list[Path]:
+    """Every ``test_*.py`` under ``tests/integration/cli_vcr/``."""
+    return sorted(CLI_VCR_DIR.glob("test_*.py"))
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _offending_sites() -> dict[str, list[int]]:
+    """Map ``relpath -> offending line numbers`` for every cli_vcr test file."""
+    offenders: dict[str, list[int]] = {}
+    for path in _cli_vcr_test_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = _rel(path)
+        lines = [line for line in _uuid_literal_lines(tree) if f"{rel}:{line}" not in ALLOWLIST]
+        if lines:
+            offenders[rel] = lines
+    return offenders
+
+
+def test_no_pinned_uuid_literals_in_cli_vcr_asserts() -> None:
+    """No ``cli_vcr`` assertion may pin an inline UUID-shaped literal.
+
+    A UUID came out of a specific recording; pinning it breaks the moment the
+    cassette is re-recorded against a different notebook. Compare to a
+    ``cli_vcr/_fixtures.py`` placeholder constant instead (the input-echo case),
+    or assert the re-record-safe invariant (UUID *shape*, ``count > 0``) rather
+    than the exact value.
+    """
+    offenders = _offending_sites()
+    assert offenders == {}, (
+        "Inline UUID-shaped literal(s) found in cli_vcr assertions (issue #1452). "
+        "Assertions must survive a re-record against a different notebook, so a "
+        "value pinned from the recorded response is forbidden. Compare to a "
+        "cli_vcr/_fixtures.py placeholder constant (input-echo) or assert the "
+        "shape/invariant instead:\n"
+        + "\n".join(
+            f"  {rel}:{','.join(map(str, lines))}" for rel, lines in sorted(offenders.items())
+        )
+    )
+
+
+def test_allowlist_entries_are_well_formed() -> None:
+    """Every ALLOWLIST entry must be ``relpath:lineno`` for an existing file.
+
+    Catches typos / renames that would silently weaken the gate (a dangling
+    entry can never suppress a real offender, but it also documents intent that
+    no longer applies).
+    """
+    bad: list[str] = []
+    for entry in ALLOWLIST:
+        rel, _, lineno = entry.partition(":")
+        if not lineno.isdigit() or not (REPO_ROOT / rel).is_file():
+            bad.append(entry)
+    assert bad == [], (
+        "Malformed or stale ALLOWLIST entries (want 'relpath:lineno' for an "
+        f"existing file): {sorted(bad)}"
+    )
+
+
+def test_detector_flags_pinned_uuid_in_assert() -> None:
+    """The detector flags an inline UUID literal in an ``assert`` comparison.
+
+    Covers both a bare ``assert ==`` and an ``assertEqual`` call, and a UUID on
+    either side of the comparison — the recorded value is just as pinned whether
+    it is the left or right operand.
+    """
+    src = "\n".join(
+        [
+            "assert data['notebook_id'] == 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",  # 1
+            "assert 'C3F6285F-1709-44C4-9CD6-E95CF0EA4F5E' == data['id']",  # 2 (uppercase)
+            "self.assertEqual(out['id'], 'fdfc8ac4-3237-4f2a-8a79-3e24297a7040')",  # 3
+            "assert src['id'] in {'00000000-0000-0000-0000-000000000000'}",  # 4 (set member)
+        ]
+    )
+    assert _uuid_literal_lines(ast.parse(src)) == [1, 2, 3, 4]
+
+
+def test_detector_ignores_re_record_safe_assertions() -> None:
+    """Placeholder names, schema/enum literals, and non-assert UUIDs are NOT flagged.
+
+    These are the re-record-safe shapes the gate must tolerate:
+
+    * comparison to a ``_fixtures`` placeholder *name* (the input-echo case);
+    * schema/enum string literals (``"pass"`` / ``"RATE_LIMITED"`` / ``"delete"``)
+      and input-echo non-UUID literals (a language code, an email);
+    * a UUID literal that is *not* inside an assertion (e.g. a command argument
+      passed to ``runner.invoke`` or a module-level placeholder definition).
+    """
+    benign = "\n".join(
+        [
+            "assert data['notebook_id'] == MUTATION_NOTEBOOK_ID",  # input-echo (Name)
+            "assert data['checks']['auth']['status'] == 'pass'",  # schema enum
+            "assert data.get('code') == 'RATE_LIMITED'",  # error enum
+            "assert data['action'] == 'delete'",  # command action
+            "assert data.get('language') == 'en'",  # input-echo language code
+            "assert data.get('added_user') == VCR_SHARE_EMAIL",  # input-echo (Name)
+            "result = runner.invoke(cli, ['source', 'get', 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'])",
+            "PLACEHOLDER_NOTEBOOK_ID = 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",
+        ]
+    )
+    assert _uuid_literal_lines(ast.parse(benign)) == []


### PR DESCRIPTION
## Summary

Phase 4 of the cli_vcr strengthening plan (#1452): two NEW **test-only** enforcement guardrails. No `src/` changes; `audit_public_api_compat.py` stays exit 0 with zero allowlist entries added.

The plan's third Phase-4 item — a **cassette secret-shape scan** — is **descoped (already built)**: `tests/_guardrails/test_cassettes_clean.py` runs `check_cassettes_clean.py --strict --recursive` over every cassette, and `test_cassette_shapes.py` + `_cassette_shape_lint.py` run the leak-pattern detectors. Re-building it would duplicate existing coverage.

## (1) Re-record-safety lint — `tests/_guardrails/test_no_pinned_cassette_values.py`

An AST lint (same style as `test_no_raw_positional_rpc_indexing.py`) over every `tests/integration/cli_vcr/test_*.py`. It **FAILS** if an inline **UUID-shaped string literal** appears as an operand in an `assert` comparison (or an `assertEqual`-style call).

**Why:** the cassette matcher keys on the RPC method id + body *shape*, never the notebook/source id — so a UUID in an assertion is a value pinned from one specific recording, and it breaks the moment a cassette is re-recorded against a different notebook (even though client behaviour is unchanged). The **input-echo** case is allowed: comparing to a `cli_vcr/_fixtures.py` placeholder *constant* (`data["notebook_id"] == MUTATION_NOTEBOOK_ID`) is a `Name`, not an inline literal — the CLI is echoing the test's *input*, not the recording.

Scoped to UUID literals deliberately: that is the unambiguous re-record-fragile shape. Schema/enum literals (`"pass"`, `"RATE_LIMITED"`, `"delete"`) and non-UUID input-echo literals (a language code, an email) are out of scope so the gate never fires on a legitimate schema assertion.

Green on `main` (Phase 1 #1458 already migrated all inline UUIDs onto `_fixtures` names); a forward ratchet with an empty allowlist.

### Teeth-proof
Temporarily added `assert ... or "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e" in result.output` to `test_notebooks.py`, ran the lint, and it **FAILED** flagging `tests/integration/cli_vcr/test_notebooks.py:59`. Reverted; the gate is green again. The detector also has its own unit self-checks (`test_detector_flags_pinned_uuid_in_assert` / `test_detector_ignores_re_record_safe_assertions`).

## (2) Group-level coverage gate — `tests/_guardrails/test_cli_vcr_coverage.py`

Enumerates the 12 top-level `click.Group` commands of `notebooklm.notebooklm_cli.cli` and asserts each is EITHER mapped to an existing cli_vcr test file (`GROUP_COVERAGE`) OR in a reasoned `COVERAGE_EXEMPT` set. Group-level, not 77 leaf commands.

Mapping is **explicit** (`group → file`) rather than `test_<group>*.py` glob inference, because file names don't all match the group (`language` → `test_settings.py`, `note` → `test_notes.py`).

The exempt set is a **shrink-only ratchet** (mirrors `test_module_size_ratchet.py`): `test_exempt_groups_have_no_cli_vcr_coverage` fails if an exempt group gains a `GROUP_COVERAGE` mapping to an existing file — a newly-covered group MUST be removed from the exempt set. New groups start gated (`test_every_cli_group_is_classified`).

### `COVERAGE_EXEMPT` (verified by reading each command module for an RPC path)
| Group | Reason |
|-------|--------|
| `research` | `Phase-3: needs maintainer recording (#1452)` — builds a `NotebookLMClient` (RPC path) but has no cassettes yet |
| `auth` | `Phase-3: needs maintainer recording (#1452)` — RPC path, no cassettes yet |
| `agent` | `local-only, no RPC path` — `agent show` prints packaged prompt templates; never builds a client |
| `skill` | `local-only, no RPC path` — reads/writes skill files on disk; never builds a client |

`profile` is **covered** (`test_profile.py`) and is itself local-only, so it stays in `GROUP_COVERAGE`.

## Verification (all green)
- `pytest tests/_guardrails/test_no_pinned_cassette_values.py tests/_guardrails/test_cli_vcr_coverage.py` → 10 passed
- Full `uv run pytest` → 8383 passed, 67 skipped, 1 xfailed
- `ruff format --check`, `ruff check`, `mypy src/notebooklm --ignore-missing-imports` → clean
- `test_no_cross_test_imports`, `test_module_size_ratchet` → green (the coverage gate defines its own `CLI_VCR_DIR` to avoid a cross-test import)
- `audit_public_api_compat.py` → exit 0, zero allowlist entries added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a guardrail that ensures every top-level CLI command is either covered by a CLI-recorded test or has an explicit, allowable exemption; it also rejects stale or incorrect exemptions.
  * Added a guardrail that detects UUID-like literals hardcoded into CLI cassette tests, with an allowlist and checks to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->