### PR TITLE
fix(rpc): close the positional-decoding perimeter — chat row adapter + single-level lint gate (#1491)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,7 +480,7 @@ Beyond the client-owned runtime graph, several feature APIs are implemented via 
 | `ArtifactDownloadService` | [`_artifact/downloads.py`](../src/notebooklm/_artifact/downloads.py) | Asynchronous download coordinator for finished artifacts. |
 | `_artifact_formatters` | [`_artifact/formatters.py`](../src/notebooklm/_artifact/formatters.py) | Markdown, HTML, and plain text formatters for artifacts. |
 | `_artifact/listing` | [`_artifact/listing.py`](../src/notebooklm/_artifact/listing.py) | Listing and filtering operations for notebook artifacts. |
-| `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `NoteRow`, `SourceRow`) behind named accessors so downloads, polling, and listing don't open-code positional indices. Soft-degrade and strict-mode behavior is pinned in `tests/unit/test_row_adapters.py`. |
+| `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/chat.py`](../src/notebooklm/_row_adapters/chat.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `NoteRow`, `SourceRow`) and the streamed-chat rows (`AnswerRow`/`CitationRow`/…) behind named accessors so downloads, polling, listing, and the chat parser don't open-code positional indices. Soft-degrade and strict-mode behavior is pinned in `tests/unit/test_row_adapters.py` and `tests/unit/test_chat_row_adapter.py`. |
 | `_research_task_parser` | [`_research_task_parser.py`](../src/notebooklm/_research_task_parser.py) | Parses deep-research task results from raw rows. Returns dict-shaped output today; a typed-model migration is not yet complete. |
 | `_types/` | [`_types/`](../src/notebooklm/_types) | Private package holding the dataclass and `Protocol` implementations behind the public `types.py` / per-feature public schemas. Split per domain (`artifacts.py`, `chat.py`, `notebooks.py`, `notes.py`, `sharing.py`, `sources.py`, plus `common.py` for shared shapes like `ConnectionLimits`). |
 
@@ -848,7 +848,8 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `paths.py`, `migration.py` | Profile-aware path resolution and locked migration from the legacy flat layout |
 | `_types/`, `types.py` | Dataclass implementation package and public type/re-export facade |
 | `_types/labels.py` | `Label` pure-value type (source-label topic grouping; `source_ids` only, no artifact members) re-exported by `types.py` |
-| `_row_adapters/artifacts.py` | `ArtifactRow` typed view over raw positional artifact RPC rows |
+| `_row_adapters/artifacts.py` | `ArtifactRow` typed view over raw positional artifact RPC rows, plus `ReportSuggestionRow` over `GET_SUGGESTED_REPORTS` rows |
+| `_row_adapters/chat.py` | Streamed-chat row adapters (`AnswerRow` / `CitationRow` / `CitationDetail` / `PassageRow` / `StreamFrameRow` / `ErrorPayloadRow` / `TextLeafRow`) that centralise the chat wire positions `_chat/wire.py` used to open-code (#1491) |
 | `_row_adapters/labels.py` | `LabelRow` strict typed view over the raw positional label tuple `[name, sources, id, emoji]` (fails loud on schema drift) |
 | `_row_adapters/notes.py` | `NoteRow` typed view over raw positional note and mind-map RPC rows |
 | `_row_adapters/sources.py` | `SourceRow` / `SourceRowShape` typed views over raw positional source RPC rows |
@@ -1023,7 +1024,8 @@ src/notebooklm/
 │   └── params.py                # Source-label RPC payload builders (CREATE/LIST/UPDATE/DELETE_LABEL)
 ├── _row_adapters/               # Positional-RPC-row adapters subpackage (promoted from flat _row_adapters_*.py, #1328)
 │   ├── __init__.py              # Re-exports the typed row views
-│   ├── artifacts.py             # Artifact row adapter
+│   ├── artifacts.py             # Artifact + GET_SUGGESTED_REPORTS row adapters (ArtifactRow / ReportSuggestionRow)
+│   ├── chat.py                  # Streamed-chat row adapters (AnswerRow / CitationRow / CitationDetail / PassageRow / StreamFrameRow / ErrorPayloadRow / TextLeafRow) — closes the chat positional-decode perimeter (#1491)
 │   ├── labels.py                # Source-label row adapter
 │   ├── notes.py                 # Note and mind-map row adapter
 │   └── sources.py               # Source row adapter

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -43,6 +43,7 @@ from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteService
 from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
+from ._row_adapters.artifacts import ReportSuggestionRow
 from ._runtime.contracts import RpcCaller
 from ._types.artifacts import _status_from_code
 from ._types.research import MindMapResult
@@ -1233,29 +1234,28 @@ class ArtifactsAPI:
             allow_null=True,
         )
 
-        suggestions = []
-        if result and isinstance(result, list) and len(result) > 0:
-            # GET_SUGGESTED_REPORTS returns a wrapped ``[[row1, ...]]`` envelope or an
-            # already-flat ``[row1, ...]``; only unwrap the wrapped case (single outer
-            # element whose first inner element is itself a row). Bind ``inner`` so the
-            # wrap probe is ``inner[0]`` not chained ``result[0][0]``.
-            items = result
-            if len(result) == 1 and isinstance(result[0], list):
-                inner = result[0]
-                if not inner or isinstance(inner[0], list):
-                    items = inner
-            for item in items:
-                if isinstance(item, list) and len(item) >= 5:
-                    suggestions.append(
-                        ReportSuggestion(
-                            title=item[0] if isinstance(item[0], str) else "",
-                            description=item[1] if isinstance(item[1], str) else "",
-                            prompt=item[4] if isinstance(item[4], str) else "",
-                            audience_level=item[5] if len(item) > 5 else 2,
-                        )
-                    )
+        if not (result and isinstance(result, list)):
+            return []
 
-        return suggestions
+        # GET_SUGGESTED_REPORTS returns a wrapped ``[[row1, ...]]`` envelope or an
+        # already-flat ``[row1, ...]``; only unwrap the wrapped case (single outer
+        # element whose first inner element is itself a row).
+        items = result
+        if len(result) == 1 and isinstance(result[0], list):
+            inner = result[0]
+            if not inner or isinstance(inner[0], list):
+                items = inner
+        # ``ReportSuggestionRow`` centralises the per-row position knowledge (#1491).
+        return [
+            ReportSuggestion(
+                title=row.title,
+                description=row.description,
+                prompt=row.prompt,
+                audience_level=row.audience_level,
+            )
+            for row in map(ReportSuggestionRow, items)
+            if row.is_well_formed
+        ]
 
     # =========================================================================
     # Private Helpers

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -16,6 +16,15 @@ from typing import Any, NoReturn, Protocol
 from urllib.parse import quote, urlencode
 
 from .._env import get_default_bl, get_default_language
+from .._row_adapters.chat import (
+    AnswerRow,
+    CitationDetail,
+    CitationRow,
+    ErrorPayloadRow,
+    PassageRow,
+    StreamFrameRow,
+    TextLeafRow,
+)
 from ..auth import format_authuser_value
 from ..exceptions import ChatError, ChatResponseParseError, UnknownRPCMethodError
 from ..rpc._safe_index import safe_index
@@ -294,26 +303,29 @@ def _extract_chunk_with_parseable(
         # The batchexecute stream emits ``["er", rpc_id, code, ...]`` frames
         # when the RPC itself failed; the old parser only inspected
         # ``"wrb.fr"`` frames, so a server error collapsed into the generic
-        # "no parseable chunks" / "empty response" failure. ``item[0]`` is a
-        # guaranteed index here (``len(item) >= 2``) so the ``safe_index``
-        # descent is byte-for-byte identical on the happy path and only raises
-        # if the frame tag slot itself drifted out from under us.
-        tag = safe_index(item, 0, method_id=None, source=_CHUNK_SOURCE)
+        # "no parseable chunks" / "empty response" failure. ``StreamFrameRow``
+        # centralises the ``item[0]`` / ``item[2]`` / ``item[5]`` frame reads
+        # (issue #1491). ``frame.tag`` is the one guaranteed slot
+        # (``len(item) >= 2``) so its ``safe_index`` descent is byte-for-byte
+        # identical on the happy path and only raises if the tag slot drifted.
+        frame = StreamFrameRow(item)
+        tag = frame.tag
         if tag == "er":
             _raise_chat_error_frame(item)
 
         if tag != "wrb.fr" or len(item) < 3:
             continue
 
-        inner_json = item[2]
+        inner_json = frame.inner_json
         if not isinstance(inner_json, str):
             # item[2] is null — check item[5] for a server-side error payload.
             # Don't flip ``parseable`` here: a null inner_json without a
             # recognized error payload is not a successfully decoded
             # envelope. The error-payload path raises, so flow only
             # reaches the next iteration when item[5] was absent/unusable.
-            if len(item) > 5 and isinstance(item[5], list):
-                raise_if_rate_limited(item[5])
+            error_payload = frame.error_payload
+            if error_payload is not None:
+                raise_if_rate_limited(error_payload)
             continue
 
         try:
@@ -359,34 +371,20 @@ def _extract_chunk_with_parseable(
                     data_at_failure=repr(first)[:200],
                 )
             if len(first) > 0:
-                # Load-bearing answer-text leaf. ``first`` already holds
-                # ``inner_data[0]`` and the ``len(first) > 0`` guard makes
-                # ``first[0]`` valid, so reuse it instead of re-traversing from
-                # ``inner_data``: byte-for-byte identical on the happy path,
-                # with a more localized ``(0,)`` drift path under drift.
-                text = safe_index(first, 0, method_id=None, source=_CHUNK_SOURCE)
-                if not isinstance(text, str) or not text:
+                # The populated record is wrapped in an ``AnswerRow`` so every
+                # leaf read (text / answer-marker / server-conv-id / citations)
+                # goes through one named position contract in
+                # ``_row_adapters/chat.py`` instead of scattered single-level
+                # subscripts here (issue #1491). ``text`` is the load-bearing
+                # answer leaf; an absent/empty/non-string leaf legitimately means
+                # "no answer in this chunk" (heartbeat-ish), so fall through.
+                answer = AnswerRow(first)
+                text = answer.text
+                if text is None:
                     continue
 
-                # ``first[4]`` is the optional type/flags block; its trailing
-                # element being ``1`` marks an answer record. Bind it so the flag
-                # read is a single-level ``type_block[-1]`` index rather than a
-                # chained ``first[4][-1]`` descent. An absent block legitimately
-                # means "not an answer" (non-answer records carry no type block).
-                type_block = first[4] if len(first) > 4 and isinstance(first[4], list) else None
-                is_answer = type_block is not None and len(type_block) > 0 and type_block[-1] == 1
-
-                # ``first[2]`` is the optional server-conversation-id block; bind
-                # it so the id read is a single-level ``conv_block[0]`` index
-                # rather than a chained ``first[2][0]`` descent. An absent/empty
-                # block legitimately means "no server conversation id present".
-                server_conv_id: str | None = None
-                conv_block = first[2] if len(first) > 2 and isinstance(first[2], list) else None
-                if conv_block and isinstance(conv_block[0], str):
-                    server_conv_id = conv_block[0]
-
                 refs = parse_citations(first)
-                return text, is_answer, refs, server_conv_id, parseable
+                return text, answer.is_answer, refs, answer.server_conversation_id, parseable
         # inner_json decoded but the record didn't yield usable answer data
         # — either the outer ``isinstance(inner_data, list) and len > 0``
         # guard failed (dict, empty list, non-list) OR the inner
@@ -416,8 +414,9 @@ def _raise_chat_error_frame(item: list) -> NoReturn:
     """
     # The error code is optional enrichment — its absence must not be treated
     # as schema drift (an ``"er"`` frame is itself the error signal), so read
-    # the slot with an explicit length guard rather than ``safe_index``.
-    code = item[2] if len(item) > 2 else None
+    # the slot via ``StreamFrameRow.error_code`` (length-guarded, not
+    # ``safe_index``) which centralises the ``item[2]`` position (issue #1491).
+    code = StreamFrameRow(item).error_code
     detail = f" (code {code!r})" if code is not None else ""
     raise ChatError(
         f"Chat request failed: the server returned an error frame{detail}. "
@@ -430,14 +429,16 @@ def raise_if_rate_limited(error_payload: list) -> None:
     """Raise ``ChatError`` if the payload contains a UserDisplayableError."""
     try:
         # Structure: [8, None, [["type.googleapis.com/.../UserDisplayableError", ...]]]
-        if len(error_payload) > 2 and isinstance(error_payload[2], list):
-            for entry in error_payload[2]:
-                if isinstance(entry, list) and entry and isinstance(entry[0], str):
-                    if "UserDisplayableError" in entry[0]:
-                        raise ChatError(
-                            "Chat request was rate limited or rejected by the API. "
-                            "Wait a few seconds and try again."
-                        )
+        # ``ErrorPayloadRow`` centralises the ``error_payload[2]`` entries read
+        # and the per-entry ``entry[0]`` type-string read (issue #1491).
+        row = ErrorPayloadRow(error_payload)
+        for entry in row.entries:
+            entry_type = ErrorPayloadRow.entry_type(entry)
+            if entry_type is not None and "UserDisplayableError" in entry_type:
+                raise ChatError(
+                    "Chat request was rate limited or rejected by the API. "
+                    "Wait a few seconds and try again."
+                )
     except ChatError:
         raise
     except Exception:
@@ -450,14 +451,11 @@ def raise_if_rate_limited(error_payload: list) -> None:
 def parse_citations(first: list) -> list[ChatReference]:
     """Parse citation details from a streamed-chat response structure."""
     try:
-        if len(first) <= 4 or not isinstance(first[4], list):
-            return []
-        type_info = first[4]
-        if len(type_info) <= 3 or not isinstance(type_info[3], list):
-            return []
-
+        # ``AnswerRow.citations`` centralises the ``first[4][3]`` descent and
+        # degrades to ``[]`` for the "answer without citations" shapes the old
+        # inline length guards tolerated (issue #1491).
         refs: list[ChatReference] = []
-        for cite in type_info[3]:
+        for cite in AnswerRow(first).citations:
             ref = parse_single_citation(cite)
             if ref is not None:
                 refs.append(ref)
@@ -473,28 +471,20 @@ def parse_citations(first: list) -> list[ChatReference]:
 
 def parse_single_citation(cite: Any) -> ChatReference | None:
     """Parse a single citation entry into a ``ChatReference``."""
-    if not isinstance(cite, list) or len(cite) < 2:
+    # ``CitationRow`` centralises the ``cite[0][0]`` chunk-id and ``cite[1]``
+    # detail-block position knowledge (issue #1491); a malformed entry yields
+    # ``detail is None`` here, matching the old "skip unusable citation" guard.
+    row = CitationRow(cite)
+    detail = row.detail
+    if detail is None:
         return None
+    cite_inner = detail.raw_list
 
-    cite_inner = cite[1]
-    if not isinstance(cite_inner, list):
-        return None
-
-    source_id_data = cite_inner[5] if len(cite_inner) > 5 else None
-    source_id = extract_uuid_from_nested(source_id_data)
+    source_id = extract_uuid_from_nested(detail.source_id_data)
     if source_id is None:
         return None
 
-    # ``cite[0]`` is the optional chunk-id block; bind it so the id read is a
-    # single-level ``chunk_block[0]`` index rather than a chained ``cite[0][0]``
-    # descent. An absent/empty block legitimately means "no chunk id" (the
-    # citation is kept; chunk_id stays None).
-    chunk_id = None
-    chunk_block = cite[0]
-    if isinstance(chunk_block, list) and chunk_block:
-        first_item = chunk_block[0]
-        if isinstance(first_item, str):
-            chunk_id = first_item
+    chunk_id = row.chunk_id
 
     cited_text, start_char, end_char = extract_text_passages(cite_inner)
     answer_start_char, answer_end_char = extract_answer_range(cite_inner)
@@ -524,15 +514,10 @@ def extract_answer_range(cite_inner: list) -> tuple[int | None, int | None]:
     semantically paired and one without the other is meaningless to
     downstream consumers.
     """
-    if len(cite_inner) <= 3 or not isinstance(cite_inner[3], list):
-        return None, None
-    outer = cite_inner[3]
-    if not outer or not isinstance(outer[0], list):
-        return None, None
-    inner = outer[0]
-    if len(inner) < 3:
-        return None, None
-    start, end = inner[1], inner[2]
+    # ``CitationDetail.answer_range`` centralises the ``cite_inner[3][0]``
+    # descent (``[None, start, end]``) and returns ``(None, None)`` for every
+    # malformed shape the old inline guards rejected (issue #1491).
+    start, end = CitationDetail(cite_inner).answer_range()
     # bool is an int subclass in Python; reject it explicitly. Treat positions
     # as paired — one without the other (or invalid ordering) is unusable.
     if (
@@ -555,9 +540,11 @@ def extract_score(cite_inner: list) -> float | None:
     [0.0, 1.0]. The bound check keeps the contract documented on the field
     enforceable for downstream consumers.
     """
-    if len(cite_inner) <= 2:
+    # ``CitationDetail.raw_score`` centralises the ``cite_inner[2]`` read
+    # (issue #1491); a short detail block yields ``None`` (no score).
+    raw = CitationDetail(cite_inner).raw_score
+    if raw is None:
         return None
-    raw = cite_inner[2]
     if isinstance(raw, bool):  # bool is a subclass of int in Python; reject
         return None
     if isinstance(raw, (int, float)):
@@ -577,26 +564,24 @@ def extract_text_passages(cite_inner: list) -> tuple[str | None, int | None, int
     never trips on a half-populated source range. The cited text (if any) is
     still returned.
     """
-    if len(cite_inner) <= 4 or not isinstance(cite_inner[4], list):
-        return None, None, None
-
+    # ``CitationDetail.passages`` centralises the ``cite_inner[4]`` descent and
+    # ``PassageRow`` the per-passage ``passage_wrapper[0]`` / ``passage_data[0..2]``
+    # reads (issue #1491); absent/short shapes degrade to ``[]`` / ``None``.
     texts: list[str] = []
     start_char: int | None = None
     end_char: int | None = None
 
-    for passage_wrapper in cite_inner[4]:
-        if not isinstance(passage_wrapper, list) or not passage_wrapper:
-            continue
-        passage_data = passage_wrapper[0]
-        if not isinstance(passage_data, list) or len(passage_data) < 3:
+    for passage_wrapper in CitationDetail(cite_inner).passages:
+        passage = PassageRow(passage_wrapper)
+        if not passage.is_well_formed:
             continue
 
-        if start_char is None and isinstance(passage_data[0], int):
-            start_char = passage_data[0]
-        if isinstance(passage_data[1], int):
-            end_char = passage_data[1]
+        if start_char is None and isinstance(passage.start_char, int):
+            start_char = passage.start_char
+        if isinstance(passage.end_char, int):
+            end_char = passage.end_char
 
-        collect_texts_from_nested(passage_data[2], texts)
+        collect_texts_from_nested(passage.text_payload, texts)
 
     cited_text = " ".join(texts) if texts else None
     # Drop a half-populated range so the ChatReference invariant accepts it.
@@ -621,9 +606,12 @@ def collect_texts_from_nested(nested: Any, texts: list[str]) -> None:
         if not isinstance(nested_group, list):
             continue
         for inner in nested_group:
-            if not isinstance(inner, list) or len(inner) < 3:
+            # ``TextLeafRow`` centralises the ``inner[2]`` text-payload read and
+            # the ``len(inner) >= 3`` well-formedness guard (issue #1491).
+            leaf = TextLeafRow(inner)
+            if not leaf.is_well_formed:
                 continue
-            text_val = inner[2]
+            text_val = leaf.text_value
             if isinstance(text_val, str) and text_val.strip():
                 texts.append(text_val.strip())
             elif isinstance(text_val, list):

--- a/src/notebooklm/_row_adapters/__init__.py
+++ b/src/notebooklm/_row_adapters/__init__.py
@@ -5,20 +5,38 @@ Re-exports the typed row views; importers may also reach submodules directly
 (``from .._row_adapters.sources import SourceRow``).
 """
 
-from . import artifacts, labels, notes, sources
-from .artifacts import ArtifactRow
+from . import artifacts, chat, labels, notes, sources
+from .artifacts import ArtifactRow, ReportSuggestionRow
+from .chat import (
+    AnswerRow,
+    CitationDetail,
+    CitationRow,
+    ErrorPayloadRow,
+    PassageRow,
+    StreamFrameRow,
+    TextLeafRow,
+)
 from .labels import LabelRow
 from .notes import NoteRow
 from .sources import SourceRow, SourceRowShape
 
 __all__ = [
     "artifacts",
+    "chat",
     "labels",
     "notes",
     "sources",
+    "AnswerRow",
     "ArtifactRow",
+    "CitationDetail",
+    "CitationRow",
+    "ErrorPayloadRow",
     "LabelRow",
     "NoteRow",
+    "PassageRow",
+    "ReportSuggestionRow",
     "SourceRow",
     "SourceRowShape",
+    "StreamFrameRow",
+    "TextLeafRow",
 ]

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -10,7 +10,7 @@ from .._types.common import _datetime_from_timestamp
 from ..exceptions import UnknownRPCMethodError
 from ..rpc import ArtifactStatus, ArtifactTypeCode, RPCMethod, safe_index
 
-__all__ = ["ArtifactRow"]
+__all__ = ["ArtifactRow", "ReportSuggestionRow"]
 
 
 @dataclass(frozen=True)
@@ -482,3 +482,75 @@ class ArtifactRow:
         if completed_only:
             return self.status == ArtifactStatus.COMPLETED
         return True
+
+
+@dataclass(frozen=True)
+class ReportSuggestionRow:
+    """Typed view of one raw ``GET_SUGGESTED_REPORTS`` suggestion row.
+
+    The wrapped row is a single AI-suggested report-format entry returned by
+    the ``ciyUvf`` (``GET_SUGGESTED_REPORTS``) RPC. Position layout:
+
+    =====  ============================================================
+    Index  Meaning
+    =====  ============================================================
+    0      title (str)
+    1      description (str)
+    4      prompt (str)
+    5      audience level (int; defaults to ``2`` when absent)
+    =====  ============================================================
+
+    Position knowledge is centralised here so ``ArtifactsAPI.suggest_reports``
+    stops open-coding ``item[0]`` / ``item[1]`` / ``item[4]`` / ``item[5]``
+    (issue #1491). Short / malformed rows degrade to the documented defaults
+    rather than raising — a suggestion list is best-effort UI sugar, not a
+    load-bearing decode, so the historical permissive contract is preserved.
+    """
+
+    _raw: list[Any] = field(repr=False)
+
+    _TITLE_POS: ClassVar[int] = 0
+    _DESCRIPTION_POS: ClassVar[int] = 1
+    _PROMPT_POS: ClassVar[int] = 4
+    _AUDIENCE_LEVEL_POS: ClassVar[int] = 5
+    _DEFAULT_AUDIENCE_LEVEL: ClassVar[int] = 2
+    # A row must carry at least the prompt slot (index 4) to be usable.
+    _MIN_LEN: ClassVar[int] = 5
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the row is a list long enough to carry title…prompt."""
+        return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
+
+    def _str_at(self, position: int) -> str:
+        """Return ``self._raw[position]`` when it is a str, else ``""``."""
+        value = self._raw[position]
+        return value if isinstance(value, str) else ""
+
+    @property
+    def title(self) -> str:
+        """Suggestion title — empty string when absent / non-string."""
+        return self._str_at(self._TITLE_POS)
+
+    @property
+    def description(self) -> str:
+        """Suggestion description — empty string when absent / non-string."""
+        return self._str_at(self._DESCRIPTION_POS)
+
+    @property
+    def prompt(self) -> str:
+        """Suggestion prompt — empty string when absent / non-string."""
+        return self._str_at(self._PROMPT_POS)
+
+    @property
+    def audience_level(self) -> int:
+        """Audience level at ``[5]``; the default ``2`` when the slot is absent.
+
+        Matches the historical contract: only the *presence* of the slot is
+        checked (``len(row) > 5``); a present-but-non-int value is returned
+        verbatim, exactly as the prior inline ``item[5] if len(item) > 5 else 2``
+        read did.
+        """
+        if len(self._raw) <= self._AUDIENCE_LEVEL_POS:
+            return self._DEFAULT_AUDIENCE_LEVEL
+        return self._raw[self._AUDIENCE_LEVEL_POS]

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -523,7 +523,14 @@ class ReportSuggestionRow:
         return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
 
     def _str_at(self, position: int) -> str:
-        """Return ``self._raw[position]`` when it is a str, else ``""``."""
+        """Return ``self._raw[position]`` when it is a str, else ``""``.
+
+        Bounds-guarded so a short / malformed row degrades to ``""`` (the
+        documented contract) instead of raising ``IndexError`` when a property
+        is read without first checking :attr:`is_well_formed`.
+        """
+        if not isinstance(self._raw, list) or len(self._raw) <= position:
+            return ""
         value = self._raw[position]
         return value if isinstance(value, str) else ""
 

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -457,7 +457,7 @@ class PassageRow:
         record too short to carry start/end/text — both legitimate "skip this
         passage" shapes, not wire drift.
         """
-        if not isinstance(self._raw, list) or not self._raw:
+        if not isinstance(self._raw, list) or len(self._raw) <= self._PASSAGE_DATA_POS:
             return None
         data = self._raw[self._PASSAGE_DATA_POS]
         if not isinstance(data, list) or len(data) < self._MIN_LEN:

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -1,0 +1,488 @@
+"""Chat row adapters for the streamed-chat (``GenerateFreeFormStreamed``) payload.
+
+The streamed-chat endpoint is **not** a ``batchexecute`` RPC, so there is no
+obfuscated method ID to thread through ``safe_index`` — descents pass
+``method_id=None`` and rely on named ``source`` labels to localise schema drift
+in raised :class:`UnknownRPCMethodError` diagnostics (ADR-0011).
+
+These adapters centralise the positional knowledge that ``_chat/wire.py``
+previously open-coded as scattered single-level subscripts (``first[4]``,
+``cite[1]``, ``cite_inner[5]``, ``passage_data[0]`` …). Consumer sites should
+wrap the raw lists in the typed views below and read named properties so a
+future Google reshape of the chat wire format is a one-place fix here, and so
+genuine drift RAISES ``UnknownRPCMethodError`` via ``safe_index`` instead of
+silently degrading to an empty/wrong answer.
+
+Position contracts (pinned by ``tests/unit/test_chat_row_adapter.py``):
+
+* :class:`AnswerRow` — one populated answer record (``inner_data[0]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  0      answer text (str)
+  2      conversation-id block; ``[2][0]`` is the server conversation id
+  4      type/flags block; ``[4][-1] == 1`` marks an answer record and
+         ``[4][3]`` is the citation list
+  =====  ============================================================
+
+* :class:`CitationRow` — one citation entry (``type_info[3][i]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  0      chunk-id block; ``[0][0]`` is the chunk id
+  1      citation detail block (:class:`CitationDetail`)
+  =====  ============================================================
+
+* :class:`CitationDetail` — ``cite[1]``:
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  2      relevance score (float 0.0-1.0)
+  3      answer-range block ``[[None, answer_start, answer_end]]``
+  4      source-side passages list
+  5      nested source-id data
+  =====  ============================================================
+
+* :class:`PassageRow` — one passage record (``passage_wrapper[0]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  0      source-side start char (int)
+  1      source-side end char (int)
+  2      nested text payload
+  =====  ============================================================
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from ..rpc import safe_index
+
+__all__ = [
+    "AnswerRow",
+    "CitationRow",
+    "CitationDetail",
+    "ErrorPayloadRow",
+    "PassageRow",
+    "StreamFrameRow",
+    "TextLeafRow",
+]
+
+
+@dataclass(frozen=True)
+class StreamFrameRow:
+    """Typed view of one streamed-chat envelope frame.
+
+    Frames arrive as ``["wrb.fr", None, inner_json, ...]`` (a successful RPC
+    result) or ``["er", rpc_id, code, ...]`` (a server-side error). This adapter
+    centralises the ``item[0]`` tag, ``item[2]`` inner-JSON / error-code, and
+    ``item[5]`` error-payload reads so ``_chat/wire.py`` stops open-coding them
+    (issue #1491).
+
+    The ``tag`` read goes through ``safe_index`` because the caller already
+    guarantees ``len(item) >= 2`` — the frame tag slot is the one position that
+    must always be present, so its absence is genuine drift. Every other slot is
+    optional and short-circuits to ``None`` on a short frame.
+    """
+
+    _raw: list[Any] = field(repr=False)
+
+    _TAG_POS: ClassVar[int] = 0
+    _INNER_JSON_POS: ClassVar[int] = 2
+    _ERROR_CODE_POS: ClassVar[int] = 2
+    _ERROR_PAYLOAD_POS: ClassVar[int] = 5
+
+    #: Source label for ``safe_index`` drift diagnostics on the tag descent.
+    _SOURCE: ClassVar[str] = "ChatStreamFrameRow.tag"
+
+    @property
+    def tag(self) -> Any:
+        """Frame tag at ``item[0]`` (``"wrb.fr"`` / ``"er"``).
+
+        The caller guarantees ``len(item) >= 2`` so this is a no-op on the happy
+        path; ``safe_index`` only fires if the tag slot itself drifted out.
+        """
+        return safe_index(self._raw, self._TAG_POS, method_id=None, source=self._SOURCE)
+
+    @property
+    def inner_json(self) -> Any:
+        """Inner-JSON payload at ``item[2]`` (a ``str`` for ``wrb.fr`` frames)."""
+        if len(self._raw) <= self._INNER_JSON_POS:
+            return None
+        return self._raw[self._INNER_JSON_POS]
+
+    @property
+    def error_code(self) -> Any:
+        """Optional error code at ``item[2]`` of an ``"er"`` frame.
+
+        Read with a length guard (not ``safe_index``): an absent code is normal
+        for a short ``"er"`` frame and must NOT be treated as schema drift — the
+        frame itself is the error signal.
+        """
+        if len(self._raw) <= self._ERROR_CODE_POS:
+            return None
+        return self._raw[self._ERROR_CODE_POS]
+
+    @property
+    def error_payload(self) -> list[Any] | None:
+        """Optional server-side error payload at ``item[5]`` (a list) or ``None``."""
+        if len(self._raw) <= self._ERROR_PAYLOAD_POS:
+            return None
+        value = self._raw[self._ERROR_PAYLOAD_POS]
+        return value if isinstance(value, list) else None
+
+
+@dataclass(frozen=True)
+class ErrorPayloadRow:
+    """Typed view of a streamed-chat error payload (``item[5]``).
+
+    Structure: ``[8, None, [["type.googleapis.com/.../UserDisplayableError", …]]]``.
+    Centralises the ``error_payload[2]`` and inner ``entry[0]`` reads so
+    ``raise_if_rate_limited`` stops open-coding them (issue #1491).
+    """
+
+    _raw: list[Any] = field(repr=False)
+
+    _ENTRIES_POS: ClassVar[int] = 2
+
+    @property
+    def entries(self) -> list[Any]:
+        """Error entries at ``error_payload[2]`` — ``[]`` when absent/non-list."""
+        if len(self._raw) <= self._ENTRIES_POS:
+            return []
+        value = self._raw[self._ENTRIES_POS]
+        return value if isinstance(value, list) else []
+
+    @staticmethod
+    def entry_type(entry: Any) -> str | None:
+        """The leading type string at ``entry[0]`` of one error entry, or ``None``."""
+        if not isinstance(entry, list) or not entry:
+            return None
+        value = entry[0]
+        return value if isinstance(value, str) else None
+
+
+@dataclass(frozen=True)
+class TextLeafRow:
+    """Typed view of one deeply-nested passage text leaf (``inner`` triple).
+
+    Centralises the ``inner[2]`` text-payload read in ``collect_texts_from_nested``
+    so the nested-walk decoder stops open-coding the position (issue #1491).
+    """
+
+    _raw: Any = field(repr=False)
+
+    _TEXT_POS: ClassVar[int] = 2
+    _MIN_LEN: ClassVar[int] = 3
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the leaf is a list long enough to carry the text payload."""
+        return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
+
+    @property
+    def text_value(self) -> Any:
+        """Raw text payload at ``inner[2]`` (str / list validated upstream)."""
+        if not self.is_well_formed:
+            return None
+        return self._raw[self._TEXT_POS]
+
+
+@dataclass(frozen=True)
+class AnswerRow:
+    """Typed view of one populated streamed-chat answer record.
+
+    The wrapped row is ``inner_data[0]`` of a decoded ``wrb.fr`` envelope
+    whose ``inner_data`` is a populated list (heartbeats decode to ``[]``
+    and never reach this adapter). Position knowledge is centralised here;
+    consumer sites should NEVER open-code ``first[0]`` / ``first[2][0]`` /
+    ``first[4][-1]`` / ``first[4][3]``.
+
+    The dataclass is frozen so the wrapped row can't be mutated through the
+    adapter; the adapter never copies the raw row, so it is cheap to build.
+    """
+
+    # Wrapped row; ``repr=False`` so logs don't explode with the entire
+    # streamed-chat payload when an AnswerRow appears in a stack trace.
+    _raw: list[Any] = field(repr=False)
+
+    # ---- Position constants (the canary contract) ------------------------
+    # ClassVar so the frozen dataclass treats these as class-level constants
+    # rather than instance fields. If any of these change,
+    # ``tests/unit/test_chat_row_adapter.py::TestAnswerRowPositionContract``
+    # MUST be updated in the same commit — that failure is the wire-shape
+    # change signal.
+    _TEXT_POS: ClassVar[int] = 0
+    _CONV_BLOCK_POS: ClassVar[int] = 2
+    _TYPE_BLOCK_POS: ClassVar[int] = 4
+    _ANSWER_MARKER_POS: ClassVar[int] = -1
+    _CITATIONS_POS: ClassVar[int] = 3
+    _ANSWER_MARKER_VALUE: ClassVar[int] = 1
+
+    @property
+    def raw(self) -> list[Any]:
+        """The wrapped raw answer row."""
+        return self._raw
+
+    @property
+    def text(self) -> str | None:
+        """Answer text at ``first[0]`` — ``None`` when absent or not a string.
+
+        The caller guarantees ``len(self._raw) > 0`` before constructing the
+        row, so the ``safe_index`` descent is a no-op on the happy path; the
+        ``ChatAnswerRow.text`` label localises any top-level reshape in
+        diagnostics.
+        """
+        if len(self._raw) <= self._TEXT_POS:
+            return None
+        value = safe_index(
+            self._raw,
+            self._TEXT_POS,
+            method_id=None,
+            source="ChatAnswerRow.text",
+        )
+        return value if isinstance(value, str) and value else None
+
+    @property
+    def server_conversation_id(self) -> str | None:
+        """Server conversation id at ``first[2][0]``.
+
+        An absent / empty / non-list block legitimately means "no server
+        conversation id present" (not drift) so it short-circuits to ``None``
+        before invoking ``safe_index``.
+        """
+        if len(self._raw) <= self._CONV_BLOCK_POS:
+            return None
+        conv_block = self._raw[self._CONV_BLOCK_POS]
+        if not isinstance(conv_block, list) or not conv_block:
+            return None
+        value = conv_block[0]
+        return value if isinstance(value, str) else None
+
+    @property
+    def _type_block(self) -> list[Any] | None:
+        """The optional type/flags block at ``first[4]`` (a list) or ``None``.
+
+        An absent block legitimately means "not an answer record" (non-answer
+        records carry no type block), so a short row or a non-list slot
+        short-circuits to ``None`` rather than tripping ``safe_index``.
+        """
+        if len(self._raw) <= self._TYPE_BLOCK_POS:
+            return None
+        block = self._raw[self._TYPE_BLOCK_POS]
+        return block if isinstance(block, list) else None
+
+    @property
+    def is_answer(self) -> bool:
+        """Whether the type block marks this record as an answer (``[4][-1] == 1``).
+
+        An absent / empty type block legitimately means "not an answer", so the
+        flag read is a single-level ``type_block[-1]`` index on a bound local
+        rather than a chained ``first[4][-1]`` descent.
+        """
+        type_block = self._type_block
+        return (
+            type_block is not None
+            and len(type_block) > 0
+            and type_block[self._ANSWER_MARKER_POS] == self._ANSWER_MARKER_VALUE
+        )
+
+    @property
+    def citations(self) -> list[Any]:
+        """Raw citation entries at ``first[4][3]`` — empty list when absent.
+
+        Mirrors the historical ``parse_citations`` permissive contract: a
+        short / non-list type block or a non-list citation slot degrades to
+        ``[]`` rather than raising, because a missing citation list is a normal
+        "answer without citations" shape, not wire drift.
+        """
+        type_block = self._type_block
+        if type_block is None or len(type_block) <= self._CITATIONS_POS:
+            return []
+        citations = type_block[self._CITATIONS_POS]
+        return citations if isinstance(citations, list) else []
+
+    def citation_rows(self) -> list[CitationRow]:
+        """Wrap each raw citation entry as a :class:`CitationRow`."""
+        return [CitationRow(cite) for cite in self.citations]
+
+
+@dataclass(frozen=True)
+class CitationRow:
+    """Typed view of one streamed-chat citation entry (``type_info[3][i]``).
+
+    Centralises the ``cite[0][0]`` chunk-id and ``cite[1]`` detail-block
+    position knowledge. Consumer sites should NEVER open-code ``cite[0]`` /
+    ``cite[1]``.
+    """
+
+    _raw: Any = field(repr=False)
+
+    _CHUNK_BLOCK_POS: ClassVar[int] = 0
+    _DETAIL_POS: ClassVar[int] = 1
+    _MIN_LEN: ClassVar[int] = 2
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the entry is a list long enough to carry chunk + detail."""
+        return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
+
+    @property
+    def chunk_id(self) -> str | None:
+        """Chunk id at ``cite[0][0]``.
+
+        An absent / empty / non-list chunk block legitimately means "no chunk
+        id" (the citation is still kept), so it short-circuits to ``None``.
+        """
+        if not self.is_well_formed:
+            return None
+        chunk_block = self._raw[self._CHUNK_BLOCK_POS]
+        if not isinstance(chunk_block, list) or not chunk_block:
+            return None
+        value = chunk_block[0]
+        return value if isinstance(value, str) else None
+
+    @property
+    def detail(self) -> CitationDetail | None:
+        """The citation detail block at ``cite[1]`` as a :class:`CitationDetail`.
+
+        Returns ``None`` when the entry is too short or ``cite[1]`` is not a
+        list — both legitimately mean "unusable citation, skip it" rather than
+        wire drift.
+        """
+        if not self.is_well_formed:
+            return None
+        inner = self._raw[self._DETAIL_POS]
+        if not isinstance(inner, list):
+            return None
+        return CitationDetail(inner)
+
+
+@dataclass(frozen=True)
+class CitationDetail:
+    """Typed view of a citation detail block (``cite[1]``).
+
+    Centralises the score / answer-range / passages / source-id position
+    knowledge. Consumer sites should NEVER open-code ``cite_inner[2]`` /
+    ``cite_inner[3]`` / ``cite_inner[4]`` / ``cite_inner[5]``.
+    """
+
+    _raw: list[Any] = field(repr=False)
+
+    _SCORE_POS: ClassVar[int] = 2
+    _ANSWER_RANGE_POS: ClassVar[int] = 3
+    _PASSAGES_POS: ClassVar[int] = 4
+    _SOURCE_ID_POS: ClassVar[int] = 5
+
+    # Inner answer-range layout: ``cite_inner[3] = [[None, start, end]]``.
+    _ANSWER_RANGE_START_POS: ClassVar[int] = 1
+    _ANSWER_RANGE_END_POS: ClassVar[int] = 2
+
+    @property
+    def raw_list(self) -> list[Any]:
+        """The wrapped ``cite[1]`` detail list (for legacy raw-list consumers)."""
+        return self._raw
+
+    @property
+    def raw_score(self) -> Any:
+        """Raw value at ``cite_inner[2]`` (validation lives in the caller)."""
+        if len(self._raw) <= self._SCORE_POS:
+            return None
+        return self._raw[self._SCORE_POS]
+
+    @property
+    def source_id_data(self) -> Any:
+        """Nested source-id data at ``cite_inner[5]`` — ``None`` when absent."""
+        if len(self._raw) <= self._SOURCE_ID_POS:
+            return None
+        return self._raw[self._SOURCE_ID_POS]
+
+    @property
+    def passages(self) -> list[Any]:
+        """Source-side passages list at ``cite_inner[4]`` — ``[]`` when absent."""
+        if len(self._raw) <= self._PASSAGES_POS:
+            return []
+        value = self._raw[self._PASSAGES_POS]
+        return value if isinstance(value, list) else []
+
+    def answer_range(self) -> tuple[Any, Any]:
+        """Raw ``(start, end)`` from ``cite_inner[3][0]`` (``[None, start, end]``).
+
+        Returns ``(None, None)`` when the answer-range block is absent,
+        not a list, empty, its first element is not a list, or that inner
+        list is too short — all legitimate "no answer range" shapes, not drift.
+        The numeric / ordering validation lives in the caller.
+        """
+        if len(self._raw) <= self._ANSWER_RANGE_POS:
+            return None, None
+        outer = self._raw[self._ANSWER_RANGE_POS]
+        if not isinstance(outer, list) or not outer:
+            return None, None
+        inner = outer[0]
+        if not isinstance(inner, list) or len(inner) <= self._ANSWER_RANGE_END_POS:
+            return None, None
+        return inner[self._ANSWER_RANGE_START_POS], inner[self._ANSWER_RANGE_END_POS]
+
+
+@dataclass(frozen=True)
+class PassageRow:
+    """Typed view of one source-side passage *wrapper* (``cite_inner[4][i]``).
+
+    The wrapped value is the outer ``passage_wrapper`` (``[passage_data, …]``);
+    the adapter unwraps the inner ``passage_data`` at ``[0]`` and centralises its
+    ``[0]`` / ``[1]`` / ``[2]`` start / end / text-payload reads. Consumer sites
+    should NEVER open-code ``passage_wrapper[0]`` or ``passage_data[0..2]``
+    (issue #1491).
+    """
+
+    _raw: Any = field(repr=False)
+
+    _PASSAGE_DATA_POS: ClassVar[int] = 0
+    _START_POS: ClassVar[int] = 0
+    _END_POS: ClassVar[int] = 1
+    _TEXT_PAYLOAD_POS: ClassVar[int] = 2
+    _MIN_LEN: ClassVar[int] = 3
+
+    @property
+    def _passage_data(self) -> list[Any] | None:
+        """Inner ``passage_data`` at ``passage_wrapper[0]`` when well-formed.
+
+        Returns ``None`` (rather than raising) for an empty wrapper or an inner
+        record too short to carry start/end/text — both legitimate "skip this
+        passage" shapes, not wire drift.
+        """
+        if not isinstance(self._raw, list) or not self._raw:
+            return None
+        data = self._raw[self._PASSAGE_DATA_POS]
+        if not isinstance(data, list) or len(data) < self._MIN_LEN:
+            return None
+        return data
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the wrapper holds an inner record long enough for start/end/text."""
+        return self._passage_data is not None
+
+    @property
+    def start_char(self) -> Any:
+        """Raw source-side start char at ``passage_data[0]`` (int validated upstream)."""
+        data = self._passage_data
+        return None if data is None else data[self._START_POS]
+
+    @property
+    def end_char(self) -> Any:
+        """Raw source-side end char at ``passage_data[1]`` (int validated upstream)."""
+        data = self._passage_data
+        return None if data is None else data[self._END_POS]
+
+    @property
+    def text_payload(self) -> Any:
+        """Nested text payload at ``passage_data[2]`` — ``None`` when malformed."""
+        data = self._passage_data
+        return None if data is None else data[self._TEXT_PAYLOAD_POS]

--- a/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
+++ b/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
@@ -1,4 +1,4 @@
-"""Guard: no raw *chained* positional indexing of RPC payloads in feature code.
+"""Guard: no raw positional indexing of RPC payloads in feature code.
 
 Google's ``batchexecute`` responses are positional lists (the project's #1
 standing risk -- the shape can move without notice). The sanctioned places to
@@ -7,34 +7,47 @@ decode those positional structures are:
 * ``src/notebooklm/rpc/`` -- the RPC protocol layer (encoder/decoder/safe_index),
   the home of ``safe_index`` itself; and
 * ``src/notebooklm/_row_adapters/`` -- the typed row views (``ArtifactRow`` /
-  ``NoteRow`` / ``SourceRow``) that centralise position knowledge behind named
-  properties.
+  ``NoteRow`` / ``SourceRow`` / the chat rows) that centralise position
+  knowledge behind named properties.
 
-Everywhere else, walking a decoded payload with a hand-rolled *chain* of
-integer-literal subscripts (``first[4][3]``, ``result[0][2][4]``,
-``cite[0][0]``) re-scatters the position knowledge the adapters exist to
-contain, and -- per **ADR-0011** -- routinely *swallows* shape drift to an
-empty/wrong value behind ``try/except (IndexError, TypeError)`` instead of
-raising ``UnknownRPCMethodError`` via ``safe_index``.
+Everywhere else, walking a decoded payload with hand-rolled integer-literal
+subscripts re-scatters the position knowledge the adapters exist to contain,
+and -- per **ADR-0011** -- routinely *swallows* shape drift to an empty/wrong
+value behind ``try/except (IndexError, TypeError)`` instead of raising
+``UnknownRPCMethodError`` via ``safe_index``.
 
-This AST lint forbids the anti-pattern: a ``Subscript`` indexed by an integer
-literal whose *own value* is another integer-literal ``Subscript`` -- i.e. a
-two-or-more-deep positional descent like ``x[i][j]``. Single-level ``x[i]``
-indexing is intentionally **not** flagged (it is too common and too benign --
-``args[0]``, ``parts[-1]`` -- to gate without noise); the chained form is the
-fragile "deep descent into an RPC payload" shape this gate targets. A
-string/slice subscript (``d["k"]``, ``s[1:]``) is likewise ignored.
+This module runs **two** AST gates:
 
-This is the durable GATE for issue #1377. The current offenders are *baselined*
-into :data:`ALLOWLIST` so the gate is green on ``main`` today; the burndown that
-drains that list (migrating each file behind ``_row_adapters/`` + ``safe_index``)
-is tracked as follow-up issue #1389. New feature files start gated -- adding a
-fresh chained positional descent outside ``rpc/`` / ``_row_adapters/`` fails the
-gate unless the file is on the allowlist.
+1. **Chained descent (issue #1377).** A ``Subscript`` indexed by an integer
+   literal whose *own value* is another integer-literal ``Subscript`` -- i.e. a
+   two-or-more-deep positional descent like ``x[i][j]`` (``first[4][3]``,
+   ``result[0][2][4]``, ``cite[0][0]``). This is the most fragile "deep descent
+   into an RPC payload" shape, and its :data:`ALLOWLIST` is **empty** -- the
+   #1377 burndown migrated every chained offender, so the chained gate
+   re-protects the whole feature tree with no exceptions.
 
-The allowlist is self-draining: :func:`test_no_stale_allowlist_entries` fails if
-an allowlisted file no longer contains any chained positional descent, so once a
-file is migrated it must be removed from the list (the gate then re-protects it).
+2. **Single-level descent (issue #1491).** A single ``Subscript`` indexed by an
+   integer literal (``x[i]``). On its own this is too common and too benign --
+   ``args[0]``, ``parts[-1]`` -- to forbid outright, but it is *also* exactly how
+   un-named row-position knowledge of an RPC payload leaks past the chained
+   gate (the chat wire parser carried dozens of ``first[4]`` / ``cite[1]`` /
+   ``passage_data[0]`` reads that the chained gate never saw). So the
+   single-level gate works as a **ratchet**: the 47 feature files that already
+   open-code single-level integer subscripts are *baselined* into
+   :data:`SINGLE_LEVEL_ALLOWLIST` (so the gate is green on ``main`` today), but
+   a *new* single-level integer subscript in a file that is NOT on that list
+   fails the gate. New code therefore decodes through a row adapter / a named
+   local rather than re-scattering raw positions. The burndown that drains
+   :data:`SINGLE_LEVEL_ALLOWLIST` (migrating each file behind ``_row_adapters/``
+   + ``safe_index`` or binding the guarded inner list to a named local) is
+   tracked as a follow-up to #1491.
+
+A string/slice subscript (``d["k"]``, ``s[1:]``) is ignored by both gates.
+
+Both allowlists are self-draining: :func:`test_no_stale_allowlist_entries` and
+:func:`test_no_stale_single_level_allowlist_entries` fail if an allowlisted file
+no longer contains the offending shape, so once a file is migrated it must be
+removed from its list (the gate then re-protects it).
 """
 
 from __future__ import annotations
@@ -59,6 +72,75 @@ SANCTIONED_PACKAGES = frozenset({"rpc", "_row_adapters"})
 # DO NOT add new entries to grow the debt -- a new offender means new code that
 # should decode through ``safe_index`` / a row adapter instead.
 ALLOWLIST: frozenset[str] = frozenset()
+
+# Baseline of feature files that open-code a *single-level* integer-literal
+# subscript (``x[i]``) of a decoded RPC payload (issue #1491). Many of these
+# reads are benign (``params[2]``, ``args[0]``) and many are genuine but
+# already-guarded inner reads -- the single-level gate is a RATCHET, not an
+# immediate ban: these files are grandfathered so the gate is green on ``main``,
+# but a single-level subscript in any file NOT on this list fails the gate.
+#
+# The chat wire parser (``_chat/wire.py``) and the ``suggest_reports`` row decode
+# in ``_artifacts.py`` were the largest un-adapted surfaces; ``_chat/wire.py`` is
+# fully migrated behind ``_row_adapters/chat.py`` and is DELIBERATELY ABSENT from
+# this list so the gate re-protects it. ``_artifacts.py`` keeps its remaining
+# envelope-unwrap / request-param reads (only its ``suggest_reports`` row decode
+# moved behind ``ReportSuggestionRow``), so it stays listed for now.
+#
+# DO NOT add new entries to grow the debt. The burndown (drain this list by
+# migrating each file behind ``_row_adapters/`` + ``safe_index``, or binding the
+# already-guarded inner list to a named local) is a follow-up to #1491.
+SINGLE_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "_app/artifacts.py",
+        "_app/download.py",
+        "_app/generate_retry.py",
+        "_app/labels.py",
+        "_app/notes.py",
+        "_app/resolve.py",
+        "_app/skill.py",
+        "_app/source_clean.py",
+        "_app/source_mutations.py",
+        "_artifact/downloads.py",
+        "_artifact/formatters.py",
+        "_artifact/listing.py",
+        "_artifact/polling.py",
+        "_artifacts.py",
+        "_auth/cookies.py",
+        "_auth/refresh.py",
+        "_chat/api.py",
+        "_chat/notes.py",
+        "_labels.py",
+        "_mind_maps_api.py",
+        "_note_service.py",
+        "_notebooks.py",
+        "_notes.py",
+        "_research.py",
+        "_research_task_parser.py",
+        "_source/add.py",
+        "_source/content.py",
+        "_source/listing.py",
+        "_source/upload.py",
+        "_types/artifacts.py",
+        "_types/notebooks.py",
+        "_types/sharing.py",
+        "_types/sources.py",
+        "_version_check.py",
+        "cli/_chromium_profiles.py",
+        "cli/_firefox_containers.py",
+        "cli/agent_templates.py",
+        "cli/artifact_cmd.py",
+        "cli/error_handler.py",
+        "cli/resolve.py",
+        "cli/services/login/browser_accounts.py",
+        "cli/services/login/chromium_accounts.py",
+        "cli/services/login/cookie_writes.py",
+        "cli/services/login/profile_targets.py",
+        "cli/services/playwright_login.py",
+        "cli/services/playwright_redaction.py",
+        "utils.py",
+    }
+)
 
 
 def _is_int_literal(node: ast.expr) -> bool:
@@ -100,6 +182,23 @@ def _chained_positional_offenders(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
+def _single_level_positional_offenders(tree: ast.AST) -> list[int]:
+    """Return sorted line numbers of single-level integer-literal subscripts.
+
+    A site is any ``Subscript`` whose index is an integer literal -- ``x[i]``.
+    This is a superset of :func:`_chained_positional_offenders` (each level of a
+    chain ``x[i][j]`` is itself a single-level subscript), so the chained gate
+    is strictly stronger; this detector is what powers the #1491 single-level
+    ratchet. Pure on its input so a planted fixture can exercise it without
+    touching the filesystem.
+    """
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Subscript) and _is_int_literal(node.slice):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
 @functools.cache
 def _feature_files() -> tuple[Path, ...]:
     """All ``src/notebooklm`` Python files outside the sanctioned decoding packages.
@@ -136,6 +235,23 @@ def _offending_files() -> dict[str, list[int]]:
     for path in _feature_files():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         lines = _chained_positional_offenders(tree)
+        if lines:
+            offenders[_rel(path)] = lines
+    return offenders
+
+
+@functools.cache
+def _single_level_offending_files() -> dict[str, list[int]]:
+    """Map ``rel-path -> single-level offending line numbers`` for every feature file.
+
+    Cached for the same reason as :func:`_offending_files` -- the #1491
+    single-level ratchet tests share one whole-tree scan. Callers treat the
+    result as read-only.
+    """
+    offenders: dict[str, list[int]] = {}
+    for path in _feature_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        lines = _single_level_positional_offenders(tree)
         if lines:
             offenders[_rel(path)] = lines
     return offenders
@@ -186,6 +302,111 @@ def test_allowlist_entries_exist() -> None:
     assert not missing, "ALLOWLIST references nonexistent files:\n" + "\n".join(
         f"  {f}" for f in missing
     )
+
+
+# ---------------------------------------------------------------------------
+# Single-level ratchet (issue #1491)
+# ---------------------------------------------------------------------------
+
+
+def test_no_unbaselined_single_level_positional_rpc_indexing() -> None:
+    """No feature file outside the single-level allowlist may add a literal ``x[i]`` read.
+
+    This is the #1491 **burndown ratchet** (introduced the way #1377 introduced
+    the chained-descent gate). It fails when a file that is NOT on
+    :data:`SINGLE_LEVEL_ALLOWLIST` open-codes a *brand-new* integer-literal
+    single-level subscript of an RPC payload. Route the read through a
+    ``_row_adapters/`` typed view so the position knowledge lives in one place
+    and shape drift RAISES ``UnknownRPCMethodError`` via ``safe_index``.
+
+    Scope (deliberate, like #1377): a *ratchet*, not a closed perimeter. It flags
+    only integer-*literal* subscripts (``x[0]``) — a named-constant index
+    (``first[TEXT_POS]``) is not detected — and raw reads inside the ~47
+    already-allowlisted files are tolerated until each is migrated and dropped
+    from the allowlist. The goal is to stop NEW raw positions accruing while the
+    existing ones burn down, not to prove "no RPC positions anywhere".
+    """
+    offenders = _single_level_offending_files()
+    unbaselined = {f: lines for f, lines in offenders.items() if f not in SINGLE_LEVEL_ALLOWLIST}
+    assert not unbaselined, (
+        "Raw single-level positional indexing of RPC payloads (`x[i]`) is forbidden "
+        "outside src/notebooklm/rpc/ and src/notebooklm/_row_adapters/ for files not "
+        "on SINGLE_LEVEL_ALLOWLIST (see ADR-0011, issue #1491). Decode through a typed "
+        "_row_adapters/ view so shape drift RAISES UnknownRPCMethodError instead of "
+        "silently degrading to empty/wrong data. NOTE: binding the read to a named local "
+        "does NOT satisfy this single-level gate (the local subscript `local[i]` is still "
+        "flagged) — move the position knowledge into an adapter; or, for a deliberate "
+        "burndown deferral, add the file to SINGLE_LEVEL_ALLOWLIST.\n\n"
+        + "\n".join(
+            f"  src/notebooklm/{f}:{','.join(map(str, lines))}"
+            for f, lines in sorted(unbaselined.items())
+        )
+    )
+
+
+def test_no_stale_single_level_allowlist_entries() -> None:
+    """Every single-level-allowlisted file must still offend -- migrated files drop off.
+
+    Keeps the #1491 burndown honest: when a file's single-level RPC reads move
+    behind a row adapter / named local, it stops offending and must drop off
+    :data:`SINGLE_LEVEL_ALLOWLIST`, which re-arms the gate for that file.
+    """
+    offenders = _single_level_offending_files()
+    stale = sorted(f for f in SINGLE_LEVEL_ALLOWLIST if f not in offenders)
+    assert not stale, (
+        "Stale entries in SINGLE_LEVEL_ALLOWLIST -- these files no longer use a "
+        "single-level integer subscript (likely migrated behind a row adapter / named "
+        "local). Remove them so the gate re-protects them:\n" + "\n".join(f"  {f}" for f in stale)
+    )
+
+
+def test_single_level_allowlist_entries_exist() -> None:
+    """Every single-level-allowlisted path must point at a real file."""
+    missing = sorted(f for f in SINGLE_LEVEL_ALLOWLIST if not (SRC_ROOT / f).is_file())
+    assert not missing, "SINGLE_LEVEL_ALLOWLIST references nonexistent files:\n" + "\n".join(
+        f"  {f}" for f in missing
+    )
+
+
+def test_migrated_chat_wire_is_not_single_level_allowlisted() -> None:
+    """``_chat/wire.py`` was migrated behind ``_row_adapters/chat.py`` (issue #1491).
+
+    Pins the headline #1491 outcome: the chat wire parser no longer open-codes
+    any single-level RPC-payload subscript, so it is absent from
+    :data:`SINGLE_LEVEL_ALLOWLIST` AND from the live offender set -- the gate now
+    re-protects it. If a future edit re-introduces a raw ``x[i]`` read there,
+    ``test_no_unbaselined_single_level_positional_rpc_indexing`` fails.
+    """
+    assert "_chat/wire.py" not in SINGLE_LEVEL_ALLOWLIST
+    assert "_chat/wire.py" not in _single_level_offending_files()
+
+
+def test_single_level_detector_flags_and_ignores() -> None:
+    """The single-level detector flags ``x[i]`` and ignores string/slice subscripts."""
+    flagged = ast.parse(
+        "\n".join(
+            [
+                "a = first[4]",  # single-level int -- flagged
+                "b = parts[-1]",  # negative literal -- still positional
+                "c = payload[+1]",  # explicit unary-plus -- still positional
+                "d = chain[0][1]",  # both levels are single-level subscripts
+            ]
+        )
+    )
+    # Line 4 contributes one line number even though it has two subscripts.
+    assert _single_level_positional_offenders(flagged) == [1, 2, 3, 4]
+
+    benign = ast.parse(
+        "\n".join(
+            [
+                "x = data['key']",  # string subscript -- not positional
+                "y = items[1:]",  # slice -- not an int literal
+                "z = flags[True]",  # bool index -- excluded
+                "w = [[[source_id]]]",  # list construction, no subscripting
+            ]
+        )
+    )
+    assert _single_level_positional_offenders(benign) == []
 
 
 def test_detector_flags_chained_descent() -> None:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -1,0 +1,302 @@
+"""Tests for the streamed-chat row adapters (issue #1491).
+
+These adapters centralise the positional knowledge ``_chat/wire.py`` used to
+open-code as scattered single-level subscripts (``first[4]``, ``cite[1]``,
+``cite_inner[5]``, ``passage_data[0]`` …). The tests cover three layers per
+adapter:
+
+1. **Position-contract pin** — the canary that fails loudly if a position
+   constant is edited (the wire-shape change signal).
+2. **Shape handling** — happy-path reads plus the permissive "absent / short /
+   non-list → default" degrade that matches the historical wire parser.
+3. **Drift** — the one descent that goes through ``safe_index``
+   (``StreamFrameRow.tag``) RAISES ``UnknownRPCMethodError`` when the
+   guaranteed slot is missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._row_adapters.chat import (
+    AnswerRow,
+    CitationDetail,
+    CitationRow,
+    ErrorPayloadRow,
+    PassageRow,
+    StreamFrameRow,
+    TextLeafRow,
+)
+from notebooklm.exceptions import UnknownRPCMethodError
+
+# ---------------------------------------------------------------------------
+# 1. Position-contract pins (the canaries)
+# ---------------------------------------------------------------------------
+
+
+class TestAnswerRowPositionContract:
+    def test_positions_pinned(self) -> None:
+        assert (
+            AnswerRow._TEXT_POS,
+            AnswerRow._CONV_BLOCK_POS,
+            AnswerRow._TYPE_BLOCK_POS,
+            AnswerRow._ANSWER_MARKER_POS,
+            AnswerRow._CITATIONS_POS,
+            AnswerRow._ANSWER_MARKER_VALUE,
+        ) == (0, 2, 4, -1, 3, 1)
+
+
+class TestCitationPositionContract:
+    def test_citation_row_positions_pinned(self) -> None:
+        assert (CitationRow._CHUNK_BLOCK_POS, CitationRow._DETAIL_POS) == (0, 1)
+
+    def test_citation_detail_positions_pinned(self) -> None:
+        assert (
+            CitationDetail._SCORE_POS,
+            CitationDetail._ANSWER_RANGE_POS,
+            CitationDetail._PASSAGES_POS,
+            CitationDetail._SOURCE_ID_POS,
+            CitationDetail._ANSWER_RANGE_START_POS,
+            CitationDetail._ANSWER_RANGE_END_POS,
+        ) == (2, 3, 4, 5, 1, 2)
+
+    def test_passage_row_positions_pinned(self) -> None:
+        assert (
+            PassageRow._PASSAGE_DATA_POS,
+            PassageRow._START_POS,
+            PassageRow._END_POS,
+            PassageRow._TEXT_PAYLOAD_POS,
+        ) == (0, 0, 1, 2)
+
+
+class TestFramePositionContract:
+    def test_stream_frame_positions_pinned(self) -> None:
+        assert (
+            StreamFrameRow._TAG_POS,
+            StreamFrameRow._INNER_JSON_POS,
+            StreamFrameRow._ERROR_CODE_POS,
+            StreamFrameRow._ERROR_PAYLOAD_POS,
+        ) == (0, 2, 2, 5)
+
+    def test_error_payload_positions_pinned(self) -> None:
+        assert ErrorPayloadRow._ENTRIES_POS == 2
+
+    def test_text_leaf_positions_pinned(self) -> None:
+        assert TextLeafRow._TEXT_POS == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. AnswerRow
+# ---------------------------------------------------------------------------
+
+
+def _answer_record(
+    *,
+    text: str = "answer text",
+    conv_id: str | None = "server-conv",
+    marker: int | None = 1,
+    citations: list | None = None,
+) -> list:
+    """Build a populated answer record matching the streamed-chat wire shape."""
+    conv = [conv_id, 123] if conv_id is not None else None
+    type_info = [[], None, None, citations or [], marker] if marker is not None else None
+    return [text, None, conv, None, type_info]
+
+
+class TestAnswerRow:
+    def test_happy_path_reads_text_conv_id_marker_citations(self) -> None:
+        row = AnswerRow(_answer_record(citations=[["c"]]))
+        assert row.text == "answer text"
+        assert row.server_conversation_id == "server-conv"
+        assert row.is_answer is True
+        assert row.citations == [["c"]]
+
+    def test_empty_text_returns_none(self) -> None:
+        assert AnswerRow(_answer_record(text="")).text is None
+
+    def test_non_string_text_returns_none(self) -> None:
+        rec = _answer_record()
+        rec[0] = 123
+        assert AnswerRow(rec).text is None
+
+    def test_missing_conv_block_returns_none(self) -> None:
+        assert AnswerRow(_answer_record(conv_id=None)).server_conversation_id is None
+
+    def test_non_answer_marker_is_false(self) -> None:
+        assert AnswerRow(_answer_record(marker=0)).is_answer is False
+
+    def test_absent_type_block_means_not_answer_and_no_citations(self) -> None:
+        row = AnswerRow(_answer_record(marker=None))
+        assert row.is_answer is False
+        assert row.citations == []
+
+    def test_short_row_degrades(self) -> None:
+        row = AnswerRow(["only-text"])
+        assert row.text == "only-text"
+        assert row.server_conversation_id is None
+        assert row.is_answer is False
+        assert row.citations == []
+
+    def test_citation_rows_wrap_each_entry(self) -> None:
+        row = AnswerRow(_answer_record(citations=[[["chunk"], [None, None, 0.5]]]))
+        rows = row.citation_rows()
+        assert len(rows) == 1
+        assert isinstance(rows[0], CitationRow)
+        assert rows[0].chunk_id == "chunk"
+
+
+# ---------------------------------------------------------------------------
+# 3. CitationRow / CitationDetail
+# ---------------------------------------------------------------------------
+
+
+class TestCitationRow:
+    def test_chunk_id_and_detail(self) -> None:
+        row = CitationRow([["chunk-1"], [None, None, 0.9, None, [], ["src"]]])
+        assert row.is_well_formed is True
+        assert row.chunk_id == "chunk-1"
+        assert isinstance(row.detail, CitationDetail)
+
+    def test_absent_chunk_block_returns_none_chunk_id(self) -> None:
+        assert CitationRow([[], [None]]).chunk_id is None
+
+    @pytest.mark.parametrize("raw", [[], ["only-one"], "not-a-list", None])
+    def test_malformed_entry_is_not_well_formed(self, raw: object) -> None:
+        row = CitationRow(raw)
+        assert row.is_well_formed is False
+        assert row.detail is None
+        assert row.chunk_id is None
+
+    def test_non_list_detail_slot_returns_none_detail(self) -> None:
+        assert CitationRow([["chunk"], "not-a-list"]).detail is None
+
+
+class TestCitationDetail:
+    def test_score_passages_source_id(self) -> None:
+        detail = CitationDetail([None, None, 0.75, None, [["p"]], ["src-data"]])
+        assert detail.raw_score == 0.75
+        assert detail.passages == [["p"]]
+        assert detail.source_id_data == ["src-data"]
+        assert detail.raw_list == [None, None, 0.75, None, [["p"]], ["src-data"]]
+
+    def test_answer_range_reads_inner_triple(self) -> None:
+        detail = CitationDetail([None, None, None, [[None, 5, 9]]])
+        assert detail.answer_range() == (5, 9)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            [None, None, None],  # too short for answer-range slot
+            [None, None, None, []],  # empty outer
+            [None, None, None, ["not-a-list"]],  # inner not a list
+            [None, None, None, [[None, 5]]],  # inner too short
+        ],
+    )
+    def test_answer_range_degrades_to_none_none(self, raw: list) -> None:
+        assert CitationDetail(raw).answer_range() == (None, None)
+
+    def test_short_detail_degrades(self) -> None:
+        detail = CitationDetail([None, None])
+        assert detail.raw_score is None
+        assert detail.passages == []
+        assert detail.source_id_data is None
+
+
+# ---------------------------------------------------------------------------
+# 4. PassageRow
+# ---------------------------------------------------------------------------
+
+
+class TestPassageRow:
+    def test_unwraps_wrapper_and_reads_start_end_text(self) -> None:
+        passage = PassageRow([[10, 20, [["text"]]]])
+        assert passage.is_well_formed is True
+        assert passage.start_char == 10
+        assert passage.end_char == 20
+        assert passage.text_payload == [["text"]]
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            [],  # empty wrapper
+            ["not-a-list"],  # inner not a list
+            [[10, 20]],  # inner too short (< 3)
+            "not-a-list",
+            None,
+        ],
+    )
+    def test_malformed_wrapper_degrades(self, raw: object) -> None:
+        passage = PassageRow(raw)
+        assert passage.is_well_formed is False
+        assert passage.start_char is None
+        assert passage.end_char is None
+        assert passage.text_payload is None
+
+
+# ---------------------------------------------------------------------------
+# 5. StreamFrameRow / ErrorPayloadRow / TextLeafRow
+# ---------------------------------------------------------------------------
+
+
+class TestStreamFrameRow:
+    def test_wrb_fr_frame_reads_tag_and_inner_json(self) -> None:
+        frame = StreamFrameRow(["wrb.fr", None, '[["x"]]'])
+        assert frame.tag == "wrb.fr"
+        assert frame.inner_json == '[["x"]]'
+        assert frame.error_payload is None
+
+    def test_er_frame_reads_tag_and_error_code(self) -> None:
+        frame = StreamFrameRow(["er", "rpc-id", 429])
+        assert frame.tag == "er"
+        assert frame.error_code == 429
+
+    def test_missing_error_code_is_none(self) -> None:
+        # A short "er" frame legitimately omits the code — NOT drift.
+        assert StreamFrameRow(["er", "rpc-id"]).error_code is None
+
+    def test_error_payload_read_when_list(self) -> None:
+        frame = StreamFrameRow(["wrb.fr", None, None, None, None, [8, None, []]])
+        assert frame.error_payload == [8, None, []]
+
+    def test_non_list_error_payload_returns_none(self) -> None:
+        frame = StreamFrameRow(["wrb.fr", None, None, None, None, "x"])
+        assert frame.error_payload is None
+
+    def test_tag_descent_raises_on_drift(self) -> None:
+        # The tag slot is the one guaranteed position; its absence is genuine
+        # drift that must RAISE rather than silently degrade. ``safe_index``
+        # cannot index an empty list at [0].
+        with pytest.raises(UnknownRPCMethodError):
+            _ = StreamFrameRow([]).tag
+
+
+class TestErrorPayloadRow:
+    def test_entries_and_entry_type(self) -> None:
+        payload = [8, None, [["type.googleapis.com/x.UserDisplayableError", "msg"]]]
+        row = ErrorPayloadRow(payload)
+        assert row.entries == [["type.googleapis.com/x.UserDisplayableError", "msg"]]
+        assert (
+            ErrorPayloadRow.entry_type(row.entries[0])
+            == "type.googleapis.com/x.UserDisplayableError"
+        )
+
+    @pytest.mark.parametrize("payload", [[8, None], [8, None, "x"], []])
+    def test_absent_or_non_list_entries_degrade(self, payload: list) -> None:
+        assert ErrorPayloadRow(payload).entries == []
+
+    @pytest.mark.parametrize("entry", [[], [123], "x", None])
+    def test_non_string_entry_type_is_none(self, entry: object) -> None:
+        assert ErrorPayloadRow.entry_type(entry) is None
+
+
+class TestTextLeafRow:
+    def test_reads_text_value(self) -> None:
+        leaf = TextLeafRow([0, 1, "hello"])
+        assert leaf.is_well_formed is True
+        assert leaf.text_value == "hello"
+
+    @pytest.mark.parametrize("raw", [[], [0, 1], "x", None])
+    def test_short_or_non_list_degrades(self, raw: object) -> None:
+        leaf = TextLeafRow(raw)
+        assert leaf.is_well_formed is False
+        assert leaf.text_value is None

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -32,7 +32,7 @@ import json
 
 import pytest
 
-from notebooklm._row_adapters.artifacts import ArtifactRow
+from notebooklm._row_adapters.artifacts import ArtifactRow, ReportSuggestionRow
 from notebooklm._row_adapters.notes import NoteRow
 from notebooklm._row_adapters.sources import (
     SourceRow,
@@ -1737,3 +1737,66 @@ class TestInterpretSourceFreshness:
         # non-boolean are all drift -> raise, not a silent bool.
         with pytest.raises(DecodingError):
             interpret_source_freshness(payload)
+
+
+# ---------------------------------------------------------------------------
+# ReportSuggestionRow (GET_SUGGESTED_REPORTS rows, issue #1491)
+# ---------------------------------------------------------------------------
+
+
+class TestReportSuggestionRowPositionContract:
+    """If these fail, Google has likely reshaped the GET_SUGGESTED_REPORTS row."""
+
+    def test_positions_pinned(self) -> None:
+        assert (
+            ReportSuggestionRow._TITLE_POS,
+            ReportSuggestionRow._DESCRIPTION_POS,
+            ReportSuggestionRow._PROMPT_POS,
+            ReportSuggestionRow._AUDIENCE_LEVEL_POS,
+            ReportSuggestionRow._DEFAULT_AUDIENCE_LEVEL,
+            ReportSuggestionRow._MIN_LEN,
+        ) == (0, 1, 4, 5, 2, 5)
+
+
+class TestReportSuggestionRow:
+    """Named-property reads with the historical permissive defaults."""
+
+    def test_full_row_reads_all_fields(self) -> None:
+        row = ReportSuggestionRow(["Title", "Desc", None, None, "Prompt", 3])
+        assert row.is_well_formed is True
+        assert row.title == "Title"
+        assert row.description == "Desc"
+        assert row.prompt == "Prompt"
+        assert row.audience_level == 3
+
+    def test_missing_audience_level_defaults_to_two(self) -> None:
+        # Exactly the historical ``item[5] if len(item) > 5 else 2`` contract.
+        row = ReportSuggestionRow(["Title", "Desc", None, None, "Prompt"])
+        assert row.is_well_formed is True
+        assert row.audience_level == 2
+
+    def test_non_string_fields_degrade_to_empty(self) -> None:
+        row = ReportSuggestionRow([None, 5, None, None, ["nested"], 1])
+        assert row.title == ""
+        assert row.description == ""
+        assert row.prompt == ""
+        assert row.audience_level == 1
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            [],
+            ["Title", "Desc"],
+            ["Title", "Desc", None, None],  # len 4 < 5, missing prompt slot
+            "not-a-list",
+            None,
+        ],
+    )
+    def test_short_or_non_list_rows_are_not_well_formed(self, raw: object) -> None:
+        assert ReportSuggestionRow(raw).is_well_formed is False
+
+    def test_present_but_non_int_audience_level_returned_verbatim(self) -> None:
+        # Mirrors the prior inline read: the slot's *presence* is checked, not
+        # its type -- a present non-int value passes through unchanged.
+        row = ReportSuggestionRow(["T", "D", None, None, "P", "high"])
+        assert row.audience_level == "high"


### PR DESCRIPTION
## What & why

Fixes #1491. The `safe_index` + row-adapter convergence (#1377) is the primary defense against `batchexecute` wire-schema drift, but it was incomplete: `_chat/wire.py` decoded the streamed-chat payload via **36 single-level positional reads** with no adapter; the existing lint only caught **chained** `x[i][j]` (single-level `x[i]` slipped); and `suggest_reports` open-coded raw rows.

## Approach

- New `_row_adapters/chat.py` (`AnswerRow`/`CitationRow`/`CitationDetail`/`PassageRow`/`StreamFrameRow`/`ErrorPayloadRow`/`TextLeafRow`) + `ReportSuggestionRow`; migrate `_chat/wire.py` (**36 → 0** single-level reads) and `suggest_reports` behind them, **preserving every drift-raise and soft-degrade contract** (both reviewers traced this).
- Add a second guardrail gate flagging single-level `x[i]` RPC-payload reads in feature code, with a 47-file `SINGLE_LEVEL_ALLOWLIST` burndown (mirroring how #1377 rolled out); `_chat/wire.py` is migrated **out** and pinned by a test.

## Review-driven fix (codex)

- The single-level gate is now documented explicitly as a **burndown ratchet**, not a closed perimeter: it flags only integer-*literal* subscripts (a named-constant index like `first[TEXT_POS]` is not detected) and tolerates reads in allowlisted files until they burn down. Corrected the failure-message guidance (binding to a named local does **not** satisfy the single-level gate, unlike the chained gate).

## Verification

- Behavior-preserving migration (both claude + codex traced the non-trivial reads); full guardrail + chat + artifact suites green; mypy + ruff clean; API-compat audit **EXIT 0** (only private `_row_adapters` changed).
- `docs/architecture.md` updated (freshness gate).

Closes #1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved chat response and report-suggestion parsing with structured row adapters for more reliable, robust handling.

* **Documentation**
  * Updated architecture docs to document the row-adapter layer and newly described chat/artifact adapters.

* **Tests**
  * Added guardrail and unit tests for chat row adapters and report suggestion parsing to detect wire-shape regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->