### PR TITLE
fix(rpc): harden 14 positional-decode sites that silently fabricated values on wire drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,13 +64,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   legitimately-empty containers) keeps its soft degrade, while
   present-but-malformed data is now loud: the chat conversation-history walk
   moved behind a new `ConversationTurnRow` adapter and raises
-  `UnknownRPCMethodError` on a malformed turns container (malformed individual
-  turns are skipped with a DEBUG diagnostic); `notebooks.list()` raises
-  `DecodingError` on an unrecognized payload shape; mind-map rows are decoded
-  through `NoteRow` and WARN when a null content slot lacks the soft-delete
-  sentinel; notebook-id, share-email, and source-type-code slots WARN with a
-  bounded payload preview when present-but-wrong-type (keeping list parsing
-  alive); and `notes.get_or_none` id matching reads through `NoteRow.id`.
+  `UnknownRPCMethodError` on a truthy non-list payload or turns container
+  (malformed individual turn rows and unrecognized role codes are skipped
+  with a DEBUG diagnostic); `notebooks.list()` raises `DecodingError` on an
+  unrecognized payload shape; mind-map rows are decoded through `NoteRow`
+  and WARN when a null content slot lacks the soft-delete sentinel;
+  notebook-id, share-email, and source-type-code slots WARN with a bounded
+  payload preview when present-but-wrong-type (keeping list parsing alive);
+  and `notes.get_or_none` id matching reads through `NoteRow.id`. One
+  behavior nuance: `SharedUser.email` is now always a `str` — a `None` email
+  slot normalizes to `""` instead of leaking `None` through the `str`-typed
+  field.
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
   returns an absent/`None` payload. `notebooks.get_summary()` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   propagate as exceptions through the standard CLI error handler instead of
   a soft-failure envelope.
 
+- **14 positional-decode sites no longer fabricate wrong-but-valid values
+  silently on wire drift.** Guarded single-level reads of decoded
+  `batchexecute` payloads could swallow a Google reshape into a plausible
+  default — an empty notebook / mind-map id, an empty share email, a deleted
+  mind map leaking as live, a silently-empty chat history, a `LIST_NOTEBOOKS`
+  wrapper mis-dispatch feeding garbage rows, an unvalidated source type code,
+  and a note lookup flipping found → not-found. Per the #1485
+  absence-vs-malformed policy, genuine absence (short rows, `None` slots,
+  legitimately-empty containers) keeps its soft degrade, while
+  present-but-malformed data is now loud: the chat conversation-history walk
+  moved behind a new `ConversationTurnRow` adapter and raises
+  `UnknownRPCMethodError` on a malformed turns container (malformed individual
+  turns are skipped with a DEBUG diagnostic); `notebooks.list()` raises
+  `DecodingError` on an unrecognized payload shape; mind-map rows are decoded
+  through `NoteRow` and WARN when a null content slot lacks the soft-delete
+  sentinel; notebook-id, share-email, and source-type-code slots WARN with a
+  bounded payload preview when present-but-wrong-type (keeping list parsing
+  alive); and `notes.get_or_none` id matching reads through `NoteRow.id`.
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
   returns an absent/`None` payload. `notebooks.get_summary()` and

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import reprlib
 import weakref
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +17,7 @@ from .._logging import get_request_id, reset_request_id, set_request_id
 from .._loop_bound import LoopBoundPrimitive
 from .._notebook_metadata import NotebookSourceIdProvider
 from .._request_types import AuthSnapshot
+from .._row_adapters.chat import ConversationTurnRow, unwrap_conversation_turns
 from .._runtime.config import DEFAULT_CHAT_TIMEOUT
 from .._runtime.contracts import LoopGuard, RpcCaller
 from ..exceptions import ChatError, NetworkError, ValidationError
@@ -537,9 +539,8 @@ class ChatAPI(LoopBoundPrimitive):
                 newest-first, so limit=2 gives the latest Q&A pair.
 
         Returns:
-            Raw turn data from API. Each turn has:
-              turn[2] == 1: user question, text at turn[3]
-              turn[2] == 2: AI answer, text at turn[4][0][0]
+            Raw turn data from API; the per-turn position contract lives in
+            :class:`~notebooklm._row_adapters.chat.ConversationTurnRow`.
         """
         logger.debug(
             "Getting conversation turns for %s (conversation=%s, limit=%d)",
@@ -627,16 +628,12 @@ class ChatAPI(LoopBoundPrimitive):
         except (ChatError, NetworkError) as e:
             logger.warning("Failed to fetch conversation turns for %s: %s", notebook_id, e)
             return []
-        # API returns individual turns newest-first: [A2, Q2, A1, Q1, ...]
-        # Reverse to chronological order [Q1, A1, Q2, A2, ...] so the
-        # Q→A forward-pairing parser works correctly.
-        if (
-            turns_data
-            and isinstance(turns_data, list)
-            and turns_data[0]
-            and isinstance(turns_data[0], list)
-        ):
-            turns_data = [list(reversed(turns_data[0]))]
+        # API returns individual turns newest-first: [A2, Q2, A1, Q1, ...];
+        # reverse to chronological [Q1, A1, ...] for the Q→A forward-pairer.
+        # The unwrap keeps an empty history soft, raises on a malformed one.
+        turns = unwrap_conversation_turns(turns_data, source="_chat.get_history")
+        if turns:
+            turns_data = [list(reversed(turns))]
         return self._parse_turns_to_qa_pairs(turns_data)
 
     @staticmethod
@@ -644,36 +641,39 @@ class ChatAPI(LoopBoundPrimitive):
         """Parse raw turn data into (question, answer) pairs in array order.
 
         Pairs are returned in the same order as the input data (newest-first
-        from the API). Callers should reverse if oldest-first is needed.
-        Each user question (turn[2]==1) is followed by its AI answer (turn[2]==2).
-        """
-        if not turns_data or not isinstance(turns_data, list):
-            return []
-        first = turns_data[0]
-        if not isinstance(first, list):
-            return []
+        from the API); callers reverse if oldest-first is needed. Each user
+        question (role 1) is followed by its AI answer (role 2); per-turn
+        positions live in :class:`~notebooklm._row_adapters.chat.ConversationTurnRow`.
 
-        turns = first
+        Drift handling (#1485): an empty/absent history parses to ``[]``; a
+        truthy-but-malformed container raises ``UnknownRPCMethodError`` via
+        ``unwrap_conversation_turns``; a malformed turn row is skipped with a
+        DEBUG diagnostic (mirroring ``_notebooks._extract_suggested_topics``).
+        """
+        turns = unwrap_conversation_turns(turns_data, source="_chat._parse_turns_to_qa_pairs")
 
         pairs: list[tuple[str, str]] = []
         i = 0
         while i < len(turns):
-            turn = turns[i]
-            if not isinstance(turn, list) or len(turn) < 3:
+            turn = ConversationTurnRow(turns[i])
+            if not turn.is_well_formed:
+                logger.debug(
+                    "_parse_turns_to_qa_pairs: skipping malformed turn at index %d: %s",
+                    i,
+                    reprlib.repr(turns[i]),
+                )
                 i += 1
                 continue
-            if turn[2] == 1 and len(turn) > 3:
-                q = str(turn[3] or "")
+            if turn.is_question:
+                q = turn.question_text
                 a = ""
-                # Look for the answer immediately following
+                # Pair with the immediately-following answer turn, if any. A
+                # non-string content leaf yields "" (empty-answer fallback);
+                # genuine drift raises through ``safe_index`` (strict mode).
                 if i + 1 < len(turns):
-                    next_turn = turns[i + 1]
-                    if isinstance(next_turn, list) and len(next_turn) > 4 and next_turn[2] == 2:
-                        # A non-string leaf yields ``None`` (empty-answer
-                        # fallback); genuine shape drift raises
-                        # ``UnknownRPCMethodError`` through ``safe_index`` under
-                        # strict decoding (the only mode).
-                        content = _extract_next_turn_content(next_turn)
+                    next_turn = ConversationTurnRow(turns[i + 1])
+                    if next_turn.is_answer:
+                        content = _extract_next_turn_content(next_turn.raw)
                         a = str(content or "")
                         i += 1  # skip the answer turn
                 pairs.append((q, a))

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -53,26 +53,17 @@ def _extract_next_turn_content(next_turn: Any) -> str | None:
     """Extract the response content from a streaming-chat next_turn frame.
 
     The ``khqZz`` (``GET_CONVERSATION_TURNS``) response packs each AI answer
-    as ``turn[4][0][0]`` — three nested wrappers around the answer text. This
-    helper delegates the inner-most descent to :func:`safe_index`, which
-    enforces strict decoding: descent failures raise
+    as ``turn[4][0][0]`` — three nested wrappers around the answer text. The
+    descent goes through :func:`safe_index` under strict decoding (the only
+    mode since the ``NOTEBOOKLM_STRICT_DECODE=0`` opt-out was retired in
+    v0.7.0; rationale in ADR-0011): a genuine descent failure raises
     :class:`~notebooklm.exceptions.UnknownRPCMethodError` so callers fail
-    fast on Google-side shape drift. The legacy
-    ``NOTEBOOKLM_STRICT_DECODE=0`` soft-mode opt-out was retired in v0.7.0.
-    See ADR-0011 (``docs/adr/0011-schema-validation-policy.md``) for the
-    rationale.
+    fast on Google-side shape drift.
 
-    Args:
-        next_turn: The candidate answer turn (a ``turn[2] == 2`` row from the
-            ``khqZz`` payload). Caller has already validated this is a list
-            with ``len(next_turn) > 4`` and ``next_turn[2] == 2``.
-
-    Returns:
-        The answer-text string on success, or ``None`` when the leaf at
-        ``[4][0][0]`` descends successfully to a non-string value. A genuine
-        descent failure (shape drift) raises
-        :class:`~notebooklm.exceptions.UnknownRPCMethodError` from
-        :func:`safe_index` — strict decoding is the only mode.
+    ``next_turn`` is a validated answer row (a list with ``len > 4`` and the
+    answer role code — see ``ConversationTurnRow.is_answer``). Returns the
+    answer-text string, or ``None`` when the leaf descends successfully to a
+    non-string value (the caller's empty-answer fallback).
     """
     content = safe_index(
         next_turn,
@@ -628,9 +619,8 @@ class ChatAPI(LoopBoundPrimitive):
         except (ChatError, NetworkError) as e:
             logger.warning("Failed to fetch conversation turns for %s: %s", notebook_id, e)
             return []
-        # API returns individual turns newest-first: [A2, Q2, A1, Q1, ...];
-        # reverse to chronological [Q1, A1, ...] for the Q→A forward-pairer.
-        # The unwrap keeps an empty history soft, raises on a malformed one.
+        # API returns turns newest-first: [A2, Q2, ...]; reverse to [Q1, A1, ...]
+        # for the Q→A pairer. Unwrap keeps an empty history soft, raises on drift.
         turns = unwrap_conversation_turns(turns_data, source="_chat.get_history")
         if turns:
             turns_data = [list(reversed(turns))]
@@ -646,9 +636,10 @@ class ChatAPI(LoopBoundPrimitive):
         positions live in :class:`~notebooklm._row_adapters.chat.ConversationTurnRow`.
 
         Drift handling (#1485): an empty/absent history parses to ``[]``; a
-        truthy-but-malformed container raises ``UnknownRPCMethodError`` via
-        ``unwrap_conversation_turns``; a malformed turn row is skipped with a
-        DEBUG diagnostic (mirroring ``_notebooks._extract_suggested_topics``).
+        truthy-but-malformed payload/container raises ``UnknownRPCMethodError``
+        via ``unwrap_conversation_turns``; a malformed turn row or an
+        unrecognized role code is skipped with a DEBUG diagnostic (ordinary
+        unpaired answer rows are consumed by pairing and never logged).
         """
         turns = unwrap_conversation_turns(turns_data, source="_chat._parse_turns_to_qa_pairs")
 
@@ -664,12 +655,21 @@ class ChatAPI(LoopBoundPrimitive):
                 )
                 i += 1
                 continue
+            if turn.has_unrecognized_role:
+                logger.debug(
+                    "_parse_turns_to_qa_pairs: unrecognized role code %r at turn %d — skipping; "
+                    "possible role-slot drift: %s",
+                    turn.role,
+                    i,
+                    reprlib.repr(turns[i]),
+                )
+                i += 1
+                continue
             if turn.is_question:
                 q = turn.question_text
                 a = ""
-                # Pair with the immediately-following answer turn, if any. A
-                # non-string content leaf yields "" (empty-answer fallback);
-                # genuine drift raises through ``safe_index`` (strict mode).
+                # Pair with the immediately-following answer turn, if any; a
+                # non-string content leaf yields "" (drift raises in the leaf).
                 if i + 1 < len(turns):
                     next_turn = ConversationTurnRow(turns[i + 1])
                     if next_turn.is_answer:

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -1,6 +1,7 @@
 """Notebook operations API."""
 
 import logging
+import reprlib
 from typing import Any
 
 from ._idempotency import idempotent_create
@@ -322,7 +323,9 @@ class NotebooksAPI:
                 return []
         raise DecodingError(
             "Unrecognized LIST_NOTEBOOKS payload shape",
-            raw_response=repr(result),
+            # reprlib bounds the preview without materialising the full repr
+            # of a large/deep payload (mirrors safe_index's own truncation).
+            raw_response=reprlib.repr(result),
             method_id=RPCMethod.LIST_NOTEBOOKS.value,
         )
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -15,6 +15,7 @@ from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
 from .exceptions import (
     AuthError,
+    DecodingError,
     NetworkError,
     NotebookLimitError,
     NotebookNotFoundError,
@@ -301,10 +302,29 @@ class NotebooksAPI:
         params = [None, 1, None, [2]]
         result = await self._rpc.rpc_call(RPCMethod.LIST_NOTEBOOKS, params)
 
-        if result and isinstance(result, list) and len(result) > 0:
-            raw_notebooks = result[0] if isinstance(result[0], list) else result
-            return [Notebook.from_api_response(nb) for nb in raw_notebooks]
-        return []
+        # LIST_NOTEBOOKS responses arrive as a single-element envelope whose
+        # first element is the notebook-row list (``[[row1, row2, ...]]``).
+        # The wrap probe mirrors the fail-loud dispatch in
+        # ``_artifact/listing.py::list_raw``: an empty/``None`` payload and a
+        # ``None`` row-list slot are legitimate "no notebooks" shapes (soft
+        # ``[]``), while a truthy payload that doesn't match the envelope — a
+        # non-list payload, or a truthy non-list where the row list belongs —
+        # is schema drift and raises ``DecodingError`` instead of flowing
+        # garbage rows into ``Notebook.from_api_response`` (which would
+        # silently fabricate empty-id notebooks).
+        if not result:
+            return []
+        if isinstance(result, list):
+            raw_notebooks = result[0]
+            if isinstance(raw_notebooks, list):
+                return [Notebook.from_api_response(nb) for nb in raw_notebooks]
+            if raw_notebooks is None:
+                return []
+        raise DecodingError(
+            "Unrecognized LIST_NOTEBOOKS payload shape",
+            raw_response=repr(result),
+            method_id=RPCMethod.LIST_NOTEBOOKS.value,
+        )
 
     async def create(self, title: str) -> Notebook:
         """Create a new notebook.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -131,7 +131,12 @@ class NotesAPI:
         """
         all_items = await self._get_all_notes_and_mind_maps(notebook_id)
         for item in all_items:
-            if isinstance(item, list) and len(item) > 0 and item[0] == note_id:
+            # The id-slot read goes through ``NoteRow.id`` so the position
+            # knowledge stays in the adapter (``NoteRow`` stringifies the raw
+            # slot, matching the unified ``SourceRow.id`` convention) instead
+            # of an open-coded ``item[0]`` that silently flips found →
+            # not-found if the id slot ever moves.
+            if isinstance(item, list) and len(item) > 0 and NoteRow(item).id == note_id:
                 return self._parse_note(item, notebook_id)
         return None
 

--- a/src/notebooklm/_row_adapters/__init__.py
+++ b/src/notebooklm/_row_adapters/__init__.py
@@ -11,10 +11,12 @@ from .chat import (
     AnswerRow,
     CitationDetail,
     CitationRow,
+    ConversationTurnRow,
     ErrorPayloadRow,
     PassageRow,
     StreamFrameRow,
     TextLeafRow,
+    unwrap_conversation_turns,
 )
 from .labels import LabelRow
 from .notes import NoteRow
@@ -37,6 +39,7 @@ __all__ = [
     "ArtifactRow",
     "CitationDetail",
     "CitationRow",
+    "ConversationTurnRow",
     "ErrorPayloadRow",
     "LabelRow",
     "NoteRow",
@@ -49,5 +52,6 @@ __all__ = [
     "SourceRowShape",
     "StreamFrameRow",
     "TextLeafRow",
+    "unwrap_conversation_turns",
     "unwrap_poll_tasks",
 ]

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -1,9 +1,14 @@
-"""Chat row adapters for the streamed-chat (``GenerateFreeFormStreamed``) payload.
+"""Chat row adapters for the streamed-chat (``GenerateFreeFormStreamed``)
+payload and the conversation-history (``GET_CONVERSATION_TURNS`` / ``khqZz``)
+payload.
 
 The streamed-chat endpoint is **not** a ``batchexecute`` RPC, so there is no
 obfuscated method ID to thread through ``safe_index`` — descents pass
 ``method_id=None`` and rely on named ``source`` labels to localise schema drift
-in raised :class:`UnknownRPCMethodError` diagnostics (ADR-0011).
+in raised :class:`UnknownRPCMethodError` diagnostics (ADR-0011). The
+conversation-history rows (:class:`ConversationTurnRow` /
+:func:`unwrap_conversation_turns`) come from a regular ``batchexecute`` RPC and
+carry ``RPCMethod.GET_CONVERSATION_TURNS`` as their drift-diagnostic method id.
 
 These adapters centralise the positional knowledge that ``_chat/wire.py``
 previously open-coded as scattered single-level subscripts (``first[4]``,
@@ -55,24 +60,186 @@ Position contracts (pinned by ``tests/unit/test_chat_row_adapter.py``):
   1      source-side end char (int)
   2      nested text payload
   =====  ============================================================
+
+* :class:`ConversationTurnRow` — one ``GET_CONVERSATION_TURNS`` turn row:
+
+  =====  ============================================================
+  Index  Meaning
+  =====  ============================================================
+  2      role code (``1`` = user question, ``2`` = AI answer)
+  3      question text (str) — only on role-1 rows
+  4      nested answer-content payload — only on role-2 rows
+         (the ``[4][0][0]`` leaf descent lives in
+         ``_chat.api._extract_next_turn_content``)
+  =====  ============================================================
 """
 
 from __future__ import annotations
 
+import reprlib
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
-from ..rpc import safe_index
+from ..exceptions import UnknownRPCMethodError
+from ..rpc import RPCMethod, safe_index
 
 __all__ = [
     "AnswerRow",
     "CitationRow",
     "CitationDetail",
+    "ConversationTurnRow",
     "ErrorPayloadRow",
     "PassageRow",
     "StreamFrameRow",
     "TextLeafRow",
+    "unwrap_conversation_turns",
 ]
+
+# ``GET_CONVERSATION_TURNS`` method id, threaded into ``safe_index`` /
+# ``UnknownRPCMethodError`` so drift diagnostics point at the right RPC.
+_TURNS_METHOD_ID = RPCMethod.GET_CONVERSATION_TURNS.value
+
+# Envelope-unwrap position: ``GET_CONVERSATION_TURNS`` wraps the turn list as
+# the first element of a single-element envelope (``[[turn, ...], ...]``).
+_TURNS_CONTAINER_POS = 0
+
+
+def unwrap_conversation_turns(turns_data: Any, *, source: str) -> list[Any]:
+    """Return the flat turn list from a raw ``GET_CONVERSATION_TURNS`` result.
+
+    The wire shape is a single-element envelope whose first element is the
+    turn list (``[[turn, ...], ...]``). This centralises the ``turns_data[0]``
+    container probe so ``_chat/api.py`` stops open-coding it, with the
+    absence-vs-malformed split of the #1485 policy:
+
+    * **Absence stays soft** — a falsy / non-list payload (no history yet) and
+      a falsy first slot (``[[]]`` / ``[None]``, a legitimately-empty
+      conversation) return ``[]`` without logging, preserving the historical
+      "no history" contract.
+    * **Present-but-malformed RAISES** — a *truthy non-list* where the turn
+      list belongs is genuine schema drift, not an empty conversation, and
+      raises :class:`UnknownRPCMethodError` (consistent with the strict
+      ``safe_index`` leaf behavior in ``_extract_next_turn_content``) instead
+      of silently yielding an empty chat history.
+
+    Args:
+        turns_data: Raw decoded ``GET_CONVERSATION_TURNS`` payload.
+        source: Caller label for drift diagnostics
+            (e.g. ``"_chat.get_history"``).
+    """
+    if not turns_data or not isinstance(turns_data, list):
+        return []
+    # ``turns_data`` is a non-empty list here, so the descent is a no-op on
+    # the happy path; routed through ``safe_index`` for the shared telemetry
+    # seam (mirrors ``StreamFrameRow.tag``).
+    turns = safe_index(
+        turns_data,
+        _TURNS_CONTAINER_POS,
+        method_id=_TURNS_METHOD_ID,
+        source=source,
+    )
+    if not turns:
+        return []
+    if not isinstance(turns, list):
+        raise UnknownRPCMethodError(
+            f"conversation turns container holds {type(turns).__name__} (expected the turn list)",
+            method_id=_TURNS_METHOD_ID,
+            path=(_TURNS_CONTAINER_POS,),
+            source=source,
+            data_at_failure=reprlib.repr(turns_data),
+        )
+    return turns
+
+
+@dataclass(frozen=True)
+class ConversationTurnRow:
+    """Typed view of one ``GET_CONVERSATION_TURNS`` (``khqZz``) turn row.
+
+    Each turn is ``[id?, ?, role, ...]`` where ``role`` at position 2 is
+    ``1`` for a user question (text at position 3) or ``2`` for an AI answer
+    (nested content at position 4, whose ``[4][0][0]`` leaf descent lives in
+    ``_chat.api._extract_next_turn_content``). Position knowledge is
+    centralised here; ``_chat/api.py`` should NEVER open-code ``turn[2]`` /
+    ``turn[3]``.
+
+    Per the #1485 absence-vs-malformed policy, every read here is a soft
+    length-guarded degrade: a short or non-list row is a *skip-this-turn*
+    signal (the QA-pair walk preserves its load-bearing skip-row contract and
+    logs a diagnostic), never a raise. The strict raise for genuine drift
+    lives in the answer-content leaf descent, which the consumer routes
+    through ``safe_index``.
+    """
+
+    # Wrapped row; ``repr=False`` so logs don't explode with the entire
+    # conversation payload when a row appears in a stack trace.
+    _raw: Any = field(repr=False)
+
+    # ---- Position constants (the canary contract) ------------------------
+    # ClassVar so the frozen dataclass treats these as class-level constants.
+    # If any of these change,
+    # ``tests/unit/test_chat_row_adapter.py::TestConversationTurnPositionContract``
+    # MUST be updated in the same commit — that failure is the wire-shape
+    # change signal.
+    _ROLE_POS: ClassVar[int] = 2
+    _QUESTION_TEXT_POS: ClassVar[int] = 3
+    _ANSWER_CONTENT_POS: ClassVar[int] = 4
+    # A turn must carry at least its role slot to be classifiable — mirrors
+    # the historical ``len(turn) < 3`` skip in ``_parse_turns_to_qa_pairs``.
+    _MIN_LEN: ClassVar[int] = 3
+
+    #: Role code marking a user-question turn.
+    ROLE_QUESTION: ClassVar[int] = 1
+    #: Role code marking an AI-answer turn.
+    ROLE_ANSWER: ClassVar[int] = 2
+
+    @property
+    def raw(self) -> Any:
+        """The wrapped raw turn row (for the answer-content leaf descent)."""
+        return self._raw
+
+    @property
+    def is_well_formed(self) -> bool:
+        """Whether the row is a list long enough to carry its role slot."""
+        return isinstance(self._raw, list) and len(self._raw) >= self._MIN_LEN
+
+    @property
+    def role(self) -> Any:
+        """Role code at ``turn[2]`` — ``None`` when the row is malformed."""
+        if not self.is_well_formed:
+            return None
+        return self._raw[self._ROLE_POS]
+
+    @property
+    def is_question(self) -> bool:
+        """Whether this is a user-question turn carrying its text slot.
+
+        Mirrors the historical ``turn[2] == 1 and len(turn) > 3`` guard: a
+        role-1 row too short to carry its question text is not usable as a
+        question (soft skip, not drift).
+        """
+        return self.role == self.ROLE_QUESTION and len(self._raw) > self._QUESTION_TEXT_POS
+
+    @property
+    def is_answer(self) -> bool:
+        """Whether this is an AI-answer turn carrying its content slot.
+
+        Mirrors the historical ``len(next_turn) > 4 and next_turn[2] == 2``
+        guard: a role-2 row too short to carry its content payload is not
+        usable as an answer (the preceding question keeps its empty-answer
+        fallback).
+        """
+        return self.role == self.ROLE_ANSWER and len(self._raw) > self._ANSWER_CONTENT_POS
+
+    @property
+    def question_text(self) -> str:
+        """Question text at ``turn[3]`` — ``""`` for a null/absent slot.
+
+        Preserves the historical ``str(turn[3] or "")`` coercion (a ``None``
+        text slot legitimately yields the empty question).
+        """
+        if not self.is_question:
+            return ""
+        return str(self._raw[self._QUESTION_TEXT_POS] or "")
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -112,23 +112,36 @@ def unwrap_conversation_turns(turns_data: Any, *, source: str) -> list[Any]:
     container probe so ``_chat/api.py`` stops open-coding it, with the
     absence-vs-malformed split of the #1485 policy:
 
-    * **Absence stays soft** — a falsy / non-list payload (no history yet) and
-      a falsy first slot (``[[]]`` / ``[None]``, a legitimately-empty
-      conversation) return ``[]`` without logging, preserving the historical
-      "no history" contract.
-    * **Present-but-malformed RAISES** — a *truthy non-list* where the turn
-      list belongs is genuine schema drift, not an empty conversation, and
-      raises :class:`UnknownRPCMethodError` (consistent with the strict
-      ``safe_index`` leaf behavior in ``_extract_next_turn_content``) instead
-      of silently yielding an empty chat history.
+    * **Absence stays soft** — a falsy payload (no history yet) and a falsy
+      first slot (``[[]]`` / ``[None]``, a legitimately-empty conversation)
+      return ``[]`` without logging, preserving the historical "no history"
+      contract.
+    * **Present-but-malformed RAISES** — a *truthy non-list* payload, or a
+      *truthy non-list* where the turn list belongs, is genuine schema drift,
+      not an empty conversation, and raises :class:`UnknownRPCMethodError`
+      (consistent with the strict ``safe_index`` leaf behavior in
+      ``_extract_next_turn_content``) instead of silently yielding an empty
+      chat history.
 
     Args:
         turns_data: Raw decoded ``GET_CONVERSATION_TURNS`` payload.
         source: Caller label for drift diagnostics
             (e.g. ``"_chat.get_history"``).
     """
-    if not turns_data or not isinstance(turns_data, list):
+    if not turns_data:
         return []
+    if not isinstance(turns_data, list):
+        # Top-level drift: the RPC returned something other than the envelope
+        # list. ``path=()`` marks top-level per the UnknownRPCMethodError
+        # contract; the preview is reprlib-bounded.
+        raise UnknownRPCMethodError(
+            f"conversation turns payload holds {type(turns_data).__name__} "
+            "(expected the envelope list)",
+            method_id=_TURNS_METHOD_ID,
+            path=(),
+            source=source,
+            data_at_failure=reprlib.repr(turns_data),
+        )
     # ``turns_data`` is a non-empty list here, so the descent is a no-op on
     # the happy path; routed through ``safe_index`` for the shared telemetry
     # seam (mirrors ``StreamFrameRow.tag``).
@@ -208,6 +221,20 @@ class ConversationTurnRow:
         if not self.is_well_formed:
             return None
         return self._raw[self._ROLE_POS]
+
+    @property
+    def has_unrecognized_role(self) -> bool:
+        """Whether a *well-formed* row carries a role outside the known set.
+
+        ``False`` for malformed rows (those are skipped as malformed, not as
+        role drift) and for the known :data:`ROLE_QUESTION` /
+        :data:`ROLE_ANSWER` codes — an ordinary unpaired answer row must NOT
+        trip this. A well-formed row whose role slot holds anything else
+        signals role-slot drift: without a diagnostic, real history would
+        silently parse to ``[]`` (the fabrication class #1485 targets), so
+        the QA-pair walk logs a DEBUG record before skipping it.
+        """
+        return self.is_well_formed and self.role not in (self.ROLE_QUESTION, self.ROLE_ANSWER)
 
     @property
     def is_question(self) -> bool:

--- a/src/notebooklm/_row_adapters/notes.py
+++ b/src/notebooklm/_row_adapters/notes.py
@@ -106,6 +106,28 @@ class NoteRow:
             and self._raw[self._STATUS_POS] == self._DELETED_SENTINEL
         )
 
+    @property
+    def has_unrecognized_tombstone(self) -> bool:
+        """Whether the content slot is ``None`` without the soft-delete sentinel.
+
+        A live note / mind-map row always carries content at position 1; the
+        only legitimate ``None``-content shape on the wire is the soft-delete
+        tombstone ``[id, None, 2]`` (see :attr:`is_deleted`). A ``None``
+        content slot that is NOT the recognised tombstone — a short
+        ``[id, None]`` row, or a drifted sentinel value at position 2 —
+        therefore signals tombstone drift: were Google to move the sentinel,
+        every deleted row would silently leak as live. Consumers
+        (``Artifact.from_mind_map``) WARN on this predicate before falling
+        through to their historical treat-as-live behavior, rather than
+        leaking silently (#1485 absence-vs-malformed policy).
+
+        ``False`` for rows too short to carry the content slot (no content
+        slot is genuine absence, not a null content value).
+        """
+        if len(self._raw) <= self._CONTENT_POS:
+            return False
+        return self._raw[self._CONTENT_POS] is None and not self.is_deleted
+
     # ---- Multi-shape content / title dispatch ----------------------------
     # Both descents short-circuit on the legacy ``str``-at-position-1
     # shape *before* invoking ``safe_index`` so the legitimate legacy

--- a/src/notebooklm/_source/content.py
+++ b/src/notebooklm/_source/content.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import builtins
 import logging
+import reprlib
 from typing import Any, Literal
 
+from .._row_adapters.sources import SourceRow
 from .._runtime.contracts import RpcCaller
 from .._types.research import SourceGuide
 from ..rpc import RPCMethod
@@ -99,8 +101,25 @@ class SourceContentRenderer:
 
             if len(descriptor) > 2 and isinstance(descriptor[2], list):
                 metadata = descriptor[2]
-                if len(metadata) > 4:
-                    source_type = metadata[4]
+                # The type-code read is delegated to ``SourceRow.type_code``
+                # (the descriptor row has the adapter's normalized-entry
+                # layout: id-envelope, title, metadata, ...), which validates
+                # that ``metadata[4]`` holds an int. An absent / ``None`` slot
+                # keeps the silent ``None`` default; a present-but-non-int
+                # value also degrades to ``None`` (the "unknown type" default)
+                # but logs a WARNING instead of silently passing a malformed
+                # value into ``SourceFulltext._type_code`` (#1485
+                # absence-vs-malformed policy).
+                source_row = SourceRow.from_entry(descriptor, method_id=RPCMethod.GET_SOURCE.value)
+                source_type = source_row.type_code
+                if source_type is None and len(metadata) > 4 and metadata[4] is not None:
+                    self._logger.warning(
+                        "Source %s metadata type-code slot malformed (expected "
+                        "int at metadata[4], got %s); treating type as unknown: %s",
+                        source_id,
+                        type(metadata[4]).__name__,
+                        reprlib.repr(metadata),
+                    )
                 url = _extract_source_url(metadata, allow_bare_http=False)
 
         if output_format == "markdown":

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import reprlib
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -9,6 +11,7 @@ from enum import Enum
 from typing import Any
 
 from .._row_adapters.artifacts import ArtifactRow
+from .._row_adapters.notes import NoteRow
 from ..rpc.types import (
     FLASHCARDS_VARIANT,
     INTERACTIVE_MIND_MAP_VARIANT,
@@ -18,6 +21,8 @@ from ..rpc.types import (
     artifact_status_to_str,
 )
 from .common import UnknownTypeWarning, _datetime_from_timestamp
+
+logger = logging.getLogger(__name__)
 
 
 class ArtifactType(str, Enum):
@@ -229,27 +234,43 @@ class Artifact:
 
         Deleted/cleared mind map: ["id", None, 2]
 
+        Mind-map rows ARE note-system rows (they come from
+        ``GET_NOTES_AND_MIND_MAPS``), so the id slot, the title, and the
+        deleted-tombstone predicate are read through
+        :class:`notebooklm._row_adapters.notes.NoteRow` — position knowledge
+        lives in the adapter, not here. A ``None`` content slot *without* the
+        recognised ``[id, None, 2]`` tombstone is sentinel drift (a deleted
+        mind map would otherwise silently leak as live): it logs a WARNING and
+        conservatively keeps the historical treat-as-live fallthrough.
+
         Returns:
             Artifact object, or None if deleted (status=2).
         """
         if not isinstance(data, list) or len(data) < 1:
             return None
 
-        mind_map_id = data[0] if len(data) > 0 else ""
+        row = NoteRow(data)
 
-        # Check for deleted status (item[1] is None with status=2)
-        if len(data) >= 3 and data[1] is None and data[2] == 2:
-            return None  # Deleted, don't include
+        # Deleted tombstone ([id, None, 2]): excluded from listings.
+        if row.is_deleted:
+            return None
+        if row.has_unrecognized_tombstone:
+            logger.warning(
+                "Mind-map row %s has a null content slot without the "
+                "soft-delete sentinel (tombstone drift? a deleted mind map "
+                "may be leaking as live): %s",
+                row.id,
+                reprlib.repr(data),
+            )
 
-        # Extract title and timestamp from nested structure
-        title = ""
+        # Title comes through the adapter (current-shape ``row[1][4]``;
+        # ``""`` for legacy/short/deleted shapes). Timestamp extraction below
+        # keeps its historical inline descent.
+        title = row.title
         created_at = None
 
         if len(data) > 1 and isinstance(data[1], list):
             inner = data[1]
-            # Title is at position [4]
-            if len(inner) > 4 and isinstance(inner[4], str):
-                title = inner[4]
             # Timestamp is at [2][2][0]. Bind the ``[2]`` metadata block first so
             # the ``[2]`` descent into it is a single-level index, not a chained
             # ``inner[2][2]`` (an absent block legitimately leaves created_at None).
@@ -260,7 +281,7 @@ class Artifact:
                     created_at = _datetime_from_timestamp(ts_data[0])
 
         return cls(
-            id=str(mind_map_id),
+            id=row.id,
             title=title,
             _artifact_type=ArtifactTypeCode.MIND_MAP.value,
             status=3,  # Mind maps are always "completed" once created

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+import reprlib
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 from .common import _datetime_from_timestamp
 from .sources import SourceType
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -49,7 +53,25 @@ class Notebook:
         raw_title = data[0] if len(data) > 0 and isinstance(data[0], str) else ""
         title = raw_title.replace("thought\n", "").strip()
         sources_count = _extract_notebook_sources_count(data)
-        notebook_id = data[2] if len(data) > 2 and isinstance(data[2], str) else ""
+        # ``data[2]`` is the notebook id. A short row / ``None`` slot keeps
+        # the historical silent ``""``-degrade — this factory parses rows out
+        # of whole-list responses, so raising would abort sibling rows. A
+        # *present-but-malformed* slot (non-str, non-None) still degrades to
+        # ``""`` for the same reason, but now logs a WARNING: a silently
+        # fabricated empty id is otherwise indistinguishable from a real row
+        # (#1485 absence-vs-malformed policy).
+        notebook_id = ""
+        if len(data) > 2:
+            raw_id = data[2]
+            if isinstance(raw_id, str):
+                notebook_id = raw_id
+            elif raw_id is not None:
+                logger.warning(
+                    "Notebook row id slot malformed — fabricating empty id "
+                    "(expected str at data[2], got %s; row=%s)",
+                    type(raw_id).__name__,
+                    reprlib.repr(data),
+                )
 
         # ``data[5]`` is the metadata block; bind it once so the timestamp and
         # owner-flag descents read a single named local instead of re-chaining

--- a/src/notebooklm/_types/sharing.py
+++ b/src/notebooklm/_types/sharing.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+import reprlib
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
 from .._env import get_base_url
 from ..rpc.types import ShareAccess, SharePermission, ShareViewLevel
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -25,7 +29,25 @@ class SharedUser:
 
         Entry format: [email, permission, [], [name, avatar]]
         """
-        email = data[0] if data else ""
+        # ``data[0]`` is the user email. An absent / ``None`` slot keeps the
+        # historical silent ``""``-degrade (this factory parses entries out of
+        # the whole shared-user list, so raising would abort sibling entries).
+        # A *present-but-malformed* slot (non-str, non-None) also degrades to
+        # ``""`` for the same reason, but now logs a WARNING instead of
+        # silently fabricating an empty email (#1485 absence-vs-malformed
+        # policy).
+        email = ""
+        if data:
+            raw_email = data[0]
+            if isinstance(raw_email, str):
+                email = raw_email
+            elif raw_email is not None:
+                logger.warning(
+                    "Share user email slot malformed — fabricating empty email "
+                    "(expected str at entry[0], got %s; entry=%s)",
+                    type(raw_email).__name__,
+                    reprlib.repr(data),
+                )
         perm_value = data[1] if len(data) > 1 else 3
         try:
             permission = SharePermission(perm_value)

--- a/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
+++ b/tests/_guardrails/test_no_raw_positional_rpc_indexing.py
@@ -166,7 +166,6 @@ SINGLE_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
         "_mind_maps_api.py",
         "_note_service.py",
         "_notebooks.py",
-        "_notes.py",
         "_research.py",
         "_source/add.py",
         "_source/content.py",

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1259,6 +1259,34 @@ class TestGetHistoryErrorHandling:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_get_history_raises_on_malformed_turns_container(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A truthy non-list where the turn list belongs raises, not [] (#1485).
+
+        Historically this shape silently parsed to an empty history —
+        indistinguishable from a genuinely-empty conversation. The container
+        unwrap now raises ``UnknownRPCMethodError`` so wire drift is loud.
+        """
+        from notebooklm.exceptions import UnknownRPCMethodError
+
+        id_response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[["conv_001"]]])
+        httpx_mock.add_response(content=id_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.chat,
+                "get_conversation_turns",
+                new_callable=AsyncMock,
+                return_value=["not-the-turn-list"],
+            ):
+                with pytest.raises(UnknownRPCMethodError):
+                    await client.chat.get_history("nb_123")
+
+    @pytest.mark.asyncio
     async def test_get_history_reverses_turns(
         self,
         auth_tokens,

--- a/tests/unit/test_chat_history.py
+++ b/tests/unit/test_chat_history.py
@@ -88,9 +88,23 @@ class TestParseTurnsToQaPairs:
         assert result[1] == ("Second?", "Answer to second.")
 
     def test_empty_turns_data(self):
+        """Falsy payloads are absence — soft ``[]``, no drift."""
         assert ChatAPI._parse_turns_to_qa_pairs(None) == []
         assert ChatAPI._parse_turns_to_qa_pairs([]) == []
-        assert ChatAPI._parse_turns_to_qa_pairs("not a list") == []
+        assert ChatAPI._parse_turns_to_qa_pairs("") == []
+
+    def test_truthy_non_list_payload_raises(self):
+        """A truthy non-list TOP-LEVEL payload is wire drift, not absence.
+
+        This historically parsed to a silent ``[]`` (the fabricated-empty-
+        history class this hardening removes); per the #1485
+        absence-vs-malformed policy it now raises ``UnknownRPCMethodError``
+        from ``unwrap_conversation_turns`` — same as the inner-slot case.
+        """
+        with pytest.raises(UnknownRPCMethodError):
+            ChatAPI._parse_turns_to_qa_pairs("not a list")
+        with pytest.raises(UnknownRPCMethodError):
+            ChatAPI._parse_turns_to_qa_pairs({"unexpected": "dict"})
 
     def test_empty_inner_list(self):
         assert ChatAPI._parse_turns_to_qa_pairs([[]]) == []
@@ -144,6 +158,52 @@ class TestParseTurnsToQaPairs:
             r.levelno == logging.DEBUG and "skipping malformed turn" in r.message
             for r in caplog.records
         )
+
+    def test_unrecognized_role_code_logs_debug_and_skips(self, caplog):
+        """A well-formed turn with a role outside {1, 2} is role-slot drift.
+
+        Historically such rows vanished silently — real history could parse
+        to ``[]`` with zero diagnostics. The walk now leaves a DEBUG record
+        before skipping, and surrounding valid pairs still parse (#1485).
+        """
+        import logging
+
+        turns_data = [
+            [
+                [None, None, "user", "Drifted question?"],  # unknown role code
+                [None, None, 1, "Valid question?"],
+                [None, None, 2, None, [["Valid answer."]]],
+            ]
+        ]
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+
+        assert result == [("Valid question?", "Valid answer.")]
+        assert any(
+            r.levelno == logging.DEBUG and "unrecognized role code" in r.message
+            for r in caplog.records
+        )
+
+    def test_unpaired_answer_rows_do_not_log_role_diagnostic(self, caplog):
+        """Ordinary unpaired ROLE_ANSWER rows are NOT role drift — no log.
+
+        Answers are legitimately consumed via pairing; only role values
+        outside {ROLE_QUESTION, ROLE_ANSWER} get the diagnostic.
+        """
+        import logging
+
+        turns_data = [
+            [
+                [None, None, 2, None, [["Orphan answer."]]],
+                [None, None, 1, "Question?"],
+                [None, None, 2, None, [["Paired answer."]]],
+            ]
+        ]
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+
+        assert result == [("Question?", "Paired answer.")]
+        assert not any("unrecognized role code" in r.message for r in caplog.records)
 
     def test_non_list_turn_skipped(self):
         """Non-list items in the turns array are skipped but break Q-A adjacency."""

--- a/tests/unit/test_chat_history.py
+++ b/tests/unit/test_chat_history.py
@@ -95,9 +95,23 @@ class TestParseTurnsToQaPairs:
     def test_empty_inner_list(self):
         assert ChatAPI._parse_turns_to_qa_pairs([[]]) == []
 
-    def test_inner_not_list(self):
-        assert ChatAPI._parse_turns_to_qa_pairs(["string"]) == []
-        assert ChatAPI._parse_turns_to_qa_pairs([42]) == []
+    def test_none_inner_slot_is_soft_empty(self):
+        """A ``None`` where the turn list belongs is absence, not drift."""
+        assert ChatAPI._parse_turns_to_qa_pairs([None]) == []
+
+    def test_inner_not_list_raises(self):
+        """A *truthy non-list* where the turn list belongs is wire drift.
+
+        Historically this silently parsed to ``[]`` — fabricating an empty
+        chat history on a Google reshape. Per the #1485 absence-vs-malformed
+        policy it now raises ``UnknownRPCMethodError`` (via
+        ``unwrap_conversation_turns``), consistent with the strict
+        ``safe_index`` leaf behavior in ``_extract_next_turn_content``.
+        """
+        with pytest.raises(UnknownRPCMethodError):
+            ChatAPI._parse_turns_to_qa_pairs(["string"])
+        with pytest.raises(UnknownRPCMethodError):
+            ChatAPI._parse_turns_to_qa_pairs([42])
 
     def test_malformed_turn_too_short(self):
         """Turns with fewer than 3 elements are skipped."""
@@ -110,6 +124,26 @@ class TestParseTurnsToQaPairs:
         ]
         result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
         assert result == [("Valid question?", "Valid answer.")]
+
+    def test_malformed_turn_skip_logs_debug_diagnostic(self, caplog):
+        """A skipped malformed turn leaves a DEBUG record (never fully silent)."""
+        import logging
+
+        turns_data = [
+            [
+                "not a turn",  # malformed row: skipped WITH a diagnostic
+                [None, None, 1, "Valid question?"],
+                [None, None, 2, None, [["Valid answer."]]],
+            ]
+        ]
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+
+        assert result == [("Valid question?", "Valid answer.")]
+        assert any(
+            r.levelno == logging.DEBUG and "skipping malformed turn" in r.message
+            for r in caplog.records
+        )
 
     def test_non_list_turn_skipped(self):
         """Non-list items in the turns array are skipped but break Q-A adjacency."""

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -349,6 +349,21 @@ class TestConversationTurnRow:
         row = ConversationTurnRow([None, None, 2, None])
         assert row.is_answer is False
 
+    def test_unrecognized_role_is_flagged(self) -> None:
+        """A well-formed row with a role outside {1, 2} is role-slot drift."""
+        assert ConversationTurnRow([None, None, "user", "Q?"]).has_unrecognized_role is True
+        assert ConversationTurnRow([None, None, 3]).has_unrecognized_role is True
+        assert ConversationTurnRow([None, None, None]).has_unrecognized_role is True
+
+    def test_known_roles_and_malformed_rows_are_not_flagged(self) -> None:
+        """Known roles (incl. unpaired answers) and malformed rows never flag."""
+        assert ConversationTurnRow([None, None, 1, "Q?"]).has_unrecognized_role is False
+        assert ConversationTurnRow([None, None, 2, None, [["A."]]]).has_unrecognized_role is False
+        # Short role-2 row: still a KNOWN role — skipped as unusable, not drift.
+        assert ConversationTurnRow([None, None, 2]).has_unrecognized_role is False
+        assert ConversationTurnRow([None]).has_unrecognized_role is False
+        assert ConversationTurnRow("not a turn").has_unrecognized_role is False
+
     def test_none_question_text_coerces_to_empty(self) -> None:
         """Preserves the historical ``str(turn[3] or "")`` coercion."""
         row = ConversationTurnRow([None, None, 1, None])
@@ -376,9 +391,23 @@ class TestUnwrapConversationTurns:
         turns = [[None, None, 1, "Q?"], [None, None, 2, None, [["A."]]]]
         assert unwrap_conversation_turns([turns], source="test") is turns
 
-    @pytest.mark.parametrize("payload", [None, [], "not a list", 0, {}])
-    def test_absent_or_non_list_payload_is_soft_empty(self, payload: object) -> None:
+    @pytest.mark.parametrize("payload", [None, [], "", 0, {}])
+    def test_falsy_payload_is_soft_empty(self, payload: object) -> None:
+        """A falsy payload is a legitimately-absent history, not drift."""
         assert unwrap_conversation_turns(payload, source="test") == []
+
+    @pytest.mark.parametrize("payload", ["not a list", 42, {"unexpected": "dict"}])
+    def test_truthy_non_list_payload_raises(self, payload: object) -> None:
+        """A truthy non-list TOP-LEVEL payload is wire drift (#1485).
+
+        Historically this degraded to a silent ``[]`` — the fabricated-
+        empty-history class. ``path=()`` marks top-level drift.
+        """
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            unwrap_conversation_turns(payload, source="test-source")
+        assert exc_info.value.method_id == RPCMethod.GET_CONVERSATION_TURNS.value
+        assert exc_info.value.source == "test-source"
+        assert exc_info.value.path == ()
 
     @pytest.mark.parametrize("payload", [[[]], [None], [0], [""]])
     def test_falsy_container_slot_is_soft_empty(self, payload: list) -> None:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -22,12 +22,15 @@ from notebooklm._row_adapters.chat import (
     AnswerRow,
     CitationDetail,
     CitationRow,
+    ConversationTurnRow,
     ErrorPayloadRow,
     PassageRow,
     StreamFrameRow,
     TextLeafRow,
+    unwrap_conversation_turns,
 )
 from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.rpc import RPCMethod
 
 # ---------------------------------------------------------------------------
 # 1. Position-contract pins (the canaries)
@@ -83,6 +86,18 @@ class TestFramePositionContract:
 
     def test_text_leaf_positions_pinned(self) -> None:
         assert TextLeafRow._TEXT_POS == 2
+
+
+class TestConversationTurnPositionContract:
+    def test_positions_pinned(self) -> None:
+        assert (
+            ConversationTurnRow._ROLE_POS,
+            ConversationTurnRow._QUESTION_TEXT_POS,
+            ConversationTurnRow._ANSWER_CONTENT_POS,
+            ConversationTurnRow._MIN_LEN,
+            ConversationTurnRow.ROLE_QUESTION,
+            ConversationTurnRow.ROLE_ANSWER,
+        ) == (2, 3, 4, 3, 1, 2)
 
 
 # ---------------------------------------------------------------------------
@@ -300,3 +315,80 @@ class TestTextLeafRow:
         leaf = TextLeafRow(raw)
         assert leaf.is_well_formed is False
         assert leaf.text_value is None
+
+
+# ---------------------------------------------------------------------------
+# ConversationTurnRow + unwrap_conversation_turns (GET_CONVERSATION_TURNS)
+# ---------------------------------------------------------------------------
+
+
+class TestConversationTurnRow:
+    def test_question_turn_reads_role_and_text(self) -> None:
+        row = ConversationTurnRow([None, None, 1, "What is AI?"])
+        assert row.is_well_formed is True
+        assert row.role == 1
+        assert row.is_question is True
+        assert row.is_answer is False
+        assert row.question_text == "What is AI?"
+
+    def test_answer_turn_classified_with_content_slot(self) -> None:
+        row = ConversationTurnRow([None, None, 2, None, [["The answer."]]])
+        assert row.is_answer is True
+        assert row.is_question is False
+        assert row.question_text == ""
+
+    def test_role_one_without_text_slot_is_not_a_question(self) -> None:
+        """Mirrors the historical ``turn[2] == 1 and len(turn) > 3`` guard."""
+        row = ConversationTurnRow([None, None, 1])
+        assert row.is_well_formed is True
+        assert row.is_question is False
+        assert row.question_text == ""
+
+    def test_role_two_without_content_slot_is_not_an_answer(self) -> None:
+        """Mirrors the historical ``len(next_turn) > 4`` guard."""
+        row = ConversationTurnRow([None, None, 2, None])
+        assert row.is_answer is False
+
+    def test_none_question_text_coerces_to_empty(self) -> None:
+        """Preserves the historical ``str(turn[3] or "")`` coercion."""
+        row = ConversationTurnRow([None, None, 1, None])
+        assert row.is_question is True
+        assert row.question_text == ""
+
+    @pytest.mark.parametrize("raw", [[], [None], [None, None], "not a turn", 42, None])
+    def test_short_or_non_list_rows_are_malformed(self, raw: object) -> None:
+        row = ConversationTurnRow(raw)
+        assert row.is_well_formed is False
+        assert row.role is None
+        assert row.is_question is False
+        assert row.is_answer is False
+        assert row.question_text == ""
+
+    def test_raw_returns_wrapped_row(self) -> None:
+        turn = [None, None, 2, None, [["x"]]]
+        assert ConversationTurnRow(turn).raw is turn
+
+
+class TestUnwrapConversationTurns:
+    """Absence-vs-malformed split for the turns container (#1485 policy)."""
+
+    def test_unwraps_single_element_envelope(self) -> None:
+        turns = [[None, None, 1, "Q?"], [None, None, 2, None, [["A."]]]]
+        assert unwrap_conversation_turns([turns], source="test") is turns
+
+    @pytest.mark.parametrize("payload", [None, [], "not a list", 0, {}])
+    def test_absent_or_non_list_payload_is_soft_empty(self, payload: object) -> None:
+        assert unwrap_conversation_turns(payload, source="test") == []
+
+    @pytest.mark.parametrize("payload", [[[]], [None], [0], [""]])
+    def test_falsy_container_slot_is_soft_empty(self, payload: list) -> None:
+        """An empty/null turn list is a legitimately-empty history, not drift."""
+        assert unwrap_conversation_turns(payload, source="test") == []
+
+    @pytest.mark.parametrize("payload", [["string"], [42], [{"k": "v"}]])
+    def test_truthy_non_list_container_raises(self, payload: list) -> None:
+        """A truthy non-list where the turn list belongs is wire drift."""
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            unwrap_conversation_turns(payload, source="test-source")
+        assert exc_info.value.method_id == RPCMethod.GET_CONVERSATION_TURNS.value
+        assert exc_info.value.source == "test-source"

--- a/tests/unit/test_get_or_none.py
+++ b/tests/unit/test_get_or_none.py
@@ -234,6 +234,21 @@ class TestNotesGetOrNone:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_id_match_reads_through_note_row_adapter(self, notes_api):
+        """The id-slot comparison goes through ``NoteRow.id`` (#1485).
+
+        ``NoteRow.id`` stringifies the raw slot (the unified ``SourceRow.id``
+        convention), so a non-string wire id still matches its string form
+        instead of silently flipping a found note to not-found.
+        """
+        notes_api._get_all_notes_and_mind_maps = AsyncMock(
+            return_value=[[12345, ["12345", "Body", None, None, "Title"]]]
+        )
+        result = await notes_api.get_or_none("nb_1", "12345")
+        assert result is not None
+        assert result.id == "12345"
+
+    @pytest.mark.asyncio
     async def test_propagates_rpc_error(self, notes_api):
         notes_api._get_all_notes_and_mind_maps = AsyncMock(side_effect=RPCError("boom"))
         with pytest.raises(RPCError):

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -598,3 +598,59 @@ class TestGetNotebookFailsClosed:
         err = NotebookNotFoundError("nb_x", method_id="rwIQyf")
         assert err.notebook_id == "nb_x"
         assert err.method_id == "rwIQyf"
+
+
+class TestListNotebooksPayloadDispatch:
+    """``list()`` wrapped-envelope dispatch — absence soft, malformed raises.
+
+    Mirrors the ``_artifact/listing.py::list_raw`` fail-loud pattern (#1485):
+    an empty/``None`` payload and a ``None`` row-list slot are legitimate "no
+    notebooks" shapes, while a truthy payload that doesn't match the
+    ``[[row, ...]]`` envelope is schema drift — it used to flow garbage rows
+    into ``Notebook.from_api_response`` and silently fabricate empty-id
+    notebooks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wrapped_envelope_parses_rows(self):
+        api = _make_api(
+            rpc_call=AsyncMock(
+                return_value=[[["Notebook A", [], "nb_a", "📓"], ["Notebook B", [], "nb_b", "📓"]]]
+            )
+        )
+
+        notebooks = await api.list()
+
+        assert [(nb.id, nb.title) for nb in notebooks] == [
+            ("nb_a", "Notebook A"),
+            ("nb_b", "Notebook B"),
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [None, []])
+    async def test_empty_payload_is_soft_empty(self, payload):
+        api = _make_api(rpc_call=AsyncMock(return_value=payload))
+        assert await api.list() == []
+
+    @pytest.mark.asyncio
+    async def test_null_row_list_slot_is_soft_empty(self):
+        """A ``None`` where the row list belongs is absence, not drift."""
+        api = _make_api(rpc_call=AsyncMock(return_value=[None]))
+        assert await api.list() == []
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_list_payload_raises_decoding_error(self):
+        from notebooklm.exceptions import DecodingError
+
+        api = _make_api(rpc_call=AsyncMock(return_value="garbage"))
+        with pytest.raises(DecodingError):
+            await api.list()
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_list_row_slot_raises_decoding_error(self):
+        """A moved wrapper (non-list where the row list belongs) is drift."""
+        from notebooklm.exceptions import DecodingError
+
+        api = _make_api(rpc_call=AsyncMock(return_value=["garbage", "rows"]))
+        with pytest.raises(DecodingError):
+            await api.list()

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -767,6 +767,34 @@ class TestNoteRowIsDeleted:
         assert NoteRow(["id", None]).is_deleted is False
 
 
+class TestNoteRowHasUnrecognizedTombstone:
+    """``None`` content slot without the recognised soft-delete sentinel.
+
+    The drift predicate consumed by ``Artifact.from_mind_map``: were Google
+    to move the ``[id, None, 2]`` sentinel, deleted rows would silently leak
+    as live — this property is the WARN trigger for that bug class (#1485).
+    """
+
+    def test_recognised_tombstone_is_not_drift(self) -> None:
+        assert NoteRow(_deleted_note_row()).has_unrecognized_tombstone is False
+
+    def test_null_content_with_drifted_sentinel_is_drift(self) -> None:
+        assert NoteRow(["id", None, 5]).has_unrecognized_tombstone is True
+        assert NoteRow(["id", None, 0]).has_unrecognized_tombstone is True
+
+    def test_null_content_without_status_slot_is_drift(self) -> None:
+        assert NoteRow(["id", None]).has_unrecognized_tombstone is True
+
+    def test_live_rows_are_not_drift(self) -> None:
+        assert NoteRow(_legacy_note_row()).has_unrecognized_tombstone is False
+        assert NoteRow(_current_note_row()).has_unrecognized_tombstone is False
+
+    def test_row_too_short_for_content_slot_is_absence(self) -> None:
+        """No content slot at all is genuine absence, not a null content value."""
+        assert NoteRow([]).has_unrecognized_tombstone is False
+        assert NoteRow(["id"]).has_unrecognized_tombstone is False
+
+
 # ---------------------------------------------------------------------------
 # NoteRow — multi-shape content dispatch (the whole point of the adapter)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -68,6 +68,37 @@ class TestSharedUser:
         assert user.email == ""
         assert user.permission == SharePermission.VIEWER
 
+    def test_from_api_response_malformed_email_warns(self, caplog):
+        """A present-but-non-str email slot fabricates ``""`` LOUDLY (#1485).
+
+        The degrade is kept (a raising entry parser would abort the whole
+        shared-user list), but the fabricated empty email now leaves a
+        WARNING with a bounded payload preview instead of silently flowing a
+        non-string into ``SharedUser.email``.
+        """
+        import logging
+
+        data = [12345, 2]
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            user = SharedUser.from_api_response(data)
+
+        assert user.email == ""
+        assert any(
+            r.levelno == logging.WARNING and "email slot malformed" in r.message
+            for r in caplog.records
+        )
+
+    def test_from_api_response_null_email_is_silent_empty(self, caplog):
+        """A ``None`` email slot is absence, not drift — silent ``""`` degrade."""
+        import logging
+
+        data = [None, 2]
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            user = SharedUser.from_api_response(data)
+
+        assert user.email == ""
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
     def test_from_api_response_partial_user_info(self):
         """Test parsing with partial user info (only name, no avatar)."""
         data = ["user@example.com", 3, [], ["Just Name"]]

--- a/tests/unit/test_source_content_renderer.py
+++ b/tests/unit/test_source_content_renderer.py
@@ -176,6 +176,61 @@ async def test_missing_source_raises_not_found() -> None:
 
 
 @pytest.mark.asyncio
+async def test_malformed_type_code_warns_and_degrades_to_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A present-but-non-int ``metadata[4]`` degrades to ``None`` LOUDLY (#1485).
+
+    Historically the slot was read with no validation at all, so a malformed
+    value flowed straight into ``SourceFulltext._type_code``. The read now
+    goes through ``SourceRow.type_code`` (int-validated); the malformed case
+    warns with a bounded payload preview.
+    """
+    renderer = SourceContentRenderer(
+        RecordingRpc(
+            [
+                ["src_bad", "Article", [None, None, None, None, "not-an-int"]],
+                None,
+                None,
+                [[["Body."]]],
+            ]
+        ),
+        logger=SOURCE_LOGGER,
+    )
+    caplog.set_level("WARNING", logger="notebooklm._sources")
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_bad")
+
+    assert fulltext._type_code is None
+    assert fulltext.content == "Body."
+    assert "type-code slot malformed" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        [None, None],  # too short to carry the type-code slot (absence)
+        [None, None, None, None, None],  # null type-code slot (absence)
+    ],
+)
+async def test_absent_type_code_stays_silent(
+    metadata: list[Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """An absent / ``None`` type-code slot keeps the silent ``None`` default."""
+    renderer = SourceContentRenderer(
+        RecordingRpc([["src_short", "Article", metadata], None, None, [[["Body."]]]]),
+        logger=SOURCE_LOGGER,
+    )
+    caplog.set_level("WARNING", logger="notebooklm._sources")
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_short")
+
+    assert fulltext._type_code is None
+    assert "type-code slot malformed" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_url_and_type_parsing_uses_shared_metadata_rules() -> None:
     renderer = SourceContentRenderer(
         RecordingRpc(

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -378,6 +378,46 @@ class TestNotebook:
 
         assert notebook.title == ""
 
+    def test_from_api_response_malformed_id_slot_warns(self, caplog):
+        """A present-but-non-str id slot fabricates ``""`` LOUDLY (#1485).
+
+        The degrade itself is kept (a raising row parser would abort
+        whole-list parsing), but the fabrication now leaves a WARNING with a
+        bounded payload preview instead of being silent.
+        """
+        import logging
+
+        data = ["My Notebook", [], 12345, "📓"]
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            notebook = Notebook.from_api_response(data)
+
+        assert notebook.id == ""
+        assert any(
+            r.levelno == logging.WARNING and "id slot malformed" in r.message
+            for r in caplog.records
+        )
+
+    def test_from_api_response_null_id_slot_is_silent(self, caplog):
+        """A ``None`` id slot is absence, not drift — silent ``""`` degrade."""
+        import logging
+
+        data = ["My Notebook", [], None, "📓"]
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            notebook = Notebook.from_api_response(data)
+
+        assert notebook.id == ""
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_from_api_response_short_row_is_silent(self, caplog):
+        """Rows too short to carry the id slot keep the silent degrade."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            notebook = Notebook.from_api_response(["Title only"])
+
+        assert notebook.id == ""
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
 
 class TestSource:
     def test_from_api_response_simple_format(self):
@@ -971,6 +1011,36 @@ class TestArtifact:
 
         assert artifact is not None
         assert artifact.created_at is None
+
+    def test_from_mind_map_deleted_tombstone_is_silent_none(self, caplog):
+        """The recognised ``[id, None, 2]`` tombstone filters silently."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            assert Artifact.from_mind_map(["mm_gone", None, 2]) is None
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_from_mind_map_unrecognized_tombstone_warns_and_stays_live(self, caplog):
+        """A null content slot WITHOUT the soft-delete sentinel WARNS (#1485).
+
+        This is the deleted-map-leaking-as-live bug class: were Google to
+        rotate the sentinel value, every deleted mind map would flow through
+        as a live artifact. The historical treat-as-live fallthrough is kept
+        (conservative), but it is no longer silent.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            artifact = Artifact.from_mind_map(["mm_drift", None, 7])
+
+        assert artifact is not None
+        assert artifact.id == "mm_drift"
+        assert artifact.title == ""
+        assert any(
+            r.levelno == logging.WARNING and "soft-delete sentinel" in r.message
+            for r in caplog.records
+        )
 
     def test_from_api_response_audio_url(self):
         """Completed audio artifacts expose their download URL."""


### PR DESCRIPTION
## What & why

A full census of the below-facade `SINGLE_LEVEL_ALLOWLIST` (137 flagged reads traced to origin) classified 14 sites as **REAL-strict**: their guards prevent crashes but the fallback **fabricates a wrong-but-valid value silently** on wire drift — empty notebook/mind-map ids, an empty share email, deleted mind maps leaking as live, silently-empty chat history, a `LIST_NOTEBOOKS` wrapper mis-dispatch, an unvalidated source type code, and a note lookup flipping found→not-found. This PR fixes exactly those 14 (the 104 deliberately-guarded soft reads stay untouched — that burndown remains paused per #1501).

## Policy (the #1485 precedent, applied uniformly)
**Absence stays soft** (short rows, `None` slots, legitimately-empty containers — zero contract changes); **present-but-malformed becomes loud** (raise via adapters/`safe_index` where structural; `logger.warning` with a `reprlib`-bounded preview where raising would break whole-list parsing).

## The fixes
- **Chat history walk (7 sites)** → new `ConversationTurnRow` + `unwrap_conversation_turns` in `_row_adapters/chat.py`: a truthy non-list payload or turn-list slot **raises** `UnknownRPCMethodError`; malformed turns skip with a DEBUG diagnostic; **unrecognized role codes** get a DEBUG diagnostic (role-slot drift can no longer empty real history invisibly); empty history stays `[]`.
- **`notebooks.list()` wrapper dispatch** → fail-loud `DecodingError` on unrecognized payload shapes (mirrors `_artifact/listing.py`); the `[None]` payload that previously crashed with a raw `TypeError` now classifies as absence → `[]`.
- **Identity fields** (`_types/notebooks.py` id, `_types/sharing.py` email) → warn-with-preview on present-but-wrong-type; `email` is now always `str` (a `None` slot normalizes to `""`).
- **`from_mind_map`** → decoded through `NoteRow` (id/title/deleted sentinel) + new `NoteRow.has_unrecognized_tombstone` warning for the deleted-leaks-as-live drift class.
- **`notes.get_or_none`** id match via `NoteRow.id` (drains `_notes.py` from the gate allowlist — one-line removal).
- **Source type code** via `SourceRow.from_entry(...).type_code` (int-validated, warn + `None`).

## Review (pre-PR polish)
claude (solid — full behavior-parity traces for all legitimate shapes) + codex (2 Important fixed: the top-level garbage payload now raises instead of soft-`[]`; unknown role codes get diagnostics).

## Verification
Full suite **9530 passed**; guardrails + gate stale-check green; **zero cassette re-records**; mypy + ruff clean; API-compat audit **EXIT 0** (private modules only). Rebased over #1504 (CHANGELOG + allowlist-line overlap resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent wrong-but-valid values from malformed RPC payloads in chat history, notebooks, notes, and related parsing; malformed-but-present payloads now surface errors while genuine absence soft-degrades.

* **Diagnostics**
  * Added warnings and DEBUG diagnostics to make malformed or drifted wire shapes observable (bounded previews in logs).

* **Tests**
  * Expanded unit tests to cover stricter absence-vs-malformed behavior and new error/logging cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->