### PR TITLE
test: forbid bare imports of tests-root modules + drop sys.path.insert hacks (#1482)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,13 @@ force-include = {"SKILL.md" = "notebooklm/data/SKILL.md", "AGENTS.md" = "noteboo
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Put the repo root on sys.path so the ``tests`` package is importable as
+# ``tests.*`` under any invocation (plain ``pytest``/``uv run pytest`` does NOT
+# add CWD; only ``python -m pytest`` does). This is what lets test files use
+# fully-qualified ``from tests.integration.conftest import ...`` instead of bare
+# ``from conftest import ...`` (which resolved only via sys.path pollution and
+# broke isolated/xdist runs — issue #1482).
+pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "--ignore=tests/e2e"

--- a/tests/_guardrails/test_no_bare_tests_root_imports.py
+++ b/tests/_guardrails/test_no_bare_tests_root_imports.py
@@ -54,7 +54,7 @@ FORBIDDEN_BARE_TOP: frozenset[str] = frozenset(
 
 def _bare_violations(path: Path) -> list[tuple[int, str]]:
     """Return ``(lineno, imported_module)`` for every bare tests-root import."""
-    tree = ast.parse(path.read_text(), filename=str(path))
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     out: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -97,7 +97,8 @@ def test_detector_flags_bare_but_allows_qualified_and_relative(tmp_path) -> None
         "from integration.conftest import b\n"  # bare group dir -> flagged (line 3)
         "from tests.vcr_config import c\n"  # qualified -> OK
         "from .conftest import d\n"  # relative -> OK
-        "from _fixtures.fake_core import e\n"  # exempt helper package -> OK
+        "from _fixtures.fake_core import e\n",  # exempt helper package -> OK
+        encoding="utf-8",
     )
     assert _bare_violations(probe) == [
         (1, "conftest"),

--- a/tests/_guardrails/test_no_bare_tests_root_imports.py
+++ b/tests/_guardrails/test_no_bare_tests_root_imports.py
@@ -1,0 +1,106 @@
+"""Forbid bare (non-``tests.``-prefixed) imports of tests-root modules (#1482).
+
+The fragile class: a bare ``from conftest import X`` / ``from vcr_config import X``
+/ ``from cassette_patterns import X`` (or ``import vcr_config``) resolves only
+because some test file ran ``sys.path.insert(0, <tests dir>)``, polluting the
+session ``sys.path``. It is **masked in full-suite runs** by collection ordering
+but **breaks isolated single-file runs** and is an **xdist** flakiness risk (a
+worker that doesn't collect a path-inserting sibling fails collection).
+``conftest`` is additionally *ambiguous* — many ``conftest.py`` exist — so a bare
+import can silently grab the wrong one depending on ``sys.path`` order.
+
+The fix is to import via the ``tests.`` package path (which resolves as a
+namespace package regardless of ``sys.path`` order) or a relative import.
+
+**Scope (deliberately narrow):** the loose tests-root ``.py`` modules
+(``conftest``, ``vcr_config``, ``cassette_patterns``, ``cassette_sanitizer``) and
+the top-level group dirs (``integration`` / ``unit`` / ``e2e``, e.g. a bare
+``from integration.conftest import …``). The shared helper *packages*
+(``_fixtures``, ``_helpers``, ``_guardrails``) are intentionally NOT covered: they
+are unique packages that resolve unambiguously via the standard ``tests/``-on-path
+mechanism (they collect fine in isolation and under xdist) and are an established
+convention. Tightening those to ``tests.*`` too is a separate, optional sweep.
+
+Detection is by import *target* (AST), covering both module-level and
+function-local imports, so an aliased or nested form cannot slip past.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+TESTS_ROOT = Path(__file__).resolve().parents[1]  # the ``tests/`` directory
+
+#: Bare top-level import names that are fragile (resolve only via sys.path
+#: pollution). A bare import whose first dotted component is one of these must
+#: instead use the ``tests.``-qualified path or a relative import.
+FORBIDDEN_BARE_TOP: frozenset[str] = frozenset(
+    {
+        "conftest",
+        "vcr_config",
+        "cassette_patterns",
+        "cassette_sanitizer",
+        "integration",
+        "unit",
+        "e2e",
+    }
+)
+
+
+def _bare_violations(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, imported_module)`` for every bare tests-root import."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import (``from . import``) — always fine
+                continue
+            top = (node.module or "").split(".")[0]
+            if top in FORBIDDEN_BARE_TOP:
+                out.append((node.lineno, node.module or ""))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] in FORBIDDEN_BARE_TOP:
+                    out.append((node.lineno, alias.name))
+    return out
+
+
+def test_no_bare_tests_root_imports() -> None:
+    """No test file may import a tests-root module by a bare top-level name."""
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for p in sorted(TESTS_ROOT.rglob("*.py")):
+        violations = _bare_violations(p)
+        if violations:
+            offenders[str(p.relative_to(TESTS_ROOT.parent))] = violations
+
+    assert not offenders, (
+        "Bare imports of tests-root modules found — use the `tests.`-qualified "
+        "path (e.g. `from tests.vcr_config import …`, `from tests.integration."
+        "conftest import …`) or a relative import. Bare imports resolve only via "
+        "`sys.path` pollution and break isolated / xdist collection (#1482):\n"
+        + "\n".join(f"  {f}: {v}" for f, v in sorted(offenders.items()))
+    )
+
+
+def test_detector_flags_bare_but_allows_qualified_and_relative(tmp_path) -> None:
+    """Self-test: only the bare form is flagged; `tests.*`, relative, and the
+    intentionally-exempt helper packages pass."""
+    probe = tmp_path / "test_probe.py"
+    probe.write_text(
+        "from conftest import a\n"  # bare -> flagged (line 1)
+        "import vcr_config\n"  # bare -> flagged (line 2)
+        "from integration.conftest import b\n"  # bare group dir -> flagged (line 3)
+        "from tests.vcr_config import c\n"  # qualified -> OK
+        "from .conftest import d\n"  # relative -> OK
+        "from _fixtures.fake_core import e\n"  # exempt helper package -> OK
+    )
+    assert _bare_violations(probe) == [
+        (1, "conftest"),
+        (2, "vcr_config"),
+        (3, "integration.conftest"),
+    ]

--- a/tests/_guardrails/test_no_bare_tests_root_imports.py
+++ b/tests/_guardrails/test_no_bare_tests_root_imports.py
@@ -54,7 +54,10 @@ FORBIDDEN_BARE_TOP: frozenset[str] = frozenset(
 
 def _bare_violations(path: Path) -> list[tuple[int, str]]:
     """Return ``(lineno, imported_module)`` for every bare tests-root import."""
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return []  # a syntactically-broken file is pytest collection's problem, not ours
     out: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -29,27 +28,23 @@ from urllib.parse import urlparse
 
 import pytest
 from click.testing import CliRunner
-
-# Add tests directory to path for vcr_config import
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-from integration.conftest import _is_vcr_record_mode, skip_no_cassettes  # noqa: E402
+from tests.integration.conftest import _is_vcr_record_mode, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
 # Enum value *sets* only — an allowed-membership definition, NOT a decoder. Reading
 # the canonical enum values from the public ``notebooklm`` types keeps the membership
 # floor in lock-step with the source of truth without importing the decode path
 # (``assert_semantic_invariants`` only checks ``value in <set>``). See issue #1452.
-from notebooklm.rpc.types import SourceStatus  # noqa: E402
-from notebooklm.types import (  # noqa: E402
+from notebooklm.rpc.types import SourceStatus
+from notebooklm.types import (
     ArtifactStatus,
     ArtifactType,
     SourceType,
     artifact_status_to_str,
     source_status_to_str,
 )
-from vcr_config import notebooklm_vcr  # noqa: E402
 
-from ._fixtures import (  # noqa: E402
+from ._fixtures import (
     PLACEHOLDER_NOTEBOOK_ID,
     VCR_READONLY_NOTEBOOK_ID,
     VCR_READONLY_SOURCE_ID,

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -32,9 +32,9 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from tests.integration.conftest import install_post_as_stream
 
 from _fixtures.kernel_test_helpers import install_http_client_for_test
-from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient, RateLimitError
 from notebooklm.rpc import RPCMethod
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,12 +11,10 @@ import pytest
 
 from notebooklm.auth import AuthTokens
 
-# Load ``tests/vcr_config.py`` by file path — the ``tests`` directory is not a
-# package (no ``__init__.py``), so ``from tests.vcr_config import ...`` only
-# works when the repo root happens to be on ``sys.path``. That holds in a
-# fresh REPL but NOT inside pytest's per-module import. Loading by file path
-# bypasses ``sys.path`` and is the same idiom used inside ``vcr_config.py``
-# itself for its sibling ``cassette_patterns.py`` import.
+# Load ``tests/vcr_config.py`` by file path. ``from tests.vcr_config import ...``
+# now resolves in pytest via ``pythonpath = ["."]`` (pyproject, #1482); loading
+# by file path is kept as a ``sys.path``-independent fallback (the same idiom
+# ``vcr_config.py`` uses for its sibling ``cassette_patterns.py`` import).
 _vcr_config_spec = importlib.util.spec_from_file_location(
     "tests_vcr_config", Path(__file__).resolve().parent.parent / "vcr_config.py"
 )

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -34,19 +34,12 @@ we substitute synthetic ``AuthTokens`` for the same reason, mirroring the
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
+from tests.integration.conftest import _vcr_record_mode, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-# Add tests directory to path for vcr_config + conftest helpers.
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-
-from conftest import _vcr_record_mode, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.auth import AuthTokens  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
+from notebooklm.auth import AuthTokens
 
 CASSETTE_NAME = "auth_rotate_cookies_refresh.yaml"
 

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from tests.integration.conftest import install_post_as_stream
 
-from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCError, RPCMethod

--- a/tests/integration/test_chat_delete_conversation_vcr.py
+++ b/tests/integration/test_chat_delete_conversation_vcr.py
@@ -25,9 +25,6 @@ from urllib.parse import parse_qs
 
 import pytest
 import yaml
-
-# Match the rest of ``tests/integration/test_vcr_*.py`` — these files are
-# imported by pytest with the repo root NOT on sys.path.
 from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_chat_delete_conversation_vcr.py
+++ b/tests/integration/test_chat_delete_conversation_vcr.py
@@ -28,12 +28,10 @@ import yaml
 
 # Match the rest of ``tests/integration/test_vcr_*.py`` — these files are
 # imported by pytest with the repo root NOT on sys.path.
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
+from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-from conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_chat_multi_source_vcr.py
+++ b/tests/integration/test_chat_multi_source_vcr.py
@@ -64,9 +64,6 @@ from urllib.parse import parse_qs
 
 import pytest
 import yaml
-
-# Match the rest of ``tests/integration/test_vcr_*.py`` — these files are
-# imported by pytest with the repo root NOT on sys.path.
 from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_chat_multi_source_vcr.py
+++ b/tests/integration/test_chat_multi_source_vcr.py
@@ -67,12 +67,10 @@ import yaml
 
 # Match the rest of ``tests/integration/test_vcr_*.py`` — these files are
 # imported by pytest with the repo root NOT on sys.path.
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
+from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-from conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_empty_results_vcr.py
+++ b/tests/integration/test_empty_results_vcr.py
@@ -29,8 +29,6 @@ not by notebook UUID.
 """
 
 import pytest
-
-# (direct pytest, ``-k`` filter, IDE runner).
 from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_empty_results_vcr.py
+++ b/tests/integration/test_empty_results_vcr.py
@@ -28,19 +28,13 @@ incidental to replay — the cassettes are matched by RPC method + body,
 not by notebook UUID.
 """
 
-import sys
-from pathlib import Path
-
 import pytest
 
-# tests/ is not a package (no __init__.py); insert both dirs onto sys.path so
-# the ``conftest`` and ``vcr_config`` siblings resolve in any invocation mode
 # (direct pytest, ``-k`` filter, IDE runner).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from notebooklm import NotebookLMClient
 
 # Skip all tests in this module if cassettes are not available (mirrors the
 # pattern in tests/integration/test_vcr_comprehensive.py).

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -58,9 +58,6 @@ synthetic shapes these cassettes carry.
 from __future__ import annotations
 
 import pytest
-
-# Add tests directory to sys.path for vcr_config + conftest helpers, mirroring
-# the pattern in ``test_auth_refresh_vcr.py``.
 from tests.integration.conftest import skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -57,25 +57,20 @@ synthetic shapes these cassettes carry.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
 # Add tests directory to sys.path for vcr_config + conftest helpers, mirroring
 # the pattern in ``test_auth_refresh_vcr.py``.
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
+from tests.integration.conftest import skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-from conftest import skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.auth import AuthTokens  # noqa: E402
-from notebooklm.exceptions import (  # noqa: E402
+from notebooklm import NotebookLMClient
+from notebooklm.auth import AuthTokens
+from notebooklm.exceptions import (
     ClientError,
     RateLimitError,
     ServerError,
 )
-from vcr_config import notebooklm_vcr  # noqa: E402
 
 # All tests in this module are VCR-tier. Skipped when cassettes are absent and
 # we're not in record mode (``NOTEBOOKLM_VCR_RECORD=1``).

--- a/tests/integration/test_mind_map_chain_vcr.py
+++ b/tests/integration/test_mind_map_chain_vcr.py
@@ -42,9 +42,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-# tests/integration/test_vcr_*.py — these files are imported by pytest with
-# the repo root NOT on sys.path).
 from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_mind_map_chain_vcr.py
+++ b/tests/integration/test_mind_map_chain_vcr.py
@@ -38,21 +38,18 @@ string. No per-cassette ``match_on`` override is needed.
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
-# Add tests directory to path for vcr_config import (parity with the rest of
 # tests/integration/test_vcr_*.py — these files are imported by pytest with
 # the repo root NOT on sys.path).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.rpc import RPCMethod  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_mind_maps_vcr.py
+++ b/tests/integration/test_mind_maps_vcr.py
@@ -22,18 +22,15 @@ only the ``[0][9][3]`` tree is needed for replay.
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.rpc.types import RPCMethod  # noqa: E402
-from notebooklm.types import MindMapKind  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
+from notebooklm.rpc.types import RPCMethod
+from notebooklm.types import MindMapKind
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_polling_vcr.py
+++ b/tests/integration/test_polling_vcr.py
@@ -71,22 +71,19 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 import yaml
 
-# Add tests directory to path for vcr_config import (parity with the rest of
 # tests/integration/test_vcr_*.py — these files are imported by pytest with
 # the repo root NOT on sys.path).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.rpc import RPCMethod  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_polling_vcr.py
+++ b/tests/integration/test_polling_vcr.py
@@ -76,9 +76,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 import yaml
-
-# tests/integration/test_vcr_*.py — these files are imported by pytest with
-# the repo root NOT on sys.path).
 from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_research_deep_poll_vcr.py
+++ b/tests/integration/test_research_deep_poll_vcr.py
@@ -69,22 +69,19 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys
 import uuid
 from pathlib import Path
 
 import pytest
 import yaml
 
-# Add tests directory to path for vcr_config import (parity with the rest of
 # tests/integration/test_vcr_*.py — these files are imported by pytest with
 # the repo root NOT on sys.path).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.rpc import RPCMethod  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_research_deep_poll_vcr.py
+++ b/tests/integration/test_research_deep_poll_vcr.py
@@ -74,9 +74,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-# tests/integration/test_vcr_*.py — these files are imported by pytest with
-# the repo root NOT on sys.path).
 from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from tests.integration.conftest import install_post_as_stream
 
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm import AuthTokens, NotebookLMClient
 from notebooklm._runtime.helpers import is_auth_error
 from notebooklm.rpc import (

--- a/tests/integration/test_settings_vcr.py
+++ b/tests/integration/test_settings_vcr.py
@@ -13,18 +13,13 @@ GET_USER_TIER is a homepage-scoped call (``source_path="/"``) so the notebook
 ID is only relevant for ensuring the recording session is logged in.
 """
 
-import sys
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import pytest
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-# Add tests directory to path for vcr_config import (mirrors test_vcr_comprehensive.py).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from vcr_config import notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -16,20 +16,15 @@ Note: These tests are automatically skipped if cassettes are not available.
 import csv
 import json
 import os
-import sys
 from contextlib import asynccontextmanager
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-# Add tests directory to path for vcr_config import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes
 from notebooklm import NotebookLMClient, ReportFormat
 from notebooklm.types import Artifact, ArtifactType
-from vcr_config import notebooklm_vcr
 
 # Skip all tests in this module if cassettes are not available
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]

--- a/tests/integration/test_vcr_example.py
+++ b/tests/integration/test_vcr_example.py
@@ -21,16 +21,9 @@ committing a new or re-recorded cassette.
 Note: These tests are automatically skipped if cassettes are not available.
 """
 
-import sys
-from pathlib import Path
-
 import pytest
-
-# Add tests directory to path for vcr_config import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import skip_no_cassettes
-from vcr_config import notebooklm_vcr
+from tests.integration.conftest import skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
 # Skip all tests in this module if cassettes are not available
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]

--- a/tests/integration/test_vcr_real_api.py
+++ b/tests/integration/test_vcr_real_api.py
@@ -12,17 +12,12 @@ Note: These tests are automatically skipped if cassettes are not available.
 """
 
 import os
-import sys
-from pathlib import Path
 
 import pytest
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
 
-# Add tests directory to path for vcr_config import
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes
 from notebooklm import NotebookLMClient
-from vcr_config import notebooklm_vcr
 
 # Skip all tests in this module if cassettes are not available
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]

--- a/tests/integration/test_workflow_tracer_vcr.py
+++ b/tests/integration/test_workflow_tracer_vcr.py
@@ -60,23 +60,17 @@ chain is the test.
 from __future__ import annotations
 
 import asyncio
-import sys
 import uuid
 from pathlib import Path
 
 import pytest
 import yaml
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import _is_vcr_record_mode, notebooklm_vcr
 
-# Add tests/ to sys.path so vcr_config + integration/conftest resolve when
-# pytest imports this module without the repo root on sys.path (parity with
-# every other ``tests/integration/test_*_vcr.py`` in the repo).
-sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent))
-from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
-from notebooklm import NotebookLMClient  # noqa: E402
-from notebooklm.rpc import RPCMethod  # noqa: E402
-from notebooklm.types import ReportFormat  # noqa: E402
-from vcr_config import _is_vcr_record_mode, notebooklm_vcr  # noqa: E402
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import ReportFormat
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 

--- a/tests/unit/test_authed_post_pipeline.py
+++ b/tests/unit/test_authed_post_pipeline.py
@@ -46,11 +46,11 @@ from typing import Any
 
 import httpx
 import pytest
+from tests.unit.conftest import install_post_as_stream
 
 import notebooklm._backoff as _backoff
 import notebooklm._runtime.helpers as _runtime_helpers
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm._logging import get_request_id
 from notebooklm._middleware.core import RpcRequest, RpcResponse
 from notebooklm._request_types import AuthSnapshot

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -19,20 +19,11 @@ tests assert:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
-
-# ``tests/cassette_patterns.py`` lives directly under ``tests/`` (not in a
-# package). Other test modules add it to ``sys.path``; we follow the same
-# convention so the validator is importable in either layout.
-REPO_ROOT = Path(__file__).resolve().parents[2]
-TESTS_DIR = REPO_ROOT / "tests"
-sys.path.insert(0, str(TESTS_DIR))
-
-import vcr_config  # noqa: E402
-from cassette_patterns import (  # noqa: E402
+from tests import vcr_config
+from tests.cassette_patterns import (
     DISPLAY_NAME_FALSE_POSITIVES,
     EMAIL_PROVIDERS,
     HOST_COOKIES,
@@ -45,6 +36,8 @@ from cassette_patterns import (  # noqa: E402
     is_clean,
     scrub_string,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # A synthetic Google API key whose *shape* (``AIza`` + 35 ``[A-Za-z0-9_-]``
 # chars) matches the canonical Google API-key pattern the registry scrubs, but

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -29,23 +29,19 @@ import sys
 from pathlib import Path
 
 import pytest
-
-pytestmark = pytest.mark.repo_lint
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-TESTS_DIR = REPO_ROOT / "tests"
-# ``tests/vcr_config.py`` lives directly under ``tests/`` (not in a package).
-# Other test modules add it to ``sys.path``; we follow the same convention.
-sys.path.insert(0, str(TESTS_DIR))
-
-from cassette_patterns import (  # noqa: E402
+from tests.cassette_patterns import (
     find_cookie_leaks,
     find_credential_leaks,
     is_clean,
     scrub_cookie_header,
     scrub_set_cookie,
 )
-from vcr_config import scrub_string  # noqa: E402
+from tests.vcr_config import scrub_string
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests"
 
 GUARD_SCRIPT = TESTS_DIR / "scripts" / "check_cassettes_clean.py"
 REGRESSION_FIXTURE = TESTS_DIR / "fixtures" / "bad_cassettes" / "bad_sid_starting_with_s.yaml"

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -29,9 +29,9 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
 import pytest
+from tests.unit.conftest import install_post_as_stream
 
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
 from notebooklm._chat import ChatAPI
 from notebooklm._request_types import AuthSnapshot

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 from pytest_httpx import HTTPXMock
+from tests.unit.conftest import install_post_as_stream
 
 from _fixtures.kernel_test_helpers import install_http_client_for_test
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm._runtime.helpers import is_auth_error
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -42,11 +42,11 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from tests.cassette_patterns import build_synthetic_error_response
 
 # pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
-from cassette_patterns import build_synthetic_error_response
 from notebooklm._error_injection import ERROR_INJECT_ENV_VAR
 from notebooklm._middleware.core import NextCall, RpcRequest, RpcResponse, build_chain
 from notebooklm._middleware.error_injection import ErrorInjectionMiddleware

--- a/tests/unit/test_middleware_chain_host.py
+++ b/tests/unit/test_middleware_chain_host.py
@@ -35,9 +35,9 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from tests.unit.conftest import install_post_as_stream
 
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm._middleware.core import RpcRequest, RpcResponse
 from notebooklm._request_types import AuthSnapshot
 from notebooklm.auth import AuthTokens

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -13,11 +13,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from tests.unit.conftest import install_post_as_stream
 
 import notebooklm._deadline as _deadline
 from _fixtures.kernel_test_helpers import install_http_client_for_test
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm.rpc import RateLimitError, RPCError, RPCMethod
 
 

--- a/tests/unit/test_rescrub_cassettes_script.py
+++ b/tests/unit/test_rescrub_cassettes_script.py
@@ -39,12 +39,6 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "scripts" / "rescrub-cassettes.py"
-_TESTS_DIR = _REPO_ROOT / "tests"
-
-# Ensure ``cassette_patterns`` resolves regardless of where pytest is run.
-# This is the same trick the script uses.
-if str(_TESTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_TESTS_DIR))
 
 
 def _run_script(*argv: str) -> int:
@@ -254,7 +248,7 @@ def test_avatar_pattern_matches_registry() -> None:
     script_pattern = script_ns["_AVATAR_URL_RE"].pattern
     script_replacement = script_ns["_AVATAR_URL_REPLACEMENT"]
 
-    from cassette_patterns import SENSITIVE_PATTERNS
+    from tests.cassette_patterns import SENSITIVE_PATTERNS
 
     avatar_entries = [
         (pat, repl) for pat, repl in SENSITIVE_PATTERNS if repl == "SCRUBBED_AVATAR_URL"

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -17,9 +17,9 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
+from tests.unit.conftest import install_post_as_stream
 
 from _helpers.client_factory import build_client_shell_for_tests
-from conftest import install_post_as_stream
 from notebooklm import _env
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient

--- a/tests/unit/test_tier_enforcement_hook.py
+++ b/tests/unit/test_tier_enforcement_hook.py
@@ -107,9 +107,6 @@ def _scaffold(pytester: pytest.Pytester, integration_body: str) -> None:
             "tests/integration/test_under_test.py": integration_body,
         }
     )
-    # Empty ``__init__.py`` files so the synthetic ``tests/integration/`` is
-    # treated as the same kind of package layout pytest sees in the real repo.
-    pytester.makepyfile(**{"tests/__init__.py": "", "tests/integration/__init__.py": ""})
 
 
 def test_violation_rejected(pytester: pytest.Pytester) -> None:
@@ -186,8 +183,6 @@ def test_use_cassette_decorator_honored(pytester: pytest.Pytester) -> None:
     pytester.makeini(MARKER_REGISTRATION)
     pytester.makepyfile(
         **{
-            "tests/__init__.py": "",
-            "tests/integration/__init__.py": "",
             "tests/integration/conftest.py": HOOK_SOURCE,
             "tests/integration/test_with_use_cassette.py": textwrap.dedent(
                 """
@@ -229,9 +224,6 @@ def test_unit_tier_not_gated(pytester: pytest.Pytester) -> None:
     pytester.makepyfile(
         **{
             "tests/integration/conftest.py": HOOK_SOURCE,
-            "tests/__init__.py": "",
-            "tests/integration/__init__.py": "",
-            "tests/unit/__init__.py": "",
             "tests/unit/test_bare.py": textwrap.dedent(
                 """
                 def test_unit_no_marker():

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -70,13 +70,11 @@ import vcr
 def _load_sibling(module_name: str, file_name: str) -> Any:
     """Load a sibling module under ``tests/`` by file path.
 
-    The ``tests`` directory is not a Python package (no ``__init__.py``), so
-    ``from tests.cassette_patterns import ...`` only works when the repo root
-    happens to be on ``sys.path``. That holds in a fresh REPL but NOT inside
-    pytest's per-module import, where the loader uses an isolated path that
-    omits the repo root. Loading by file path bypasses ``sys.path`` entirely
-    and is the same idiom ``tests/unit/test_cookie_redaction.py`` uses to
-    import this very file.
+    ``from tests.cassette_patterns import ...`` now resolves inside pytest via
+    ``pythonpath = ["."]`` (pyproject, #1482); loading by file path is kept as a
+    ``sys.path``-independent fallback so this module also works when imported
+    outside pytest, the same idiom ``tests/unit/test_cookie_redaction.py`` uses
+    to import this very file.
     """
     spec = importlib.util.spec_from_file_location(
         module_name, Path(__file__).resolve().parent / file_name


### PR DESCRIPTION
Closes #1482.

## Problem

The test suite had bare top-level imports of `tests/`-root modules — `from conftest import …`, `from vcr_config import …`, `from cassette_patterns import …`, `import vcr_config`, `from integration.conftest import …` — that resolved **only** via per-file `sys.path.insert(0, <tests dir>)` hacks polluting the session `sys.path`. Masked in full-suite runs by collection ordering, they break **isolated single-file runs** and are an **xdist** flakiness risk. `conftest` is additionally *ambiguous* (many `conftest.py` exist), so a bare import can grab the wrong one. Surfaced during the MCP-server Phase-0 review; the `sys.path.insert` cleanup was explicitly deferred here.

## Fix (narrow, deliberate)

1. **Repoint** every bare tests-root import to the `tests.`-qualified path (resolves as a namespace package regardless of `sys.path` order) — 28 files.
2. **Drop** the `sys.path.insert(...tests...)` hacks (legit repo-root/script inserts kept).
3. **`pythonpath = ["."]`** in the pytest config — the prerequisite that puts the repo root on `sys.path` so `tests.*` is importable under *any* invocation (plain `pytest` / `uv run pytest` do **not** add CWD; only `python -m pytest` does). Without this the repoint would `ModuleNotFoundError` under CI.
4. **Guardrail lint** (`tests/_guardrails/test_no_bare_tests_root_imports.py`) — AST-scans `tests/` and fails on any bare import of `conftest`/`vcr_config`/`cassette_patterns`/`cassette_sanitizer` or a group dir; prevents recurrence of the whole class (enforce, don't document). Scans function-local imports; self-tested.

The stable `_fixtures.X`/`_helpers.X`/`_guardrails.X` **package** convention (95 files, unique unambiguous packages that resolve via `tests/`-on-path) is intentionally left as-is — out of scope; a separate optional sweep if ever wanted.

## Verification

- **Full suite green under plain `pytest`** (9277 passed) — not just `python -m pytest`.
- Previously-fragile VCR/concurrency/cassette files now pass in **true isolation** (each `pytest <file>` alone) and under xdist.
- The lint passes on the clean tree + self-test confirms detection.
- Collateral: `test_tier_enforcement_hook.py` dropped its synthetic `tests/**__init__**.py` (collided with the now-cached real `tests.*`; the real repo has none either).
- Tests-only + pytest config — no `src/` change, no public-API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a repository lint check to enforce disallowed bare imports from test-root modules.
  * Standardized many test modules to use package-qualified imports for shared test helpers instead of manipulating import paths.
  * Adjusted guardrail self-tests to allow qualified and relative imports while flagging bare forms.

* **Chores**
  * Updated pytest configuration to ensure the repository root is on the import path for test runs.
  * Simplified test scaffolding by removing unnecessary package marker creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->