### PR TITLE
test(cli_vcr): fix inverted source url containment direction (re-record-safety, #1452)

### DIFF
--- a/tests/integration/cli_vcr/test_sources.py
+++ b/tests/integration/cli_vcr/test_sources.py
@@ -14,10 +14,12 @@ DIFFERENT notebook with different data:
   ids/urls/count are checked against an INDEPENDENT shallow projection of the
   recorded ``GET_NOTEBOOK`` payload (``_cassette_expectations``). This catches
   fabrication / drop / duplicate / miscount: ``count == proj.count``, the CLI id
-  set equals ``proj.ids``, every CLI url is in ``proj.urls``. The projection
-  reads the cassette with stdlib + yaml only (no production decoder), so the
-  assert is a real oracle, not a tautology — and it stays re-record-safe because
-  both sides are read from the *same* cassette.
+  set equals ``proj.ids``, and every url the shallow projection found is present
+  in the CLI render (``proj.urls ⊆ cli_urls`` — the shallow read may miss a url
+  the deep decoder finds, so it must be the subset side). The projection reads
+  the cassette with stdlib + yaml only (no production decoder), so the assert is
+  a real oracle, not a tautology — and it stays re-record-safe because both sides
+  are read from the *same* cassette.
 * **Tier 2c — Per-field semantic invariants.** ``assert_semantic_invariants``
   pins per-field meaning (url parses, enum value is known, timestamp parses) —
   catching a "valid type but wrong field" read.
@@ -154,21 +156,22 @@ class TestSourceListCommand:
         )
         # Id set: every CLI id is in the cassette and vice versa (no fabricated
         # id, no dropped source). Source ids are reliably UUID-shaped.
-        cli_ids = {src["id"] for src in cli_items}
+        cli_ids = {src.get("id") for src in cli_items}
         assert cli_ids == proj.ids, (
             "CLI source id set differs from the cassette projection "
             f"(only-in-CLI={sorted(cli_ids - proj.ids)}, "
             f"only-in-cassette={sorted(proj.ids - cli_ids)})"
         )
-        # Urls: every url the CLI rendered came from the recorded payload (no
-        # fabricated url). Containment, not equality — the projection's shallow
-        # url read may miss a url the deep decoder finds, but never invents one.
-        for src in cli_items:
-            url = src.get("url")
-            if url:
-                assert url in proj.urls, (
-                    f"CLI rendered url {url!r} that is not present in the cassette projection"
-                )
+        # Urls: every url the shallow projection found must surface in the CLI
+        # output. Containment in THIS direction (proj ⊆ cli) is the re-record-safe
+        # one: the shallow projection may MISS a url the deep decoder finds (so it
+        # must not be the superset side), but it never invents one — so any url it
+        # did extract from the recorded payload must appear in the CLI's render.
+        cli_urls = {url for src in cli_items if (url := src.get("url"))}
+        assert proj.urls <= cli_urls, (
+            "cassette-projected urls missing from the CLI output "
+            f"(missing={sorted(proj.urls - cli_urls)})"
+        )
 
     @notebooklm_vcr.use_cassette("sources_list.yaml", allow_playback_repeats=True)
     def test_source_list_text_and_json_agree(self, runner, mock_auth_for_vcr, mock_context):

--- a/tests/integration/cli_vcr/test_sources.py
+++ b/tests/integration/cli_vcr/test_sources.py
@@ -155,8 +155,11 @@ class TestSourceListCommand:
             f"CLI emitted {len(cli_items)} sources but the cassette payload holds {proj.count}"
         )
         # Id set: every CLI id is in the cassette and vice versa (no fabricated
-        # id, no dropped source). Source ids are reliably UUID-shaped.
-        cli_ids = {src.get("id") for src in cli_items}
+        # id, no dropped source). Source ids are reliably UUID-shaped. Filter out
+        # a (schema-forbidden) ``None`` id so a missing id surfaces as a clean
+        # set-difference rather than a ``TypeError`` while ``sorted()``-ing the
+        # diff in the message.
+        cli_ids = {id_ for src in cli_items if (id_ := src.get("id")) is not None}
         assert cli_ids == proj.ids, (
             "CLI source id set differs from the cassette projection "
             f"(only-in-CLI={sorted(cli_ids - proj.ids)}, "


### PR DESCRIPTION
## Why

Follow-up to #1462, which merged before this CodeRabbit **Major** review fix could land (the PR was squash-merged at the first review-fix commit; this correctness fix was pushed moments after). Carries the missing change forward as a tiny test-only PR.

## What

The `source list` depth-2 url assertion in `test_sources.py` was checking the **wrong containment direction**:

```python
# before (on main) — every CLI url must be in the projection
for src in cli_items:
    url = src.get("url")
    if url:
        assert url in proj.urls, ...
```

But the projection is a **deliberately shallow** read that — by its own docstring — *may miss a url the deep decoder (the CLI) finds*. So `CLI ⊆ projection` is the fragile direction: a re-record whose source carries a url in a slot the shallow `_shallow_http_url` walk doesn't reach would make the CLI emit a valid url **not** in `proj.urls` → a **false failure**. That's exactly the re-record brittleness this suite exists to avoid.

Reversed to the re-record-safe direction (the shallow projection never *invents* a url, so every url it extracted from the recorded payload must surface in the CLI render):

```python
cli_urls = {url for src in cli_items if (url := src.get("url"))}
assert proj.urls <= cli_urls, (
    "cassette-projected urls missing from the CLI output "
    f"(missing={sorted(proj.urls - cli_urls)})"
)
```

This still has teeth: a CLI that dropped a recorded url makes `proj.urls - cli_urls` non-empty → fail. Also updates the module docstring to match, and switches the `cli_ids` set comprehension to `.get("id")` (project convention — avoid `KeyError` tracebacks in assertions; the prior Gemini comment).

## Scope / safety

- **Test-only**: no `src/` changes; 0 api-compat allowlist entries.
- `record_mode="none"` — no cassettes touched.
- Green: `pytest tests/integration/cli_vcr/test_sources.py`, `ruff check`, `mypy`, and `test_no_pinned_cassette_values` (the reversed assert still pins no recorded literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined source-list command tests to assert that cassette-projected URLs are a subset of CLI output, kept strict ID equality checks, improved handling of missing values, and enhanced failure messages to report missing URLs for clearer debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->