### PR TITLE
test(guardrails): tighten _app boundary + enforce __all__ on public modules (#1493)

### DIFF
--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -145,6 +145,11 @@ CLIENT_NAMESPACE_ATTRIBUTES = set(json.loads(sys.argv[3])) if len(sys.argv) > 3 
 PKG = sys.argv[4]
 EXCLUDED = set(json.loads(sys.argv[5]))
 EXTRA_PACKAGES = tuple(json.loads(sys.argv[6]))
+# Enforce the "every public module declares __all__" rule only for the CURRENT
+# checkout. Historical baselines (e.g. v0.4.1) predate the rule and legitimately
+# lack __all__ on some public modules; raising there would abort the baseline
+# collection before any diff runs (issue #1493 review).
+ENFORCE_ALL = (sys.argv[7] == "1") if len(sys.argv) > 7 else True
 
 
 def discover_modules() -> list[str]:
@@ -320,13 +325,26 @@ def collect_class(cls) -> dict:
 
 def collect_module(module_name: str) -> dict:
     module = importlib.import_module(module_name)
+    has_all = hasattr(module, "__all__")
+    if not has_all and ENFORCE_ALL:
+        # Every discovered public top-level module MUST declare ``__all__`` so a
+        # brand-new public module cannot ship un-baselined (its surface would
+        # otherwise be invisible to this audit). The presence flag was captured
+        # historically but never enforced; enforce it now (issue #1493) — but
+        # only for the current checkout (ENFORCE_ALL), never for an older
+        # baseline that predates the rule.
+        raise RuntimeError(
+            f"public module {module_name!r} must declare __all__ "
+            "(every public top-level module defines its exported surface so "
+            "the compat audit can baseline it)"
+        )
     all_names = list(getattr(module, "__all__", []))
     extra_names = list(EXTRA_PUBLIC_NAMES.get(module_name, []))
     names = []
     for name in [*all_names, *extra_names]:
         if name not in names:
             names.append(name)
-    payload = {"exports": {}, "has_all": hasattr(module, "__all__")}
+    payload = {"exports": {}, "has_all": has_all}
     for name in names:
         try:
             value = getattr(module, name)
@@ -396,8 +414,16 @@ def normalize_default_repr(default_repr: str | None) -> str | None:
 def collect_manifest(
     source_root: Path,
     extra_public_names: dict[str, list[str]] | None = None,
+    *,
+    enforce_all: bool = True,
 ) -> dict[str, Any]:
-    """Run the collector in a clean Python process for ``source_root``."""
+    """Run the collector in a clean Python process for ``source_root``.
+
+    ``enforce_all`` gates the "every public module declares ``__all__``" rule
+    (issue #1493): pass ``True`` for the current checkout and ``False`` for a
+    historical baseline that predates the rule, so baseline collection never
+    aborts before the diff.
+    """
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH")
     pythonpath = str(source_root / "src")
@@ -416,6 +442,7 @@ def collect_manifest(
             PUBLIC_PACKAGE,
             json.dumps(sorted(EXCLUDED_TOP_LEVEL_MODULES)),
             json.dumps(EXTRA_PUBLIC_PACKAGES),
+            "1" if enforce_all else "0",
         ],
         cwd=source_root,
         env=env,
@@ -852,8 +879,12 @@ def main(argv: list[str] | None = None) -> int:
         allowances, extra_public_names = load_policy(allowlist_path)
         with tempfile.TemporaryDirectory(prefix="notebooklm-api-compat-") as tmp:
             baseline_root = export_git_ref(repo_root, baseline_ref, Path(tmp))
-            baseline_manifest = collect_manifest(baseline_root, extra_public_names)
-            current_manifest = collect_manifest(repo_root, extra_public_names)
+            # Enforce the __all__ rule only for the current checkout; an older
+            # baseline may legitimately predate it (issue #1493 review).
+            baseline_manifest = collect_manifest(
+                baseline_root, extra_public_names, enforce_all=False
+            )
+            current_manifest = collect_manifest(repo_root, extra_public_names, enforce_all=True)
 
         breakages = compare_manifests(baseline_manifest, current_manifest)
         unapproved, approved = partition_allowed(breakages, allowances)

--- a/src/notebooklm/_app/chat.py
+++ b/src/notebooklm/_app/chat.py
@@ -33,8 +33,12 @@ Conversation IDs pass straight through (no validation / resolution here) — the
 server owns their shape and a partial/explicit id is forwarded verbatim to
 ``ChatAPI.ask``.
 
-This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
-``fastmcp`` imports (enforced by ``tests/_guardrails/test_app_boundary.py``).
+This module depends only on the public ``notebooklm`` surface — no ``click`` /
+``rich`` / ``cli`` / ``fastmcp`` and no runtime-internal (``notebooklm.rpc`` /
+``notebooklm._*``) imports (enforced by
+``tests/_guardrails/test_app_boundary.py``). The chat RPC enums ``ChatGoal`` /
+``ChatResponseLength`` are consumed through their ``notebooklm.types``
+re-export, not by reaching into ``notebooklm.rpc.types``.
 """
 
 from __future__ import annotations
@@ -45,8 +49,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from ..exceptions import ValidationError
-from ..rpc.types import ChatGoal, ChatResponseLength
-from ..types import ChatMode
+from ..types import ChatGoal, ChatMode, ChatResponseLength
 from .events import ProgressEvent, ProgressSink
 
 if TYPE_CHECKING:

--- a/tests/_guardrails/test_app_boundary.py
+++ b/tests/_guardrails/test_app_boundary.py
@@ -1,20 +1,39 @@
-"""AST lint: enforce the transport-neutral boundary of ``notebooklm._app``.
+"""AST lint: enforce the layered boundary of ``notebooklm._app``.
 
 ``_app`` is the shared business-logic layer consumed by every transport
-adapter (the Click CLI, the FastMCP server, future HTTP). To stay reusable it
-MUST NOT import any transport dependency. This guardrail walks every
+adapter (the Click CLI, the FastMCP server, future HTTP). Its contract is two
+fold: it must stay transport-neutral AND it must depend only on the **public**
+``notebooklm`` surface (plus intra-``_app`` siblings). It must never reach
+sideways/downward into a runtime-internal layer. This guardrail walks every
 ``src/notebooklm/_app/**/*.py`` file and rejects an import of:
 
-* ``click`` (and any ``click.*`` submodule),
-* ``rich`` (and any ``rich.*`` submodule),
-* ``notebooklm.cli`` (and any ``notebooklm.cli.*`` submodule), via absolute
-  (``import notebooklm.cli...`` / ``from notebooklm.cli... import``) or
-  relative (``from ..cli import`` / ``from ..cli.x import``) forms, and
-* ``fastmcp`` (and any ``fastmcp.*`` submodule).
+* a forbidden *external* transport package — ``click`` / ``rich`` / ``fastmcp``
+  (and any ``*.<submodule>``), or
+* a forbidden ``notebooklm`` *sibling* sub-target, via absolute
+  (``import notebooklm.X...`` / ``from notebooklm.X... import``) or relative
+  (``from ..X import`` / ``from ..X.y import`` / ``from .. import X``) forms,
+  where ``X`` is:
+
+  - ``cli`` — the transport adapter (``notebooklm.cli.*``),
+  - ``rpc`` — the batchexecute runtime layer (``notebooklm.rpc.*``); ``_app``
+    must consume RPC enums through their public ``notebooklm.types`` re-export,
+    not by reaching into ``rpc.types`` directly, or
+  - any *private* sibling whose name starts with ``_`` (``notebooklm._kernel``,
+    ``notebooklm._runtime``, ``notebooklm._middleware``,
+    ``notebooklm._rpc_executor``, ``notebooklm._auth``, …) — the client
+    runtime internals. ``_app`` may only depend on the public facade.
+
+``_app``'s *own* package is ``notebooklm._app``; intra-``_app`` imports are
+**relative within ``_app``** (e.g. ``from .events import ...`` /
+``from .errors import ...``) and resolve at a shallower level than the ``..``
+that points at ``notebooklm``, so they are never flagged. Only a relative import
+whose ``..`` resolves to the ``notebooklm`` package *and* targets a forbidden
+sibling is a violation.
 
 The walk is a full ``ast.walk`` over *all* import statements, so an import
 hidden inside ``if TYPE_CHECKING:`` (or any other block) is still caught —
-even a type-only ``click`` import would couple ``_app`` to the CLI surface.
+even a type-only ``click`` (or ``rpc.types``) import would couple ``_app`` to a
+layer it must not depend on.
 """
 
 from __future__ import annotations
@@ -29,15 +48,52 @@ APP_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / 
 # Forbidden top-level *external* package roots.
 FORBIDDEN_EXTERNAL_ROOTS = {"click", "rich", "fastmcp"}
 
+# Forbidden non-private ``notebooklm`` siblings. ``cli`` is the transport
+# adapter; ``rpc`` is the batchexecute runtime layer (consume its enums via the
+# public ``notebooklm.types`` re-export instead). Private ``_*`` siblings are
+# caught separately by :func:`_is_forbidden_notebooklm_child`.
+FORBIDDEN_NOTEBOOKLM_CHILDREN = {"cli", "rpc"}
+
 
 def _is_forbidden_external(parts: list[str]) -> bool:
     """True if a dotted module path's root is a forbidden external package."""
     return bool(parts) and parts[0] in FORBIDDEN_EXTERNAL_ROOTS
 
 
-def _is_notebooklm_cli(parts: list[str]) -> bool:
-    """True if ``parts`` (below no prefix) is ``notebooklm.cli`` or a sub-path."""
-    return parts[:2] == ["notebooklm", "cli"]
+def _is_forbidden_notebooklm_child(child: str) -> bool:
+    """True if ``child`` is a forbidden ``notebooklm`` sibling for ``_app``.
+
+    Forbidden siblings are the explicit transport/runtime layers
+    (``cli`` / ``rpc``) plus every private ``_*`` runtime-internal module or
+    package (``_kernel``, ``_runtime``, ``_middleware``, ``_rpc_executor``,
+    ``_auth``, …). ``_app`` is allowed to import only the *public* surface
+    (``exceptions`` / ``types`` / ``client`` / ``urls`` / ``auth`` /
+    ``migration`` / ``artifacts`` / …, none of which start with ``_``), so any
+    underscore-prefixed sibling is rejected.
+    """
+    if not child:
+        return False
+    if child in FORBIDDEN_NOTEBOOKLM_CHILDREN:
+        return True
+    # Public dunder attributes of the package (``__version__``, …) are part of
+    # the public surface, not a private runtime module — allow them.
+    if child.startswith("__"):
+        return False
+    # ``notebooklm._app`` is the package under audit itself: an *absolute*
+    # intra-_app import (``import notebooklm._app.events`` / ``from
+    # notebooklm._app.events import X``) is allowed, exactly like the relative
+    # ``from .events import ...`` form. Only a *sideways* reach into a different
+    # ``notebooklm._*`` runtime internal is forbidden.
+    if child == "_app":
+        return False
+    return child.startswith("_")
+
+
+def _is_forbidden_notebooklm_path(parts: list[str]) -> bool:
+    """True if ``parts`` is ``notebooklm.<forbidden-child>`` or a sub-path."""
+    return (
+        parts[:1] == ["notebooklm"] and len(parts) >= 2 and _is_forbidden_notebooklm_child(parts[1])
+    )
 
 
 def _app_package_level(relative_parts: tuple[str, ...]) -> int:
@@ -63,30 +119,31 @@ def _boundary_violations(tree: ast.AST, relative_parts: tuple[str, ...]) -> list
         if isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")
-                if _is_forbidden_external(parts) or _is_notebooklm_cli(parts):
+                if _is_forbidden_external(parts) or _is_forbidden_notebooklm_path(parts):
                     bad.append(f"import {alias.name}")
         elif isinstance(node, ast.ImportFrom):
             mod = node.module or ""
             mod_parts = mod.split(".") if mod else []
             if node.level == 0:
                 # Absolute import.
-                if _is_forbidden_external(mod_parts) or _is_notebooklm_cli(mod_parts):
+                if _is_forbidden_external(mod_parts) or _is_forbidden_notebooklm_path(mod_parts):
                     bad.append(f"from {mod} import ...")
                 elif mod_parts == ["notebooklm"]:
                     bad.extend(
                         f"from notebooklm import {alias.name}"
                         for alias in node.names
-                        if alias.name == "cli"
+                        if _is_forbidden_notebooklm_child(alias.name)
                     )
-            else:
-                # Relative import. Resolve the form against ``notebooklm.cli``.
-                if node.level == notebooklm_level and mod_parts[:1] == ["cli"]:
+            elif node.level == notebooklm_level:
+                # Relative import whose ``..`` resolves to ``notebooklm``.
+                if mod_parts and _is_forbidden_notebooklm_child(mod_parts[0]):
                     bad.append(f"from {'.' * node.level}{mod} import ...")
-                elif node.level == notebooklm_level and not mod:
+                elif not mod:
+                    # ``from .. import X`` — X is a notebooklm sibling.
                     bad.extend(
                         f"from {'.' * node.level} import {alias.name}"
                         for alias in node.names
-                        if alias.name == "cli"
+                        if _is_forbidden_notebooklm_child(alias.name)
                     )
     return bad
 
@@ -101,9 +158,11 @@ def test_app_has_no_transport_dependency_imports() -> None:
             offenders.append((str(path.relative_to(APP_ROOT.parent.parent)), bad))
 
     assert not offenders, (
-        "notebooklm._app must stay transport-neutral: no imports of click, rich, "
-        "notebooklm.cli.*, or fastmcp (even under TYPE_CHECKING). Move "
-        "transport-specific code into the adapter (cli/ or mcp/).\n"
+        "notebooklm._app must depend only on the public notebooklm surface "
+        "(+ intra-_app): no imports of click, rich, fastmcp, notebooklm.cli.*, "
+        "notebooklm.rpc.*, or any private notebooklm._* runtime sibling (even "
+        "under TYPE_CHECKING). Consume RPC enums via their notebooklm.types "
+        "re-export; move transport-specific code into the adapter (cli/ or mcp/).\n"
         f"Offenders: {offenders}"
     )
 
@@ -127,7 +186,21 @@ def test_app_has_no_transport_dependency_imports() -> None:
         "from notebooklm.cli import error_handler\n",
         "from notebooklm.cli.resolve import validate_id\n",
         "from notebooklm import cli\n",
+        # rpc runtime layer — consume enums via notebooklm.types instead.
+        "import notebooklm.rpc\n",
+        "import notebooklm.rpc.types\n",
+        "from notebooklm.rpc import RPCMethod\n",
+        "from notebooklm.rpc.types import ChatGoal\n",
+        "from notebooklm import rpc\n",
+        # private runtime-internal siblings.
+        "import notebooklm._kernel\n",
+        "from notebooklm._kernel import Kernel\n",
+        "from notebooklm._runtime.config import Config\n",
+        "from notebooklm._rpc_executor import execute\n",
+        "from notebooklm._middleware import retry\n",
+        "from notebooklm import _kernel\n",
         "if False:\n    import click\n",  # block-nested still flagged
+        "if False:\n    from notebooklm.rpc.types import ChatGoal\n",
     ],
 )
 def test_matcher_flags_forbidden_absolute_imports(source: str) -> None:
@@ -140,12 +213,23 @@ def test_matcher_flags_forbidden_absolute_imports(source: str) -> None:
         ("from ..cli import error_handler\n", ("serialize.py",)),
         ("from ..cli.resolve import validate_id\n", ("serialize.py",)),
         ("from .. import cli\n", ("serialize.py",)),
+        # rpc runtime layer (the historical evadable seam, issue #1493).
+        ("from ..rpc import RPCMethod\n", ("serialize.py",)),
+        ("from ..rpc.types import ChatGoal, ChatResponseLength\n", ("serialize.py",)),
+        ("from .. import rpc\n", ("serialize.py",)),
+        # private runtime-internal siblings.
+        ("from .._kernel import Kernel\n", ("serialize.py",)),
+        ("from .._runtime.config import Config\n", ("serialize.py",)),
+        ("from .._rpc_executor import execute\n", ("serialize.py",)),
+        ("from .. import _kernel\n", ("serialize.py",)),
         # Nested file: ``notebooklm`` is one level deeper.
         ("from ...cli import error_handler\n", ("sub", "mod.py")),
         ("from ... import cli\n", ("sub", "mod.py")),
+        ("from ...rpc.types import ChatGoal\n", ("sub", "mod.py")),
+        ("from ..._kernel import Kernel\n", ("sub", "mod.py")),
     ],
 )
-def test_matcher_flags_forbidden_relative_cli_imports(
+def test_matcher_flags_forbidden_relative_imports(
     source: str, relative_parts: tuple[str, ...]
 ) -> None:
     assert _boundary_violations(ast.parse(source), relative_parts)
@@ -158,9 +242,17 @@ def test_matcher_flags_forbidden_relative_cli_imports(
         "import dataclasses\n",
         "from datetime import date\n",
         "from ..exceptions import ValidationError\n",  # public sibling — allowed
-        "from .errors import classify\n",  # intra-_app — allowed
+        "from ..types import ChatGoal, ChatResponseLength\n",  # public re-export — allowed
+        "from ..artifacts import retry_artifact\n",  # public sibling — allowed
+        "from .. import artifacts\n",  # public sibling — allowed
+        "from .. import __version__\n",  # public package attr — allowed
+        "from .errors import classify\n",  # intra-_app (relative) — allowed
+        "from .events import ProgressSink\n",  # intra-_app (relative) — allowed
+        "import notebooklm._app.events\n",  # intra-_app (absolute) — allowed (#1493)
+        "from notebooklm._app.events import ProgressSink\n",  # intra-_app (absolute) — allowed (#1493)
         "from notebooklm.exceptions import NotebookLMError\n",  # public — allowed
         "from notebooklm.types import Notebook\n",  # public — allowed
+        "from notebooklm.urls import is_youtube_url\n",  # public — allowed
     ],
 )
 def test_matcher_allows_neutral_imports(source: str) -> None:

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -1116,6 +1116,9 @@ def test_public_top_level_module_declares_all(module_name: str) -> None:
     assert all(isinstance(name, str) for name in all_value), (
         f"{module_name}.__all__ must contain only str names"
     )
+    assert len(all_value) == len(set(all_value)), (
+        f"{module_name}.__all__ contains duplicate entries"
+    )
     for name in all_value:
         assert hasattr(module, name), f"{module_name}.__all__ references missing attribute {name!r}"
 

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -1001,6 +1001,126 @@ def test_auth_update_cookie_input_lives_in_cookies_module() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Every discovered public top-level module must declare ``__all__``.
+#
+# ``scripts/audit_public_api_compat.py`` captures ``has_all`` per module but
+# (historically) never asserted it, and the shim-pair sweep below only covered a
+# hardcoded trio. A brand-new public top-level module could therefore ship
+# without ``__all__`` and slip past both gates (issue #1493). This sweep mirrors
+# the audit's module-discovery rule — every non-underscore top-level ``*.py``
+# (minus the excluded entrypoints) plus the public ``rpc`` subpackage and the
+# top-level ``notebooklm`` package — and requires each to declare ``__all__``.
+# ---------------------------------------------------------------------------
+
+# Mirrors scripts/audit_public_api_compat.py: EXCLUDED_TOP_LEVEL_MODULES /
+# EXTRA_PUBLIC_PACKAGES. Keep in sync with the audit's discovery so the two
+# gates agree on the public top-level surface.
+_AUDIT_EXCLUDED_TOP_LEVEL_MODULES = {"__main__", "notebooklm_cli"}
+_AUDIT_EXTRA_PUBLIC_PACKAGES = ("rpc",)
+_NOTEBOOKLM_PACKAGE_DIR = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+
+
+def _discover_public_top_level_modules() -> list[str]:
+    """Discover the public top-level ``notebooklm`` modules the audit baselines.
+
+    Identical discovery to ``scripts/audit_public_api_compat.py``'s
+    ``discover_modules``: the ``notebooklm`` package itself, every
+    non-underscore top-level ``*.py`` (minus the excluded entrypoints), and each
+    public subpackage in ``EXTRA_PUBLIC_PACKAGES`` that ships an ``__init__``.
+    """
+    modules = {"notebooklm"}
+    for path in _NOTEBOOKLM_PACKAGE_DIR.glob("*.py"):
+        stem = path.stem
+        if stem.startswith("_") or stem in _AUDIT_EXCLUDED_TOP_LEVEL_MODULES:
+            continue
+        modules.add(f"notebooklm.{stem}")
+    for name in _AUDIT_EXTRA_PUBLIC_PACKAGES:
+        if (_NOTEBOOKLM_PACKAGE_DIR / name / "__init__.py").is_file():
+            modules.add(f"notebooklm.{name}")
+    return sorted(modules)
+
+
+_PUBLIC_TOP_LEVEL_MODULES = _discover_public_top_level_modules()
+
+
+def test_public_top_level_module_discovery_is_non_trivial() -> None:
+    """Guard the discovery itself: it must find the known anchor modules.
+
+    A discovery bug that returned an empty/degenerate set would make the
+    per-module ``__all__`` sweep vacuously pass. Pin a few stable anchors so a
+    regression in ``_discover_public_top_level_modules`` is caught loudly.
+    """
+    found = set(_PUBLIC_TOP_LEVEL_MODULES)
+    for anchor in ("notebooklm", "notebooklm.types", "notebooklm.client", "notebooklm.rpc"):
+        assert anchor in found, f"discovery dropped the public anchor module {anchor!r}"
+    # The excluded entrypoints must never be treated as public surface.
+    assert "notebooklm.__main__" not in found
+    assert "notebooklm.notebooklm_cli" not in found
+
+
+def test_discovery_constants_match_the_audit_source() -> None:
+    """The mirrored discovery constants must EQUAL the audit's, self-checked.
+
+    ``_AUDIT_EXCLUDED_TOP_LEVEL_MODULES`` / ``_AUDIT_EXTRA_PUBLIC_PACKAGES`` are
+    hand-copied from ``scripts/audit_public_api_compat.py`` so this gate and the
+    audit agree on the public surface. Assert equality against the source of
+    truth rather than relying on a "keep in sync" comment — an un-enforced copy
+    is exactly the consistency-drift failure shape this gate exists to close
+    (#1493 review).
+    """
+    import scripts.audit_public_api_compat as audit
+
+    assert set(audit.EXCLUDED_TOP_LEVEL_MODULES) == _AUDIT_EXCLUDED_TOP_LEVEL_MODULES
+    assert tuple(_AUDIT_EXTRA_PUBLIC_PACKAGES) == tuple(audit.EXTRA_PUBLIC_PACKAGES)
+
+
+def test_all_enforcement_flags_a_module_without_all() -> None:
+    """Probe: the ``__all__`` requirement catches a module lacking ``__all__``.
+
+    A synthetic public-shaped module with no ``__all__`` would have evaded both
+    gates before issue #1493. This pins that the enforcement predicate
+    (``hasattr(module, "__all__")``) actually distinguishes the two cases, so
+    the per-module sweep above is not vacuous.
+    """
+    without_all = ModuleType("notebooklm._probe_without_all")
+    with_all = ModuleType("notebooklm._probe_with_all")
+    with_all.__all__ = ["x"]  # type: ignore[attr-defined]
+    with_all.x = 1  # type: ignore[attr-defined]
+
+    assert not hasattr(without_all, "__all__")
+    assert hasattr(with_all, "__all__")
+
+
+@pytest.mark.parametrize("module_name", _PUBLIC_TOP_LEVEL_MODULES)
+def test_public_top_level_module_declares_all(module_name: str) -> None:
+    """Every public top-level module must declare ``__all__``.
+
+    This is the assertion behind the audit's captured ``has_all`` flag: a public
+    module without ``__all__`` ships an un-baselined surface. ``__all__`` must be
+    a list/tuple of ``str`` so the audit and ``import *`` consumers see a
+    well-formed export manifest.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        module = importlib.import_module(module_name)
+
+    assert hasattr(module, "__all__"), (
+        f"{module_name} must declare __all__ — every public top-level module "
+        "defines its exported surface so the compat audit can baseline it "
+        "(scripts/audit_public_api_compat.py)."
+    )
+    all_value = module.__all__
+    assert isinstance(all_value, (list, tuple)), (
+        f"{module_name}.__all__ must be a list/tuple, got {type(all_value).__name__}"
+    )
+    assert all(isinstance(name, str) for name in all_value), (
+        f"{module_name}.__all__ must contain only str names"
+    )
+    for name in all_value:
+        assert hasattr(module, name), f"{module_name}.__all__ references missing attribute {name!r}"
+
+
+# ---------------------------------------------------------------------------
 # __all__ contract tests for the public shim modules.
 #
 # Enforces, for each shim, that:

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -633,7 +633,11 @@ def test_audit_json_includes_stale_allowances_field(script, tmp_path, monkeypatc
 
     def _stub_manifests():
         manifests = iter([baseline, current])
-        monkeypatch.setattr(script, "collect_manifest", lambda root, extra=None: next(manifests))
+        monkeypatch.setattr(
+            script,
+            "collect_manifest",
+            lambda root, extra=None, *, enforce_all=True: next(manifests),
+        )
 
     _stub_manifests()
 
@@ -699,7 +703,11 @@ def test_check_stale_does_not_print_ok_when_stale_blocks(script, tmp_path, monke
     monkeypatch.setattr(script, "latest_release_tag", lambda repo_root: "v9.9.9")
     monkeypatch.setattr(script, "export_git_ref", lambda repo_root, ref, dest: dest)
     manifests = iter([baseline, current])
-    monkeypatch.setattr(script, "collect_manifest", lambda root, extra=None: next(manifests))
+    monkeypatch.setattr(
+        script,
+        "collect_manifest",
+        lambda root, extra=None, *, enforce_all=True: next(manifests),
+    )
 
     allowlist = tmp_path / "allowlist.json"
     allowlist.write_text(


### PR DESCRIPTION
## What & why

Fixes #1493. Two CI guards enforced a slightly **narrower dimension than their invariant**, leaving evadable seams (the project's own "un-enforced consistency = ruinous-to-reverse" failure shape):

1. **`_app` boundary lint** forbade only `click`/`rich`/`cli`/`fastmcp` — not deep `notebooklm.rpc`/private `_*` imports. So `_app/chat.py:48` did `from ..rpc.types import ChatGoal, ChatResponseLength`, reaching past the public facade into the RPC runtime layer, undetected.
2. **API-compat audit** captured `has_all` (`scripts/audit_public_api_compat.py`) but never asserted it; the public-surface manifest gate only checked a hardcoded `client.py`/`auth.py` pair. A brand-new public module could ship without `__all__`, un-baselined.

## Approach

- **Generalize the boundary matcher** to forbid the `notebooklm` siblings `cli`/`rpc` + any private `_*` sibling (public dunders like `__version__` excluded; absolute *intra-*`_app` imports allowed), keeping the full `ast.walk` (TYPE_CHECKING / relative / aliased forms). Repoint the one offender to the public `notebooklm.types` re-export — verified `ChatGoal`/`ChatResponseLength` are the **identical objects** there, both in `types.__all__`, so it's behavior-preserving.
- **Enforce `__all__`** in the audit collector *and* a generalized, anti-vacuous manifest sweep that discovers public modules the same way the audit does. All 15 current public modules already declare `__all__`, so this is a forward-looking tripwire.

## Review-driven fixes (codex)

- The `__all__` enforcement now runs **only for the current checkout** (`enforce_all`), never a historical baseline that predates the rule — `--baseline-ref v0.4.1` no longer aborts collection before diffing.
- The boundary matcher now also allows **absolute** intra-`_app` imports (`import notebooklm._app.events`), not just the relative form.
- The mirrored discovery constants are now **self-checked for equality** against the audit's source of truth (no comment-policed drift).

## Verification

- `scripts/audit_public_api_compat.py` → **EXIT 0** (additive); `--baseline-ref v0.4.1` collects cleanly (no abort).
- Full guardrail suite green (boundary + manifest + surface: 451 passed); new self-check probes prove the gates now catch the previously-evadable cases (deep `rpc` import; module without `__all__`; absolute intra-`_app` allowed). mypy + ruff clean.
- Polished: claude + codex review; codex's 2 Important + shared Minor all addressed.

Closes #1493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Audit tooling can now optionally enforce that each public top-level module declares its exported names, while avoiding failures against older baselines.
  * App import-boundary tests strengthened to forbid internal/transport-layer imports and clarify failure messages; RPC enums must be consumed via public re-exports.
  * New public-surface manifest checks validate discovered modules declare a usable public interface.
  * Unit tests updated to match the revised audit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->