### PR TITLE
fix(download): drop redundant second LIST_ARTIFACTS + make cli_vcr tests assert real success (#1488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shape. As part of the fix, `safe_index` rejects a `str`/`bytes` value at an
   intermediate descent hop (it is indexable but never a valid container, so
   descending it would smuggle a single character past drift detection).
+- **`download <type>` no longer exits 1 with no file written** (#1488). The
+  download path listed artifacts twice — the executor listed to select the
+  target, then each per-type download re-listed to re-find it by id — so the
+  second `LIST_ARTIFACTS` could not replay against a single-interaction VCR
+  cassette and aborted the download. The executor now lists once and threads
+  the already-fetched rows into the download method (which skips its redundant
+  second list); studio downloads also no longer trigger the note-backed
+  mind-map sub-fetch they never needed. Live behavior is unchanged for direct
+  `client.artifacts.download_*()` calls.
 
 ## [0.8.0]
 

--- a/src/notebooklm/_app/download.py
+++ b/src/notebooklm/_app/download.py
@@ -524,7 +524,10 @@ async def _fetch_artifacts_once(
     """
     list_for_download = getattr(facade.artifacts, "_list_for_download", None)
     if list_for_download is not None:
-        all_artifacts, raw_studio_rows, mind_map_rows = await list_for_download(notebook_id)
+        # spec.kind => skip the mind-map sub-fetch for non-mind-map downloads (#1488 review).
+        all_artifacts, raw_studio_rows, mind_map_rows = await list_for_download(
+            notebook_id, spec.kind
+        )
     else:
         all_artifacts = await facade.artifacts.list(notebook_id)
 

--- a/src/notebooklm/_app/download.py
+++ b/src/notebooklm/_app/download.py
@@ -502,25 +502,63 @@ def build_download_plan(
 # ---------------------------------------------------------------------------
 
 
-async def _get_completed_artifacts_as_dicts(
+async def _fetch_artifacts_once(
     facade: _DownloadFacade, notebook_id: str, spec: DownloadTypeSpec
-) -> list[ArtifactDict]:
-    """Fetch artifacts, filter by kind + completion, project to ArtifactDict.
+) -> tuple[list[ArtifactDict], dict[str, Any]]:
+    """List artifacts once; return ``(selection_dicts, prefetch_kwargs)`` (issue #1488).
 
-    The ``isinstance(a, Artifact)`` guard mirrors the legacy implementation and
-    protects against a heterogeneous list with stub entries that don't expose
-    the ``kind`` / ``is_completed`` properties.
+    ``execute_download`` lists a single time to select the target, then threads
+    the raw rows it already fetched into the per-type ``download_<x>`` (as the
+    returned ``prefetch_kwargs``) so that method skips its redundant second list
+    RPC. The prefetch kwarg(s) match the bound method: quiz/flashcards →
+    ``artifacts`` (the matching-kind typed list); mind-map → ``mind_maps``
+    (note-backed rows) + ``artifacts_data`` (raw studio rows, interactive branch);
+    other studio types → ``artifacts_data``.
+
+    The single-pass ``_list_for_download`` facade seam (``list`` + raw rows) is
+    used when present. When it is absent — a narrow test double exposing only
+    ``.list()`` — we list for selection but thread **no** prefetch kwargs, so
+    each ``download_<x>`` self-fetches exactly as before (and an old-style
+    ``download_<x>`` lacking the new kwargs keeps working). The ``isinstance``
+    guard tolerates stub entries lacking ``kind``/``is_completed``.
     """
-    all_artifacts = await facade.artifacts.list(notebook_id)
-    return [
+    list_for_download = getattr(facade.artifacts, "_list_for_download", None)
+    if list_for_download is not None:
+        all_artifacts, raw_studio_rows, mind_map_rows = await list_for_download(notebook_id)
+    else:
+        all_artifacts = await facade.artifacts.list(notebook_id)
+
+    typed = [
+        a
+        for a in all_artifacts
+        if isinstance(a, Artifact) and a.kind == spec.kind and a.is_completed
+    ]
+    dicts: list[ArtifactDict] = [
         {
             "id": a.id,
             "title": a.title,
             "created_at": int(a.created_at.timestamp()) if a.created_at else 0,
         }
-        for a in all_artifacts
-        if isinstance(a, Artifact) and a.kind == spec.kind and a.is_completed
+        for a in typed
     ]
+
+    # No single-pass seam: thread nothing so each download_<x> self-fetches as
+    # before (binding ``...=[]`` would suppress that and break old-style fakes).
+    if list_for_download is None:
+        return dicts, {}
+
+    if spec.kind in (ArtifactType.QUIZ, ArtifactType.FLASHCARDS):
+        prefetch: dict[str, Any] = {"artifacts": typed}
+    elif spec.kind == ArtifactType.MIND_MAP:
+        # ``None`` => note-backed sub-fetch failed: thread None so
+        # download_mind_map self-fetches and raises as the standalone path would.
+        prefetch = {
+            "mind_maps": None if mind_map_rows is None else list(mind_map_rows),
+            "artifacts_data": list(raw_studio_rows),
+        }
+    else:
+        prefetch = {"artifacts_data": list(raw_studio_rows)}
+    return dicts, prefetch
 
 
 def _resolve_conflict(
@@ -546,29 +584,33 @@ def _resolve_conflict(
     return path, None
 
 
-def _bind_download_fn(plan: DownloadPlan, facade: _DownloadFacade) -> _DownloadFn:
-    """Bind the spec's ``download_attr`` coroutine, partialing the format kwarg
-    when the spec requests it.
+def _bind_download_fn(
+    plan: DownloadPlan,
+    facade: _DownloadFacade,
+    prefetch_kwargs: dict[str, Any] | None = None,
+) -> _DownloadFn:
+    """Bind ``download_attr``, partialing the format + prefetch kwargs.
 
-    Three branches:
-
-    - No ``format_kwarg`` (audio/video/report/mind-map/data-table/infographic
-      and the slide-deck ``--format pdf`` default): use the bare attr.
-    - ``forward_format_only_if_set`` AND the user picked the non-default
-      (slide-deck pptx): partial-bind with the format kwarg.
-    - Always-forward (quiz/flashcards): partial-bind regardless.
+    The format kwarg is forwarded unless absent or it is slide-deck's pdf default
+    (``forward_format_only_if_set`` forwards only the non-default pptx);
+    quiz/flashcards always forward it. ``prefetch_kwargs`` (issue #1488) carries
+    the already-fetched rows so the bound method skips its redundant second list
+    RPC. Both are partial-bound here, so ``_execute_download_*`` stays unchanged.
     """
     spec = plan.spec
     base_fn = getattr(facade.artifacts, spec.download_attr, None)
     if base_fn is None:
         raise ValueError(f"Unknown artifact download method: {spec.download_attr}")
-    if not spec.format_kwarg:
+
+    bound_kwargs: dict[str, Any] = dict(prefetch_kwargs or {})
+    if spec.format_kwarg and not (
+        spec.forward_format_only_if_set and plan.format_choice == spec.format_default
+    ):
+        bound_kwargs[spec.format_kwarg] = plan.format_choice
+
+    if not bound_kwargs:
         return base_fn
-    if spec.forward_format_only_if_set:
-        if plan.format_choice == spec.format_default:
-            return base_fn
-        return partial(base_fn, **{spec.format_kwarg: plan.format_choice})
-    return partial(base_fn, **{spec.format_kwarg: plan.format_choice})
+    return partial(base_fn, **bound_kwargs)
 
 
 async def _execute_download_all(
@@ -822,9 +864,12 @@ async def execute_download(
     """
     nb_id_resolved = await notebook_resolver(plan.notebook_id)
 
-    download_fn = _bind_download_fn(plan, facade)
+    # List ONCE; thread the raw rows into the bound download method so it does
+    # not re-issue the same list RPC (issue #1488).
+    type_artifacts, prefetch_kwargs = await _fetch_artifacts_once(facade, nb_id_resolved, plan.spec)
 
-    type_artifacts = await _get_completed_artifacts_as_dicts(facade, nb_id_resolved, plan.spec)
+    download_fn = _bind_download_fn(plan, facade, prefetch_kwargs)
+
     if not type_artifacts:
         return DownloadResult(
             outcome=DownloadOutcome.NO_ARTIFACTS,

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -48,6 +48,14 @@ _TRUSTED_DOWNLOAD_DOMAINS = (".google.com", ".googleusercontent.com", ".googleap
 # a brief read stall. 8 slots × 64 KiB ≈ 512 KiB of in-flight buffering.
 _DOWNLOAD_WRITER_QUEUE_SIZE = 8
 
+# ``_PREFETCH_NOTE`` — referenced by the per-method docstrings below. Each
+# ``download_<x>`` accepts an optional pre-fetched list (``artifacts_data`` raw
+# studio rows / ``artifacts`` typed list / ``mind_maps`` note-backed rows). When
+# supplied — the ``_app`` executor lists once to select the target and threads
+# what it already fetched — the method skips its own otherwise-redundant second
+# ``LIST_ARTIFACTS`` / ``GET_NOTES_AND_MIND_MAPS`` RPC; ``None`` re-lists as before
+# (issue #1488).
+
 
 async def _await_writer_exit(
     writer_thread: threading.Thread,
@@ -250,10 +258,16 @@ class ArtifactDownloadService:
         return tree_json if isinstance(tree_json, str) else None
 
     async def download_audio(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download an Audio Overview to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download an Audio Overview to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         audio_art = self._select_artifact(
             artifacts_data,
@@ -282,10 +296,16 @@ class ArtifactDownloadService:
         return await self.download_url(url, output_path)
 
     async def download_video(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a Video Overview to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a Video Overview to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         # Note: distinct error keys preserved — specific-ID miss raises
         # "video" (from type_name="Video"); empty-list raises
@@ -317,10 +337,16 @@ class ArtifactDownloadService:
         return await self.download_url(url, output_path)
 
     async def download_infographic(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download an Infographic to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download an Infographic to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         info_art = self._select_artifact(
             artifacts_data,
@@ -354,12 +380,15 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "pdf",
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a slide deck as PDF or PPTX."""
+        """Download a slide deck as PDF or PPTX (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
         if output_format not in ("pdf", "pptx"):
             raise ValidationError(f"Invalid format '{output_format}'. Must be 'pdf' or 'pptx'.")
 
-        artifacts_data = await self._list_raw(notebook_id)
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         slide_art = self._select_artifact(
             artifacts_data,
@@ -401,8 +430,15 @@ class ArtifactDownloadService:
         artifact_id: str | None,
         output_format: str,
         artifact_type: str,
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
-        """Download quiz or flashcard artifact."""
+        """Download quiz or flashcard artifact.
+
+        ``artifacts`` is the optional pre-fetched *typed* list of the matching
+        ``list_type`` (see ``_PREFETCH_NOTE``); this method still filters it to
+        completed entries and id-matches within it.
+        """
         valid_formats = ("json", "markdown", "html")
         if output_format not in valid_formats:
             raise ValidationError(
@@ -413,7 +449,8 @@ class ArtifactDownloadService:
         default_title = "Untitled Quiz" if is_quiz else "Untitled Flashcards"
         list_type = ArtifactType.QUIZ if is_quiz else ArtifactType.FLASHCARDS
 
-        artifacts = await self._list_artifacts(notebook_id, list_type)
+        if artifacts is None:
+            artifacts = await self._list_artifacts(notebook_id, list_type)
         completed = [a for a in artifacts if a.is_completed]
         if not completed:
             raise ArtifactNotReadyError(artifact_type)
@@ -456,9 +493,12 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a report artifact as markdown."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a report artifact as markdown (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         report_art = self._select_artifact(
             artifacts_data,
@@ -500,14 +540,23 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        mind_maps: list[Any] | None = None,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a mind map as JSON (note-backed or interactive kind)."""
+        """Download a mind map as JSON (note-backed or interactive kind).
+
+        ``mind_maps`` (note-backed rows) and ``artifacts_data`` (raw studio rows,
+        used only by the interactive-mind-map branch) are optional pre-fetched
+        lists; see ``_PREFETCH_NOTE``. Each is fetched on demand when ``None``.
+        """
         mind_maps_service = self._mind_maps
 
         # Fetch the note-backed list first: it is the primary backing for this
         # method, so an explicit id that resolves here (the happy path) avoids
         # the extra _list_raw artifact-collection network call entirely.
-        mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
+        if mind_maps is None:
+            mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
 
         # The JSON tree string to write — sourced from the note content for
         # note-backed maps, or from GET_INTERACTIVE_HTML for interactive ones.
@@ -525,9 +574,13 @@ class ArtifactDownloadService:
                 # The id is not a note-backed mind map. Interactive
                 # (studio-artifact) mind maps live in the artifact collection,
                 # not the note-backed list — fetch the tree there so both kinds
-                # download to the same JSON shape (issue #1256).
+                # download to the same JSON shape (issue #1256). Reuse the
+                # caller-provided ``artifacts_data`` when present to avoid a
+                # redundant second ``LIST_ARTIFACTS``.
+                if artifacts_data is None:
+                    artifacts_data = await self._list_raw(notebook_id)
                 interactive = False
-                for row in await self._list_raw(notebook_id):
+                for row in artifacts_data:
                     if not isinstance(row, list):
                         continue
                     artifact = Artifact.from_api_response(row)
@@ -581,9 +634,12 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a data table as CSV."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a data table as CSV (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         table_art = self._select_artifact(
             artifacts_data,
@@ -626,10 +682,12 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
         """Download quiz questions."""
         return await self.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "quiz"
+            notebook_id, output_path, artifact_id, output_format, "quiz", artifacts=artifacts
         )
 
     async def download_flashcards(
@@ -638,10 +696,12 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
         """Download flashcard deck."""
         return await self.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "flashcards"
+            notebook_id, output_path, artifact_id, output_format, "flashcards", artifacts=artifacts
         )
 
     async def download_urls_batch(self, urls_and_paths: list[tuple[str, str]]) -> DownloadResult:

--- a/src/notebooklm/_artifact/listing.py
+++ b/src/notebooklm/_artifact/listing.py
@@ -133,27 +133,63 @@ class ArtifactListingService:
         list_mind_maps: ListMindMapsCallback,
     ) -> list[Artifact]:
         """List public artifacts from studio rows plus mind-map rows."""
-        artifacts = self._filter_studio_artifacts(await list_raw(notebook_id), artifact_type)
+        artifacts, _raw, _mm = await self.list_artifacts_with_raw(
+            notebook_id,
+            artifact_type,
+            list_raw=list_raw,
+            list_mind_maps=list_mind_maps,
+        )
+        return artifacts
 
+    async def list_artifacts_with_raw(
+        self,
+        notebook_id: str,
+        artifact_type: ArtifactType | None,
+        *,
+        list_raw: ListRawCallback,
+        list_mind_maps: ListMindMapsCallback,
+    ) -> tuple[list[Artifact], list[Any], list[Any] | None]:
+        """List artifacts *and* return the raw rows fetched to build them.
+
+        Returns ``(typed_artifacts, raw_studio_rows, mind_map_rows)`` from a
+        single pass over each backing RPC. The download executor uses this to
+        select a target from the typed list while threading the raw rows it
+        already fetched into the per-type ``download_<x>`` method — so that
+        method does not re-issue ``LIST_ARTIFACTS`` / ``GET_NOTES_AND_MIND_MAPS``
+        (issue #1488). The typed projection / merge / partial-availability policy
+        is identical to :meth:`list_artifacts`, which now delegates here.
+
+        ``mind_map_rows`` is the raw note-backed list when the mind-map sub-fetch
+        ran (``artifact_type`` is ``None`` or ``MIND_MAP``) and succeeded — ``[]``
+        included, meaning "fetched, genuinely no mind maps". It is ``None`` when
+        the sub-fetch's transport failed (``RPCError`` / ``HTTPError``): a
+        distinct "fetch failed, value unknown" sentinel so a caller threading it
+        into ``download_mind_map`` passes ``None`` and the method re-fetches (and
+        surfaces the error) rather than mistaking the outage for "no mind maps".
+        It is also ``[]`` when the sub-fetch was skipped (a specific non-mind-map
+        ``artifact_type``); that list is never threaded to ``download_mind_map``.
+        """
+        raw_studio_rows = await list_raw(notebook_id)
+        artifacts = self._filter_studio_artifacts(raw_studio_rows, artifact_type)
+
+        mind_map_rows: list[Any] | None = []
         if artifact_type is None or artifact_type == ArtifactType.MIND_MAP:
             try:
-                artifacts.extend(
-                    self._filter_mind_map_artifacts(
-                        await list_mind_maps(notebook_id),
-                        artifact_type,
-                    )
-                )
+                mind_map_rows = await list_mind_maps(notebook_id)
+                artifacts.extend(self._filter_mind_map_artifacts(mind_map_rows, artifact_type))
             except DecodingError:
                 # Schema drift is not a transient outage: surface it (#1344)
                 # rather than masking drifted mind-map rows as "no mind maps".
                 raise
             except (RPCError, httpx.HTTPError) as e:
-                # Network/API errors - log and continue with studio artifacts.
-                # This ensures users can see audio/video/reports even if the
-                # mind-map endpoint is temporarily unavailable.
+                # Network/API errors - log and continue with studio artifacts so
+                # users still see audio/video/reports when the mind-map endpoint
+                # is temporarily unavailable. Use ``None`` (not ``[]``) as the
+                # "fetch failed" sentinel so a downstream caller re-fetches.
+                mind_map_rows = None
                 logger.warning("Failed to fetch mind maps: %s", e)
 
-        return artifacts
+        return artifacts, raw_studio_rows, mind_map_rows
 
     async def get(
         self,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -196,6 +196,18 @@ class ArtifactsAPI:
             list_mind_maps=self._list_mind_maps,
         )
 
+    async def _list_for_download(
+        self, notebook_id: str, artifact_type: ArtifactType | None = None
+    ) -> tuple[builtins.list[Artifact], builtins.list[Any], builtins.list[Any] | None]:
+        """List artifacts + the raw rows fetched to build them — same RPC set as
+        :meth:`list`. Internal seam for the ``_app`` download executor (#1488)."""
+        return await self._listing.list_artifacts_with_raw(
+            notebook_id,
+            artifact_type,
+            list_raw=self._list_raw,
+            list_mind_maps=self._list_mind_maps,
+        )
+
     async def get(self, notebook_id: str, artifact_id: str) -> Artifact:
         """Get a specific artifact by ID.
 
@@ -756,22 +768,43 @@ class ArtifactsAPI:
     # =========================================================================
 
     async def download_audio(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download an Audio Overview to a file."""
-        return await self._downloads.download_audio(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_audio(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_video(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a Video Overview to a file."""
-        return await self._downloads.download_video(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_video(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_infographic(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download an Infographic to a file."""
-        return await self._downloads.download_infographic(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_infographic(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_slide_deck(
         self,
@@ -779,10 +812,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "pdf",
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a slide deck as PDF or PPTX."""
         return await self._downloads.download_slide_deck(
-            notebook_id, output_path, artifact_id, output_format
+            notebook_id, output_path, artifact_id, output_format, artifacts_data=artifacts_data
         )
 
     async def _download_interactive_artifact(
@@ -792,10 +827,12 @@ class ArtifactsAPI:
         artifact_id: str | None,
         output_format: str,
         artifact_type: str,
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download quiz or flashcard artifact."""
         return await self._downloads.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, artifact_type
+            notebook_id, output_path, artifact_id, output_format, artifact_type, artifacts=artifacts
         )
 
     def _format_interactive_content(
@@ -831,27 +868,44 @@ class ArtifactsAPI:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a report artifact as markdown."""
-        return await self._downloads.download_report(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_report(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_mind_map(
         self,
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        mind_maps: builtins.list[Any] | None = None,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a mind map as JSON."""
-        return await self._downloads.download_mind_map(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_mind_map(
+            notebook_id,
+            output_path,
+            artifact_id,
+            mind_maps=mind_maps,
+            artifacts_data=artifacts_data,
+        )
 
     async def download_data_table(
         self,
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a data table as CSV."""
-        return await self._downloads.download_data_table(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_data_table(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_quiz(
         self,
@@ -859,10 +913,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download quiz questions."""
         return await self._download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "quiz"
+            notebook_id, output_path, artifact_id, output_format, "quiz", artifacts=artifacts
         )
 
     async def download_flashcards(
@@ -871,10 +927,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download flashcard deck."""
         return await self._download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "flashcards"
+            notebook_id, output_path, artifact_id, output_format, "flashcards", artifacts=artifacts
         )
 
     # =========================================================================

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -63,11 +63,19 @@ MODULE_SIZE_BUDGET = 900
 # DO lower a ceiling when a module shrinks (the gate will tell you the value).
 ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/source_cmd.py": 964,
+    # _artifacts.py + _artifact/downloads.py: raised for the #1488 double-list
+    # fix, which threads an optional pre-fetched-list kwarg through every
+    # ``download_<x>`` method (and its public ``ArtifactsAPI`` delegate) plus the
+    # new ``_list_for_download`` seam so the download path issues ONE list RPC
+    # instead of two. The growth is the keyword-only params + ``is None`` guards
+    # on existing methods (ruff one-param-per-line wraps each 6-param signature);
+    # it is irreducible without splitting these modules, which is out of scope for
+    # the bug fix. New ceilings are the measured post-fix LOC.
     "exceptions.py": 1515,
-    "_artifacts.py": 1393,
+    "_artifacts.py": 1451,
     "_source/upload.py": 1236,
     "_sources.py": 1007,
-    "_artifact/downloads.py": 973,
+    "_artifact/downloads.py": 1033,
     "client.py": 993,
     "_research.py": 936,
     "_chat/api.py": 955,

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -138,12 +138,19 @@ def mock_auth_for_vcr():
         yield
 
 
-def assert_command_success(result, *, allow_no_context: bool = True) -> None:
-    """Assert a CLI command completed without crashing.
+def assert_command_success(result, *, allow_no_context: bool = False) -> None:
+    """Assert a CLI command completed successfully (exit 0).
+
+    The default is **strict** (``exit_code == 0``): a permissive default that
+    accepted exit 1 "for any reason" silently masked a genuinely-broken command
+    (issue #1488: the download flow exited 1 with no file written, yet passed).
+    Callers that legitimately expect a no-notebook-context exit-1 path opt in
+    explicitly via ``allow_no_context=True``.
 
     Args:
         result: The CliRunner result object.
-        allow_no_context: If True, exit code 1 (no notebook context) is acceptable.
+        allow_no_context: If True, exit code 1 (e.g. no notebook context) is
+            also acceptable. Opt-in per call site, not the default.
     """
     acceptable_codes = (0, 1) if allow_no_context else (0,)
     assert result.exit_code in acceptable_codes, f"Command failed: {result.output}"

--- a/tests/integration/cli_vcr/test_downloads.py
+++ b/tests/integration/cli_vcr/test_downloads.py
@@ -11,7 +11,6 @@ from notebooklm.notebooklm_cli import cli
 
 from ._fixtures import ARTIFACT_NOTEBOOK_ID, VCR_READONLY_NOTEBOOK_ID
 from .conftest import (
-    assert_command_success,
     notebooklm_vcr,
     skip_no_cassettes,
 )
@@ -50,7 +49,18 @@ class TestDownloadCommands:
         cassette,
         extra_args,
     ):
-        """Download commands work with real client."""
+        """Download commands genuinely succeed: exit 0 AND the file is written.
+
+        Each ``artifacts_download_*.yaml`` cassette records a *single*
+        ``LIST_ARTIFACTS`` (/ ``GET_NOTES_AND_MIND_MAPS``) interaction. Before
+        issue #1488 the command listed artifacts twice (once in the ``_app``
+        executor to select, once inside ``download_<x>`` to re-find), so the
+        second list hit no recorded interaction and the command exited 1 with no
+        file written — which the old ``assert_command_success`` (``allow_no_context``
+        default) masked. These assertions now fail loud if the download regresses:
+        a re-introduced double-list would exit 1 (caught by ``== 0``) and write
+        nothing (caught by ``output_file.exists()``).
+        """
         output_file = tmp_path / filename
         with notebooklm_vcr.use_cassette(cassette):
             result = runner.invoke(
@@ -64,27 +74,31 @@ class TestDownloadCommands:
                     str(output_file),
                 ],
             )
-            assert_command_success(result)
+            assert result.exit_code == 0, f"Command failed: {result.output}"
+            assert output_file.exists(), f"Output file not written: {result.output}"
 
     def test_download_mind_map_interactive(self, runner, mock_auth_for_vcr, mock_context, tmp_path):
         """`download mind-map <interactive_id>` exports the interactive map's tree.
 
         Reuses the interactive recording (``mind_maps_interactive.yaml``,
         ``ARTIFACT_NOTEBOOK_ID`` / artifact ``47523923``) captured for the
-        API-level ``client.mind_maps`` tests. The CLI download flow lists studio
-        artifacts twice — once to resolve the id, once inside
-        ``download_mind_map`` — so the ``LIST_ARTIFACTS`` interaction must be
-        replayable (``allow_playback_repeats``). The tree itself comes from the
-        real ``GET_INTERACTIVE_HTML`` (``[0][9][3]``) response in the cassette
+        API-level ``client.mind_maps`` tests. The CLI download flow now lists
+        studio artifacts only **once** — the ``_app`` executor selects the id and
+        threads the already-fetched raw rows into ``download_mind_map`` so its
+        interactive branch does not re-list (issue #1488) — so the single
+        recorded ``LIST_ARTIFACTS`` interaction replays without
+        ``allow_playback_repeats``. The tree itself comes from the real
+        ``GET_INTERACTIVE_HTML`` (``[0][9][3]``) response in the cassette
         (issue #1256).
         """
         nb = ARTIFACT_NOTEBOOK_ID
         art_id = "47523923"
         output_file = tmp_path / "interactive_mindmap.json"
-        with notebooklm_vcr.use_cassette("mind_maps_interactive.yaml", allow_playback_repeats=True):
+        with notebooklm_vcr.use_cassette("mind_maps_interactive.yaml"):
             result = runner.invoke(
                 cli, ["download", "mind-map", "-n", nb, "-a", art_id, str(output_file)]
             )
-            assert_command_success(result)
+            assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert output_file.exists(), f"Output file not written: {result.output}"
         data = json.loads(output_file.read_text(encoding="utf-8"))
         assert "name" in data  # a {"name", "children"} mind-map node tree

--- a/tests/integration/cli_vcr/test_notebooks.py
+++ b/tests/integration/cli_vcr/test_notebooks.py
@@ -42,8 +42,7 @@ class TestSummaryCommand:
     def test_summary(self, runner, mock_auth_for_vcr, mock_context):
         """Summary command shows notebook summary."""
         result = runner.invoke(cli, ["summary"])
-        # allow_no_context=True: cassette may not match mock notebook ID
-        assert_command_success(result)
+        assert_command_success(result)  # strict: the summary command exits 0
 
 
 class TestStatusCommand:

--- a/tests/unit/app/test_app_download.py
+++ b/tests/unit/app/test_app_download.py
@@ -424,6 +424,11 @@ def _make_facade(*, artifacts: list, download_return: str | None = "/out/path") 
     facade = MagicMock()
     facade.artifacts = MagicMock()
     facade.artifacts.list = AsyncMock(return_value=artifacts)
+    # The executor lists once via ``_list_for_download`` (``list`` + raw rows;
+    # issue #1488). On a bare MagicMock this would auto-spawn a non-awaitable
+    # child; wire it to return the typed list plus empty raw rows (the mocked
+    # ``download_<x>`` never consumes the raw rows here).
+    facade.artifacts._list_for_download = AsyncMock(return_value=(artifacts, [], []))
     facade.artifacts.download_audio = AsyncMock(return_value=download_return)
     facade.artifacts.download_slide_deck = AsyncMock(return_value=download_return)
     facade.artifacts.download_quiz = AsyncMock(return_value=download_return)
@@ -681,7 +686,7 @@ class TestExecuteDownload:
         )
         call_count = {"n": 0}
 
-        async def fake_download(_nb, output_path, artifact_id=None):
+        async def fake_download(_nb, output_path, artifact_id=None, **_kwargs):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise RuntimeError("boom")
@@ -735,8 +740,10 @@ class TestExecuteDownload:
             artifact_resolver=_artifact_resolver_identity,
         )
         resolver.assert_awaited_once_with("nb_partial")
-        # The resolved id flows into the artifacts.list() call.
-        facade.artifacts.list.assert_awaited_once_with("resolved_nb")
+        # The resolved id flows into the single ``_list_for_download`` call — the
+        # executor lists once and threads the raw rows down (#1488), so it no
+        # longer goes through the plain ``artifacts.list`` seam.
+        facade.artifacts._list_for_download.assert_awaited_once_with("resolved_nb")
 
     @pytest.mark.asyncio
     async def test_artifact_resolver_used_for_partial_id(self, tmp_path):
@@ -757,6 +764,46 @@ class TestExecuteDownload:
         )
         resolver.assert_called_once()
         assert result.outcome is DownloadOutcome.SINGLE_DOWNLOADED
+
+    @pytest.mark.asyncio
+    async def test_fallback_without_seam_threads_no_prefetch(self, tmp_path):
+        """A narrow facade exposing only ``.list()`` (no ``_list_for_download``)
+        gets NO prefetch kwargs, so the bound ``download_<x>`` self-fetches as
+        before. Regression for #1488: the seam-absent fallback must not bind
+        ``artifacts_data=[]`` — that would suppress the method's self-fetch (it
+        only fetches on ``is None``) and break an old-style ``download_<x>``
+        whose signature lacks the new keyword-only param.
+        """
+        artifacts = [_make_artifact("audio_1", "Only One")]
+        facade = MagicMock()
+        # ``spec`` restricts the attribute set so
+        # ``getattr(facade.artifacts, "_list_for_download", None)`` is ``None``,
+        # exercising the fallback branch; ``download_audio`` takes no prefetch kwarg.
+        facade.artifacts = MagicMock(spec=["list", "download_audio"])
+        facade.artifacts.list = AsyncMock(return_value=artifacts)
+        facade.artifacts.download_audio = AsyncMock(return_value="/out/audio.mp3")
+
+        plan = build_download_plan(
+            _AUDIO_SPEC,
+            {"notebook_id": "nb_1", "artifact_id": "audio_1"},
+            cwd=tmp_path,
+        )
+        result = await execute_download(
+            plan,
+            facade,
+            notebook_resolver=_passthrough_notebook_resolver(),
+            artifact_resolver=_artifact_resolver_identity,
+        )
+
+        assert result.outcome is DownloadOutcome.SINGLE_DOWNLOADED
+        # Selection used the plain ``.list()`` seam (the only one available)...
+        facade.artifacts.list.assert_awaited_once_with("nb_1")
+        # ...and the bound download fn received NO prefetch kwarg, so it would
+        # self-fetch (rather than being handed an empty list).
+        _args, kwargs = facade.artifacts.download_audio.call_args
+        assert "artifacts_data" not in kwargs
+        assert "artifacts" not in kwargs
+        assert "mind_maps" not in kwargs
 
 
 def test_format_extensions_map_contract():

--- a/tests/unit/app/test_app_download.py
+++ b/tests/unit/app/test_app_download.py
@@ -742,8 +742,10 @@ class TestExecuteDownload:
         resolver.assert_awaited_once_with("nb_partial")
         # The resolved id flows into the single ``_list_for_download`` call — the
         # executor lists once and threads the raw rows down (#1488), so it no
-        # longer goes through the plain ``artifacts.list`` seam.
-        facade.artifacts._list_for_download.assert_awaited_once_with("resolved_nb")
+        # longer goes through the plain ``artifacts.list`` seam. Assert awaited
+        # first, then the first positional arg (a ``spec.kind`` arg follows it).
+        facade.artifacts._list_for_download.assert_awaited_once()
+        assert facade.artifacts._list_for_download.call_args[0][0] == "resolved_nb"
 
     @pytest.mark.asyncio
     async def test_artifact_resolver_used_for_partial_id(self, tmp_path):

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -399,6 +399,19 @@ def create_mock_client():
     mock_client.artifacts.list = AsyncMock(side_effect=make_artifact_list)
     mock_client.notes.list = AsyncMock(side_effect=make_note_list)
 
+    # The ``_app`` download executor prefers the ``_list_for_download`` seam
+    # (``list`` + raw rows in one RPC pass; issue #1488). On a bare ``MagicMock``
+    # this attribute would auto-spawn a non-awaitable child mock, so wire it to
+    # delegate to the (possibly test-overridden) ``artifacts.list`` and return
+    # the ``(typed, raw_studio_rows, mind_map_rows)`` tuple the executor expects.
+    # Empty raw rows are correct for these doubles: ``download_<x>`` is itself
+    # mocked, so its (now-suppressed) inner re-list never runs.
+    async def _list_for_download(notebook_id, artifact_type=None):
+        typed = await mock_client.artifacts.list(notebook_id)
+        return typed, [], []
+
+    mock_client.artifacts._list_for_download = AsyncMock(side_effect=_list_for_download)
+
     return mock_client
 
 

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -115,7 +115,7 @@ class TestDownloadStandardTypes:
         mock_client = create_mock_client()
         output_target = tmp_path / output_name
 
-        async def mock_download(notebook_id, output_path, artifact_id=None):
+        async def mock_download(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"fake content")
             return output_path
 
@@ -157,7 +157,7 @@ class TestDownloadStandardTypes:
         mock_client = create_mock_client()
         output_dir = tmp_path / "slides"
 
-        async def mock_download_slide_deck(notebook_id, output_path, artifact_id=None):
+        async def mock_download_slide_deck(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).mkdir(parents=True, exist_ok=True)
             (Path(output_path) / "slide_1.png").write_bytes(b"fake slide")
             return output_path
@@ -237,7 +237,7 @@ class TestDownloadFlags:
 
         output_file = tmp_path / "audio.mp3"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"fake audio")
             return output_path
 
@@ -274,7 +274,7 @@ class TestDownloadFlags:
 
         output_file = tmp_path / "audio.mp3"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"fake audio")
             return output_path
 
@@ -312,7 +312,7 @@ class TestDownloadFlags:
         output_file = tmp_path / "audio.mp3"
         output_file.write_bytes(b"existing content")
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"new content")
             return output_path
 
@@ -476,7 +476,7 @@ class TestDownloadCommandsExist:
 
         output_file = tmp_path / "cinematic.mp4"
 
-        async def mock_download_video(notebook_id, output_path, artifact_id=None):
+        async def mock_download_video(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"fake cinematic content")
             return output_path
 
@@ -573,7 +573,7 @@ class TestDownloadAutoRename:
         output_file = tmp_path / "audio.mp3"
         output_file.write_bytes(b"existing content")
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"new content")
             return output_path
 
@@ -611,7 +611,7 @@ class TestDownloadAll:
 
         output_dir = tmp_path / "downloads"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"audio content")
             return output_path
 
@@ -672,7 +672,7 @@ class TestDownloadAll:
         output_dir = tmp_path / "downloads"
         call_count = 0
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -727,7 +727,7 @@ class TestDownloadAllExitCodeContract:
         mock_client = create_mock_client()
         output_dir = tmp_path / "downloads"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             raise Exception("Network error")
 
         mock_client.artifacts.list = AsyncMock(
@@ -770,7 +770,7 @@ class TestDownloadAllExitCodeContract:
         output_dir = tmp_path / "downloads"
         call_count = 0
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -824,7 +824,7 @@ class TestDownloadAllExitCodeContract:
         output_dir = tmp_path / "downloads"
         call_count = 0
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -867,7 +867,7 @@ class TestDownloadAllExitCodeContract:
         mock_client = create_mock_client()
         output_dir = tmp_path / "downloads"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"audio content")
             return output_path
 
@@ -910,7 +910,7 @@ class TestDownloadAllNameFilter:
         output_dir = tmp_path / "downloads"
         downloaded_ids: list[str | None] = []
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             downloaded_ids.append(artifact_id)
             Path(output_path).write_bytes(b"audio content")
             return output_path
@@ -1110,7 +1110,7 @@ class TestDownloadAllDryRunFilenameParity:
         mock_client = create_mock_client()
         output_dir_exec = tmp_path / "exec"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"audio content")
             return output_path
 
@@ -1145,7 +1145,7 @@ class TestDownloadAllDryRunFilenameParity:
         # Create existing file
         (output_dir / "First Audio.mp3").write_bytes(b"existing")
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"new content")
             return output_path
 
@@ -1184,7 +1184,7 @@ class TestDownloadArtifactFlag:
         output_file = tmp_path / "audio.mp3"
         downloaded_ids = []
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             downloaded_ids.append(artifact_id)
             Path(output_path).write_bytes(b"audio")
             return output_path
@@ -1239,7 +1239,7 @@ class TestDownloadArtifactFlag:
         output_file = tmp_path / "audio.mp3"
         downloaded_ids = []
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             downloaded_ids.append(artifact_id)
             Path(output_path).write_bytes(b"audio")
             return output_path
@@ -1312,7 +1312,7 @@ class TestDownloadErrorHandling:
 
         output_file = tmp_path / "audio.mp3"
 
-        async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+        async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             raise Exception("Connection refused")
 
         mock_client.artifacts.list = AsyncMock(
@@ -1407,7 +1407,7 @@ class TestDownloadQuizStandardFlags:
         output_file = tmp_path / "quiz.json"
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text('{"questions": []}')
             return output_path
@@ -1433,7 +1433,7 @@ class TestDownloadQuizStandardFlags:
         chosen_ids: list[str | None] = []
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             chosen_ids.append(artifact_id)
             Path(output_path).write_text("{}")
@@ -1469,7 +1469,7 @@ class TestDownloadQuizStandardFlags:
         chosen_ids: list[str | None] = []
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             chosen_ids.append(artifact_id)
             Path(output_path).write_text("{}")
@@ -1503,7 +1503,7 @@ class TestDownloadQuizStandardFlags:
         chosen_ids: list[str | None] = []
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             chosen_ids.append(artifact_id)
             Path(output_path).write_text("{}")
@@ -1559,7 +1559,7 @@ class TestDownloadQuizStandardFlags:
         downloaded: list[str | None] = []
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             downloaded.append(artifact_id)
             Path(output_path).write_text('{"q": []}')
@@ -1592,7 +1592,7 @@ class TestDownloadQuizStandardFlags:
         output_file.write_text("OLD")
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("NEW")
             return output_path
@@ -1620,7 +1620,7 @@ class TestDownloadQuizStandardFlags:
         output_file.write_text("EXISTING")
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("OVERWROTE")
             return output_path
@@ -1659,7 +1659,7 @@ class TestDownloadQuizStandardFlags:
         output_file = tmp_path / "quiz.json"
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("{}")
             return output_path
@@ -1690,7 +1690,7 @@ class TestDownloadQuizStandardFlags:
         captured: dict[str, str] = {}
 
         async def fake_download_quiz(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             captured["output_format"] = output_format
             Path(output_path).write_text("# Quiz")
@@ -1748,7 +1748,7 @@ class TestDownloadFlashcardsStandardFlags:
         output_file = tmp_path / "cards.json"
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text('{"cards": []}')
             return output_path
@@ -1776,7 +1776,7 @@ class TestDownloadFlashcardsStandardFlags:
         downloaded: list[str | None] = []
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             downloaded.append(artifact_id)
             Path(output_path).write_text('{"cards": []}')
@@ -1837,7 +1837,7 @@ class TestDownloadFlashcardsStandardFlags:
         output_file.write_text("OLD")
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("NEW")
             return output_path
@@ -1865,7 +1865,7 @@ class TestDownloadFlashcardsStandardFlags:
         output_file.write_text("EXISTING")
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("OVERWROTE")
             return output_path
@@ -1891,7 +1891,7 @@ class TestDownloadFlashcardsStandardFlags:
         output_file = tmp_path / "cards.json"
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             Path(output_path).write_text("{}")
             return output_path
@@ -1922,7 +1922,7 @@ class TestDownloadFlashcardsStandardFlags:
         captured: dict[str, str] = {}
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             captured["output_format"] = output_format
             Path(output_path).write_text("<html></html>")
@@ -1959,7 +1959,7 @@ class TestDownloadFlashcardsStandardFlags:
         chosen_ids: list[str | None] = []
 
         async def fake_download_flashcards(
-            notebook_id, output_path, artifact_id=None, output_format="json"
+            notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
         ):
             chosen_ids.append(artifact_id)
             Path(output_path).write_text("{}")

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -394,7 +394,7 @@ async def test_download_quiz_delegates():
 
     assert result == "/tmp/q.json"
     service.download_interactive_artifact.assert_awaited_once_with(
-        "nb", "/tmp/q.json", None, "json", "quiz"
+        "nb", "/tmp/q.json", None, "json", "quiz", artifacts=None
     )
 
 
@@ -407,7 +407,7 @@ async def test_download_flashcards_delegates():
 
     assert result == "/tmp/f.json"
     service.download_interactive_artifact.assert_awaited_once_with(
-        "nb", "/tmp/f.json", None, "markdown", "flashcards"
+        "nb", "/tmp/f.json", None, "markdown", "flashcards", artifacts=None
     )
 
 

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -173,8 +173,13 @@ async def test_execute_download_all_reports_partial_failure_and_progress(tmp_pat
 @pytest.mark.asyncio
 async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> None:
     spec = DOWNLOAD_SPECS_BY_NAME["quiz"]
+    quiz = _artifact("quiz_1", "Quiz", 4, variant=2)
     artifacts = SimpleNamespace(
-        list=AsyncMock(return_value=[_artifact("quiz_1", "Quiz", 4, variant=2)]),
+        list=AsyncMock(return_value=[quiz]),
+        # Single-pass seam (#1488): the executor lists once via _list_for_download
+        # (typed + raw studio rows + mind-map rows) and threads the typed quiz
+        # list into download_quiz so it skips its own second LIST_ARTIFACTS.
+        _list_for_download=AsyncMock(return_value=([quiz], [], [])),
         download_quiz=AsyncMock(return_value=str(tmp_path / "quiz.md")),
     )
     facade = SimpleNamespace(artifacts=artifacts)
@@ -187,9 +192,13 @@ async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> 
     result = await execute_download(plan, facade)
 
     assert result["status"] == "downloaded"
+    # The executor now lists once and threads the already-fetched typed quiz list
+    # into ``download_quiz`` so it skips its own second LIST_ARTIFACTS (#1488);
+    # the format kwarg is still forwarded alongside it.
     artifacts.download_quiz.assert_awaited_once_with(
         "nb_resolved",
         str(tmp_path / "quiz.md"),
+        artifacts=[quiz],
         artifact_id="quiz_1",
         output_format="markdown",
     )


### PR DESCRIPTION
## What & why

Fixes #1488. The artifact-download path issued `LIST_ARTIFACTS` **twice**: the `_app` executor listed to *select* the target, then each per-type `download_<x>` re-listed to *re-find* it by id. VCR cassettes record one list interaction, so the 2nd hit raised `CannotOverwriteExistingCassetteException` → **exit 1 with no file written**. A second bug let it slip past CI: the cli_vcr helper `assert_command_success(allow_no_context=True)` accepted exit 1, masking the failure.

## Approach

- **Single-pass listing seam.** New `ArtifactListingService.list_artifacts_with_raw` returns `(typed_artifacts, raw_studio_rows, mind_map_rows)` in one pass; `list_artifacts` delegates to it. `ArtifactsAPI._list_for_download` exposes it to the executor.
- **List once, thread down.** `_fetch_artifacts_once` lists a single time and returns `(selection_dicts, prefetch_kwargs)`; `_bind_download_fn` partial-binds the prefetch + format kwargs so the bound `download_<x>` skips its redundant second list RPC. Each method gained an optional keyword-only pre-fetched-list param and self-fetches only when it's `None`, so the **standalone public-API path is byte-identical**.
- **Strict test assertions.** `assert_command_success` default flipped to strict (exit 0 only); the download cli_vcr tests now assert exit 0 **and** the output file exists. No other masked failures surfaced; no opt-ins needed.

## Review-driven hardening (codex)

A two-round codex review caught and I fixed:
- **Seam-absent fallback** (narrow test double exposing only `.list()`) now threads **no** prefetch kwargs, so each `download_<x>` self-fetches as before — binding `...=[]` would suppress that self-fetch and break an old-style method lacking the kwarg. New `test_fallback_without_seam_threads_no_prefetch` exercises this branch.
- **Mind-map partial-availability preserved exactly** via a `None` sentinel: a failed note-backed sub-fetch yields `mind_map_rows=None` (vs `[]` = "fetched, genuinely empty"), threaded as `mind_maps=None` so `download_mind_map` self-fetches and raises as the standalone path would, rather than silently treating the outage as "no mind maps".

## ⚠️ Ratchet ceilings raised (please eyeball)

This raises two module-size ratchet ceilings to their measured post-fix LOC: `_artifacts.py` 1393→1451, `_artifact/downloads.py` 973→1033. The growth is **irreducible keyword-only-param expansion** — the prefetch param is threaded through ~9 explicitly-typed public `ArtifactsAPI.download_*` delegates *and* their `ArtifactDownloadService` impls (the public API must keep explicit typed signatures; ruff wraps each 6-param signature one-per-line). Splitting these modules is a separate refactor out of scope for a bug fix. New ceilings equal current LOC (no slack). Flagging explicitly since the ratchet policy prefers tightening.

## Verification

- Full suite green; **cassettes replay with zero re-records** (the refactor invariant). mypy + ruff clean. API-compat audit `EXIT=0`, zero allowlist additions — **not** an API-breaking change.
- Polished: claude + codex review; codex's Critical + 2 Important + Minor all addressed across two rounds.

Closes #1488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized artifact download flow to prefetch and reuse listings, reducing redundant network calls and improving download performance.

* **Bug Fixes**
  * CLI download no longer fails with exit code 1 when writing output files; single-listing avoids missing files.
  * Empty/sourceless notebook summaries now return an empty summary ("") instead of raising an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->