### PR TITLE
feat(observability): add rpc_decode_errors drift counter + chat drift canary (#1492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Schema-drift observability: `rpc_decode_errors` counter + chat drift canary**
+  (#1492). Wire-schema drift is the stated #1 breakage class, but
+  decode/drift failures (`DecodingError` / `UnknownRPCMethodError`) were
+  invisible to metrics — they did not even reach the transport-leg
+  `rpc_calls_failed` counter (the middleware chain wraps only the transport
+  leg; decode happens after). `ClientMetricsSnapshot` now exposes a dedicated
+  `rpc_decode_errors` counter (additive, defaults to `0`, appended at the end
+  of the dataclass so existing positional construction is unaffected),
+  incremented at the executor's response-decode boundary whenever a decoded
+  response envelope is rejected as drift — both the wrapped shape-drift case
+  (bad JSON / missing key-or-index) and a surfaced `DecodingError` /
+  `UnknownRPCMethodError` from the envelope decoder. A decoded *semantic* error
+  (rate-limit, not-found, auth) is not drift and does not bump the counter; a
+  drift error recovered by refresh-and-retry is not counted. (Positional drift
+  raised later by feature-layer `safe_index` navigation, after `rpc_call`
+  returns, is not yet routed through this counter — a tracked follow-up.)
+  Operators can now alert on "Google reshaped a response" distinctly from
+  ordinary 5xx / network failures. Separately,
+  `scripts/check_rpc_health.py` now probes the streamed-chat orchestration RPC
+  `GenerateFreeFormStreamed` — a `PATH_NOT_METHOD` (`v1` URL) endpoint with no
+  obfuscated method ID — by asserting a 200 plus a recognizable stream frame,
+  closing the gap where the chat surface escaped the daily drift canary.
+
 ### Fixed
 
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -785,12 +785,14 @@ async def check_chat_query(
 
     try:
         parse_streaming_chat_response(response.text)
-    except (ChatResponseParseError, DecodingError) as e:
-        # Zero parseable chunks (empty/drifted body) OR strict positional drift
-        # raising DecodingError / UnknownRPCMethodError from the wire decoder:
-        # both are the schema-drift signal the canary exists to surface. Catch
-        # them here so a drifted response returns a clean ERROR result rather
-        # than crashing the canary with an uncaught exception.
+    except (ChatResponseParseError, DecodingError, json.JSONDecodeError) as e:
+        # Zero parseable chunks (empty/drifted body), a structurally malformed
+        # JSON body (``json.JSONDecodeError`` — a ``ValueError`` subclass we
+        # catch specifically so a bare ``ValueError`` from a real bug still
+        # propagates), OR strict positional drift raising DecodingError /
+        # UnknownRPCMethodError from the wire decoder: all are the schema-drift
+        # signal the canary exists to surface. Catch them here so a drifted
+        # response returns a clean ERROR result rather than crashing the canary.
         return CheckResult(
             method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
             status=CheckStatus.ERROR,

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -52,6 +52,10 @@ from uuid import uuid4
 import httpx
 
 from notebooklm._artifact.payloads import build_retry_artifact_params
+from notebooklm._chat.wire import (
+    build_streaming_chat_request,
+    parse_streaming_chat_response,
+)
 from notebooklm._env import get_default_language
 from notebooklm._logging import scrub_secrets
 from notebooklm._notebooks import build_create_notebook_params
@@ -62,6 +66,7 @@ from notebooklm.auth import (
     get_authuser_for_storage,
     load_auth_from_storage,
 )
+from notebooklm.exceptions import ChatError, ChatResponseParseError, DecodingError
 from notebooklm.paths import get_storage_path
 from notebooklm.rpc import (
     RPCError,
@@ -76,6 +81,7 @@ from notebooklm.rpc.decoder import (
     parse_chunked_response,
     strip_anti_xssi,
 )
+from notebooklm.rpc.types import _QUERY_ENDPOINT_PATH
 
 
 class CheckStatus(str, Enum):
@@ -680,6 +686,140 @@ async def check_method(
     )
 
 
+@dataclass
+class _ChatQueryProbe:
+    """Method-like sentinel for the ``GenerateFreeFormStreamed`` chat probe.
+
+    The streamed-chat orchestration endpoint is NOT a batchexecute RPC ID — it
+    is a ``PATH_NOT_METHOD`` ``v1`` URL segment (see ``_QUERY_ENDPOINT_PATH`` in
+    ``rpc/types.py``), so it has no :class:`RPCMethod` enum member and cannot be
+    probed by ``make_rpc_call``/``check_method`` like the obfuscated method IDs.
+    This ducktype gives the probe's :class:`CheckResult` the ``.name`` /
+    ``.value`` attributes that ``print_summary`` / ``format_check_output`` /
+    ``partition_errors`` read, so the chat result flows through the existing
+    summary + exit-code machinery unchanged (an ``ERROR`` here is classified
+    and reported as drift exactly like a method-ID probe).
+    """
+
+    name: str = "GENERATE_FREE_FORM_STREAMED"
+    value: str = _QUERY_ENDPOINT_PATH
+
+
+# Singleton sentinel reused for every chat-probe CheckResult.
+CHAT_QUERY_PROBE = _ChatQueryProbe()
+
+
+async def check_chat_query(
+    client: httpx.AsyncClient,
+    auth: AuthTokens,
+    notebook_id: str | None,
+) -> CheckResult:
+    """Probe the streamed-chat ``GenerateFreeFormStreamed`` orchestration RPC.
+
+    This is the chat surface's drift canary. Unlike the batchexecute method-ID
+    probes, the chat endpoint is a hardcoded ``v1`` path with no obfuscated RPC
+    ID to echo back, so liveness is asserted on the *wire shape* instead: issue
+    one minimal request and require an HTTP 200 plus a recognizable stream frame
+    (a ``wrb.fr`` envelope or a server ``"er"`` frame).
+
+    Classification mirrors the method-ID probes:
+
+    * Parseable stream (an answer, or a server-side ``ChatError`` frame the
+      parser recognizes — including a rate-limit / rejected frame) -> ``OK``:
+      the wire contract is intact, the server merely declined this request.
+    * Zero parseable chunks (:class:`ChatResponseParseError`) -> ``ERROR``: the
+      response body was empty or the wire format drifted. This is the schema
+      drift the canary exists to catch.
+    * Non-200 / transport failure -> ``ERROR`` (rate-limit / ReadTimeout text is
+      still classified as transient downstream by ``is_transient_error``).
+
+    Skipped when no notebook ID is configured (the request needs one for
+    server-side conversation persistence).
+    """
+    if not notebook_id:
+        return CheckResult(
+            method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+            status=CheckStatus.SKIPPED,
+            expected_id=CHAT_QUERY_PROBE.value,
+            found_ids=[],
+            error="No notebook ID provided (chat probe needs one)",
+        )
+
+    url, body, extra_headers = build_streaming_chat_request(
+        snapshot=auth,
+        notebook_id=notebook_id,
+        question="RPC health check ping.",
+        source_ids=[],
+        conversation_history=None,
+        conversation_id=None,
+        reqid=int(uuid4().int % 1_000_000),
+    )
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Cookie": auth.cookie_header,
+        **extra_headers,
+    }
+
+    try:
+        response = await client.post(url, content=body, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return CheckResult(
+            method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+            status=CheckStatus.ERROR,
+            expected_id=CHAT_QUERY_PROBE.value,
+            found_ids=[],
+            error=f"HTTP {e.response.status_code}",
+        )
+    except httpx.RequestError as e:
+        # ``httpx.ReadTimeout`` can stringify to ``""``; fall back to the class
+        # name so the downstream transient classifier (and the operator) sees a
+        # usable signal — same posture as ``make_rpc_request`` (#864).
+        return CheckResult(
+            method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+            status=CheckStatus.ERROR,
+            expected_id=CHAT_QUERY_PROBE.value,
+            found_ids=[],
+            error=str(e) or type(e).__name__,
+        )
+
+    try:
+        parse_streaming_chat_response(response.text)
+    except (ChatResponseParseError, DecodingError) as e:
+        # Zero parseable chunks (empty/drifted body) OR strict positional drift
+        # raising DecodingError / UnknownRPCMethodError from the wire decoder:
+        # both are the schema-drift signal the canary exists to surface. Catch
+        # them here so a drifted response returns a clean ERROR result rather
+        # than crashing the canary with an uncaught exception.
+        return CheckResult(
+            method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+            status=CheckStatus.ERROR,
+            expected_id=CHAT_QUERY_PROBE.value,
+            found_ids=[],
+            error=f"Parse error: {e}",
+        )
+    except ChatError as e:
+        # A recognized server-side ``"er"`` / rate-limit frame: the wire shape
+        # is INTACT (the parser identified the frame), the server simply
+        # declined this request. Treat as OK — the contract is healthy. The
+        # message is preserved for the operator (and so a rate-limit frame
+        # stays visible), but it does not fail the canary.
+        return CheckResult(
+            method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+            status=CheckStatus.OK,
+            expected_id=CHAT_QUERY_PROBE.value,
+            found_ids=[CHAT_QUERY_PROBE.value],
+            error=f"Server declined (recognized frame): {e}",
+        )
+
+    return CheckResult(
+        method=CHAT_QUERY_PROBE,  # type: ignore[arg-type]
+        status=CheckStatus.OK,
+        expected_id=CHAT_QUERY_PROBE.value,
+        found_ids=[CHAT_QUERY_PROBE.value],
+    )
+
+
 async def setup_temp_resources(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1042,6 +1182,19 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
 
                 if i < total and result.status != CheckStatus.SKIPPED:
                     await asyncio.sleep(CALL_DELAY)
+
+            # Probe the streamed-chat orchestration RPC. It is not an
+            # ``RPCMethod`` (it is a ``PATH_NOT_METHOD`` ``v1`` URL segment),
+            # so it is checked separately from the method-ID loop above — but
+            # its ``CheckResult`` flows through the same summary + exit-code
+            # machinery so chat drift fails the canary like any other probe.
+            chat_result = await check_chat_query(client, auth, notebook_id)
+            results.append(chat_result)
+            chat_icon = STATUS_ICONS[chat_result.status]
+            chat_line = f"{chat_icon:8} {chat_result.method.name} ({chat_result.expected_id})"
+            if chat_result.error and chat_result.status != CheckStatus.OK:
+                chat_line += f" - {scrub_secrets(chat_result.error)}"
+            print(chat_line)
 
         finally:
             if full_mode and temp_resources.notebook_id:

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -30,6 +30,7 @@ from ._transport_errors import (
     parse_retry_after,
 )
 from .auth import format_authuser_value
+from .exceptions import DecodingError
 from .rpc import (
     ClientError,
     NetworkError,
@@ -353,6 +354,17 @@ class RpcExecutor:
                 )
                 return refreshed
 
+            # Count only genuine wire-schema drift, not every decoded
+            # ``RPCError``. ``DecodingError`` (and its ``UnknownRPCMethodError``
+            # subclass, e.g. from ``safe_index``) means "Google reshaped a
+            # response"; a decoded ``RateLimitError`` / ``AuthError`` /
+            # ``*NotFoundError`` is a semantic outcome, not drift, and must not
+            # inflate the drift signal. This is the surfaced leg only — a decode
+            # error recovered by the refresh-and-retry above returns before
+            # reaching here, so it is correctly not counted.
+            if isinstance(exc, DecodingError):
+                self._metrics.increment(rpc_decode_errors=1)
+
             error_details = [type(exc).__name__]
             if exc.rpc_code is not None:
                 error_details.append(f"rpc_code={exc.rpc_code}")
@@ -377,6 +389,12 @@ class RpcExecutor:
             # this guard exists to remove.
             elapsed = time.perf_counter() - start
             logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
+            # Genuine shape drift: a malformed body or a missing key/index in
+            # the decoded payload. Count it under the dedicated drift signal
+            # before re-raising as ``RPCError`` (the wrap is the executor's
+            # single decode-boundary, so this is the one site for the wrapped
+            # case — symmetric with the surfaced ``DecodingError`` leg above).
+            self._metrics.increment(rpc_decode_errors=1)
             raise RPCError(
                 f"Failed to decode response for {method.name}: {exc}",
                 method_id=method.value,

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -90,6 +90,31 @@ class ClientMetricsSnapshot:
     upload_queue_wait_seconds_max: float = 0.0
     lock_wait_seconds_total: float = 0.0
     lock_wait_seconds_max: float = 0.0
+    # Appended at the END so no existing positional parameter shifts — the
+    # public ``ClientMetricsSnapshot`` is constructed positionally in places,
+    # and inserting mid-list would be a breaking signature change (the
+    # api-compat audit flags a moved positional parameter). Keep new counters
+    # here at the tail.
+    rpc_decode_errors: int = 0
+    """Schema-drift failures surfaced at the **RPC executor's response-decode
+    boundary**.
+
+    Bumped whenever the executor rejects a decoded RPC response as schema
+    drift — a wrapped shape-drift error (bad JSON / missing key-or-index) or a
+    surfaced ``DecodingError`` / ``UnknownRPCMethodError`` raised while decoding
+    the response envelope (``safe_index`` inside the decoder). Wire-schema drift
+    is the stated #1 breakage class, so this counter separates "Google reshaped
+    a response" from an ordinary 5xx / network failure (which lands in
+    ``rpc_calls_failed`` via the transport-leg ``MetricsMiddleware``). A decode
+    error recovered by a refresh-and-retry is NOT counted; only the error that
+    ultimately surfaces is.
+
+    Scope note: this covers drift detected at the executor boundary. Positional
+    drift raised *later* by feature-layer ``safe_index`` navigation (after
+    ``rpc_call`` returns — e.g. ``_extract_summary``) propagates straight to the
+    caller and is not routed through this counter yet; broadening the counting
+    boundary to those sites is tracked as a follow-up.
+    """
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -19,6 +19,7 @@ auth-failure test by invoking ``main()`` with a missing storage env var.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from collections import Counter
 from pathlib import Path
@@ -560,6 +561,139 @@ def test_print_summary_lists_affected_methods_on_exit_three(
     assert "timeout" in affected and "parse" in affected
     # …and the transient one is NOT listed as an affected method.
     assert "rate" not in affected
+
+
+# ---------------------------------------------------------------------------
+# check_chat_query: GenerateFreeFormStreamed (PATH_NOT_METHOD) drift probe
+#
+# The streamed-chat orchestration RPC has no obfuscated method ID to echo back
+# (it is a hardcoded ``v1`` URL path), so the canary probes its WIRE SHAPE:
+# 200 + a recognizable stream frame -> OK; zero parseable chunks -> ERROR
+# (drift). These tests pin that classification (issue #1492).
+# ---------------------------------------------------------------------------
+
+
+def _chat_auth() -> Any:
+    return check_rpc_health.AuthTokens(
+        cookies={"SID": "sid"},
+        csrf_token="csrf",
+        session_id="session",
+        authuser=2,
+        account_email="bob@example.com",
+    )
+
+
+class _ChatClient:
+    """Minimal httpx-like client returning a fixed response (or raising)."""
+
+    def __init__(self, *, text: str = "", status: int = 200, raises: Exception | None = None):
+        self._text = text
+        self._status = status
+        self._raises = raises
+        self.url: str | None = None
+        self.content: str | None = None
+
+    async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+        self.url = url
+        self.content = content
+        if self._raises is not None:
+            raise self._raises
+        return httpx.Response(
+            self._status,
+            text=self._text,
+            request=httpx.Request("POST", url),
+        )
+
+
+def _wrb_fr_body(inner: Any) -> str:
+    """Build an anti-XSSI-prefixed body wrapping one ``wrb.fr`` frame."""
+    frame = json.dumps([["wrb.fr", "GenerateFreeFormStreamed", json.dumps(inner)]])
+    return ")]}'\n" + frame
+
+
+def test_chat_probe_uses_query_endpoint_path() -> None:
+    """The probe's CheckResult is labelled with the streamed-chat path, not an
+    RPCMethod value, and matches the library's ``_QUERY_ENDPOINT_PATH``.
+    """
+    assert check_rpc_health.CHAT_QUERY_PROBE.value == check_rpc_health._QUERY_ENDPOINT_PATH
+    assert "GenerateFreeFormStreamed" in check_rpc_health.CHAT_QUERY_PROBE.value
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_skipped_without_notebook() -> None:
+    result = await check_rpc_health.check_chat_query(_ChatClient(), _chat_auth(), None)
+    assert result.status is CheckStatus.SKIPPED
+    assert result.method.name == "GENERATE_FREE_FORM_STREAMED"
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_ok_on_parseable_frame() -> None:
+    # An empty-list ``wrb.fr`` frame is a recognized (heartbeat) frame: the
+    # wire shape is intact even though there's no answer text. -> OK.
+    client = _ChatClient(text=_wrb_fr_body([]))
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.OK
+    # The probe hit the streamed-chat endpoint, not batchexecute.
+    assert "GenerateFreeFormStreamed" in (client.url or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_error_on_zero_parseable_chunks() -> None:
+    # Empty/garbage body -> ChatResponseParseError -> ERROR (this is the
+    # wire-drift signal the chat canary exists to catch).
+    client = _ChatClient(text=")]}'\n\n")
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.ERROR
+    assert "Parse error" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_error_on_strict_decode_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Strict positional drift in the wire decoder raises UnknownRPCMethodError
+    # (a DecodingError subclass), NOT ChatResponseParseError. The probe must
+    # CATCH it and return ERROR rather than letting it escape and crash the
+    # canary (#1492 review). This is the drift the chat canary exists to catch.
+    from notebooklm.exceptions import UnknownRPCMethodError
+
+    def _raise_drift(_text: str) -> Any:
+        raise UnknownRPCMethodError("safe_index drift at path ()[0]")
+
+    monkeypatch.setattr(check_rpc_health, "parse_streaming_chat_response", _raise_drift)
+    client = _ChatClient(text=_wrb_fr_body([]))
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.ERROR
+    assert "Parse error" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_ok_on_recognized_server_error_frame() -> None:
+    # An ``"er"`` frame is a RECOGNIZED frame (the parser raises ChatError):
+    # the wire contract is intact, the server merely declined. -> OK.
+    body = ")]}'\n" + json.dumps([["er", "GenerateFreeFormStreamed", 7]])
+    client = _ChatClient(text=body)
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_error_on_http_status() -> None:
+    client = _ChatClient(status=500, text="boom")
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.ERROR
+    assert result.error == "HTTP 500"
+
+
+@pytest.mark.asyncio
+async def test_chat_probe_surfaces_class_name_for_empty_message_errors() -> None:
+    # Mirror the make_rpc_request #864 fallback: ``httpx.ReadTimeout("")``
+    # stringifies to "" and must surface as the class name, not be swallowed.
+    client = _ChatClient(raises=httpx.ReadTimeout(""))
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.ERROR
+    assert result.error == "ReadTimeout"
+    # And ReadTimeout is classified as transient downstream (does not fail the
+    # canary) — same posture as the method-ID probes.
+    assert is_transient_error(result.error) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_client_metrics.py
+++ b/tests/unit/test_client_metrics.py
@@ -94,6 +94,19 @@ def test_increment_accumulates_across_calls() -> None:
     assert snapshot.rpc_calls_failed == 0
 
 
+def test_decode_errors_counter_defaults_zero_and_accumulates() -> None:
+    """The drift counter (issue #1492) starts at 0 and accumulates through the
+    same locked ``increment()`` path as every other counter — confirming it is
+    threadsafe-consistent with the existing metrics locking.
+    """
+    metrics = ClientMetrics()
+    assert metrics.snapshot().rpc_decode_errors == 0
+
+    metrics.increment(rpc_decode_errors=1)
+    metrics.increment(rpc_decode_errors=2)
+    assert metrics.snapshot().rpc_decode_errors == 3
+
+
 def test_increment_holds_metrics_lock_during_update() -> None:
     """``increment()`` itself must run under ``_metrics_lock``.
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -97,12 +97,57 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
     assert snapshot.rpc_calls_started == 1
     assert snapshot.rpc_calls_succeeded == 1
     assert snapshot.rpc_calls_failed == 0
+    # A clean decode never touches the drift counter (issue #1492).
+    assert snapshot.rpc_decode_errors == 0
     assert snapshot.rpc_latency_seconds_total >= 0
 
     assert len(events) == 1
     assert events[0].method == "GET_NOTEBOOK"
     assert events[0].status == "success"
     assert events[0].request_id == "batch-42"
+
+
+@pytest.mark.asyncio
+async def test_rpc_decode_error_bumps_drift_counter(auth_tokens: AuthTokens) -> None:
+    """Public contract: a decode/drift failure increments ``rpc_decode_errors``.
+
+    End-to-end mirror of the success test above (issue #1492). The transport
+    leg returns 200 OK; the injected decoder then raises a ``DecodingError``
+    (the base of ``UnknownRPCMethodError``), exercising the executor's
+    decode-boundary increment. Wire-schema drift is the stated #1 breakage
+    class, so the snapshot must expose it as a dedicated counter distinct from
+    ``rpc_calls_failed`` (which tracks transport-leg failures).
+    """
+    from notebooklm.exceptions import DecodingError
+
+    def drifting_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
+        raise DecodingError("Google reshaped the response", method_id=rpc_id)
+
+    core = build_client_shell_for_tests(auth_tokens, decode_response=drifting_decode)
+    install_http_client_for_test(core._collaborators.kernel, AsyncMock(spec=httpx.AsyncClient))
+
+    from notebooklm._middleware.core import RpcResponse, build_chain
+
+    async def fake_terminal(request: object) -> RpcResponse:
+        return RpcResponse(
+            response=httpx.Response(200, text=")]}'\n[]"),
+            context=request.context,  # type: ignore[attr-defined]
+        )
+
+    core._composed.chain_host._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
+    core._composed.chain_host._authed_post_chain = build_chain(
+        core._composed.middlewares, fake_terminal
+    )
+
+    with pytest.raises(DecodingError):
+        await core._rpc_executor.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])
+
+    snapshot = core._collaborators.metrics.snapshot()
+    assert snapshot.rpc_decode_errors == 1
+    # The transport leg succeeded (200 OK), so the generic transport-failure
+    # counter stays 0 — the drift is counted ONLY under the dedicated signal.
+    assert snapshot.rpc_calls_failed == 0
+    assert snapshot.rpc_calls_started == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -12,6 +12,7 @@ from notebooklm._logging import get_request_id, reset_request_id, set_request_id
 from notebooklm._request_types import AuthSnapshot
 from notebooklm._rpc_executor import RpcExecutor
 from notebooklm.auth import AuthTokens
+from notebooklm.exceptions import DecodingError, UnknownRPCMethodError
 from notebooklm.rpc import (
     ClientError,
     NetworkError,
@@ -933,3 +934,161 @@ async def test_decode_code_bug_propagates(
         )
 
     assert raised.value is decoder_exc
+
+
+# =============================================================================
+# rpc_decode_errors drift counter (issue #1492)
+#
+# Wire-schema drift is the stated #1 breakage class. The executor's decode
+# boundary bumps the dedicated ``rpc_decode_errors`` counter so operators can
+# distinguish "Google reshaped a response" from an ordinary transport failure.
+# These tests pin the two increment sites (wrapped shape-drift + surfaced
+# ``DecodingError``), the no-increment cases (success, non-drift ``RPCError``),
+# and that a decode error recovered by refresh-and-retry is NOT counted.
+# =============================================================================
+
+
+def _decode_error_count(owner: _Owner) -> int:
+    """Sum ``rpc_decode_errors`` deltas recorded by the stub's ``increment``."""
+    return sum(int(inc.get("rpc_decode_errors", 0)) for inc in owner.metric_increments)
+
+
+@pytest.mark.asyncio
+async def test_decode_errors_metric_zero_on_success() -> None:
+    """A clean decode never touches the drift counter."""
+    owner = _Owner()
+
+    result = await _executor(owner)._execute_once(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        False,
+    )
+
+    assert result == {"rpc_id": RPCMethod.LIST_NOTEBOOKS.value, "allow_null": False}
+    assert _decode_error_count(owner) == 0
+
+
+@pytest.mark.parametrize(
+    "decoder_exc_factory",
+    [
+        lambda: KeyError("missing"),
+        lambda: IndexError("oob"),
+        lambda: TypeError("bad type"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_decode_errors_metric_increments_on_wrapped_shape_drift(
+    decoder_exc_factory: Callable[[], Exception],
+) -> None:
+    """The wrap branch (bad JSON / missing key-or-index) bumps the counter."""
+    owner = _Owner()
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise decoder_exc_factory()
+
+    with pytest.raises(RPCError):
+        await _executor(owner, decode_response=decode)._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert _decode_error_count(owner) == 1
+
+
+@pytest.mark.parametrize(
+    "drift_exc_factory",
+    [
+        lambda: DecodingError("unexpected shape", method_id="x"),
+        lambda: UnknownRPCMethodError(
+            "safe_index drift", method_id="x", path=(0,), source="_decoder"
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_decode_errors_metric_increments_on_surfaced_drift(
+    drift_exc_factory: Callable[[], Exception],
+) -> None:
+    """A ``DecodingError`` / ``UnknownRPCMethodError`` surfaced by the decoder
+    (e.g. from ``safe_index``) bumps the drift counter on the surfaced leg.
+    """
+    owner = _Owner()
+    drift_exc = drift_exc_factory()
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise drift_exc
+
+    with pytest.raises(DecodingError) as raised:
+        await _executor(owner, decode_response=decode)._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert raised.value is drift_exc
+    assert _decode_error_count(owner) == 1
+
+
+@pytest.mark.asyncio
+async def test_decode_errors_metric_not_bumped_for_non_drift_rpc_error() -> None:
+    """A decoded *semantic* ``RPCError`` (rate-limit / not-found / auth) is not
+    schema drift and MUST NOT inflate ``rpc_decode_errors`` — only
+    ``DecodingError`` and its subclasses count.
+    """
+    owner = _Owner()
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise RateLimitError("quota", method_id=RPCMethod.LIST_NOTEBOOKS.value)
+
+    with pytest.raises(RateLimitError):
+        await _executor(owner, decode_response=decode)._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert _decode_error_count(owner) == 0
+
+
+@pytest.mark.asyncio
+async def test_decode_errors_metric_not_counted_when_recovered_by_retry() -> None:
+    """A decode error cured by refresh-and-retry returns before the surfaced
+    leg, so it is NOT counted — only an error that ultimately surfaces is.
+    """
+
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    decode_calls = 0
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        nonlocal decode_calls
+        decode_calls += 1
+        if decode_calls == 1:
+            raise DecodingError("auth-shaped drift on first attempt")
+        return {"ok": True}
+
+    result = await _executor(
+        owner,
+        decode_response=decode,
+        is_auth_error=lambda exc: True,
+    )._execute_once(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        False,
+    )
+
+    assert result == {"ok": True}
+    assert decode_calls == 2
+    assert _decode_error_count(owner) == 0


### PR DESCRIPTION
## What & why

Fixes #1492. Wire-schema drift is the stated #1 breakage class, but decode/drift failures (`DecodingError`/`UnknownRPCMethodError`) were **invisible to metrics** — they didn't even reach the transport-leg `rpc_calls_failed` counter (the middleware wraps only the transport leg; decode happens after). And the chat surface (`GenerateFreeFormStreamed`, a `PATH_NOT_METHOD` `v1` endpoint) escaped the daily drift canary entirely.

## Approach

- **`rpc_decode_errors` counter** on `ClientMetricsSnapshot` — additive (default `0`, appended at the dataclass tail; audit EXIT 0), incremented at the executor's response-decode boundary. Semantic errors (rate-limit/auth/not-found) and retry-cured drift are **not** counted; increments go through the locked `ClientMetrics.increment()`.
- **Chat drift probe** in `scripts/check_rpc_health.py` — issues one minimal `GenerateFreeFormStreamed` request, asserts 200 + a parseable stream frame; a recognized server `er`/rate-limit frame is OK (contract intact), zero-parseable or transport failure is ERROR, transient (ReadTimeout) stays non-blocking, SKIPPED without a notebook.

## Review-driven fixes (codex)

- **The probe no longer crashes on the drift it exists to detect** — it now catches `DecodingError`/`UnknownRPCMethodError` (strict positional drift from the wire decoder) and returns a clean ERROR `CheckResult` instead of letting the exception escape and crash the canary. Regression test added.
- **The counter's scope is documented honestly** (field docstring + CHANGELOG): it covers drift at the executor response-decode boundary. Positional drift raised *later* by feature-layer `safe_index` navigation (after `rpc_call` returns) is not yet routed through the counter — tracked as #1497.

## Verification

- 112 metrics/executor/probe tests pass (incl. the new drift-crash regression); mypy + ruff clean; API-compat audit **EXIT 0** (additive, zero allowlist entries).
- Polished: claude (solid) + codex review; codex's 2 Critical + Minor addressed/scoped.

Closes #1492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-drift observability: a dedicated RPC decode-errors metric that tracks decode/shape-drift failures (excludes recovered or semantic errors) and an enhanced health check that probes streamed-chat drift.

* **Tests**
  * Added and expanded tests covering the decode-errors counter, drift classification semantics, and the streamed-chat health probe.

* **Documentation**
  * Updated changelog to document the new metric and improved drift canary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->