### PR TITLE
test(cli_vcr): cassette-derived + semantic-invariant deep assertions for sources/artifacts (depth-2, #1452)

### DIFF
--- a/tests/integration/cli_vcr/_cassette_expectations.py
+++ b/tests/integration/cli_vcr/_cassette_expectations.py
@@ -46,9 +46,6 @@ _CASSETTE_DIR = Path(__file__).resolve().parents[2] / "cassettes"
 # (not imported) from ``tests/_guardrails/test_cassette_shapes.py``.
 _XSSI_PREFIX = ")]}'"
 
-# WRB envelope tags that are housekeeping, not RPC responses.
-_HOUSEKEEPING_WRB_TAGS = frozenset({"di", "af.httprm", "e"})
-
 
 def _strip_xssi(body: str) -> str:
     """Drop the Google anti-XSSI ``)]}'`` prefix and the blank line after it."""
@@ -103,12 +100,14 @@ def _wrb_payloads(body: str, rpc_id: str) -> list[str]:
         if not isinstance(chunk, list):
             continue
         for envelope in chunk:
+            # Matching ``envelope[1] == rpc_id`` already excludes the
+            # housekeeping ``di`` / ``af.httprm`` / ``e`` envelopes (a real rpc id
+            # is never one of those), so no separate housekeeping filter is needed.
             if (
                 isinstance(envelope, list)
                 and len(envelope) >= 3
                 and envelope[0] == "wrb.fr"
                 and envelope[1] == rpc_id
-                and envelope[1] not in _HOUSEKEEPING_WRB_TAGS
                 and isinstance(envelope[2], str)
             ):
                 payloads.append(envelope[2])

--- a/tests/integration/cli_vcr/_cassette_expectations.py
+++ b/tests/integration/cli_vcr/_cassette_expectations.py
@@ -1,0 +1,310 @@
+"""Independent cassette *projection* helper for cli_vcr depth-2 assertions (#1452).
+
+Why this module exists — and the hard independence rule
+-------------------------------------------------------
+The cli_vcr tests run the real CLI -> Client -> RPC path and replay HTTP from a
+recorded cassette. A depth-1 assertion checks the ``--json`` envelope *shape*;
+this module enables a depth-2 assertion that checks the *values* the CLI emitted
+against the values that actually sit in the recorded RPC response — catching
+fabrication (an id the CLI invented), a drop (a recorded row the CLI lost), a
+duplicate, or a miscount.
+
+To be a real oracle, that comparison must come from an **independent** reading of
+the cassette. If this helper imported the production decoder
+(``notebooklm.rpc.decoder`` / ``notebooklm._row_adapters`` / ``notebooklm._types``)
+the assertion would be a tautology: "the CLI's decode equals the decoder's
+decode" proves nothing. So this module is built on **stdlib + ``yaml`` only** and
+re-implements just enough of the batchexecute envelope walk (copied as our own
+code from the patterns in ``tests/_guardrails/test_cassette_shapes.py`` — not
+imported) to reach the payload.
+
+The projection is deliberately a **coarse, shallow** read. It is a *projection
+layer*, not a second decoder: it pulls the handful of well-known leaf tokens
+(ids, urls, top-level type/status codes) by a simple top-level walk and never
+replicates the adapters' deep positional field-mapping. Catching field-*position*
+confusion is a separate (adapter-level) concern; this layer catches
+fabrication / drop / duplicate / miscount, which a shallow read suffices for. If
+this file ever grows the adapters' field constants and object construction it has
+crossed into circularity — keep it shallow.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import yaml
+
+# Cassettes live at ``tests/cassettes`` — three parents up from this file
+# (``tests/integration/cli_vcr/_cassette_expectations.py``).
+_CASSETTE_DIR = Path(__file__).resolve().parents[2] / "cassettes"
+
+# Google's anti-XSSI guard prefixes every batchexecute response body. Copied
+# (not imported) from ``tests/_guardrails/test_cassette_shapes.py``.
+_XSSI_PREFIX = ")]}'"
+
+# WRB envelope tags that are housekeeping, not RPC responses.
+_HOUSEKEEPING_WRB_TAGS = frozenset({"di", "af.httprm", "e"})
+
+
+def _strip_xssi(body: str) -> str:
+    """Drop the Google anti-XSSI ``)]}'`` prefix and the blank line after it."""
+    if body.startswith(_XSSI_PREFIX):
+        return body[len(_XSSI_PREFIX) :].lstrip("\n")
+    return body
+
+
+def _rpcids_from_uri(uri: str) -> list[str]:
+    """Return the rpcids named in a request URL's ``rpcids=`` query param."""
+    raw = parse_qs(urlparse(uri).query).get("rpcids", [""])[0]
+    return [p for p in raw.split(",") if p]
+
+
+def _wrb_payloads(body: str, rpc_id: str) -> list[str]:
+    """Return the raw slot-[2] JSON *strings* of every ``wrb.fr`` envelope for ``rpc_id``.
+
+    Walks the chunked batchexecute frames (alternating ``<int-byte-count>\\n``
+    ``<json-line>\\n`` records, with the count line occasionally omitted for
+    trivial bodies), parses each JSON frame, and collects the third slot of any
+    ``["wrb.fr", "<rpc_id>", "<json-string>", ...]`` envelope. Housekeeping
+    envelopes (``di`` / ``af.httprm`` / ``e``) and other rpc ids are ignored.
+
+    Slot [2] is itself a JSON *string* (the nested array, JSON-encoded once
+    more) — the caller does the second ``json.loads`` so this stays a pure
+    envelope extractor.
+    """
+    payloads: list[str] = []
+    lines = _strip_xssi(body).split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line:
+            i += 1
+            continue
+        try:
+            int(line)  # byte-count prefix
+        except ValueError:
+            # No count prefix — try to parse this line as a JSON frame directly.
+            chunk_line = lines[i]
+            i += 1
+        else:
+            i += 1
+            if i >= len(lines):
+                break
+            chunk_line = lines[i]
+            i += 1
+        try:
+            chunk = json.loads(chunk_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(chunk, list):
+            continue
+        for envelope in chunk:
+            if (
+                isinstance(envelope, list)
+                and len(envelope) >= 3
+                and envelope[0] == "wrb.fr"
+                and envelope[1] == rpc_id
+                and envelope[1] not in _HOUSEKEEPING_WRB_TAGS
+                and isinstance(envelope[2], str)
+            ):
+                payloads.append(envelope[2])
+    return payloads
+
+
+def load_rpc_payload(cassette_name: str, rpc_id: str, occurrence: int = 0) -> list:
+    """Load the decoded RPC payload for ``rpc_id`` from a cassette.
+
+    Selects the cassette interaction whose request URL ``rpcids=`` query param
+    names ``rpc_id``, walks the chunked batchexecute frames of its response,
+    finds the ``["wrb.fr", rpc_id, "<json-string>", ...]`` envelope, and returns
+    ``json.loads`` of slot [2] (the *second* ``json.loads`` — slot [2] is a JSON
+    string wrapping the nested array).
+
+    A cassette may answer the same rpc id more than once (e.g. a list call
+    repeated for two render paths); ``occurrence`` selects which (0-based,
+    counted across all matching interactions in file order).
+
+    Raises:
+        LookupError: when no ``occurrence``-th ``rpc_id`` payload is found.
+    """
+    cassette_path = _CASSETTE_DIR / cassette_name
+    data = yaml.safe_load(cassette_path.read_text(encoding="utf-8")) or {}
+    seen = 0
+    for interaction in data.get("interactions") or []:
+        uri = (interaction.get("request") or {}).get("uri") or ""
+        if rpc_id not in _rpcids_from_uri(uri):
+            continue
+        body = ((interaction.get("response") or {}).get("body") or {}).get("string") or ""
+        for raw_payload in _wrb_payloads(body, rpc_id):
+            if seen == occurrence:
+                decoded = json.loads(raw_payload)
+                if not isinstance(decoded, list):
+                    raise LookupError(
+                        f"{rpc_id} payload in {cassette_name} is not a list: "
+                        f"{type(decoded).__name__}"
+                    )
+                return decoded
+            seen += 1
+    raise LookupError(
+        f"no occurrence {occurrence} of rpc id {rpc_id!r} found in cassette {cassette_name!r} "
+        f"(saw {seen})"
+    )
+
+
+@dataclass(frozen=True)
+class Projection:
+    """A coarse, shallow projection of a list-RPC payload.
+
+    Carries only the fabrication/drop/duplicate/miscount-catching aggregates —
+    never a per-field positional decode:
+
+    * ``count`` — number of top-level rows the projection saw.
+    * ``ids`` — the set of id tokens (UUID-or-string leaf at the row's id slot).
+    * ``urls`` — the set of ``http(s)://`` tokens found in a row's metadata.
+    * ``type_codes`` — histogram of the raw integer type codes.
+    * ``status_codes`` — histogram of the raw integer status codes.
+    """
+
+    count: int
+    ids: set[str] = field(default_factory=set)
+    urls: set[str] = field(default_factory=set)
+    type_codes: Counter[int] = field(default_factory=Counter)
+    status_codes: Counter[int] = field(default_factory=Counter)
+
+
+def _id_token(envelope: object) -> str | None:
+    """Pull the first string leaf from a row's id slot (shallow, <=2 deep).
+
+    Source id slots come as ``"id"`` (flat), ``["id"]`` (typical), or
+    ``[None, True, ["id"]]`` (drive-backed). Rather than encode those exact
+    positions (the adapter's job), grab the first string found in a shallow
+    walk — coarse but independent and sufficient to compare id *sets*.
+    """
+    if isinstance(envelope, str):
+        return envelope
+    if isinstance(envelope, list):
+        for element in envelope:
+            if isinstance(element, str):
+                return element
+            if isinstance(element, list):
+                for nested in element:
+                    if isinstance(nested, str):
+                        return nested
+    return None
+
+
+def _shallow_http_url(metadata: object) -> str | None:
+    """Return the first ``http(s)://`` token in a row's metadata sub-list.
+
+    Looks only at the leading element of each top-level metadata slot — a coarse
+    read that finds the canonical/youtube/bare-url slots without committing to
+    their exact indices.
+    """
+    if not isinstance(metadata, list):
+        return None
+    for slot in metadata:
+        if isinstance(slot, str) and slot.startswith(("http://", "https://")):
+            return slot
+        if isinstance(slot, list) and slot:
+            first = slot[0]
+            if isinstance(first, str) and first.startswith(("http://", "https://")):
+                return first
+    return None
+
+
+def _int_at(seq: object, *path: int) -> int | None:
+    """Return the int reached by following ``path`` into nested lists, else ``None``.
+
+    A tiny shallow descent (``bool`` is rejected — it is an ``int`` subclass but
+    never a type/status code). Used by the two projections to read a leaf integer
+    code without committing to a deep positional decode.
+    """
+    cursor: object = seq
+    for index in path:
+        if not isinstance(cursor, list) or len(cursor) <= index:
+            return None
+        cursor = cursor[index]
+    return cursor if isinstance(cursor, int) and not isinstance(cursor, bool) else None
+
+
+def project_source_list(payload: list) -> Projection:
+    """Project a ``GET_NOTEBOOK`` (``rLM1Ne``) payload's source list.
+
+    The source list sits at ``payload[0][1]`` (the notebook's second slot). Each
+    entry is ``[<id-slot>, <title>, <metadata>, <status-block>, ...]``. We pull
+    the id token, a shallow http(s) url, the type code (``metadata[4]``), and the
+    status code (``status-block[1]``) — a coarse read, never the adapter's full
+    positional mapping.
+    """
+    notebook = payload[0] if payload and isinstance(payload[0], list) else None
+    rows: list = (
+        notebook[1]
+        if isinstance(notebook, list) and len(notebook) > 1 and isinstance(notebook[1], list)
+        else []
+    )
+    ids: set[str] = set()
+    urls: set[str] = set()
+    type_codes: Counter[int] = Counter()
+    status_codes: Counter[int] = Counter()
+    count = 0
+    for row in rows:
+        if not isinstance(row, list):
+            continue
+        count += 1
+        token = _id_token(row[0]) if row else None
+        if token:
+            ids.add(token)
+        metadata = row[2] if len(row) > 2 else None
+        url = _shallow_http_url(metadata)
+        if url:
+            urls.add(url)
+        type_code = _int_at(metadata, 4)
+        if type_code is not None:
+            type_codes[type_code] += 1
+        status_code = _int_at(row[3], 1) if len(row) > 3 else None
+        if status_code is not None:
+            status_codes[status_code] += 1
+    return Projection(count, ids, urls, type_codes, status_codes)
+
+
+def project_artifact_list(payload: list) -> Projection:
+    """Project a ``LIST_ARTIFACTS`` (``gArtLc``) payload's artifact rows.
+
+    The rows sit at ``payload[0]``. Each row is
+    ``[<id>, <title>, <type-code>, <error>, <status-code>, ...]`` — id at the
+    row's leading slot, type code at index 2, status code at index 4. Note the
+    CLI artifact list is a *superset* of this projection: it merges note-backed
+    mind maps from a separate RPC, so assertions must use containment / a count
+    floor, not equality (artifact ids are also not all UUID-shaped).
+    """
+    rows: list = payload[0] if payload and isinstance(payload[0], list) else []
+    ids: set[str] = set()
+    type_codes: Counter[int] = Counter()
+    status_codes: Counter[int] = Counter()
+    count = 0
+    for row in rows:
+        if not isinstance(row, list):
+            continue
+        count += 1
+        token = _id_token(row[0]) if row else None
+        if token:
+            ids.add(token)
+        type_code = _int_at(row, 2)
+        if type_code is not None:
+            type_codes[type_code] += 1
+        status_code = _int_at(row, 4)
+        if status_code is not None:
+            status_codes[status_code] += 1
+    return Projection(count, ids, set(), type_codes, status_codes)
+
+
+__all__ = [
+    "Projection",
+    "load_rpc_payload",
+    "project_artifact_list",
+    "project_source_list",
+]

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -321,6 +321,7 @@ def _assert_url_field(item: dict[str, Any], field: str) -> None:
     value = item.get(field)
     if value is None:
         return
+    assert isinstance(value, str), f"{field}={value!r} is not a string URL"
     parsed = urlparse(value)
     assert parsed.scheme and parsed.netloc, (
         f"{field}={value!r} does not parse as a URL (needs scheme + netloc)"
@@ -345,8 +346,11 @@ def _assert_timestamp_field(item: dict[str, Any], field: str) -> None:
     if value is None:
         return
     assert isinstance(value, str), f"{field}={value!r} is not a string timestamp"
+    # ``datetime.fromisoformat`` only learned to parse a trailing ``Z`` in 3.11;
+    # the CI matrix includes 3.10, so normalize ``Z`` -> ``+00:00`` first.
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
     try:
-        datetime.fromisoformat(value)
+        datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise AssertionError(f"{field}={value!r} does not parse as a timestamp: {exc}") from exc
 

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from click.testing import CliRunner
@@ -31,6 +34,19 @@ from click.testing import CliRunner
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from integration.conftest import _is_vcr_record_mode, skip_no_cassettes  # noqa: E402
+
+# Enum value *sets* only — an allowed-membership definition, NOT a decoder. Reading
+# the canonical enum values from the public ``notebooklm`` types keeps the membership
+# floor in lock-step with the source of truth without importing the decode path
+# (``assert_semantic_invariants`` only checks ``value in <set>``). See issue #1452.
+from notebooklm.rpc.types import SourceStatus  # noqa: E402
+from notebooklm.types import (  # noqa: E402
+    ArtifactStatus,
+    ArtifactType,
+    SourceType,
+    artifact_status_to_str,
+    source_status_to_str,
+)
 from vcr_config import notebooklm_vcr  # noqa: E402
 
 from ._fixtures import (  # noqa: E402
@@ -47,7 +63,9 @@ __all__ = [
     "notebooklm_vcr",
     "assert_command_success",
     "assert_json_envelope",
+    "assert_semantic_invariants",
     "parse_json_output",
+    "parse_json_dict",
     "VCR_READONLY_NOTEBOOK_ID",
     "VCR_READONLY_SOURCE_ID",
     "SOURCE_LIST_SCHEMA",
@@ -168,6 +186,19 @@ def parse_json_output(output: str) -> list | dict | None:
     return None
 
 
+def parse_json_dict(output: str) -> dict[str, Any]:
+    """Parse CLI ``--json`` output and assert it is a JSON object.
+
+    A typed convenience over :func:`parse_json_output` for the common
+    ``--json``-envelope case: narrows the ``list | dict | None`` union to a
+    ``dict`` (so callers can index fields without a type-checker complaint) and
+    fails loudly when the output is not a single JSON object.
+    """
+    data = parse_json_output(output)
+    assert isinstance(data, dict), f"Expected a JSON object, got: {output!r}"
+    return data
+
+
 # ---------------------------------------------------------------------------
 # ``--json`` envelope shape validation (issue #1452)
 # ---------------------------------------------------------------------------
@@ -245,6 +276,112 @@ def assert_json_envelope(result, *, schema: dict[str, FieldSpec]) -> None:
     data = parse_json_output(result.output)
     assert isinstance(data, dict), f"Expected a JSON object, got: {result.output!r}"
     _assert_schema("$", data, schema)
+
+
+# ---------------------------------------------------------------------------
+# Per-field semantic invariants (issue #1452, depth-2)
+# ---------------------------------------------------------------------------
+# Where ``assert_json_envelope`` pins *types*, ``assert_semantic_invariants``
+# pins per-field *meaning* — catching the "valid type but wrong field" class
+# (e.g. a title read out of the url slot: a ``str`` that satisfies the schema but
+# fails to parse as a URL). All of these are notebook-agnostic: a ``url`` parses,
+# an enum value is in the known set, a timestamp parses, a source id is
+# UUID-shaped. None pins a *recorded value*, so they survive a re-record.
+#
+# The enum *value sets* below are read from the public ``notebooklm`` types as an
+# allowed-membership definition. That is a set-membership check, NOT a decode —
+# importing the enum's allowed values is fine; importing the positional decoder
+# would make the assertion a tautology (the rule the projection helper obeys).
+
+# 8-4-4-4-12 hex UUID, anchored. Source ids are reliably UUID-shaped; artifact
+# ids are NOT (some are numeric), so the UUID invariant is opt-in per ``kind``.
+_UUID_INVARIANT_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# Allowed string-enum value sets, derived from the canonical enums.
+_SOURCE_TYPE_VALUES = frozenset(member.value for member in SourceType)
+_ARTIFACT_TYPE_VALUES = frozenset(member.value for member in ArtifactType)
+_SOURCE_STATUS_STR_VALUES = frozenset(
+    source_status_to_str(member.value) for member in SourceStatus
+) | {source_status_to_str(0)}
+_ARTIFACT_STATUS_STR_VALUES = frozenset(
+    artifact_status_to_str(member.value) for member in ArtifactStatus
+) | {artifact_status_to_str(0)}
+
+
+def _assert_url_field(item: dict[str, Any], field: str) -> None:
+    """When ``item[field]`` is a present non-null string, it must parse as a URL.
+
+    A URL must carry both a scheme and a netloc (``https`` + ``example.com``).
+    This is the field-confusion canary: a title accidentally read out of the url
+    slot is a valid ``str`` (passes the schema) but lacks a scheme/netloc.
+    """
+    value = item.get(field)
+    if value is None:
+        return
+    parsed = urlparse(value)
+    assert parsed.scheme and parsed.netloc, (
+        f"{field}={value!r} does not parse as a URL (needs scheme + netloc)"
+    )
+
+
+def _assert_enum_field(item: dict[str, Any], field: str, allowed: frozenset[str]) -> None:
+    """When ``item[field]`` is present and non-null, it must be in ``allowed``."""
+    value = item.get(field)
+    if value is None:
+        return
+    assert value in allowed, f"{field}={value!r} not in known enum values {sorted(allowed)}"
+
+
+def _assert_timestamp_field(item: dict[str, Any], field: str) -> None:
+    """When ``item[field]`` is a present non-null string, it must parse as a datetime.
+
+    The CLI emits ``datetime.isoformat()`` for ``created_at``; a value that is a
+    ``str`` but not parseable as an ISO timestamp means the wrong slot was read.
+    """
+    value = item.get(field)
+    if value is None:
+        return
+    assert isinstance(value, str), f"{field}={value!r} is not a string timestamp"
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise AssertionError(f"{field}={value!r} does not parse as a timestamp: {exc}") from exc
+
+
+def assert_semantic_invariants(item: dict[str, Any], kind: str) -> None:
+    """Assert per-field semantic invariants on one decoded ``--json`` list item.
+
+    ``kind`` selects the field rules:
+
+    * ``"source"`` — ``id`` is UUID-shaped; ``type`` (when present) is a known
+      :class:`~notebooklm.types.SourceType` value; ``status`` (when present) is a
+      known source status string; ``url`` (when present) parses as a URL;
+      ``created_at`` (when present) parses as a timestamp.
+    * ``"artifact"`` — ``type_id`` (when present) is a known
+      :class:`~notebooklm.types.ArtifactType` value; ``status`` (when present) is
+      a known artifact status string; ``created_at`` (when present) parses. The
+      ``id`` is deliberately NOT UUID-checked — artifact ids are not all UUIDs.
+
+    All rules are notebook-agnostic (no recorded values), so they survive a
+    re-record. They catch the "valid type but wrong field" defect that a pure
+    shape check (``assert_json_envelope``) cannot.
+    """
+    assert kind in {"source", "artifact"}, f"unknown semantic-invariant kind: {kind!r}"
+    _assert_timestamp_field(item, "created_at")
+    if kind == "source":
+        source_id = item.get("id")
+        assert isinstance(source_id, str) and _UUID_INVARIANT_RE.match(source_id), (
+            f"source id is not UUID-shaped: {source_id!r}"
+        )
+        _assert_enum_field(item, "type", _SOURCE_TYPE_VALUES)
+        _assert_enum_field(item, "status", _SOURCE_STATUS_STR_VALUES)
+        _assert_url_field(item, "url")
+    else:  # "artifact"
+        _assert_enum_field(item, "type_id", _ARTIFACT_TYPE_VALUES)
+        _assert_enum_field(item, "status", _ARTIFACT_STATUS_STR_VALUES)
 
 
 # Per-family schemas. ``str()``-typed ids/titles are shape-only — value

--- a/tests/integration/cli_vcr/test_artifacts.py
+++ b/tests/integration/cli_vcr/test_artifacts.py
@@ -1,16 +1,50 @@
 """CLI integration tests for artifact commands.
 
 These tests exercise the full CLI → Client → RPC path using VCR cassettes.
+
+The ``artifact list --json`` test carries the depth-2 re-record-safe tiers
+(issue #1452), adapted for artifacts:
+
+* **Schema/invariants.** The ``--json`` envelope is an object with a list of
+  artifact items; ids are non-empty (but NOT forced UUID — some artifact ids are
+  numeric).
+* **Cassette-derived value correctness (depth-2).** The CLI's emitted ids/count
+  are checked against an INDEPENDENT shallow projection of the recorded
+  ``LIST_ARTIFACTS`` payload (``_cassette_expectations``). Because the CLI list
+  merges note-backed mind maps from a *separate* RPC, the CLI output is a
+  superset of the ``gArtLc`` projection — so this uses CONTAINMENT and a count
+  floor (``proj.ids ⊆ cli_ids``, ``len(cli) >= proj.count``), not equality.
+* **Per-field semantic invariants.** ``assert_semantic_invariants`` pins per-field
+  meaning (``type_id``/``status`` are known enum values, ``created_at`` parses).
 """
 
 import pytest
 
 from notebooklm.notebooklm_cli import cli
 
+# Enum *code* sets — an allowed-membership floor for the projection's raw integer
+# type/status codes (a set-membership check, not a decode; see #1452).
+from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode
+
+from ._cassette_expectations import load_rpc_payload, project_artifact_list
 from ._fixtures import ARTIFACT_NOTEBOOK_ID
-from .conftest import assert_command_success, notebooklm_vcr, parse_json_output, skip_no_cassettes
+from .conftest import (
+    assert_command_success,
+    assert_semantic_invariants,
+    notebooklm_vcr,
+    parse_json_dict,
+    parse_json_output,
+    skip_no_cassettes,
+)
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# ``artifact list`` reads the recorded ``LIST_ARTIFACTS`` (``gArtLc``) payload —
+# the same RPC the projection helper reads independently.
+_LIST_ARTIFACTS_RPC_ID = "gArtLc"
+
+_KNOWN_ARTIFACT_TYPE_CODES = frozenset(member.value for member in ArtifactTypeCode)
+_KNOWN_ARTIFACT_STATUS_CODES = frozenset(member.value for member in ArtifactStatus)
 
 
 class TestArtifactListCommand:
@@ -31,6 +65,70 @@ class TestArtifactListCommand:
             data = parse_json_output(result.output)
             assert data is not None, "Expected valid JSON output"
             assert isinstance(data, list | dict)
+
+    @notebooklm_vcr.use_cassette("artifacts_list.yaml")
+    def test_artifact_list_matches_cassette_projection(
+        self, runner, mock_auth_for_vcr, mock_context
+    ):
+        """Depth-2: the CLI's artifact ids/count + per-field meaning are checked
+        against an INDEPENDENT projection of the recorded ``LIST_ARTIFACTS`` payload.
+
+        Containment, not equality: ``artifact list`` merges note-backed mind maps
+        from a separate RPC, so the CLI output is a superset of the ``gArtLc``
+        projection. Artifact ids are also not all UUID-shaped, so this anchors on
+        id CONTAINMENT + a count floor (never a recorded value), which stays
+        re-record-safe — both sides are read from the same cassette.
+        """
+        result = runner.invoke(cli, ["artifact", "list", "--json"])
+        assert_command_success(result)
+        data = parse_json_dict(result.output)
+        cli_items = data["artifacts"]
+        assert isinstance(cli_items, list)
+
+        payload = load_rpc_payload("artifacts_list.yaml", _LIST_ARTIFACTS_RPC_ID)
+        proj = project_artifact_list(payload)
+        assert proj.count > 0, "projection found no artifacts — cassette/projection drift"
+
+        cli_ids = {art["id"] for art in cli_items}
+        assert len(cli_ids) == len(cli_items), "CLI emitted a duplicate artifact id"
+        # Count floor: the CLI list is the gArtLc rows PLUS merged note-backed
+        # mind maps, so it can only be >= the projection's row count.
+        assert len(cli_items) >= proj.count, (
+            f"CLI emitted {len(cli_items)} artifacts, fewer than the "
+            f"{proj.count} recorded LIST_ARTIFACTS rows (a drop)"
+        )
+        # Containment: every recorded gArtLc artifact id must surface in the CLI
+        # output (none dropped); the projection ids are a subset of the CLI's.
+        assert proj.ids <= cli_ids, (
+            "recorded LIST_ARTIFACTS ids missing from CLI output (a drop): "
+            f"{sorted(proj.ids - cli_ids)}"
+        )
+        # No duplicate id within the recorded rows: each projected row has a
+        # distinct id, so the id set is exactly as large as the row count (a
+        # server-side duplicate would collapse the set below ``count``).
+        assert len(proj.ids) == proj.count, (
+            "recorded LIST_ARTIFACTS rows carry a duplicate id "
+            f"({proj.count} rows, {len(proj.ids)} distinct ids)"
+        )
+
+        # Per-field semantic invariants: type_id/status are known enum values and
+        # created_at parses — for EVERY CLI item, not just the projected subset.
+        for art in cli_items:
+            assert art.get("id"), "artifact id must be non-empty"
+            assert_semantic_invariants(art, "artifact")
+
+        # Type/status histogram consistency: every type code the projection saw
+        # is a known artifact type code, and likewise for status — the projection
+        # is coarser than the CLI's variant-aware mapping, so this checks the
+        # codes are in-range rather than equal to the CLI histogram.
+        for status_id in proj.status_codes:
+            assert status_id in _KNOWN_ARTIFACT_STATUS_CODES, (
+                f"recorded artifact status code {status_id} is not a known code"
+            )
+        for type_code in proj.type_codes:
+            assert type_code in _KNOWN_ARTIFACT_TYPE_CODES, (
+                f"recorded artifact type code {type_code} is not a known code"
+            )
 
 
 class TestArtifactListByType:

--- a/tests/integration/cli_vcr/test_artifacts.py
+++ b/tests/integration/cli_vcr/test_artifacts.py
@@ -44,7 +44,10 @@ pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 _LIST_ARTIFACTS_RPC_ID = "gArtLc"
 
 _KNOWN_ARTIFACT_TYPE_CODES = frozenset(member.value for member in ArtifactTypeCode)
-_KNOWN_ARTIFACT_STATUS_CODES = frozenset(member.value for member in ArtifactStatus)
+# ``0`` is the "unknown" status the CLI degrades an unrecognized code to (see
+# ``conftest._ARTIFACT_STATUS_STR_VALUES`` which keeps ``artifact_status_to_str(0)``);
+# tolerate it here so a re-record carrying a status-0 row is not a spurious failure.
+_KNOWN_ARTIFACT_STATUS_CODES = frozenset(member.value for member in ArtifactStatus) | {0}
 
 
 class TestArtifactListCommand:
@@ -89,7 +92,9 @@ class TestArtifactListCommand:
         proj = project_artifact_list(payload)
         assert proj.count > 0, "projection found no artifacts — cassette/projection drift"
 
-        cli_ids = {art["id"] for art in cli_items}
+        for art in cli_items:
+            assert art.get("id"), f"artifact item is missing a non-empty id: {art!r}"
+        cli_ids = {art.get("id") for art in cli_items}
         assert len(cli_ids) == len(cli_items), "CLI emitted a duplicate artifact id"
         # Count floor: the CLI list is the gArtLc rows PLUS merged note-backed
         # mind maps, so it can only be >= the projection's row count.
@@ -114,7 +119,6 @@ class TestArtifactListCommand:
         # Per-field semantic invariants: type_id/status are known enum values and
         # created_at parses — for EVERY CLI item, not just the projected subset.
         for art in cli_items:
-            assert art.get("id"), "artifact id must be non-empty"
             assert_semantic_invariants(art, "artifact")
 
         # Type/status histogram consistency: every type code the projection saw

--- a/tests/integration/cli_vcr/test_sources.py
+++ b/tests/integration/cli_vcr/test_sources.py
@@ -10,6 +10,17 @@ DIFFERENT notebook with different data:
   ``SOURCE_LIST_SCHEMA`` (via ``assert_json_envelope``).
 * **Tier 2 — Invariants.** ``count > 0``; each id is UUID-shaped; each title is
   non-empty. Never ``== N`` and never a recorded value.
+* **Tier 2b — Cassette-derived value correctness (depth-2).** The CLI's emitted
+  ids/urls/count are checked against an INDEPENDENT shallow projection of the
+  recorded ``GET_NOTEBOOK`` payload (``_cassette_expectations``). This catches
+  fabrication / drop / duplicate / miscount: ``count == proj.count``, the CLI id
+  set equals ``proj.ids``, every CLI url is in ``proj.urls``. The projection
+  reads the cassette with stdlib + yaml only (no production decoder), so the
+  assert is a real oracle, not a tautology — and it stays re-record-safe because
+  both sides are read from the *same* cassette.
+* **Tier 2c — Per-field semantic invariants.** ``assert_semantic_invariants``
+  pins per-field meaning (url parses, enum value is known, timestamp parses) —
+  catching a "valid type but wrong field" read.
 * **Tier 3 — Cross-render.** ``source list`` text mode and ``--json`` of the
   same cassette agree on the row count.
 * **Tier 5 — Input-echo.** ``source delete --json`` echoes the source/notebook
@@ -27,18 +38,24 @@ import pytest
 
 from notebooklm.notebooklm_cli import cli
 
+from ._cassette_expectations import load_rpc_payload, project_source_list
 from ._fixtures import DELETE_NOTEBOOK_ID, DELETE_SOURCE_ID, VCR_READONLY_SOURCE_ID
 from .conftest import (
     SOURCE_LIST_SCHEMA,
     SOURCE_MUTATION_SCHEMA,
     assert_command_success,
     assert_json_envelope,
+    assert_semantic_invariants,
     notebooklm_vcr,
-    parse_json_output,
+    parse_json_dict,
     skip_no_cassettes,
 )
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# ``source list`` resolves the source list out of the ``GET_NOTEBOOK`` (``rLM1Ne``)
+# payload — the same RPC the projection helper reads independently.
+_GET_NOTEBOOK_RPC_ID = "rLM1Ne"
 
 # Loose UUID shape check (8-4-4-4-12 hex). Deliberately not anchored to a
 # specific value — a re-record yields different ids that must still be UUIDs.
@@ -80,14 +97,15 @@ class TestSourceListCommand:
 
     @notebooklm_vcr.use_cassette("sources_list.yaml")
     def test_source_list_json_schema(self, runner, mock_auth_for_vcr, mock_context):
-        """Tier 1 + 2: ``source list --json`` matches the schema + invariants."""
+        """Tier 1 + 2 + 2c: ``source list --json`` matches the schema, invariants,
+        and per-field semantic rules."""
         result = runner.invoke(cli, ["source", "list", "--json"])
         assert_command_success(result, allow_no_context=False)
 
         # Tier 1 — envelope shape (field names + types).
         assert_json_envelope(result, schema=SOURCE_LIST_SCHEMA)
 
-        data = parse_json_output(result.output)
+        data = parse_json_dict(result.output)
         sources = data["sources"]
 
         # Tier 2 — value invariants, never pinned to recorded values.
@@ -105,6 +123,52 @@ class TestSourceListCommand:
             title = src.get("title")
             if title is not None:
                 assert title.strip(), "a present source title must be non-blank"
+            # Tier 2c — per-field semantic invariants (url parses, enum value is
+            # known, timestamp parses): catches a "valid type but wrong field".
+            assert_semantic_invariants(src, "source")
+
+    @notebooklm_vcr.use_cassette("sources_list.yaml")
+    def test_source_list_matches_cassette_projection(self, runner, mock_auth_for_vcr, mock_context):
+        """Tier 2b: the CLI's ids/urls/count match an INDEPENDENT projection of
+        the recorded ``GET_NOTEBOOK`` payload.
+
+        The projection (``_cassette_expectations``) reads the cassette with
+        stdlib + yaml only — it does NOT import the production decoder — so this
+        is a real fabrication/drop/duplicate/miscount oracle rather than a
+        tautology. Both sides are read from the *same* cassette, so the assert is
+        re-record-safe: a re-record against a different notebook re-reads both
+        the CLI output and the projection, and they still must agree.
+        """
+        result = runner.invoke(cli, ["source", "list", "--json"])
+        assert_command_success(result, allow_no_context=False)
+        cli_items = parse_json_dict(result.output)["sources"]
+
+        payload = load_rpc_payload("sources_list.yaml", _GET_NOTEBOOK_RPC_ID)
+        proj = project_source_list(payload)
+
+        assert proj.count > 0, "projection found no sources — cassette/projection drift"
+        # Count: the CLI must emit exactly as many rows as the cassette holds
+        # (no drop, no duplicate, no miscount).
+        assert len(cli_items) == proj.count, (
+            f"CLI emitted {len(cli_items)} sources but the cassette payload holds {proj.count}"
+        )
+        # Id set: every CLI id is in the cassette and vice versa (no fabricated
+        # id, no dropped source). Source ids are reliably UUID-shaped.
+        cli_ids = {src["id"] for src in cli_items}
+        assert cli_ids == proj.ids, (
+            "CLI source id set differs from the cassette projection "
+            f"(only-in-CLI={sorted(cli_ids - proj.ids)}, "
+            f"only-in-cassette={sorted(proj.ids - cli_ids)})"
+        )
+        # Urls: every url the CLI rendered came from the recorded payload (no
+        # fabricated url). Containment, not equality — the projection's shallow
+        # url read may miss a url the deep decoder finds, but never invents one.
+        for src in cli_items:
+            url = src.get("url")
+            if url:
+                assert url in proj.urls, (
+                    f"CLI rendered url {url!r} that is not present in the cassette projection"
+                )
 
     @notebooklm_vcr.use_cassette("sources_list.yaml", allow_playback_repeats=True)
     def test_source_list_text_and_json_agree(self, runner, mock_auth_for_vcr, mock_context):
@@ -117,7 +181,7 @@ class TestSourceListCommand:
         """
         json_result = runner.invoke(cli, ["source", "list", "--json"])
         assert_command_success(json_result, allow_no_context=False)
-        json_count = parse_json_output(json_result.output)["count"]
+        json_count = parse_json_dict(json_result.output)["count"]
 
         text_result = runner.invoke(cli, ["source", "list", "--no-truncate"])
         assert_command_success(text_result, allow_no_context=False)
@@ -221,7 +285,7 @@ class TestSourceDeleteCommand:
         # Tier 1 — envelope shape.
         assert_json_envelope(result, schema=SOURCE_MUTATION_SCHEMA)
 
-        data = parse_json_output(result.output)
+        data = parse_json_dict(result.output)
         # Tier 5 — input-echo.
         assert data["action"] == "delete"
         assert data["source_id"] == DELETE_SOURCE_ID


### PR DESCRIPTION
## What

Adds **depth-2** value-correctness assertions to the `cli_vcr` suite for the two richest list outputs (`source list --json`, `artifact list --json`). Every new assert is cassette-derived or an invariant — no pinned recorded literals — so they survive a re-record against a different notebook and pass the widened re-record-safety lint (`test_no_pinned_cassette_values`).

Implements **PR-B** of the cli_vcr reality-based plan (`.sisyphus/plans/2026-06-06-vcr-cli-reality-based.md`, #1452). Keeps Phase-1's structural tiers; these are additive depth.

## The projection-helper independence rule (load-bearing)

New `tests/integration/cli_vcr/_cassette_expectations.py` is a `_`-prefixed non-`test_*` module (so the #1445 cross-test-import gate stays green). It reads a cassette with **stdlib + `yaml` ONLY** — it does **not** import `notebooklm.rpc.decoder`, `notebooklm._row_adapters`, `notebooklm._types`, the cli services, or any client code.

Why: a cassette-derived assertion is a **projection layer, not a decoder oracle**. If the helper imported the production decoder, the assert would be a tautology ("the CLI's decode == the decoder's decode" proves nothing). Instead it re-implements just the batchexecute envelope walk as its own code — XSSI `)]}'` strip, chunked `wrb.fr` frame extraction, and the **second** `json.loads` of slot `[2]` — copied from the patterns in `tests/_guardrails/test_cassette_shapes.py` (not imported). The projection is a coarse, **shallow** read (id/url tokens + top-level type/status codes) and never replicates the adapters' deep positional field-mapping. It catches **fabrication / drop / duplicate / miscount**, not field-position (that's a separate adapter-level follow-up).

`load_rpc_payload(cassette, rpc_id, occurrence=0)` selects the interaction by request `rpcids=`, then the `wrb.fr` envelope by id (ignoring `di`/`af.httprm`/`e` housekeeping), and supports an `occurrence` index for repeated rpc ids.

## The two new tiers

**Tier 2b — cassette-derived value correctness.** The CLI's emitted ids/urls/count are checked against the independent projection of the *same* cassette:
- `source list --json` (`test_sources.py`): `count == proj.count`; id-set **EQUALITY** (`{i["id"]} == proj.ids`, sources are reliably UUID-shaped); every CLI url ∈ `proj.urls`.
- `artifact list --json` (`test_artifacts.py`): id **CONTAINMENT** + count floor (`proj.ids ⊆ cli_ids`, `len(cli) >= proj.count`). The CLI artifact list merges note-backed mind maps from a *separate* RPC (so the CLI output is a superset of the `gArtLc` projection), and artifact ids are **not** all UUID-shaped — so uuid-anchoring / set-equality don't hold here. Type/status code-histogram in-range consistency too.

**Tier 2c — per-field semantic invariants** (`assert_semantic_invariants(item, kind)` in `conftest.py`): a `url` parses (`urllib.parse`, scheme + netloc); `type`/`type_id`/`status` ∈ the known enum value sets; `created_at` parses; a source `id` is UUID-shaped. The enum value sets are read from `notebooklm` types **only as an allowed-membership definition** (a `value in <set>` check, not a decode). Catches "valid type but wrong field" (e.g. a title read out of the url slot fails the URL-shape check).

## Teeth-proof

Temporarily mutated the projection to **drop one id** → the `source list` id-set-equality test **FAILED** loudly with an actionable diff (`only-in-CLI=[...]`). Separately **fabricated an id** → the `artifact list` containment test **FAILED** (`recorded LIST_ARTIFACTS ids missing from CLI output`). Both reverted. The cassette-derived assert is a real oracle with teeth, not a tautology.

## Scope / safety

- **Test-only**: no `src/` changes. `audit_public_api_compat.py` stays exit 0 with **0** new allowlist entries.
- `record_mode="none"` — no cassettes recorded or modified.
- Verified green: `pytest tests/integration/cli_vcr/`, full `pytest`, `ruff format --check`, `ruff check`, `mypy src/notebooklm`, and the guardrails `test_no_cross_test_imports` + `test_no_pinned_cassette_values` (the new asserts PASS the pinned-value lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added cassette-based projection helpers to validate CLI list outputs against recorded RPC payloads.
  * Strengthened integration tests for artifact and source list commands with containment/count checks and per-item semantic invariants (UUIDs, URLs, enums, timestamps).
  * New/updated tests exercise projected expectations and reuse a typed JSON parsing helper for consistent --json validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->