### PR TITLE
refactor(test-infra): replace the __new__-based test client shell with a shared production assembly seam

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -808,6 +808,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | File | Purpose |
 |------|---------|
 | `client.py` | Main `NotebookLMClient` class |
+| `_client_assembly.py` | Single private assembly seam (`_assemble_client`) that wires every constructor-set attribute; shared by `NotebookLMClient.__init__` and the canonical test factory (`tests/_helpers/client_factory.py`) so the two construction paths cannot drift. |
 | `_client_composed.py` | Client-owned composition holder for transport, executor, chain host, middleware metadata, and runtime collaborator bundle. |
 | `_client_seams.py` | Constructor-only injectable seams used by tests and collaborator construction. |
 | `_runtime/init.py` | Constructor helpers that validate client runtime kwargs, build collaborators (returning a `RuntimeCollaborators` bundle), wire middleware, and bind `ClientComposed`. |
@@ -922,6 +923,7 @@ src/notebooklm/
 ├── _auth_refresh_retry.py       # Shared auth refresh-and-retry core (RefreshBudget + refresh_and_count) for both retry layers
 ├── _backoff.py                  # Shared retry backoff calculation
 ├── _callbacks.py                # Sync/async callback invocation helper
+├── _client_assembly.py          # Shared client-assembly seam (constructor + test factory)
 ├── _client_composed.py          # Client-owned composition holder
 ├── _client_seams.py             # Constructor-only injectable seams
 ├── _deadline.py                 # RuntimeDeadline helper for aggregate timeouts

--- a/src/notebooklm/_client_assembly.py
+++ b/src/notebooklm/_client_assembly.py
@@ -1,0 +1,372 @@
+"""Single client-assembly seam shared by production and the test factory.
+
+:func:`_assemble_client` is the ONE place that wires a
+:class:`~notebooklm.client.NotebookLMClient` instance: auth normalization,
+seam resolution, collaborator composition (via
+:func:`notebooklm._runtime.init.compose_client_internals`), the upload
+pipeline, and every feature API. Two callers exist:
+
+1. ``NotebookLMClient.__init__`` (production) — delegates its whole body
+   here, passing only its public kwargs.
+2. ``tests/_helpers/client_factory.build_client_shell_for_tests`` — calls
+   ``NotebookLMClient.__new__`` and then this function with the
+   test-only injection seams (``decode_response`` / ``sleep`` /
+   ``is_auth_error`` / ``async_client_factory`` plus ``refresh_callback`` /
+   ``refresh_retry_delay`` / ``connect_timeout`` /
+   ``keepalive_storage_path``).
+
+History: the test factory previously duplicated this wiring by hand
+against ``NotebookLMClient.__new__``. That drifted twice — issue #1196
+(the open-time upload-semaphore loop reset needed ``_source_uploader``)
+and issue #1225 (the open-time ChatAPI conversation-lock reset needed
+``chat``) — each time silently stranding the shell until a test happened
+to exercise the missing attribute. Sharing one assembly function makes
+that whole drift class structurally impossible;
+``tests/_guardrails/test_client_factory_parity.py`` pins the remaining
+edges (attributes added *outside* this function).
+
+This module is private: it is not exported from ``notebooklm`` and the
+test-only parameters MUST NOT be promoted to ``NotebookLMClient``'s
+public constructor (see the seam policy in ``_client_seams``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from ._artifacts import ArtifactsAPI
+from ._chat import ChatAPI
+from ._client_composed import ClientComposed
+from ._client_seams import resolve_client_seams
+from ._labels import LabelsAPI
+from ._mind_map import NoteBackedMindMapService
+from ._mind_maps_api import MindMapsAPI
+from ._note_service import NoteService
+from ._notebooks import NotebooksAPI
+from ._notes import NotesAPI
+from ._research import ResearchAPI
+from ._runtime.config import (
+    DEFAULT_CHAT_TIMEOUT,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_KEEPALIVE_MIN_INTERVAL,
+    DEFAULT_MAX_CONCURRENT_RPCS,
+    DEFAULT_MAX_CONCURRENT_UPLOADS,
+    DEFAULT_TIMEOUT,
+)
+from ._runtime.init import compose_client_internals
+from ._runtime.lifecycle import CookieRotator, CookieSaver
+from ._settings import SettingsAPI
+from ._sharing import SharingAPI
+from ._source.upload import SourceUploadPipeline
+from ._sources import SourcesAPI
+from .auth import AuthTokens
+
+if TYPE_CHECKING:
+    from .client import NotebookLMClient
+    from .types import ConnectionLimits, RpcTelemetryEvent
+
+
+class _UnsetType:
+    """Sentinel type: resolve the production default inside ``_assemble_client``.
+
+    Used where ``None`` is itself a meaningful caller value
+    (``refresh_callback=None`` means "no refresh callback";
+    ``keepalive_storage_path=None`` means "no keepalive persistence"), so
+    the production default ("use ``client.refresh_auth``" / "derive from
+    ``auth.storage_path``") needs a distinct marker.
+    """
+
+
+_UNSET = _UnsetType()
+
+
+def _assemble_client(
+    client: NotebookLMClient,
+    *,
+    auth: AuthTokens,
+    timeout: float = DEFAULT_TIMEOUT,
+    storage_path: Path | None = None,
+    keepalive: float | None = None,
+    keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
+    rate_limit_max_retries: int = 3,
+    server_error_max_retries: int = 3,
+    limits: ConnectionLimits | None = None,
+    max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
+    max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
+    upload_timeout: httpx.Timeout | None = None,
+    on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+    cookie_saver: CookieSaver | None = None,
+    cookie_rotator: CookieRotator | None = None,
+    chat_timeout: float | None = DEFAULT_CHAT_TIMEOUT,
+    # --- Production-default overrides (test factory only) -----------------
+    # ``NotebookLMClient.__init__`` never passes these; the sentinels
+    # resolve to the exact behavior the constructor had when this logic
+    # lived inline. The test factory forwards its caller's values
+    # explicitly to preserve the historical shell semantics (e.g.
+    # ``refresh_callback=None`` → no auth refresh coordination).
+    refresh_callback: Callable[[], Awaitable[AuthTokens]] | None | _UnsetType = _UNSET,
+    refresh_retry_delay: float = 0.2,
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    keepalive_storage_path: Path | None | _UnsetType = _UNSET,
+    # --- Test-only injection seams (see ``_client_seams`` docstring) ------
+    decode_response: Callable[..., Any] | None = None,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+    is_auth_error: Callable[[Exception], bool] | None = None,
+    async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
+) -> None:
+    """Wire every constructor-set attribute onto ``client``.
+
+    This is the production assembly path — ``NotebookLMClient.__init__``
+    is a thin delegate to this function — and simultaneously the seam the
+    canonical test factory builds on, so the two can never drift apart
+    (incidents #1196 / #1225). Any new constructor-time attribute MUST be
+    set here, not in ``__init__`` after the delegation call; the parity
+    gate ``tests/_guardrails/test_client_factory_parity.py`` fails
+    otherwise.
+    """
+    # Normalize the effective storage path onto the auth object so every
+    # downstream code path (refresh_auth, lifecycle on-close save,
+    # the keepalive loop) writes to the same file. Without this, an
+    # explicit ``storage_path=`` kwarg only reaches the keepalive loop
+    # while ``auth.storage_path is None`` causes refresh and on-close
+    # saves to silently skip persistence. ``dataclasses.replace`` instead
+    # of in-place mutation so a caller reusing ``AuthTokens`` across
+    # multiple clients (with different storage paths) doesn't see one
+    # client's path leak into another.
+    if storage_path is not None and auth.storage_path != storage_path:
+        auth = dataclasses.replace(auth, storage_path=storage_path)
+
+    # Direct client-owned reference to the authoritative ``AuthTokens``
+    # instance. Set AFTER the ``storage_path`` normalization above so it
+    # captures the same (possibly rebound) instance that
+    # :func:`compose_client_internals` then propagates into
+    # :class:`CookiePersistence`, the snapshot-provider lambdas,
+    # and :class:`SourceUploadPipeline`. ADR-0016's Auth Instance
+    # Invariant requires every reference across the live object graph
+    # to alias this exact same mutable object so
+    # :meth:`AuthRefreshCoordinator.update_auth_tokens` in-place
+    # mutations are observed everywhere.
+    #
+    # ``refresh_auth()``, the public ``auth`` property, and the
+    # ``SourceUploadPipeline(auth=...)`` constructor argument all back
+    # off this field. The client shell helper
+    # (``tests/_helpers/client_factory.build_client_shell_for_tests``)
+    # runs this exact function, so tests exercise the same code path as
+    # production.
+    client._auth = auth
+
+    # Production default: the client's own ``refresh_auth`` bound method.
+    # The test factory overrides this (typically with ``None`` or a fake)
+    # to keep shells network-free.
+    if isinstance(refresh_callback, _UnsetType):
+        refresh_callback = client.refresh_auth
+
+    # Canonicalize the keepalive storage path so different representations
+    # of the same physical file (relative vs absolute, ``~`` shorthand,
+    # symlink components) hash to the same key in the in-process rotation
+    # dedupe (``_get_poke_lock`` / ``_try_claim_rotation`` /
+    # ``_rotation_lock_path`` in auth.py). The auth refresh path already
+    # canonicalizes at ``auth.py:_fetch_tokens_with_refresh`` via
+    # ``Path(p).expanduser().resolve()``; this mirrors it so two clients
+    # pointing at the same file via different path syntaxes share one
+    # ``_LAST_POKE_ATTEMPT_MONOTONIC`` entry instead of bypassing dedupe
+    # and firing duplicate ``RotateCookies`` POSTs.
+    # NOTE: the public ``storage_path`` argument and ``auth.storage_path``
+    # are intentionally left as the caller provided them — only the
+    # internal-derived keepalive storage path is canonicalized. The test
+    # factory passes its own ``keepalive_storage_path`` explicitly, which
+    # bypasses the derivation (preserving the historical shell semantics).
+    if isinstance(keepalive_storage_path, _UnsetType):
+        derived_keepalive_path: Path | None = auth.storage_path
+        if derived_keepalive_path is not None:
+            derived_keepalive_path = Path(derived_keepalive_path).expanduser().resolve()
+        keepalive_storage_path = derived_keepalive_path
+
+    # Cross-validate the RPC throttle against the underlying httpx pool
+    # before the collaborator builder swallows the ``limits=None``
+    # sentinel into its own ``ConnectionLimits()`` synthesis.
+    # Performed here so the constraint is enforced uniformly regardless
+    # of whether the caller passed an explicit ``ConnectionLimits``
+    # instance or relied on the default — scalar config validation
+    # can't see the caller's intent once the default has been substituted.
+    # Skip when either side opts out (``max_concurrent_rpcs is None``
+    # means "no gate"; we deliberately don't second-guess the caller's
+    # external-throttle setup).
+    if max_concurrent_rpcs is not None:
+        from .types import ConnectionLimits
+
+        effective_limits = limits if limits is not None else ConnectionLimits()
+        if max_concurrent_rpcs > effective_limits.max_connections:
+            raise ValueError(
+                "max_concurrent_rpcs must be <= limits.max_connections "
+                f"(got max_concurrent_rpcs={max_concurrent_rpcs}, "
+                f"max_connections={effective_limits.max_connections}). "
+                "A semaphore wider than the connection pool surfaces "
+                "saturation as opaque httpx.PoolTimeout instead of "
+                "clean back-pressure."
+            )
+
+    # The client is the composition root: :func:`compose_client_internals`
+    # binds composition state onto ``client._composed`` and returns only the
+    # collaborators + executor that feature adapters need.
+    #
+    # The public NotebookLMClient kwarg surface is unchanged — the
+    # four seam kwargs (``decode_response`` / ``sleep`` /
+    # ``is_auth_error`` / ``async_client_factory``) live on
+    # ``compose_client_internals`` and this private assembly function
+    # only.
+    #
+    # TEST-ONLY injection points: production passes ``None`` for all
+    # three runtime seams here (and never supplies an
+    # ``async_client_factory``), so they always resolve to the
+    # canonical module bindings. The non-``None`` paths exist solely
+    # for deterministic test injection — see ``_client_seams`` module
+    # docstring. Do not promote any of them to a public kwarg without
+    # a production caller that varies them.
+    client._seams = resolve_client_seams(
+        decode_response=decode_response,
+        sleep=sleep,
+        is_auth_error=is_auth_error,
+    )
+    client._composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
+
+    internals = compose_client_internals(
+        auth=auth,
+        timeout=timeout,
+        connect_timeout=connect_timeout,
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=refresh_retry_delay,
+        keepalive=keepalive,
+        keepalive_min_interval=keepalive_min_interval,
+        keepalive_storage_path=keepalive_storage_path,
+        rate_limit_max_retries=rate_limit_max_retries,
+        server_error_max_retries=server_error_max_retries,
+        limits=limits,
+        max_concurrent_uploads=max_concurrent_uploads,
+        max_concurrent_rpcs=max_concurrent_rpcs,
+        on_rpc_event=on_rpc_event,
+        # Injectable seams — pass-through to the lifecycle. ``None``
+        # (default) preserves the late-binding contract via
+        # ``_default_cookie_saver`` / ``_default_cookie_rotator``.
+        cookie_saver=cookie_saver,
+        cookie_rotator=cookie_rotator,
+        async_client_factory=async_client_factory,
+        seams=client._seams,
+        composed=client._composed,
+    )
+    # Owned reference to the collaborator bundle so
+    # :meth:`metrics_snapshot` (and any future
+    # NotebookLMClient-side collaborator consumers) read from the
+    # same bundle feature internals use.
+    client._collaborators = internals.collaborators
+    # Owned reference to the RPC executor so ``client.rpc_call``
+    # dispatches through it directly rather than through a
+    # compatibility wrapper. The executor satisfies the
+    # ``RpcCaller`` Protocol and is the same instance the feature
+    # APIs receive (``internals.executor`` is shared with
+    # ``SourcesAPI`` / ``NotebooksAPI`` / ``ArtifactsRuntimeAdapter``
+    # / ``ChatAPI`` / etc., so a test that swaps the executor's
+    # ``rpc_call`` sees the swap on every feature consumer).
+    client._rpc_executor = internals.executor
+
+    # ADR-0014 Rule 2: the upload pipeline takes its three runtime
+    # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
+    # instead of via a composite-runtime adapter. ``Kernel`` and
+    # ``AuthMetadata`` continue to flow as separate parameters per
+    # the ADR-0014 Rule 6 example. This assembly function is
+    # the composition root that knows these internals;
+    # ``SourcesAPI`` no longer reads them back off a broad host.
+    source_uploader = SourceUploadPipeline(
+        rpc=internals.executor,
+        drain=internals.collaborators.drain_tracker,
+        lifecycle=internals.collaborators.lifecycle,
+        kernel=internals.collaborators.kernel,
+        # ADR-0016's Auth Instance Invariant: the upload pipeline
+        # reads the client-owned ``client._auth`` reference set above
+        # instead of a detached auth copy. Production refresh-time
+        # mutation is therefore observed by the uploader unchanged.
+        auth=client._auth,
+        upload_timeout=upload_timeout,
+        max_concurrent_uploads=max_concurrent_uploads,
+        record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
+    )
+    # Hold the uploader as a first-class client attribute so the
+    # open-time loop-affinity reset (issue #1196 upload variant) can
+    # reach it independently of the ``client.sources`` feature surface:
+    # the upload semaphore is a lazily-built loop-bound
+    # ``asyncio.Semaphore`` that must be discarded on close→reopen, the
+    # same as the RPC semaphore. ``__aenter__`` threads this into
+    # ``ClientLifecycle.open`` which calls
+    # ``set_bound_loop`` / ``reset_after_open`` on it.
+    client._source_uploader = source_uploader
+    # Per ADR-0014 Rule 3: simple features take their RpcCaller dependency
+    # directly from the composition root's executor.
+    client.sources = SourcesAPI(
+        internals.executor,
+        uploader=source_uploader,
+        upload_timeout=upload_timeout,
+        max_concurrent_uploads=max_concurrent_uploads,
+    )
+    client.notebooks = NotebooksAPI(internals.executor, sources_api=client.sources)
+    # Note wiring (see docs/refactor-history.md): an explicit
+    # NoteService + NoteBackedMindMapService split. NoteService owns the
+    # raw row primitives; NoteBackedMindMapService is the mind-map-only
+    # adapter the download path uses; the artifact-generation path uses
+    # NoteService.create_note directly to persist a generated mind map.
+    note_service = NoteService(internals.executor)
+    mind_maps = NoteBackedMindMapService(note_service)
+    # ADR-0014 Rule 2: the artifacts API takes its three runtime
+    # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
+    # instead of via a composite-runtime adapter. ``rpc`` covers
+    # RPC dispatch; ``drain`` covers ``operation_scope`` and the
+    # close-time ``register_drain_hook`` used by the polling
+    # service; ``lifecycle`` covers ``assert_bound_loop``.
+    client.artifacts = ArtifactsAPI(
+        rpc=internals.executor,
+        drain=internals.collaborators.drain_tracker,
+        lifecycle=internals.collaborators.lifecycle,
+        notebooks=client.notebooks,
+        mind_maps=mind_maps,
+        note_service=note_service,
+        storage_path=storage_path,
+    )
+    # ChatAPI (per ADR-0014) takes its
+    # four direct collaborators (RpcCaller, RuntimeTransport,
+    # ReqidCounter, LoopGuard) by keyword argument. The transport is
+    # sourced from ``client._composed``; other runtime fields come from
+    # the :class:`ClientInternals` returned by the composition root.
+    client.chat = ChatAPI(
+        rpc=internals.executor,
+        transport=client._composed.transport,
+        reqid=internals.collaborators.reqid,
+        loop_guard=internals.collaborators.lifecycle,
+        chat_timeout=chat_timeout,
+        notebooks=client.notebooks,
+    )
+    client.notes = NotesAPI(
+        notes=note_service,
+        mind_maps=mind_maps,
+    )
+    # Unified mind-map surface over both backends (note-backed + interactive
+    # studio artifact); dispatches each op to the correct RPC family (#1256).
+    client.mind_maps = MindMapsAPI(
+        rpc=internals.executor,
+        mind_maps=mind_maps,
+        artifacts=client.artifacts,
+        notebooks=client.notebooks,
+    )
+    # Pure-RPC features (typed as ``rpc: RpcCaller``). Pass the
+    # ``RpcExecutor`` collaborator directly, sourced from the composed
+    # executor.
+    client.research = ResearchAPI(internals.executor)
+    client.settings = SettingsAPI(internals.executor)
+    client.sharing = SharingAPI(internals.executor)
+    # Source labels. Takes a narrow ``list_sources`` callable (not the whole
+    # SourcesAPI) for the membership->Source join in ``labels.sources()``;
+    # wired after ``client.sources`` exists. Same client/bound loop (ADR-0004).
+    client.labels = LabelsAPI(internals.executor, list_sources=client.sources.list)

--- a/src/notebooklm/_client_assembly.py
+++ b/src/notebooklm/_client_assembly.py
@@ -76,9 +76,12 @@ class _UnsetType:
 
     Used where ``None`` is itself a meaningful caller value
     (``refresh_callback=None`` means "no refresh callback";
-    ``keepalive_storage_path=None`` means "no keepalive persistence"), so
-    the production default ("use ``client.refresh_auth``" / "derive from
-    ``auth.storage_path``") needs a distinct marker.
+    ``keepalive_storage_path=None`` skips the constructor-level
+    canonicalization and lets ``compose_client_internals`` apply its own
+    raw ``auth.storage_path`` fallback — the historical test-shell
+    behavior), so the production default ("use ``client.refresh_auth``" /
+    "derive the canonicalized path from ``auth.storage_path``") needs a
+    distinct marker.
     """
 
 
@@ -180,7 +183,10 @@ def _assemble_client(
     # are intentionally left as the caller provided them — only the
     # internal-derived keepalive storage path is canonicalized. The test
     # factory passes its own ``keepalive_storage_path`` explicitly, which
-    # bypasses the derivation (preserving the historical shell semantics).
+    # bypasses THIS canonicalizing derivation (preserving the historical
+    # shell semantics); an explicit ``None`` still falls through to
+    # ``compose_client_internals``' own raw ``auth.storage_path``
+    # fallback downstream.
     if isinstance(keepalive_storage_path, _UnsetType):
         derived_keepalive_path: Path | None = auth.storage_path
         if derived_keepalive_path is not None:

--- a/src/notebooklm/_client_assembly.py
+++ b/src/notebooklm/_client_assembly.py
@@ -141,8 +141,16 @@ def _assemble_client(
     # of in-place mutation so a caller reusing ``AuthTokens`` across
     # multiple clients (with different storage paths) doesn't see one
     # client's path leak into another.
-    if storage_path is not None and auth.storage_path != storage_path:
-        auth = dataclasses.replace(auth, storage_path=storage_path)
+    # Type-coerce only (``Path(...)``) — deliberately NOT
+    # ``expanduser().resolve()``: the caller-provided ``storage_path`` and
+    # ``auth.storage_path`` stay as supplied (see the keepalive NOTE
+    # below); without the coercion a ``str`` argument would compare
+    # unequal to an identical ``Path`` and bind a raw ``str`` onto
+    # ``auth.storage_path``.
+    if storage_path is not None:
+        storage_path = Path(storage_path)
+        if auth.storage_path != storage_path:
+            auth = dataclasses.replace(auth, storage_path=storage_path)
 
     # Direct client-owned reference to the authoritative ``AuthTokens``
     # instance. Set AFTER the ``storage_path`` normalization above so it

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -31,28 +31,39 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 if TYPE_CHECKING:
-    from ._artifacts import ArtifactsAPI
-    from ._chat import ChatAPI
-    from ._client_composed import ClientComposed
-    from ._client_seams import ClientSeams
-    from ._labels import LabelsAPI
-    from ._mind_maps_api import MindMapsAPI
-    from ._notebooks import NotebooksAPI
-    from ._notes import NotesAPI
-    from ._research import ResearchAPI
-    from ._rpc_executor import RpcExecutor
-    from ._runtime.init import RuntimeCollaborators
-    from ._settings import SettingsAPI
-    from ._sharing import SharingAPI
-    from ._source.upload import SourceUploadPipeline
-    from ._sources import SourcesAPI
     from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
+# The construction wiring lives in ``_client_assembly`` (the seam shared
+# with the canonical test factory), but the names below stay runtime
+# imports on purpose:
+#
+# - the feature-API / collaborator types annotate the class-level
+#   attribute block, and keeping them importable at runtime keeps
+#   ``typing.get_type_hints(NotebookLMClient)`` working for downstream
+#   introspection;
+# - this module's attribute surface (``notebooklm.client.SourcesAPI``
+#   etc.) predates the assembly split and is kept byte-compatible so
+#   external tooling/imports against it don't break. The F401-suppressed
+#   names are exactly the previously-importable names the annotations no
+#   longer reference.
+from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
+from ._chat import ChatAPI
 from ._client_assembly import _assemble_client
+from ._client_composed import ClientComposed
+from ._client_seams import ClientSeams
+from ._client_seams import resolve_client_seams as resolve_client_seams  # noqa: F401
 from ._deprecation import warn_deprecated
 from ._env import get_base_url as get_base_url
+from ._labels import LabelsAPI
+from ._mind_map import NoteBackedMindMapService as NoteBackedMindMapService  # noqa: F401
+from ._mind_maps_api import MindMapsAPI
+from ._note_service import NoteService as NoteService  # noqa: F401
+from ._notebooks import NotebooksAPI
+from ._notes import NotesAPI
+from ._research import ResearchAPI
+from ._rpc_executor import RpcExecutor
 from ._runtime.config import (
     DEFAULT_CHAT_TIMEOUT,
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -60,7 +71,13 @@ from ._runtime.config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
+from ._runtime.init import RuntimeCollaborators
+from ._runtime.init import compose_client_internals as compose_client_internals  # noqa: F401
 from ._runtime.lifecycle import CookieRotator, CookieSaver
+from ._settings import SettingsAPI
+from ._sharing import SharingAPI
+from ._source.upload import SourceUploadPipeline
+from ._sources import SourcesAPI
 from ._url_utils import is_google_auth_redirect as is_google_auth_redirect
 from .auth import AuthTokens
 from .auth import authuser_query as authuser_query

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -22,7 +22,6 @@ Example:
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import logging
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -32,23 +31,28 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 if TYPE_CHECKING:
+    from ._artifacts import ArtifactsAPI
+    from ._chat import ChatAPI
+    from ._client_composed import ClientComposed
+    from ._client_seams import ClientSeams
+    from ._labels import LabelsAPI
+    from ._mind_maps_api import MindMapsAPI
+    from ._notebooks import NotebooksAPI
+    from ._notes import NotesAPI
+    from ._research import ResearchAPI
+    from ._rpc_executor import RpcExecutor
+    from ._runtime.init import RuntimeCollaborators
+    from ._settings import SettingsAPI
+    from ._sharing import SharingAPI
+    from ._source.upload import SourceUploadPipeline
+    from ._sources import SourcesAPI
     from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
-from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
-from ._chat import ChatAPI
-from ._client_composed import ClientComposed
-from ._client_seams import resolve_client_seams
+from ._client_assembly import _assemble_client
 from ._deprecation import warn_deprecated
 from ._env import get_base_url as get_base_url
-from ._labels import LabelsAPI
-from ._mind_map import NoteBackedMindMapService
-from ._mind_maps_api import MindMapsAPI
-from ._note_service import NoteService
-from ._notebooks import NotebooksAPI
-from ._notes import NotesAPI
-from ._research import ResearchAPI
 from ._runtime.config import (
     DEFAULT_CHAT_TIMEOUT,
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -56,12 +60,7 @@ from ._runtime.config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
-from ._runtime.init import compose_client_internals
 from ._runtime.lifecycle import CookieRotator, CookieSaver
-from ._settings import SettingsAPI
-from ._sharing import SharingAPI
-from ._source.upload import SourceUploadPipeline
-from ._sources import SourcesAPI
 from ._url_utils import is_google_auth_redirect as is_google_auth_redirect
 from .auth import AuthTokens
 from .auth import authuser_query as authuser_query
@@ -109,6 +108,30 @@ class NotebookLMClient:
         labels: LabelsAPI for source labels (topic grouping)
         auth: The AuthTokens used for authentication
     """
+
+    # Constructor-set attribute surface. Declared here (annotation-only;
+    # no runtime effect) because the assignments live in the shared
+    # assembly seam :func:`notebooklm._client_assembly._assemble_client`,
+    # not in ``__init__`` — see the delegation comment there. Keep this
+    # block in sync with ``_assemble_client``; the parity gate
+    # ``tests/_guardrails/test_client_factory_parity.py`` pins the
+    # runtime attribute surface itself.
+    _auth: AuthTokens
+    _seams: ClientSeams
+    _composed: ClientComposed
+    _collaborators: RuntimeCollaborators
+    _rpc_executor: RpcExecutor
+    _source_uploader: SourceUploadPipeline
+    sources: SourcesAPI
+    notebooks: NotebooksAPI
+    artifacts: ArtifactsAPI
+    chat: ChatAPI
+    notes: NotesAPI
+    mind_maps: MindMapsAPI
+    research: ResearchAPI
+    settings: SettingsAPI
+    sharing: SharingAPI
+    labels: LabelsAPI
 
     def __init__(
         self,
@@ -225,235 +248,35 @@ class NotebookLMClient:
                 late-bound wrapper. Must be async — it is awaited from
                 the keepalive loop.
         """
-        # Normalize the effective storage path onto the auth object so every
-        # downstream code path (refresh_auth, lifecycle on-close save,
-        # the keepalive loop) writes to the same file. Without this, an
-        # explicit ``storage_path=`` kwarg only reaches the keepalive loop
-        # while ``auth.storage_path is None`` causes refresh and on-close
-        # saves to silently skip persistence. ``dataclasses.replace`` instead
-        # of in-place mutation so a caller reusing ``AuthTokens`` across
-        # multiple clients (with different storage paths) doesn't see one
-        # client's path leak into another.
-        if storage_path is not None and auth.storage_path != storage_path:
-            auth = dataclasses.replace(auth, storage_path=storage_path)
-
-        # Direct client-owned reference to the authoritative ``AuthTokens``
-        # instance. Set AFTER the ``storage_path`` normalization above so it
-        # captures the same (possibly rebound) instance that
-        # :func:`compose_client_internals` then propagates into
-        # :class:`CookiePersistence`, the snapshot-provider lambdas,
-        # and :class:`SourceUploadPipeline`. ADR-0016's Auth Instance
-        # Invariant requires every reference across the live object graph
-        # to alias this exact same mutable object so
-        # :meth:`AuthRefreshCoordinator.update_auth_tokens` in-place
-        # mutations are observed everywhere.
-        #
-        # ``refresh_auth()``, the public ``auth`` property, and the
-        # ``SourceUploadPipeline(auth=...)`` constructor argument all back
-        # off this field. The client shell helper
+        # The full assembly lives in ``notebooklm._client_assembly`` —
+        # one private seam shared with the canonical test factory
         # (``tests/_helpers/client_factory.build_client_shell_for_tests``)
-        # mirrors the production attribute shape so tests exercise the
-        # same code path as production.
-        self._auth = auth
-
-        # Canonicalize the keepalive storage path so different representations
-        # of the same physical file (relative vs absolute, ``~`` shorthand,
-        # symlink components) hash to the same key in the in-process rotation
-        # dedupe (``_get_poke_lock`` / ``_try_claim_rotation`` /
-        # ``_rotation_lock_path`` in auth.py). The auth refresh path already
-        # canonicalizes at ``auth.py:_fetch_tokens_with_refresh`` via
-        # ``Path(p).expanduser().resolve()``; this mirrors it so two clients
-        # pointing at the same file via different path syntaxes share one
-        # ``_LAST_POKE_ATTEMPT_MONOTONIC`` entry instead of bypassing dedupe
-        # and firing duplicate ``RotateCookies`` POSTs.
-        # NOTE: the public ``storage_path`` argument and ``auth.storage_path``
-        # are intentionally left as the caller provided them — only the
-        # internal-derived keepalive storage path is
-        # canonicalized.
-        keepalive_storage_path: Path | None = auth.storage_path
-        if keepalive_storage_path is not None:
-            keepalive_storage_path = Path(keepalive_storage_path).expanduser().resolve()
-
-        # Cross-validate the RPC throttle against the underlying httpx pool
-        # before the collaborator builder swallows the ``limits=None``
-        # sentinel into its own ``ConnectionLimits()`` synthesis.
-        # Performed here so the constraint is enforced uniformly regardless
-        # of whether the caller passed an explicit ``ConnectionLimits``
-        # instance or relied on the default — scalar config validation
-        # can't see the caller's intent once the default has been substituted.
-        # Skip when either side opts out (``max_concurrent_rpcs is None``
-        # means "no gate"; we deliberately don't second-guess the caller's
-        # external-throttle setup).
-        if max_concurrent_rpcs is not None:
-            from .types import ConnectionLimits
-
-            effective_limits = limits if limits is not None else ConnectionLimits()
-            if max_concurrent_rpcs > effective_limits.max_connections:
-                raise ValueError(
-                    "max_concurrent_rpcs must be <= limits.max_connections "
-                    f"(got max_concurrent_rpcs={max_concurrent_rpcs}, "
-                    f"max_connections={effective_limits.max_connections}). "
-                    "A semaphore wider than the connection pool surfaces "
-                    "saturation as opaque httpx.PoolTimeout instead of "
-                    "clean back-pressure."
-                )
-
-        # The client is the composition root: :func:`compose_client_internals`
-        # binds composition state onto ``self._composed`` and returns only the
-        # collaborators + executor that feature adapters need.
-        #
-        # The public NotebookLMClient kwarg surface is unchanged — the
-        # four seam kwargs (``decode_response`` / ``sleep`` /
-        # ``is_auth_error`` / ``async_client_factory``) live on
-        # ``compose_client_internals`` and the client-shell test helper
-        # only.
-        #
-        # TEST-ONLY injection points: production passes ``None`` for all
-        # three runtime seams here (and never supplies an
-        # ``async_client_factory``), so they always resolve to the
-        # canonical module bindings. The non-``None`` paths exist solely
-        # for deterministic test injection — see ``_client_seams`` module
-        # docstring. Do not promote any of them to a public kwarg without
-        # a production caller that varies them.
-        self._seams = resolve_client_seams(
-            decode_response=None,
-            sleep=None,
-            is_auth_error=None,
-        )
-        self._composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
-
-        internals = compose_client_internals(
+        # so the two construction paths cannot drift (incidents #1196 /
+        # #1225). Set EVERY constructor-time attribute inside
+        # ``_assemble_client``, never here after the delegation call —
+        # the parity gate
+        # ``tests/_guardrails/test_client_factory_parity.py`` fails
+        # otherwise. The test-only seam kwargs (``decode_response`` /
+        # ``sleep`` / ``is_auth_error`` / ``async_client_factory``) stay
+        # off this public constructor by design.
+        _assemble_client(
+            self,
             auth=auth,
             timeout=timeout,
-            refresh_callback=self.refresh_auth,
+            storage_path=storage_path,
             keepalive=keepalive,
             keepalive_min_interval=keepalive_min_interval,
-            keepalive_storage_path=keepalive_storage_path,
             rate_limit_max_retries=rate_limit_max_retries,
             server_error_max_retries=server_error_max_retries,
             limits=limits,
             max_concurrent_uploads=max_concurrent_uploads,
             max_concurrent_rpcs=max_concurrent_rpcs,
+            upload_timeout=upload_timeout,
             on_rpc_event=on_rpc_event,
-            # Injectable seams — pass-through to the lifecycle. ``None``
-            # (default) preserves the late-binding contract via
-            # ``_default_cookie_saver`` / ``_default_cookie_rotator``.
             cookie_saver=cookie_saver,
             cookie_rotator=cookie_rotator,
-            seams=self._seams,
-            composed=self._composed,
-        )
-        # Owned reference to the collaborator bundle so
-        # :meth:`metrics_snapshot` (and any future
-        # NotebookLMClient-side collaborator consumers) read from the
-        # same bundle feature internals use.
-        self._collaborators = internals.collaborators
-        # Owned reference to the RPC executor so ``client.rpc_call``
-        # dispatches through it directly rather than through a
-        # compatibility wrapper. The executor satisfies the
-        # ``RpcCaller`` Protocol and is the same instance the feature
-        # APIs receive (``internals.executor`` is shared with
-        # ``SourcesAPI`` / ``NotebooksAPI`` / ``ArtifactsRuntimeAdapter``
-        # / ``ChatAPI`` / etc., so a test that swaps the executor's
-        # ``rpc_call`` sees the swap on every feature consumer).
-        self._rpc_executor = internals.executor
-
-        # ADR-0014 Rule 2: the upload pipeline takes its three runtime
-        # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
-        # instead of via a composite-runtime adapter. ``Kernel`` and
-        # ``AuthMetadata`` continue to flow as separate parameters per
-        # the ADR-0014 Rule 6 example. ``NotebookLMClient.__init__`` is
-        # the composition root that knows these internals;
-        # ``SourcesAPI`` no longer reads them back off a broad host.
-        source_uploader = SourceUploadPipeline(
-            rpc=internals.executor,
-            drain=internals.collaborators.drain_tracker,
-            lifecycle=internals.collaborators.lifecycle,
-            kernel=internals.collaborators.kernel,
-            # ADR-0016's Auth Instance Invariant: the upload pipeline
-            # reads the client-owned ``self._auth`` reference set above
-            # instead of a detached auth copy. Production refresh-time
-            # mutation is therefore observed by the uploader unchanged.
-            auth=self._auth,
-            upload_timeout=upload_timeout,
-            max_concurrent_uploads=max_concurrent_uploads,
-            record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
-        )
-        # Hold the uploader as a first-class client attribute so the
-        # open-time loop-affinity reset (issue #1196 upload variant) can
-        # reach it independently of the ``self.sources`` feature surface:
-        # the upload semaphore is a lazily-built loop-bound
-        # ``asyncio.Semaphore`` that must be discarded on close→reopen, the
-        # same as the RPC semaphore. ``__aenter__`` threads this into
-        # ``ClientLifecycle.open`` which calls
-        # ``set_bound_loop`` / ``reset_after_open`` on it.
-        self._source_uploader = source_uploader
-        # Per ADR-0014 Rule 3: simple features take their RpcCaller dependency
-        # directly from the composition root's executor.
-        self.sources = SourcesAPI(
-            internals.executor,
-            uploader=source_uploader,
-            upload_timeout=upload_timeout,
-            max_concurrent_uploads=max_concurrent_uploads,
-        )
-        self.notebooks = NotebooksAPI(internals.executor, sources_api=self.sources)
-        # Note wiring (see docs/refactor-history.md): an explicit
-        # NoteService + NoteBackedMindMapService split. NoteService owns the
-        # raw row primitives; NoteBackedMindMapService is the mind-map-only
-        # adapter the download path uses; the artifact-generation path uses
-        # NoteService.create_note directly to persist a generated mind map.
-        note_service = NoteService(internals.executor)
-        mind_maps = NoteBackedMindMapService(note_service)
-        # ADR-0014 Rule 2: the artifacts API takes its three runtime
-        # collaborators (``rpc`` + ``drain`` + ``lifecycle``) directly
-        # instead of via a composite-runtime adapter. ``rpc`` covers
-        # RPC dispatch; ``drain`` covers ``operation_scope`` and the
-        # close-time ``register_drain_hook`` used by the polling
-        # service; ``lifecycle`` covers ``assert_bound_loop``.
-        self.artifacts = ArtifactsAPI(
-            rpc=internals.executor,
-            drain=internals.collaborators.drain_tracker,
-            lifecycle=internals.collaborators.lifecycle,
-            notebooks=self.notebooks,
-            mind_maps=mind_maps,
-            note_service=note_service,
-            storage_path=storage_path,
-        )
-        # ChatAPI (per ADR-0014) takes its
-        # four direct collaborators (RpcCaller, RuntimeTransport,
-        # ReqidCounter, LoopGuard) by keyword argument. The transport is
-        # sourced from ``self._composed``; other runtime fields come from
-        # the :class:`ClientInternals` returned by the composition root.
-        self.chat = ChatAPI(
-            rpc=internals.executor,
-            transport=self._composed.transport,
-            reqid=internals.collaborators.reqid,
-            loop_guard=internals.collaborators.lifecycle,
             chat_timeout=chat_timeout,
-            notebooks=self.notebooks,
         )
-        self.notes = NotesAPI(
-            notes=note_service,
-            mind_maps=mind_maps,
-        )
-        # Unified mind-map surface over both backends (note-backed + interactive
-        # studio artifact); dispatches each op to the correct RPC family (#1256).
-        self.mind_maps = MindMapsAPI(
-            rpc=internals.executor,
-            mind_maps=mind_maps,
-            artifacts=self.artifacts,
-            notebooks=self.notebooks,
-        )
-        # Pure-RPC features (typed as ``rpc: RpcCaller``). Pass the
-        # ``RpcExecutor`` collaborator directly, sourced from the composed
-        # executor.
-        self.research = ResearchAPI(internals.executor)
-        self.settings = SettingsAPI(internals.executor)
-        self.sharing = SharingAPI(internals.executor)
-        # Source labels. Takes a narrow ``list_sources`` callable (not the whole
-        # SourcesAPI) for the membership->Source join in ``labels.sources()``;
-        # wired after ``self.sources`` exists. Same client/bound loop (ADR-0004).
-        self.labels = LabelsAPI(internals.executor, list_sources=self.sources.list)
 
     @property
     def auth(self) -> AuthTokens:
@@ -856,10 +679,12 @@ class NotebookLMClient:
         Invariant guarantees this is the same object every auth consumer
         observes), and the remaining four come from the collaborator
         bundle the composition root produced
-        (:func:`compose_client_internals`). The
+        (:func:`notebooklm._runtime.init.compose_client_internals`). The
         ``tests/_helpers/client_factory.build_client_shell_for_tests``
-        helper wires ``_auth`` and ``_collaborators`` from the composed
-        runtime directly, so test shells observe the same resolution path.
+        helper wires ``_auth`` and ``_collaborators`` through the same
+        :func:`notebooklm._client_assembly._assemble_client` seam this
+        constructor delegates to, so test shells observe the same
+        resolution path.
 
         Returns:
             Updated AuthTokens.

--- a/tests/_guardrails/_ast_reach_in.py
+++ b/tests/_guardrails/_ast_reach_in.py
@@ -18,24 +18,31 @@ from __future__ import annotations
 import ast
 
 
-def _self_attr_name(node: ast.AST) -> str | None:
+def _owned_attr_name(node: ast.AST, owner: str = "self") -> str | None:
+    """``<owner>.<attr>`` → ``attr`` (``owner`` is the host-object name).
+
+    ``owner`` defaults to ``"self"`` for method bodies; the client-assembly
+    checks pass ``owner="client"`` because the construction seam
+    (``notebooklm._client_assembly._assemble_client``) binds the instance
+    to a ``client`` parameter instead of ``self``.
+    """
     if (
         isinstance(node, ast.Attribute)
         and isinstance(node.value, ast.Name)
-        and node.value.id == "self"
+        and node.value.id == owner
     ):
         return node.attr
     return None
 
 
-def _assigned_self_attr_name(node: ast.AST) -> str | None:
+def _assigned_owned_attr_name(node: ast.AST, owner: str = "self") -> str | None:
     if isinstance(node, ast.Assign):
         for target in node.targets:
-            attr_name = _self_attr_name(target)
+            attr_name = _owned_attr_name(target, owner=owner)
             if attr_name is not None:
                 return attr_name
     if isinstance(node, ast.AnnAssign):
-        return _self_attr_name(node.target)
+        return _owned_attr_name(node.target, owner=owner)
     return None
 
 
@@ -47,24 +54,23 @@ def _assignment_value(node: ast.AST) -> ast.AST | None:
     return None
 
 
-def _self_attr_assignment(body: list[ast.stmt], attr_name: str) -> tuple[int, ast.stmt]:
+def _owned_attr_assignment(
+    body: list[ast.stmt], attr_name: str, owner: str = "self"
+) -> tuple[int, ast.stmt]:
     for index, statement in enumerate(body):
-        if _assigned_self_attr_name(statement) == attr_name:
+        if _assigned_owned_attr_name(statement, owner=owner) == attr_name:
             return index, statement
-    raise AssertionError(f"self.{attr_name} assignment not found")
+    raise AssertionError(f"{owner}.{attr_name} assignment not found")
 
 
-def _method_body(tree: ast.AST, class_name: str, method_name: str) -> list[ast.stmt]:
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef) or node.name != class_name:
-            continue
-        for item in node.body:
-            if (
-                isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
-                and item.name == method_name
-            ):
-                return item.body
-    raise AssertionError(f"{class_name}.{method_name} not found")
+def _module_function_body(tree: ast.AST, function_name: str) -> list[ast.stmt]:
+    """Body of a module-level (non-class) function definition."""
+    if not isinstance(tree, ast.Module):
+        raise AssertionError("expected an ast.Module")
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            return node.body
+    raise AssertionError(f"module-level function {function_name} not found")
 
 
 def _facade_call_name(node: ast.AST, facade_names: set[str]) -> str | None:

--- a/tests/_guardrails/test_client_composition.py
+++ b/tests/_guardrails/test_client_composition.py
@@ -26,7 +26,10 @@ CLIENT_HOST_NAMES = {"self", "client"}
 FEATURE_API_NAMES = {
     "ArtifactsAPI",
     "ChatAPI",
+    "LabelsAPI",
+    "MindMapsAPI",
     "NotebooksAPI",
+    "NoteBackedMindMapService",
     "NotesAPI",
     "ResearchAPI",
     "SettingsAPI",

--- a/tests/_guardrails/test_client_composition.py
+++ b/tests/_guardrails/test_client_composition.py
@@ -5,9 +5,23 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLIENT_PATH = REPO_ROOT / "src" / "notebooklm" / "client.py"
+ASSEMBLY_PATH = REPO_ROOT / "src" / "notebooklm" / "_client_assembly.py"
 COMPOSED_PATH = REPO_ROOT / "src" / "notebooklm" / "_client_composed.py"
+
+# Both composition-root files: ``client.py`` (the thin ``__init__``
+# delegate) and ``_client_assembly.py`` (the shared assembly seam the
+# constructor and the canonical test factory both run). The guards below
+# scan both so moving wiring between them can't dodge the gate.
+COMPOSITION_ROOT_PATHS = (CLIENT_PATH, ASSEMBLY_PATH)
+
+# Names a composition-root scope may bind the client instance to:
+# ``self`` inside ``NotebookLMClient`` methods, ``client`` inside
+# ``_assemble_client``.
+CLIENT_HOST_NAMES = {"self", "client"}
 
 FEATURE_API_NAMES = {
     "ArtifactsAPI",
@@ -36,8 +50,9 @@ def _tree(path: Path) -> ast.AST:
     return ast.parse(path.read_text(encoding="utf-8"))
 
 
-def test_features_receive_specific_collaborators_not_whole_client() -> None:
-    tree = _tree(CLIENT_PATH)
+@pytest.mark.parametrize("path", COMPOSITION_ROOT_PATHS, ids=lambda p: p.name)
+def test_features_receive_specific_collaborators_not_whole_client(path: Path) -> None:
+    tree = _tree(path)
     violations: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
@@ -45,31 +60,32 @@ def test_features_receive_specific_collaborators_not_whole_client() -> None:
         if node.func.id not in FEATURE_API_NAMES:
             continue
         for arg in node.args:
-            if isinstance(arg, ast.Name) and arg.id == "self":
-                violations.append(f"{node.func.id} line {node.lineno}: passes self")
+            if isinstance(arg, ast.Name) and arg.id in CLIENT_HOST_NAMES:
+                violations.append(f"{node.func.id} line {node.lineno}: passes {arg.id}")
         for kw in node.keywords:
-            if isinstance(kw.value, ast.Name) and kw.value.id == "self":
-                violations.append(f"{node.func.id} line {node.lineno}: passes self")
+            if isinstance(kw.value, ast.Name) and kw.value.id in CLIENT_HOST_NAMES:
+                violations.append(f"{node.func.id} line {node.lineno}: passes {kw.value.id}")
 
     assert not violations, (
-        "Feature APIs must receive explicit collaborators, not the whole client:\n  "
-        + "\n  ".join(violations)
+        f"Feature APIs in {path.name} must receive explicit collaborators, "
+        "not the whole client:\n  " + "\n  ".join(violations)
     )
 
 
-def test_notebooklm_client_does_not_inline_composition_holder_state() -> None:
-    tree = _tree(CLIENT_PATH)
+@pytest.mark.parametrize("path", COMPOSITION_ROOT_PATHS, ids=lambda p: p.name)
+def test_notebooklm_client_does_not_inline_composition_holder_state(path: Path) -> None:
+    tree = _tree(path)
     violations: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Attribute):
             continue
         if node.attr not in INLINE_CLIENT_ATTRS:
             continue
-        if isinstance(node.value, ast.Name) and node.value.id == "self":
-            violations.append(f"line {node.lineno}: self.{node.attr}")
+        if isinstance(node.value, ast.Name) and node.value.id in CLIENT_HOST_NAMES:
+            violations.append(f"line {node.lineno}: {node.value.id}.{node.attr}")
 
     assert not violations, (
-        "NotebookLMClient must keep composition holder state on ClientComposed:\n  "
+        f"{path.name} must keep composition holder state on ClientComposed:\n  "
         + "\n  ".join(violations)
     )
 

--- a/tests/_guardrails/test_client_factory_parity.py
+++ b/tests/_guardrails/test_client_factory_parity.py
@@ -1,0 +1,126 @@
+"""Gate: the canonical test factory and the production constructor never diverge.
+
+Rule: a client built by ``tests/_helpers/client_factory.build_client_shell_for_tests``
+must carry exactly the same instance-attribute surface (names AND attribute
+types) as one built by ``NotebookLMClient(...)``.
+
+Why it matters: the factory used to hand-wire private attributes against
+``NotebookLMClient.__new__``. That duplicated wiring drifted twice —
+issue #1196 (the open-time upload-semaphore loop reset needed
+``_source_uploader``) and issue #1225 (the open-time ChatAPI
+conversation-lock reset needed ``chat``) — each time silently stranding
+the shell that the whole unit tier builds on. Both paths now run one
+shared seam, :func:`notebooklm._client_assembly._assemble_client`, so the
+remaining drift vector is wiring added OUTSIDE the seam (e.g. a new
+``self.foo = ...`` in ``NotebookLMClient.__init__`` after the delegation
+call, or a factory-only attribute). This gate catches exactly that.
+
+How to fix a failure: move the new attribute assignment into
+``_assemble_client`` (with a parameter default that preserves production
+behavior) instead of setting it in ``__init__`` or in the factory — see
+the module docstring of ``notebooklm._client_assembly``.
+
+Per docs/development.md gate conventions the comparison is a pure
+function (:func:`_attribute_surface_divergence`) self-tested below
+against known-divergent inputs so the gate cannot silently become
+vacuous.
+"""
+
+from __future__ import annotations
+
+from _helpers.client_factory import build_client_shell_for_tests
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+
+
+def _attribute_surface_divergence(
+    production: dict[str, type],
+    factory: dict[str, type],
+) -> list[str]:
+    """Pure detector: differences between two ``{attr_name: type}`` surfaces.
+
+    Returns a list of human-readable divergence descriptions (empty =
+    parity). Checks both directions plus per-attribute type equality, so
+    a factory that wires a stand-in object where production wires the
+    real collaborator is also caught.
+    """
+    problems: list[str] = []
+    for name in sorted(production.keys() - factory.keys()):
+        problems.append(
+            f"attribute {name!r} is set by NotebookLMClient.__init__ but missing "
+            "on a factory-built shell — move its assignment into "
+            "notebooklm._client_assembly._assemble_client (incidents #1196/#1225)"
+        )
+    for name in sorted(factory.keys() - production.keys()):
+        problems.append(
+            f"attribute {name!r} is set on a factory-built shell but not by "
+            "NotebookLMClient.__init__ — the factory must not wire extras "
+            "outside _assemble_client"
+        )
+    for name in sorted(production.keys() & factory.keys()):
+        if production[name] is not factory[name]:
+            problems.append(
+                f"attribute {name!r} type diverges: production wires "
+                f"{production[name].__name__}, factory wires {factory[name].__name__}"
+            )
+    return problems
+
+
+def _attribute_surface(client: NotebookLMClient) -> dict[str, type]:
+    return {name: type(value) for name, value in vars(client).items()}
+
+
+def _make_auth() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "test-sid"},
+        csrf_token="test-csrf",
+        session_id="test-session",
+    )
+
+
+def test_factory_shell_matches_production_constructor_surface() -> None:
+    """The real gate: build through both paths and compare surfaces.
+
+    Both clients are constructed but never opened — construction is pure
+    object wiring (no I/O, no event-loop binding; the loop binds at
+    ``open()`` time), so this is safe in the no-network unit tier.
+    """
+    production = NotebookLMClient(_make_auth())
+    shell = build_client_shell_for_tests(auth=_make_auth())
+
+    problems = _attribute_surface_divergence(
+        _attribute_surface(production),
+        _attribute_surface(shell),
+    )
+    assert problems == [], (
+        "build_client_shell_for_tests diverged from NotebookLMClient.__init__ "
+        "(the #1196/#1225 drift class):\n  " + "\n  ".join(problems)
+    )
+
+
+# --- detector self-tests (non-vacuity, per docs/development.md) ------------
+
+
+def test_detector_flags_attribute_missing_on_factory_shell() -> None:
+    problems = _attribute_surface_divergence({"chat": object, "x": int}, {"chat": object})
+    assert len(problems) == 1
+    assert "'x'" in problems[0]
+    assert "missing" in problems[0]
+
+
+def test_detector_flags_factory_only_attribute() -> None:
+    problems = _attribute_surface_divergence({"chat": object}, {"chat": object, "y": int})
+    assert len(problems) == 1
+    assert "'y'" in problems[0]
+    assert "not by" in problems[0]
+
+
+def test_detector_flags_type_divergence() -> None:
+    problems = _attribute_surface_divergence({"chat": int}, {"chat": str})
+    assert len(problems) == 1
+    assert "type diverges" in problems[0]
+
+
+def test_detector_accepts_parity() -> None:
+    surface = {"chat": object, "_auth": dict}
+    assert _attribute_surface_divergence(surface, dict(surface)) == []

--- a/tests/_guardrails/test_client_factory_parity.py
+++ b/tests/_guardrails/test_client_factory_parity.py
@@ -98,6 +98,40 @@ def test_factory_shell_matches_production_constructor_surface() -> None:
     )
 
 
+def test_shared_wiring_identities_hold_on_both_paths() -> None:
+    """Identity pins the surface comparison cannot see.
+
+    The name+type comparison above would miss *same-type rewiring* — e.g.
+    a path that builds its ``ChatAPI`` against a privately constructed
+    ``NotebooksAPI`` instead of the client's own (the #1225 drift was an
+    open-time dependency on exactly this kind of shared wiring). Pin the
+    load-bearing identities on BOTH construction paths:
+
+    - ``chat`` resolves source ids through the client's own ``notebooks``;
+    - every collaborator consumer shares the one RPC executor;
+    - the uploader aliases the client-owned ``AuthTokens`` (ADR-0016's
+      Auth Instance Invariant).
+    """
+    for label, client in (
+        ("NotebookLMClient(...)", NotebookLMClient(_make_auth())),
+        ("build_client_shell_for_tests(...)", build_client_shell_for_tests(auth=_make_auth())),
+    ):
+        assert client.chat._notebooks is client.notebooks, (
+            f"{label}: chat must share the client's NotebooksAPI instance, "
+            "not a privately constructed one"
+        )
+        assert client.notebooks._rpc is client._rpc_executor, (
+            f"{label}: notebooks must dispatch through the client's shared RpcExecutor"
+        )
+        assert client._source_uploader._auth is client._auth, (
+            f"{label}: the upload pipeline must alias the client-owned AuthTokens "
+            "(ADR-0016 Auth Instance Invariant)"
+        )
+        assert client.auth is client._auth, (
+            f"{label}: the public auth property must alias the client-owned AuthTokens"
+        )
+
+
 # --- detector self-tests (non-vacuity, per docs/development.md) ------------
 
 

--- a/tests/_guardrails/test_client_factory_parity.py
+++ b/tests/_guardrails/test_client_factory_parity.py
@@ -112,20 +112,25 @@ def test_shared_wiring_identities_hold_on_both_paths() -> None:
     - the uploader aliases the client-owned ``AuthTokens`` (ADR-0016's
       Auth Instance Invariant).
     """
+    _missing = object()
     for label, client in (
         ("NotebookLMClient(...)", NotebookLMClient(_make_auth())),
         ("build_client_shell_for_tests(...)", build_client_shell_for_tests(auth=_make_auth())),
     ):
-        assert client.chat._notebooks is client.notebooks, (
-            f"{label}: chat must share the client's NotebooksAPI instance, "
-            "not a privately constructed one"
+        # ``getattr`` with a sentinel so a renamed private storage
+        # attribute fails THIS assertion with the contract message
+        # instead of an unexplained AttributeError.
+        assert getattr(client.chat, "_notebooks", _missing) is client.notebooks, (
+            f"{label}: chat must share the client's NotebooksAPI instance "
+            "(ChatAPI._notebooks), not a privately constructed one"
         )
-        assert client.notebooks._rpc is client._rpc_executor, (
-            f"{label}: notebooks must dispatch through the client's shared RpcExecutor"
+        assert getattr(client.notebooks, "_rpc", _missing) is client._rpc_executor, (
+            f"{label}: notebooks (NotebooksAPI._rpc) must dispatch through the "
+            "client's shared RpcExecutor"
         )
-        assert client._source_uploader._auth is client._auth, (
-            f"{label}: the upload pipeline must alias the client-owned AuthTokens "
-            "(ADR-0016 Auth Instance Invariant)"
+        assert getattr(client._source_uploader, "_auth", _missing) is client._auth, (
+            f"{label}: the upload pipeline (SourceUploadPipeline._auth) must alias "
+            "the client-owned AuthTokens (ADR-0016 Auth Instance Invariant)"
         )
         assert client.auth is client._auth, (
             f"{label}: the public auth property must alias the client-owned AuthTokens"

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -76,7 +76,9 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_source/upload.py": 1236,
     "_sources.py": 1007,
     "_artifact/downloads.py": 1033,
-    "client.py": 993,
+    # client.py dropped below the budget when its ``__init__`` body moved to
+    # ``_client_assembly.py`` (the shared constructor/test-factory seam), so
+    # its ceiling entry was removed per the one-way-ratchet rule.
     "_research.py": 936,
     "_chat/api.py": 955,
 }

--- a/tests/_helpers/client_factory.py
+++ b/tests/_helpers/client_factory.py
@@ -8,9 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from notebooklm._chat import ChatAPI
-from notebooklm._client_composed import ClientComposed
-from notebooklm._client_seams import resolve_client_seams
+from notebooklm._client_assembly import _assemble_client
 from notebooklm._runtime.config import (
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -18,9 +16,7 @@ from notebooklm._runtime.config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     DEFAULT_TIMEOUT,
 )
-from notebooklm._runtime.init import compose_client_internals
 from notebooklm._runtime.lifecycle import CookieRotator, CookieSaver
-from notebooklm._source.upload import SourceUploadPipeline
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 from notebooklm.types import RpcTelemetryEvent
@@ -52,20 +48,36 @@ def build_client_shell_for_tests(
     is_auth_error: Callable[[Exception], bool] | None = None,
     async_client_factory: Callable[..., httpx.AsyncClient] | None = None,
 ) -> NotebookLMClient:
-    """Build a minimal client shell with composed runtime attributes populated.
+    """Build a client shell through the production assembly seam.
 
     The helper preserves the historical test-only seam kwargs without adding
-    them to :class:`NotebookLMClient`'s public constructor. It intentionally
-    does not construct feature API attributes; tests that need the public
-    feature surface should instantiate :class:`NotebookLMClient` directly.
+    them to :class:`NotebookLMClient`'s public constructor: it creates an
+    uninitialized instance and runs the same
+    :func:`notebooklm._client_assembly._assemble_client` function that
+    ``NotebookLMClient.__init__`` delegates to, forwarding the seam kwargs
+    that only exist on the assembly function.
+
+    Because the wiring is the production function itself, a constructor
+    refactor can no longer strand this factory the way issues #1196
+    (open-time upload-semaphore loop reset needed ``_source_uploader``)
+    and #1225 (open-time ChatAPI conversation-lock reset needed ``chat``)
+    did when this helper still hand-wired private attributes against
+    ``NotebookLMClient.__new__``. The shell therefore carries the full
+    production attribute surface (feature APIs included) — pinned by
+    ``tests/_guardrails/test_client_factory_parity.py``.
+
+    Shell-specific defaults (unchanged from the historical helper):
+
+    - ``refresh_callback=None`` — no auth-refresh coordination unless a
+      test injects one (production wires ``client.refresh_auth``).
+    - ``keepalive_storage_path=None`` — passed through verbatim; the
+      production derivation from ``auth.storage_path`` is bypassed.
+    - The client is returned **unopened**: loop binding still happens at
+      ``open()`` time (via ``__aenter__``), exactly as in production.
     """
-    seams = resolve_client_seams(
-        decode_response=decode_response,
-        sleep=sleep,
-        is_auth_error=is_auth_error,
-    )
-    composed = ClientComposed(max_concurrent_rpcs=max_concurrent_rpcs)
-    internals = compose_client_internals(
+    client = NotebookLMClient.__new__(NotebookLMClient)
+    _assemble_client(
+        client,
         auth=auth,
         timeout=timeout,
         connect_timeout=connect_timeout,
@@ -82,41 +94,9 @@ def build_client_shell_for_tests(
         on_rpc_event=on_rpc_event,
         cookie_saver=cookie_saver,
         cookie_rotator=cookie_rotator,
+        decode_response=decode_response,
+        sleep=sleep,
+        is_auth_error=is_auth_error,
         async_client_factory=async_client_factory,
-        seams=seams,
-        composed=composed,
-    )
-
-    client = NotebookLMClient.__new__(NotebookLMClient)
-    client._auth = auth
-    client._seams = seams
-    client._composed = composed
-    client._collaborators = internals.collaborators
-    client._rpc_executor = internals.executor
-    # The shell skips feature-API construction, but ``ClientLifecycle.open``
-    # (driven via ``client.__aenter__``) now resets the upload semaphore's
-    # loop binding through ``client._source_uploader`` (issue #1196 upload
-    # variant), so the shell must wire a real uploader the same way
-    # ``NotebookLMClient.__init__`` does.
-    client._source_uploader = SourceUploadPipeline(
-        rpc=internals.executor,
-        drain=internals.collaborators.drain_tracker,
-        lifecycle=internals.collaborators.lifecycle,
-        kernel=internals.collaborators.kernel,
-        auth=auth,
-        max_concurrent_uploads=max_concurrent_uploads,
-        record_upload_queue_wait=internals.collaborators.metrics.record_upload_queue_wait,
-    )
-    # ``ClientLifecycle.open`` (driven via ``client.__aenter__``) also resets
-    # the ChatAPI conversation-lock loop binding through ``client.chat``
-    # (issue #1225), so the shell must wire a real ChatAPI the same way
-    # ``NotebookLMClient.__init__`` does. Defaults are sufficient: the shell
-    # exercises lifecycle open/close + cross-loop reset, not the full chat
-    # graph, so a bare ChatAPI over the composed collaborators is enough.
-    client.chat = ChatAPI(
-        rpc=internals.executor,
-        transport=composed.transport,
-        reqid=internals.collaborators.reqid,
-        loop_guard=internals.collaborators.lifecycle,
     )
     return client

--- a/tests/_helpers/client_factory.py
+++ b/tests/_helpers/client_factory.py
@@ -70,8 +70,11 @@ def build_client_shell_for_tests(
 
     - ``refresh_callback=None`` — no auth-refresh coordination unless a
       test injects one (production wires ``client.refresh_auth``).
-    - ``keepalive_storage_path=None`` — passed through verbatim; the
-      production derivation from ``auth.storage_path`` is bypassed.
+    - ``keepalive_storage_path`` — passed through verbatim, bypassing the
+      production canonicalization (``expanduser().resolve()``) of
+      ``auth.storage_path``; an explicit ``None`` still falls through to
+      ``compose_client_internals``' own raw ``auth.storage_path``
+      fallback, as it always did.
     - The client is returned **unopened**: loop binding still happens at
       ``open()`` time (via ``__aenter__``), exactly as in production.
     """

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -29,10 +29,10 @@ from _guardrails._ast_reach_in import (
     _assignment_value,
     _call_keyword_value,
     _facade_construction_lines,
-    _method_body,
+    _module_function_body,
+    _owned_attr_assignment,
+    _owned_attr_name,
     _RuntimeImportVisitor,
-    _self_attr_assignment,
-    _self_attr_name,
 )
 from _helpers.client_factory import build_client_shell_for_tests
 from notebooklm._artifacts import ArtifactsAPI
@@ -237,11 +237,21 @@ def test_notebooks_api_has_no_hidden_sources_api_runtime_dependency() -> None:
 
 
 def test_client_constructs_sources_before_notebooks_and_injects_sources_api() -> None:
-    """Client wiring must avoid hidden SourcesAPI construction inside NotebooksAPI."""
-    client_tree = ast.parse((SRC_ROOT / "client.py").read_text(encoding="utf-8"))
-    init_body = _method_body(client_tree, "NotebookLMClient", "__init__")
-    sources_index, sources_assignment = _self_attr_assignment(init_body, "sources")
-    notebooks_index, notebook_assignment = _self_attr_assignment(init_body, "notebooks")
+    """Client wiring must avoid hidden SourcesAPI construction inside NotebooksAPI.
+
+    The wiring lives in :func:`notebooklm._client_assembly._assemble_client`
+    (the single construction seam ``NotebookLMClient.__init__`` and the
+    canonical test factory both run), where the client instance is bound to
+    the ``client`` parameter — hence the ``owner="client"`` matchers.
+    """
+    assembly_tree = ast.parse((SRC_ROOT / "_client_assembly.py").read_text(encoding="utf-8"))
+    assembly_body = _module_function_body(assembly_tree, "_assemble_client")
+    sources_index, sources_assignment = _owned_attr_assignment(
+        assembly_body, "sources", owner="client"
+    )
+    notebooks_index, notebook_assignment = _owned_attr_assignment(
+        assembly_body, "notebooks", owner="client"
+    )
 
     assert sources_index < notebooks_index
 
@@ -256,7 +266,10 @@ def test_client_constructs_sources_before_notebooks_and_injects_sources_api() ->
     assert isinstance(notebooks_call.func, ast.Name)
     assert notebooks_call.func.id == "NotebooksAPI"
 
-    assert _self_attr_name(_call_keyword_value(notebooks_call, "sources_api")) == "sources"
+    assert (
+        _owned_attr_name(_call_keyword_value(notebooks_call, "sources_api"), owner="client")
+        == "sources"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

`tests/_helpers/client_factory.py` built the canonical unit-test client via `NotebookLMClient.__new__` plus hand-wiring of private attributes (`_auth`, `_seams`, `_composed`, `_collaborators`, `_rpc_executor`, `_source_uploader`, `chat`). Its own comments recorded two incidents (#1196, #1225) where production constructor changes silently stranded the shell until a test happened to exercise the missing attribute.

This PR makes that drift class structurally impossible:

- **New private seam `src/notebooklm/_client_assembly.py::_assemble_client(client, ...)`** — the entire former `__init__` body (auth normalization, seam resolution, `compose_client_internals`, upload pipeline, every feature API). `NotebookLMClient.__init__` is now a thin delegate to it; the test factory runs the **same function** on a `__new__`-created instance, forwarding the historical test-only kwargs (`decode_response` / `sleep` / `is_auth_error` / `async_client_factory` / `refresh_callback` / `refresh_retry_delay` / `connect_timeout` / `keepalive_storage_path`) that stay off the public constructor.
- **Two sentinels preserve exact behavior on both sides:** `refresh_callback` defaults to `client.refresh_auth` in production while the factory's `None` still means "no refresh coordination"; `keepalive_storage_path` derives (canonicalized) from `auth.storage_path` in production while the factory's explicit value passes through verbatim.
- **New parity gate `tests/_guardrails/test_client_factory_parity.py`** — builds a client through both paths and compares the full instance-attribute surface (names + types, both directions; self-tested pure detector) plus identity invariants (`chat` shares the client's `NotebooksAPI`, shared `RpcExecutor`, ADR-0016 auth aliasing). The next constructor refactor fails this gate with an actionable message instead of stranding the shell.
- **Existing gates retargeted, not weakened:** `test_client_composition.py` now scans BOTH composition roots (`client.py` + `_client_assembly.py`, host names `self`/`client`) and gains `LabelsAPI`/`MindMapsAPI`/`NoteBackedMindMapService`; `test_init_order.py`'s sources-before-notebooks pin now targets `_assemble_client` via generalized owner-aware AST helpers in `_ast_reach_in.py`.

### Why no public API change

`_client_assembly` is private (underscore module, not exported, in no `__all__`). `NotebookLMClient`'s constructor signature and `client.__all__ == ["NotebookLMClient"]` are untouched. `client.py` keeps its previous runtime module-attribute surface (`notebooklm.client.SourcesAPI` etc.) and `typing.get_type_hints(NotebookLMClient)` keeps working — the class now *declares* its attribute surface with class-level annotations (a typing improvement). `scripts/audit_public_api_compat.py` passes with **zero** new allowlist entries (`scripts/api-compat-allowlist.json` untouched).

### Behavioral notes

- The factory-built shell now carries the full production attribute surface (feature APIs included) instead of a partial shell — additive only; all 36 factory-caller test files pass unchanged.
- The shell now also gets the `max_concurrent_rpcs <= limits.max_connections` cross-validation; no test builds an invalid combination, and failing fast matches production.
- Loop affinity unchanged: the factory still returns an **unopened** client; binding happens at `open()` time.
- `client.py` drops 993 → 818 lines (below the 900 budget), so its size-ratchet ceiling entry is removed per the one-way-ratchet rule. No ceiling was raised.
- `docs/architecture.md` gains the new module in the per-file index and repository tree (freshness gate).

## Test plan

- `uv run pytest` — full suite green (9538 passed, 71 skipped, 1 xfailed)
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run ruff format --check` / `uv run ruff check` — clean
- `uv run python scripts/audit_public_api_compat.py` — OK, no new allowlist entries
- Pre-PR codex review: applied both surface findings (runtime imports / get_type_hints, identity invariants in the parity gate) and both minors; pushed back on exempting the shell from constructor validation (evidence: no caller affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture docs to reflect the new centralized client assembly and its role in keeping production and test wiring aligned.

* **Refactor**
  * Consolidated client initialization into a single shared assembly to ensure consistent runtime wiring and simplify construction parity.

* **Tests**
  * Strengthened guardrail and parity tests to validate identical construction surfaces and preserved wiring between production and test client creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->