### PR TITLE
fix(sources): source delete honors exact-id-wins-over-prefix, matching get/rename/refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This is the production sibling of the timezone slip pinned out of the #1511
   golden VCR test.
 
+- **`source delete` now honors exact-id-wins over prefix matching, in lockstep
+  with `source get` / `rename` / `refresh`** (#1522). The delete-path resolver
+  (`_app/source_mutations.resolve_source_for_delete`) built its prefix-match
+  list and branched solely on `len(matches)` with no exact-id short-circuit, so
+  `source delete abc` raised `AMBIGUOUS_ID` when a notebook held both `abc` and
+  `abcdef` — even though the shared resolvers (`cli.resolve.resolve_partial_id_in_items`
+  and its `_app` twin `_app.resolve.resolve_ref`) both return on an exact
+  (case-insensitive) id match before evaluating prefixes, so the other verbs
+  resolved the same input. The delete resolver now mirrors that Rule 3: a
+  source whose id equals the input (case-insensitively) wins over any
+  longer-id prefix match (and is not treated as a partial expansion, so no
+  "Matched:" prose is emitted). Genuine prefix ambiguity (two strict prefixes,
+  no exact match) and the not-found / title-instead-of-id paths are unchanged.
 - **Playwright login: closing the browser during the final storage-state
   capture now shows the browser-closed help instead of a bug-report prompt**
   (#1514, deferred from the #1512 review). Every in-flow Playwright call in

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -224,7 +224,22 @@ async def resolve_source_for_delete(
         return SourceIdResolution(source_id=source_id)
 
     sources = await client.sources.list(notebook_id)
-    matches = [item for item in sources if item.id.lower().startswith(source_id.lower())]
+    # Exact (case-insensitive) id match wins over prefix matching — mirroring
+    # the shared resolvers' Rule 3 (``_app.resolve.resolve_ref`` /
+    # ``cli.resolve.resolve_partial_id_in_items``) so ``source delete X`` stays
+    # in lockstep with ``source get/rename/refresh X``. Without this, a
+    # short-but-complete id that is also a strict prefix of another source's id
+    # (e.g. ``abc`` vs ``abcdef``) would be reported as AMBIGUOUS_ID here while
+    # the other verbs resolve it (issue #1522). An exact match is not a partial
+    # expansion, so no "Matched:" status prose is emitted.
+    source_id_lower = source_id.lower()
+    matches = []
+    for item in sources:
+        item_id_lower = item.id.lower()
+        if item_id_lower == source_id_lower:
+            return SourceIdResolution(source_id=item.id)
+        if item_id_lower.startswith(source_id_lower):
+            matches.append(item)
 
     if len(matches) == 1:
         status_message = None

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from notebooklm._app.resolve import resolve_ref
 from notebooklm._app.source_mutations import (
     SourceAddDrivePlan,
     SourceDeleteByTitlePlan,
@@ -150,12 +151,46 @@ class TestResolveSourceForDelete:
         assert resolution.status_message is None
 
     @pytest.mark.asyncio
+    async def test_exact_match_wins_over_prefix_ambiguity(self) -> None:
+        # "abc" is an exact (case-insensitive) match for the first source AND a
+        # strict prefix of "abcdef" — exact must win and not report ambiguity,
+        # mirroring resolve_ref / resolve_partial_id_in_items Rule 3 so delete
+        # stays in lockstep with get/rename/refresh (issue #1522).
+        client = _client(
+            sources=[Source(id="abc", title="Exact"), Source(id="abcdef", title="Prefixed")]
+        )
+        resolution = await resolve_source_for_delete(client, "nb_1", "abc")
+        assert resolution.source_id == "abc"
+        # An exact match is not a partial expansion, so no "Matched:" prose.
+        assert resolution.status_message is None
+
+    @pytest.mark.asyncio
+    async def test_exact_match_wins_case_insensitive(self) -> None:
+        # Exact match is case-insensitive and returns the source's canonical id.
+        client = _client(
+            sources=[Source(id="ABC", title="Exact"), Source(id="abcdef", title="Prefixed")]
+        )
+        resolution = await resolve_source_for_delete(client, "nb_1", "abc")
+        assert resolution.source_id == "ABC"
+        assert resolution.status_message is None
+
+    @pytest.mark.asyncio
     async def test_ambiguous_partial_raises(self) -> None:
         client = _client(
             sources=[Source(id="src_aaa111", title="One"), Source(id="src_aaa222", title="Two")]
         )
         with pytest.raises(SourceMutationError) as exc:
             await resolve_source_for_delete(client, "nb_1", "src_aaa")
+        assert exc.value.code == "AMBIGUOUS_ID"
+
+    @pytest.mark.asyncio
+    async def test_genuine_ambiguity_without_exact_still_raises(self) -> None:
+        # Two strict prefixes and NO exact match → genuine ambiguity is preserved.
+        client = _client(
+            sources=[Source(id="abc111", title="One"), Source(id="abc222", title="Two")]
+        )
+        with pytest.raises(SourceMutationError) as exc:
+            await resolve_source_for_delete(client, "nb_1", "abc")
         assert exc.value.code == "AMBIGUOUS_ID"
 
     @pytest.mark.asyncio
@@ -172,6 +207,17 @@ class TestResolveSourceForDelete:
         with pytest.raises(SourceMutationError) as exc:
             await resolve_source_for_delete(client, "nb_1", "zzz")
         assert exc.value.code == "NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_exact_match_parity_with_shared_resolver(self) -> None:
+        # Parity guard (issue #1522): delete's bespoke resolver must agree with
+        # the canonical resolve_ref on the exact-match-wins outcome, the rule
+        # get/rename/refresh already get for free via resolve_source_id.
+        sources = [Source(id="abc", title="Exact"), Source(id="abcdef", title="Prefixed")]
+        client = _client(sources=sources)
+        resolution = await resolve_source_for_delete(client, "nb_1", "abc")
+        shared = resolve_ref("abc", sources, id_of=lambda s: s.id, title_of=lambda s: s.title)
+        assert resolution.source_id == shared.id == "abc"
 
     @pytest.mark.asyncio
     async def test_injected_validate_id_runs_first(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #1522 (from the adversarially-verified audit). `resolve_source_for_delete` (`src/notebooklm/_app/source_mutations.py`) built its `matches` list via `startswith` and branched solely on `len(matches)` with **no exact-id short-circuit** — so `source delete X` raised `AMBIGUOUS_ID` where `source get/rename/refresh X` resolve. The canonical resolvers (`_app/resolve.py:resolve_ref` Rule 3, `cli/resolve.py:resolve_partial_id_in_items`) both return on an exact id match *before* evaluating prefixes; delete had drifted from a contract its sibling verbs honor (id `abc` exactly vs `abcdef` as a strict prefix).

### Fix
Added the exact-match short-circuit (case-insensitive `id == input` wins, returns the canonical `item.id`, no "Matched:" status — an exact match is not a partial expansion), placed before prefix evaluation, mirroring the shared Rule 3.

**Why short-circuit, not route-through-shared:** `resolve_source_for_delete` carries bespoke branches the shared resolver lacks — the title-instead-of-id `VALIDATION_ERROR` fallback (with the delete-by-title hint), the `AMBIGUOUS_ID`/`NOT_FOUND` `SourceMutationError` codes, and the Rich-markup `status_message`. Routing through `resolve_ref` would change those error codes, which the issue explicitly forbids. The targeted short-circuit (the issue's stated acceptable fallback) reuses the exact semantics without disturbing the other branches.

### Tests (red-first)
- `test_exact_match_wins_over_prefix_ambiguity`, `test_exact_match_wins_case_insensitive`, `test_exact_match_parity_with_shared_resolver` — all failed pre-fix with `AMBIGUOUS_ID`.
- `test_genuine_ambiguity_without_exact_still_raises` — green pre- and post-fix (genuine ambiguity preserved).
- The parity test pins delete's resolution against `resolve_ref` on the same inputs (no resolver-parity conformance gate existed to register into).

### Verification
- Full `uv run pytest -m "not e2e"`: 9687 passed, 71 skipped, 1 xfailed
- mypy clean (236 files) · ruff clean · API-compat audit exit 0 (non-breaking) · module-size ratchet green

Polish: claude implementer + codex independent review — codex SHIP, no findings, confirmed empirical parity across blank/full-UUID/exact/case-insensitive-exact/unique-prefix/ambiguous-prefix/no-match classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `source delete` now prioritizes case-insensitive exact ID matches over prefix matching, removing erroneous ambiguity messages when an exact match exists and aligning behavior with other source operations.

* **Tests**
  * Added tests confirming exact-match precedence, preserving genuine ambiguous-prefix errors, and ensuring parity with the shared resolver.

* **Documentation**
  * Changelog updated to describe the exact-match resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->