### PR TITLE
test(vcr): golden decoded-row pinning for every cassette RPC family + standing coverage gate

### DIFF
--- a/tests/_guardrails/test_golden_decode_coverage.py
+++ b/tests/_guardrails/test_golden_decode_coverage.py
@@ -8,15 +8,17 @@ suite (``tests/integration/test_golden_decoded_vcr.py`` and
 decoded dataclass field values, so positional-decode drift fails loudly.
 
 This gate keeps that compensating control complete as the cassette corpus
-grows. It enumerates every ``rpcids`` value recorded in ``tests/cassettes/``
-(top level — ``examples/`` fixtures are illustrative, not replayed) and asserts
-each one is EITHER:
+grows. It enumerates every ``rpcids`` value recorded under ``tests/cassettes/``
+(recursively — ``examples/`` fixtures are illustrative, not replayed) and
+asserts each one is EITHER:
 
 1. **Covered** — listed in :data:`GOLDEN_COVERAGE`, keyed by the
-   :class:`~notebooklm.rpc.RPCMethod` constant and mapped to the test (file +
-   test name) that pins at least one decoded-field value produced from a
-   cassette replay of that RPC. The file must exist and contain the named
-   test, OR
+   :class:`~notebooklm.rpc.RPCMethod` constant and mapped to one or more test
+   pointers ``(file, qualified test name)``. Each pointer is verified by AST:
+   the function must exist at that exact ``Class::name`` location, and at
+   least one cassette named in its ``use_cassette`` decorators must really
+   record this rpcid — so a pointer can't silently rot into a comment, a
+   same-named sibling test, or a test that replays an unrelated cassette, OR
 2. **Exempt** — listed in :data:`GOLDEN_EXEMPT` with one of the sanctioned
    reasons, chosen by READING the client decode path: either the client
    discards the RPC's response outright, or the method's success contract is
@@ -28,6 +30,16 @@ cassettes are re-recorded, this gate follows automatically. A cassette
 recording an rpcid that no current ``RPCMethod`` knows fails loudly — that is
 either a stale cassette or an un-modelled RPC, both worth a human look.
 
+Granularity (a deliberate scoping decision): the gate is **family-level** —
+one rpcid is satisfied by at least one golden pointer per entry. Where a
+family has multiple recorded response *shapes* today (web vs drive freshness,
+text vs url add, notes vs mind-map rows), each shape gets its own pointer in
+:data:`GOLDEN_COVERAGE`, and all pointers are verified. But a *future* cassette
+recording an already-covered rpcid with a brand-new shape does not, by itself,
+force a new golden test — per-shape assertion depth is the golden modules' job
+(and the review's), not this gate's. The gate guarantees no family is ever
+fully un-pinned.
+
 New cassettes start gated: recording a new RPC family without classifying it
 here fails :func:`test_every_cassette_rpcid_is_classified` with instructions.
 
@@ -37,7 +49,9 @@ Modelled on the covered-or-exempt gate in
 
 from __future__ import annotations
 
+import ast
 import re
+from functools import cache, lru_cache
 from pathlib import Path
 
 import pytest
@@ -56,71 +70,151 @@ CASSETTES_DIR = REPO_ROOT / "tests" / "cassettes"
 # 40+ MB of recordings.
 _RPCIDS_RE = re.compile(r"[?&]rpcids=([A-Za-z0-9]+)")
 
-# Golden-covered families → (test file relative to repo root, test name).
-# The named test pins at least one DECODED field value for a cassette replay of
-# that RPC. Most live in the two golden modules; three are pinned where the
-# family's only decoded contract already had exact-value assertions.
+# Golden-covered families → one or more pointers ``(file relative to repo
+# root, qualified test name)``. A qualified name is ``ClassName::test_name``
+# for a method or a bare ``test_name`` for a module-level function. Every
+# pointer names a test that pins at least one DECODED field value from a
+# cassette replay of that RPC; multi-pointer entries pin each recorded
+# response shape of the family. Most live in the two golden modules; three
+# families are pinned where their only decoded contract already had
+# exact-value assertions.
 _GOLDEN_VCR = "tests/integration/test_golden_decoded_vcr.py"
 _GOLDEN_EXPANSION = "tests/integration/test_golden_decoded_vcr_expansion.py"
 _COMPREHENSIVE = "tests/integration/test_vcr_comprehensive.py"
 _GAP_BACKFILL = "tests/integration/test_rpc_gap_backfill_vcr.py"
 
-GOLDEN_COVERAGE: dict[RPCMethod, tuple[str, str]] = {
+GoldenPointer = tuple[str, str]
+
+GOLDEN_COVERAGE: dict[RPCMethod, tuple[GoldenPointer, ...]] = {
     # --- original high-risk four (issue #1494) ---
-    RPCMethod.GET_LAST_CONVERSATION_ID: (_GOLDEN_VCR, "test_ask_decoded_golden"),
-    RPCMethod.LIST_ARTIFACTS: (_GOLDEN_VCR, "test_list_decoded_golden"),
-    RPCMethod.GET_NOTEBOOK: (_GOLDEN_VCR, "test_list_decoded_golden"),
-    RPCMethod.GET_SOURCE_GUIDE: (_GOLDEN_VCR, "test_get_guide_decoded_golden"),
-    RPCMethod.GET_SOURCE: (_GOLDEN_VCR, "test_get_fulltext_decoded_golden"),
+    RPCMethod.GET_LAST_CONVERSATION_ID: (
+        (_GOLDEN_VCR, "TestChatGoldenDecoded::test_ask_decoded_golden"),
+        (_GOLDEN_VCR, "TestChatGoldenDecoded::test_ask_with_references_decoded_golden"),
+    ),
+    RPCMethod.LIST_ARTIFACTS: (
+        (_GOLDEN_VCR, "TestArtifactsListGoldenDecoded::test_list_decoded_golden"),
+        (_GOLDEN_VCR, "TestArtifactsListGoldenDecoded::test_list_reports_decoded_golden"),
+    ),
+    RPCMethod.GET_NOTEBOOK: (
+        # Source rows (sources_list.yaml) + the notebook row itself
+        # (notebooks_get.yaml) — two distinct decoded views of rLM1Ne.
+        (_GOLDEN_VCR, "TestSourcesGoldenDecoded::test_list_decoded_golden"),
+        (_GOLDEN_EXPANSION, "TestNotebooksGoldenDecoded::test_get_decoded_golden"),
+    ),
+    RPCMethod.GET_SOURCE_GUIDE: (
+        (_GOLDEN_VCR, "TestSourcesGoldenDecoded::test_get_guide_decoded_golden"),
+    ),
+    RPCMethod.GET_SOURCE: (
+        (_GOLDEN_VCR, "TestSourcesGoldenDecoded::test_get_fulltext_decoded_golden"),
+    ),
     # --- notebooks ---
-    RPCMethod.LIST_NOTEBOOKS: (_GOLDEN_EXPANSION, "test_list_decoded_golden"),
-    RPCMethod.SUMMARIZE: (_GOLDEN_EXPANSION, "test_get_summary_decoded_golden"),
-    RPCMethod.CREATE_NOTEBOOK: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    RPCMethod.LIST_NOTEBOOKS: (
+        (_GOLDEN_EXPANSION, "TestNotebooksGoldenDecoded::test_list_decoded_golden"),
+    ),
+    RPCMethod.SUMMARIZE: (
+        # Plain-summary and description+topics — the two decoded VfAZjd views.
+        (_GOLDEN_EXPANSION, "TestNotebooksGoldenDecoded::test_get_summary_decoded_golden"),
+        (_GOLDEN_EXPANSION, "TestNotebooksGoldenDecoded::test_get_description_decoded_golden"),
+    ),
+    RPCMethod.CREATE_NOTEBOOK: (
+        (_GOLDEN_EXPANSION, "TestNotebooksGoldenDecoded::test_create_decoded_golden"),
+    ),
     # --- sources ---
-    RPCMethod.ADD_SOURCE: (_GOLDEN_EXPANSION, "test_add_url_decoded_golden"),
-    RPCMethod.ADD_SOURCE_FILE: (_GOLDEN_EXPANSION, "test_add_file_decoded_golden"),
-    RPCMethod.UPDATE_SOURCE: (_GOLDEN_EXPANSION, "test_rename_decoded_golden"),
+    RPCMethod.ADD_SOURCE: (
+        # Text and URL adds return differently-shaped izAoDd rows.
+        (_GOLDEN_EXPANSION, "TestSourceMutationsGoldenDecoded::test_add_text_decoded_golden"),
+        (_GOLDEN_EXPANSION, "TestSourceMutationsGoldenDecoded::test_add_url_decoded_golden"),
+    ),
+    RPCMethod.ADD_SOURCE_FILE: (
+        (_GOLDEN_EXPANSION, "TestSourceMutationsGoldenDecoded::test_add_file_decoded_golden"),
+    ),
+    RPCMethod.UPDATE_SOURCE: (
+        (_GOLDEN_EXPANSION, "TestSourceMutationsGoldenDecoded::test_rename_decoded_golden"),
+    ),
     # --- notes / mind maps ---
     RPCMethod.GET_NOTES_AND_MIND_MAPS: (
-        _GOLDEN_EXPANSION,
-        "test_interactive_list_and_tree_decoded_golden",
+        # The empty-notes view and the mind-map-row view of the same payload.
+        (_GOLDEN_EXPANSION, "TestNotesGoldenDecoded::test_list_decoded_golden"),
+        (
+            _GOLDEN_EXPANSION,
+            "TestMindMapsGoldenDecoded::test_interactive_list_and_tree_decoded_golden",
+        ),
     ),
-    RPCMethod.CREATE_NOTE: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    RPCMethod.CREATE_NOTE: (
+        (_GOLDEN_EXPANSION, "TestNotesGoldenDecoded::test_create_decoded_golden"),
+        # The mind-map chain's note_id pin is the decoded CREATE_NOTE id too.
+        (_GOLDEN_EXPANSION, "TestMindMapsGoldenDecoded::test_generate_mind_map_decoded_golden"),
+    ),
     RPCMethod.GET_INTERACTIVE_HTML: (
-        _GOLDEN_EXPANSION,
-        "test_interactive_list_and_tree_decoded_golden",
+        (
+            _GOLDEN_EXPANSION,
+            "TestMindMapsGoldenDecoded::test_interactive_list_and_tree_decoded_golden",
+        ),
     ),
-    RPCMethod.GENERATE_MIND_MAP: (_GOLDEN_EXPANSION, "test_generate_mind_map_decoded_golden"),
+    RPCMethod.GENERATE_MIND_MAP: (
+        (_GOLDEN_EXPANSION, "TestMindMapsGoldenDecoded::test_generate_mind_map_decoded_golden"),
+    ),
     # --- chat ---
-    RPCMethod.GET_CONVERSATION_TURNS: (_GOLDEN_EXPANSION, "test_get_history_decoded_golden"),
+    RPCMethod.GET_CONVERSATION_TURNS: (
+        (_GOLDEN_EXPANSION, "TestChatHistoryGoldenDecoded::test_get_history_decoded_golden"),
+    ),
     # --- labels ---
-    RPCMethod.LIST_LABELS: (_GOLDEN_EXPANSION, "test_list_decoded_golden"),
-    RPCMethod.CREATE_LABEL: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    RPCMethod.LIST_LABELS: (
+        (_GOLDEN_EXPANSION, "TestLabelsGoldenDecoded::test_list_decoded_golden"),
+    ),
+    RPCMethod.CREATE_LABEL: (
+        (_GOLDEN_EXPANSION, "TestLabelsGoldenDecoded::test_create_decoded_golden"),
+    ),
     # --- sharing ---
-    RPCMethod.GET_SHARE_STATUS: (_GOLDEN_EXPANSION, "test_get_status_decoded_golden"),
+    RPCMethod.GET_SHARE_STATUS: (
+        (_GOLDEN_EXPANSION, "TestSharingGoldenDecoded::test_get_status_decoded_golden"),
+    ),
     # --- research ---
-    RPCMethod.START_FAST_RESEARCH: (_GOLDEN_EXPANSION, "test_start_fast_decoded_golden"),
-    RPCMethod.START_DEEP_RESEARCH: (_GOLDEN_EXPANSION, "test_start_deep_decoded_golden"),
-    RPCMethod.POLL_RESEARCH: (_GOLDEN_EXPANSION, "test_poll_decoded_golden"),
+    RPCMethod.START_FAST_RESEARCH: (
+        (_GOLDEN_EXPANSION, "TestResearchGoldenDecoded::test_start_fast_decoded_golden"),
+    ),
+    RPCMethod.START_DEEP_RESEARCH: (
+        (_GOLDEN_EXPANSION, "TestResearchGoldenDecoded::test_start_deep_decoded_golden"),
+    ),
+    RPCMethod.POLL_RESEARCH: (
+        (_GOLDEN_EXPANSION, "TestResearchGoldenDecoded::test_poll_decoded_golden"),
+    ),
     # IMPORT_RESEARCH's decoded contract (the imported id/title list) is pinned
     # exactly in the gap-backfill module that owns its cassette.
-    RPCMethod.IMPORT_RESEARCH: (_GAP_BACKFILL, "test_import_research_rpc_has_cassette_coverage"),
+    RPCMethod.IMPORT_RESEARCH: ((_GAP_BACKFILL, "test_import_research_rpc_has_cassette_coverage"),),
     # --- settings ---
-    RPCMethod.GET_USER_SETTINGS: (_GOLDEN_EXPANSION, "test_get_output_language_decoded_golden"),
-    RPCMethod.SET_USER_SETTINGS: (_GOLDEN_EXPANSION, "test_set_output_language_decoded_golden"),
-    RPCMethod.GET_USER_TIER: (_GOLDEN_EXPANSION, "test_get_account_tier_decoded_golden"),
+    RPCMethod.GET_USER_SETTINGS: (
+        (_GOLDEN_EXPANSION, "TestSettingsGoldenDecoded::test_get_output_language_decoded_golden"),
+    ),
+    RPCMethod.SET_USER_SETTINGS: (
+        (_GOLDEN_EXPANSION, "TestSettingsGoldenDecoded::test_set_output_language_decoded_golden"),
+    ),
+    RPCMethod.GET_USER_TIER: (
+        (_GOLDEN_EXPANSION, "TestSettingsGoldenDecoded::test_get_account_tier_decoded_golden"),
+    ),
     # --- artifacts ---
-    RPCMethod.CREATE_ARTIFACT: (_GOLDEN_EXPANSION, "test_generate_report_decoded_golden"),
-    RPCMethod.GET_SUGGESTED_REPORTS: (_GOLDEN_EXPANSION, "test_suggest_reports_decoded_golden"),
-    RPCMethod.EXPORT_ARTIFACT: (_GOLDEN_EXPANSION, "test_export_report_decoded_golden"),
-    RPCMethod.REVISE_SLIDE: (_GOLDEN_EXPANSION, "test_revise_slide_decoded_golden"),
+    RPCMethod.CREATE_ARTIFACT: (
+        (_GOLDEN_EXPANSION, "TestArtifactsWriteGoldenDecoded::test_generate_report_decoded_golden"),
+    ),
+    RPCMethod.GET_SUGGESTED_REPORTS: (
+        (_GOLDEN_EXPANSION, "TestArtifactsWriteGoldenDecoded::test_suggest_reports_decoded_golden"),
+    ),
+    RPCMethod.EXPORT_ARTIFACT: (
+        (_GOLDEN_EXPANSION, "TestArtifactsWriteGoldenDecoded::test_export_report_decoded_golden"),
+    ),
+    RPCMethod.REVISE_SLIDE: (
+        (_GOLDEN_EXPANSION, "TestArtifactsWriteGoldenDecoded::test_revise_slide_decoded_golden"),
+    ),
     # RETRY_ARTIFACT's decoded contract (task_id echo + "in_progress") is pinned
     # exactly where its cassette is owned.
-    RPCMethod.RETRY_ARTIFACT: (_COMPREHENSIVE, "test_retry_failed"),
-    # CHECK_SOURCE_FRESHNESS decodes to a single boolean; both recorded shapes
-    # ([] and [[null, true, [id]]]) are pinned to ``is True`` where the
-    # cassettes are owned.
-    RPCMethod.CHECK_SOURCE_FRESHNESS: (_COMPREHENSIVE, "test_check_freshness"),
+    RPCMethod.RETRY_ARTIFACT: ((_COMPREHENSIVE, "TestArtifactsGenerateAPI::test_retry_failed"),),
+    # CHECK_SOURCE_FRESHNESS decodes to a single boolean; BOTH recorded shapes
+    # ([] for web, [[null, true, [id]]] for drive) are pinned to ``is True``
+    # where the cassettes are owned.
+    RPCMethod.CHECK_SOURCE_FRESHNESS: (
+        (_COMPREHENSIVE, "TestSourcesAdditionalAPI::test_check_freshness"),
+        (_COMPREHENSIVE, "TestSourcesAdditionalAPI::test_check_freshness_drive"),
+    ),
 }
 
 # Sanctioned exemption reasons (named constants so a typo can't fork them).
@@ -163,8 +257,19 @@ _VALID_REASONS = frozenset({_REASON_NONE_CONTRACT, _REASON_RESPONSE_DISCARDED})
 
 
 def _cassette_files() -> list[Path]:
-    """Real cassettes: top-level ``tests/cassettes/*.yaml`` (examples/ excluded)."""
-    return sorted(f for f in CASSETTES_DIR.glob("*.yaml") if not f.name.startswith("example_"))
+    """Real cassettes anywhere under ``tests/cassettes/`` (examples/ excluded).
+
+    Recursive so nested replay corpora (e.g. ``gzip_coverage/``) are gated
+    too; the ``examples/`` directory and ``example_*`` files are illustrative
+    fixtures, never replayed (same filter as
+    ``tests/integration/conftest.py``).
+    """
+    return sorted(
+        f
+        for f in CASSETTES_DIR.rglob("*.yaml")
+        if "examples" not in f.relative_to(CASSETTES_DIR).parts
+        and not f.name.startswith("example_")
+    )
 
 
 def _recorded_rpcids(text: str) -> set[str]:
@@ -172,13 +277,63 @@ def _recorded_rpcids(text: str) -> set[str]:
     return set(_RPCIDS_RE.findall(text))
 
 
+@lru_cache(maxsize=1)
+def _corpus_rpcids_by_cassette() -> dict[str, frozenset[str]]:
+    """Map each cassette file name -> the rpcids it records (cached: ~40 MB read)."""
+    return {
+        path.name: frozenset(_recorded_rpcids(path.read_text(encoding="utf-8")))
+        for path in _cassette_files()
+    }
+
+
 def _corpus_rpcids() -> dict[str, set[str]]:
     """Map each recorded rpcid -> the cassette file names that record it."""
     corpus: dict[str, set[str]] = {}
-    for path in _cassette_files():
-        for rpcid in _recorded_rpcids(path.read_text(encoding="utf-8")):
-            corpus.setdefault(rpcid, set()).add(path.name)
+    for name, rpcids in _corpus_rpcids_by_cassette().items():
+        for rpcid in rpcids:
+            corpus.setdefault(rpcid, set()).add(name)
     return corpus
+
+
+def _decorator_cassettes(tree: ast.Module) -> dict[str, frozenset[str]]:
+    """Map qualified test name -> ``*.yaml`` literals in its decorator list.
+
+    Qualified names are ``ClassName::method`` for class-level tests and the
+    bare function name for module-level tests — mirroring how pytest node ids
+    disambiguate the same-named methods that exist across golden classes. Only
+    *decorator* string literals count (``@notebooklm_vcr.use_cassette("x.yaml",
+    ...)``); a cassette name mentioned in the body or a comment does not.
+    Pure on its input so the self-test can exercise it without touching disk.
+    """
+
+    def yaml_literals(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> frozenset[str]:
+        return frozenset(
+            node.value
+            for decorator in fn.decorator_list
+            for node in ast.walk(decorator)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.endswith(".yaml")
+        )
+
+    out: dict[str, frozenset[str]] = {}
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    out[f"{node.name}::{sub.name}"] = yaml_literals(sub)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            out[node.name] = yaml_literals(node)
+    return out
+
+
+@cache
+def _file_decorator_cassettes(rel: str) -> dict[str, frozenset[str]] | None:
+    """``_decorator_cassettes`` for a repo-relative file, or None if missing."""
+    path = REPO_ROOT / rel
+    if not path.is_file():
+        return None
+    return _decorator_cassettes(ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
 
 
 def test_every_cassette_rpcid_is_classified() -> None:
@@ -216,21 +371,50 @@ def test_every_cassette_rpcid_is_classified() -> None:
     )
 
 
-def test_covered_entries_point_at_existing_tests() -> None:
-    """Every ``GOLDEN_COVERAGE`` entry maps to a real file containing the named test.
+def test_covered_pointers_are_real_tests_replaying_the_right_cassettes() -> None:
+    """Every ``GOLDEN_COVERAGE`` pointer names a real test that replays this family.
 
-    A dangling mapping (renamed test, deleted file) would silently claim
-    coverage that no longer exists.
+    Three failure modes are rejected per pointer, so a mapping can't silently
+    claim coverage that no longer exists:
+
+    * the file is missing, or no test exists at the exact qualified
+      ``Class::name`` location (a same-named test in ANOTHER class does not
+      satisfy the pointer — names repeat across golden classes);
+    * the test carries no ``use_cassette("*.yaml")`` decorator (it replays
+      nothing);
+    * none of its decorator cassettes actually records this entry's rpcid
+      (the test replays an unrelated family).
     """
-    broken: dict[str, str] = {}
-    for method, (rel, test_name) in GOLDEN_COVERAGE.items():
-        path = REPO_ROOT / rel
-        if not path.is_file():
-            broken[method.name] = f"missing file {rel}"
-        elif f"def {test_name}(" not in path.read_text(encoding="utf-8"):
-            broken[method.name] = f"no test named {test_name!r} in {rel}"
+    broken: dict[str, list[str]] = {}
+    by_cassette = _corpus_rpcids_by_cassette()
+    for method, pointers in GOLDEN_COVERAGE.items():
+        problems: list[str] = []
+        if not pointers:
+            problems.append("entry has no pointers")
+        for rel, qualname in pointers:
+            tests = _file_decorator_cassettes(rel)
+            if tests is None:
+                problems.append(f"missing file {rel}")
+                continue
+            if qualname not in tests:
+                problems.append(f"no test at {rel}::{qualname}")
+                continue
+            cassettes = tests[qualname]
+            if not cassettes:
+                problems.append(f"{rel}::{qualname} has no use_cassette decorator")
+                continue
+            if not any(method.value in by_cassette.get(name, frozenset()) for name in cassettes):
+                problems.append(
+                    f"{rel}::{qualname} replays {sorted(cassettes)}, none of which "
+                    f"records rpcid {method.value!r}"
+                )
+        if problems:
+            broken[method.name] = problems
     assert broken == {}, (
-        f"GOLDEN_COVERAGE entries point at tests that do not exist — fix or remove them: {broken}"
+        "GOLDEN_COVERAGE pointer(s) do not hold up — each pointer must name an "
+        "existing test (exact Class::name) whose use_cassette decorator replays "
+        "a cassette recording that family's rpcid. Fix or remove:\n"
+        + "\n".join(f"  {name}: {problems}" for name, problems in sorted(broken.items()))
     )
 
 
@@ -293,3 +477,35 @@ def test_rpcids_extractor_self_test() -> None:
     )
     assert _recorded_rpcids(sample) == {"wXbhsf", "gArtLc"}
     assert _recorded_rpcids("no ids here") == set()
+
+
+def test_decorator_cassette_collector_self_test() -> None:
+    """The AST collector maps qualified names to decorator cassettes only.
+
+    Pure-input self-test: class methods get ``Class::name`` keys, module
+    functions get bare keys, multiple/parametrized decorator literals are all
+    collected, and a cassette mentioned only in a body string or comment does
+    NOT count — so the pointer check can't be satisfied by prose.
+    """
+    src = "\n".join(
+        [
+            "import pytest",
+            "class TestAlpha:",
+            "    @pytest.mark.vcr",
+            "    @notebooklm_vcr.use_cassette('alpha.yaml', match_on=['freq'])",
+            "    async def test_one(self):",
+            "        pass",
+            "    async def test_bare(self):",
+            "        x = 'body_mention.yaml'  # not a decorator",
+            "@notebooklm_vcr.use_cassette('gamma.yaml')",
+            "@notebooklm_vcr.use_cassette('delta.yaml')",
+            "def test_module_level():",
+            "    pass",
+        ]
+    )
+    collected = _decorator_cassettes(ast.parse(src))
+    assert collected == {
+        "TestAlpha::test_one": frozenset({"alpha.yaml"}),
+        "TestAlpha::test_bare": frozenset(),
+        "test_module_level": frozenset({"gamma.yaml", "delta.yaml"}),
+    }

--- a/tests/_guardrails/test_golden_decode_coverage.py
+++ b/tests/_guardrails/test_golden_decode_coverage.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import ast
 import re
-from functools import cache, lru_cache
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -68,6 +68,13 @@ CASSETTES_DIR = REPO_ROOT / "tests" / "cassettes"
 # POST, and the ids are strictly alphanumeric (see ``rpc/types.py``), so a
 # regex over the raw cassette text is exact — and far cheaper than YAML-parsing
 # 40+ MB of recordings.
+#
+# Deliberately FULL-TEXT (not scoped to ``uri:`` lines): a hypothetical
+# ``?rpcids=...`` URL inside a recorded response body would be counted too,
+# but that failure mode is LOUD (an unknown/unclassified rpcid fails the
+# gate and a human looks), whereas scoping to ``uri:`` lines could silently
+# DROP a real request id if YAML ever folds a long URI across lines —
+# turning the gate vacuous for that family. Loud-over-silent wins.
 _RPCIDS_RE = re.compile(r"[?&]rpcids=([A-Za-z0-9]+)")
 
 # Golden-covered families → one or more pointers ``(file relative to repo
@@ -277,13 +284,22 @@ def _recorded_rpcids(text: str) -> set[str]:
     return set(_RPCIDS_RE.findall(text))
 
 
-@lru_cache(maxsize=1)
+@cache
 def _corpus_rpcids_by_cassette() -> dict[str, frozenset[str]]:
-    """Map each cassette file name -> the rpcids it records (cached: ~40 MB read)."""
-    return {
-        path.name: frozenset(_recorded_rpcids(path.read_text(encoding="utf-8")))
-        for path in _cassette_files()
-    }
+    """Map each cassette base name -> the rpcids it records (cached: ~40 MB read).
+
+    Keyed by base name because that is what ``use_cassette`` decorators carry.
+    Should two cassettes in different subdirectories ever share a base name,
+    their rpcid sets are UNIONED (not last-wins), so a pointer can never be
+    invalidated — or falsely satisfied for a *different* family — by a
+    directory-level name collision.
+    """
+    corpus: dict[str, set[str]] = {}
+    for path in _cassette_files():
+        corpus.setdefault(path.name, set()).update(
+            _recorded_rpcids(path.read_text(encoding="utf-8"))
+        )
+    return {name: frozenset(rpcids) for name, rpcids in corpus.items()}
 
 
 def _corpus_rpcids() -> dict[str, set[str]]:
@@ -403,7 +419,12 @@ def test_covered_pointers_are_real_tests_replaying_the_right_cassettes() -> None
             if not cassettes:
                 problems.append(f"{rel}::{qualname} has no use_cassette decorator")
                 continue
-            if not any(method.value in by_cassette.get(name, frozenset()) for name in cassettes):
+            # Normalize to base names: a decorator may carry a subdirectory
+            # path (e.g. ``"gzip_coverage/foo.yaml"``) while the corpus map is
+            # keyed by base name.
+            if not any(
+                method.value in by_cassette.get(Path(name).name, frozenset()) for name in cassettes
+            ):
                 problems.append(
                     f"{rel}::{qualname} replays {sorted(cassettes)}, none of which "
                     f"records rpcid {method.value!r}"
@@ -477,6 +498,13 @@ def test_rpcids_extractor_self_test() -> None:
     )
     assert _recorded_rpcids(sample) == {"wXbhsf", "gArtLc"}
     assert _recorded_rpcids("no ids here") == set()
+    # Full-text scan is INTENTIONAL (see the ``_RPCIDS_RE`` comment): a
+    # ``?rpcids=`` URL inside a recorded response body IS extracted, because
+    # that false positive fails the gate loudly, whereas scoping to ``uri:``
+    # lines could silently drop a folded request URI and turn the gate
+    # vacuous for that family.
+    body_url = "    string: 'see https://x.test/page?rpcids=Zz9fake for details'"
+    assert _recorded_rpcids(body_url) == {"Zz9fake"}
 
 
 def test_decorator_cassette_collector_self_test() -> None:

--- a/tests/_guardrails/test_golden_decode_coverage.py
+++ b/tests/_guardrails/test_golden_decode_coverage.py
@@ -1,0 +1,295 @@
+"""Guard: every cassette-backed RPC family is golden-decode-covered or exempt.
+
+The VCR cassette matcher (``tests/vcr_config.py``) compares request **shape**,
+never response leaves, so a decode regression that puts a wrong value in the
+right slot replays green. The compensating control is the *golden decoded-row*
+suite (``tests/integration/test_golden_decoded_vcr.py`` and
+``test_golden_decoded_vcr_expansion.py``): for each recorded RPC family it pins
+decoded dataclass field values, so positional-decode drift fails loudly.
+
+This gate keeps that compensating control complete as the cassette corpus
+grows. It enumerates every ``rpcids`` value recorded in ``tests/cassettes/``
+(top level — ``examples/`` fixtures are illustrative, not replayed) and asserts
+each one is EITHER:
+
+1. **Covered** — listed in :data:`GOLDEN_COVERAGE`, keyed by the
+   :class:`~notebooklm.rpc.RPCMethod` constant and mapped to the test (file +
+   test name) that pins at least one decoded-field value produced from a
+   cassette replay of that RPC. The file must exist and contain the named
+   test, OR
+2. **Exempt** — listed in :data:`GOLDEN_EXEMPT` with one of the sanctioned
+   reasons, chosen by READING the client decode path: either the client
+   discards the RPC's response outright, or the method's success contract is
+   ``None`` so there is no decoded payload to pin.
+
+Keying by ``RPCMethod`` (not by obfuscated string literals) keeps
+``rpc/types.py`` the single source of truth: when Google rotates an ID and the
+cassettes are re-recorded, this gate follows automatically. A cassette
+recording an rpcid that no current ``RPCMethod`` knows fails loudly — that is
+either a stale cassette or an un-modelled RPC, both worth a human look.
+
+New cassettes start gated: recording a new RPC family without classifying it
+here fails :func:`test_every_cassette_rpcid_is_classified` with instructions.
+
+Modelled on the covered-or-exempt gate in
+``tests/_guardrails/test_cli_vcr_coverage.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from notebooklm.rpc import RPCMethod
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASSETTES_DIR = REPO_ROOT / "tests" / "cassettes"
+
+# Recorded request URIs carry the RPC family as a query param:
+# ``.../batchexecute?rpcids=<id>&...``. The client sends exactly one rpcid per
+# POST, and the ids are strictly alphanumeric (see ``rpc/types.py``), so a
+# regex over the raw cassette text is exact — and far cheaper than YAML-parsing
+# 40+ MB of recordings.
+_RPCIDS_RE = re.compile(r"[?&]rpcids=([A-Za-z0-9]+)")
+
+# Golden-covered families → (test file relative to repo root, test name).
+# The named test pins at least one DECODED field value for a cassette replay of
+# that RPC. Most live in the two golden modules; three are pinned where the
+# family's only decoded contract already had exact-value assertions.
+_GOLDEN_VCR = "tests/integration/test_golden_decoded_vcr.py"
+_GOLDEN_EXPANSION = "tests/integration/test_golden_decoded_vcr_expansion.py"
+_COMPREHENSIVE = "tests/integration/test_vcr_comprehensive.py"
+_GAP_BACKFILL = "tests/integration/test_rpc_gap_backfill_vcr.py"
+
+GOLDEN_COVERAGE: dict[RPCMethod, tuple[str, str]] = {
+    # --- original high-risk four (issue #1494) ---
+    RPCMethod.GET_LAST_CONVERSATION_ID: (_GOLDEN_VCR, "test_ask_decoded_golden"),
+    RPCMethod.LIST_ARTIFACTS: (_GOLDEN_VCR, "test_list_decoded_golden"),
+    RPCMethod.GET_NOTEBOOK: (_GOLDEN_VCR, "test_list_decoded_golden"),
+    RPCMethod.GET_SOURCE_GUIDE: (_GOLDEN_VCR, "test_get_guide_decoded_golden"),
+    RPCMethod.GET_SOURCE: (_GOLDEN_VCR, "test_get_fulltext_decoded_golden"),
+    # --- notebooks ---
+    RPCMethod.LIST_NOTEBOOKS: (_GOLDEN_EXPANSION, "test_list_decoded_golden"),
+    RPCMethod.SUMMARIZE: (_GOLDEN_EXPANSION, "test_get_summary_decoded_golden"),
+    RPCMethod.CREATE_NOTEBOOK: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    # --- sources ---
+    RPCMethod.ADD_SOURCE: (_GOLDEN_EXPANSION, "test_add_url_decoded_golden"),
+    RPCMethod.ADD_SOURCE_FILE: (_GOLDEN_EXPANSION, "test_add_file_decoded_golden"),
+    RPCMethod.UPDATE_SOURCE: (_GOLDEN_EXPANSION, "test_rename_decoded_golden"),
+    # --- notes / mind maps ---
+    RPCMethod.GET_NOTES_AND_MIND_MAPS: (
+        _GOLDEN_EXPANSION,
+        "test_interactive_list_and_tree_decoded_golden",
+    ),
+    RPCMethod.CREATE_NOTE: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    RPCMethod.GET_INTERACTIVE_HTML: (
+        _GOLDEN_EXPANSION,
+        "test_interactive_list_and_tree_decoded_golden",
+    ),
+    RPCMethod.GENERATE_MIND_MAP: (_GOLDEN_EXPANSION, "test_generate_mind_map_decoded_golden"),
+    # --- chat ---
+    RPCMethod.GET_CONVERSATION_TURNS: (_GOLDEN_EXPANSION, "test_get_history_decoded_golden"),
+    # --- labels ---
+    RPCMethod.LIST_LABELS: (_GOLDEN_EXPANSION, "test_list_decoded_golden"),
+    RPCMethod.CREATE_LABEL: (_GOLDEN_EXPANSION, "test_create_decoded_golden"),
+    # --- sharing ---
+    RPCMethod.GET_SHARE_STATUS: (_GOLDEN_EXPANSION, "test_get_status_decoded_golden"),
+    # --- research ---
+    RPCMethod.START_FAST_RESEARCH: (_GOLDEN_EXPANSION, "test_start_fast_decoded_golden"),
+    RPCMethod.START_DEEP_RESEARCH: (_GOLDEN_EXPANSION, "test_start_deep_decoded_golden"),
+    RPCMethod.POLL_RESEARCH: (_GOLDEN_EXPANSION, "test_poll_decoded_golden"),
+    # IMPORT_RESEARCH's decoded contract (the imported id/title list) is pinned
+    # exactly in the gap-backfill module that owns its cassette.
+    RPCMethod.IMPORT_RESEARCH: (_GAP_BACKFILL, "test_import_research_rpc_has_cassette_coverage"),
+    # --- settings ---
+    RPCMethod.GET_USER_SETTINGS: (_GOLDEN_EXPANSION, "test_get_output_language_decoded_golden"),
+    RPCMethod.SET_USER_SETTINGS: (_GOLDEN_EXPANSION, "test_set_output_language_decoded_golden"),
+    RPCMethod.GET_USER_TIER: (_GOLDEN_EXPANSION, "test_get_account_tier_decoded_golden"),
+    # --- artifacts ---
+    RPCMethod.CREATE_ARTIFACT: (_GOLDEN_EXPANSION, "test_generate_report_decoded_golden"),
+    RPCMethod.GET_SUGGESTED_REPORTS: (_GOLDEN_EXPANSION, "test_suggest_reports_decoded_golden"),
+    RPCMethod.EXPORT_ARTIFACT: (_GOLDEN_EXPANSION, "test_export_report_decoded_golden"),
+    RPCMethod.REVISE_SLIDE: (_GOLDEN_EXPANSION, "test_revise_slide_decoded_golden"),
+    # RETRY_ARTIFACT's decoded contract (task_id echo + "in_progress") is pinned
+    # exactly where its cassette is owned.
+    RPCMethod.RETRY_ARTIFACT: (_COMPREHENSIVE, "test_retry_failed"),
+    # CHECK_SOURCE_FRESHNESS decodes to a single boolean; both recorded shapes
+    # ([] and [[null, true, [id]]]) are pinned to ``is True`` where the
+    # cassettes are owned.
+    RPCMethod.CHECK_SOURCE_FRESHNESS: (_COMPREHENSIVE, "test_check_freshness"),
+}
+
+# Sanctioned exemption reasons (named constants so a typo can't fork them).
+_REASON_NONE_CONTRACT = (
+    "success contract returns None; the response carries no decodable row to pin"
+)
+_REASON_RESPONSE_DISCARDED = (
+    "client discards this RPC's response; any returned object is decoded from a "
+    "separate (golden-covered) read RPC"
+)
+
+# Families with a cassette but nothing decodable to pin → reason. Verified by
+# reading each client decode path (see the per-entry notes).
+GOLDEN_EXEMPT: dict[RPCMethod, str] = {
+    # Deletes / fire-and-forget writes: ``None`` on success by contract.
+    RPCMethod.DELETE_NOTEBOOK: _REASON_NONE_CONTRACT,
+    RPCMethod.DELETE_SOURCE: _REASON_NONE_CONTRACT,
+    RPCMethod.DELETE_ARTIFACT: _REASON_NONE_CONTRACT,
+    RPCMethod.DELETE_NOTE: _REASON_NONE_CONTRACT,
+    RPCMethod.DELETE_LABEL: _REASON_NONE_CONTRACT,
+    RPCMethod.DELETE_CONVERSATION: _REASON_NONE_CONTRACT,
+    RPCMethod.REMOVE_RECENTLY_VIEWED: _REASON_NONE_CONTRACT,
+    # ``sources.refresh`` returns None on success (v0.8.0, #1290).
+    RPCMethod.REFRESH_SOURCE: _REASON_NONE_CONTRACT,
+    # ``notes.update`` returns None (the UPDATE_NOTE echo is not decoded).
+    RPCMethod.UPDATE_NOTE: _REASON_NONE_CONTRACT,
+    # Rename/share/update writes whose returned object is re-fetched through a
+    # covered read RPC (GET_NOTEBOOK / LIST_ARTIFACTS / LIST_LABELS /
+    # GET_SHARE_STATUS), so the write response itself is never decoded.
+    RPCMethod.RENAME_NOTEBOOK: _REASON_RESPONSE_DISCARDED,
+    RPCMethod.RENAME_ARTIFACT: _REASON_RESPONSE_DISCARDED,
+    RPCMethod.UPDATE_LABEL: _REASON_RESPONSE_DISCARDED,
+    RPCMethod.SHARE_NOTEBOOK: _REASON_RESPONSE_DISCARDED,
+    # Legacy ``notebooks.share`` (SHARE_ARTIFACT): the return dict is built
+    # entirely from the caller's inputs; the response is discarded.
+    RPCMethod.SHARE_ARTIFACT: _REASON_RESPONSE_DISCARDED,
+}
+
+_VALID_REASONS = frozenset({_REASON_NONE_CONTRACT, _REASON_RESPONSE_DISCARDED})
+
+
+def _cassette_files() -> list[Path]:
+    """Real cassettes: top-level ``tests/cassettes/*.yaml`` (examples/ excluded)."""
+    return sorted(f for f in CASSETTES_DIR.glob("*.yaml") if not f.name.startswith("example_"))
+
+
+def _recorded_rpcids(text: str) -> set[str]:
+    """Extract the set of recorded ``rpcids`` query values from cassette text."""
+    return set(_RPCIDS_RE.findall(text))
+
+
+def _corpus_rpcids() -> dict[str, set[str]]:
+    """Map each recorded rpcid -> the cassette file names that record it."""
+    corpus: dict[str, set[str]] = {}
+    for path in _cassette_files():
+        for rpcid in _recorded_rpcids(path.read_text(encoding="utf-8")):
+            corpus.setdefault(rpcid, set()).add(path.name)
+    return corpus
+
+
+def test_every_cassette_rpcid_is_classified() -> None:
+    """Every rpcid recorded in ``tests/cassettes/`` is golden-covered or exempt.
+
+    A new cassette that records an unclassified RPC family is a fresh blind
+    spot for the shape-only matcher: add a golden decoded-row test (and map it
+    in ``GOLDEN_COVERAGE``), or — only when the client genuinely decodes
+    nothing from the response — add a ``GOLDEN_EXEMPT`` entry with one of the
+    sanctioned reasons.
+    """
+    known_values = {method.value: method for method in RPCMethod}
+    classified_values = {m.value for m in GOLDEN_COVERAGE} | {m.value for m in GOLDEN_EXEMPT}
+    corpus = _corpus_rpcids()
+
+    unknown = {rpcid: sorted(files) for rpcid, files in corpus.items() if rpcid not in known_values}
+    assert unknown == {}, (
+        "Cassette(s) record rpcid(s) that no current RPCMethod constant knows — "
+        "either Google rotated an ID (update rpc/types.py and re-record) or a "
+        f"stale cassette slipped in: {unknown}"
+    )
+
+    unclassified = {
+        rpcid: sorted(files) for rpcid, files in corpus.items() if rpcid not in classified_values
+    }
+    assert unclassified == {}, (
+        "Cassette-recorded RPC familie(s) have no golden decoded-row coverage and "
+        "no exemption (golden-decode coverage gate). Add a golden test pinning a "
+        "decoded field value (map it in GOLDEN_COVERAGE) or a reasoned "
+        "GOLDEN_EXEMPT entry:\n"
+        + "\n".join(
+            f"  {RPCMethod(rpcid).name} ({rpcid}): recorded in {files}"
+            for rpcid, files in sorted(unclassified.items())
+        )
+    )
+
+
+def test_covered_entries_point_at_existing_tests() -> None:
+    """Every ``GOLDEN_COVERAGE`` entry maps to a real file containing the named test.
+
+    A dangling mapping (renamed test, deleted file) would silently claim
+    coverage that no longer exists.
+    """
+    broken: dict[str, str] = {}
+    for method, (rel, test_name) in GOLDEN_COVERAGE.items():
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            broken[method.name] = f"missing file {rel}"
+        elif f"def {test_name}(" not in path.read_text(encoding="utf-8"):
+            broken[method.name] = f"no test named {test_name!r} in {rel}"
+    assert broken == {}, (
+        f"GOLDEN_COVERAGE entries point at tests that do not exist — fix or remove them: {broken}"
+    )
+
+
+def test_covered_and_exempt_sets_are_disjoint() -> None:
+    """No RPC family may be both covered and exempt."""
+    overlap = sorted(m.name for m in set(GOLDEN_COVERAGE) & set(GOLDEN_EXEMPT))
+    assert overlap == [], (
+        f"RPC familie(s) appear in BOTH GOLDEN_COVERAGE and GOLDEN_EXEMPT: {overlap}. "
+        "A covered family must not also be exempt."
+    )
+
+
+def test_every_exemption_has_a_sanctioned_reason() -> None:
+    """Each ``GOLDEN_EXEMPT`` reason must be one of the sanctioned constants.
+
+    Forces every exemption into an audited bucket so a free-text reason can't
+    smuggle in an un-triaged blind spot.
+    """
+    bad = {m.name: r for m, r in GOLDEN_EXEMPT.items() if r not in _VALID_REASONS}
+    assert bad == {}, (
+        "GOLDEN_EXEMPT entries with an unrecognised reason — use one of the "
+        f"sanctioned constants: {bad}"
+    )
+
+
+def test_no_stale_classifications() -> None:
+    """Every classified family must still be recorded by at least one cassette.
+
+    A classification whose cassettes were all deleted is dead weight that would
+    mask a future re-recording under the same id arriving unreviewed.
+    """
+    recorded = set(_corpus_rpcids())
+    stale = sorted(
+        m.name for m in (set(GOLDEN_COVERAGE) | set(GOLDEN_EXEMPT)) if m.value not in recorded
+    )
+    assert stale == [], (
+        "Classified RPC familie(s) are no longer recorded by any cassette — "
+        f"remove the stale entries: {stale}"
+    )
+
+
+def test_rpcids_extractor_self_test() -> None:
+    """The rpcid extractor finds query-param ids and ignores look-alikes.
+
+    Pure-input self-test (no filesystem) so a regex regression in
+    :data:`_RPCIDS_RE` cannot silently empty the corpus and turn the gate
+    vacuous.
+    """
+    sample = "\n".join(
+        [
+            "interactions:",
+            "- request:",
+            "    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=wXbhsf&source-path=%2F&f.sid=1",
+            "- request:",
+            "    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?bl=boq&rpcids=gArtLc&rt=c",
+            "    body: 'f.req=%5B%5B%22rpcids%22%5D%5D'",  # body mention, not a query param
+            "- request:",
+            "    uri: https://accounts.google.com/RotateCookies",  # no rpcids at all
+        ]
+    )
+    assert _recorded_rpcids(sample) == {"wXbhsf", "gArtLc"}
+    assert _recorded_rpcids("no ids here") == set()

--- a/tests/integration/_golden_assert.py
+++ b/tests/integration/_golden_assert.py
@@ -1,0 +1,32 @@
+"""Shared golden decoded-row assertion helper.
+
+Used by ``test_golden_decoded_vcr.py`` and ``test_golden_decoded_vcr_expansion.py``
+(extracted so the two modules don't cross-import — see the
+``tests/_guardrails/test_no_cross_test_imports.py`` gate: a shared helper belongs
+in a ``_``-prefixed non-test module both test modules import).
+"""
+
+from __future__ import annotations
+
+import reprlib
+from typing import Any
+
+
+def assert_decoded_equals(actual: Any, expected: Any, *, field: str) -> None:
+    """Pin one decoded leaf value, with a decode-drift-flavoured failure message.
+
+    A thin wrapper over ``assert actual == expected`` whose only value is the
+    message: when a golden value diverges it is almost always a *decoder*
+    regression (a positional column mis-map or a leaf-shape change in the
+    recorded response), not a test bug — the message says so, and names the
+    field, so the failure points at the right place. ``field`` is a
+    human-readable label like ``"artifacts_list[0].kind"``.
+    """
+    assert actual == expected, (
+        f"Decoded golden value drift for {field}: "
+        f"expected {reprlib.repr(expected)}, got {reprlib.repr(actual)}. "
+        "The cassette replayed but the decoder produced a different leaf value than the "
+        "golden recording — likely a positional mis-map (row-adapter column moved) or a "
+        "leaf-shape change in the recorded response. If the cassette was deliberately "
+        "re-recorded against a different notebook, refresh the golden value here."
+    )

--- a/tests/integration/_vcr_helpers.py
+++ b/tests/integration/_vcr_helpers.py
@@ -1,0 +1,22 @@
+"""Shared VCR-replay client helper for the golden decoded-row modules.
+
+Used by ``test_golden_decoded_vcr.py`` and ``test_golden_decoded_vcr_expansion.py``
+(extracted, like ``_golden_assert.py``, so the two modules don't cross-import —
+see the ``tests/_guardrails/test_no_cross_test_imports.py`` gate).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from tests.integration.conftest import get_vcr_auth
+
+from notebooklm import NotebookLMClient
+
+
+@asynccontextmanager
+async def vcr_client():
+    """Authenticated client bound to VCR replay (mock auth in replay mode)."""
+    auth = await get_vcr_auth()
+    async with NotebookLMClient(auth) as client:
+        yield client

--- a/tests/integration/test_golden_decoded_vcr.py
+++ b/tests/integration/test_golden_decoded_vcr.py
@@ -48,9 +48,9 @@ from __future__ import annotations
 import os
 import reprlib
 from contextlib import asynccontextmanager
-from typing import Any
 
 import pytest
+from tests.integration._golden_assert import assert_decoded_equals
 from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 
@@ -88,29 +88,10 @@ async def vcr_client():
         yield client
 
 
-# =============================================================================
-# Golden helper
-# =============================================================================
-
-
-def assert_decoded_equals(actual: Any, expected: Any, *, field: str) -> None:
-    """Pin one decoded leaf value, with a decode-drift-flavoured failure message.
-
-    A thin wrapper over ``assert actual == expected`` whose only value is the
-    message: when a golden value diverges it is almost always a *decoder*
-    regression (a positional column mis-map or a leaf-shape change in the
-    recorded response), not a test bug — the message says so, and names the
-    field, so the failure points at the right place. ``field`` is a
-    human-readable label like ``"artifacts_list[0].kind"``.
-    """
-    assert actual == expected, (
-        f"Decoded golden value drift for {field}: "
-        f"expected {reprlib.repr(expected)}, got {reprlib.repr(actual)}. "
-        "The cassette replayed but the decoder produced a different leaf value than the "
-        "golden recording — likely a positional mis-map (row-adapter column moved) or a "
-        "leaf-shape change in the recorded response. If the cassette was deliberately "
-        "re-recorded against a different notebook, refresh the golden value here."
-    )
+# ``assert_decoded_equals`` (the golden helper) lives in
+# ``tests/integration/_golden_assert.py`` so the expansion module
+# (``test_golden_decoded_vcr_expansion.py``) can share it without a
+# cross-test-module import.
 
 
 # =============================================================================

--- a/tests/integration/test_golden_decoded_vcr.py
+++ b/tests/integration/test_golden_decoded_vcr.py
@@ -47,14 +47,13 @@ from __future__ import annotations
 
 import os
 import reprlib
-from contextlib import asynccontextmanager
 
 import pytest
 from tests.integration._golden_assert import assert_decoded_equals
-from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.integration._vcr_helpers import vcr_client
+from tests.integration.conftest import skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 
-from notebooklm import NotebookLMClient
 from notebooklm.types import Artifact, ArtifactType, Source, SourceType
 
 # Skip all tests in this module if cassettes are not available.
@@ -80,18 +79,10 @@ MUTABLE_NOTEBOOK_ID = os.environ.get(
 _CHAT_MATCH_ON = ["method", "scheme", "host", "port", "path", "freq"]
 
 
-@asynccontextmanager
-async def vcr_client():
-    """Authenticated client bound to VCR replay (mock auth in replay mode)."""
-    auth = await get_vcr_auth()
-    async with NotebookLMClient(auth) as client:
-        yield client
-
-
-# ``assert_decoded_equals`` (the golden helper) lives in
-# ``tests/integration/_golden_assert.py`` so the expansion module
-# (``test_golden_decoded_vcr_expansion.py``) can share it without a
-# cross-test-module import.
+# ``assert_decoded_equals`` and ``vcr_client`` live in
+# ``tests/integration/_golden_assert.py`` / ``_vcr_helpers.py`` so the
+# expansion module (``test_golden_decoded_vcr_expansion.py``) can share them
+# without a cross-test-module import.
 
 
 # =============================================================================

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -47,15 +47,15 @@ Field-selection rules
 from __future__ import annotations
 
 import os
-from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 from tests.integration._golden_assert import assert_decoded_equals
-from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.integration._vcr_helpers import vcr_client
+from tests.integration.conftest import skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 
-from notebooklm import NotebookLMClient, ReportFormat
+from notebooklm import ReportFormat
 from notebooklm.types import (
     MindMapKind,
     ResearchStatus,
@@ -88,14 +88,6 @@ MINDMAP_NOTEBOOK_ID = os.environ.get(
 # RPCs recorded in ``generate_mind_map_chain.yaml`` (same constant as
 # ``test_mind_map_chain_vcr.py``).
 _WIKIPEDIA_SOURCE_ID = "466b9ee3-c1ce-45ef-861c-1d4bfcd939ad"
-
-
-@asynccontextmanager
-async def vcr_client():
-    """Authenticated client bound to VCR replay (mock auth in replay mode)."""
-    auth = await get_vcr_auth()
-    async with NotebookLMClient(auth) as client:
-        yield client
 
 
 # =============================================================================
@@ -146,12 +138,16 @@ class TestNotebooksGoldenDecoded:
         )
         # The created_at slot decodes to a real timestamp (not a fabricated
         # default) — pin the first row's to catch a timestamp-column slip.
+        # The decoder renders LOCAL wall time (``datetime.fromtimestamp``), so
+        # pin the round-tripped epoch — identical on every timezone/CI host —
+        # never the rendered wall-time string (that one varies with TZ and
+        # failed CI's UTC runners against a UTC-5 recording sandbox).
         first = notebooks[0]
         assert first.created_at is not None
         assert_decoded_equals(
-            first.created_at.isoformat(),
-            "2026-01-13T08:40:05",
-            field="notebooks_list[0].created_at",
+            int(first.created_at.timestamp()),
+            1768311605,
+            field="notebooks_list[0].created_at (epoch seconds)",
         )
 
     @pytest.mark.vcr
@@ -294,7 +290,8 @@ class TestSourceMutationsGoldenDecoded:
         them would assert the synthesizer, not the decoder.
         """
         test_file = tmp_path / "vcr_test_document.txt"
-        test_file.write_text("This is a test document for VCR cassette recording.")
+        with test_file.open("w", encoding="utf-8", newline="\n") as f:
+            f.write("This is a test document for VCR cassette recording.")
 
         async with vcr_client() as client:
             source = await client.sources.add_file(MUTABLE_NOTEBOOK_ID, str(test_file))

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -1,0 +1,836 @@
+"""Golden decoded-row assertions for the remaining replayable RPC cassette families.
+
+Why this file exists
+--------------------
+``test_golden_decoded_vcr.py`` (issue #1494) pins decoded dataclass fields for
+the four highest-blast-radius read RPCs (chat, artifacts list, sources
+list/get), closing the VCR shape-only-matcher blind spot *for those families*:
+the tolerant body matcher in ``tests/vcr_config.py`` compares request **shape**,
+never response leaves, so a positional mis-decode replays green unless a golden
+assertion pins the decoded values. The 2026-06-09 architecture review's top
+testing recommendation was to extend that pinning to **every** recorded
+response family.
+
+This module is that extension: for every cassette-backed RPC family with a
+typed decode path that was not already golden-covered — notebooks, source
+mutations, notes, chat history, labels, sharing, research, settings, artifact
+generation/export/revision, and both mind-map paths — it pins a small number of
+identity/semantic fields (ids, titles, enum codes, counts, status strings) of
+the DECODED result. ``tests/_guardrails/test_golden_decode_coverage.py`` is the
+standing gate that keeps the corpus classified: every rpcid found in
+``tests/cassettes/`` must be golden-covered or carry a reasoned exemption.
+
+Contract
+--------
+Same cassette-coupled contract as ``test_golden_decoded_vcr.py`` (see its
+docstring for the full rationale): golden values come out of the recorded
+*responses* and are expected to change if a cassette is re-recorded — a
+re-record SHOULD force a golden refresh here, because the whole point is to
+detect decode drift against a known-good recording. This is the opposite
+contract from ``tests/integration/cli_vcr/`` (whose
+``test_no_pinned_cassette_values.py`` gate forbids pinned recorded ids; that
+gate scopes only to ``cli_vcr/``, and this file lives outside it on purpose).
+No cassette is recorded or modified by this file; it only adds read-only
+assertions on the decoded objects produced from the existing cassettes.
+
+Field-selection rules
+---------------------
+* Pin identity/semantic fields: ids, titles, enum/type codes, counts, language
+  codes, status strings, tree node names.
+* Values scrubbed by the cassette sanitizer (``SCRUBBED_NAME`` /
+  ``SCRUBBED_EMAIL@...``) are NOT pinned — they prove nothing about the decoder
+  and would couple the golden to the scrubber instead.
+* All assertions go through the public typed decode path (client namespaces /
+  row adapters) — never raw positional indexing in the test.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from tests.integration._golden_assert import assert_decoded_equals
+from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from notebooklm import NotebookLMClient, ReportFormat
+from notebooklm.types import (
+    MindMapKind,
+    ResearchStatus,
+    SharePermission,
+    SourceStatus,
+)
+
+# Skip all tests in this module if cassettes are not available.
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# Same recording notebook ids as ``test_vcr_comprehensive.py`` /
+# ``test_golden_decoded_vcr.py`` — they matter only when RECORDING (replay
+# serves the recorded response regardless of id).
+READONLY_NOTEBOOK_ID = os.environ.get(
+    "NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID",
+    "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e",
+)
+MUTABLE_NOTEBOOK_ID = os.environ.get(
+    "NOTEBOOKLM_GENERATION_NOTEBOOK_ID",
+    "bb00c9e3-656c-4fd2-b890-2b71e1cf3814",
+)
+# The notebook the interactive mind-map cassette was recorded against
+# (``test_mind_maps_vcr.py`` uses the same default).
+MINDMAP_NOTEBOOK_ID = os.environ.get(
+    "NOTEBOOKLM_MINDMAP_NOTEBOOK_ID",
+    "f7d1e2b6-2334-4016-b81d-aded7b3fa9b6",
+)
+# Source ID for the Wikipedia "NotebookLM" page attached to the generation
+# notebook — passing it explicitly keeps ``generate_mind_map`` to the three
+# RPCs recorded in ``generate_mind_map_chain.yaml`` (same constant as
+# ``test_mind_map_chain_vcr.py``).
+_WIKIPEDIA_SOURCE_ID = "466b9ee3-c1ce-45ef-861c-1d4bfcd939ad"
+
+
+@asynccontextmanager
+async def vcr_client():
+    """Authenticated client bound to VCR replay (mock auth in replay mode)."""
+    auth = await get_vcr_auth()
+    async with NotebookLMClient(auth) as client:
+        yield client
+
+
+# =============================================================================
+# Notebooks (wXbhsf list, rLM1Ne get, VfAZjd summarize, CCqFvf create)
+# =============================================================================
+
+
+# Per-row golden for the first three recorded notebooks:
+# (id, title, sources_count, is_owner). The (id <-> title <-> count <-> owner)
+# tuple is the positional canary for the notebook-list decoder.
+_NOTEBOOKS_LIST_GOLDEN_HEAD = [
+    (
+        "f66923f0-1df4-4ffe-9822-3ed63c558b1c",
+        "GENERATION: Claude Code Deep Dive: Skills, Agents, Commands & Plugins",
+        42,
+        True,
+    ),
+    (
+        "167481cd-23a3-4331-9a45-c8948900bf91",
+        "READ ONLY: Learn Claude Code & AI Agents for High School Students",
+        8,
+        False,
+    ),
+    (
+        "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e",
+        "TypeScript Fundamentals: A Handbook of Type Systems and Rules",
+        2,
+        True,
+    ),
+]
+
+
+class TestNotebooksGoldenDecoded:
+    """Pin decoded ``Notebook`` / summary / description fields."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notebooks_list.yaml")
+    async def test_list_decoded_golden(self):
+        """``notebooks.list`` decodes id/title/sources_count/is_owner per row."""
+        async with vcr_client() as client:
+            notebooks = await client.notebooks.list()
+
+        assert_decoded_equals(len(notebooks), 12, field="notebooks_list length")
+        actual_head = [(n.id, n.title, n.sources_count, n.is_owner) for n in notebooks[:3]]
+        assert_decoded_equals(
+            actual_head, _NOTEBOOKS_LIST_GOLDEN_HEAD, field="notebooks_list[:3] rows"
+        )
+        # The created_at slot decodes to a real timestamp (not a fabricated
+        # default) — pin the first row's to catch a timestamp-column slip.
+        first = notebooks[0]
+        assert first.created_at is not None
+        assert_decoded_equals(
+            first.created_at.isoformat(),
+            "2026-01-13T08:40:05",
+            field="notebooks_list[0].created_at",
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notebooks_get.yaml")
+    async def test_get_decoded_golden(self):
+        """``notebooks.get`` decodes the recorded notebook row."""
+        async with vcr_client() as client:
+            notebook = await client.notebooks.get(READONLY_NOTEBOOK_ID)
+
+        assert_decoded_equals(
+            notebook.id, "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e", field="notebooks_get.id"
+        )
+        assert_decoded_equals(
+            notebook.title,
+            "TypeScript Fundamentals: A Handbook of Type Systems and Rules",
+            field="notebooks_get.title",
+        )
+        assert_decoded_equals(notebook.sources_count, 2, field="notebooks_get.sources_count")
+        assert_decoded_equals(notebook.is_owner, True, field="notebooks_get.is_owner")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notebooks_get_summary.yaml")
+    async def test_get_summary_decoded_golden(self):
+        """``notebooks.get_summary`` decodes the recorded summary text (VfAZjd)."""
+        async with vcr_client() as client:
+            summary = await client.notebooks.get_summary(READONLY_NOTEBOOK_ID)
+
+        assert_decoded_equals(len(summary), 1016, field="notebooks_get_summary length")
+        assert summary.startswith(
+            "The provided sources introduce **Learn Claude Code**, an educational repository"
+        ), f"Unexpected summary head: {summary[:120]!r}"
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notebooks_get_description.yaml")
+    async def test_get_description_decoded_golden(self):
+        """``notebooks.get_description`` decodes summary + suggested topics (VfAZjd)."""
+        async with vcr_client() as client:
+            description = await client.notebooks.get_description(READONLY_NOTEBOOK_ID)
+
+        assert description.summary.startswith(
+            "The provided sources introduce **learn-claude-code**, an educational GitHub"
+        ), f"Unexpected description head: {description.summary[:120]!r}"
+        assert_decoded_equals(
+            len(description.suggested_topics),
+            3,
+            field="notebooks_get_description.suggested_topics length",
+        )
+        assert_decoded_equals(
+            description.suggested_topics[0].question,
+            "How do the five progressive versions demystify the core mechanics of AI agents?",
+            field="notebooks_get_description.suggested_topics[0].question",
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notebooks_create.yaml")
+    async def test_create_decoded_golden(self):
+        """``notebooks.create`` decodes the server-assigned notebook id (CCqFvf)."""
+        async with vcr_client() as client:
+            notebook = await client.notebooks.create("VCR Test Notebook")
+
+        # The id is server-assigned — it can only come from the decoded
+        # CREATE_NOTEBOOK response (the title alone could be an input echo).
+        assert_decoded_equals(
+            notebook.id, "afefc562-f8d1-41ec-a5d5-c197efdf52e1", field="notebooks_create.id"
+        )
+        assert_decoded_equals(notebook.title, "VCR Test Notebook", field="notebooks_create.title")
+        assert_decoded_equals(notebook.sources_count, 0, field="notebooks_create.sources_count")
+
+
+# =============================================================================
+# Source mutations (izAoDd add text/url, o4cbdc add file, b7Wfje rename)
+# =============================================================================
+
+
+class TestSourceMutationsGoldenDecoded:
+    """Pin the decoded ``Source`` returned by the add/rename mutation paths."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("sources_add_text.yaml")
+    async def test_add_text_decoded_golden(self):
+        """``sources.add_text`` decodes the server-assigned source id + status."""
+        async with vcr_client() as client:
+            source = await client.sources.add_text(
+                MUTABLE_NOTEBOOK_ID,
+                title="VCR Test Source",
+                content="This is a test source created by VCR recording.",
+            )
+
+        assert_decoded_equals(
+            source.id, "467b7f67-1b66-45fb-8cc7-6c04723f152d", field="sources_add_text.id"
+        )
+        assert_decoded_equals(source.title, "VCR Test Source", field="sources_add_text.title")
+        assert_decoded_equals(source.status, SourceStatus.READY, field="sources_add_text.status")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("sources_add_url.yaml")
+    async def test_add_url_decoded_golden(self):
+        """``sources.add_url`` decodes the server-extracted page title.
+
+        The title is the strongest pin here: the test passes only the URL, so
+        ``"Artificial intelligence - Wikipedia"`` can only come out of the
+        decoded ADD_SOURCE response (never an input echo).
+        """
+        async with vcr_client() as client:
+            source = await client.sources.add_url(
+                MUTABLE_NOTEBOOK_ID,
+                url="https://en.wikipedia.org/wiki/Artificial_intelligence",
+            )
+
+        assert_decoded_equals(
+            source.id, "20d66b0b-787f-480e-a9c1-6823f7a12d8e", field="sources_add_url.id"
+        )
+        assert_decoded_equals(
+            source.title,
+            "Artificial intelligence - Wikipedia",
+            field="sources_add_url.title",
+        )
+        assert_decoded_equals(
+            source.url,
+            "https://en.wikipedia.org/wiki/Artificial_intelligence",
+            field="sources_add_url.url",
+        )
+        assert_decoded_equals(source.status, SourceStatus.READY, field="sources_add_url.status")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("sources_add_file.yaml")
+    async def test_add_file_decoded_golden(self, tmp_path):
+        """``sources.add_file`` decodes the registered source id + PROCESSING status."""
+        test_file = tmp_path / "vcr_test_document.txt"
+        test_file.write_text("This is a test document for VCR cassette recording.")
+
+        async with vcr_client() as client:
+            source = await client.sources.add_file(MUTABLE_NOTEBOOK_ID, str(test_file))
+
+        assert_decoded_equals(
+            source.id, "dc84ca28-2629-49ac-aec3-de45f0ec93e4", field="sources_add_file.id"
+        )
+        assert_decoded_equals(source.title, "vcr_test_document.txt", field="sources_add_file.title")
+        # A freshly-uploaded file is still PROCESSING in the recording — a
+        # status-column slip onto the READY default would flip this.
+        assert_decoded_equals(
+            source.status, SourceStatus.PROCESSING, field="sources_add_file.status"
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("sources_rename.yaml")
+    async def test_rename_decoded_golden(self):
+        """``sources.rename`` decodes the renamed ``Source`` row (b7Wfje)."""
+        async with vcr_client() as client:
+            sources = await client.sources.list(MUTABLE_NOTEBOOK_ID)
+            assert sources, "expected the recorded notebook to have sources"
+            original = sources[0]
+            renamed = await client.sources.rename(
+                MUTABLE_NOTEBOOK_ID, original.id, "VCR Test Renamed Source"
+            )
+            # Restore (replays the second recorded UPDATE_SOURCE interaction).
+            await client.sources.rename(MUTABLE_NOTEBOOK_ID, original.id, original.title)
+
+        assert_decoded_equals(
+            renamed.id, "b1b9efdd-b2af-4974-ad97-16025c05f1d7", field="sources_rename.id"
+        )
+        assert_decoded_equals(
+            renamed.title, "VCR Test Renamed Source", field="sources_rename.title"
+        )
+        assert_decoded_equals(renamed.status, SourceStatus.READY, field="sources_rename.status")
+
+
+# =============================================================================
+# Notes (cFji9 list, CYK0Xb create)
+# =============================================================================
+
+
+class TestNotesGoldenDecoded:
+    """Pin decoded ``Note`` fields for the notes cassettes."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notes_list.yaml")
+    async def test_list_decoded_golden(self):
+        """``notes.list`` decodes the recorded (empty) note list without drift.
+
+        The recorded notebook has one mind map and zero notes, so the decoded
+        list MUST be empty — a filter mis-decode that lets the mind-map row
+        leak into the notes list would make this non-empty while the cassette
+        still replays. (The mind-map side of the same ``cFji9`` payload is
+        pinned via ``mind_maps.list`` below.)
+        """
+        async with vcr_client() as client:
+            notes = await client.notes.list(READONLY_NOTEBOOK_ID)
+
+        assert_decoded_equals(len(notes), 0, field="notes_list length")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("notes_create.yaml")
+    async def test_create_decoded_golden(self):
+        """``notes.create`` decodes the server-assigned note id (CYK0Xb)."""
+        async with vcr_client() as client:
+            note = await client.notes.create(
+                MUTABLE_NOTEBOOK_ID,
+                title="VCR Test Note",
+                content="This is a test note created by VCR recording.",
+            )
+
+        assert_decoded_equals(
+            note.id, "3ba71644-5e30-4330-96d8-d29f5f1ecef4", field="notes_create.id"
+        )
+        assert_decoded_equals(note.title, "VCR Test Note", field="notes_create.title")
+        assert_decoded_equals(
+            note.content,
+            "This is a test note created by VCR recording.",
+            field="notes_create.content",
+        )
+
+
+# =============================================================================
+# Chat history (khqZz conversation turns via get_history)
+# =============================================================================
+
+
+class TestChatHistoryGoldenDecoded:
+    """Pin the decoded Q&A pairs from the conversation-turns cassette."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("chat_get_history.yaml")
+    async def test_get_history_decoded_golden(self):
+        """``chat.get_history`` decodes the recorded (question, answer) pair.
+
+        Exercises the ``ConversationTurnRow`` adapter end-to-end: a role-column
+        or text-column slip would swap/garble the Q&A pairing while the
+        cassette still replays.
+        """
+        async with vcr_client() as client:
+            pairs = await client.chat.get_history(MUTABLE_NOTEBOOK_ID)
+
+        assert_decoded_equals(len(pairs), 1, field="chat_get_history length")
+        question, answer = pairs[0]
+        assert_decoded_equals(
+            question, "What question should I ask?", field="chat_get_history[0].question"
+        )
+        assert_decoded_equals(len(answer), 233, field="chat_get_history[0].answer length")
+        assert answer.startswith(
+            "Based on the sources provided, you can ask about the main topics"
+        ), f"Unexpected answer head: {answer[:120]!r}"
+
+
+# =============================================================================
+# Labels (I3xc3c list, agX4Bc create)
+# =============================================================================
+
+
+class TestLabelsGoldenDecoded:
+    """Pin decoded ``Label`` fields for the label cassettes."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("label_list.yaml")
+    async def test_list_decoded_golden(self):
+        """``labels.list`` decodes the recorded label row (id/name/emoji)."""
+        async with vcr_client() as client:
+            labels = await client.labels.list(MUTABLE_NOTEBOOK_ID)
+
+        assert_decoded_equals(len(labels), 1, field="label_list length")
+        label = labels[0]
+        assert_decoded_equals(
+            label.id, "fdfc8ac4-3237-4f2a-8a79-3e24297a7040", field="label_list[0].id"
+        )
+        assert_decoded_equals(label.name, "VCR Test Label", field="label_list[0].name")
+        assert_decoded_equals(label.emoji, "\U0001f4c4", field="label_list[0].emoji")
+        assert_decoded_equals(label.source_ids, [], field="label_list[0].source_ids")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("label_create.yaml")
+    async def test_create_decoded_golden(self):
+        """``labels.create`` ID-diffs the create echo to the new ``Label`` (agX4Bc)."""
+        async with vcr_client() as client:
+            label = await client.labels.create(MUTABLE_NOTEBOOK_ID, "VCR Label")
+
+        assert_decoded_equals(
+            label.id, "fdfc8ac4-3237-4f2a-8a79-3e24297a7040", field="label_create.id"
+        )
+        # The recorded server echo carries the label as actually created
+        # (name + emoji come from the response, not the test's input).
+        assert_decoded_equals(label.name, "VCR Test Label", field="label_create.name")
+        assert_decoded_equals(label.emoji, "\U0001f4c4", field="label_create.emoji")
+
+
+# =============================================================================
+# Sharing (JFMDGd get_status)
+# =============================================================================
+
+
+class TestSharingGoldenDecoded:
+    """Pin the decoded ``ShareStatus`` fields."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("sharing_get_status.yaml")
+    async def test_get_status_decoded_golden(self):
+        """``sharing.get_status`` decodes access/view-level/user-permission slots."""
+        async with vcr_client() as client:
+            status = await client.sharing.get_status(READONLY_NOTEBOOK_ID)
+
+        assert_decoded_equals(status.is_public, False, field="sharing_get_status.is_public")
+        assert_decoded_equals(status.access.name, "RESTRICTED", field="sharing_get_status.access")
+        assert_decoded_equals(
+            status.view_level.name, "FULL_NOTEBOOK", field="sharing_get_status.view_level"
+        )
+        assert_decoded_equals(status.share_url, None, field="sharing_get_status.share_url")
+        # One shared user (the owner) is recorded; the email/name are scrubbed
+        # by the sanitizer so only the decoded permission enum is pinned.
+        assert_decoded_equals(
+            len(status.shared_users), 1, field="sharing_get_status.shared_users length"
+        )
+        assert_decoded_equals(
+            status.shared_users[0].permission,
+            SharePermission.OWNER,
+            field="sharing_get_status.shared_users[0].permission",
+        )
+
+
+# =============================================================================
+# Research (Ljjv0c fast start, QA9ei deep start, e3bVqc poll)
+# =============================================================================
+
+
+class TestResearchGoldenDecoded:
+    """Pin decoded research start/poll fields."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("research_start_fast.yaml")
+    async def test_start_fast_decoded_golden(self):
+        """``research.start(mode="fast")`` decodes the server task id (Ljjv0c)."""
+        async with vcr_client() as client:
+            result = await client.research.start(
+                MUTABLE_NOTEBOOK_ID,
+                query="Python programming best practices",
+                source="web",
+                mode="fast",
+            )
+
+        assert_decoded_equals(
+            result.task_id,
+            "ac0bc757-fa42-4a0d-8c22-755a9ff075a3",
+            field="research_start_fast.task_id",
+        )
+        assert_decoded_equals(result.report_id, None, field="research_start_fast.report_id")
+        assert_decoded_equals(result.mode, "fast", field="research_start_fast.mode")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("research_start_deep.yaml")
+    async def test_start_deep_decoded_golden(self):
+        """``research.start(mode="deep")`` decodes BOTH the task and report ids (QA9ei).
+
+        Deep research is the one start variant that returns a second id — a
+        column slip between the two would satisfy any is-not-None check.
+        """
+        async with vcr_client() as client:
+            result = await client.research.start(
+                MUTABLE_NOTEBOOK_ID,
+                query="Artificial intelligence history",
+                source="web",
+                mode="deep",
+            )
+
+        assert_decoded_equals(
+            result.task_id,
+            "e9b7cb1c-268a-4678-8a50-686722f65e27",
+            field="research_start_deep.task_id",
+        )
+        assert_decoded_equals(
+            result.report_id,
+            "24f83c74-9f7a-4137-aaf3-68e54840dca5",
+            field="research_start_deep.report_id",
+        )
+        assert_decoded_equals(result.mode, "deep", field="research_start_deep.mode")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("research_poll.yaml")
+    async def test_poll_decoded_golden(self):
+        """``research.poll`` decodes the recorded poll outcome (e3bVqc).
+
+        The recorded POLL_RESEARCH response carries no entry for the started
+        task, so the decoder must return the NOT_FOUND sentinel — a poll-row
+        mis-decode that fabricated a task entry would flip the status.
+        """
+        async with vcr_client() as client:
+            start = await client.research.start(
+                MUTABLE_NOTEBOOK_ID,
+                query="Machine learning fundamentals",
+                source="web",
+                mode="fast",
+            )
+            result = await client.research.poll(MUTABLE_NOTEBOOK_ID, task_id=start.task_id)
+
+        # The start task id is decoded from the Ljjv0c response recorded in
+        # this cassette (distinct from research_start_fast.yaml's).
+        assert_decoded_equals(
+            start.task_id,
+            "32b1e6c3-863f-4502-8509-fe9d5801db14",
+            field="research_poll.start.task_id",
+        )
+        assert_decoded_equals(result.status, ResearchStatus.NOT_FOUND, field="research_poll.status")
+        assert_decoded_equals(result.sources, (), field="research_poll.sources")
+
+
+# =============================================================================
+# Settings (ZwVcOc get, hT54vc set, ozz5Z tier)
+# =============================================================================
+
+
+class TestSettingsGoldenDecoded:
+    """Pin decoded settings values (language codes, account tier)."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("settings_get_output_language.yaml")
+    async def test_get_output_language_decoded_golden(self):
+        """``settings.get_output_language`` decodes the recorded language code."""
+        async with vcr_client() as client:
+            language = await client.settings.get_output_language()
+
+        assert_decoded_equals(language, "fr", field="settings_get_output_language")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("settings_set_output_language.yaml")
+    async def test_set_output_language_decoded_golden(self):
+        """``settings.set_output_language`` decodes the SET response echo (hT54vc).
+
+        ``set_output_language`` parses the language back out of the
+        SET_USER_SETTINGS response (it is NOT an input echo) — the recorded
+        flow reads ``fr``, sets ``en``, restores ``fr``.
+        """
+        async with vcr_client() as client:
+            original = await client.settings.get_output_language()
+            result = await client.settings.set_output_language("en")
+            restored = await client.settings.set_output_language(original)
+
+        assert_decoded_equals(original, "fr", field="settings_set_output_language.original")
+        assert_decoded_equals(result, "en", field="settings_set_output_language.set result")
+        assert_decoded_equals(restored, "fr", field="settings_set_output_language.restore result")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("settings_get_user_tier.yaml")
+    async def test_get_account_tier_decoded_golden(self):
+        """``settings.get_account_tier`` decodes the recorded tier token (ozz5Z)."""
+        async with vcr_client() as client:
+            tier = await client.settings.get_account_tier()
+
+        assert_decoded_equals(
+            tier.tier,
+            "NOTEBOOKLM_TIER_PRO_CONSUMER_USER",
+            field="settings_get_user_tier.tier",
+        )
+        assert_decoded_equals(tier.plan_name, None, field="settings_get_user_tier.plan_name")
+
+
+# =============================================================================
+# Artifact generation / export / revision (R7cb6c, ciyUvf, Krh3pd, KmcKPe)
+# =============================================================================
+
+
+class TestArtifactsWriteGoldenDecoded:
+    """Pin decoded ``GenerationStatus`` / suggestion / export values."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("artifacts_generate_report.yaml")
+    async def test_generate_report_decoded_golden(self):
+        """``artifacts.generate_report`` decodes the server task id (R7cb6c)."""
+        async with vcr_client() as client:
+            status = await client.artifacts.generate_report(
+                MUTABLE_NOTEBOOK_ID,
+                report_format=ReportFormat.BRIEFING_DOC,
+            )
+
+        assert_decoded_equals(
+            status.task_id,
+            "31dc7d61-2b07-444e-8be2-5da70154ac5a",
+            field="artifacts_generate_report.task_id",
+        )
+        assert_decoded_equals(
+            status.status, "in_progress", field="artifacts_generate_report.status"
+        )
+        assert_decoded_equals(status.error, None, field="artifacts_generate_report.error")
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("artifacts_suggest_reports.yaml")
+    async def test_suggest_reports_decoded_golden(self):
+        """``artifacts.suggest_reports`` decodes per-suggestion semantic fields (ciyUvf).
+
+        Titles are scrubbed in the cassette, so the pins are the decoded
+        audience-level column (the positional canary) and the first
+        suggestion's description text.
+        """
+        async with vcr_client() as client:
+            suggestions = await client.artifacts.suggest_reports(READONLY_NOTEBOOK_ID)
+
+        assert_decoded_equals(len(suggestions), 4, field="artifacts_suggest_reports length")
+        assert_decoded_equals(
+            [s.audience_level for s in suggestions],
+            [2, 2, 1, 1],
+            field="artifacts_suggest_reports audience_levels",
+        )
+        assert_decoded_equals(
+            suggestions[0].description,
+            "A long-form plan for applying the source's core methodologies within a "
+            "professional organization.",
+            field="artifacts_suggest_reports[0].description",
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("artifacts_export_report.yaml")
+    async def test_export_report_decoded_golden(self):
+        """``artifacts.export_report`` decodes the exported Google Doc URL (Krh3pd)."""
+        async with vcr_client() as client:
+            reports = await client.artifacts.list_reports(MUTABLE_NOTEBOOK_ID)
+            completed = [r for r in reports if r.is_completed]
+            assert completed, "expected a completed report in the recorded list"
+            result = await client.artifacts.export_report(
+                MUTABLE_NOTEBOOK_ID, completed[0].id, title="VCR Export Test"
+            )
+
+        assert_decoded_equals(
+            completed[0].id,
+            "07733c15-fa16-4c17-8a6f-2e8b7a9da2dd",
+            field="artifacts_export_report.report id",
+        )
+        # The export response is a single-element envelope holding the doc URL.
+        assert_decoded_equals(
+            result,
+            ["https://docs.google.com/document/d/1bAgBGlybk82LZfbz6IPCwpQ12E4hlDQsuWTVWJVEHfM"],
+            field="artifacts_export_report.result",
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("artifacts_revise_slide.yaml")
+    async def test_revise_slide_decoded_golden(self):
+        """``artifacts.revise_slide`` decodes the revision task id (KmcKPe)."""
+        async with vcr_client() as client:
+            status = await client.artifacts.revise_slide(
+                MUTABLE_NOTEBOOK_ID,
+                "848df2ec-4916-4dea-aa20-3dc02954cfd0",
+                0,
+                "Make it shorter",
+            )
+
+        assert_decoded_equals(
+            status.task_id,
+            "b84c4e66-ce7b-43b8-ac86-80c8add3fa23",
+            field="artifacts_revise_slide.task_id",
+        )
+        assert_decoded_equals(status.status, "in_progress", field="artifacts_revise_slide.status")
+
+
+# =============================================================================
+# Mind maps (v9rmvd interactive tree, yyryJe generate chain)
+# =============================================================================
+
+
+class TestMindMapsGoldenDecoded:
+    """Pin decoded ``MindMap`` rows and tree node values."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("mind_maps_interactive.yaml")
+    async def test_interactive_list_and_tree_decoded_golden(self):
+        """``mind_maps.list`` + ``get_tree`` decode the interactive mind map (v9rmvd).
+
+        The tree lives at a deep positional slot of the GET_INTERACTIVE_HTML
+        response — pinning the root/child node names catches a slot slip that
+        would otherwise surface as a structurally-valid-but-wrong tree.
+        """
+        async with vcr_client() as client:
+            maps = await client.mind_maps.list(MINDMAP_NOTEBOOK_ID)
+            interactive = [m for m in maps if m.kind == MindMapKind.INTERACTIVE]
+            assert interactive, "expected an interactive mind map in the recording"
+            mind_map = interactive[0]
+            tree = await client.mind_maps.get_tree(
+                MINDMAP_NOTEBOOK_ID, mind_map.id, kind=MindMapKind.INTERACTIVE
+            )
+
+        assert_decoded_equals(
+            mind_map.id,
+            "47523923-9839-48fd-ae10-25bb685a0644",
+            field="mind_maps_interactive.list[0].id",
+        )
+        assert_decoded_equals(
+            mind_map.title, "Learning Mindmap AAA", field="mind_maps_interactive.list[0].title"
+        )
+        assert_decoded_equals(
+            tree["name"], "Machine Learning Fundamentals", field="mind_maps_interactive.tree.name"
+        )
+        children = tree["children"]
+        assert_decoded_equals(len(children), 4, field="mind_maps_interactive.tree children count")
+        assert_decoded_equals(
+            children[0]["name"],
+            "Key Concepts",
+            field="mind_maps_interactive.tree.children[0].name",
+        )
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette("generate_mind_map_chain.yaml")
+    async def test_generate_mind_map_decoded_golden(self):
+        """``artifacts.generate_mind_map`` decodes the generated tree + note id (yyryJe).
+
+        The mind-map JSON comes out of the GENERATE_MIND_MAP response and the
+        note id out of the chained CREATE_NOTE response — pinning both proves
+        the chain plumbed the decoded values, not fabricated defaults.
+        """
+        async with vcr_client() as client:
+            result = await client.artifacts.generate_mind_map(
+                MUTABLE_NOTEBOOK_ID,
+                source_ids=[_WIKIPEDIA_SOURCE_ID],
+            )
+
+        assert_decoded_equals(
+            result.note_id,
+            "208ac8c0-5206-4e93-ae24-4b83ce14084b",
+            field="generate_mind_map_chain.note_id",
+        )
+        assert result.mind_map is not None
+        assert_decoded_equals(
+            result.mind_map["name"], "NotebookLM", field="generate_mind_map_chain.mind_map.name"
+        )
+        assert_decoded_equals(
+            len(result.mind_map["children"]),
+            6,
+            field="generate_mind_map_chain.mind_map children count",
+        )
+
+
+# =============================================================================
+# Cassette-side sanity: golden values really are in the recordings
+# =============================================================================
+
+
+def test_golden_values_visible_in_cassette_bytes() -> None:
+    """Spot-check that representative golden values exist in the cassette bytes.
+
+    Belt-and-braces against a hypothetical future where a decode path starts
+    fabricating plausible defaults: each sampled golden value must literally
+    appear in its cassette's recorded response, so the pins above are provably
+    recording-derived (not synthesized by the client).
+    """
+    cassette_dir = Path(__file__).resolve().parent.parent / "cassettes"
+    samples = {
+        "notebooks_create.yaml": "afefc562-f8d1-41ec-a5d5-c197efdf52e1",
+        "notes_create.yaml": "3ba71644-5e30-4330-96d8-d29f5f1ecef4",
+        "settings_get_user_tier.yaml": "NOTEBOOKLM_TIER_PRO_CONSUMER_USER",
+        "artifacts_export_report.yaml": "1bAgBGlybk82LZfbz6IPCwpQ12E4hlDQsuWTVWJVEHfM",
+        "research_poll.yaml": "32b1e6c3-863f-4502-8509-fe9d5801db14",
+        "generate_mind_map_chain.yaml": "208ac8c0-5206-4e93-ae24-4b83ce14084b",
+    }
+    missing = {
+        name: value
+        for name, value in samples.items()
+        if value not in (cassette_dir / name).read_text(encoding="utf-8")
+    }
+    assert missing == {}, (
+        "Golden value(s) not found in their cassette bytes — either the cassette "
+        f"was re-recorded (refresh the goldens) or the pin is wrong: {missing}"
+    )

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -286,7 +286,13 @@ class TestSourceMutationsGoldenDecoded:
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("sources_add_file.yaml")
     async def test_add_file_decoded_golden(self, tmp_path):
-        """``sources.add_file`` decodes the registered source id + PROCESSING status."""
+        """``sources.add_file`` decodes the registered source id (o4cbdc).
+
+        The id is the ONLY recording-derived field on this path: in the
+        default no-wait flow the returned ``Source``'s title/status are
+        client-synthesized placeholders (``_source/upload.py``), so pinning
+        them would assert the synthesizer, not the decoder.
+        """
         test_file = tmp_path / "vcr_test_document.txt"
         test_file.write_text("This is a test document for VCR cassette recording.")
 
@@ -295,12 +301,6 @@ class TestSourceMutationsGoldenDecoded:
 
         assert_decoded_equals(
             source.id, "dc84ca28-2629-49ac-aec3-de45f0ec93e4", field="sources_add_file.id"
-        )
-        assert_decoded_equals(source.title, "vcr_test_document.txt", field="sources_add_file.title")
-        # A freshly-uploaded file is still PROCESSING in the recording — a
-        # status-column slip onto the READY default would flip this.
-        assert_decoded_equals(
-            source.status, SourceStatus.PROCESSING, field="sources_add_file.status"
         )
 
     @pytest.mark.vcr


### PR DESCRIPTION
## Summary

Closes the VCR shape-only matcher blind spot corpus-wide. The cassette body matcher (`tests/vcr_config.py`) deliberately compares request **shape**, never response leaves — so a decode regression that puts a wrong value in the right slot replays green. The compensating control, golden decoded-row assertions (#1494 / #1500), covered only ~4 high-risk families. Per the 2026-06-09 architecture review's top testing recommendation, this PR extends golden decoded-field pinning to **every cassette-backed RPC family with a decodable payload**, and adds a standing guardrail gate so the classification can never silently regress.

- **`tests/integration/test_golden_decoded_vcr_expansion.py`** — golden tests for 24 additional RPC families (existing cassettes only, public typed decode paths only, scrubbed values never pinned). Includes a cassette-bytes spot-check proving representative goldens are recording-derived, not client-fabricated.
- **`tests/_guardrails/test_golden_decode_coverage.py`** — standing gate: every `rpcids` value recorded under `tests/cassettes/` (recursive; `examples/` excluded) must be golden-covered or carry a sanctioned exemption. Coverage pointers are `(file, ClassName::test_name)` and **AST-verified**: the test must exist at the exact qualified location AND replay (via its `use_cassette` decorators) a cassette that records the mapped rpcid — a pointer can't rot into a comment, a same-named sibling test, or a test replaying an unrelated family. Multi-pointer entries pin each recorded response shape of a family (web+drive freshness, text+url adds, notes+mind-map views of cFji9, both VfAZjd views, both chat-ask cassettes). Keyed by `RPCMethod` so `rpc/types.py` stays the single source of truth across Google ID rotations; an unknown recorded rpcid fails loudly; new cassettes start gated. Family-level granularity (a future cassette reusing a covered rpcid with a brand-new shape doesn't force a new golden by itself) is documented as a deliberate scoping decision in the module docstring.
- **`tests/integration/_golden_assert.py`** — `assert_decoded_equals` extracted from `test_golden_decoded_vcr.py` so both golden modules share it without a cross-test-module import (per `test_no_cross_test_imports`).

No cassettes, matchers, or production code were touched.

## Per-family coverage

All **46** rpcids recorded across the cassette corpus are now classified: **32 golden-covered + 14 reasoned-exempt**.

### Golden-covered (decoded-field values pinned)

| Family (RPCMethod) | Cassette | Pinned decoded fields |
|---|---|---|
| LIST_NOTEBOOKS | notebooks_list | count, first 3 rows (id/title/sources_count/is_owner), created_at |
| GET_NOTEBOOK *(already #1494, + notebook-get pins)* | sources_list, notebooks_get | source rows; notebook id/title/sources_count/is_owner |
| SUMMARIZE | notebooks_get_summary, notebooks_get_description | summary length+head, 3 suggested topics, first question |
| CREATE_NOTEBOOK | notebooks_create | server-assigned id, title, sources_count |
| ADD_SOURCE | sources_add_text, sources_add_url | id, server-extracted page title, url, status enum |
| ADD_SOURCE_FILE | sources_add_file | id (title/status are client-synthesized on the no-wait path, deliberately not pinned) |
| UPDATE_SOURCE | sources_rename | renamed row id/title/status |
| GET_NOTES_AND_MIND_MAPS | notes_list, mind_maps_interactive | empty-notes decode; mind-map id/title |
| CREATE_NOTE | notes_create | server-assigned id, title, content |
| GET_CONVERSATION_TURNS | chat_get_history | Q text exact, A length+head (ConversationTurnRow path) |
| LIST_LABELS | label_list | id, name, emoji, source_ids |
| CREATE_LABEL | label_create | ID-diffed new label id/name/emoji |
| GET_SHARE_STATUS | sharing_get_status | is_public, access, view_level, owner permission, user count |
| START_FAST_RESEARCH / START_DEEP_RESEARCH | research_start_* | task_id; deep also report_id (two-id column canary) |
| POLL_RESEARCH | research_poll | NOT_FOUND sentinel + decoded start task_id |
| GET_USER_SETTINGS / SET_USER_SETTINGS | settings_*_output_language | "fr" / set→"en" / restore→"fr" (set parses the response, not an echo) |
| GET_USER_TIER | settings_get_user_tier | tier token, plan_name |
| CREATE_ARTIFACT | artifacts_generate_report | task_id, "in_progress", error None |
| GET_SUGGESTED_REPORTS | artifacts_suggest_reports | count, audience-level column [2,2,1,1], description text |
| EXPORT_ARTIFACT | artifacts_export_report | report id + exported Google Doc URL envelope |
| REVISE_SLIDE | artifacts_revise_slide | task_id, "in_progress" |
| GET_INTERACTIVE_HTML | mind_maps_interactive | tree root name, child count, first child name |
| GENERATE_MIND_MAP | generate_mind_map_chain | chained note_id + tree root name + child count |
| GET_LAST_CONVERSATION_ID, LIST_ARTIFACTS, GET_SOURCE_GUIDE, GET_SOURCE | *(unchanged, #1494)* | chat answer/references, artifact rows, guide, fulltext |
| IMPORT_RESEARCH | research_import_sources_direct | exact imported list (pinned in `test_rpc_gap_backfill_vcr.py`) |
| RETRY_ARTIFACT | artifacts_retry_failed | task_id echo + "in_progress" (pinned in `test_vcr_comprehensive.py`) |
| CHECK_SOURCE_FRESHNESS | sources_check_freshness* | boolean pinned `is True` for both recorded shapes (in `test_vcr_comprehensive.py`) |

### Reasoned-exempt (verified by reading each decode path)

| Reason | Families |
|---|---|
| Success contract returns `None`; no decodable row | DELETE_NOTEBOOK, DELETE_SOURCE, DELETE_ARTIFACT, DELETE_NOTE, DELETE_LABEL, DELETE_CONVERSATION, REMOVE_RECENTLY_VIEWED, REFRESH_SOURCE, UPDATE_NOTE |
| Response discarded; returned object re-fetched via a golden-covered read RPC | RENAME_NOTEBOOK, RENAME_ARTIFACT, UPDATE_LABEL, SHARE_NOTEBOOK, SHARE_ARTIFACT |

## Test plan

- [x] `uv run pytest` — full suite green (9565 passed, 71 skipped, 1 xfailed)
- [x] `uv run pytest tests/integration/test_golden_decoded_vcr_expansion.py tests/integration/test_golden_decoded_vcr.py tests/_guardrails/test_golden_decode_coverage.py` — 42 passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff format --check` / `uv run ruff check` — clean
- [x] Gate self-consistency: 32 covered + 14 exempt = 46 recorded rpcids, zero unclassified
- [x] Every golden value verified recording-derived (decoded under mock auth + network guard; representative values byte-checked against cassettes)
- [x] Mutation-tested the gate's pointer verification (wrong-class pointer and nonexistent test both rejected)
- [x] Codex review of the diff applied pre-PR: Critical (add_file synthesized-field pins) fixed; both Importants (weak `def name(` containment / duplicate names; single-pointer multi-shape hole) fixed via AST-verified qualified pointers + multi-pointer entries; Minor (nested cassette dirs) fixed via recursive corpus walk. Codex's reported 60s timeout in `test_add_file_decoded_golden` was not reproducible (3 isolated runs at 0.17s, 3 full-module runs at ~4s with `-p no:rerunfailures`); attributed to resource contention with the concurrently-running full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a repo-level guard that enforces every recorded RPC in test cassettes is classified as covered or exempt and validates those classifications.
  * Introduced a shared golden-value assertion helper for clearer decode-drift failures.
  * Expanded golden-decoded integration tests across many client areas and added a VCR-backed client helper for replayed tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->