### PR TITLE
fix(auth): surface BROWSER_CLOSED_HELP when the browser closes during the final storage-state capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Playwright login: closing the browser during the final storage-state
+  capture now shows the browser-closed help instead of a bug-report prompt**
+  (#1514, deferred from the #1512 review). Every in-flow Playwright call in
+  the login flow (page recovery, the navigation retry loop, the login wait,
+  cookie-forcing) already mapped `TargetClosedError` to the friendly
+  `BROWSER_CLOSED_HELP` text + exit 1, but a closure in the narrow window
+  during the final `context.storage_state()` capture fell through the outer
+  handler's bare `raise` and exited 2 ("Unexpected error … please report a
+  bug"). The outer handler in `run_browser_capture` now recognizes
+  TargetClosed and surfaces the same help + exit 1; every other unexpected
+  failure keeps the exit-2 bug-report contract.
+
 - **`sources.add_text` no longer swallows typed transport errors into
   `SourceAddError`.** Its bare `except RPCError` wrapped *everything* —
   including the `RPCError` subclasses `RateLimitError`, `AuthError`, and

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -566,8 +566,21 @@ def run_browser_capture(
                         "Or use the default Chromium browser: notebooklm login"
                     )
                     io.fail(1)
-            # Diagnostic stays at debug level; the bare ``raise`` propagates to
-            # ``handle_errors`` → friendly ``Unexpected error: <msg>`` + exit 2.
+            # Last-resort TargetClosed mapping for anything that escapes the
+            # in-flow guards (recover_page, the navigation retry loop,
+            # wait_for_url, cookie-forcing) — in practice the final
+            # ``context.storage_state()`` capture (#1514). Those paths already
+            # map TargetClosed to BROWSER_CLOSED_HELP + exit 1; mirror them
+            # here so the user gets the same friendly help instead of the
+            # exit-2 bug-report hint. (The launch branch above never falls
+            # through for handled not-found errors — it io.fail(1)s — and
+            # launch failures are not TargetClosed.)
+            if isinstance(e, PlaywrightError) and TARGET_CLOSED_ERROR in str(e):
+                io.emit(BROWSER_CLOSED_HELP)
+                io.fail(1)
+            # For everything else, the diagnostic stays at debug level; the bare
+            # ``raise`` propagates to ``handle_errors`` → friendly
+            # ``Unexpected error: <msg>`` + exit 2.
             logger.debug("Login failed: %s", e, exc_info=True)
             raise
         finally:

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -300,6 +300,11 @@ class TestLoginCommand:
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page]
+            # Real Playwright pages expose their owning BrowserContext via
+            # ``page.context``; wire it so tests can reach the context from the
+            # yielded page (e.g. to make ``storage_state()`` raise) without
+            # rebuilding this harness.
+            mock_page.context = mock_context
             # storage_state() now returns a dict; atomic_write_json writes it.
             mock_context.storage_state.return_value = {"cookies": [], "origins": []}
             mock_launch = (
@@ -1396,6 +1401,57 @@ class TestLoginCommand:
 
         assert result.exit_code == 1
         assert "browser" in result.output.lower() and "closed" in result.output.lower()
+
+    @pytest.mark.requires_playwright
+    def test_login_browser_closed_during_storage_capture_shows_help(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """TargetClosed at the final ``storage_state()`` capture surfaces BROWSER_CLOSED_HELP (#1514).
+
+        Every in-flow Playwright call (recover_page, the navigation retry
+        loop, wait_for_url, cookie-forcing) already maps TargetClosedError to
+        BROWSER_CLOSED_HELP + exit 1. Closing the browser in the narrow window
+        before ``context.storage_state()`` used to fall through the outer
+        handler's bare ``raise`` instead — exit 2 + "Unexpected error" + the
+        bug-report hint, for something that isn't a bug.
+        """
+        from playwright.sync_api import Error as PlaywrightError
+
+        mock_page = mock_login_browser_with_storage
+        mock_page.context.storage_state.side_effect = PlaywrightError(
+            "BrowserContext.storage_state: Target page, context or browser has been closed"
+        )
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 1
+        assert "browser window was closed" in result.output.lower()
+        assert "Unexpected error" not in result.output
+        assert "Authentication saved" not in result.output
+
+    @pytest.mark.requires_playwright
+    def test_login_non_target_closed_error_during_storage_capture_propagates(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """A non-TargetClosed failure at ``storage_state()`` keeps the exit-2 contract.
+
+        Counter-case for the #1514 fix: only TargetClosed gets the friendly
+        browser-closed help; any other failure at the capture site still
+        propagates through the outer handler's bare ``raise`` to
+        ``handle_errors`` ("Unexpected error: ..." + exit 2).
+        """
+        from playwright.sync_api import Error as PlaywrightError
+
+        mock_page = mock_login_browser_with_storage
+        mock_page.context.storage_state.side_effect = PlaywrightError(
+            "BrowserContext.storage_state: Protocol error (Storage.getCookies)"
+        )
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 2
+        assert "Unexpected error" in result.output
+        assert "browser window was closed" not in result.output.lower()
 
 
 class TestLoginNoTraceback:


### PR DESCRIPTION
## Summary

Fixes #1514 (deferred from PR #1512 review). In `run_browser_capture` (`src/notebooklm/_auth/browser_capture.py`), the in-flow paths (recover_page, the navigation retry loop, wait_for_url, the cookie-forcing loop) already map Playwright TargetClosed to `BROWSER_CLOSED_HELP` + exit 1. The uncovered window: the browser/tab closing during the final `context.storage_state()` capture fell through the outer `except Exception` and exited **2** ("Unexpected error … please report a bug") — a misleading bug-report hint for an ordinary user action.

### What changed
- The outer handler now has a last-resort TargetClosed branch — `isinstance(e, PlaywrightError) and TARGET_CLOSED_ERROR in str(e)` → `BROWSER_CLOSED_HELP` + exit 1 — mirroring the four in-flow paths exactly (same emit+fail sequence). Everything else keeps the `logger.debug` + bare-`raise` → exit-2 contract.
- Placement after the channel-browser launch-error branch: handled not-found launch errors `io.fail(1)` and never fall through; launch failures are never TargetClosed.
- `SystemExit` unwinding through `finally: context.close()` with a dead context is the established pattern of the three pre-existing in-flow `io.fail(1)` sites — no new risk.

### Tests
- `test_login_browser_closed_during_storage_capture_shows_help` — **proven red pre-fix** (failed with `SystemExit(2)`, the exact #1514 bug).
- `test_login_non_target_closed_error_during_storage_capture_propagates` — counter-case pinning the propagate→exit-2 contract for non-TargetClosed errors (passes pre- and post-fix, so it's genuinely decoupled).
- Fixture now wires `mock_page.context = mock_context`, matching Playwright's real `Page.context` property; zero new string patches (ratchet untouched).

### Verification
- Full `uv run pytest -m "not e2e"`: 9671 passed, 71 skipped, 1 xfailed (on the pre-rebase base; post-rebase: login suite + boundary/ratchet guardrails + mypy 236 files clean)
- ruff check + format clean · API-compat audit exit 0 (no new allowlist entries)

Polish: claude + codex review, both SHIP. Codex's Minor (handler comment overstated the storage_state-only scope — it's a last-resort branch for anything escaping the in-flow guards) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during login when the browser closes unexpectedly. Users now receive a clear, helpful message instead of a generic error, with proper exit code handling for better integration with automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->