### PR TITLE
docs: correct stale v0.8.0 semantic drift (get() raises; ADR/dep-audit status)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ When you bump a cap (e.g. moving `pytest>=8.0,<10` to `pytest>=8.0,<11`):
 2. Run the full pre-commit one-liner above.
 3. Mention the upgrade rationale in the PR description.
 
-The `dependency-audit` workflow (`.github/workflows/dependency-audit.yml`) runs `pip-audit --strict` against the locked env on every push to `main` and nightly. It is currently in soft-launch mode (`continue-on-error: true`) and will be flipped to a hard merge gate after the first release cycle. New deps should still pass `pip-audit` cleanly when introduced.
+The `dependency-audit` workflow (`.github/workflows/dependency-audit.yml`) runs `pip-audit --strict --require-hashes` against the locked env on every push to `main` and nightly. It is a **hard gate** (no `continue-on-error`): a CVE in the locked environment fails the workflow. New deps must pass `pip-audit` cleanly when introduced; pin a fixed version or record a tracked exception via `pip-audit`'s `--ignore-vuln` if no fix is yet available.
 
 ### Test tiers
 

--- a/docs/adr/0019-error-and-return-contract.md
+++ b/docs/adr/0019-error-and-return-contract.md
@@ -19,11 +19,15 @@ miss path to assert today's warn-contract (`get()` warns + returns `None`;
 `get_or_none()` is silent), so a correctly-annotated `get()` that forgets to
 warn — the exact historical `mind_maps` bug — is now caught at runtime, not just
 by signature. Tier-2's single-sourced `unwrap_or_raise` helper (`_lookup.py`)
-also landed. Still **pending** are the v0.8.0 *breaking* flips this ADR
-queues: issue #1247 (`get()` → raise `*NotFoundError`, dropping `| None`)
-and issue #1251 (`MappingCompat` removal). The "Enforcement (in scope for
-0.8.0)" section below describes that pending breaking work; the static +
-behavioural gates that guard it are already green.
+also landed.
+
+**Status update (v0.8.0):** the *breaking* flips this ADR queued have now
+shipped — most notably issue #1247 (`get()` → **raises** `*NotFoundError`,
+dropping `| None`, single-sourced through `_lookup.py`'s `unwrap_or_raise`), so
+every namespace `get()` now raises on a miss and `get_or_none()` is the
+sanctioned `None`-on-miss lookup. The "Enforcement (in scope for 0.8.0)" section
+below describes that work; the static + behavioural gates that guarded the
+rollout are green against the post-flip surface.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,7 @@ This directory holds the canonical decisions that shape the `notebooklm-py` code
 
 The pull-request template asks contributors to confirm that any change to the _architectural shape_ of the codebase carries an ADR addition or update. "Architectural shape" means any of:
 
-- New / removed / relocated modules in `src/notebooklm/_core*.py`, `src/notebooklm/_capabilities.py`, `src/notebooklm/auth.py`, `src/notebooklm/_auth/`, `src/notebooklm/cli/services/`.
+- New / removed / relocated modules in `src/notebooklm/_runtime/`, `src/notebooklm/_middleware/`, `src/notebooklm/auth.py`, `src/notebooklm/_auth/`, `src/notebooklm/cli/services/`.
 - Changes to the contracts between layers (CLI ↔ Client ↔ Core ↔ RPC).
 - New or retired test patterns (fixtures, monkeypatch policy, conformance tests).
 - New cross-cutting policies (retry, idempotency, scrubbing, loop affinity).

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -245,19 +245,17 @@ sit at the intersection — they're catchable as **any** of `NotFoundError`
 it is the prerequisite type for the note not-found work landing in **v0.8.0**
 (issue #1346).
 
-Use the table to pick the right level of catch. `client.sources.get(...)`,
-`client.artifacts.get(...)`, `client.notes.get(...)`, and
-`client.mind_maps.get(...)` currently return
-`None` for a missing entity rather than raising — **but this is deprecated.**
-They now emit a `DeprecationWarning` on a miss and, in **v0.8.0**, will raise
-the matching `*NotFoundError` (`SourceNotFoundError` / `ArtifactNotFoundError` /
-`NoteNotFoundError` / `MindMapNotFoundError`) to match `client.notebooks.get(...)`,
-which already raises
-`NotebookNotFoundError`. Migrate any `if result is None:` check to
-`try/except <Resource>NotFoundError` before v0.8.0 (suppress the warning
-meanwhile with `NOTEBOOKLM_QUIET_DEPRECATIONS=1`); see
-[`deprecations.md`](deprecations.md) and issue #1247. `client.mind_maps.get(...)`
-joined this warned deprecation in v0.7.0 (issue #1358) — it was the last
+Use the table to pick the right level of catch. As of **v0.8.0** (the #1247
+flip), `client.sources.get(...)`, `client.artifacts.get(...)`,
+`client.notes.get(...)`, and `client.mind_maps.get(...)` **raise** the matching
+`*NotFoundError` (`SourceNotFoundError` / `ArtifactNotFoundError` /
+`NoteNotFoundError` / `MindMapNotFoundError`) on a missing entity — matching
+`client.notebooks.get(...)`, which raises `NotebookNotFoundError`. The previous
+`None`-on-miss return (deprecated with a `DeprecationWarning` through v0.7.0) is
+gone; migrate any `if result is None:` check to `try/except
+<Resource>NotFoundError`, or use the paired `get_or_none(...)` (below) for the
+sanctioned `None`-on-miss contract. See [`deprecations.md`](deprecations.md) and
+issue #1247. `client.mind_maps.get(...)` was the last
 namespace in the #1247 cohort without a runway; use `client.mind_maps.get_or_none(...)`
 for the warning-free `None`-on-miss contract. If you genuinely want
 `None`-on-miss after the flip, every namespace now offers a paired
@@ -443,17 +441,15 @@ event loop on which it was opened. A loop-affinity guard checks
 the active loop on the authed POST hot path — `rpc_call()` →
 `query_post()` → `_perform_authed_post()` — and raises a clear `RuntimeError`
 when the instance is re-used from a different loop. **Scope limitation:** the
-guard fires on the hot path only. Two cold paths reach asyncio primitives
-before the guard runs:
+guard fires on the hot path only. `ChatAPI.ask` adds its own
+`assert_bound_loop()` check as its first statement, so cross-loop chat raises the
+same friendly loop-affinity `RuntimeError`. One cold path remains:
 
-- `ChatAPI.ask` calls `next_reqid()` before its `query_post() →
-  _perform_authed_post` chain. The first cross-loop call's `_reqid_lock` will
-  raise a deep asyncio `RuntimeError` (not the friendly loop-affinity message).
 - `close()` awaits `save_cookies` + `aclose` and never routes through
-  `_perform_authed_post`; cross-loop close gets a deep asyncio error.
+  `_perform_authed_post` or a loop guard; a cross-loop close gets a deep asyncio
+  `RuntimeError` — opaque, not the friendly loop-affinity message.
 
-In both cases you still get a `RuntimeError` — just an opaque one. **Best
-practice:** one client per loop, full stop.
+**Best practice:** one client per loop, full stop.
 
 **Refresh deduplication**. Concurrent RPCs that all
 trigger a token refresh share a single underlying refresh attempt via

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -338,11 +338,12 @@ except NotFoundError as e:
     print(f"Missing resource: {e}")
 ```
 
-Methods that *raise* (rather than return `None`) on not-found include
-`client.notebooks.get`, `client.sources.get_fulltext`,
-`client.sources.wait_until_ready`, and the artifact download paths.
-`client.sources.get` and `client.artifacts.get` return `None` on missing
-IDs; use those when you want a lookup that does *not* trigger the umbrella.
+Methods that *raise* a `*NotFoundError` on not-found include every namespace
+`get()` (as of v0.8.0 — `client.notebooks.get`, `client.sources.get`,
+`client.artifacts.get`, `client.notes.get`, `client.mind_maps.get`),
+`client.sources.get_fulltext`, `client.sources.wait_until_ready`, and the
+artifact download paths. For a `None`-on-miss lookup that does *not* trigger the
+umbrella, use the paired `get_or_none(...)`.
 
 ##### Ordering matters
 

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -161,18 +161,18 @@ class NotFoundError(NotebookLMError):
             await client.artifacts.download_audio(nb_id, dest, audio_id)
         except NotFoundError as e:
             # Catches NotebookNotFoundError, SourceNotFoundError,
-            # ArtifactNotFoundError, and MindMapNotFoundError uniformly (and
-            # NoteNotFoundError once its not-found paths land in v0.8.0).
+            # ArtifactNotFoundError, NoteNotFoundError, and MindMapNotFoundError
+            # uniformly (all namespace get() raise their *NotFoundError as of v0.8.0).
             handle_missing_resource(e)
 
     The example uses methods that *raise* a ``*NotFoundError`` on missing
-    IDs (:meth:`NotebooksAPI.get`, :meth:`SourcesAPI.wait_until_ready`,
-    the artifact download / content paths). :meth:`SourcesAPI.get` and
-    :meth:`ArtifactsAPI.get` instead return ``None`` for missing IDs — use
-    them when you want a lookup that does not trigger the umbrella.
-    :class:`MindMapNotFoundError` is raised by the ``client.mind_maps``
-    mutation paths (issue #1291); :class:`NoteNotFoundError` is defined but
-    not raised by any method yet (the prerequisite for the v0.8.0 work).
+    IDs. As of v0.8.0 (the #1247 flip) **every** namespace ``get()`` —
+    :meth:`NotebooksAPI.get`, :meth:`SourcesAPI.get`, :meth:`ArtifactsAPI.get`,
+    :meth:`NotesAPI.get`, and :meth:`MindMapsAPI.get` — raises its matching
+    ``*NotFoundError`` on a miss; use the paired ``get_or_none()`` when you want
+    a ``None``-on-miss lookup that does not trigger the umbrella.
+    :class:`MindMapNotFoundError` is also raised by the ``client.mind_maps``
+    mutation paths (issue #1291).
 
     Subclasses retain their existing type-specific bases — for example,
     :class:`SourceNotFoundError` is still a :class:`SourceError`, and

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -162,7 +162,7 @@ class NotFoundError(NotebookLMError):
         except NotFoundError as e:
             # Catches NotebookNotFoundError, SourceNotFoundError,
             # ArtifactNotFoundError, NoteNotFoundError, and MindMapNotFoundError
-            # uniformly (all namespace get() raise their *NotFoundError as of v0.8.0).
+            # uniformly (all namespace get() methods raise their *NotFoundError as of v0.8.0).
             handle_missing_resource(e)
 
     The example uses methods that *raise* a ``*NotFoundError`` on missing
@@ -866,10 +866,10 @@ class SourceNotFoundError(NotFoundError, RPCError, SourceError):
     RPC layer. ``except NotFoundError`` catches it alongside
     :class:`NotebookNotFoundError` and :class:`ArtifactNotFoundError`.
 
-    Note that ``client.sources.get`` returns ``None`` for a missing source
-    rather than raising — only the workflows that need a concrete source to
-    proceed (e.g. ``get_fulltext``, ``wait_until_ready``) surface the missing
-    source as an exception.
+    As of v0.8.0 ``client.sources.get`` **raises** this error for a missing
+    source; use ``client.sources.get_or_none`` for a ``None``-on-miss lookup.
+    Workflows that need a concrete source to proceed (e.g. ``get_fulltext``,
+    ``wait_until_ready``) also surface the missing source as this exception.
 
     .. note::
        **v0.6.0 BREAKING CHANGE:** prior to v0.6.0, :class:`SourceNotFoundError`


### PR DESCRIPTION
## What

Corrects stale documentation/docstrings that still describe **pre-v0.8.0** behavior. The package is on `v0.8.0`, which shipped the #1247 flip — every namespace `get()` now **raises** its `*NotFoundError` on a miss (single-sourced through `_lookup.py`'s `unwrap_or_raise`) — but several public-facing places still said it returns `None`. Docs/docstring-only; **no behavior change, no `src` logic change, 0 api-compat allowlist entries.**

Surfaced by a cross-model codebase review (codex flagged the `get()→None` drift from four aspects; verified against the code).

## Fixes
- **`docs/python-api.md`** — the error-handling table now states `get()` **raises** `*NotFoundError` as of v0.8.0 (was "currently returns `None` / will raise in v0.8.0", written in future tense while already on v0.8.0); points users at `get_or_none(...)` for `None`-on-miss. Also corrected the concurrency-contract cold-path paragraph: `ChatAPI.ask` now guards via `assert_bound_loop()` (`_chat/api.py:342`), so cross-loop chat raises the *friendly* error — only `close()` remains the opaque cold path.
- **`src/notebooklm/exceptions.py`** — `NotFoundError` docstring + the example comment now say every namespace `get()` raises (was "`SourcesAPI`/`ArtifactsAPI.get` return `None`" and "`NoteNotFoundError` … not raised by any method yet"). Docstring-only; file line count unchanged (1460), ratchet green.
- **`docs/adr/0019-error-and-return-contract.md`** — status updated: the queued v0.8.0 breaking flips (esp. #1247) have shipped (was "Still pending").
- **`docs/adr/README.md`** — ADR-trigger module paths now point at `_runtime/` + `_middleware/` (the listed `_core*.py` / `_capabilities.py` were deleted in the runtime promotion).
- **`CONTRIBUTING.md`** — `dependency-audit` is a **hard gate** (no `continue-on-error`), not soft-launch.

## Verification
`ruff format --check` + `ruff check` clean; module-size ratchet green (exceptions.py still 1460); `audit_public_api_compat.py` exit 0 / 0 new allowlist entries; docs/ADR freshness + public-API contract/behavior guardrails pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated error-handling guidance: `get()` methods now raise `*NotFoundError` on missing resources; use `get_or_none()` for `None` semantics.
  * Refined concurrency contract wording for loop-affinity and cross-loop errors.
  * Updated ADRs and contribution guidance around architectural-change triggers.
  * Clarified dependency-audit guidance: audits now run on each push and nightly, treating detected CVEs as a hard gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->