### PR TITLE
ci(test): add workflow_dispatch with custom_branch to gate release branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,18 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      custom_branch:
+        description: 'Branch/ref to test (leave empty to use the triggering ref). Use this to run the full gate against a release branch that conflicts with main and so cannot run via pull_request.'
+        required: false
+        default: ''
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include the dispatch input so a manual run against a release branch gets its
+  # own group instead of sharing (and cancelling) the push/PR run on the
+  # triggering ref. Empty for push/pull_request, so their behavior is unchanged.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.custom_branch }}
   cancel-in-progress: true
 
 permissions:
@@ -20,6 +29,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
+        # Honor the workflow_dispatch custom_branch input; falls back to the
+        # triggering ref for push/pull_request (input is empty there).
+        ref: ${{ inputs.custom_branch || github.ref }}
         fetch-depth: 0
 
     - name: Set up Python
@@ -121,6 +133,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        # Honor the workflow_dispatch custom_branch input; falls back to the
+        # triggering ref for push/pull_request (input is empty there).
+        ref: ${{ inputs.custom_branch || github.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger (with a `custom_branch` input) to the **Test**
workflow so the full `quality` + cross-platform matrix gate can be run **on
demand against an arbitrary branch**.

### Why
`test.yml` only triggers on `push`/`pull_request` to `main`. A release backport
branch (e.g. `release/v0.7.1`) is intentionally based on the old `0.7.x` line and
**conflicts with `main`**, so it can't run CI via a PR — GitHub can't build the
test-merge commit (`refs/pull/N/merge`) for a `DIRTY` PR, and `pull_request` runs
never start. There was no way to run the gate on such a branch short of polluting
it by merging `main` in.

### What
- New `workflow_dispatch.inputs.custom_branch` (mirrors the existing
  `nightly.yml` pattern).
- Both jobs check out the target via `ref: ${{ inputs.custom_branch || github.ref }}`.
- `custom_branch` folded into the `concurrency.group` so a manual release-branch
  run doesn't cancel `main`'s push/PR run.

### No behavior change for existing triggers
For `push`/`pull_request` the input is empty, so checkout falls back to
`github.ref` (identical to today) and the concurrency group just gains a trailing
`-`.

### Usage (after merge)
`workflow_dispatch` only appears once the workflow is on the default branch, so
this must land on `main` first. Then:

```bash
gh workflow run test.yml --ref main -f custom_branch=release/v0.7.1
```

## Test plan
- [x] `yaml.safe_load` parses; `on:` = push / pull_request / workflow_dispatch
- [x] `scripts/check_workflow_permissions.py` passes
- [x] `scripts/check_workflow_secret_gates.py` passes
- [x] `scripts/check_action_pinning.py` passes
- [ ] CI green on this PR
- [ ] After merge: dispatch against `release/v0.7.1` and confirm it runs the gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test workflow to support manual execution with custom branch selection. Improved concurrency handling to prevent conflicts between automated and manually-triggered test runs on different branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->