### PR TITLE
Backport post-0.7.1 bug fixes to release/v0.7.1 (v0.7.2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-09
+
+Maintenance patch on the 0.7.x line. Backports fixes from `main`
+(cherry-picked ahead of the v0.8.0 breaking release).
+
+### Fixed
+
+- **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
+  A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
+  returns an absent/`None` payload. `notebooks.get_summary()` and
+  `notebooks.get_description()` now treat that routine "no summary yet" state as
+  an empty summary (`""`) instead of mis-classifying it as wire-schema drift.
+  Genuinely-malformed payloads (a present-but-non-list `result[0]`, a scalar, or
+  a string where a nested list is expected) still raise. `get_summary` now shares
+  the `_extract_summary` descent with `get_description`, so both agree on every
+  shape. As part of the fix, `safe_index` rejects a `str`/`bytes` value at an
+  intermediate descent hop (it is indexable but never a valid container, so
+  descending it would smuggle a single character past drift detection).
+
 ## [0.7.1] - 2026-06-06
 
 Maintenance patch on the 0.7.x line. Backports two fixes from `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Maintenance patch on the 0.7.x line. Backports fixes from `main`
   shape. As part of the fix, `safe_index` rejects a `str`/`bytes` value at an
   intermediate descent hop (it is indexable but never a valid container, so
   descending it would smuggle a single character past drift detection).
+- **`download <type>` no longer exits 1 with no file written** (#1488). The
+  download path listed artifacts twice — the executor listed to select the
+  target, then each per-type download re-listed to re-find it by id — so the
+  second `LIST_ARTIFACTS` could not replay against a single-interaction VCR
+  cassette and aborted the download. The executor now lists once and threads
+  the already-fetched rows into the download method (which skips its redundant
+  second list); studio downloads also no longer trigger the note-backed
+  mind-map sub-fetch they never needed. Live behavior is unchanged for direct
+  `client.artifacts.download_*()` calls.
 
 ## [0.7.1] - 2026-06-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.7.1"
+version = "0.7.2"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -362,6 +363,28 @@ main()
 """
 
 
+_OBJECT_SENTINEL_REPR_RE = re.compile(r"<object object at 0x[0-9a-fA-F]+>")
+
+
+def normalize_default_repr(default_repr: str | None) -> str | None:
+    """Collapse a bare object() sentinel default repr to an address-free form.
+
+    A bare object() sentinel default (e.g. the wait_for_completion
+    initial_interval sentinel) reprs as <object object at 0xADDR>; the hex
+    address differs between the baseline collector process and the current one,
+    so identical code would otherwise read as a changed default. Only the bare
+    object() sentinel (matching the whole repr) is normalized, so two
+    same-identity sentinels compare equal while every other default — including
+    an address-bearing instance or function repr — is left intact and a genuine
+    change is still caught.
+    """
+    if default_repr is None:
+        return None
+    if _OBJECT_SENTINEL_REPR_RE.fullmatch(default_repr):
+        return "<object object at 0x...>"
+    return default_repr
+
+
 def collect_manifest(
     source_root: Path,
     extra_public_names: dict[str, list[str]] | None = None,
@@ -459,15 +482,10 @@ def _signature_breakage(old: dict[str, Any] | None, new: dict[str, Any] | None) 
                 return f"parameter {name!r} no longer accepts keyword calls"
             if old_param["has_default"] and not new_param["has_default"]:
                 return f"optional parameter {name!r} became required"
-            if (
-                old_param["has_default"]
-                and new_param["has_default"]
-                and old_param.get("default_repr") != new_param.get("default_repr")
-            ):
-                return (
-                    f"default for parameter {name!r} changed from "
-                    f"{old_param.get('default_repr')} to {new_param.get('default_repr')}"
-                )
+            old_default = normalize_default_repr(old_param.get("default_repr"))
+            new_default = normalize_default_repr(new_param.get("default_repr"))
+            if old_param["has_default"] and new_param["has_default"] and old_default != new_default:
+                return f"default for parameter {name!r} changed from {old_default} to {new_default}"
 
     old_positional = [param for param in old_params if _accepts_positional(param)]
     new_positional = [param for param in new_params if _accepts_positional(param)]

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -48,6 +48,14 @@ _TRUSTED_DOWNLOAD_DOMAINS = (".google.com", ".googleusercontent.com", ".googleap
 # a brief read stall. 8 slots × 64 KiB ≈ 512 KiB of in-flight buffering.
 _DOWNLOAD_WRITER_QUEUE_SIZE = 8
 
+# ``_PREFETCH_NOTE`` — referenced by the per-method docstrings below. Each
+# ``download_<x>`` accepts an optional pre-fetched list (``artifacts_data`` raw
+# studio rows / ``artifacts`` typed list / ``mind_maps`` note-backed rows). When
+# supplied — the ``_app`` executor lists once to select the target and threads
+# what it already fetched — the method skips its own otherwise-redundant second
+# ``LIST_ARTIFACTS`` / ``GET_NOTES_AND_MIND_MAPS`` RPC; ``None`` re-lists as before
+# (issue #1488).
+
 
 async def _await_writer_exit(
     writer_thread: threading.Thread,
@@ -250,10 +258,16 @@ class ArtifactDownloadService:
         return tree_json if isinstance(tree_json, str) else None
 
     async def download_audio(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download an Audio Overview to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download an Audio Overview to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         audio_art = self._select_artifact(
             artifacts_data,
@@ -282,10 +296,16 @@ class ArtifactDownloadService:
         return await self.download_url(url, output_path)
 
     async def download_video(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a Video Overview to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a Video Overview to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         # Note: distinct error keys preserved — specific-ID miss raises
         # "video" (from type_name="Video"); empty-list raises
@@ -317,10 +337,16 @@ class ArtifactDownloadService:
         return await self.download_url(url, output_path)
 
     async def download_infographic(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download an Infographic to a file."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download an Infographic to a file (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         info_art = self._select_artifact(
             artifacts_data,
@@ -354,12 +380,15 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "pdf",
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a slide deck as PDF or PPTX."""
+        """Download a slide deck as PDF or PPTX (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
         if output_format not in ("pdf", "pptx"):
             raise ValidationError(f"Invalid format '{output_format}'. Must be 'pdf' or 'pptx'.")
 
-        artifacts_data = await self._list_raw(notebook_id)
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         slide_art = self._select_artifact(
             artifacts_data,
@@ -401,8 +430,15 @@ class ArtifactDownloadService:
         artifact_id: str | None,
         output_format: str,
         artifact_type: str,
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
-        """Download quiz or flashcard artifact."""
+        """Download quiz or flashcard artifact.
+
+        ``artifacts`` is the optional pre-fetched *typed* list of the matching
+        ``list_type`` (see ``_PREFETCH_NOTE``); this method still filters it to
+        completed entries and id-matches within it.
+        """
         valid_formats = ("json", "markdown", "html")
         if output_format not in valid_formats:
             raise ValidationError(
@@ -413,7 +449,8 @@ class ArtifactDownloadService:
         default_title = "Untitled Quiz" if is_quiz else "Untitled Flashcards"
         list_type = ArtifactType.QUIZ if is_quiz else ArtifactType.FLASHCARDS
 
-        artifacts = await self._list_artifacts(notebook_id, list_type)
+        if artifacts is None:
+            artifacts = await self._list_artifacts(notebook_id, list_type)
         completed = [a for a in artifacts if a.is_completed]
         if not completed:
             raise ArtifactNotReadyError(artifact_type)
@@ -456,9 +493,12 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a report artifact as markdown."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a report artifact as markdown (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         report_art = self._select_artifact(
             artifacts_data,
@@ -500,14 +540,23 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        mind_maps: list[Any] | None = None,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a mind map as JSON (note-backed or interactive kind)."""
+        """Download a mind map as JSON (note-backed or interactive kind).
+
+        ``mind_maps`` (note-backed rows) and ``artifacts_data`` (raw studio rows,
+        used only by the interactive-mind-map branch) are optional pre-fetched
+        lists; see ``_PREFETCH_NOTE``. Each is fetched on demand when ``None``.
+        """
         mind_maps_service = self._mind_maps
 
         # Fetch the note-backed list first: it is the primary backing for this
         # method, so an explicit id that resolves here (the happy path) avoids
         # the extra _list_raw artifact-collection network call entirely.
-        mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
+        if mind_maps is None:
+            mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
 
         # The JSON tree string to write — sourced from the note content for
         # note-backed maps, or from GET_INTERACTIVE_HTML for interactive ones.
@@ -525,9 +574,13 @@ class ArtifactDownloadService:
                 # The id is not a note-backed mind map. Interactive
                 # (studio-artifact) mind maps live in the artifact collection,
                 # not the note-backed list — fetch the tree there so both kinds
-                # download to the same JSON shape (issue #1256).
+                # download to the same JSON shape (issue #1256). Reuse the
+                # caller-provided ``artifacts_data`` when present to avoid a
+                # redundant second ``LIST_ARTIFACTS``.
+                if artifacts_data is None:
+                    artifacts_data = await self._list_raw(notebook_id)
                 interactive = False
-                for row in await self._list_raw(notebook_id):
+                for row in artifacts_data:
                     if not isinstance(row, list):
                         continue
                     artifact = Artifact.from_api_response(row)
@@ -581,9 +634,12 @@ class ArtifactDownloadService:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
     ) -> str:
-        """Download a data table as CSV."""
-        artifacts_data = await self._list_raw(notebook_id)
+        """Download a data table as CSV (``artifacts_data``: see ``_PREFETCH_NOTE``)."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
 
         table_art = self._select_artifact(
             artifacts_data,
@@ -626,10 +682,12 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
         """Download quiz questions."""
         return await self.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "quiz"
+            notebook_id, output_path, artifact_id, output_format, "quiz", artifacts=artifacts
         )
 
     async def download_flashcards(
@@ -638,10 +696,12 @@ class ArtifactDownloadService:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: list[Artifact] | None = None,
     ) -> str:
         """Download flashcard deck."""
         return await self.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "flashcards"
+            notebook_id, output_path, artifact_id, output_format, "flashcards", artifacts=artifacts
         )
 
     async def download_urls_batch(self, urls_and_paths: list[tuple[str, str]]) -> DownloadResult:

--- a/src/notebooklm/_artifact/listing.py
+++ b/src/notebooklm/_artifact/listing.py
@@ -124,23 +124,59 @@ class ArtifactListingService:
         list_mind_maps: ListMindMapsCallback,
     ) -> list[Artifact]:
         """List public artifacts from studio rows plus mind-map rows."""
-        artifacts = self._filter_studio_artifacts(await list_raw(notebook_id), artifact_type)
+        artifacts, _raw, _mm = await self.list_artifacts_with_raw(
+            notebook_id,
+            artifact_type,
+            list_raw=list_raw,
+            list_mind_maps=list_mind_maps,
+        )
+        return artifacts
 
+    async def list_artifacts_with_raw(
+        self,
+        notebook_id: str,
+        artifact_type: ArtifactType | None,
+        *,
+        list_raw: ListRawCallback,
+        list_mind_maps: ListMindMapsCallback,
+    ) -> tuple[list[Artifact], list[Any], list[Any] | None]:
+        """List artifacts *and* return the raw rows fetched to build them.
+
+        Returns ``(typed_artifacts, raw_studio_rows, mind_map_rows)`` from a
+        single pass over each backing RPC. The download executor uses this to
+        select a target from the typed list while threading the raw rows it
+        already fetched into the per-type ``download_<x>`` method — so that
+        method does not re-issue ``LIST_ARTIFACTS`` / ``GET_NOTES_AND_MIND_MAPS``
+        (issue #1488). The typed projection / merge / partial-availability policy
+        is identical to :meth:`list_artifacts`, which now delegates here.
+
+        ``mind_map_rows`` is the raw note-backed list when the mind-map sub-fetch
+        ran (``artifact_type`` is ``None`` or ``MIND_MAP``) and succeeded — ``[]``
+        included, meaning "fetched, genuinely no mind maps". It is ``None`` when
+        the sub-fetch's transport failed (``RPCError`` / ``HTTPError``): a
+        distinct "fetch failed, value unknown" sentinel so a caller threading it
+        into ``download_mind_map`` passes ``None`` and the method re-fetches (and
+        surfaces the error) rather than mistaking the outage for "no mind maps".
+        It is also ``[]`` when the sub-fetch was skipped (a specific non-mind-map
+        ``artifact_type``); that list is never threaded to ``download_mind_map``.
+        """
+        raw_studio_rows = await list_raw(notebook_id)
+        artifacts = self._filter_studio_artifacts(raw_studio_rows, artifact_type)
+
+        mind_map_rows: list[Any] | None = []
         if artifact_type is None or artifact_type == ArtifactType.MIND_MAP:
             try:
-                artifacts.extend(
-                    self._filter_mind_map_artifacts(
-                        await list_mind_maps(notebook_id),
-                        artifact_type,
-                    )
-                )
+                mind_map_rows = await list_mind_maps(notebook_id)
+                artifacts.extend(self._filter_mind_map_artifacts(mind_map_rows, artifact_type))
             except (RPCError, httpx.HTTPError) as e:
-                # Network/API errors - log and continue with studio artifacts.
-                # This ensures users can see audio/video/reports even if the
-                # mind-map endpoint is temporarily unavailable.
+                # Network/API errors - log and continue with studio artifacts so
+                # users still see audio/video/reports when the mind-map endpoint
+                # is temporarily unavailable. Use ``None`` (not ``[]``) as the
+                # "fetch failed" sentinel so a downstream caller re-fetches.
+                mind_map_rows = None
                 logger.warning("Failed to fetch mind maps: %s", e)
 
-        return artifacts
+        return artifacts, raw_studio_rows, mind_map_rows
 
     async def get(
         self,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -198,6 +198,18 @@ class ArtifactsAPI:
             list_mind_maps=self._list_mind_maps,
         )
 
+    async def _list_for_download(
+        self, notebook_id: str, artifact_type: ArtifactType | None = None
+    ) -> tuple[builtins.list[Artifact], builtins.list[Any], builtins.list[Any] | None]:
+        """List artifacts + the raw rows fetched to build them — same RPC set as
+        :meth:`list`. Internal seam for the download executor (#1488)."""
+        return await self._listing.list_artifacts_with_raw(
+            notebook_id,
+            artifact_type,
+            list_raw=self._list_raw,
+            list_mind_maps=self._list_mind_maps,
+        )
+
     async def get(self, notebook_id: str, artifact_id: str) -> Artifact | None:
         """Get a specific artifact by ID.
 
@@ -775,22 +787,43 @@ class ArtifactsAPI:
     # =========================================================================
 
     async def download_audio(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download an Audio Overview to a file."""
-        return await self._downloads.download_audio(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_audio(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_video(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a Video Overview to a file."""
-        return await self._downloads.download_video(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_video(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_infographic(
-        self, notebook_id: str, output_path: str, artifact_id: str | None = None
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download an Infographic to a file."""
-        return await self._downloads.download_infographic(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_infographic(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_slide_deck(
         self,
@@ -798,10 +831,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "pdf",
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a slide deck as PDF or PPTX."""
         return await self._downloads.download_slide_deck(
-            notebook_id, output_path, artifact_id, output_format
+            notebook_id, output_path, artifact_id, output_format, artifacts_data=artifacts_data
         )
 
     async def _download_interactive_artifact(
@@ -811,10 +846,12 @@ class ArtifactsAPI:
         artifact_id: str | None,
         output_format: str,
         artifact_type: str,
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download quiz or flashcard artifact."""
         return await self._downloads.download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, artifact_type
+            notebook_id, output_path, artifact_id, output_format, artifact_type, artifacts=artifacts
         )
 
     def _format_interactive_content(
@@ -850,27 +887,44 @@ class ArtifactsAPI:
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a report artifact as markdown."""
-        return await self._downloads.download_report(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_report(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_mind_map(
         self,
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        mind_maps: builtins.list[Any] | None = None,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a mind map as JSON."""
-        return await self._downloads.download_mind_map(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_mind_map(
+            notebook_id,
+            output_path,
+            artifact_id,
+            mind_maps=mind_maps,
+            artifacts_data=artifacts_data,
+        )
 
     async def download_data_table(
         self,
         notebook_id: str,
         output_path: str,
         artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
     ) -> str:
         """Download a data table as CSV."""
-        return await self._downloads.download_data_table(notebook_id, output_path, artifact_id)
+        return await self._downloads.download_data_table(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
 
     async def download_quiz(
         self,
@@ -878,10 +932,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download quiz questions."""
         return await self._download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "quiz"
+            notebook_id, output_path, artifact_id, output_format, "quiz", artifacts=artifacts
         )
 
     async def download_flashcards(
@@ -890,10 +946,12 @@ class ArtifactsAPI:
         output_path: str,
         artifact_id: str | None = None,
         output_format: str = "json",
+        *,
+        artifacts: builtins.list[Artifact] | None = None,
     ) -> str:
         """Download flashcard deck."""
         return await self._download_interactive_artifact(
-            notebook_id, output_path, artifact_id, output_format, "flashcards"
+            notebook_id, output_path, artifact_id, output_format, "flashcards", artifacts=artifacts
         )
 
     # =========================================================================

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -41,15 +41,33 @@ def _extract_summary(outer: Any) -> str:
     """Extract the summary string from a SUMMARIZE ``result[0]`` payload.
 
     The expected shape is ``[[summary_string, ...], ...]`` — i.e. the summary
-    lives at ``outer[0][0]``. ``safe_index`` is used for the inner-most
-    descent so drift is logged with method_id + source rather than raising
-    ``IndexError`` from a raw subscript.
+    lives at ``outer[0][0]``. Only a genuinely *absent* summary is treated as
+    routinely-optional: a brand-new, source-less notebook has no summary yet,
+    so the server returns ``None`` at ``outer``, an empty ``outer``, or an
+    explicitly-null summary slot (``outer[0] is None``). Those three shapes
+    short-circuit to ``""`` so a healthy "no summary yet" response doesn't
+    surface as schema drift.
+
+    Everything else descends through ``safe_index``: a *present-but-malformed*
+    payload — a scalar ``outer`` (e.g. ``123``), or a non-``None`` ``outer[0]``
+    that isn't the expected ``[summary_string, ...]`` list — is genuine drift
+    and raises ``UnknownRPCMethodError`` with method_id + source rather than
+    silently becoming an empty summary (which would mask the wire-schema move).
 
     Returns:
-        The summary string, or ``""`` when the payload is missing the
-        expected slot (the caller is responsible for treating an empty
-        summary as "no description available").
+        The summary string, or ``""`` when the payload omits the summary
+        slot (the caller is responsible for treating an empty summary as
+        "no description available").
     """
+    # Genuinely-absent summary (no payload, empty payload, or null slot) is the
+    # routine "no summary yet" case — return "" without logging drift.
+    if outer is None:
+        return ""
+    if isinstance(outer, list) and (not outer or outer[0] is None):
+        return ""
+    # Descend outer[0][0] via safe_index. A scalar ``outer`` or a malformed
+    # ``outer[0]`` (present, non-None, but not the expected list) raises drift
+    # at the failing step rather than silently returning "".
     summary_val = safe_index(
         outer,
         0,
@@ -587,16 +605,13 @@ class NotebooksAPI:
             params,
             source_path=f"/notebook/{notebook_id}",
         )
-        # Response structure: [[[summary_string, ...], topics, ...]]
-        summary = safe_index(
-            result,
-            0,
-            0,
-            0,
-            method_id=RPCMethod.SUMMARIZE.value,
-            source="_notebooks.get_summary",
-        )
-        return str(summary) if summary else ""
+        # Response structure: [[[summary_string, ...], topics, ...]]. ``result[0]``
+        # is the ``outer`` payload that ``_extract_summary`` descends, so delegate
+        # to it: empty/None/null-slot → "" and present-but-malformed → drift,
+        # identically to ``get_description`` (single source of truth — #1485).
+        if not isinstance(result, list) or not result:
+            return ""
+        return _extract_summary(result[0])
 
     async def get_description(self, notebook_id: str) -> NotebookDescription:
         """Get AI-generated summary and suggested topics for a notebook.

--- a/src/notebooklm/cli/services/download.py
+++ b/src/notebooklm/cli/services/download.py
@@ -305,26 +305,66 @@ def build_download_plan(
     )
 
 
-async def _get_completed_artifacts_as_dicts(
+async def _fetch_artifacts_once(
     facade: _DownloadFacade, notebook_id: str, spec: DownloadTypeSpec
-) -> list[ArtifactDict]:
-    """Fetch artifacts, filter by kind + completion, project to ArtifactDict.
+) -> tuple[list[ArtifactDict], dict[str, Any]]:
+    """List artifacts once; return ``(selection_dicts, prefetch_kwargs)`` (issue #1488).
 
-    The ``isinstance(a, Artifact)`` guard mirrors the legacy ``download_cmd``
-    implementation and protects against the (unlikely but possible) case
-    where ``client.artifacts.list`` returns a heterogeneous list with stub
-    entries that don't expose the ``kind`` / ``is_completed`` properties.
+    ``execute_download`` lists a single time to select the target, then threads
+    the raw rows it already fetched into the per-type ``download_<x>`` (as the
+    returned ``prefetch_kwargs``) so that method skips its redundant second list
+    RPC. The prefetch kwarg(s) match the bound method: quiz/flashcards →
+    ``artifacts`` (the matching-kind typed list); mind-map → ``mind_maps``
+    (note-backed rows) + ``artifacts_data`` (raw studio rows, interactive branch);
+    other studio types → ``artifacts_data``.
+
+    The single-pass ``_list_for_download`` facade seam (``list`` + raw rows) is
+    used when present. When it is absent — a narrow test double exposing only
+    ``.list()`` — we list for selection but thread **no** prefetch kwargs, so
+    each ``download_<x>`` self-fetches exactly as before (and an old-style
+    ``download_<x>`` lacking the new kwargs keeps working). The ``isinstance``
+    guard tolerates stub entries lacking ``kind``/``is_completed``.
     """
-    all_artifacts = await facade.artifacts.list(notebook_id)
-    return [
+    list_for_download = getattr(facade.artifacts, "_list_for_download", None)
+    if list_for_download is not None:
+        # spec.kind => skip the mind-map sub-fetch for non-mind-map downloads (#1488 review).
+        all_artifacts, raw_studio_rows, mind_map_rows = await list_for_download(
+            notebook_id, spec.kind
+        )
+    else:
+        all_artifacts = await facade.artifacts.list(notebook_id)
+
+    typed = [
+        a
+        for a in all_artifacts
+        if isinstance(a, Artifact) and a.kind == spec.kind and a.is_completed
+    ]
+    dicts: list[ArtifactDict] = [
         {
             "id": a.id,
             "title": a.title,
             "created_at": int(a.created_at.timestamp()) if a.created_at else 0,
         }
-        for a in all_artifacts
-        if isinstance(a, Artifact) and a.kind == spec.kind and a.is_completed
+        for a in typed
     ]
+
+    # No single-pass seam: thread nothing so each download_<x> self-fetches as
+    # before (binding ``...=[]`` would suppress that and break old-style fakes).
+    if list_for_download is None:
+        return dicts, {}
+
+    if spec.kind in (ArtifactType.QUIZ, ArtifactType.FLASHCARDS):
+        prefetch: dict[str, Any] = {"artifacts": typed}
+    elif spec.kind == ArtifactType.MIND_MAP:
+        # ``None`` => note-backed sub-fetch failed: thread None so
+        # download_mind_map self-fetches and raises as the standalone path would.
+        prefetch = {
+            "mind_maps": None if mind_map_rows is None else list(mind_map_rows),
+            "artifacts_data": list(raw_studio_rows),
+        }
+    else:
+        prefetch = {"artifacts_data": list(raw_studio_rows)}
+    return dicts, prefetch
 
 
 def _resolve_conflict(
@@ -350,31 +390,34 @@ def _resolve_conflict(
     return path, None
 
 
-def _bind_download_fn(plan: DownloadPlan, facade: _DownloadFacade) -> _DownloadFn:
-    """Bind the spec's ``download_attr`` coroutine, partialing the format kwarg
-    when the spec requests it.
+def _bind_download_fn(
+    plan: DownloadPlan,
+    facade: _DownloadFacade,
+    prefetch_kwargs: dict[str, Any] | None = None,
+) -> _DownloadFn:
+    """Bind ``download_attr``, partialing the format + prefetch kwargs.
 
-    Three branches:
-
-    - No ``format_kwarg`` (audio/video/report/mind-map/data-table/infographic
-      and the slide-deck ``--format pdf`` default): use the bare attr.
-    - ``forward_format_only_if_set`` AND the user picked the non-default
-      (slide-deck pptx): partial-bind with the format kwarg.
-    - Always-forward (quiz/flashcards): partial-bind regardless.
+    The format kwarg is forwarded unless absent or it is slide-deck's pdf default
+    (``forward_format_only_if_set`` forwards only the non-default pptx);
+    quiz/flashcards always forward it. ``prefetch_kwargs`` (issue #1488) carries
+    the already-fetched rows so the bound method skips its redundant second list
+    RPC. Both are partial-bound here, so the ``_execute_download_*`` paths stay
+    unchanged.
     """
     spec = plan.spec
     base_fn = getattr(facade.artifacts, spec.download_attr, None)
     if base_fn is None:
         raise ValueError(f"Unknown artifact download method: {spec.download_attr}")
-    if not spec.format_kwarg:
+
+    bound_kwargs: dict[str, Any] = dict(prefetch_kwargs or {})
+    if spec.format_kwarg and not (
+        spec.forward_format_only_if_set and plan.format_choice == spec.format_default
+    ):
+        bound_kwargs[spec.format_kwarg] = plan.format_choice
+
+    if not bound_kwargs:
         return base_fn
-    if spec.forward_format_only_if_set:
-        # slide-deck: only pptx triggers the partial (pdf default keeps bare).
-        if plan.format_choice == spec.format_default:
-            return base_fn
-        return partial(base_fn, **{spec.format_kwarg: plan.format_choice})
-    # quiz/flashcards: always forward the chosen format.
-    return partial(base_fn, **{spec.format_kwarg: plan.format_choice})
+    return partial(base_fn, **bound_kwargs)
 
 
 async def _execute_download_all(
@@ -628,9 +671,12 @@ async def execute_download(
         facade, plan.notebook_id, json_output=plan.json_output
     )
 
-    download_fn = _bind_download_fn(plan, facade)
+    # List ONCE; thread the raw rows into the bound download method so it does
+    # not re-issue the same list RPC (issue #1488).
+    type_artifacts, prefetch_kwargs = await _fetch_artifacts_once(facade, nb_id_resolved, plan.spec)
 
-    type_artifacts = await _get_completed_artifacts_as_dicts(facade, nb_id_resolved, plan.spec)
+    download_fn = _bind_download_fn(plan, facade, prefetch_kwargs)
+
     if not type_artifacts:
         return {
             "error": f"No completed {plan.spec.name} artifacts found",

--- a/src/notebooklm/rpc/_safe_index.py
+++ b/src/notebooklm/rpc/_safe_index.py
@@ -71,12 +71,33 @@ def safe_index(
         The value at ``data[path[0]][path[1]]...`` on success.
 
     Raises:
-        UnknownRPCMethodError: When descent fails. The exception carries
-            ``method_id``, ``source``, ``path`` (truncated to where descent
-            stopped), and a truncated ``data_at_failure`` repr.
+        UnknownRPCMethodError: When descent fails — an out-of-range index, a
+            non-indexable value (``None``/``int``), a missing key, or a
+            ``str``/``bytes`` value at an intermediate hop (which is indexable
+            but never a valid container, so descending it would silently yield a
+            single character/byte instead of surfacing the shape drift). The
+            exception carries ``method_id``, ``source``, ``path`` (truncated to
+            where descent stopped), and a truncated ``data_at_failure`` repr.
     """
     current: Any = data
     for i, key in enumerate(path):
+        # A str/bytes is indexable but is NEVER a valid container at an
+        # *intermediate* descent hop in a decoded RPC payload: ``"abc"[0]``
+        # silently returns ``"a"`` instead of descending into a nested list,
+        # which would smuggle a bogus single-character "value" past drift
+        # detection (the payload shape has actually moved). Reject it as drift
+        # before indexing. (A string is fine as the returned *leaf* — the loop
+        # never indexes the final value.)
+        if isinstance(current, (str, bytes, bytearray)):
+            failing_path = tuple(path[:i])
+            raise UnknownRPCMethodError(
+                f"safe_index drift at path {failing_path}[{key}]: cannot index "
+                f"into {type(current).__name__} (expected a nested list/tuple)",
+                method_id=method_id,
+                path=failing_path,
+                source=source,
+                data_at_failure=_truncate(current),
+            )
         try:
             current = current[key]
         except (IndexError, TypeError, KeyError) as exc:

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -64,12 +64,20 @@ MODULE_SIZE_BUDGET = 900
 ALLOWLISTED_CEILINGS: dict[str, int] = {
     "cli/source_cmd.py": 1498,
     "exceptions.py": 1426,
-    "_artifacts.py": 1420,
+    # _artifacts.py + _artifact/downloads.py: raised for the #1488 double-list
+    # fix, which threads an optional pre-fetched-list kwarg through every
+    # ``download_<x>`` method (and its public ``ArtifactsAPI`` delegate) plus the
+    # new ``_list_for_download`` seam so the download path issues ONE list RPC
+    # instead of two. The growth is the keyword-only params + ``is None`` guards
+    # on existing methods (ruff one-param-per-line wraps each 6-param signature);
+    # it is irreducible without splitting these modules, which is out of scope for
+    # the bug fix. New ceilings are the measured post-fix LOC.
+    "_artifacts.py": 1478,
     "_source/upload.py": 1236,
     "cli/session_cmd.py": 1080,
     "_sources.py": 1023,
     "cli/services/playwright_login.py": 988,
-    "_artifact/downloads.py": 973,
+    "_artifact/downloads.py": 1033,
     "client.py": 986,
     "_research.py": 969,
     "cli/services/generate.py": 954,

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -103,12 +103,19 @@ def mock_auth_for_vcr():
         yield
 
 
-def assert_command_success(result, *, allow_no_context: bool = True) -> None:
-    """Assert a CLI command completed without crashing.
+def assert_command_success(result, *, allow_no_context: bool = False) -> None:
+    """Assert a CLI command completed successfully (exit 0).
+
+    The default is **strict** (``exit_code == 0``): a permissive default that
+    accepted exit 1 "for any reason" silently masked a genuinely-broken command
+    (issue #1488: the download flow exited 1 with no file written, yet passed).
+    Callers that legitimately expect a no-notebook-context exit-1 path opt in
+    explicitly via ``allow_no_context=True``.
 
     Args:
         result: The CliRunner result object.
-        allow_no_context: If True, exit code 1 (no notebook context) is acceptable.
+        allow_no_context: If True, exit code 1 (e.g. no notebook context) is
+            also acceptable. Opt-in per call site, not the default.
     """
     acceptable_codes = (0, 1) if allow_no_context else (0,)
     assert result.exit_code in acceptable_codes, f"Command failed: {result.output}"

--- a/tests/integration/cli_vcr/test_downloads.py
+++ b/tests/integration/cli_vcr/test_downloads.py
@@ -11,7 +11,6 @@ from notebooklm.notebooklm_cli import cli
 
 from .conftest import (
     VCR_READONLY_NOTEBOOK_ID,
-    assert_command_success,
     notebooklm_vcr,
     skip_no_cassettes,
 )
@@ -50,7 +49,18 @@ class TestDownloadCommands:
         cassette,
         extra_args,
     ):
-        """Download commands work with real client."""
+        """Download commands genuinely succeed: exit 0 AND the file is written.
+
+        Each ``artifacts_download_*.yaml`` cassette records a *single*
+        ``LIST_ARTIFACTS`` (/ ``GET_NOTES_AND_MIND_MAPS``) interaction. Before
+        issue #1488 the command listed artifacts twice (once in the executor to
+        select, once inside ``download_<x>`` to re-find), so the second list hit
+        no recorded interaction and the command exited 1 with no file written —
+        which the old ``assert_command_success`` (``allow_no_context`` default)
+        masked. These assertions now fail loud if the download regresses: a
+        re-introduced double-list would exit 1 (caught by ``== 0``) and write
+        nothing (caught by ``output_file.exists()``).
+        """
         output_file = tmp_path / filename
         with notebooklm_vcr.use_cassette(cassette):
             result = runner.invoke(
@@ -64,26 +74,30 @@ class TestDownloadCommands:
                     str(output_file),
                 ],
             )
-            assert_command_success(result)
+            assert result.exit_code == 0, f"Command failed: {result.output}"
+            assert output_file.exists(), f"Output file not written: {result.output}"
 
     def test_download_mind_map_interactive(self, runner, mock_auth_for_vcr, mock_context, tmp_path):
         """`download mind-map <interactive_id>` exports the interactive map's tree.
 
         Reuses the interactive recording (``mind_maps_interactive.yaml``, notebook
         ``f7d1e2b6`` / artifact ``47523923``) captured for the API-level
-        ``client.mind_maps`` tests. The CLI download flow lists studio artifacts
-        twice — once to resolve the id, once inside ``download_mind_map`` — so the
-        ``LIST_ARTIFACTS`` interaction must be replayable (``allow_playback_repeats``).
+        ``client.mind_maps`` tests. The CLI download flow now lists studio
+        artifacts only **once** — the executor selects the id and threads the
+        already-fetched raw rows into ``download_mind_map`` so its interactive
+        branch does not re-list (issue #1488) — so the single recorded
+        ``LIST_ARTIFACTS`` interaction replays without ``allow_playback_repeats``.
         The tree itself comes from the real ``GET_INTERACTIVE_HTML`` (``[0][9][3]``)
         response in the cassette (issue #1256).
         """
         nb = "f7d1e2b6-2334-4016-b81d-aded7b3fa9b6"
         art_id = "47523923"
         output_file = tmp_path / "interactive_mindmap.json"
-        with notebooklm_vcr.use_cassette("mind_maps_interactive.yaml", allow_playback_repeats=True):
+        with notebooklm_vcr.use_cassette("mind_maps_interactive.yaml"):
             result = runner.invoke(
                 cli, ["download", "mind-map", "-n", nb, "-a", art_id, str(output_file)]
             )
-            assert_command_success(result)
+            assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert output_file.exists(), f"Output file not written: {result.output}"
         data = json.loads(output_file.read_text(encoding="utf-8"))
         assert "name" in data  # a {"name", "children"} mind-map node tree

--- a/tests/integration/cli_vcr/test_notebooks.py
+++ b/tests/integration/cli_vcr/test_notebooks.py
@@ -42,8 +42,7 @@ class TestSummaryCommand:
     def test_summary(self, runner, mock_auth_for_vcr, mock_context):
         """Summary command shows notebook summary."""
         result = runner.invoke(cli, ["summary"])
-        # allow_no_context=True: cassette may not match mock notebook ID
-        assert_command_success(result)
+        assert_command_success(result)  # strict: the summary command exits 0
 
 
 class TestStatusCommand:

--- a/tests/integration/test_notebooks_integration.py
+++ b/tests/integration/test_notebooks_integration.py
@@ -580,26 +580,60 @@ class TestNotebookEdgeCases:
         assert notebooks == []
 
     @pytest.mark.asyncio
-    async def test_get_summary_empty_response_raises(
+    async def test_get_summary_empty_response_returns_empty(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """An empty SUMMARIZE response drifts and raises under strict decoding.
+        """A summary-less SUMMARIZE response returns "" rather than drifting.
 
-        Strict decoding is the only mode (the ``NOTEBOOKLM_STRICT_DECODE=0``
-        soft-mode opt-out was retired in v0.7.0); a ``[]`` response cannot be
-        descended to the summary slot, so it surfaces as
-        ``UnknownRPCMethodError``. Strict-mode unit coverage lives in
+        Regression for #1485: a brand-new, source-less notebook has no summary
+        yet, so the server returns an empty/absent result[0] payload. That
+        routine "no summary yet" state must surface as "" instead of being
+        mis-classified as wire-schema drift. Strict-mode unit coverage lives in
         ``tests/unit/test_get_summary_drift.py``.
         """
-        response = build_rpc_response(RPCMethod.SUMMARIZE, [])
-        httpx_mock.add_response(content=response.encode())
+        # ``[]`` (no outer[0] slot), ``[None]`` (result[0] is None), and ``[[]]``
+        # (result[0] is an empty list — no summary slot) are all legitimate
+        # summary-less payloads. ``[[None]]`` (summary slot explicitly null) is
+        # the same routine absence, now consistent between get_summary and
+        # get_description after delegating to _extract_summary (#1485).
+        for data in ([], [None], [[]], [[None]]):
+            response = build_rpc_response(RPCMethod.SUMMARIZE, data)
+            httpx_mock.add_response(content=response.encode())
 
-        async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(UnknownRPCMethodError):
-                await client.notebooks.get_summary("nb_123")
+            async with NotebookLMClient(auth_tokens) as client:
+                assert await client.notebooks.get_summary("nb_123") == ""
+
+    @pytest.mark.asyncio
+    async def test_get_summary_malformed_response_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A present-but-malformed SUMMARIZE payload still drifts and raises.
+
+        Distinct from the routinely-absent summary slot (#1485): when result[0]
+        is present (non-None) but cannot be descended to the summary value, that
+        is genuine schema drift and must surface as ``UnknownRPCMethodError``
+        under strict decoding (the only mode; the ``NOTEBOOKLM_STRICT_DECODE=0``
+        soft-mode opt-out was retired in v0.7.0). This guards against
+        over-suppressing real drift while fixing the empty-summary case — in
+        particular a scalar ``result[0]`` must raise, not collapse to "".
+        """
+        # Each payload has a present, non-None result[0] that cannot be descended
+        # to result[0][0][0]: a non-empty-but-malformed inner list, and a bare
+        # scalar (the #1485 codex over-suppression case). Contrast with [] /
+        # [None] / [[]] which are routine absence and return "" above.
+        for data in ([[[]]], [[42]], [123]):
+            response = build_rpc_response(RPCMethod.SUMMARIZE, data)
+            httpx_mock.add_response(content=response.encode())
+
+            async with NotebookLMClient(auth_tokens) as client:
+                with pytest.raises(UnknownRPCMethodError):
+                    await client.notebooks.get_summary("nb_123")
 
     @pytest.mark.asyncio
     async def test_get_description_empty_topics(

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -399,6 +399,19 @@ def create_mock_client():
     mock_client.artifacts.list = AsyncMock(side_effect=make_artifact_list)
     mock_client.notes.list = AsyncMock(side_effect=make_note_list)
 
+    # The download executor prefers the ``_list_for_download`` seam (``list`` +
+    # raw rows in one RPC pass; issue #1488). On a bare ``MagicMock`` this
+    # attribute would auto-spawn a non-awaitable child mock, so wire it to
+    # delegate to the (possibly test-overridden) ``artifacts.list`` and return
+    # the ``(typed, raw_studio_rows, mind_map_rows)`` tuple the executor expects.
+    # Empty raw rows are correct for these doubles: ``download_<x>`` is itself
+    # mocked, so its (now-suppressed) inner re-list never runs.
+    async def _list_for_download(notebook_id, artifact_type=None):
+        typed = await mock_client.artifacts.list(notebook_id)
+        return typed, [], []
+
+    mock_client.artifacts._list_for_download = AsyncMock(side_effect=_list_for_download)
+
     return mock_client
 
 

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -116,7 +116,7 @@ class TestDownloadStandardTypes:
             mock_client = create_mock_client()
             output_target = tmp_path / output_name
 
-            async def mock_download(notebook_id, output_path, artifact_id=None):
+            async def mock_download(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"fake content")
                 return output_path
 
@@ -160,7 +160,9 @@ class TestDownloadStandardTypes:
             mock_client = create_mock_client()
             output_dir = tmp_path / "slides"
 
-            async def mock_download_slide_deck(notebook_id, output_path, artifact_id=None):
+            async def mock_download_slide_deck(
+                notebook_id, output_path, artifact_id=None, **kwargs
+            ):
                 Path(output_path).mkdir(parents=True, exist_ok=True)
                 (Path(output_path) / "slide_1.png").write_bytes(b"fake slide")
                 return output_path
@@ -238,7 +240,7 @@ class TestDownloadFlags:
 
             output_file = tmp_path / "audio.mp3"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"fake audio")
                 return output_path
 
@@ -275,7 +277,7 @@ class TestDownloadFlags:
 
             output_file = tmp_path / "audio.mp3"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"fake audio")
                 return output_path
 
@@ -313,7 +315,7 @@ class TestDownloadFlags:
             output_file = tmp_path / "audio.mp3"
             output_file.write_bytes(b"existing content")
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"new content")
                 return output_path
 
@@ -478,7 +480,7 @@ class TestDownloadCommandsExist:
 
             output_file = tmp_path / "cinematic.mp4"
 
-            async def mock_download_video(notebook_id, output_path, artifact_id=None):
+            async def mock_download_video(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"fake cinematic content")
                 return output_path
 
@@ -577,7 +579,7 @@ class TestDownloadAutoRename:
             output_file = tmp_path / "audio.mp3"
             output_file.write_bytes(b"existing content")
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"new content")
                 return output_path
 
@@ -613,7 +615,7 @@ class TestDownloadAll:
 
             output_dir = tmp_path / "downloads"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"audio content")
                 return output_path
 
@@ -675,7 +677,7 @@ class TestDownloadAll:
             output_dir = tmp_path / "downloads"
             call_count = 0
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
@@ -730,7 +732,7 @@ class TestDownloadAllExitCodeContract:
             mock_client = create_mock_client()
             output_dir = tmp_path / "downloads"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 raise Exception("Network error")
 
             mock_client.artifacts.list = AsyncMock(
@@ -774,7 +776,7 @@ class TestDownloadAllExitCodeContract:
             output_dir = tmp_path / "downloads"
             call_count = 0
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
@@ -829,7 +831,7 @@ class TestDownloadAllExitCodeContract:
             output_dir = tmp_path / "downloads"
             call_count = 0
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
@@ -872,7 +874,7 @@ class TestDownloadAllExitCodeContract:
             mock_client = create_mock_client()
             output_dir = tmp_path / "downloads"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"audio content")
                 return output_path
 
@@ -916,7 +918,7 @@ class TestDownloadAllNameFilter:
             output_dir = tmp_path / "downloads"
             downloaded_ids: list[str | None] = []
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 downloaded_ids.append(artifact_id)
                 Path(output_path).write_bytes(b"audio content")
                 return output_path
@@ -1121,7 +1123,7 @@ class TestDownloadAllDryRunFilenameParity:
             mock_client = create_mock_client()
             output_dir_exec = tmp_path / "exec"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"audio content")
                 return output_path
 
@@ -1157,7 +1159,7 @@ class TestDownloadAllDryRunFilenameParity:
             # Create existing file
             (output_dir / "First Audio.mp3").write_bytes(b"existing")
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 Path(output_path).write_bytes(b"new content")
                 return output_path
 
@@ -1197,7 +1199,7 @@ class TestDownloadArtifactFlag:
             output_file = tmp_path / "audio.mp3"
             downloaded_ids = []
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 downloaded_ids.append(artifact_id)
                 Path(output_path).write_bytes(b"audio")
                 return output_path
@@ -1254,7 +1256,7 @@ class TestDownloadArtifactFlag:
             output_file = tmp_path / "audio.mp3"
             downloaded_ids = []
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 downloaded_ids.append(artifact_id)
                 Path(output_path).write_bytes(b"audio")
                 return output_path
@@ -1330,7 +1332,7 @@ class TestDownloadErrorHandling:
 
             output_file = tmp_path / "audio.mp3"
 
-            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
                 raise Exception("Connection refused")
 
             mock_client.artifacts.list = AsyncMock(
@@ -1423,7 +1425,7 @@ class TestDownloadQuizStandardFlags:
             output_file = tmp_path / "quiz.json"
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text('{"questions": []}')
                 return output_path
@@ -1447,7 +1449,7 @@ class TestDownloadQuizStandardFlags:
             chosen_ids: list[str | None] = []
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 chosen_ids.append(artifact_id)
                 Path(output_path).write_text("{}")
@@ -1484,7 +1486,7 @@ class TestDownloadQuizStandardFlags:
             chosen_ids: list[str | None] = []
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 chosen_ids.append(artifact_id)
                 Path(output_path).write_text("{}")
@@ -1519,7 +1521,7 @@ class TestDownloadQuizStandardFlags:
             chosen_ids: list[str | None] = []
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 chosen_ids.append(artifact_id)
                 Path(output_path).write_text("{}")
@@ -1577,7 +1579,7 @@ class TestDownloadQuizStandardFlags:
             downloaded: list[str | None] = []
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 downloaded.append(artifact_id)
                 Path(output_path).write_text('{"q": []}')
@@ -1611,7 +1613,7 @@ class TestDownloadQuizStandardFlags:
             output_file.write_text("OLD")
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("NEW")
                 return output_path
@@ -1640,7 +1642,7 @@ class TestDownloadQuizStandardFlags:
             output_file.write_text("EXISTING")
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("OVERWROTE")
                 return output_path
@@ -1683,7 +1685,7 @@ class TestDownloadQuizStandardFlags:
             output_file = tmp_path / "quiz.json"
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("{}")
                 return output_path
@@ -1715,7 +1717,7 @@ class TestDownloadQuizStandardFlags:
             captured: dict[str, str] = {}
 
             async def fake_download_quiz(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 captured["output_format"] = output_format
                 Path(output_path).write_text("# Quiz")
@@ -1774,7 +1776,7 @@ class TestDownloadFlashcardsStandardFlags:
             output_file = tmp_path / "cards.json"
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text('{"cards": []}')
                 return output_path
@@ -1802,7 +1804,7 @@ class TestDownloadFlashcardsStandardFlags:
             downloaded: list[str | None] = []
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 downloaded.append(artifact_id)
                 Path(output_path).write_text('{"cards": []}')
@@ -1865,7 +1867,7 @@ class TestDownloadFlashcardsStandardFlags:
             output_file.write_text("OLD")
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("NEW")
                 return output_path
@@ -1894,7 +1896,7 @@ class TestDownloadFlashcardsStandardFlags:
             output_file.write_text("EXISTING")
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("OVERWROTE")
                 return output_path
@@ -1921,7 +1923,7 @@ class TestDownloadFlashcardsStandardFlags:
             output_file = tmp_path / "cards.json"
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 Path(output_path).write_text("{}")
                 return output_path
@@ -1953,7 +1955,7 @@ class TestDownloadFlashcardsStandardFlags:
             captured: dict[str, str] = {}
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 captured["output_format"] = output_format
                 Path(output_path).write_text("<html></html>")
@@ -1991,7 +1993,7 @@ class TestDownloadFlashcardsStandardFlags:
             chosen_ids: list[str | None] = []
 
             async def fake_download_flashcards(
-                notebook_id, output_path, artifact_id=None, output_format="json"
+                notebook_id, output_path, artifact_id=None, output_format="json", **kwargs
             ):
                 chosen_ids.append(artifact_id)
                 Path(output_path).write_text("{}")

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -394,7 +394,7 @@ async def test_download_quiz_delegates():
 
     assert result == "/tmp/q.json"
     service.download_interactive_artifact.assert_awaited_once_with(
-        "nb", "/tmp/q.json", None, "json", "quiz"
+        "nb", "/tmp/q.json", None, "json", "quiz", artifacts=None
     )
 
 
@@ -407,7 +407,7 @@ async def test_download_flashcards_delegates():
 
     assert result == "/tmp/f.json"
     service.download_interactive_artifact.assert_awaited_once_with(
-        "nb", "/tmp/f.json", None, "markdown", "flashcards"
+        "nb", "/tmp/f.json", None, "markdown", "flashcards", artifacts=None
     )
 
 

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -173,8 +173,13 @@ async def test_execute_download_all_reports_partial_failure_and_progress(tmp_pat
 @pytest.mark.asyncio
 async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> None:
     spec = DOWNLOAD_SPECS_BY_NAME["quiz"]
+    quiz = _artifact("quiz_1", "Quiz", 4, variant=2)
     artifacts = SimpleNamespace(
-        list=AsyncMock(return_value=[_artifact("quiz_1", "Quiz", 4, variant=2)]),
+        list=AsyncMock(return_value=[quiz]),
+        # Single-pass seam (#1488): the executor lists once via _list_for_download
+        # (typed + raw studio rows + mind-map rows) and threads the typed quiz
+        # list into download_quiz so it skips its own second LIST_ARTIFACTS.
+        _list_for_download=AsyncMock(return_value=([quiz], [], [])),
         download_quiz=AsyncMock(return_value=str(tmp_path / "quiz.md")),
     )
     facade = SimpleNamespace(artifacts=artifacts)
@@ -187,9 +192,13 @@ async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> 
     result = await execute_download(plan, facade)
 
     assert result["status"] == "downloaded"
+    # The executor now lists once and threads the already-fetched typed quiz list
+    # into ``download_quiz`` so it skips its own second LIST_ARTIFACTS (#1488);
+    # the format kwarg is still forwarded alongside it.
     artifacts.download_quiz.assert_awaited_once_with(
         "nb_resolved",
         str(tmp_path / "quiz.md"),
+        artifacts=[quiz],
         artifact_id="quiz_1",
         output_format="markdown",
     )

--- a/tests/unit/test_get_summary_drift.py
+++ b/tests/unit/test_get_summary_drift.py
@@ -3,8 +3,12 @@
 The site at ``_notebooks.py:get_summary`` used to swallow ``IndexError`` /
 ``TypeError`` from an unguarded ``result[0][0][0]`` descent. It was migrated
 to ``safe_index`` so drift raises ``UnknownRPCMethodError`` carrying
-``method_id=RPCMethod.SUMMARIZE.value`` and ``source='_notebooks.get_summary'``
-for debuggability. Strict decoding is the only mode — the legacy
+``method_id=RPCMethod.SUMMARIZE.value`` for debuggability. As of #1485 the
+descent is delegated to the shared ``_extract_summary`` helper (single source
+of truth with ``get_description``), so drift now surfaces with
+``source='_notebooks._extract_summary'`` and the genuinely-absent shapes
+(``result[0]`` None / empty / null summary slot) return ``""`` identically in
+both entry points. Strict decoding is the only mode — the legacy
 ``NOTEBOOKLM_STRICT_DECODE=0`` soft-mode opt-out (which warn-logged and
 returned ``""``) was retired in v0.7.0; see ADR-0011.
 """
@@ -42,19 +46,62 @@ async def test_get_summary_happy_path_returns_string():
 
 @pytest.mark.asyncio
 async def test_get_summary_drift_raises_typed_error():
-    """Drift raises ``UnknownRPCMethodError`` with context (the only mode)."""
-    # result[0] is an empty list → result[0][0] raises IndexError.
-    api = _make_api([[]])
+    """Present-but-malformed payload raises ``UnknownRPCMethodError`` (the only mode)."""
+    # result = [[[]]]: result[0] (== outer) is [[]] — present and non-None — but
+    # its summary slot result[0][0] is an empty list, so the safe_index descent
+    # into result[0][0][0] raises IndexError. A present-but-malformed inner
+    # payload is genuine drift (distinct from a routinely-absent/None result[0]).
+    api = _make_api([[[]]])
 
     with pytest.raises(UnknownRPCMethodError) as exc_info:
         await api.get_summary("nb_drift")
 
     err = exc_info.value
     assert err.method_id == RPCMethod.SUMMARIZE.value
-    assert err.source == "_notebooks.get_summary"
-    # Descent succeeded for result[0]; failure landed at the next hop.
-    assert err.path == (0,)
+    # The descent is delegated to _extract_summary, so the drift carries the
+    # shared helper's source label (#1485).
+    assert err.source == "_notebooks._extract_summary"
     assert err.data_at_failure is not None
+
+
+@pytest.mark.asyncio
+async def test_get_summary_scalar_result_zero_raises():
+    """A scalar ``result[0]`` is present-but-malformed drift, not absence.
+
+    Regression for #1485 codex review: the server returned ``result == [123]``,
+    so ``result[0]`` is a bare int rather than the expected
+    ``[summary_string, ...]`` list. This must raise drift — a
+    ``not isinstance(..., list)`` short-circuit would wrongly suppress it to "".
+    """
+    api = _make_api([123])
+
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        await api.get_summary("nb_scalar_drift")
+
+    err = exc_info.value
+    assert err.method_id == RPCMethod.SUMMARIZE.value
+    assert err.source == "_notebooks._extract_summary"
+    # The very first descent hop (result[0][0]) fails on the scalar, so the
+    # truncated path is empty.
+    assert err.path == ()
+
+
+@pytest.mark.asyncio
+async def test_get_summary_str_result_zero_raises():
+    """A *string* ``result[0]`` raises drift, not a 1-char "summary".
+
+    Regression for #1485 codex review (second round): the server returned
+    ``result == ["abc"]``, so ``result[0]`` is a bare string. A string is
+    indexable, so a naive descent would return ``"a"`` (``"abc"[0]``) and
+    silently pass it off as the summary. safe_index now rejects intermediate
+    str/bytes, so this surfaces as drift.
+    """
+    api = _make_api(["abc"])
+
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        await api.get_summary("nb_str_drift")
+
+    assert exc_info.value.source == "_notebooks._extract_summary"
 
 
 @pytest.mark.asyncio
@@ -68,5 +115,67 @@ async def test_get_summary_falsy_summary_returns_empty():
     api = _make_api([[[None]]])
 
     summary = await api.get_summary("nb_empty_value")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_notebook_returns_empty():
+    """A summary-less notebook (result[0] is None) returns "" not drift.
+
+    Regression for #1485: a brand-new, source-less notebook has no summary
+    yet, so the SUMMARIZE result[0] payload is None. That routine "no summary
+    yet" state must surface as "" rather than ``UnknownRPCMethodError``.
+    """
+    api = _make_api([None])
+
+    summary = await api.get_summary("nb_empty_notebook")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_result_list_returns_empty():
+    """An empty/absent outer result returns "" rather than raising.
+
+    Regression for #1485: result being [] (no outer[0] slot at all) is the
+    same routine "no summary yet" state and must not be mis-classified as
+    wire-schema drift.
+    """
+    api = _make_api([])
+
+    summary = await api.get_summary("nb_empty_result")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_null_summary_slot_returns_empty():
+    """A null summary slot (result[0][0] is None) returns "" — consistency win.
+
+    Regression for #1485 codex review: ``result == [[None]]`` means the
+    ``outer`` payload is present but its summary slot is explicitly null. Before
+    delegating to ``_extract_summary``, ``get_summary`` raised drift here while
+    ``get_description`` returned "" for the same shape. Both now agree on "".
+    """
+    api = _make_api([[None]])
+
+    summary = await api.get_summary("nb_null_slot")
+
+    assert summary == ""
+
+
+@pytest.mark.asyncio
+async def test_get_summary_empty_outer_returns_empty():
+    """An empty ``outer`` (result == [[]]) returns "" — consistency win.
+
+    Regression for #1485 codex review: ``result == [[]]`` means ``result[0]``
+    is an empty list (no summary slot at all) — the same routine "no summary
+    yet" absence that ``_extract_summary`` already treated as "". ``get_summary``
+    now delegates and agrees, rather than raising drift on an empty container.
+    """
+    api = _make_api([[]])
+
+    summary = await api.get_summary("nb_empty_outer")
 
     assert summary == ""

--- a/tests/unit/test_notebooks_extractors.py
+++ b/tests/unit/test_notebooks_extractors.py
@@ -26,9 +26,30 @@ class TestExtractSummary:
 
         assert _extract_summary(outer) == "the summary"
 
+    def test_none_outer_returns_empty(self) -> None:
+        # Regression for #1485: a brand-new, source-less notebook has no
+        # summary, so result[0] (== outer) is None. Routine "no summary yet",
+        # NOT schema drift.
+        assert _extract_summary(None) == ""
+
+    def test_empty_outer_list_returns_empty(self) -> None:
+        # Regression for #1485: outer with no [0] slot at all is the same
+        # routine "no summary yet" state.
+        assert _extract_summary([]) == ""
+
+    def test_none_at_outer_zero_returns_empty(self) -> None:
+        # Regression for #1485: outer[0] is explicitly None (no summary slot)
+        # — routine absence, handled by the plain guard, not safe_index drift.
+        assert _extract_summary([None, [[["Q", "P"]]]]) == ""
+
+    def test_nested_summary_string_returns_string(self) -> None:
+        # outer[0][0] holds the summary string at the documented shape.
+        assert _extract_summary([["the summary"]]) == "the summary"
+
     def test_drift_missing_inner_index_raises(self) -> None:
-        # outer[0] is an empty list — outer[0][0] drifts and raises under
-        # strict decoding (the only mode).
+        # outer[0] is present but an empty list — the inner safe_index descent
+        # into outer[0][0] drifts and raises under strict decoding (the only
+        # mode). Present-but-malformed is real drift, distinct from absence.
         outer: list = [[], [[["Q", "P"]]]]
 
         with pytest.raises(UnknownRPCMethodError) as exc_info:
@@ -37,12 +58,40 @@ class TestExtractSummary:
         assert exc_info.value.source == "_notebooks._extract_summary"
 
     def test_drift_wrong_type_at_outer_zero_raises(self) -> None:
-        # outer[0] is an int — outer[0][0] raises TypeError, surfaced by
-        # safe_index as a typed drift error.
+        # outer[0] is present but an int — the inner safe_index descent into
+        # outer[0][0] raises TypeError, surfaced as a typed drift error. A
+        # present-but-malformed slot must NOT be over-suppressed as "absence".
         outer = [42, [[["Q", "P"]]]]
 
         with pytest.raises(UnknownRPCMethodError):
             _extract_summary(outer)
+
+    def test_drift_scalar_outer_raises(self) -> None:
+        # Regression for #1485 codex review: ``outer`` is itself a scalar (not
+        # None, not a list) — e.g. the server returned ``result[0] == 123``.
+        # This is present-but-malformed at the payload level, NOT the routine
+        # "no summary yet" absence, so it must raise drift rather than silently
+        # collapse to "". A `not isinstance(outer, list)` short-circuit would
+        # wrongly suppress it; the descent must reach safe_index.
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            _extract_summary(123)
+
+        assert exc_info.value.source == "_notebooks._extract_summary"
+
+    def test_drift_str_outer_raises(self) -> None:
+        # Regression for #1485 codex review (second round): a *string* outer is
+        # indexable, so a naive safe_index descent would char-index it
+        # ("abc"[0] -> "a") and silently return "a" instead of raising. A string
+        # at the outer-payload level is genuine drift, not a 1-char summary.
+        with pytest.raises(UnknownRPCMethodError):
+            _extract_summary("abc")
+
+    def test_drift_str_at_outer_zero_raises(self) -> None:
+        # And a string at outer[0] (present, non-None, but not the expected
+        # [summary_string, ...] list) is drift too — must not collapse to the
+        # first character of the string.
+        with pytest.raises(UnknownRPCMethodError):
+            _extract_summary(["summary text"])
 
 
 class TestExtractSuggestedTopics:

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -257,6 +257,41 @@ def test_signature_compare_rejects_default_value_change(script):
     )
 
 
+def test_signature_compare_ignores_object_sentinel_default_address(script):
+    # A bare ``object()`` sentinel default (e.g. wait_for_completion's
+    # initial_interval) reprs as "<object object at 0xADDR>"; the hex address
+    # differs between the baseline collector process and the current one, so
+    # identical code must NOT read as a changed default (the v0.7.0 baseline
+    # regression that this normalization fixes).
+    old = _signature(
+        _param("initial_interval", default=True, default_repr="<object object at 0x7f00aaaa>")
+    )
+    new = _signature(
+        _param("initial_interval", default=True, default_repr="<object object at 0x55bbbbbb>")
+    )
+
+    assert script._signature_breakage(old, new) is None
+
+
+def test_normalize_default_repr_strips_object_addresses(script):
+    a = script.normalize_default_repr("<object object at 0x7f001234>")
+    b = script.normalize_default_repr("<object object at 0x55009999>")
+    assert a == b == "<object object at 0x...>"
+    # a genuine default differs in more than the address and is preserved verbatim
+    assert script.normalize_default_repr("5") == "5"
+    assert script.normalize_default_repr(None) is None
+    # ONLY the bare object() sentinel is normalized — an address-bearing instance
+    # or function default is left intact, so a real change to it is still caught.
+    assert script.normalize_default_repr("<Foo object at 0x7f00>") == "<Foo object at 0x7f00>"
+    assert (
+        script._signature_breakage(
+            _signature(_param("cb", default=True, default_repr="<function f at 0x1>")),
+            _signature(_param("cb", default=True, default_repr="<function g at 0x2>")),
+        )
+        == "default for parameter 'cb' changed from <function f at 0x1> to <function g at 0x2>"
+    )
+
+
 def test_signature_compare_rejects_positional_parameter_reordering(script):
     old = _signature(_param("notebook_id"), _param("title"), _param("content"))
     new = _signature(_param("notebook_id"), _param("content"), _param("title"))

--- a/tests/unit/test_safe_index.py
+++ b/tests/unit/test_safe_index.py
@@ -83,6 +83,45 @@ def test_descending_into_int_is_caught_and_rerouted(monkeypatch):
     assert isinstance(exc_info.value.__cause__, TypeError)
 
 
+def test_descending_into_str_raises_drift():
+    """A str at an intermediate hop is drift, NOT a silent char index.
+
+    ``"abc"[0] == "a"`` — a string is indexable but is never a valid container
+    at an intermediate descent hop in a decoded RPC payload. Descending it would
+    smuggle a bogus 1-char "value" past drift detection. safe_index must reject
+    it as drift instead (regression for #1485 codex review).
+    """
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(["abc"], 0, 0, method_id="abc", source="test.str")
+    err = exc_info.value
+    # hop 0 descends ["abc"][0] -> "abc" (a str); hop 1 ([0]) is rejected, so
+    # the truncated path stops at (0,).
+    assert err.path == (0,)
+    assert err.source == "test.str"
+    assert err.data_at_failure is not None
+    assert "abc" in err.data_at_failure
+
+
+def test_descending_into_top_level_str_raises_drift():
+    """A str passed directly as ``data`` (descended at hop 0) is drift."""
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index("abc", 0, method_id="abc", source="test.top_str")
+    assert exc_info.value.path == ()
+
+
+def test_descending_into_bytes_raises_drift():
+    """bytes is also indexable-but-not-a-container; reject it as drift too."""
+    with pytest.raises(UnknownRPCMethodError):
+        safe_index([b"abc"], 0, 0, method_id="abc", source="test.bytes")
+
+
+def test_str_leaf_value_is_returned_not_rejected():
+    """A str as the *final* leaf is fine — only intermediate hops are checked."""
+    assert safe_index([["leaf"]], 0, 0, method_id="abc", source="test.leaf") == "leaf"
+    # And a bare string with no descent is returned untouched.
+    assert safe_index("leaf", method_id="abc", source="test.no_descent") == "leaf"
+
+
 def test_strict_mode_exception_is_catchable_as_rpc_error(monkeypatch):
     """Backward compat: ``except RPCError`` still catches strict-mode raise."""
     monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -103,22 +103,28 @@ def test_qa_pairs_raises_on_unguarded_shape():
 async def test_summary_raises_on_indexerror_drift():
     """_notebooks.py: summary extraction raises when result[0][0][0] drifts.
 
-    This site was migrated to ``safe_index``; under strict decoding (the only
-    mode) a drifted response raises ``UnknownRPCMethodError`` carrying the
-    call-site label ``source='_notebooks.get_summary'``.
+    ``get_summary`` delegates the descent to ``_extract_summary`` (the single
+    source of truth shared with ``get_description`` — #1485), so under strict
+    decoding (the only mode) a *present-but-malformed* response raises
+    ``UnknownRPCMethodError`` carrying the helper label
+    ``source='_notebooks._extract_summary'``. A genuinely-absent summary
+    (None / empty / null slot) returns "" instead and is covered in
+    ``test_get_summary_drift.py``.
     """
     from _fixtures.fake_core import make_fake_core
     from notebooklm._notebooks import NotebooksAPI
 
     api = NotebooksAPI.__new__(NotebooksAPI)
-    # result[0] is an empty list → result[0][0] raises IndexError.
-    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[]]))
+    # result[0] == [42]: the summary slot is present and non-None but holds an
+    # int, so the inner result[0][0][0] descent raises TypeError — genuine
+    # drift, distinct from a routinely-absent summary.
+    mock_core = make_fake_core(rpc_call=AsyncMock(return_value=[[42]]))
     api._rpc = mock_core
 
     with pytest.raises(UnknownRPCMethodError) as exc_info:
         await api.get_summary("nb_summary")
 
-    assert exc_info.value.source == "_notebooks.get_summary"
+    assert exc_info.value.source == "_notebooks._extract_summary"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Backports the two user-facing bug fixes that landed on `main` after the v0.7.1 release onto the `release/v0.7.1` line, and cuts version `0.7.2`.

## Fixes

### #1489 — empty notebook summary no longer raises `UnknownRPCMethodError` (#1485)
Clean cherry-pick of `5374411d`. A brand-new, source-less notebook has no summary yet, so `SUMMARIZE` returns an absent/`None` payload. `notebooks.get_summary()` / `get_description()` now treat that routine "no summary yet" state as `""` instead of mis-classifying it as wire-schema drift; genuinely-malformed payloads still raise. `safe_index` also now rejects a `str`/`bytes` value at an intermediate descent hop.

### #1490 — `download <type>` no longer exits 1 with no file written (#1488)
Manual port of `64ec8621`. The download executor listed artifacts twice — once to select the target, then each per-type `download_<x>` re-listed to re-find it by id — so the second `LIST_ARTIFACTS` could not replay against a single-interaction VCR cassette and aborted the download.

This bug exists on 0.7.x too; #1479 (not on this branch) only *relocated* the executor from `cli/services/download.py` to `_app/download.py`. The port therefore applies the **identical runtime-layer changes** as `main` and adapts only the executor to its 0.7.x home:

- `ArtifactListingService.list_artifacts_with_raw` returns `(typed, raw_studio_rows, mind_map_rows)` in one pass; `ArtifactsAPI` gains the `_list_for_download` seam.
- The executor lists once and threads the already-fetched rows into the bound `download_<x>` (which self-fetches only when the kwarg is `None` — standalone path unchanged). Studio downloads pass `spec.kind`, skipping the needless mind-map sub-fetch; mind-map partial-availability is preserved via a `None` sentinel.
- `cli_vcr` `assert_command_success` now defaults strict (exit 0); the download tests assert exit 0 **and** file written so a regression fails loud.

## Also

- Bumps version to `0.7.2` (pyproject + uv.lock).
- Records both fixes under a new `[0.7.2]` CHANGELOG section.
- Bumps the module-size ratchet to the measured post-fix 0.7.x LOC.

## Verification

- `mypy src/notebooklm --ignore-missing-imports`: clean (198 files)
- `ruff check` + `ruff format --check`: clean
- Full suite: **8354 passed, 130 skipped, 1 xfailed**

## Notes

Already-backported fixes (#1466 chat timeout, #1469 decoder warning) are present in the `v0.7.1` tag and excluded. The main-only `fix(audit)` (#1433) is CI infra, not user-facing, and excluded.

https://claude.ai/code/session_01TxizgdMxj575e4t6sSsWVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxizgdMxj575e4t6sSsWVd)_