### PR TITLE
fix: treat empty notebook summary as "" not safe_index drift (#1485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
+  A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
+  returns an absent/`None` payload. `notebooks.get_summary()` and
+  `notebooks.get_description()` now treat that routine "no summary yet" state as
+  an empty summary (`""`) instead of mis-classifying it as wire-schema drift.
+  Genuinely-malformed payloads (a present-but-non-list `result[0]`, a scalar, or
+  a string where a nested list is expected) still raise. `get_summary` now shares
+  the `_extract_summary` descent with `get_description`, so both agree on every
+  shape. As part of the fix, `safe_index` rejects a `str`/`bytes` value at an
+  intermediate descent hop (it is indexable but never a valid container, so
+  descending it would smuggle a single character past drift detection).
+
 ## [0.8.0]
 
 This release lands the **breaking half** of the ADR-0019 error contract

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -62,7 +62,7 @@ def _extract_summary(outer: Any) -> str:
     # routine "no summary yet" case — return "" without logging drift.
     if outer is None:
         return ""
-    if isinstance(outer, list) and (len(outer) < 1 or outer[0] is None):
+    if isinstance(outer, list) and (not outer or outer[0] is None):
         return ""
     # Descend outer[0][0] via safe_index. A scalar ``outer`` or a malformed
     # ``outer[0]`` (present, non-None, but not the expected list) raises drift
@@ -608,7 +608,7 @@ class NotebooksAPI:
         # is the ``outer`` payload that ``_extract_summary`` descends, so delegate
         # to it: empty/None/null-slot → "" and present-but-malformed → drift,
         # identically to ``get_description`` (single source of truth — #1485).
-        if not isinstance(result, list) or len(result) < 1:
+        if not isinstance(result, list) or not result:
             return ""
         return _extract_summary(result[0])
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -40,15 +40,33 @@ def _extract_summary(outer: Any) -> str:
     """Extract the summary string from a SUMMARIZE ``result[0]`` payload.
 
     The expected shape is ``[[summary_string, ...], ...]`` — i.e. the summary
-    lives at ``outer[0][0]``. ``safe_index`` is used for the inner-most
-    descent so drift is logged with method_id + source rather than raising
-    ``IndexError`` from a raw subscript.
+    lives at ``outer[0][0]``. Only a genuinely *absent* summary is treated as
+    routinely-optional: a brand-new, source-less notebook has no summary yet,
+    so the server returns ``None`` at ``outer``, an empty ``outer``, or an
+    explicitly-null summary slot (``outer[0] is None``). Those three shapes
+    short-circuit to ``""`` so a healthy "no summary yet" response doesn't
+    surface as schema drift.
+
+    Everything else descends through ``safe_index``: a *present-but-malformed*
+    payload — a scalar ``outer`` (e.g. ``123``), or a non-``None`` ``outer[0]``
+    that isn't the expected ``[summary_string, ...]`` list — is genuine drift
+    and raises ``UnknownRPCMethodError`` with method_id + source rather than
+    silently becoming an empty summary (which would mask the wire-schema move).
 
     Returns:
-        The summary string, or ``""`` when the payload is missing the
-        expected slot (the caller is responsible for treating an empty
-        summary as "no description available").
+        The summary string, or ``""`` when the payload omits the summary
+        slot (the caller is responsible for treating an empty summary as
+        "no description available").
     """
+    # Genuinely-absent summary (no payload, empty payload, or null slot) is the
+    # routine "no summary yet" case — return "" without logging drift.
+    if outer is None:
+        return ""
+    if isinstance(outer, list) and (len(outer) < 1 or outer[0] is None):
+        return ""
+    # Descend outer[0][0] via safe_index. A scalar ``outer`` or a malformed
+    # ``outer[0]`` (present, non-None, but not the expected list) raises drift
+    # at the failing step rather than silently returning "".
     summary_val = safe_index(
         outer,
         0,
@@ -586,16 +604,13 @@ class NotebooksAPI:
             params,
             source_path=f"/notebook/{notebook_id}",
         )
-        # Response structure: [[[summary_string, ...], topics, ...]]
-        summary = safe_index(
-            result,
-            0,
-            0,
-            0,
-            method_id=RPCMethod.SUMMARIZE.value,
-            source="_notebooks.get_summary",
-        )
-        return str(summary) if summary else ""
+        # Response structure: [[[summary_string, ...], topics, ...]]. ``result[0]``
+        # is the ``outer`` payload that ``_extract_summary`` descends, so delegate
+        # to it: empty/None/null-slot → "" and present-but-malformed → drift,
+        # identically to ``get_description`` (single source of truth — #1485).
+        if not isinstance(result, list) or len(result) < 1:
+            return ""
+        return _extract_summary(result[0])
 
     async def get_description(self, notebook_id: str) -> NotebookDescription:
         """Get AI-generated summary and suggested topics for a notebook.

--- a/src/notebooklm/rpc/_safe_index.py
+++ b/src/notebooklm/rpc/_safe_index.py
@@ -71,12 +71,33 @@ def safe_index(
         The value at ``data[path[0]][path[1]]...`` on success.
 
     Raises:
-        UnknownRPCMethodError: When descent fails. The exception carries
-            ``method_id``, ``source``, ``path`` (truncated to where descent
-            stopped), and a truncated ``data_at_failure`` repr.
+        UnknownRPCMethodError: When descent fails — an out-of-range index, a
+            non-indexable value (``None``/``int``), a missing key, or a
+            ``str``/``bytes`` value at an intermediate hop (which is indexable
+            but never a valid container, so descending it would silently yield a
+            single character/byte instead of surfacing the shape drift). The
+            exception carries ``method_id``, ``source``, ``path`` (truncated to
+            where descent stopped), and a truncated ``data_at_failure`` repr.
     """
     current: Any = data
     for i, key in enumerate(path):
+        # A str/bytes is indexable but is NEVER a valid container at an
+        # *intermediate* descent hop in a decoded RPC payload: ``"abc"[0]``
+        # silently returns ``"a"`` instead of descending into a nested list,
+        # which would smuggle a bogus single-character "value" past drift
+        # detection (the payload shape has actually moved). Reject it as drift
+        # before indexing. (A string is fine as the returned *leaf* — the loop
+        # never indexes the final value.)
+        if isinstance(current, (str, bytes, bytearray)):
+            failing_path = tuple(path[:i])
+            raise UnknownRPCMethodError(
+                f"safe_index drift at path {failing_path}[{key}]: cannot index "
+                f"into {type(current).__name__} (expected a nested list/tuple)",
+                method_id=method_id,
+                path=failing_path,
+                source=source,
+                data_at_failure=_truncate(current),
+            )
         try:
             current = current[key]
         except (IndexError, TypeError, KeyError) as exc:

--- a/tests/integration/test_notebooks_integration.py
+++ b/tests/integration/test_notebooks_integration.py
@@ -569,26 +569,60 @@ class TestNotebookEdgeCases:
         assert notebooks == []
 
     @pytest.mark.asyncio
-    async def test_get_summary_empty_response_raises(
+    async def test_get_summary_empty_response_returns_empty(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """An empty SUMMARIZE response drifts and raises under strict decoding.
+        """A summary-less SUMMARIZE response returns "" rather than drifting.
 
-        Strict decoding is the only mode (the ``NOTEBOOKLM_STRICT_DECODE=0``
-        soft-mode opt-out was retired in v0.7.0); a ``[]`` response cannot be
-        descended to the summary slot, so it surfaces as
-        ``UnknownRPCMethodError``. Strict-mode unit coverage lives in
+        Regression for #1485: a brand-new, source-less notebook has no summary
+        yet, so the server returns an empty/absent result[0] payload. That
+        routine "no summary yet" state must surface as "" instead of being
+        mis-classified as wire-schema drift. Strict-mode unit coverage lives in
         ``tests/unit/test_get_summary_drift.py``.
         """
-        response = build_rpc_response(RPCMethod.SUMMARIZE, [])
-        httpx_mock.add_response(content=response.encode())
+        # ``[]`` (no outer[0] slot), ``[None]`` (result[0] is None), and ``[[]]``
+        # (result[0] is an empty list — no summary slot) are all legitimate
+        # summary-less payloads. ``[[None]]`` (summary slot explicitly null) is
+        # the same routine absence, now consistent between get_summary and
+        # get_description after delegating to _extract_summary (#1485).
+        for data in ([], [None], [[]], [[None]]):
+            response = build_rpc_response(RPCMethod.SUMMARIZE, data)
+            httpx_mock.add_response(content=response.encode())
 
-        async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(UnknownRPCMethodError):
-                await client.notebooks.get_summary("nb_123")
+            async with NotebookLMClient(auth_tokens) as client:
+                assert await client.notebooks.get_summary("nb_123") == ""
+
+    @pytest.mark.asyncio
+    async def test_get_summary_malformed_response_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A present-but-malformed SUMMARIZE payload still drifts and raises.
+
+        Distinct from the routinely-absent summary slot (#1485): when result[0]
+        is present (non-None) but cannot be descended to the summary value, that
+        is genuine schema drift and must surface as ``UnknownRPCMethodError``
+        under strict decoding (the only mode; the ``NOTEBOOKLM_STRICT_DECODE=0``
+        soft-mode opt-out was retired in v0.7.0). This guards against
+        over-suppressing real drift while fixing the empty-summary case — in
+        particular a scalar ``result[0]`` must raise, not collapse to "".
+        """
+        # Each payload has a present, non-None result[0] that cannot be descended
+        # to result[0][0][0]: a non-empty-but-malformed inner list, and a bare
+        # scalar (the #1485 codex over-suppression case). Contrast with [] /
+        # [None] / [[]] which are routine absence and return "" above.
+        for data in ([[[]]], [[42]], [123]):
+            response = build_rpc_response(RPCMethod.SUMMARIZE, data)
+            httpx_mock.add_response(content=response.encode())
+
+            async with NotebookLMClient(auth_tokens) as client:
+                with pytest.raises(UnknownRPCMethodError):
+                    await client.notebooks.get_summary("nb_123")
 
     @pytest.mark.asyncio
     async def test_get_description_empty_topics(

--- a/tests/unit/test_get_summary_drift.py
+++ b/tests/unit/test_get_summary_drift.py
@@ -3,8 +3,12 @@
 The site at ``_notebooks.py:get_summary`` used to swallow ``IndexError`` /
 ``TypeError`` from an unguarded ``result[0][0][0]`` descent. It was migrated
 to ``safe_index`` so drift raises ``UnknownRPCMethodError`` carrying
-``method_id=RPCMethod.SUMMARIZE.value`` and ``source='_notebooks.get_summary'``
-for debuggability. Strict decoding is the only mode — the legacy
+``method_id=RPCMethod.SUMMARIZE.value`` for debuggability. As of #1485 the
+descent is delegated to the shared ``_extract_summary`` helper (single source
+of truth with ``get_description``), so drift now surfaces with
+``source='_notebooks._extract_summary'`` and the genuinely-absent shapes
+(``result[0]`` None / empty / null summary slot) return ``""`` identically in
+both entry points. Strict decoding is the only mode — the legacy
 ``NOTEBOOKLM_STRICT_DECODE=0`` soft-mode opt-out (which warn-logged and
 returned ``""``) was retired in v0.7.0; see ADR-0011.
 """
@@ -42,19 +46,61 @@ async def test_get_summary_happy_path_returns_string():
 
 @pytest.mark.asyncio
 async def test_get_summary_drift_raises_typed_error():
-    """Drift raises ``UnknownRPCMethodError`` with context (the only mode)."""
-    # result[0] is an empty list → result[0][0] raises IndexError.
-    api = _make_api([[]])
+    """Present-but-malformed payload raises ``UnknownRPCMethodError`` (the only mode)."""
+    # result[0] is present but an empty list → the safe_index descent into
+    # result[0][0] raises IndexError. A present-but-malformed inner payload is
+    # genuine drift (distinct from a routinely-absent/None result[0]).
+    api = _make_api([[[]]])
 
     with pytest.raises(UnknownRPCMethodError) as exc_info:
         await api.get_summary("nb_drift")
 
     err = exc_info.value
     assert err.method_id == RPCMethod.SUMMARIZE.value
-    assert err.source == "_notebooks.get_summary"
-    # Descent succeeded for result[0]; failure landed at the next hop.
-    assert err.path == (0,)
+    # The descent is delegated to _extract_summary, so the drift carries the
+    # shared helper's source label (#1485).
+    assert err.source == "_notebooks._extract_summary"
     assert err.data_at_failure is not None
+
+
+@pytest.mark.asyncio
+async def test_get_summary_scalar_result_zero_raises():
+    """A scalar ``result[0]`` is present-but-malformed drift, not absence.
+
+    Regression for #1485 codex review: the server returned ``result == [123]``,
+    so ``result[0]`` is a bare int rather than the expected
+    ``[summary_string, ...]`` list. This must raise drift — a
+    ``not isinstance(..., list)`` short-circuit would wrongly suppress it to "".
+    """
+    api = _make_api([123])
+
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        await api.get_summary("nb_scalar_drift")
+
+    err = exc_info.value
+    assert err.method_id == RPCMethod.SUMMARIZE.value
+    assert err.source == "_notebooks._extract_summary"
+    # The very first descent hop (result[0][0]) fails on the scalar, so the
+    # truncated path is empty.
+    assert err.path == ()
+
+
+@pytest.mark.asyncio
+async def test_get_summary_str_result_zero_raises():
+    """A *string* ``result[0]`` raises drift, not a 1-char "summary".
+
+    Regression for #1485 codex review (second round): the server returned
+    ``result == ["abc"]``, so ``result[0]`` is a bare string. A string is
+    indexable, so a naive descent would return ``"a"`` (``"abc"[0]``) and
+    silently pass it off as the summary. safe_index now rejects intermediate
+    str/bytes, so this surfaces as drift.
+    """
+    api = _make_api(["abc"])
+
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        await api.get_summary("nb_str_drift")
+
+    assert exc_info.value.source == "_notebooks._extract_summary"
 
 
 @pytest.mark.asyncio
@@ -68,5 +114,67 @@ async def test_get_summary_falsy_summary_returns_empty():
     api = _make_api([[[None]]])
 
     summary = await api.get_summary("nb_empty_value")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_notebook_returns_empty():
+    """A summary-less notebook (result[0] is None) returns "" not drift.
+
+    Regression for #1485: a brand-new, source-less notebook has no summary
+    yet, so the SUMMARIZE result[0] payload is None. That routine "no summary
+    yet" state must surface as "" rather than ``UnknownRPCMethodError``.
+    """
+    api = _make_api([None])
+
+    summary = await api.get_summary("nb_empty_notebook")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_result_list_returns_empty():
+    """An empty/absent outer result returns "" rather than raising.
+
+    Regression for #1485: result being [] (no outer[0] slot at all) is the
+    same routine "no summary yet" state and must not be mis-classified as
+    wire-schema drift.
+    """
+    api = _make_api([])
+
+    summary = await api.get_summary("nb_empty_result")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_null_summary_slot_returns_empty():
+    """A null summary slot (result[0][0] is None) returns "" — consistency win.
+
+    Regression for #1485 codex review: ``result == [[None]]`` means the
+    ``outer`` payload is present but its summary slot is explicitly null. Before
+    delegating to ``_extract_summary``, ``get_summary`` raised drift here while
+    ``get_description`` returned "" for the same shape. Both now agree on "".
+    """
+    api = _make_api([[None]])
+
+    summary = await api.get_summary("nb_null_slot")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_outer_returns_empty():
+    """An empty ``outer`` (result == [[]]) returns "" — consistency win.
+
+    Regression for #1485 codex review: ``result == [[]]`` means ``result[0]``
+    is an empty list (no summary slot at all) — the same routine "no summary
+    yet" absence that ``_extract_summary`` already treated as "". ``get_summary``
+    now delegates and agrees, rather than raising drift on an empty container.
+    """
+    api = _make_api([[]])
+
+    summary = await api.get_summary("nb_empty_outer")
 
     assert summary == ""

--- a/tests/unit/test_get_summary_drift.py
+++ b/tests/unit/test_get_summary_drift.py
@@ -47,9 +47,10 @@ async def test_get_summary_happy_path_returns_string():
 @pytest.mark.asyncio
 async def test_get_summary_drift_raises_typed_error():
     """Present-but-malformed payload raises ``UnknownRPCMethodError`` (the only mode)."""
-    # result[0] is present but an empty list → the safe_index descent into
-    # result[0][0] raises IndexError. A present-but-malformed inner payload is
-    # genuine drift (distinct from a routinely-absent/None result[0]).
+    # result = [[[]]]: result[0] (== outer) is [[]] — present and non-None — but
+    # its summary slot result[0][0] is an empty list, so the safe_index descent
+    # into result[0][0][0] raises IndexError. A present-but-malformed inner
+    # payload is genuine drift (distinct from a routinely-absent/None result[0]).
     api = _make_api([[[]]])
 
     with pytest.raises(UnknownRPCMethodError) as exc_info:

--- a/tests/unit/test_notebooks_extractors.py
+++ b/tests/unit/test_notebooks_extractors.py
@@ -26,9 +26,30 @@ class TestExtractSummary:
 
         assert _extract_summary(outer) == "the summary"
 
+    def test_none_outer_returns_empty(self) -> None:
+        # Regression for #1485: a brand-new, source-less notebook has no
+        # summary, so result[0] (== outer) is None. Routine "no summary yet",
+        # NOT schema drift.
+        assert _extract_summary(None) == ""
+
+    def test_empty_outer_list_returns_empty(self) -> None:
+        # Regression for #1485: outer with no [0] slot at all is the same
+        # routine "no summary yet" state.
+        assert _extract_summary([]) == ""
+
+    def test_none_at_outer_zero_returns_empty(self) -> None:
+        # Regression for #1485: outer[0] is explicitly None (no summary slot)
+        # — routine absence, handled by the plain guard, not safe_index drift.
+        assert _extract_summary([None, [[["Q", "P"]]]]) == ""
+
+    def test_nested_summary_string_returns_string(self) -> None:
+        # outer[0][0] holds the summary string at the documented shape.
+        assert _extract_summary([["the summary"]]) == "the summary"
+
     def test_drift_missing_inner_index_raises(self) -> None:
-        # outer[0] is an empty list — outer[0][0] drifts and raises under
-        # strict decoding (the only mode).
+        # outer[0] is present but an empty list — the inner safe_index descent
+        # into outer[0][0] drifts and raises under strict decoding (the only
+        # mode). Present-but-malformed is real drift, distinct from absence.
         outer: list = [[], [[["Q", "P"]]]]
 
         with pytest.raises(UnknownRPCMethodError) as exc_info:
@@ -37,12 +58,40 @@ class TestExtractSummary:
         assert exc_info.value.source == "_notebooks._extract_summary"
 
     def test_drift_wrong_type_at_outer_zero_raises(self) -> None:
-        # outer[0] is an int — outer[0][0] raises TypeError, surfaced by
-        # safe_index as a typed drift error.
+        # outer[0] is present but an int — the inner safe_index descent into
+        # outer[0][0] raises TypeError, surfaced as a typed drift error. A
+        # present-but-malformed slot must NOT be over-suppressed as "absence".
         outer = [42, [[["Q", "P"]]]]
 
         with pytest.raises(UnknownRPCMethodError):
             _extract_summary(outer)
+
+    def test_drift_scalar_outer_raises(self) -> None:
+        # Regression for #1485 codex review: ``outer`` is itself a scalar (not
+        # None, not a list) — e.g. the server returned ``result[0] == 123``.
+        # This is present-but-malformed at the payload level, NOT the routine
+        # "no summary yet" absence, so it must raise drift rather than silently
+        # collapse to "". A `not isinstance(outer, list)` short-circuit would
+        # wrongly suppress it; the descent must reach safe_index.
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            _extract_summary(123)
+
+        assert exc_info.value.source == "_notebooks._extract_summary"
+
+    def test_drift_str_outer_raises(self) -> None:
+        # Regression for #1485 codex review (second round): a *string* outer is
+        # indexable, so a naive safe_index descent would char-index it
+        # ("abc"[0] -> "a") and silently return "a" instead of raising. A string
+        # at the outer-payload level is genuine drift, not a 1-char summary.
+        with pytest.raises(UnknownRPCMethodError):
+            _extract_summary("abc")
+
+    def test_drift_str_at_outer_zero_raises(self) -> None:
+        # And a string at outer[0] (present, non-None, but not the expected
+        # [summary_string, ...] list) is drift too — must not collapse to the
+        # first character of the string.
+        with pytest.raises(UnknownRPCMethodError):
+            _extract_summary(["summary text"])
 
 
 class TestExtractSuggestedTopics:

--- a/tests/unit/test_safe_index.py
+++ b/tests/unit/test_safe_index.py
@@ -83,6 +83,45 @@ def test_descending_into_int_is_caught_and_rerouted(monkeypatch):
     assert isinstance(exc_info.value.__cause__, TypeError)
 
 
+def test_descending_into_str_raises_drift():
+    """A str at an intermediate hop is drift, NOT a silent char index.
+
+    ``"abc"[0] == "a"`` — a string is indexable but is never a valid container
+    at an intermediate descent hop in a decoded RPC payload. Descending it would
+    smuggle a bogus 1-char "value" past drift detection. safe_index must reject
+    it as drift instead (regression for #1485 codex review).
+    """
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(["abc"], 0, 0, method_id="abc", source="test.str")
+    err = exc_info.value
+    # hop 0 descends ["abc"][0] -> "abc" (a str); hop 1 ([0]) is rejected, so
+    # the truncated path stops at (0,).
+    assert err.path == (0,)
+    assert err.source == "test.str"
+    assert err.data_at_failure is not None
+    assert "abc" in err.data_at_failure
+
+
+def test_descending_into_top_level_str_raises_drift():
+    """A str passed directly as ``data`` (descended at hop 0) is drift."""
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index("abc", 0, method_id="abc", source="test.top_str")
+    assert exc_info.value.path == ()
+
+
+def test_descending_into_bytes_raises_drift():
+    """bytes is also indexable-but-not-a-container; reject it as drift too."""
+    with pytest.raises(UnknownRPCMethodError):
+        safe_index([b"abc"], 0, 0, method_id="abc", source="test.bytes")
+
+
+def test_str_leaf_value_is_returned_not_rejected():
+    """A str as the *final* leaf is fine — only intermediate hops are checked."""
+    assert safe_index([["leaf"]], 0, 0, method_id="abc", source="test.leaf") == "leaf"
+    # And a bare string with no descent is returned untouched.
+    assert safe_index("leaf", method_id="abc", source="test.no_descent") == "leaf"
+
+
 def test_strict_mode_exception_is_catchable_as_rpc_error(monkeypatch):
     """Backward compat: ``except RPCError`` still catches strict-mode raise."""
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -103,22 +103,28 @@ def test_qa_pairs_raises_on_unguarded_shape():
 async def test_summary_raises_on_indexerror_drift():
     """_notebooks.py: summary extraction raises when result[0][0][0] drifts.
 
-    This site was migrated to ``safe_index``; under strict decoding (the only
-    mode) a drifted response raises ``UnknownRPCMethodError`` carrying the
-    call-site label ``source='_notebooks.get_summary'``.
+    ``get_summary`` delegates the descent to ``_extract_summary`` (the single
+    source of truth shared with ``get_description`` — #1485), so under strict
+    decoding (the only mode) a *present-but-malformed* response raises
+    ``UnknownRPCMethodError`` carrying the helper label
+    ``source='_notebooks._extract_summary'``. A genuinely-absent summary
+    (None / empty / null slot) returns "" instead and is covered in
+    ``test_get_summary_drift.py``.
     """
     from _fixtures.fake_core import make_fake_core
     from notebooklm._notebooks import NotebooksAPI
 
     api = NotebooksAPI.__new__(NotebooksAPI)
-    # result[0] is an empty list → result[0][0] raises IndexError.
-    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[]]))
+    # result[0] == [42]: the summary slot is present and non-None but holds an
+    # int, so the inner result[0][0][0] descent raises TypeError — genuine
+    # drift, distinct from a routinely-absent summary.
+    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[42]]))
     api._rpc = mock_core
 
     with pytest.raises(UnknownRPCMethodError) as exc_info:
         await api.get_summary("nb_summary")
 
-    assert exc_info.value.source == "_notebooks.get_summary"
+    assert exc_info.value.source == "_notebooks._extract_summary"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Fixes #1485. A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC returns an absent/`None` `result[0]` payload. The extraction helpers descended straight into that slot with `safe_index`, so the routine "no summary yet" state raised `UnknownRPCMethodError` ("safe_index drift") — breaking `client.notebooks.get_summary()`, `get_description()`, the CLI `summary` command, and the MCP `notebook_describe` path for **any** empty notebook.

## Approach

Distinguish genuine **absence** from genuine **drift**, and unify the two entry points:

- **`_extract_summary`** — short-circuit to `""` only for `outer is None`, an empty `outer` list, or `outer[0] is None` (the routine "no summary yet" shapes). Everything else descends via `safe_index(outer, 0, 0)`: a scalar `outer`, or a non-`None` `outer[0]` that isn't the expected `[summary_string, ...]` list, is present-but-malformed and still **raises** drift. (Earlier this over-suppressed a scalar/string `outer` to `""`.)
- **`get_summary`** now delegates to `_extract_summary(result[0])`, so it and `get_description` resolve `result[0][0][0]` identically — **single source of truth**. Both agree on every shape: `None`/`[]`/`[None]`/`[[]]`/`[[None]]` → `""`; malformed/scalar/string → raise.
- **`safe_index`** rejects a `str`/`bytes`/`bytearray` value at an **intermediate** descent hop. A string is indexable but never a valid container in a decoded RPC payload, so descending it (`"abc"[0] → "a"`) would smuggle a single character past drift detection. A string **leaf** (the returned final value) is unaffected. This hardens the shared primitive for all 45 call sites (aligns with #1377).

## Tests

| Shape | `get_summary` / `get_description` |
|---|---|
| `None`, `[]`, `[None]`, `[[]]`, `[[None]]` (absence) | `""` |
| `[["the summary"]]` (happy) | `"the summary"` |
| `[[]]`-inner, `[42]`, scalar `123`, `"abc"`, `["summary"]` (malformed) | **raise** `UnknownRPCMethodError` |

- `tests/unit/test_safe_index.py` — str/bytes intermediate hops raise; str leaf returned untouched.
- `tests/unit/test_notebooks_extractors.py`, `tests/unit/test_get_summary_drift.py`, `tests/unit/test_swallow_observability.py`, `tests/integration/test_notebooks_integration.py` — full absence/drift/consistency matrix.

## Verification

- Full suite green (8550 passed; the only failure is the pre-existing, gitignored `.sisyphus/` ADR-format lint that CI never sees). mypy + ruff clean. All 738 repo_lint gates pass.
- API-compat audit `EXIT=0`, **zero** allowlist additions — not an API-breaking change.
- Polished: claude + codex review, both rounds of codex findings (scalar over-suppression, then the `safe_index` string hole) addressed; codex final verdict **RESOLVED**.

Closes #1485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or missing notebook summaries now return an empty string instead of causing an error.
  * Detection of malformed summary payloads is stricter (e.g., rejects unexpected string/byte-like structures), so only truly malformed responses raise errors.

* **Tests**
  * Expanded edge-case coverage to validate absent vs. malformed summaries and the stricter payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->