### PR TITLE
fix(chat): citation-structure drift is no longer swallowed silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   truthy non-list where the citation *container* belongs (`first[4][3]`) is
   structural wire drift and raises `UnknownRPCMethodError` (matching the
   parser's existing `inner_data[0]` raise and `unwrap_conversation_turns`);
-  a present-but-unusable individual citation row now logs one WARNING with a
-  bounded preview and is skipped, so a good answer keeps its surviving
-  citations.
+  a present-but-unusable individual citation row now logs at least one
+  bounded WARNING and is skipped, so a good answer keeps its surviving
+  citations. Surviving citations keep their **raw wire ordinal** as
+  `citation_number` (a skipped row leaves a hole; with nothing skipped this
+  equals the dense numbering always produced), so the answer's literal `[N]`
+  markers never shift onto a different citation. Correspondingly,
+  save-as-note's positional marker fallback (`references[N-1]`) now applies
+  only when that positional reference carries no `citation_number`: a holed
+  marker drops its anchor with a warning instead of anchoring the wrong
+  chunk.
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
   returns an absent/`None` payload. `notebooks.get_summary()` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior nuance: `SharedUser.email` is now always a `str` — a `None` email
   slot normalizes to `""` instead of leaking `None` through the `str`-typed
   field.
+- **Chat citation-structure drift is no longer swallowed at DEBUG** (#1505
+  continuity — the last named survivor of that drift-swallow class). A Google
+  reshape of the streamed-chat citation structure previously degraded to
+  "answers with no citations" via a blanket `except → logger.debug → []` in
+  `parse_citations` — invisible, and it also discarded already-parsed
+  citations. Per the absence-vs-malformed policy: genuine absence (no type
+  block, short type block, `None`/empty citation slot — the routine "answer
+  without citations" shapes on real traffic) stays completely silent; a
+  truthy non-list where the citation *container* belongs (`first[4][3]`) is
+  structural wire drift and raises `UnknownRPCMethodError` (matching the
+  parser's existing `inner_data[0]` raise and `unwrap_conversation_turns`);
+  a present-but-unusable individual citation row now logs one WARNING with a
+  bounded preview and is skipped, so a good answer keeps its surviving
+  citations.
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
   returns an absent/`None` payload. `notebooks.get_summary()` and

--- a/src/notebooklm/_chat/notes.py
+++ b/src/notebooklm/_chat/notes.py
@@ -157,17 +157,24 @@ def _resolve_reference(
 ) -> ChatReference | None:
     """Look up the ChatReference that backs citation marker ``[N]``.
 
-    Prefers an exact ``citation_number`` match; falls back to positional
-    lookup (``references[N-1]``) when ``citation_number`` is unset on
-    the reference. Returns ``None`` if neither path resolves to a
-    reference with a usable ``chunk_id``.
+    Prefers an exact ``citation_number`` match. The positional fallback
+    (``references[N-1]``) applies ONLY when that positional candidate has no
+    ``citation_number`` set — the legacy unset-number contract it was built
+    for. It must NOT fire for a *numbered* list with a hole: the wire parser
+    keeps raw ordinals when it skips a malformed citation row, so after
+    ``[good#1, skipped#2, good#3]`` a positional fallback for marker ``[2]``
+    would anchor raw citation #3 — a WRONG anchor. Returns ``None`` instead
+    (the caller skips that marker's anchor with a warning): a missing anchor
+    is recoverable, a mis-anchored note is silently wrong.
     """
     for ref in references:
         if ref.citation_number == citation_number and ref.chunk_id:
             return ref
     idx = citation_number - 1
-    if 0 <= idx < len(references) and references[idx].chunk_id:
-        return references[idx]
+    if 0 <= idx < len(references):
+        candidate = references[idx]
+        if candidate.citation_number is None and candidate.chunk_id:
+            return candidate
     return None
 
 

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -250,7 +250,11 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
     # Assign citation numbers without mutating the dataclass instances in place
     # (prepares for an eventual ``frozen=True`` sweep on public domain types).
     # The list is rebuilt — externally identical to the prior mutation since
-    # only ``citation_number`` ever changes here.
+    # only ``citation_number`` ever changes here. ``parse_citations`` already
+    # stamps raw wire ordinals; the ``is None`` guard deliberately preserves
+    # them (a skipped malformed row leaves a hole so [N] markers never shift
+    # onto the wrong citation) — the dense fill applies only to refs that
+    # arrived unnumbered.
     final_refs = [
         replace(ref, citation_number=idx) if ref.citation_number is None else ref
         for idx, ref in enumerate(final_refs, start=1)
@@ -469,10 +473,22 @@ def parse_citations(first: list) -> list[ChatReference]:
       silently degrade to "answer without citations".
     * **Per-row malformed WARNS and skips** — a citation entry that is present
       but unusable (wrong shape/type at a slot, no extractable source id, or
-      an unexpected error while decoding it) logs one ``WARNING`` with a
-      ``reprlib``-bounded preview, then drops only that row; surviving
-      citations are still returned so one bad row never destroys a good
-      answer's remaining citations.
+      an unexpected error while decoding it) logs at least one bounded
+      ``WARNING`` (``reprlib`` previews; a deep malformed source-id tree may
+      additionally emit the UUID max-recursion warning), then drops only that
+      row; surviving citations are still returned so one bad row never
+      destroys a good answer's remaining citations.
+
+    Survivors keep their **raw wire ordinal** as ``citation_number`` (1-based
+    position in the citation container), NOT a dense re-count. The answer
+    text's literal ``[N]`` markers refer to raw positions, so re-densifying
+    after a skip would silently re-anchor ``[N]`` onto a *different* citation
+    (e.g. save-as-note anchoring the wrong chunk). A skipped row instead
+    leaves a hole: its marker resolves to no reference and downstream
+    consumers drop that anchor rather than mis-anchoring. With nothing
+    skipped, raw ordinals equal the dense numbering this parser always
+    produced. The final assignment in :func:`parse_streaming_chat_response`
+    preserves non-``None`` numbers, so the ordinals survive unchanged.
 
     The pre-hardening behavior swallowed *every* citation drift at DEBUG and
     returned ``[]`` — a Google reshape degraded to "answers with no
@@ -490,7 +506,7 @@ def parse_citations(first: list) -> list[ChatReference]:
             data_at_failure=reprlib.repr(first),
         )
     refs: list[ChatReference] = []
-    for cite in AnswerRow(first).citations:
+    for raw_idx, cite in enumerate(AnswerRow(first).citations, start=1):
         try:
             ref = parse_single_citation(cite)
         except (IndexError, TypeError, AttributeError) as exc:
@@ -509,7 +525,10 @@ def parse_citations(first: list) -> list[ChatReference]:
                 _CITATION_SOURCE,
             )
             continue
-        refs.append(ref)
+        # Raw wire ordinal, not a dense re-count — see the docstring: the
+        # answer's literal [N] markers point at raw positions, so a skipped
+        # row must leave a hole rather than shift survivors onto wrong markers.
+        refs.append(replace(ref, citation_number=raw_idx))
     return refs
 
 

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -11,6 +11,7 @@ import json
 import logging
 import math
 import re
+import reprlib
 from dataclasses import dataclass, replace
 from typing import Any, NoReturn, Protocol
 from urllib.parse import quote, urlencode
@@ -43,6 +44,7 @@ logger = logging.getLogger("notebooklm._chat")
 # and rely on these labels to localize schema drift in raised
 # ``UnknownRPCMethodError`` diagnostics (ADR-0011).
 _CHUNK_SOURCE = "_chat_wire._extract_chunk_with_parseable"
+_CITATION_SOURCE = "_chat_wire.parse_citations"
 
 _UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
@@ -449,24 +451,66 @@ def raise_if_rate_limited(error_payload: list) -> None:
 
 
 def parse_citations(first: list) -> list[ChatReference]:
-    """Parse citation details from a streamed-chat response structure."""
-    try:
-        # ``AnswerRow.citations`` centralises the ``first[4][3]`` descent and
-        # degrades to ``[]`` for the "answer without citations" shapes the old
-        # inline length guards tolerated (issue #1491).
-        refs: list[ChatReference] = []
-        for cite in AnswerRow(first).citations:
-            ref = parse_single_citation(cite)
-            if ref is not None:
-                refs.append(ref)
-        return refs
-    except (IndexError, TypeError, AttributeError) as e:
-        logger.debug(
-            "Citation parsing failed (API structure may have changed): %s",
-            e,
-            exc_info=True,
+    """Parse citation details from a streamed-chat response structure.
+
+    Absence-vs-malformed policy (#1505 continuity). Citations are *secondary*
+    payload riding on a usable answer, so loudness is tiered:
+
+    * **Absence is silent** — an answer with no citations is the common case
+      (real traffic routinely sends ``None`` in the ``first[4][3]`` slot):
+      no/short type block and falsy citation slots return ``[]`` with zero
+      logging, via ``AnswerRow.citations`` (issue #1491).
+    * **Container drift RAISES** — a non-list ``first`` (the answer row) or a
+      truthy non-list citation container is structural wire drift; it raises
+      :class:`UnknownRPCMethodError`, matching this parser's existing raise
+      for the ``inner_data[0]`` non-list case and the
+      ``unwrap_conversation_turns`` container raise (#1505): a reshaped
+      container means the payload can no longer be trusted, so it must not
+      silently degrade to "answer without citations".
+    * **Per-row malformed WARNS and skips** — a citation entry that is present
+      but unusable (wrong shape/type at a slot, no extractable source id, or
+      an unexpected error while decoding it) logs one ``WARNING`` with a
+      ``reprlib``-bounded preview, then drops only that row; surviving
+      citations are still returned so one bad row never destroys a good
+      answer's remaining citations.
+
+    The pre-hardening behavior swallowed *every* citation drift at DEBUG and
+    returned ``[]`` — a Google reshape degraded to "answers with no
+    citations" invisibly.
+    """
+    if not isinstance(first, list):
+        # Same structural-drift signal ``_extract_chunk_with_parseable``
+        # raises for a non-list answer row; reachable only via direct calls
+        # since the stream parser already enforces it before delegating here.
+        raise UnknownRPCMethodError(
+            f"Streamed chat answer row is not a list (got {type(first).__name__})",
+            method_id=None,
+            path=(0,),
+            source=_CITATION_SOURCE,
+            data_at_failure=reprlib.repr(first),
         )
-        return []
+    refs: list[ChatReference] = []
+    for cite in AnswerRow(first).citations:
+        try:
+            ref = parse_single_citation(cite)
+        except (IndexError, TypeError, AttributeError) as exc:
+            logger.warning(
+                "Skipping malformed citation entry (%s: %s; cite=%s) [%s]",
+                type(exc).__name__,
+                exc,
+                reprlib.repr(cite),
+                _CITATION_SOURCE,
+            )
+            continue
+        if ref is None:
+            logger.warning(
+                "Skipping unusable citation entry (no parsable detail or source id; cite=%s) [%s]",
+                reprlib.repr(cite),
+                _CITATION_SOURCE,
+            )
+            continue
+        refs.append(ref)
+    return refs
 
 
 def parse_single_citation(cite: Any) -> ChatReference | None:

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -494,11 +494,17 @@ class AnswerRow:
         Absence-vs-malformed split (#1485 policy, the #1505 follow-up for
         the citation path):
 
-        * **Absence stays soft** — a short row, a non-list type block (also
-          a legitimate "not an answer record" shape consumed by
-          :attr:`is_answer`), a type block too short to carry the slot, or a
-          *falsy* slot all degrade to ``[]``: real wire traffic routinely
-          sends ``None`` here for "answer without citations".
+        * **Absence stays soft** — a short row, a non-list type block, a
+          type block too short to carry the slot, or a *falsy* slot all
+          degrade to ``[]``: real wire traffic routinely sends ``None`` here
+          for "answer without citations". The non-list *type block*
+          (``first[4]``) is deliberately kept soft even though it could be
+          drift: it doubles as the legitimate "not an answer record" shape
+          consumed by :attr:`is_answer`. Visibility is narrow by design —
+          it surfaces only on the stream path, and only when no other
+          marked chunk wins (the parser's "No marked answer found"
+          WARNING); on a losing chunk, or in a direct ``parse_citations``
+          call, it stays silent.
         * **Truthy non-list RAISES** — a truthy non-list where the citation
           container belongs is structural wire drift, not a citation-less
           answer, and raises :class:`UnknownRPCMethodError`. Precedent: the

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -491,16 +491,38 @@ class AnswerRow:
     def citations(self) -> list[Any]:
         """Raw citation entries at ``first[4][3]`` — empty list when absent.
 
-        Mirrors the historical ``parse_citations`` permissive contract: a
-        short / non-list type block or a non-list citation slot degrades to
-        ``[]`` rather than raising, because a missing citation list is a normal
-        "answer without citations" shape, not wire drift.
+        Absence-vs-malformed split (#1485 policy, the #1505 follow-up for
+        the citation path):
+
+        * **Absence stays soft** — a short row, a non-list type block (also
+          a legitimate "not an answer record" shape consumed by
+          :attr:`is_answer`), a type block too short to carry the slot, or a
+          *falsy* slot all degrade to ``[]``: real wire traffic routinely
+          sends ``None`` here for "answer without citations".
+        * **Truthy non-list RAISES** — a truthy non-list where the citation
+          container belongs is structural wire drift, not a citation-less
+          answer, and raises :class:`UnknownRPCMethodError`. Precedent: the
+          :func:`unwrap_conversation_turns` container raise above and the
+          ``inner_data[0]`` non-list raise in ``_chat/wire.py`` — this
+          parser family treats reshaped containers as a raise, never a
+          silent ``[]``.
         """
         type_block = self._type_block
         if type_block is None or len(type_block) <= self._CITATIONS_POS:
             return []
         citations = type_block[self._CITATIONS_POS]
-        return citations if isinstance(citations, list) else []
+        if not citations:
+            return []
+        if not isinstance(citations, list):
+            raise UnknownRPCMethodError(
+                f"chat citation container holds {type(citations).__name__} "
+                "(expected the citation list)",
+                method_id=None,
+                path=(self._TYPE_BLOCK_POS, self._CITATIONS_POS),
+                source="ChatAnswerRow.citations",
+                data_at_failure=reprlib.repr(citations),
+            )
+        return citations
 
     def citation_rows(self) -> list[CitationRow]:
         """Wrap each raw citation entry as a :class:`CitationRow`."""

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -2125,18 +2125,13 @@ class TestParseAskResponseBranchCoverage:
         ]
         inner_json = json.dumps(inner_data)
         chunk_json = json.dumps([["wrb.fr", None, inner_json]])
-        # Two identical chunks - second one produces a ref with citation_number already set
-        # But actually each call to _parse_ask_response creates fresh refs, so two chunks
-        # means two refs (same source), first gets 1, second gets 2 (both had citation_number=None)
-        # To trigger 496->495 we need ref.citation_number to already be set.
-        # This can happen if we manually set citation_number before the assignment loop.
-        # However, in the normal flow, refs from _parse_citations don't have citation_number set.
-        # The only way to get citation_number != None before the assignment loop is if
-        # somehow the code path sets it earlier - which it doesn't.
-        # So arc 496->495 requires citation_number to be not None from _parse_citations.
-        # Since _parse_citations creates ChatReference with citation_number=None by default,
-        # this arc may not be reachable in normal flow - it's a defensive check.
-        # Let's verify the assignment logic works correctly with multiple refs.
+        # Since the citation-hardening pass, _parse_citations stamps each
+        # surviving reference with its RAW wire ordinal (so a skipped
+        # malformed row leaves a hole instead of shifting [N] markers onto
+        # the wrong citation). The final assignment's preserve-non-None arc
+        # is therefore the NORMAL path now: it must keep the raw ordinal
+        # untouched. With nothing skipped, raw ordinal == dense ordinal,
+        # which is what this asserts (citation_number == 1 for the sole ref).
         response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
         answer, refs, conv_id = client.chat._parse_ask_response_with_references(response_body)
         assert len(refs) == 1

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1605,14 +1605,20 @@ class TestExtractAnswerAndRefsFromChunk:
 
 
 class TestParseCitationsEdgeCases:
-    """Tests for _parse_citations edge cases (lines 599-605)."""
+    """Tests for _parse_citations edge cases (absence soft, malformed loud)."""
 
-    def test_parse_citations_returns_empty_on_type_error(self, auth_tokens):
-        """Test _parse_citations returns [] when first causes TypeError (lines 599-605)."""
+    def test_parse_citations_raises_on_non_list_answer_row(self, auth_tokens):
+        """A non-list ``first`` is structural drift and raises (was a silent-DEBUG ``[]``).
+
+        Flipped under the #1505 absence-vs-malformed policy: the stream parser
+        already raises ``UnknownRPCMethodError`` for a non-list answer row, so
+        the direct-call surface now matches instead of swallowing a TypeError.
+        """
+        from notebooklm.exceptions import UnknownRPCMethodError
+
         client = NotebookLMClient(auth_tokens)
-        # Passing None triggers TypeError in len(first) at the guard check
-        refs = client.chat._parse_citations(None)  # type: ignore[arg-type]
-        assert refs == []
+        with pytest.raises(UnknownRPCMethodError):
+            client.chat._parse_citations(None)  # type: ignore[arg-type]
 
     def test_parse_citations_returns_empty_when_first_too_short(self, auth_tokens):
         """Test _parse_citations returns [] when first has <= 4 elements."""
@@ -1628,12 +1634,19 @@ class TestParseCitationsEdgeCases:
         refs = client.chat._parse_citations(first)
         assert refs == []
 
-    def test_parse_citations_returns_empty_when_type_info_3_not_list(self, auth_tokens):
-        """Test _parse_citations returns [] when type_info[3] is not a list."""
+    def test_parse_citations_raises_when_type_info_3_truthy_non_list(self, auth_tokens):
+        """A truthy non-list citation container is structural drift and raises.
+
+        Flipped under the #1505 absence-vs-malformed policy (was a silent
+        ``[]``): real traffic sends ``None`` (absence, still soft) or a list
+        here — a truthy non-list means the container itself was reshaped.
+        """
+        from notebooklm.exceptions import UnknownRPCMethodError
+
         client = NotebookLMClient(auth_tokens)
         first = ["text", None, None, None, [1, 2, 3, "not_a_list"]]
-        refs = client.chat._parse_citations(first)
-        assert refs == []
+        with pytest.raises(UnknownRPCMethodError):
+            client.chat._parse_citations(first)
 
 
 class TestParseSingleCitationEdgeCases:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -159,6 +159,27 @@ class TestAnswerRow:
         assert isinstance(rows[0], CitationRow)
         assert rows[0].chunk_id == "chunk"
 
+    def test_none_citation_slot_is_absence(self) -> None:
+        """``first[4][3] is None`` is the routine real-traffic "no citations" shape."""
+        rec = _answer_record()
+        rec[4][3] = None
+        assert AnswerRow(rec).citations == []
+
+    def test_truthy_non_list_citation_slot_raises(self) -> None:
+        """A truthy non-list where the citation container belongs is wire drift.
+
+        #1505 absence-vs-malformed policy: matches the container raise in
+        ``unwrap_conversation_turns`` and the ``inner_data[0]`` non-list raise
+        in ``_chat/wire.py`` (was a silent ``[]`` degrade).
+        """
+        for drifted in ("reshaped", {"v2": []}, 7):
+            rec = _answer_record()
+            rec[4][3] = drifted
+            with pytest.raises(UnknownRPCMethodError) as raised:
+                _ = AnswerRow(rec).citations
+            assert raised.value.path == (4, 3)
+            assert raised.value.source == "ChatAnswerRow.citations"
+
 
 # ---------------------------------------------------------------------------
 # 3. CitationRow / CitationDetail

--- a/tests/unit/test_save_chat_as_note_encoder.py
+++ b/tests/unit/test_save_chat_as_note_encoder.py
@@ -24,6 +24,7 @@ import pytest
 
 from notebooklm._chat.notes import (
     _CITATION_MARKER_RE,
+    _resolve_reference,
     _strip_citation_markers,
     build_save_chat_as_note_params,
 )
@@ -242,14 +243,19 @@ class TestBuildSaveChatAsNoteParamsBehavior:
         assert chunk_refs[1] == [["chunk-b"], [None, 0, 23]]
 
     def test_dedupes_source_passages_by_chunk_id(self):
-        # Same chunk_id referenced twice → only one source_passages entry,
-        # but each [N] marker still gets its own anchor.
-        ref = self._make_ref(1, "chunk-shared", "src-shared")
-        refs = [ref, ref]  # caller may legitimately repeat
+        # Same chunk_id under two distinct citation numbers (the realistic
+        # repeat: one chunk cited at two markers) → only one source_passages
+        # entry, but each [N] marker still gets its own anchor. (Previously
+        # this pinned the numbered-positional fallback — both refs numbered 1
+        # and [2] resolved via references[1]; that fallback is now gated to
+        # unnumbered candidates so a numbering hole can't mis-anchor.)
+        refs = [
+            self._make_ref(1, "chunk-shared", "src-shared"),
+            self._make_ref(2, "chunk-shared", "src-shared"),
+        ]
         params = build_save_chat_as_note_params("nb-id", "A [1] B [2]", refs, "Title")
         assert len(params[3]) == 1  # deduped
         # Two markers found in answer_text → two chunk_refs
-        # (the lookup of [2] falls back to references[1] = same ref)
         assert len(params[5][0][1]) == 2
 
     def test_marker_without_matching_reference_is_skipped(self, caplog):
@@ -261,6 +267,45 @@ class TestBuildSaveChatAsNoteParamsBehavior:
         # Only one anchor — the [99] marker is silently dropped with a warning
         assert len(chunk_refs) == 1
         assert any("[99]" in record.message or "99" in record.message for record in caplog.records)
+
+    def test_holed_numbering_skips_missing_marker_instead_of_mis_anchoring(self, caplog):
+        """Regression (codex review of the citation hardening): no wrong anchors.
+
+        The wire parser keeps RAW ordinals when it skips a malformed citation
+        row, so ``[good#1, skipped#2, good#3]`` reaches the encoder as refs
+        numbered ``{1, 3}``. Marker ``[2]`` must resolve to nothing — the old
+        positional fallback would have anchored ``references[1]`` = raw #3,
+        a silently WRONG anchor. Missing anchor (with a warning) is the only
+        acceptable outcome.
+        """
+        refs = [
+            self._make_ref(1, "chunk-1", "src-1"),
+            self._make_ref(3, "chunk-3", "src-3"),
+        ]
+        # Resolver level: exact matches work, the hole yields None.
+        resolved_1 = _resolve_reference(refs, 1)
+        assert resolved_1 is not None and resolved_1.chunk_id == "chunk-1"
+        assert _resolve_reference(refs, 2) is None
+        resolved_3 = _resolve_reference(refs, 3)
+        assert resolved_3 is not None and resolved_3.chunk_id == "chunk-3"
+
+        # Encoder level: [2]'s anchor is dropped with a warning; [1] and [3]
+        # anchor their own chunks.
+        with caplog.at_level("WARNING"):
+            params = build_save_chat_as_note_params("nb-id", "A [1] B [2] C [3]", refs, "Title")
+        chunk_refs = params[5][0][1]
+        assert [anchor[0] for anchor in chunk_refs] == [["chunk-1"], ["chunk-3"]]
+        assert any("[2]" in record.message for record in caplog.records)
+
+    def test_positional_fallback_still_serves_unnumbered_references(self):
+        """The legacy unset-number contract is preserved: positional lookup
+        applies when the positional candidate carries no citation_number."""
+        refs = [
+            ChatReference(source_id="src-a", chunk_id="chunk-a"),
+            ChatReference(source_id="src-b", chunk_id="chunk-b"),
+        ]
+        resolved = _resolve_reference(refs, 2)
+        assert resolved is not None and resolved.chunk_id == "chunk-b"
 
     def test_seven_element_params_shape(self):
         """Sanity: top-level params is always exactly 7 elements."""

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -489,7 +489,13 @@ def test_stream_with_reshaped_citation_container_raises() -> None:
 
 
 def test_malformed_citation_rows_warn_and_keep_survivors(caplog) -> None:
-    """Per-row malformation warns (once per row) and keeps the surviving citations."""
+    """Per-row malformation warns (at least once per row) and keeps survivors.
+
+    The rows crafted here each emit exactly one warning. A deep malformed
+    source-id tree could additionally trip the UUID max-recursion warning,
+    so the production contract is "at least one bounded warning per
+    malformed row" rather than exactly one.
+    """
     good_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
     class _ExplodingLen(list):
@@ -516,9 +522,49 @@ def test_malformed_citation_rows_warn_and_keep_survivors(caplog) -> None:
         refs = parse_citations(first)
 
     assert [ref.source_id for ref in refs] == [good_id]
+    # The survivor keeps its RAW wire ordinal (position 5, after 4 skipped
+    # rows) — not a dense re-count — so the answer's [5] marker still
+    # resolves to it and [1]-[4] resolve to nothing.
+    assert [ref.citation_number for ref in refs] == [5]
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == len(bad_rows)  # one warning per malformed row
+    assert len(warnings) == len(bad_rows)  # these rows: exactly one each
     assert all("citation" in r.message for r in warnings)
+
+
+def test_skipped_citation_row_leaves_numbering_hole_for_markers(caplog) -> None:
+    """Regression: raw rows [good#1, bad#2, good#3] yield citation numbers {1, 3}.
+
+    Dense renumbering after a skip would re-anchor the answer's literal
+    ``[2]`` marker onto raw citation #3 (save-as-note would anchor the WRONG
+    chunk via the positional fallback). Survivors must keep raw ordinals so
+    the skipped row leaves a hole: marker ``[2]`` resolves to ``None`` and
+    its anchor is dropped — never mis-anchored.
+    """
+    from notebooklm._chat.notes import _resolve_reference
+
+    good_1 = _citation(source_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", chunk_id="chunk-1")
+    bad_2 = ["present-but-unusable"]
+    good_3 = _citation(source_id="11111111-2222-3333-4444-555555555555", chunk_id="chunk-3")
+    first = ["Answer [1][2][3].", None, None, None, [[], None, None, [good_1, bad_2, good_3], 1]]
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        refs = parse_citations(first)
+    assert [ref.citation_number for ref in refs] == [1, 3]
+
+    # End-to-end: the stream parser's final dense fill only touches None
+    # numbers, so the hole survives parse_streaming_chat_response.
+    inner = json.dumps([first])
+    chunk = json.dumps([["wrb.fr", None, inner]])
+    result = parse_streaming_chat_response(_length_prefixed(chunk))
+    assert [ref.citation_number for ref in result.references] == [1, 3]
+
+    # Downstream marker resolution: the hole yields None (anchor skipped),
+    # the surviving markers resolve to their own chunks.
+    resolved_1 = _resolve_reference(result.references, 1)
+    assert resolved_1 is not None and resolved_1.chunk_id == "chunk-1"
+    assert _resolve_reference(result.references, 2) is None
+    resolved_3 = _resolve_reference(result.references, 3)
+    assert resolved_3 is not None and resolved_3.chunk_id == "chunk-3"
 
 
 def test_row_level_citation_helpers_keep_soft_contracts() -> None:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -31,7 +31,7 @@ from notebooklm._chat.wire import (
     parse_streaming_chat_response,
     raise_if_rate_limited,
 )
-from notebooklm.exceptions import ChatError
+from notebooklm.exceptions import ChatError, UnknownRPCMethodError
 from notebooklm.rpc.types import get_query_url
 
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
@@ -425,9 +425,104 @@ def test_extract_score_accepts_float_and_int_rejects_bool_and_out_of_range() -> 
     assert extract_score([None, None, float("-inf")]) is None
 
 
-def test_missing_and_malformed_citation_shapes_degrade_without_raising() -> None:
-    assert parse_citations(["Answer", None, None, None]) == []
-    assert parse_citations(["Answer", None, None, None, [[], None, None, None, 1]]) == []
+def test_citation_absence_shapes_stay_silent(caplog) -> None:
+    """Genuine absence (answer without citations) emits ZERO log records.
+
+    Pins the soft half of the #1505 absence-vs-malformed policy for the
+    citation path: no type block, a short type block, a ``None`` citation
+    slot (the routine real-traffic shape), and an empty citation list all
+    parse to ``[]`` with no logging at any level.
+    """
+    absent_shapes = [
+        ["Answer only"],  # short row: no type block at all
+        ["Answer", None, None, None],  # no first[4]
+        ["Answer", None, None, None, [1, 2, 3]],  # type block too short for [3]
+        ["Answer", None, None, None, [[], None, None, None, 1]],  # slot is None
+        ["Answer", None, None, None, [[], None, None, [], 1]],  # empty citation list
+    ]
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
+        for first in absent_shapes:
+            assert parse_citations(first) == []
+    assert [r for r in caplog.records if r.name.startswith("notebooklm")] == []
+
+
+def test_citationless_answer_stream_parses_silently(caplog) -> None:
+    """End-to-end absence pin: a citation-less answer stream stays soft/silent."""
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(
+            _length_prefixed(_chunk("Answer without citations."))
+        )
+    assert result.answer == "Answer without citations."
+    assert result.references == []
+    assert [r for r in caplog.records if r.name.startswith("notebooklm")] == []
+
+
+def test_citation_container_truthy_non_list_raises() -> None:
+    """PRESENT-BUT-MALFORMED container: a truthy non-list at ``first[4][3]`` raises.
+
+    Documented choice (raise, not warn): the surrounding parser already treats
+    equivalent container drift as a raise — ``_extract_chunk_with_parseable``
+    raises ``UnknownRPCMethodError`` for a non-list ``inner_data[0]``, and the
+    #1505 ``unwrap_conversation_turns`` raises for a truthy non-list turn
+    container — so the citation container follows the same precedent.
+    """
+    first = ["Answer", None, None, None, [[], None, None, {"reshaped": True}, 1]]
+    with pytest.raises(UnknownRPCMethodError) as raised:
+        parse_citations(first)
+    assert raised.value.source == "ChatAnswerRow.citations"
+    assert raised.value.path == (4, 3)
+
+
+def test_non_list_answer_row_raises_in_parse_citations() -> None:
+    """A non-list answer row mirrors the stream parser's structural raise."""
+    with pytest.raises(UnknownRPCMethodError) as raised:
+        parse_citations("not-a-row")  # type: ignore[arg-type]
+    assert raised.value.source == "_chat_wire.parse_citations"
+
+
+def test_stream_with_reshaped_citation_container_raises() -> None:
+    """Container drift inside a real stream surfaces loudly (no silent no-citations answer)."""
+    inner = json.dumps([["Answer.", None, None, None, [[], None, None, "drifted", 1]]])
+    chunk = json.dumps([["wrb.fr", None, inner]])
+    with pytest.raises(UnknownRPCMethodError):
+        parse_streaming_chat_response(_length_prefixed(chunk))
+
+
+def test_malformed_citation_rows_warn_and_keep_survivors(caplog) -> None:
+    """Per-row malformation warns (once per row) and keeps the surviving citations."""
+    good_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    class _ExplodingLen(list):
+        """A list whose ``len()`` raises — exercises the defensive per-row except."""
+
+        def __len__(self) -> int:
+            raise TypeError("boom")
+
+    bad_rows: list = [
+        ["present-but-too-short"],  # no detail slot -> unusable
+        [["chunk-x"], "detail-not-a-list"],  # wrong type at the detail slot
+        _citation(source_id="not-a-uuid"),  # no extractable source id
+        _ExplodingLen(),  # unexpected error while decoding the row
+    ]
+    first = [
+        "Answer",
+        None,
+        None,
+        None,
+        [[], None, None, [*bad_rows, _citation(source_id=good_id)], 1],
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        refs = parse_citations(first)
+
+    assert [ref.source_id for ref in refs] == [good_id]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == len(bad_rows)  # one warning per malformed row
+    assert all("citation" in r.message for r in warnings)
+
+
+def test_row_level_citation_helpers_keep_soft_contracts() -> None:
+    """Row-level helper contracts are unchanged: unusable rows yield None/defaults."""
     assert parse_single_citation(_citation(source_id="not-a-uuid")) is None
     assert extract_text_passages([None, None, None, None, ["bad-passage"]]) == (
         None,


### PR DESCRIPTION
## Summary

Tier-1 fix: `parse_citations` (`src/notebooklm/_chat/wire.py`) previously degraded **silently** on citation-structure drift — any unexpected shape in the wire citation container became "answer with no citations" logged at DEBUG. Citation drift is invisible exactly when it happens. This PR makes structural drift loud while keeping per-row resilience, and closes a mis-anchor hazard the hardening itself would have introduced.

### What changed

**1. Structural drift now raises (absence stays soft — #1485 policy)**
- `AnswerRow.citations` (`_row_adapters/chat.py`): a *present-but-non-list* citations container raises `UnknownRPCMethodError` with path `(4, 3)` and a `reprlib`-bounded payload preview. Absent container still returns `[]`.
- `parse_citations`: a non-list answer-row container raises instead of returning `[]`.

**2. Per-row failures: warn + skip, survivors KEPT**
The old code discarded *all* citations when *any* row failed. Now each malformed row emits at least one bounded WARNING and is skipped; well-formed rows survive.

**3. Survivors keep their RAW wire ordinals (codex review finding — mis-anchor hazard)**
Dense renumbering of survivors would shift the answer's literal `[N]` markers: raw rows `[good#1, bad#2, good#3]` densely numbered `[1, 2]` let marker `[2]` resolve to raw citation #3 via the `notes.py` positional fallback — a silently **wrong** save-as-note anchor. Two-sided fix:
- `parse_citations` stamps each surviving reference with its raw 1-based wire ordinal, so a skipped row leaves a **hole**. With nothing skipped, raw == dense — legitimate parses are byte-identical (golden decoded VCR `citation_number` pins unchanged; cassette replay 7/9/5 refs numbered `1..N`, zero warnings, zero cassette changes).
- `_resolve_reference` (`notes.py`) positional fallback now applies only when the positional candidate has **no** `citation_number` (the legacy unset-number contract it was built for). A holed numbered list resolves the missing marker to `None` and the encoder drops that anchor with a warning — **missing anchor, never wrong anchor**.

### Tests
- `test_skipped_citation_row_leaves_numbering_hole_for_markers` — `[good, bad, good]` → `{1, 3}` end-to-end through `parse_streaming_chat_response`; `_resolve_reference(refs, 2) is None`; markers 1/3 resolve to their own chunks.
- `test_holed_numbering_skips_missing_marker_instead_of_mis_anchoring` — full encoder emits anchors for chunks 1 and 3 only; `[2]` warned-and-skipped.
- `test_positional_fallback_still_serves_unnumbered_references` — legacy unnumbered lists still resolve positionally.
- Raise-on-structural-drift + survivors-kept + characterization updates.

### Verification
- Full `uv run pytest -m "not e2e"`: **9541 passed**, 71 skipped, 1 xfailed
- mypy clean (234 files) · ruff clean · API-compat audit exit 0
- Module-size ratchet intact: `wire.py` 704, `notes.py` 359, `_row_adapters/chat.py` 710 (all ≤900)
- Zero cassette changes; golden decoded-row pins untouched

Polish: claude + codex review applied (codex Important = the ordinal mis-anchor above; 2 Minors = docstring precision on the kept-soft `first[4]` type block and warning-count wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat citation handling hardened: malformed citation rows now emit warnings and are skipped instead of silently degrading.
  * Citation numbering preserved to avoid mis-anchoring when there are gaps; positional fallbacks only used for truly unnumbered citations.
  * Missing vs malformed citation data is now distinguished with stricter error signaling.

* **Documentation**
  * Changelog updated describing these citation-handling fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->