### PR TITLE
test(guardrails): widen re-record-safety lint to non-UUID recorded ids + fix artifact landmine (#1452)

### DIFF
--- a/tests/_guardrails/test_no_pinned_cassette_values.py
+++ b/tests/_guardrails/test_no_pinned_cassette_values.py
@@ -91,21 +91,33 @@ _NUMERIC_ID_RE = re.compile(r"\d{6,}")
 # spaces) never match.
 _BLOB_RE = re.compile(r"^[A-Za-z0-9+/=_-]{16,}$")
 _HAS_DIGIT_RE = re.compile(r"\d")
-# A readable identifier segment: an alpha word with an optional short digit tail
-# (``study``, ``guide``, ``v2``, ``h264``). A blob token split on ``_``/``-`` whose
-# every segment reads like this is a field name / enum value, NOT a recorded id.
-_WORD_SEGMENT_RE = re.compile(r"^[A-Za-z]+[0-9]{0,3}$")
+# A readable identifier segment is either purely alphabetic (any length, e.g.
+# ``synced`` / ``NOTEBOOKLM``) or a short (<=8-char) alphanumeric wordlet (e.g.
+# ``v2`` / ``h264`` / ``v1beta1`` / ``x86`` / ``1st``). A blob token split on
+# ``_``/``-`` whose every segment reads like this is a field name / enum / version
+# string, NOT a recorded id; a high-entropy hash/base64 token has a long
+# no-separator alphanumeric run that fails both shapes.
+_ALPHA_SEGMENT_RE = re.compile(r"^[A-Za-z]+$")
+_SHORT_ALNUM_SEGMENT_RE = re.compile(r"^[A-Za-z0-9]{1,8}$")
 
 
 def _is_readable_identifier(value: str) -> bool:
     """True if ``value`` reads as a ``snake_case`` / ``kebab-case`` identifier.
 
-    Splits on ``_``/``-`` and checks every non-empty segment is a short word
-    (alpha + optional <=3-digit tail). ``"synced_to_server"``, ``"briefing_doc"``,
-    ``"NOTEBOOKLM_ERROR"`` and ``"x264_high_profile"`` all read as identifiers;
-    a hash (``"f8cb37228518a4c33b744"``) or base64 token does not.
+    Splits on ``_``/``-`` and checks every non-empty segment is either purely
+    alphabetic (any length) or a short (<=8-char) alphanumeric wordlet. This
+    tolerates digits anywhere in a segment, so common identifiers stay readable:
+    ``"synced_to_server"``, ``"briefing_doc"``, ``"NOTEBOOKLM_ERROR"``,
+    ``"x264_high_profile"``, ``"v1beta1_api_client"`` and ``"x86_64_ubuntu"`` all
+    read as identifiers; a hash (``"f8cb37228518a4c33b744"``) or base64 token has
+    a long (>8) non-alpha run and does not.
     """
-    return all(_WORD_SEGMENT_RE.match(seg) for seg in re.split(r"[_-]", value) if seg)
+    for seg in re.split(r"[_-]", value):
+        if not seg:
+            continue
+        if not (_ALPHA_SEGMENT_RE.match(seg) or _SHORT_ALNUM_SEGMENT_RE.match(seg)):
+            return False
+    return True
 
 
 def _is_opaque_blob(value: str) -> bool:
@@ -350,8 +362,10 @@ def test_detector_ignores_re_record_safe_assertions() -> None:
       input-echo case — the ``Name`` operand carries the recorded-safe id);
     * schema/enum/status/field literals (``"pass"`` / ``"NOTEBOOKLM_ERROR"`` /
       ``"synced_to_server"`` / ``"briefing_doc"``), type filters (``"mind-map"``),
-      CLI flags (``"--json"``), small numbers (``"200"``) and prose
-      assert-messages — none reach the digit-run / blob thresholds;
+      version-bearing identifiers (``"v1beta1_api_client"`` / ``"x86_64_ubuntu"``,
+      the digit-in-segment cases from PR #1461 review), CLI flags (``"--json"``),
+      small numbers (``"200"``) and prose assert-messages — none reach the
+      digit-run / blob thresholds or all read as identifiers;
     * an opaque id literal that is *not* inside an assertion (a command argument
       passed to ``runner.invoke`` or a module-level placeholder definition).
     """
@@ -363,6 +377,8 @@ def test_detector_ignores_re_record_safe_assertions() -> None:
             "assert data.get('code') == 'NOTEBOOKLM_ERROR'",  # error-code enum (16-char ident)
             "assert data.get('synced_to_server') is True",  # field name (16-char ident)
             "assert data['type_id'] == 'briefing_doc'",  # report subtype enum
+            "assert data['client'] == 'v1beta1_api_client'",  # version-bearing identifier
+            "assert data['image'] == 'x86_64_ubuntu_image'",  # arch identifier (digit-in-segment)
             "assert 'mind-map' in args",  # kebab type filter
             "assert data['action'] == 'delete'",  # command action",
             "assert data.get('language') == 'en'",  # input-echo language code

--- a/tests/_guardrails/test_no_pinned_cassette_values.py
+++ b/tests/_guardrails/test_no_pinned_cassette_values.py
@@ -26,23 +26,36 @@ So the lint's rule is narrow and unambiguous:
 
     FAIL if an ``assert`` statement (or a value-comparing ``assert*`` unittest
     call — ``assertEqual`` / ``assertIn`` / ``assertDictEqual`` / …, but not the
-    ``assertRaises``-style context managers) contains an **inline UUID-shaped
-    string literal**.
+    ``assertRaises``-style context managers) contains an **inline string literal
+    whose value is opaque-recorded-id-shaped** (see :func:`_is_opaque_recorded_id`).
 
-A UUID literal is the concrete, notebook-tied, re-record-fragile shape. The
-input-echo case never trips this because it compares to a ``_fixtures``
+An opaque-recorded-id literal is the concrete, notebook-tied, re-record-fragile
+shape. Three families count (issue #1452, codex review of #1460):
+
+* a **UUID** (``8-4-4-4-12`` hex) — the original case;
+* a run of **≥6 consecutive digits** — a numeric recorded id such as the
+  mind-map artifact ``47523923`` that slipped the UUID-only lint and is what
+  this widening was written to catch;
+* a **≥16-char opaque base64/hex blob** — a single high-entropy token (a cursor
+  page-token, a content hash) that carries at least one digit and is *not* a
+  readable ``snake_case`` / ``kebab-case`` / ``SCREAMING_CASE`` identifier.
+
+The input-echo case never trips this because it compares to a ``_fixtures``
 placeholder *name*, not an inline literal — so there is nothing to allow-list in
-practice. Schema/enum literals (``"pass"``, ``"RATE_LIMITED"``, ``"delete"``)
-and input-echo string literals (a language code, an email the test passed) are
-**not** UUIDs and are intentionally out of scope: pinning a server-returned UUID
-is the unambiguous violation worth gating, and widening to "any literal" would
-fire on every legitimate schema/enum assertion.
+practice. The shape tests are deliberately tuned so legitimate literals do NOT
+match: schema/enum/status values (``"ready"``, ``"NOTEBOOKLM_ERROR"``,
+``"synced_to_server"``, ``"briefing_doc"``), type filters (``"mind-map"``), CLI
+flags (``"--json"``), small numbers, short tokens, and prose assert-messages all
+stay below the digit-run / blob thresholds or read as identifiers. Pinning a
+server-returned id is the unambiguous violation worth gating; widening to "any
+literal" would fire on every legitimate schema/enum assertion.
 
-This is a forward ratchet: Phase 1 (#1458) already migrated every inline UUID in
-the ``cli_vcr`` tests onto ``_fixtures`` placeholder names, so the gate is GREEN
-on ``main`` today and stays green unless someone re-introduces a pinned recorded
-value. If a genuinely-legitimate inline UUID literal ever appears (none is known
-today), add it to :data:`ALLOWLIST` with a one-line justification.
+This is a forward ratchet: every inline recorded id in the ``cli_vcr`` tests has
+been migrated onto ``_fixtures`` placeholder names or replaced with a
+shape/invariant assertion, so the gate is GREEN on ``main`` today and stays green
+unless someone re-introduces a pinned recorded value. If a genuinely-legitimate
+opaque-shaped inline literal ever appears (none is known today), add it to
+:data:`ALLOWLIST` with a one-line justification.
 
 Modelled on the AST/path lints in ``tests/_guardrails/`` (e.g.
 ``test_no_raw_positional_rpc_indexing.py``).
@@ -66,11 +79,81 @@ _UUID_RE = re.compile(
     re.IGNORECASE,
 )
 
+# A run of >=6 consecutive digits anywhere in the literal — a numeric recorded
+# id (e.g. the mind-map artifact ``47523923``). Six digits is comfortably above
+# any legitimate small number a cli_vcr assertion compares against (exit codes,
+# counts, page sizes, HTTP statuses), so it is the re-record-fragile shape.
+_NUMERIC_ID_RE = re.compile(r"\d{6,}")
+
+# An opaque base64/hex blob: the whole literal is one >=16-char token drawn from
+# the base64/hex alphabet (incl. ``+`` ``/`` ``=`` padding and ``_`` ``-`` of the
+# URL-safe variant), anchored so prose/sentence assert-messages (which contain
+# spaces) never match.
+_BLOB_RE = re.compile(r"^[A-Za-z0-9+/=_-]{16,}$")
+_HAS_DIGIT_RE = re.compile(r"\d")
+# A readable identifier segment: an alpha word with an optional short digit tail
+# (``study``, ``guide``, ``v2``, ``h264``). A blob token split on ``_``/``-`` whose
+# every segment reads like this is a field name / enum value, NOT a recorded id.
+_WORD_SEGMENT_RE = re.compile(r"^[A-Za-z]+[0-9]{0,3}$")
+
+
+def _is_readable_identifier(value: str) -> bool:
+    """True if ``value`` reads as a ``snake_case`` / ``kebab-case`` identifier.
+
+    Splits on ``_``/``-`` and checks every non-empty segment is a short word
+    (alpha + optional <=3-digit tail). ``"synced_to_server"``, ``"briefing_doc"``,
+    ``"NOTEBOOKLM_ERROR"`` and ``"x264_high_profile"`` all read as identifiers;
+    a hash (``"f8cb37228518a4c33b744"``) or base64 token does not.
+    """
+    return all(_WORD_SEGMENT_RE.match(seg) for seg in re.split(r"[_-]", value) if seg)
+
+
+def _is_opaque_blob(value: str) -> bool:
+    """True if ``value`` is a >=16-char high-entropy base64/hex recorded blob.
+
+    Distinguishes an opaque recorded token (a cursor page-token, a content hash)
+    from a long-but-readable identifier/field-name/enum value. A blob must:
+
+    * be a single 16+ char token over the base64/hex(-safe) alphabet (anchored,
+      so prose assert-messages with spaces never match);
+    * carry at least one digit (recorded ids do; pure-word identifiers do not);
+    * either use base64 ``+``/``/``/``=`` (never an identifier) or fail the
+      readable-identifier shape.
+    """
+    if not _BLOB_RE.match(value):
+        return False
+    if not _HAS_DIGIT_RE.search(value):
+        return False
+    if "=" in value or "+" in value or "/" in value:
+        return True
+    return not _is_readable_identifier(value)
+
+
+def _is_opaque_recorded_id(value: str) -> bool:
+    """True if ``value`` has the shape of a value pinned from a recording.
+
+    Three families, any of which is re-record-fragile: a UUID, a >=6-digit
+    numeric id, or an opaque >=16-char base64/hex blob. Tuned so schema/enum
+    literals, CLI flags, type filters, small numbers and prose stay out of scope
+    (see the module docstring).
+    """
+    return (
+        bool(_UUID_RE.match(value)) or bool(_NUMERIC_ID_RE.search(value)) or _is_opaque_blob(value)
+    )
+
+
+# Inline opaque-id literals that are legitimately pinned (NOT recorded-response
+# values). Empty today: every inline recorded id has been removed, and the
+# input-echo case compares to a ``_fixtures`` placeholder *name*, never an inline
+# literal. Add an entry as ``"relpath:lineno"`` only with a justifying comment.
+ALLOWLIST: frozenset[str] = frozenset()
+
+
 # ``unittest`` ``assert*`` methods that do NOT compare values for equality:
 # context managers (``assertRaises`` / ``assertWarns`` / ``assertLogs`` and
 # their ``*Regex`` variants). Every *other* ``assert*`` method
 # (``assertEqual``, ``assertIn``, ``assertDictEqual``, …) takes the asserted
-# value as a positional arg, so a UUID literal in any of those is a pinned
+# value as a positional arg, so an opaque-id literal in any of those is a pinned
 # value and must be flagged. Excluding by this small denylist (rather than
 # allow-listing the comparison methods) keeps the gate robust as new
 # ``assert*`` helpers appear.
@@ -85,15 +168,9 @@ _NON_COMPARISON_ASSERT_METHODS = frozenset(
     }
 )
 
-# Inline UUID literals that are legitimately pinned (NOT recorded-response
-# values). Empty today: Phase 1 (#1458) removed every inline UUID, and the
-# input-echo case compares to a ``_fixtures`` placeholder *name*, never an inline
-# literal. Add an entry as ``"relpath:lineno"`` only with a justifying comment.
-ALLOWLIST: frozenset[str] = frozenset()
 
-
-def _is_uuid_literal(node: ast.AST) -> TypeGuard[ast.Constant]:
-    """True if ``node`` is a string constant whose value is UUID-shaped.
+def _is_opaque_id_literal(node: ast.AST) -> TypeGuard[ast.Constant]:
+    """True if ``node`` is a string constant whose value is opaque-recorded-id-shaped.
 
     A ``TypeGuard`` so callers can read ``node.lineno`` after a positive check
     (it narrows ``ast.AST`` -> ``ast.Constant``, which carries position info).
@@ -101,7 +178,7 @@ def _is_uuid_literal(node: ast.AST) -> TypeGuard[ast.Constant]:
     return (
         isinstance(node, ast.Constant)
         and isinstance(node.value, str)
-        and bool(_UUID_RE.match(node.value))
+        and _is_opaque_recorded_id(node.value)
     )
 
 
@@ -127,15 +204,16 @@ def _is_assert_call(node: ast.Call) -> bool:
     )
 
 
-class _UUIDAssertVisitor(ast.NodeVisitor):
-    """Collect line numbers of inline UUID literals that sit inside an assertion.
+class _OpaqueIdAssertVisitor(ast.NodeVisitor):
+    """Collect line numbers of opaque-id literals that sit inside an assertion.
 
     Single-pass over the tree: a depth counter (``_depth``) tracks whether the
     current node is nested inside an ``assert`` statement or an ``assert*``
-    call. Any UUID-shaped string constant seen while ``_depth > 0`` is a value
-    pinned from a specific recording, wherever in the asserted expression it
-    sits (a comparison operand, a set/list member, a call arg). Visiting once
-    avoids the nested-``ast.walk`` re-scan of every subtree.
+    call. Any opaque-recorded-id string constant seen while ``_depth > 0`` is a
+    value pinned from a specific recording, wherever in the asserted expression
+    it sits (a comparison operand, a membership left operand, a set/list member,
+    a call arg). Visiting once avoids the nested-``ast.walk`` re-scan of every
+    subtree.
     """
 
     def __init__(self) -> None:
@@ -156,19 +234,19 @@ class _UUIDAssertVisitor(ast.NodeVisitor):
             self.generic_visit(node)
 
     def generic_visit(self, node: ast.AST) -> None:
-        if self._depth > 0 and _is_uuid_literal(node):
+        if self._depth > 0 and _is_opaque_id_literal(node):
             self.lines.add(node.lineno)
         super().generic_visit(node)
 
 
-def _uuid_literal_lines(tree: ast.AST) -> list[int]:
-    """Return sorted line numbers of inline UUID literals inside assertions.
+def _opaque_id_literal_lines(tree: ast.AST) -> list[int]:
+    """Return sorted line numbers of opaque-id literals inside assertions.
 
     An "assertion" is an ``assert`` statement or a value-comparing ``assert*``
     unittest call (see :func:`_is_assert_call`). Pure on its input so a planted
     fixture can exercise it without touching the filesystem.
     """
-    visitor = _UUIDAssertVisitor()
+    visitor = _OpaqueIdAssertVisitor()
     visitor.visit(tree)
     return sorted(visitor.lines)
 
@@ -188,26 +266,29 @@ def _offending_sites() -> dict[str, list[int]]:
     for path in _cli_vcr_test_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         rel = _rel(path)
-        lines = [line for line in _uuid_literal_lines(tree) if f"{rel}:{line}" not in ALLOWLIST]
+        lines = [
+            line for line in _opaque_id_literal_lines(tree) if f"{rel}:{line}" not in ALLOWLIST
+        ]
         if lines:
             offenders[rel] = lines
     return offenders
 
 
-def test_no_pinned_uuid_literals_in_cli_vcr_asserts() -> None:
-    """No ``cli_vcr`` assertion may pin an inline UUID-shaped literal.
+def test_no_pinned_recorded_id_literals_in_cli_vcr_asserts() -> None:
+    """No ``cli_vcr`` assertion may pin an inline opaque-recorded-id literal.
 
-    A UUID came out of a specific recording; pinning it breaks the moment the
-    cassette is re-recorded against a different notebook. Compare to a
-    ``cli_vcr/_fixtures.py`` placeholder constant instead (the input-echo case),
-    or assert the re-record-safe invariant (UUID *shape*, ``count > 0``) rather
-    than the exact value.
+    A UUID / numeric id / opaque blob came out of a specific recording; pinning
+    it breaks the moment the cassette is re-recorded against a different
+    notebook. Compare to a ``cli_vcr/_fixtures.py`` placeholder constant instead
+    (the input-echo case), or assert the re-record-safe invariant (the id
+    *shape*, ``count > 0``, a type-display string) rather than the exact value.
     """
     offenders = _offending_sites()
     assert offenders == {}, (
-        "Inline UUID-shaped literal(s) found in cli_vcr assertions (issue #1452). "
-        "Assertions must survive a re-record against a different notebook, so a "
-        "value pinned from the recorded response is forbidden. Compare to a "
+        "Inline opaque-recorded-id literal(s) found in cli_vcr assertions (issue "
+        "#1452). Assertions must survive a re-record against a different "
+        "notebook, so a value pinned from the recorded response (a UUID, a "
+        "numeric id, or an opaque base64/hex blob) is forbidden. Compare to a "
         "cli_vcr/_fixtures.py placeholder constant (input-echo) or assert the "
         "shape/invariant instead:\n"
         + "\n".join(
@@ -234,45 +315,61 @@ def test_allowlist_entries_are_well_formed() -> None:
     )
 
 
-def test_detector_flags_pinned_uuid_in_assert() -> None:
-    """The detector flags an inline UUID literal in any value-comparing assertion.
+def test_detector_flags_pinned_recorded_ids_in_assert() -> None:
+    """The detector flags every opaque-recorded-id shape in a value-comparing assertion.
 
-    Covers a bare ``assert ==`` (UUID on either side), and the ``assert*``
-    unittest helpers beyond ``assertEqual`` — ``assertIn`` / ``assertDictEqual``
-    must NOT bypass the gate (the broadened-method case from PR #1460 review).
+    Covers all three families across the assertion surface: a UUID (either side
+    of ``==``, in a set member, via ``assertEqual`` / ``assertIn`` /
+    ``assertDictEqual``), a >=6-digit numeric id (the ``47523923`` mind-map case
+    the UUID-only lint missed, incl. the ``in result.output`` membership form),
+    and an opaque >=16-char base64/hex blob.
     """
     src = "\n".join(
         [
-            "assert data['notebook_id'] == 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",  # 1
-            "assert 'C3F6285F-1709-44C4-9CD6-E95CF0EA4F5E' == data['id']",  # 2 (uppercase)
-            "self.assertEqual(out['id'], 'fdfc8ac4-3237-4f2a-8a79-3e24297a7040')",  # 3
-            "assert src['id'] in {'00000000-0000-0000-0000-000000000000'}",  # 4 (set member)
-            "self.assertIn('11111111-1111-1111-1111-111111111111', ids)",  # 5 (assertIn)
-            "self.assertDictEqual(d, {'id': '22222222-2222-2222-2222-222222222222'})",  # 6
+            "assert data['notebook_id'] == 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",  # 1 UUID
+            "assert 'C3F6285F-1709-44C4-9CD6-E95CF0EA4F5E' == data['id']",  # 2 UUID (upper)
+            "self.assertEqual(out['id'], 'fdfc8ac4-3237-4f2a-8a79-3e24297a7040')",  # 3 UUID
+            "assert src['id'] in {'00000000-0000-0000-0000-000000000000'}",  # 4 UUID (set)
+            "self.assertIn('11111111-1111-1111-1111-111111111111', ids)",  # 5 UUID assertIn
+            "self.assertDictEqual(d, {'id': '22222222-2222-2222-2222-222222222222'})",  # 6 UUID
+            "assert '47523923' in result.output",  # 7 numeric id (the landmine shape)
+            "assert data['count'] == '1234567'",  # 8 numeric id (>=6 digits)
+            "assert 'MTc4MDEzMzM5OS01ODQyMjkwMDA=' in result.output",  # 9 base64 blob
+            "self.assertIn('f8cb37228518a4c33b744ef1', tokens)",  # 10 hex blob
         ]
     )
-    assert _uuid_literal_lines(ast.parse(src)) == [1, 2, 3, 4, 5, 6]
+    assert _opaque_id_literal_lines(ast.parse(src)) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 
 def test_detector_ignores_re_record_safe_assertions() -> None:
-    """Placeholder names, schema/enum literals, and non-assert UUIDs are NOT flagged.
+    """Placeholder names, schema/enum literals, and non-assert ids are NOT flagged.
 
     These are the re-record-safe shapes the gate must tolerate:
 
-    * comparison to a ``_fixtures`` placeholder *name* (the input-echo case);
-    * schema/enum string literals (``"pass"`` / ``"RATE_LIMITED"`` / ``"delete"``)
-      and input-echo non-UUID literals (a language code, an email);
-    * a UUID literal that is *not* inside an assertion (e.g. a command argument
+    * comparison/membership against a ``_fixtures`` placeholder *name* (the
+      input-echo case — the ``Name`` operand carries the recorded-safe id);
+    * schema/enum/status/field literals (``"pass"`` / ``"NOTEBOOKLM_ERROR"`` /
+      ``"synced_to_server"`` / ``"briefing_doc"``), type filters (``"mind-map"``),
+      CLI flags (``"--json"``), small numbers (``"200"``) and prose
+      assert-messages — none reach the digit-run / blob thresholds;
+    * an opaque id literal that is *not* inside an assertion (a command argument
       passed to ``runner.invoke`` or a module-level placeholder definition).
     """
     benign = "\n".join(
         [
             "assert data['notebook_id'] == MUTATION_NOTEBOOK_ID",  # input-echo (Name)
+            "assert ARTIFACT_NOTEBOOK_ID in result.output",  # input-echo membership (Name)
             "assert data['checks']['auth']['status'] == 'pass'",  # schema enum
-            "assert data.get('code') == 'RATE_LIMITED'",  # error enum
-            "assert data['action'] == 'delete'",  # command action
+            "assert data.get('code') == 'NOTEBOOKLM_ERROR'",  # error-code enum (16-char ident)
+            "assert data.get('synced_to_server') is True",  # field name (16-char ident)
+            "assert data['type_id'] == 'briefing_doc'",  # report subtype enum
+            "assert 'mind-map' in args",  # kebab type filter
+            "assert data['action'] == 'delete'",  # command action",
             "assert data.get('language') == 'en'",  # input-echo language code
+            "assert result.exit_code == 0, 'expected the command to succeed cleanly'",  # prose msg
             "assert data.get('added_user') == VCR_SHARE_EMAIL",  # input-echo (Name)
+            "assert 'Mind Map' in result.output",  # type-display marker (the landmine fix)
+            "assert data['count'] == '200'",  # small number
             "result = runner.invoke(cli, ['source', 'get', 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'])",
             "PLACEHOLDER_NOTEBOOK_ID = 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'",
             # A context-manager assert takes no asserted *value* — a UUID inside
@@ -281,4 +378,4 @@ def test_detector_ignores_re_record_safe_assertions() -> None:
             "    runner.invoke(cli, ['source', 'get', 'c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e'])",
         ]
     )
-    assert _uuid_literal_lines(ast.parse(benign)) == []
+    assert _opaque_id_literal_lines(ast.parse(benign)) == []

--- a/tests/integration/cli_vcr/test_artifacts.py
+++ b/tests/integration/cli_vcr/test_artifacts.py
@@ -94,16 +94,31 @@ class TestArtifactListByType:
         """`artifact list --type mind-map` surfaces an interactive (studio-artifact) map.
 
         Reuses the interactive recording (``mind_maps_interactive.yaml``,
-        ``ARTIFACT_NOTEBOOK_ID`` / artifact ``47523923``). Stays on the table
-        renderer (no ``--json``) so it needs only ``LIST_ARTIFACTS`` +
-        ``GET_NOTES_AND_MIND_MAPS``, both present in the cassette — proving the
-        type-4/variant-4 map is recognized end-to-end through the CLI (#1256).
+        ``ARTIFACT_NOTEBOOK_ID``). Stays on the table renderer (no ``--json``) so
+        it needs only ``LIST_ARTIFACTS`` + ``GET_NOTES_AND_MIND_MAPS``, both
+        present in the cassette — proving the type-4/variant-4 map is recognized
+        end-to-end through the CLI (#1256).
+
+        Re-record-safe assertion: the rendered table must carry the mind-map
+        **type display** (``get_artifact_type_display`` → ``Mind Map``), which
+        the renderer only emits for a row whose parsed kind is
+        ``ArtifactType.MIND_MAP``. That proves the type-4/variant-4 artifact was
+        recognized as a mind map and survived the ``--type mind-map`` filter,
+        without pinning the recorded artifact id/title (which change on a
+        re-record against a different notebook). The empty-state path prints
+        ``No mind-map artifacts found`` instead, so the marker also proves the
+        filter returned a non-empty row.
         """
         nb = ARTIFACT_NOTEBOOK_ID
         with notebooklm_vcr.use_cassette("mind_maps_interactive.yaml", allow_playback_repeats=True):
             result = runner.invoke(cli, ["artifact", "list", "--type", "mind-map", "-n", nb])
             assert_command_success(result)
-            assert "47523923" in result.output
+            assert "Mind Map" in result.output, (
+                "Expected the rendered table to carry the mind-map type display, "
+                "proving the type-4/variant-4 interactive map was recognized and "
+                f"passed the --type mind-map filter; output was:\n{result.output}"
+            )
+            assert "No mind-map artifacts found" not in result.output
 
 
 class TestArtifactSuggestionsCommand:


### PR DESCRIPTION
## The gap

A codex review of the `cli_vcr` suite (#1452) found a re-record landmine the #1460 lint missed. The re-record-safety gate (`tests/_guardrails/test_no_pinned_cassette_values.py`) only flagged **UUID-shaped** string literals in cli_vcr asserts, so a pinned **numeric** recorded id slipped through:

```python
# tests/integration/cli_vcr/test_artifacts.py
assert "47523923" in result.output   # leading hex of a recorded mind-map artifact UUID
```

That literal came out of one specific recording (`mind_maps_interactive.yaml`, artifact `47523923-9839-48fd-ae10-25bb685a0644`). It WILL break the moment the cassette is re-recorded against a different notebook — exactly the brittle coupling the gate exists to forbid.

## The widened detection

`_is_opaque_recorded_id` now flags three families of opaque recorded-id-shaped **inline string literals** inside cli_vcr `assert` statements / value-comparing `assert*` calls (incl. `"X" in result.output` membership and `==` / `assertIn` against output):

1. **UUID** — the original `8-4-4-4-12` hex case.
2. **>=6 consecutive digits** — a numeric recorded id (e.g. `47523923`). Six digits sits comfortably above any legit small number a cli_vcr assert compares against (exit codes, counts, page sizes, HTTP statuses).
3. **>=16-char opaque base64/hex blob** — a single high-entropy token (cursor page-token, content hash) that carries at least one digit and is **not** a readable `snake_case` / `kebab-case` / `SCREAMING_CASE` identifier.

**No false positives** on legitimate literals — verified across the whole suite: enum/status/field values (`"ready"`, `"NOTEBOOKLM_ERROR"`, `"synced_to_server"`, `"briefing_doc"`), type filters (`"mind-map"`), CLI flags (`"--json"`), small numbers, short tokens, and prose assert-messages all stay below the digit-run / blob thresholds or read as identifiers. The **input-echo** case stays allowed (it compares to a `_fixtures` placeholder `Name`, never an inline literal). The empty `ALLOWLIST` escape hatch + its well-formedness self-test are preserved; the positive/negative detector self-tests now cover the numeric + blob shapes.

Running the widened lint across `tests/integration/cli_vcr/*.py` flagged **only** the one landmine site — no other numeric/blob recorded literals exist in the suite.

## The landmine fix

`test_artifact_list_type_mind_map_interactive` proves the type-4/variant-4 interactive mind map is recognized end-to-end through `artifact list --type mind-map` (text render). The pinned assertion is replaced with a re-record-safe one that preserves that intent:

```python
assert "Mind Map" in result.output   # type display, emitted only for a parsed ArtifactType.MIND_MAP row
assert "No mind-map artifacts found" not in result.output   # non-empty filter result
```

`get_artifact_type_display` renders `🧠 Mind Map` only for a row whose parsed kind is `ArtifactType.MIND_MAP`, so this proves the variant-4 artifact was recognized as a mind map and survived the `--type mind-map` filter — without pinning the recorded id/title. The empty-state path prints `No mind-map artifacts found` instead. The nearby docstring that referenced `47523923` is updated. (A deeper cassette-derived assertion is a follow-up; this just makes it re-record-safe while keeping the "variant-4 recognized" intent.)

## Teeth-proof

Temporarily injected `assert "12345678" in result.output` into a cli_vcr test and confirmed the widened lint **FAILS** it (`tests/integration/cli_vcr/test_artifacts.py:NNN` flagged as a pinned recorded-id literal); reverted.

## Verification

- `tests/_guardrails/test_no_pinned_cassette_values.py` + `tests/integration/cli_vcr/`: 86 passed
- Full `uv run pytest`: 8383 passed, 67 skipped, 1 xfailed
- `ruff format --check`, `ruff check`: clean
- `mypy src/notebooklm`: clean
- `test_no_cross_test_imports`: passed
- `scripts/audit_public_api_compat.py`: exit 0, **0 new allowlist entries**

Test-only — no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded guardrails to detect a broader range of recorded ID formats in assertions (UUIDs, long numeric IDs, and high-entropy blob tokens).
  * Improved stability of the artifact-list integration test by asserting the displayed artifact type and absence of the empty-state message instead of relying on specific recorded IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->