### PR TITLE
fix(decoder): drop misleading byte-count-mismatch WARNING from chunked parse

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -59,16 +59,9 @@ _BYTE_COUNT_MISMATCH_TOTAL = 0
 # threads (``run_in_executor`` / ``ThreadPoolExecutor``) or from several
 # per-thread ``NotebookLMClient`` instances at once. ``x += 1`` is a
 # read-modify-write over multiple bytecodes, so the GIL does not make it
-# atomic — without this lock increments could be lost and the "warn every N"
-# cadence could fire on a stale count.
+# atomic — without this lock increments could be lost and the counter read by
+# ``byte_count_mismatch_total`` could be stale.
 _BYTE_COUNT_MISMATCH_LOCK = threading.Lock()
-
-# Emit at most one byte-count-mismatch WARNING per this many observed
-# mismatches so a live multi-chunk response cannot flood CI logs while a real
-# drift event still surfaces above DEBUG. The counter is post-incremented
-# before the modulo test, so the first mismatch of a process always warns
-# (1 % interval == 1) and subsequent warnings land at interval + 1.
-_BYTE_COUNT_MISMATCH_WARN_INTERVAL = 500
 
 
 def byte_count_mismatch_total() -> int:
@@ -241,12 +234,11 @@ def parse_chunked_response(response: str) -> list[Any]:
         valid JSON, because recorded and proxy-transformed streams may not
         preserve Google's original byte count and live Google responses use a
         different unit (likely UTF-16 code units) than ``len(s.encode("utf-8"))``.
-        Each mismatch also increments the process-wide
-        ``byte_count_mismatch_total`` counter and emits a rate-limited WARNING
-        (one per ``_BYTE_COUNT_MISMATCH_WARN_INTERVAL`` mismatches) so a real
-        framing-unit change is a visible drift signal without the tolerant
-        parse changing or per-chunk DEBUG noise flooding CI logs.
-        A JSONDecodeError on the payload still emits a WARNING on the
+        Because a mismatch is the *expected* case on healthy live streams, it is
+        deliberately NOT a WARNING: it only increments the process-wide
+        ``byte_count_mismatch_total`` counter, which is the honest drift signal
+        (telemetry alerts on a sudden *rate-of-change*, not on the existence of
+        mismatches). A JSONDecodeError on the payload still emits a WARNING on the
         subsequent parse-failure path. If the malformed-payload rate exceeds
         10%, raises RPCError as this likely indicates API changes. Framing and
         mixed payload/framing corruption keep their own strict guards without
@@ -301,26 +293,13 @@ def parse_chunked_response(response: str) -> list[Any]:
                     actual_byte_count,
                     _truncate_response_preview(json_str),
                 )
-                # Surface the mismatch as a drift signal WITHOUT changing the
-                # tolerant parse: bump a process-wide counter (telemetry probes
-                # alert on a sudden rise) and emit a rate-limited WARNING so a
-                # real framing-unit change rises above the per-chunk DEBUG noise
-                # without flooding CI logs on every live multi-chunk response.
-                # Snapshot the count under the lock so the modulo decision and
-                # the logged total are consistent even under concurrent parses.
+                # Surface the mismatch as a drift signal without escalating to a
+                # WARNING (which would fire on essentially every multi-chunk
+                # response): bump only the process-wide counter. Telemetry probes
+                # alert on a sudden *rate-of-change* via
+                # ``byte_count_mismatch_total()``.
                 with _BYTE_COUNT_MISMATCH_LOCK:
                     _BYTE_COUNT_MISMATCH_TOTAL += 1
-                    mismatch_total = _BYTE_COUNT_MISMATCH_TOTAL
-                if mismatch_total % _BYTE_COUNT_MISMATCH_WARN_INTERVAL == 1:
-                    logger.warning(
-                        "Byte-count mismatch in chunked response (declared %d, "
-                        "actual %d bytes); tolerated. Total mismatches this "
-                        "process: %d — a sudden rise may indicate the "
-                        "batchexecute framing unit changed.",
-                        byte_count,
-                        actual_byte_count,
-                        mismatch_total,
-                    )
 
             try:
                 chunk = json.loads(json_str)

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -141,13 +141,14 @@ class TestParseChunkedResponse:
         assert mismatch_records[0].levelno == logging.DEBUG
         assert "payload is" in mismatch_records[0].message
 
-    def test_byte_count_mismatch_bumps_counter_and_warns_first_time(self, caplog):
-        """A byte-count mismatch is a drift signal: counter + one WARNING.
+    def test_byte_count_mismatch_bumps_counter_without_warning(self, caplog):
+        """A byte-count mismatch is the expected case: counter only, no WARNING.
 
         The tolerant parse is unchanged (valid JSON payloads are still
-        returned), but each mismatch increments the process-wide counter and
-        the first mismatch of the process emits a rate-limited WARNING so a
-        real framing-unit change rises above the per-chunk DEBUG noise.
+        returned) and each mismatch increments the process-wide counter, but no
+        WARNING is emitted: a mismatch trips on essentially every healthy live
+        multi-chunk response, so it is tracked silently and surfaced only via
+        ``byte_count_mismatch_total()`` (telemetry alerts on its rate-of-change).
         """
         reset_byte_count_mismatch_total()
         try:
@@ -155,32 +156,33 @@ class TestParseChunkedResponse:
             response = f"{len(payload) + 1}\n{payload}\n"
 
             assert byte_count_mismatch_total() == 0
-            with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
+            with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
                 chunks = parse_chunked_response(response)
 
             # Tolerant parse preserved: valid JSON still returned.
             assert chunks == [["wrong-size"]]
             assert byte_count_mismatch_total() == 1
 
-            warnings = [
+            # No WARNING for the expected mismatch; the DEBUG line still fires.
+            assert not [
                 r
                 for r in caplog.records
-                if r.name == "notebooklm.rpc.decoder"
-                and r.levelno == logging.WARNING
-                and "Byte-count mismatch" in r.message
+                if r.name == "notebooklm.rpc.decoder" and r.levelno == logging.WARNING
             ]
-            assert len(warnings) == 1
-            assert "framing unit changed" in warnings[0].message
+            assert any(
+                r.levelno == logging.DEBUG and "declares" in r.message
+                for r in caplog.records
+                if r.name == "notebooklm.rpc.decoder"
+            )
         finally:
             reset_byte_count_mismatch_total()
 
-    def test_byte_count_mismatch_warning_is_rate_limited(self, caplog):
-        """Repeated mismatches keep counting but do not flood WARNING logs."""
+    def test_byte_count_mismatch_counts_silently_across_records(self, caplog):
+        """Repeated mismatches keep counting without ever emitting a WARNING."""
         reset_byte_count_mismatch_total()
         try:
             payload = json.dumps(["wrong-size"])
             record = f"{len(payload) + 1}\n{payload}"
-            # 50 mismatching records well under the WARN interval (500).
             response = "\n".join(record for _ in range(50)) + "\n"
 
             with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
@@ -188,16 +190,12 @@ class TestParseChunkedResponse:
 
             assert chunks == [["wrong-size"]] * 50
             assert byte_count_mismatch_total() == 50
-            warnings = [
+            # Mismatches are counted silently; none escalate to WARNING.
+            assert not [
                 r
                 for r in caplog.records
-                if r.name == "notebooklm.rpc.decoder"
-                and r.levelno == logging.WARNING
-                and "Byte-count mismatch" in r.message
+                if r.name == "notebooklm.rpc.decoder" and r.levelno == logging.WARNING
             ]
-            # Only the first mismatch of the process warns; the rest are
-            # counted silently (still DEBUG-logged).
-            assert len(warnings) == 1
         finally:
             reset_byte_count_mismatch_total()
 


### PR DESCRIPTION
## Summary

The `parse_chunked_response` decoder emitted a rate-limited WARNING on byte-count mismatches, e.g.:

> `Byte-count mismatch in chunked response (declared 151, actual 149 bytes); tolerated. Total mismatches this process: 1 — a sudden rise may indicate the batchexecute framing unit changed.`

This was **annoying and misleading** because:

- A byte-count mismatch is the **expected** case on healthy live multi-chunk responses. Google's `batchexecute` declares the count in a different unit (likely UTF-16 code units) than `len(s.encode("utf-8"))`, and recorded / proxy-transformed streams don't preserve the original count — the decoder's own docstring already documents this.
- The cadence was tuned to fire on the **first** mismatch of every process (`total % 500 == 1` is true at `total == 1`), so the happy path printed the scary "framing unit changed" message on essentially every multi-chunk response — even though nothing had changed.
- The WARNING couldn't actually distinguish drift from normal operation, since both produce mismatches.

### Change

- Remove the rate-limited WARNING from `parse_chunked_response`.
- Keep the honest signals: the per-chunk **DEBUG** log and the monotonic **`byte_count_mismatch_total()`** counter (exposed in `__all__` for telemetry / drift dashboards to alert on a sudden *rate-of-change*).
- Drop the now-unused `_BYTE_COUNT_MISMATCH_WARN_INTERVAL` constant. The counter stays lock-guarded since `int +=` isn't atomic under the GIL.
- Update the two pinned tests to assert the counter still increments and the DEBUG line still fires while **no** WARNING is emitted.

### Note for reviewers

`byte_count_mismatch_total()` currently has no in-repo consumer — it's public API intended for external telemetry. After this change, runtime drift visibility rests on an external probe polling that counter (drift is otherwise visible only at DEBUG). This is the deliberate tradeoff: the WARNING was noise by construction. A follow-up could wire the counter into `ClientMetrics`/`on_rpc_event`; intentionally left out of scope here.

## Test plan

- [x] `ruff format --check .` + `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` — no issues (203 files)
- [x] `pytest tests/unit/test_decoder.py` — 128 passed
- [x] Full suite: `pytest` — 8361 passed, 131 skipped, 1 xfailed
- [ ] CI green on all platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal diagnostic logging and telemetry collection for response parsing robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->