### PR TITLE
arch(rpc): narrow single-level positional gate to name[int] + migrate research parser behind row adapters (#1501 phase 1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,7 +480,7 @@ Beyond the client-owned runtime graph, several feature APIs are implemented via 
 | `ArtifactDownloadService` | [`_artifact/downloads.py`](../src/notebooklm/_artifact/downloads.py) | Asynchronous download coordinator for finished artifacts. |
 | `_artifact_formatters` | [`_artifact/formatters.py`](../src/notebooklm/_artifact/formatters.py) | Markdown, HTML, and plain text formatters for artifacts. |
 | `_artifact/listing` | [`_artifact/listing.py`](../src/notebooklm/_artifact/listing.py) | Listing and filtering operations for notebook artifacts. |
-| `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/chat.py`](../src/notebooklm/_row_adapters/chat.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `NoteRow`, `SourceRow`) and the streamed-chat rows (`AnswerRow`/`CitationRow`/…) behind named accessors so downloads, polling, listing, and the chat parser don't open-code positional indices. Soft-degrade and strict-mode behavior is pinned in `tests/unit/test_row_adapters.py` and `tests/unit/test_chat_row_adapter.py`. |
+| `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/chat.py`](../src/notebooklm/_row_adapters/chat.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/research.py`](../src/notebooklm/_row_adapters/research.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `NoteRow`, `SourceRow`, the `POLL_RESEARCH` rows) and the streamed-chat rows (`AnswerRow`/`CitationRow`/…) behind named accessors so downloads, polling, listing, research, and the chat parser don't open-code positional indices. Soft-degrade and strict-mode behavior is pinned in `tests/unit/test_row_adapters.py`, `tests/unit/test_chat_row_adapter.py`, and `tests/unit/test_research_row_adapter.py`. |
 | `_research_task_parser` | [`_research_task_parser.py`](../src/notebooklm/_research_task_parser.py) | Parses deep-research task results from raw rows. Returns dict-shaped output today; a typed-model migration is not yet complete. |
 | `_types/` | [`_types/`](../src/notebooklm/_types) | Private package holding the dataclass and `Protocol` implementations behind the public `types.py` / per-feature public schemas. Split per domain (`artifacts.py`, `chat.py`, `notebooks.py`, `notes.py`, `sharing.py`, `sources.py`, plus `common.py` for shared shapes like `ConnectionLimits`). |
 
@@ -852,6 +852,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_row_adapters/chat.py` | Streamed-chat row adapters (`AnswerRow` / `CitationRow` / `CitationDetail` / `PassageRow` / `StreamFrameRow` / `ErrorPayloadRow` / `TextLeafRow`) that centralise the chat wire positions `_chat/wire.py` used to open-code (#1491) |
 | `_row_adapters/labels.py` | `LabelRow` strict typed view over the raw positional label tuple `[name, sources, id, emoji]` (fails loud on schema drift) |
 | `_row_adapters/notes.py` | `NoteRow` typed view over raw positional note and mind-map RPC rows |
+| `_row_adapters/research.py` | `ResearchTaskRow` / `ResearchTaskInfoRow` / `ResearchResultRow` typed views over raw positional `POLL_RESEARCH` rows that centralise the single-level positions `_research_task_parser.py` used to open-code (#1501) |
 | `_row_adapters/sources.py` | `SourceRow` / `SourceRowShape` typed views over raw positional source RPC rows |
 | `artifacts.py`, `research.py`, `utils.py` | Public helper modules for artifact retry, research citation/report utilities, and common async helpers |
 | `_research_task_parser.py` | Internal parser for research task result-type selection |
@@ -1028,6 +1029,7 @@ src/notebooklm/
 │   ├── chat.py                  # Streamed-chat row adapters (AnswerRow / CitationRow / CitationDetail / PassageRow / StreamFrameRow / ErrorPayloadRow / TextLeafRow) — closes the chat positional-decode perimeter (#1491)
 │   ├── labels.py                # Source-label row adapter
 │   ├── notes.py                 # Note and mind-map row adapter
+│   ├── research.py              # POLL_RESEARCH row adapters (ResearchTaskRow / ResearchTaskInfoRow / ResearchResultRow) — drains the research parser's single-level positional reads (#1501)
 │   └── sources.py               # Source row adapter
 ├── _chat/                       # Chat-feature subpackage — facade + helpers unified (#1328)
 │   ├── __init__.py              # Re-exports ChatAPI so `from ._chat import ChatAPI` keeps resolving

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -12,6 +12,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from ._row_adapters.research import (
+    ResearchResultRow,
+    ResearchTaskInfoRow,
+    ResearchTaskRow,
+    unwrap_poll_tasks,
+)
 from ._types.research import (
     RESEARCH_RESULT_TYPE_REPORT,
     RESEARCH_RESULT_TYPE_WEB,
@@ -43,15 +49,17 @@ _POLL_METHOD_ID = RPCMethod.POLL_RESEARCH.value
 
 def extract_legacy_report_chunks(src: list[Any]) -> str:
     """Join legacy deep-research report chunks stored in ``src[6]``."""
-    if len(src) <= 6 or not isinstance(src[6], list):
-        return ""
-    chunks = [chunk for chunk in src[6] if isinstance(chunk, str) and chunk]
+    chunks = [
+        chunk
+        for chunk in ResearchResultRow(src).legacy_report_chunks
+        if isinstance(chunk, str) and chunk
+    ]
     return "\n\n".join(chunks)
 
 
 def _extract_task_id(task_data: Any) -> str | None:
     """Return ``task_data[0]`` as a string when present, else ``None``."""
-    value = safe_index(task_data, 0, method_id=_POLL_METHOD_ID, source=_POLL_SOURCE)
+    value = ResearchTaskRow(task_data).task_id_raw
     if isinstance(value, str):
         return value
     if value is not None:
@@ -66,7 +74,7 @@ def _extract_task_id(task_data: Any) -> str | None:
 
 def _extract_task_info(task_data: Any) -> list[Any] | None:
     """Return ``task_data[1]`` as a list when present, else ``None``."""
-    value = safe_index(task_data, 1, method_id=_POLL_METHOD_ID, source=_POLL_SOURCE)
+    value = ResearchTaskRow(task_data).task_info_raw
     if isinstance(value, list):
         return value
     if value is not None:
@@ -92,7 +100,7 @@ def _extract_query_text(task_info: Any) -> str | None:
             )
         return None
 
-    value = query_info[0] if query_info else None
+    value = ResearchTaskInfoRow.query_text(query_info)
     if isinstance(value, str):
         return value
     if value is not None:
@@ -142,18 +150,18 @@ def _extract_sources_and_summary(task_info: Any) -> tuple[list[Any], str | None]
             )
         return [], None
 
-    sources_data = bundle[0] if isinstance(bundle[0], list) else []
-    if bundle[0] is not None and not isinstance(bundle[0], list):
+    raw_sources = ResearchTaskInfoRow.bundle_sources(bundle)
+    sources_data = raw_sources if isinstance(raw_sources, list) else []
+    if raw_sources is not None and not isinstance(raw_sources, list):
         logger.warning(
             "task_info[3][0] is not a list (method_id=%r, source=%r): %r",
             _POLL_METHOD_ID,
             _POLL_SOURCE,
-            type(bundle[0]).__name__,
+            type(raw_sources).__name__,
         )
 
-    summary: str | None = None
-    if len(bundle) >= 2 and isinstance(bundle[1], str):
-        summary = bundle[1]
+    raw_summary = ResearchTaskInfoRow.bundle_summary(bundle)
+    summary: str | None = raw_summary if isinstance(raw_summary, str) else None
 
     return sources_data, summary
 
@@ -172,7 +180,8 @@ def _status_from_code(status_code: int | None) -> ResearchStatus:
 def _parse_source_row(
     src: Any, *, task_id: str, report_found: bool = False
 ) -> tuple[ResearchSource | None, str]:
-    if not isinstance(src, list) or len(src) < 2:
+    row = ResearchResultRow(src)
+    if not row.is_well_formed:
         return None, ""
 
     title = ""
@@ -183,22 +192,19 @@ def _parse_source_row(
     # Deep research (legacy): [None, title, None, type, ..., [report_markdown]]
     # Deep research (current): [None, [title, report_markdown], None, type, ...]
     # src[3] is the authoritative result_type when present.
-    result_type = parse_result_type(src[3]) if len(src) > 3 else RESEARCH_RESULT_TYPE_WEB
-    if src[0] is None and len(src) > 1:
-        # Deep-research (current) packs ``[title, report_markdown]`` at ``src[1]``.
-        # Bind it once so the title/report reads are single-level ``payload[0]`` /
-        # ``payload[1]`` indices instead of chained ``src[1][0]`` / ``src[1][1]``
-        # descents; the legitimate alternatives (bare-string title, or neither)
-        # fall through to the elif / outer branches below.
-        payload = src[1]
-        if (
-            isinstance(payload, list)
-            and len(payload) >= 2
-            and isinstance(payload[0], str)
-            and isinstance(payload[1], str)
-        ):
-            title = payload[0]
-            source_report = payload[1]
+    result_type = (
+        parse_result_type(row.result_type_slot) if row.has_result_type else RESEARCH_RESULT_TYPE_WEB
+    )
+    if row.url_slot is None and row.length > 1:
+        # Deep-research (current) packs ``[title, report_markdown]`` at ``src[1]``;
+        # ``ResearchResultRow.deep_payload`` unpacks that exact shape (a 2+-length
+        # list of two strings) and returns ``None`` for the legitimate
+        # alternatives (bare-string title, or neither), which fall through to the
+        # elif / outer branches below.
+        payload = row.title_slot
+        deep = ResearchResultRow.deep_payload(payload)
+        if deep is not None:
+            title, source_report = deep
             url = ""
             if result_type == RESEARCH_RESULT_TYPE_WEB:
                 result_type = RESEARCH_RESULT_TYPE_REPORT
@@ -207,9 +213,9 @@ def _parse_source_row(
             url = ""
             if result_type == RESEARCH_RESULT_TYPE_WEB:
                 result_type = RESEARCH_RESULT_TYPE_REPORT
-    elif isinstance(src[0], str) or len(src) >= 3:
-        url = src[0] if isinstance(src[0], str) else ""
-        title = src[1] if len(src) > 1 and isinstance(src[1], str) else ""
+    elif isinstance(row.url_slot, str) or row.length >= 3:
+        url = row.url_slot if isinstance(row.url_slot, str) else ""
+        title = row.title_slot if row.length > 1 and isinstance(row.title_slot, str) else ""
 
     parsed_source = None
     if title or url:
@@ -230,15 +236,11 @@ def _parse_source_row(
 
 
 def _unwrap_poll_result(result: Any) -> list[Any]:
-    if not result or not isinstance(result, list):
-        return []
     # POLL_RESEARCH returns either a wrapped envelope (``[[task1, ...]]``) or an
-    # already-flat list of tasks. Bind the first element so the wrap probe reads
-    # ``first[0]`` (single-level) instead of a chained ``result[0][0]`` descent.
-    first = result[0]
-    if isinstance(first, list) and len(first) > 0 and isinstance(first[0], list):
-        return first
-    return result
+    # already-flat list of tasks; ``unwrap_poll_tasks`` centralises that envelope
+    # probe (the former ``result[0]`` / ``first[0]`` reads) behind the research
+    # row adapter.
+    return unwrap_poll_tasks(result)
 
 
 def parse_research_task_models(result: Any) -> list[ResearchTask]:

--- a/src/notebooklm/_row_adapters/__init__.py
+++ b/src/notebooklm/_row_adapters/__init__.py
@@ -5,7 +5,7 @@ Re-exports the typed row views; importers may also reach submodules directly
 (``from .._row_adapters.sources import SourceRow``).
 """
 
-from . import artifacts, chat, labels, notes, sources
+from . import artifacts, chat, labels, notes, research, sources
 from .artifacts import ArtifactRow, ReportSuggestionRow
 from .chat import (
     AnswerRow,
@@ -18,6 +18,12 @@ from .chat import (
 )
 from .labels import LabelRow
 from .notes import NoteRow
+from .research import (
+    ResearchResultRow,
+    ResearchTaskInfoRow,
+    ResearchTaskRow,
+    unwrap_poll_tasks,
+)
 from .sources import SourceRow, SourceRowShape
 
 __all__ = [
@@ -25,6 +31,7 @@ __all__ = [
     "chat",
     "labels",
     "notes",
+    "research",
     "sources",
     "AnswerRow",
     "ArtifactRow",
@@ -35,8 +42,12 @@ __all__ = [
     "NoteRow",
     "PassageRow",
     "ReportSuggestionRow",
+    "ResearchResultRow",
+    "ResearchTaskInfoRow",
+    "ResearchTaskRow",
     "SourceRow",
     "SourceRowShape",
     "StreamFrameRow",
     "TextLeafRow",
+    "unwrap_poll_tasks",
 ]

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -139,7 +139,6 @@ class ResearchTaskRow:
         )
 
 
-@dataclass(frozen=True)
 class ResearchTaskInfoRow:
     """Typed view of one task info block (``task_data[1]``).
 

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -167,11 +167,17 @@ class ResearchTaskInfoRow:
 
     @staticmethod
     def bundle_sources(bundle: Any) -> Any:
-        """Sources list at ``task_info[3][0]`` — the raw value (list-validated upstream).
+        """Sources list at ``task_info[3][0]`` — ``None`` when the slot is absent.
 
-        ``bundle`` is ``task_info[3]`` (already validated as a non-empty list by
-        the caller), so ``[0]`` is always present.
+        ``bundle`` is ``task_info[3]``. The parser's caller already
+        short-circuits an empty bundle, but the adapter still length-guards its
+        own read (mirroring :meth:`bundle_summary`) so an empty bundle degrades
+        to the missing-slot default instead of raising ``IndexError`` — the
+        soft-read contract this module documents. The caller coerces a
+        non-list (including ``None``) to ``[]``.
         """
+        if len(bundle) <= ResearchTaskInfoRow._SOURCES_POS:
+            return None
         return bundle[ResearchTaskInfoRow._SOURCES_POS]
 
     @staticmethod

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -1,0 +1,298 @@
+"""Research row adapters for the ``POLL_RESEARCH`` (``e3bVqc``) payload.
+
+These adapters centralise the positional knowledge that
+``_research_task_parser.py`` previously open-coded as scattered single-level
+subscripts (``result[0]``, ``src[1]``, ``bundle[0]``, ``task_info[1][0]`` …).
+The parser wraps the raw lists in the typed views below and reads named
+properties so a future Google reshape of the research wire format is a
+one-place fix here, and so genuine drift on the *guaranteed* descents RAISES
+``UnknownRPCMethodError`` via ``safe_index`` instead of silently degrading to
+empty/wrong data (ADR-0011).
+
+Two descent flavours are preserved exactly as the historical parser had them:
+
+* **Guaranteed** slots — the two leading slots of a task row (``task_data[0]``
+  task id, ``task_data[1]`` task info) — descend through ``safe_index`` so an
+  absent slot RAISES (that is genuine shape drift; the task cannot be parsed
+  without them).
+* **Routinely-optional** slots — every research-source field and the
+  query / sources / summary bundle reads — are length-guarded *inside* the
+  adapter and short-circuit to a default, matching the parser's permissive
+  contract (a deep-research source legitimately omits its URL, a fast-research
+  task legitimately omits its summary, …).
+
+Position contracts (pinned by ``tests/unit/test_research_row_adapter.py``):
+
+* :class:`ResearchTaskRow` — one task row (``tasks[i]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  0      task id (str) — GUARANTEED (``safe_index``)
+  1      task info block (list) — GUARANTEED (``safe_index``)
+  =====  ============================================================
+
+* :class:`ResearchTaskInfoRow` — one task info block (``task_data[1]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  1      query block; ``[1][0]`` is the original query text
+  3      sources/summary bundle; ``[3][0]`` sources list, ``[3][1]`` summary
+  4      status code (int)
+  =====  ============================================================
+
+* :class:`ResearchResultRow` — one source row (``sources_data[i]``):
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  0      URL (str) for fast research; ``None`` sentinel for deep research
+  1      title (str) — or, for current deep research, ``[title, report]``
+  3      authoritative result-type tag
+  6      legacy deep-research report chunks (list of str)
+  =====  ============================================================
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from ..rpc import RPCMethod, safe_index
+
+__all__ = [
+    "ResearchResultRow",
+    "ResearchTaskInfoRow",
+    "ResearchTaskRow",
+    "unwrap_poll_tasks",
+]
+
+# The ``POLL_RESEARCH`` method id and a stable source label, threaded into
+# ``safe_index`` so drift on the guaranteed descents points at the right RPC.
+_POLL_METHOD_ID = RPCMethod.POLL_RESEARCH.value
+
+# Envelope-unwrap positions: ``POLL_RESEARCH`` returns either a wrapped
+# envelope (``[[task1, ...]]``) or an already-flat list of tasks.
+_ENVELOPE_OUTER_POS = 0
+_ENVELOPE_PROBE_POS = 0
+
+
+def unwrap_poll_tasks(result: Any) -> list[Any]:
+    """Return the flat list of task rows from a raw ``POLL_RESEARCH`` result.
+
+    ``POLL_RESEARCH`` returns either a wrapped envelope (``[[task1, ...]]``) or
+    an already-flat list of tasks. This centralises that ``result[0]`` /
+    ``result[0][0]`` envelope probe so the parser stops open-coding it; the
+    reads are soft (an unrecognised shape falls through to ``result`` unchanged
+    or ``[]``), preserving the historical ``_unwrap_poll_result`` contract.
+    """
+    if not result or not isinstance(result, list):
+        return []
+    first = result[_ENVELOPE_OUTER_POS]
+    if isinstance(first, list) and len(first) > 0 and isinstance(first[_ENVELOPE_PROBE_POS], list):
+        return first
+    return result
+
+
+@dataclass(frozen=True)
+class ResearchTaskRow:
+    """Typed view of one raw ``POLL_RESEARCH`` task row (``tasks[i]``).
+
+    The two leading slots are GUARANTEED: a task that is missing its id
+    (``task_data[0]``) or its info block (``task_data[1]``) is genuine shape
+    drift, so both reads descend through ``safe_index`` and RAISE
+    ``UnknownRPCMethodError`` on absence — mirroring the historical
+    ``_extract_task_id`` / ``_extract_task_info`` contract exactly (an empty or
+    non-list ``task_data`` raised; a present-but-wrong-type value logged and
+    degraded to ``None``).
+    """
+
+    _raw: Any = field(repr=False)
+
+    _ID_POS: ClassVar[int] = 0
+    _INFO_POS: ClassVar[int] = 1
+
+    _ID_SOURCE: ClassVar[str] = "ResearchTaskRow.task_id"
+    _INFO_SOURCE: ClassVar[str] = "ResearchTaskRow.task_info"
+
+    @property
+    def task_id_raw(self) -> Any:
+        """Raw value at ``task_data[0]`` (str validated by the caller).
+
+        Descends through ``safe_index`` so an absent id slot RAISES — a task
+        row that cannot supply its id is genuine drift, not a soft default.
+        """
+        return safe_index(
+            self._raw, self._ID_POS, method_id=_POLL_METHOD_ID, source=self._ID_SOURCE
+        )
+
+    @property
+    def task_info_raw(self) -> Any:
+        """Raw value at ``task_data[1]`` (list validated by the caller).
+
+        Descends through ``safe_index`` so an absent info slot RAISES — a task
+        row without its info block is genuine drift.
+        """
+        return safe_index(
+            self._raw, self._INFO_POS, method_id=_POLL_METHOD_ID, source=self._INFO_SOURCE
+        )
+
+
+@dataclass(frozen=True)
+class ResearchTaskInfoRow:
+    """Typed view of one task info block (``task_data[1]``).
+
+    The ``[1]`` query block, ``[3]`` sources/summary bundle, and ``[4]`` status
+    code are themselves read through ``safe_index`` by the parser's
+    ``_extract_*`` helpers (an absent slot is drift). This adapter centralises
+    the *inner* single-level reads those helpers then perform on the bound
+    blocks — ``query_info[0]``, ``bundle[0]``, ``bundle[1]`` — which are
+    routinely-optional and short-circuit to a default rather than raising.
+    """
+
+    _QUERY_TEXT_POS: ClassVar[int] = 0
+    _SOURCES_POS: ClassVar[int] = 0
+    _SUMMARY_POS: ClassVar[int] = 1
+    _SUMMARY_MIN_LEN: ClassVar[int] = 2
+
+    @staticmethod
+    def query_text(query_info: Any) -> Any:
+        """First element of the query block (``task_info[1][0]``) or ``None``.
+
+        ``query_info`` is ``task_info[1]`` (already validated as a list by the
+        caller). An empty block legitimately means "no query text", so this
+        short-circuits to ``None`` rather than raising.
+        """
+        return query_info[ResearchTaskInfoRow._QUERY_TEXT_POS] if query_info else None
+
+    @staticmethod
+    def bundle_sources(bundle: Any) -> Any:
+        """Sources list at ``task_info[3][0]`` — the raw value (list-validated upstream).
+
+        ``bundle`` is ``task_info[3]`` (already validated as a non-empty list by
+        the caller), so ``[0]`` is always present.
+        """
+        return bundle[ResearchTaskInfoRow._SOURCES_POS]
+
+    @staticmethod
+    def bundle_summary(bundle: Any) -> Any:
+        """Summary at ``task_info[3][1]`` — ``None`` when the slot is absent.
+
+        A sources-only bundle legitimately omits the summary, so this is a
+        length-guarded soft read (``[1]`` only when ``len(bundle) >= 2``).
+        """
+        if len(bundle) < ResearchTaskInfoRow._SUMMARY_MIN_LEN:
+            return None
+        return bundle[ResearchTaskInfoRow._SUMMARY_POS]
+
+
+@dataclass(frozen=True)
+class ResearchResultRow:
+    """Typed view of one raw research source row (``sources_data[i]``).
+
+    The source row carries three shapes the historical parser handled inline:
+
+    * fast research — ``[url, title, desc, type, ...]``
+    * deep research (legacy) — ``[None, title, None, type, ..., [report_md]]``
+    * deep research (current) — ``[None, [title, report_md], None, type, ...]``
+
+    Every field is routinely-optional (a deep-research row omits its URL; a
+    fast-research row omits the report), so the adapter length-guards each read
+    and short-circuits to a default — preserving the parser's permissive
+    contract (a malformed source is skipped, never raised). Position knowledge
+    is centralised here; the parser reads named properties instead of
+    ``src[0]`` / ``src[1]`` / ``src[3]`` / ``src[6]``.
+    """
+
+    _raw: Any = field(repr=False)
+
+    _URL_POS: ClassVar[int] = 0
+    _TITLE_POS: ClassVar[int] = 1
+    _RESULT_TYPE_POS: ClassVar[int] = 3
+    _LEGACY_CHUNKS_POS: ClassVar[int] = 6
+    # A source row must carry at least ``[url/sentinel, title]`` to be usable —
+    # mirrors the historical ``len(src) < 2`` early return.
+    _MIN_LEN: ClassVar[int] = 2
+
+    # Layout of the current-deep-research ``[title, report_markdown]`` payload
+    # packed at ``src[1]``.
+    _PAYLOAD_TITLE_POS: ClassVar[int] = 0
+    _PAYLOAD_REPORT_POS: ClassVar[int] = 1
+    _PAYLOAD_MIN_LEN: ClassVar[int] = 2
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the row is a list long enough to carry url/sentinel + title."""
+        return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
+
+    @property
+    def length(self) -> int:
+        """Length of the raw row (``0`` when not a list).
+
+        Exposed so the parser can preserve its ``len(src) > 3`` / ``len(src) >= 3``
+        branch conditions without re-reaching for ``self._raw``.
+        """
+        return len(self._raw) if isinstance(self._raw, list) else 0
+
+    @property
+    def url_slot(self) -> Any:
+        """Raw value at ``src[0]`` — URL (str) for fast research, ``None`` sentinel
+        for deep research. ``None`` when the slot is absent."""
+        if self.length <= self._URL_POS:
+            return None
+        return self._raw[self._URL_POS]
+
+    @property
+    def title_slot(self) -> Any:
+        """Raw value at ``src[1]`` — a title ``str`` or, for current deep
+        research, the ``[title, report_markdown]`` payload. ``None`` when absent."""
+        if self.length <= self._TITLE_POS:
+            return None
+        return self._raw[self._TITLE_POS]
+
+    @property
+    def result_type_slot(self) -> Any:
+        """Authoritative result-type tag at ``src[3]`` — ``None`` when absent.
+
+        The caller (``parse_result_type``) is responsible for normalising the
+        value; the adapter only reports presence. ``None`` here makes the parser
+        fall back to the web default exactly as ``len(src) > 3`` did.
+        """
+        if self.length <= self._RESULT_TYPE_POS:
+            return None
+        return self._raw[self._RESULT_TYPE_POS]
+
+    @property
+    def has_result_type(self) -> bool:
+        """Whether ``src[3]`` is present (``len(src) > 3``)."""
+        return self.length > self._RESULT_TYPE_POS
+
+    @property
+    def legacy_report_chunks(self) -> list[Any]:
+        """Legacy deep-research report chunks at ``src[6]`` — ``[]`` when absent/non-list."""
+        if self.length <= self._LEGACY_CHUNKS_POS:
+            return []
+        value = self._raw[self._LEGACY_CHUNKS_POS]
+        return value if isinstance(value, list) else []
+
+    @staticmethod
+    def deep_payload(payload: Any) -> tuple[str, str] | None:
+        """Unpack a current-deep-research ``[title, report_markdown]`` payload.
+
+        Returns ``(title, report_markdown)`` only when ``payload`` is a list of
+        at least two strings (the exact shape the historical parser required at
+        ``src[1]``); otherwise ``None`` so the caller falls through to the
+        bare-string-title / fast-research branches.
+        """
+        if (
+            isinstance(payload, list)
+            and len(payload) >= ResearchResultRow._PAYLOAD_MIN_LEN
+            and isinstance(payload[ResearchResultRow._PAYLOAD_TITLE_POS], str)
+            and isinstance(payload[ResearchResultRow._PAYLOAD_REPORT_POS], str)
+        ):
+            return (
+                payload[ResearchResultRow._PAYLOAD_TITLE_POS],
+                payload[ResearchResultRow._PAYLOAD_REPORT_POS],
+            )
+        return None

--- a/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
+++ b/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
@@ -26,21 +26,25 @@ This module runs **two** AST gates:
    #1377 burndown migrated every chained offender, so the chained gate
    re-protects the whole feature tree with no exceptions.
 
-2. **Single-level descent (issue #1491).** A single ``Subscript`` indexed by an
-   integer literal (``x[i]``). On its own this is too common and too benign --
-   ``args[0]``, ``parts[-1]`` -- to forbid outright, but it is *also* exactly how
-   un-named row-position knowledge of an RPC payload leaks past the chained
-   gate (the chat wire parser carried dozens of ``first[4]`` / ``cite[1]`` /
-   ``passage_data[0]`` reads that the chained gate never saw). So the
-   single-level gate works as a **ratchet**: the 47 feature files that already
-   open-code single-level integer subscripts are *baselined* into
-   :data:`SINGLE_LEVEL_ALLOWLIST` (so the gate is green on ``main`` today), but
-   a *new* single-level integer subscript in a file that is NOT on that list
-   fails the gate. New code therefore decodes through a row adapter / a named
-   local rather than re-scattering raw positions. The burndown that drains
+2. **Single-level descent (issue #1491, narrowed in #1501).** A single
+   ``Subscript`` indexed by an integer literal whose *value is a bare local*
+   ``Name`` -- the RPC-payload shape ``name[int]`` (``first[4]`` / ``cite[1]`` /
+   ``passage_data[0]``). That is exactly how un-named row-position knowledge of
+   an RPC payload leaks past the chained gate (the chat wire parser carried
+   dozens of such reads the chained gate never saw), because a decoded
+   ``batchexecute`` list is always bound to a local before it is walked.
+   Attribute/call subscripts (``sys.version_info[0]``, ``url.split("@", 1)[0]``)
+   are **excluded as structurally-benign** -- they are never positional descents
+   into an RPC payload -- so the gate is precise and benign indexing need not be
+   grandfathered. The gate works as a **ratchet**: the feature files that
+   already open-code a ``name[int]`` RPC read are *baselined* into
+   :data:`SINGLE_LEVEL_ALLOWLIST` (so the gate is green on ``main`` today), but a
+   *new* ``name[int]`` read in a file that is NOT on that list fails the gate.
+   New code therefore decodes through a row adapter / a named local rather than
+   re-scattering raw positions. The burndown that drains
    :data:`SINGLE_LEVEL_ALLOWLIST` (migrating each file behind ``_row_adapters/``
    + ``safe_index`` or binding the guarded inner list to a named local) is
-   tracked as a follow-up to #1491.
+   tracked by #1501.
 
 A string/slice subscript (``d["k"]``, ``s[1:]``) is ignored by both gates.
 
@@ -116,7 +120,6 @@ SINGLE_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
         "_notebooks.py",
         "_notes.py",
         "_research.py",
-        "_research_task_parser.py",
         "_source/add.py",
         "_source/content.py",
         "_source/listing.py",
@@ -128,14 +131,9 @@ SINGLE_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
         "_version_check.py",
         "cli/_chromium_profiles.py",
         "cli/_firefox_containers.py",
-        "cli/agent_templates.py",
-        "cli/artifact_cmd.py",
-        "cli/error_handler.py",
         "cli/resolve.py",
-        "cli/services/login/browser_accounts.py",
         "cli/services/login/chromium_accounts.py",
         "cli/services/login/cookie_writes.py",
-        "cli/services/login/profile_targets.py",
         "cli/services/playwright_login.py",
         "cli/services/playwright_redaction.py",
         "utils.py",
@@ -183,18 +181,40 @@ def _chained_positional_offenders(tree: ast.AST) -> list[int]:
 
 
 def _single_level_positional_offenders(tree: ast.AST) -> list[int]:
-    """Return sorted line numbers of single-level integer-literal subscripts.
+    """Return sorted line numbers of the RPC-payload shape ``name[int]``.
 
-    A site is any ``Subscript`` whose index is an integer literal -- ``x[i]``.
-    This is a superset of :func:`_chained_positional_offenders` (each level of a
-    chain ``x[i][j]`` is itself a single-level subscript), so the chained gate
-    is strictly stronger; this detector is what powers the #1491 single-level
-    ratchet. Pure on its input so a planted fixture can exercise it without
-    touching the filesystem.
+    A site is a ``Subscript`` indexed by an integer literal whose *value is a
+    bare* :class:`ast.Name` -- i.e. ``data[0]`` / ``result[2]``, a positional
+    read of a **decoded RPC payload bound to a local name**. That is the shape
+    the #1491 single-level ratchet targets: a genuine RPC-payload position read
+    is always rooted at a local variable, because the decoded ``batchexecute``
+    list is bound to a name before it is walked.
+
+    Subscripts whose value is an :class:`ast.Attribute` (``sys.version_info[0]``,
+    ``e.args[0]``, ``context.pages[0]``), an :class:`ast.Call`
+    (``url.split("@", 1)[0]``, ``Path(...).parents[3]``), or another
+    :class:`ast.Subscript` are **excluded as structurally-benign**: every such
+    site in the feature tree is a stdlib / string / path read, never a
+    positional descent into an RPC payload (which is *always* bound to a local
+    ``Name`` first). Excluding them keeps the ratchet precise -- it flags only
+    the ``name[int]`` shape that re-scatters RPC-row position knowledge -- so
+    benign attribute/call indexing does not have to be grandfathered into
+    :data:`SINGLE_LEVEL_ALLOWLIST`.
+
+    Note this is therefore NOT a strict superset of
+    :func:`_chained_positional_offenders`: the *inner* level of a chain
+    ``x[i][j]`` (where the outer value is itself a ``Subscript``) is excluded
+    here, but the chained gate -- which is the strictly-stronger gate for that
+    deep-descent shape -- still catches it. Pure on its input so a planted
+    fixture can exercise it without touching the filesystem.
     """
     lines: set[int] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Subscript) and _is_int_literal(node.slice):
+        if (
+            isinstance(node, ast.Subscript)
+            and _is_int_literal(node.slice)
+            and isinstance(node.value, ast.Name)
+        ):
             lines.add(node.lineno)
     return sorted(lines)
 
@@ -320,11 +340,15 @@ def test_no_unbaselined_single_level_positional_rpc_indexing() -> None:
     and shape drift RAISES ``UnknownRPCMethodError`` via ``safe_index``.
 
     Scope (deliberate, like #1377): a *ratchet*, not a closed perimeter. It flags
-    only integer-*literal* subscripts (``x[0]``) — a named-constant index
-    (``first[TEXT_POS]``) is not detected — and raw reads inside the ~47
-    already-allowlisted files are tolerated until each is migrated and dropped
-    from the allowlist. The goal is to stop NEW raw positions accruing while the
-    existing ones burn down, not to prove "no RPC positions anywhere".
+    only the RPC-payload shape ``name[int]`` -- an integer-*literal* subscript of
+    a bare local :class:`ast.Name` (``data[0]``). A named-constant index
+    (``first[TEXT_POS]``) is not detected, and attribute/call subscripts
+    (``sys.version_info[0]``, ``url.split("@", 1)[0]``) are excluded as
+    structurally-benign (see :func:`_single_level_positional_offenders`). Raw
+    reads inside the already-allowlisted files are tolerated until each is
+    migrated and dropped from the allowlist. The goal is to stop NEW raw RPC-row
+    positions accruing while the existing ones burn down, not to prove "no
+    integer subscripts anywhere".
     """
     offenders = _single_level_offending_files()
     unbaselined = {f: lines for f, lines in offenders.items() if f not in SINGLE_LEVEL_ALLOWLIST}
@@ -382,18 +406,20 @@ def test_migrated_chat_wire_is_not_single_level_allowlisted() -> None:
 
 
 def test_single_level_detector_flags_and_ignores() -> None:
-    """The single-level detector flags ``x[i]`` and ignores string/slice subscripts."""
+    """The single-level detector flags ``name[i]`` and ignores string/slice subscripts."""
     flagged = ast.parse(
         "\n".join(
             [
-                "a = first[4]",  # single-level int -- flagged
-                "b = parts[-1]",  # negative literal -- still positional
-                "c = payload[+1]",  # explicit unary-plus -- still positional
-                "d = chain[0][1]",  # both levels are single-level subscripts
+                "a = first[4]",  # name[int] -- flagged
+                "b = parts[-1]",  # negative literal of a name -- still positional
+                "c = payload[+1]",  # explicit unary-plus of a name -- still positional
+                "d = chain[0][1]",  # inner ``chain[0]`` is name-rooted -- flagged
             ]
         )
     )
-    # Line 4 contributes one line number even though it has two subscripts.
+    # Line 4 contributes one line number: the OUTER ``chain[0][1]`` has a
+    # ``Subscript`` value (excluded), but its INNER ``chain[0]`` is name-rooted
+    # and fires (the chained gate is the stronger gate for the outer descent).
     assert _single_level_positional_offenders(flagged) == [1, 2, 3, 4]
 
     benign = ast.parse(
@@ -407,6 +433,48 @@ def test_single_level_detector_flags_and_ignores() -> None:
         )
     )
     assert _single_level_positional_offenders(benign) == []
+
+
+def test_single_level_detector_targets_name_rooted_rpc_shape_only() -> None:
+    """The single-level detector flags only ``name[int]``, not attribute/call subscripts.
+
+    Pins the #1501 narrowing: by current codebase convention a genuine
+    RPC-payload position read is rooted at a local ``Name`` (``data[0]`` /
+    ``result[2]``) — every decoded batchexecute payload is bound to a local
+    before it is walked (verified across the whole feature tree at narrowing
+    time: all 15 non-``Name`` integer subscripts were benign stdlib/string/path
+    reads). The ratchet therefore targets exactly that shape and *excludes*
+    integer subscripts of an attribute (``sys.version_info[0]``, ``e.args[0]``,
+    ``ctx.pages[0]``) or a call (``Path(...).parents[3]``, ``s.split("@", 1)[0]``,
+    ``f()[0]``). This is a convention-backed scope, not an absolute guarantee —
+    a future ``self._payload[0]`` or ``parse_rpc()[0]`` would evade it; if that
+    idiom ever appears in feature code, widen the detector rather than adopting
+    the idiom.
+    """
+    excluded = ast.parse(
+        "\n".join(
+            [
+                "a = sys.version_info[0]",  # attribute value -- excluded
+                "b = e.args[0]",  # attribute value -- excluded
+                "c = ctx.pages[0]",  # attribute value -- excluded
+                "d = Path(__file__).resolve().parents[3]",  # call value -- excluded
+                "e = email.split('@', 1)[0]",  # call value -- excluded
+                "f = parse()[0]",  # call value -- excluded
+            ]
+        )
+    )
+    assert _single_level_positional_offenders(excluded) == []
+
+    rpc_shape = ast.parse(
+        "\n".join(
+            [
+                "data = decode(raw)",
+                "a = data[0]",  # name[int] -- flagged (an RPC-row read)
+                "b = result[2]",  # name[int] -- flagged
+            ]
+        )
+    )
+    assert _single_level_positional_offenders(rpc_shape) == [2, 3]
 
 
 def test_detector_flags_chained_descent() -> None:

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -108,6 +108,12 @@ class TestResearchTaskInfoRow:
     def test_bundle_sources_returns_first(self) -> None:
         assert ResearchTaskInfoRow.bundle_sources([["a", "b"], "summary"]) == ["a", "b"]
 
+    def test_bundle_sources_empty_bundle_soft_degrades(self) -> None:
+        # Regression (#1502 review): an empty task_info[3] must hit the
+        # missing-slot default like every other soft read in this adapter —
+        # not raise IndexError. The parser's caller coerces None to [].
+        assert ResearchTaskInfoRow.bundle_sources([]) is None
+
     def test_bundle_summary_present(self) -> None:
         assert ResearchTaskInfoRow.bundle_summary([["a"], "Summary text"]) == "Summary text"
 

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -1,0 +1,208 @@
+"""Tests for the ``POLL_RESEARCH`` row adapters (issue #1501).
+
+These adapters centralise the positional knowledge ``_research_task_parser.py``
+used to open-code as scattered single-level subscripts (``result[0]``,
+``src[1]``, ``bundle[0]``, ``task_info[1][0]`` …). The tests cover three layers:
+
+1. **Position-contract pins** — the canaries that fail loudly if a position
+   constant is edited (the wire-shape change signal).
+2. **Shape handling** — happy-path reads plus the permissive "absent / short /
+   non-list → default" degrade that matches the historical wire parser.
+3. **Drift** — the two GUARANTEED descents (``ResearchTaskRow.task_id_raw`` /
+   ``task_info_raw``) RAISE ``UnknownRPCMethodError`` when their slot is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._row_adapters.research import (
+    ResearchResultRow,
+    ResearchTaskInfoRow,
+    ResearchTaskRow,
+    unwrap_poll_tasks,
+)
+from notebooklm.exceptions import UnknownRPCMethodError
+
+# ---------------------------------------------------------------------------
+# 1. Position-contract pins (the canaries)
+# ---------------------------------------------------------------------------
+
+
+class TestResearchTaskRowPositionContract:
+    def test_positions_pinned(self) -> None:
+        assert (ResearchTaskRow._ID_POS, ResearchTaskRow._INFO_POS) == (0, 1)
+
+
+class TestResearchTaskInfoRowPositionContract:
+    def test_positions_pinned(self) -> None:
+        assert (
+            ResearchTaskInfoRow._QUERY_TEXT_POS,
+            ResearchTaskInfoRow._SOURCES_POS,
+            ResearchTaskInfoRow._SUMMARY_POS,
+            ResearchTaskInfoRow._SUMMARY_MIN_LEN,
+        ) == (0, 0, 1, 2)
+
+
+class TestResearchResultRowPositionContract:
+    def test_positions_pinned(self) -> None:
+        assert (
+            ResearchResultRow._URL_POS,
+            ResearchResultRow._TITLE_POS,
+            ResearchResultRow._RESULT_TYPE_POS,
+            ResearchResultRow._LEGACY_CHUNKS_POS,
+            ResearchResultRow._MIN_LEN,
+        ) == (0, 1, 3, 6, 2)
+
+    def test_deep_payload_positions_pinned(self) -> None:
+        assert (
+            ResearchResultRow._PAYLOAD_TITLE_POS,
+            ResearchResultRow._PAYLOAD_REPORT_POS,
+            ResearchResultRow._PAYLOAD_MIN_LEN,
+        ) == (0, 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# 2. ResearchTaskRow — GUARANTEED descents
+# ---------------------------------------------------------------------------
+
+
+class TestResearchTaskRow:
+    def test_happy_path(self) -> None:
+        row = ResearchTaskRow(["task_abc", ["info"]])
+        assert row.task_id_raw == "task_abc"
+        assert row.task_info_raw == ["info"]
+
+    def test_missing_id_slot_raises(self) -> None:
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ResearchTaskRow([]).task_id_raw
+
+    def test_non_list_input_id_raises(self) -> None:
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ResearchTaskRow(None).task_id_raw
+
+    def test_missing_info_slot_raises(self) -> None:
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ResearchTaskRow(["only_id"]).task_info_raw
+
+    def test_wrong_type_id_is_returned_verbatim(self) -> None:
+        # The adapter only *reads* the slot; the parser validates the type.
+        assert ResearchTaskRow([42, ["info"]]).task_id_raw == 42
+
+    def test_wrong_type_info_is_returned_verbatim(self) -> None:
+        assert ResearchTaskRow(["id", "not_a_list"]).task_info_raw == "not_a_list"
+
+
+# ---------------------------------------------------------------------------
+# 3. ResearchTaskInfoRow — routinely-optional inner reads (soft)
+# ---------------------------------------------------------------------------
+
+
+class TestResearchTaskInfoRow:
+    def test_query_text_happy_path(self) -> None:
+        assert ResearchTaskInfoRow.query_text(["quantum computing", "extra"]) == "quantum computing"
+
+    def test_query_text_empty_returns_none(self) -> None:
+        assert ResearchTaskInfoRow.query_text([]) is None
+
+    def test_bundle_sources_returns_first(self) -> None:
+        assert ResearchTaskInfoRow.bundle_sources([["a", "b"], "summary"]) == ["a", "b"]
+
+    def test_bundle_summary_present(self) -> None:
+        assert ResearchTaskInfoRow.bundle_summary([["a"], "Summary text"]) == "Summary text"
+
+    def test_bundle_summary_absent_returns_none(self) -> None:
+        assert ResearchTaskInfoRow.bundle_summary([["a"]]) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. ResearchResultRow — routinely-optional source-row reads (soft)
+# ---------------------------------------------------------------------------
+
+
+class TestResearchResultRow:
+    def test_fast_research_shape(self) -> None:
+        row = ResearchResultRow(["https://example.com", "Example", "desc", "web"])
+        assert row.is_well_formed is True
+        assert row.length == 4
+        assert row.url_slot == "https://example.com"
+        assert row.title_slot == "Example"
+        assert row.has_result_type is True
+        assert row.result_type_slot == "web"
+
+    def test_short_row_not_well_formed(self) -> None:
+        row = ResearchResultRow(["only_one"])
+        assert row.is_well_formed is False
+
+    def test_non_list_not_well_formed(self) -> None:
+        row = ResearchResultRow(None)
+        assert row.is_well_formed is False
+        assert row.length == 0
+        assert row.url_slot is None
+        assert row.title_slot is None
+        assert row.result_type_slot is None
+        assert row.has_result_type is False
+        assert row.legacy_report_chunks == []
+
+    def test_result_type_absent_short_circuits(self) -> None:
+        row = ResearchResultRow([None, "title"])
+        assert row.has_result_type is False
+        assert row.result_type_slot is None
+
+    def test_deep_research_sentinel_url(self) -> None:
+        row = ResearchResultRow([None, ["Deep Report", "# Report"], None, 1])
+        assert row.url_slot is None
+        assert row.title_slot == ["Deep Report", "# Report"]
+
+    def test_legacy_chunks_present(self) -> None:
+        row = ResearchResultRow([None, "Legacy", None, "report", None, None, ["a", "b"]])
+        assert row.legacy_report_chunks == ["a", "b"]
+
+    def test_legacy_chunks_non_list_returns_empty(self) -> None:
+        row = ResearchResultRow([None, "t", None, 5, None, None, "str"])
+        assert row.legacy_report_chunks == []
+
+    def test_legacy_chunks_absent_returns_empty(self) -> None:
+        row = ResearchResultRow([None, "t", None, 5, None, None])
+        assert row.legacy_report_chunks == []
+
+
+class TestResearchResultRowDeepPayload:
+    def test_two_strings_unpacked(self) -> None:
+        assert ResearchResultRow.deep_payload(["Title", "# Report"]) == ("Title", "# Report")
+
+    def test_bare_string_is_not_payload(self) -> None:
+        assert ResearchResultRow.deep_payload("Title") is None
+
+    def test_non_string_elements_rejected(self) -> None:
+        assert ResearchResultRow.deep_payload([123, "# Report"]) is None
+        assert ResearchResultRow.deep_payload(["Title", 456]) is None
+
+    def test_too_short_rejected(self) -> None:
+        assert ResearchResultRow.deep_payload(["Title"]) is None
+
+    def test_non_list_rejected(self) -> None:
+        assert ResearchResultRow.deep_payload(None) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. unwrap_poll_tasks — envelope probe (soft)
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapPollTasks:
+    def test_empty_and_non_list_return_empty(self) -> None:
+        assert unwrap_poll_tasks(None) == []
+        assert unwrap_poll_tasks([]) == []
+        assert unwrap_poll_tasks("not rows") == []
+
+    def test_wrapped_envelope_is_unwrapped(self) -> None:
+        tasks = [["task_1", ["info"]]]
+        assert unwrap_poll_tasks([tasks]) == tasks
+
+    def test_flat_list_is_returned_unchanged(self) -> None:
+        flat = [["task_1", ["info"]]]
+        # A flat list whose first element's first element is itself a list is
+        # treated as wrapped; a flat list of task rows (first element's first is
+        # a str id) is returned unchanged.
+        assert unwrap_poll_tasks(flat) == flat


### PR DESCRIPTION
## What & why

**Phase 1 of #1501** (drain the `SINGLE_LEVEL_ALLOWLIST` — the #1491 burndown ratchet). Two parts:

### A. Gate precision
The single-level detector flagged ANY `x[i]` int-literal subscript, mixing genuine RPC-payload reads with benign indexing. It now requires the subscripted value to be a bare `ast.Name` (`data[0]` / `result[2]` — the RPC-payload shape), excluding Attribute/Call-valued subscripts (`sys.version_info[0]`, `e.args[0]`, `.split(...)[0]`, `Path(...).parents[3]`).

**Verified safe across the whole feature tree**: all 15 non-`Name` flagged sites were benign — zero are RPC reads (a decoded batchexecute payload is always bound to a local before it is walked; both reviewers re-verified independently, including a `self.<attr>[int]` sweep that returned nothing). The new self-check documents this as a **convention-backed scope with named escapes** — a future `self._payload[0]` / `parse_rpc()[0]` idiom must widen the detector, not be adopted.

### B. First migration: the research parser
New `_row_adapters/research.py` (`ResearchTaskRow` — strict id/info via `safe_index`; `ResearchTaskInfoRow` + `ResearchResultRow` — soft length-guarded reads; `unwrap_poll_tasks` envelope probe), mirroring the chat/artifacts adapter conventions. `_research_task_parser.py` rewritten onto named properties with **exact soft-vs-strict semantics preserved** — a differential harness ran the verbatim originals against the new code over an edge-case battery: **0 mismatches**. 31 new adapter tests pin positions + behavior.

### Net
`SINGLE_LEVEL_ALLOWLIST`: **47 → 41** (5 benign-only files via gate precision + `_research_task_parser.py` via migration; 0 stale, 0 unbaselined — exact). Chained-descent gate untouched.

## Verification

- Full suite green (9401 passed); gate + stale-check + new self-checks pass; research parser/service/API tests unchanged (110 pass).
- mypy + ruff clean; API-compat audit **EXIT 0** (private-only changes); `docs/architecture.md` updated (freshness gate).
- Polished: claude (solid, hole-question empirically re-verified) + codex (**SHIP**; 3 Minor doc-accuracy fixes applied: POLL_RESEARCH id `e3bVqc`, "research parser" wording, convention-scoped detector docstring).

Part of #1501 (remaining ~41-file burndown continues there — do not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal refactor of research/task parsing to use structured row adapters for more reliable, centralized parsing and fewer positional-index errors.

* **Documentation**
  * Architecture docs and file map updated to reflect the new adapter organization and structure.

* **Tests**
  * New unit tests validating research parsing behavior and envelope-unwrapping.
  * Tightened AST guardrail tests for single-level positional indexing detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->