### PR TITLE
test(e2e): skip generation tests on typed RateLimitError instead of failing

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,8 +27,8 @@ from notebooklm.paths import get_profile_dir
 # or quota rejection rather than a client bug. Covers both the explicit
 # UserDisplayableError message and the HTTP-status-wrapped 429 path in
 # _chat/api.py:156, the generation skip phrase in assert_generation_started,
-# and the typed RateLimitError message ("API rate limit or quota exceeded...")
-# surfaced by _install_generation_rate_limit_skip.
+# and the "Rate limit:" prefix _install_generation_rate_limit_skip adds to
+# typed RateLimitError skips.
 _RATE_LIMIT_PHRASES = (
     "rate limit",
     "rate limited",
@@ -74,7 +74,10 @@ def _install_generation_rate_limit_skip(client: NotebookLMClient) -> None:
             try:
                 return await original(*args, **kwargs)
             except RateLimitError as e:
-                pytest.skip(str(e))
+                # The "Rate limit:" prefix guarantees a _RATE_LIMIT_PHRASES
+                # match regardless of the exception message wording, so the
+                # skip always lands in pytest_terminal_summary's section.
+                pytest.skip(f"Rate limit: {e}")
 
         return _with_skip
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,13 +20,15 @@ except ImportError:
 
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens, load_auth_from_storage
-from notebooklm.exceptions import ChatError
+from notebooklm.exceptions import ChatError, RateLimitError
 from notebooklm.paths import get_profile_dir
 
 # Substrings in ChatError / skip messages that mark a server-side rate-limit
 # or quota rejection rather than a client bug. Covers both the explicit
 # UserDisplayableError message and the HTTP-status-wrapped 429 path in
-# _chat/api.py:156, plus the generation skip phrase in assert_generation_started.
+# _chat/api.py:156, the generation skip phrase in assert_generation_started,
+# and the typed RateLimitError message ("API rate limit or quota exceeded...")
+# surfaced by _install_generation_rate_limit_skip.
 _RATE_LIMIT_PHRASES = (
     "rate limit",
     "rate limited",
@@ -53,6 +55,36 @@ def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
             raise
 
     client.chat.ask = _ask_with_skip
+
+
+def _install_generation_rate_limit_skip(client: NotebookLMClient) -> None:
+    """Wrap ``client.artifacts.generate_*``/``revise_*`` so ``RateLimitError`` becomes a skip.
+
+    The RPC layer raises a typed ``RateLimitError`` when Google rejects
+    CREATE_ARTIFACT with a quota error (e.g. upstream status 8, Resource
+    exhausted) — before any ``GenerationStatus`` exists, so the
+    ``is_rate_limited`` skip in ``assert_generation_started`` never runs.
+    That is server-side throttling, not a client defect. Only the precise
+    typed ``RateLimitError`` skips; every other exception still raises so
+    real defects stay visible.
+    """
+
+    def _wrap(original):
+        async def _with_skip(*args, **kwargs):
+            try:
+                return await original(*args, **kwargs)
+            except RateLimitError as e:
+                pytest.skip(str(e))
+
+        return _with_skip
+
+    for name in dir(client.artifacts):
+        if not (name.startswith("generate_") or name.startswith("revise_")):
+            continue
+        original = getattr(client.artifacts, name)
+        if not callable(original):
+            continue
+        setattr(client.artifacts, name, _wrap(original))
 
 
 def _emit_auth_route_diagnostic(auth_tokens: AuthTokens) -> None:
@@ -356,6 +388,7 @@ def auth_tokens() -> AuthTokens:
 async def client(auth_tokens) -> AsyncGenerator[NotebookLMClient, None]:
     async with NotebookLMClient(auth_tokens, storage_path=auth_tokens.storage_path) as c:
         _install_chat_rate_limit_skip(c)
+        _install_generation_rate_limit_skip(c)
         yield c
 
 

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -15,6 +15,10 @@ import os
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
+from notebooklm.exceptions import RateLimitError
+
 CONFTEST_PATH = Path(__file__).resolve().parents[1] / "e2e" / "conftest.py"
 
 
@@ -201,3 +205,69 @@ class TestRateLimitSkipSummary:
         # Still emits the pytest section locally — just no GH-specific bits.
         assert any(call[0] == "sep" for call in tr._writes)
         assert capsys.readouterr().out == ""
+
+
+class TestGenerationRateLimitSkip:
+    """_install_generation_rate_limit_skip turns typed RateLimitError into skips.
+
+    The RPC layer raises RateLimitError from generate_* before any
+    GenerationStatus exists, so assert_generation_started's is_rate_limited
+    path never runs. Only the typed RateLimitError may skip; every other
+    exception must propagate (no-xfail-live-service-errors policy).
+    """
+
+    @staticmethod
+    def _make_client():
+        class FakeArtifacts:
+            async def generate_audio(self, notebook_id):
+                raise RateLimitError(
+                    "API rate limit or quota exceeded. Please wait before retrying."
+                )
+
+            async def generate_video(self, notebook_id):
+                return f"video:{notebook_id}"
+
+            async def revise_slide(self, notebook_id):
+                raise ValueError("not a rate limit")
+
+            async def delete(self, notebook_id, artifact_id):
+                raise RateLimitError("should never be wrapped")
+
+        return SimpleNamespace(artifacts=FakeArtifacts())
+
+    async def test_rate_limit_error_becomes_skip(self):
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(pytest.skip.Exception) as excinfo:
+            await client.artifacts.generate_audio("nb-1")
+
+        # Reason must match _RATE_LIMIT_PHRASES so pytest_terminal_summary
+        # surfaces the skip in the rate-limit section + GH annotations.
+        reason = str(excinfo.value).lower()
+        assert any(phrase in reason for phrase in conftest._RATE_LIMIT_PHRASES)
+
+    async def test_other_exceptions_propagate(self):
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(ValueError, match="not a rate limit"):
+            await client.artifacts.revise_slide("nb-1")
+
+    async def test_successful_calls_pass_through_per_method(self):
+        # Closure safety: each wrapped name must bind its own original.
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        assert await client.artifacts.generate_video("nb-1") == "video:nb-1"
+
+    async def test_non_generation_methods_are_not_wrapped(self):
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(RateLimitError):
+            await client.artifacts.delete("nb-1", "art-1")


### PR DESCRIPTION
## Summary
- Nightly e2e failed on pure server-side throttling: `generate_cinematic_video` raised a typed `RateLimitError` (CREATE_ARTIFACT rejected, upstream status 8 Resource exhausted) **before** any `GenerationStatus` exists, so `assert_generation_started`'s `is_rate_limited` skip path never runs ([failing run](https://github.com/teng-lin/notebooklm-py/actions/runs/27189909976/job/80267388218)).
- Adds `_install_generation_rate_limit_skip` to `tests/e2e/conftest.py`, mirroring the existing `_install_chat_rate_limit_skip` pattern: wraps `artifacts.generate_*`/`revise_*` coroutines in the e2e `client` fixture so **only** the precise typed `RateLimitError` converts to `pytest.skip` — every other exception (including sibling `RPCError` subclasses like `DecodingError`/`UnknownRPCMethodError`) still propagates loudly, per the no-xfail-live-service-errors policy.
- Skips stay observable: all `RateLimitError` raise-site messages contain "rate limit", so they surface via the existing `pytest_terminal_summary` rate-limit section, `GITHUB_STEP_SUMMARY`, and `::warning` annotations.

## Test plan
- [x] 4 new unit tests in `tests/unit/test_e2e_conftest_options.py` (`TestGenerationRateLimitSkip`): RateLimitError→skip with `_RATE_LIMIT_PHRASES` match, other exceptions propagate, per-method closure binding, non-generation methods left unwrapped
- [x] `uv run pytest` — 9475 passed, 71 skipped, 1 xfailed
- [x] `uv run ruff format --check` + `uv run ruff check` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean

## Deferred polish findings
none (code-simplifier applied one structural cleanup; claude + codex reviews both clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E test runner now treats server-side rate/quota rejections during content generation and chat as skips instead of failures.
  * Added unit tests covering generation-time rate-limit skipping, propagation of other errors, correct wrapping of generation methods, and ensuring non-generation methods are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->