### PR TITLE
feat(auth): headless re-auth as layer-3 recovery (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Layer-3 headless re-auth: `client.refresh_auth(allow_headless=True)`** (#1525,
+  P2; P1 was #1512). When NotebookLM's first-party cookies are fully dead — the
+  homepage GET 302s to the Google login page and neither token refresh (L1) nor
+  `RotateCookies` rotation (L2) can help — a persisted browser profile may still
+  hold a live Google SSO session that outlives `storage_state.json`. The new
+  opt-in re-auth layer drives an unattended **headless** browser against that
+  profile to silently re-mint cookies, then retries. It is **explicit by
+  default**: `refresh_auth(allow_headless=True)` (additive keyword-only,
+  defaults to `False`) triggers it on demand, and a *mid-RPC* auto-fire happens
+  only when `NOTEBOOKLM_HEADLESS_REAUTH=1` is set — L3 **never** fires by
+  default, so behavior with no opt-in and no profile is unchanged. Outcomes are
+  typed and honest (re-minted / profile-session-also-dead / unavailable) and it
+  never reports success on dead tokens. **SECURITY:** the persistent profile is
+  an account-equivalent credential; L3 is **local-unattended-only** and must not
+  be the auth path for a remote / hosted MCP server. It reuses the existing
+  cookie-domain allowlist and never logs a captured cookie value.
+
 - **`client.mind_maps.list_note_backed(notebook_id)`** — typed list of only
   the **note-backed** mind maps (every `kind` is `NOTE_BACKED`, `tree`
   populated, deleted rows excluded) via a single `GET_NOTES_AND_MIND_MAPS`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -504,7 +504,8 @@ the default dependency.
 | [`_auth/headers.py`](../src/notebooklm/_auth/headers.py) | HTTP header construction. |
 | [`_auth/cookies.py`](../src/notebooklm/_auth/cookies.py) | Cookie maps + `_update_cookie_input` helper. |
 | [`_auth/cookie_policy.py`](../src/notebooklm/_auth/cookie_policy.py) | Domain allowlist, cookie-domain builder (`build_cookie_domain_allowlist`), and cookie policy decisions. |
-| [`_auth/browser_capture.py`](../src/notebooklm/_auth/browser_capture.py) | Transport-neutral browser launch→navigate→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter and the future headless re-auth layer (ADR-0021). |
+| [`_auth/browser_capture.py`](../src/notebooklm/_auth/browser_capture.py) | Transport-neutral browser launch→navigate→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter and the layer-3 headless re-auth layer (ADR-0021). The headless arm classifies the landing URL (authenticated→capture, redirected-to-login→`HeadlessLoginRequiredError`). |
+| [`_auth/headless_reauth.py`](../src/notebooklm/_auth/headless_reauth.py) | Layer-3 (deepest) auth recovery: when first-party cookies are dead, drive a headless browser against the persistent profile to silently re-mint cookies. Typed honest outcomes (`HeadlessReauthStatus` UNAVAILABLE/FAILED/SUCCESS — never silent `None`). Opt-in only (`refresh_auth(allow_headless=True)` or `NOTEBOOKLM_HEADLESS_REAUTH=1`); local-unattended-only, never the remote/MCP auth path. |
 | [`_auth/account.py`](../src/notebooklm/_auth/account.py) | Account profile + multi-account switching. |
 | [`_auth/session.py`](../src/notebooklm/_auth/session.py) | `refresh_auth_session(auth=..., kernel=..., auth_coord=..., lifecycle=..., cookie_persistence=...)` implementation called by `AuthRefreshCoordinator`. Takes five explicit keyword-only collaborators instead of a Session-shaped owner Protocol; the previous `RefreshAuthCore` Protocol and the `update_auth_tokens` / `update_auth_headers` Session-level forwards have been removed. |
 | [`_auth/refresh.py`](../src/notebooklm/_auth/refresh.py) | Token refresh driver (external login command, coalesced runs, secret redaction). |
@@ -907,7 +908,8 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_auth/headers.py` | HTTP header construction |
 | `_auth/cookies.py` | Cookie map manipulation + `_update_cookie_input` |
 | `_auth/cookie_policy.py` | Cookie-domain allowlist, `build_cookie_domain_allowlist` builder, and policy decisions |
-| `_auth/browser_capture.py` | Transport-neutral browser launch→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter (`cli/services/playwright_login.py`) and the future headless re-auth layer (ADR-0021) |
+| `_auth/browser_capture.py` | Transport-neutral browser launch→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter (`cli/services/playwright_login.py`) and the layer-3 headless re-auth layer (ADR-0021) |
+| `_auth/headless_reauth.py` | Layer-3 headless re-auth decision layer: opt-in/profile-gated, typed honest outcomes (`HeadlessReauthStatus`); drives `run_browser_capture(headless=True, interactive=False)`. Local-unattended-only |
 | `cli/label_cmd.py` | `label` command group (list/sources/generate/create/rename/emoji/add/delete); thin Click shells over `client.labels` and the label-listing service (ADR-0008) |
 | `cli/services/label_listing.py` | `label` CLI service: the `label list` members→source-titles join (`execute_label_list`/`LabelListPlan`). Re-exports `resolve_label_id` + `LabelResolutionError` from `_app/labels.py` (the composite `<id\|name>` resolver moved to the neutral layer; the re-export keeps `from .services.label_listing import resolve_label_id` resolving for the command layer + tests) |
 
@@ -1058,6 +1060,7 @@ src/notebooklm/
 │   ├── cookies.py               # Cookie maps + _update_cookie_input
 │   ├── cookie_policy.py         # Domain allowlist + cookie-domain builder and policy
 │   ├── browser_capture.py       # Transport-neutral browser launch→capture→filter→persist core (lazy playwright)
+│   ├── headless_reauth.py       # Layer-3 headless re-auth (opt-in; typed outcomes; local-unattended-only)
 │   ├── account.py               # Account profile + multi-account switching
 │   ├── session.py               # Auth-session refresh implementation via `refresh_auth_session()` and explicit collaborators
 │   ├── storage.py               # Profile/state persistence on disk

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -51,6 +51,7 @@ from urllib.parse import urlparse
 
 from .._atomic_io import atomic_write_json
 from ..config import get_base_host, get_base_url
+from ..exceptions import HeadlessLoginRequiredError
 from .cookie_policy import build_cookie_domain_allowlist
 
 if TYPE_CHECKING:
@@ -313,31 +314,36 @@ def ensure_playwright_available(io: BrowserCaptureIO, *, browser: str) -> None:
 
 
 def _reject_unsupported_mode(*, headless: bool, interactive: bool, io: BrowserCaptureIO) -> None:
-    """Guard the P1 contract: only the interactive, non-headless arm is wired.
+    """Guard the supported ``(headless, interactive)`` combinations.
 
-    The ``headless`` / ``interactive`` parameters and their branch points exist
-    so the future headless re-auth layer (P2) can wire its arm without
-    re-carving this core. P1 ships refactor-only, so any other combination is an
-    explicit, programmer-facing error rather than a silent behavior change. The
-    interactive (``interactive=True, headless=False``) path is the sole mode the
-    existing ``notebooklm login`` flow exercises.
+    Two arms are wired:
 
-    ``io`` is accepted but deliberately unused in P1: this is a programmer-facing
+    * ``interactive=True, headless=False`` — the interactive ``notebooklm
+      login`` flow (a human completes the Google SSO in a visible browser).
+    * ``interactive=False, headless=True`` — the layer-3 headless re-auth flow
+      (P2): an unattended browser harvests a still-live Google session from the
+      persistent profile, with NO human to wait on.
+
+    Any other combination (interactive + headless, or non-interactive +
+    non-headless) is a programmer error: a visible-but-unattended browser would
+    hang waiting for a human who isn't there, and a headless-but-interactive
+    flow is contradictory. Refuse loudly so a caller cannot silently get a
+    half-wired flow.
+
+    ``io`` is accepted but deliberately unused: this is a programmer-facing
     guard that raises ``NotImplementedError`` (not an end-user condition routed
-    through ``io.fail``). The parameter is reserved so P2's headless arm can,
-    if it chooses, surface a user-facing ``io.fail`` / silent path here instead
-    of raising — without changing this signature.
+    through ``io.fail``).
     """
     if interactive and not headless:
         return
-    # P2 will implement the headless arm; until then refuse loudly so a caller
-    # cannot silently get a half-wired flow. (See ``io`` note above — this is a
-    # programmer error, not an ``io.fail`` end-user condition.)
-    _ = io  # reserved for P2's headless arm; intentionally unused in P1
+    if headless and not interactive:
+        return
+    _ = io  # programmer-facing guard; not an ``io.fail`` end-user condition
     raise NotImplementedError(
-        "Headless / non-interactive browser capture is not implemented yet "
-        "(reserved for the layer-3 headless re-auth feature). "
-        "Only interactive=True, headless=False is supported."
+        "Unsupported browser-capture mode "
+        f"(headless={headless}, interactive={interactive}). "
+        "Only interactive=True/headless=False (interactive login) and "
+        "interactive=False/headless=True (headless re-auth) are supported."
     )
 
 
@@ -463,7 +469,27 @@ def run_browser_capture(
                         logger.debug("Non-retryable error: %s", error_str)
                         raise
 
-            if url_matches_base_host(page.url):
+            if headless:
+                # Layer-3 headless re-auth: there is NO human to complete a
+                # login form, so we never wait. Classify the landing instead:
+                #   * lands on the NotebookLM host  → the persistent profile
+                #     still holds a live Google session; proceed to capture.
+                #   * redirected to a login page    → the profile's Google
+                #     session is ALSO dead; fail loudly (raise) rather than
+                #     hang. ``HeadlessLoginRequiredError`` is the typed,
+                #     honest signal the caller maps to a FAILED outcome.
+                if not url_matches_base_host(page.url):
+                    logger.warning(
+                        "Headless re-auth: landed off-host after navigation "
+                        "(the persisted browser profile's Google session is "
+                        "likely expired); cannot silently re-mint cookies."
+                    )
+                    raise HeadlessLoginRequiredError(
+                        "Headless re-auth could not reach NotebookLM: the "
+                        "persisted browser profile's Google session is "
+                        "expired. Run 'notebooklm login' to re-authenticate."
+                    )
+            elif url_matches_base_host(page.url):
                 # Persistent browser profile already has a valid session.
                 io.emit("[green]Already logged in.[/green]")
             else:

--- a/src/notebooklm/_auth/headless_reauth.py
+++ b/src/notebooklm/_auth/headless_reauth.py
@@ -91,6 +91,13 @@ NOTEBOOKLM_HEADLESS_REAUTH_ENV = "NOTEBOOKLM_HEADLESS_REAUTH"
 # best-effort, single-process guard; cross-process coordination (two CLI
 # invocations) is out of scope here — they each own their own browser, the same
 # way the interactive ``notebooklm login`` flow does.
+#
+# Lifetime: this registry is keyed on the resolved storage path and is never
+# pruned, but it is bounded by the number of DISTINCT storage paths a process
+# ever re-auths against — i.e. the profile count, typically one. The same
+# never-pruned-but-profile-bounded shape as ``_REFRESH_GENERATIONS`` /
+# ``_LAST_POKE_ATTEMPT_MONOTONIC`` elsewhere in the auth layer; a long-running
+# process does not accumulate entries from RPC traffic, only from new profiles.
 _DRIVE_REGISTRY_LOCK = threading.Lock()
 _DRIVE_LOCKS_BY_PATH: dict[str, threading.Lock] = {}
 

--- a/src/notebooklm/_auth/headless_reauth.py
+++ b/src/notebooklm/_auth/headless_reauth.py
@@ -1,0 +1,433 @@
+"""Layer-3 headless re-auth: silently re-mint dead NotebookLM cookies.
+
+This is the **deepest** auth-recovery layer. When NotebookLM's first-party
+cookies (``SID`` / ``__Secure-1PSIDTS`` / …) are fully dead — the homepage GET
+302s to ``accounts.google.com`` and even L1 token refresh and L2 PSIDTS
+rotation cannot help — the user's persistent *browser profile* may still hold a
+live Google SSO session (it outlives ``storage_state.json``). L3 drives a
+**headless** browser against that profile to re-mint NotebookLM cookies without
+a human, then lets the normal auth path retry.
+
+Recovery layering (deepest last):
+
+* **L1** — token / CSRF refresh (homepage GET re-extracts ``SNlM0e`` /
+  ``FdrFJe``; :func:`notebooklm._auth.session.refresh_auth_session`).
+* **L2** — ``__Secure-1PSIDTS`` rotation via the ``RotateCookies`` POST
+  (:mod:`notebooklm._auth.keepalive` / :mod:`notebooklm._auth.psidts_recovery`).
+* **L3** — headless browser re-auth (this module). Fired only after L1/L2
+  cannot help, and only when explicitly allowed.
+
+**Locked design decision (inherited from the P1 browser-capture core).**
+Headless re-auth is EXPLICIT by default via
+``client.refresh_auth(allow_headless=True)``; a mid-RPC auto-fire happens
+ONLY when ``NOTEBOOKLM_HEADLESS_REAUTH=1`` is set in the environment. L3 never
+auto-fires by default. With no opt-in and no profile the behavior is
+byte-identical to the pre-L3 terminal "Run 'notebooklm login'" path.
+
+**SECURITY — local-unattended-only.** The persistent browser profile is an
+**account-equivalent credential**: a live Google session, longer-lived than
+``storage_state.json``. L3 must NOT become the auth story for a remote / hosted
+MCP server — it is for a local, unattended agent/worker on the operator's own
+machine. It reuses the existing cookie-domain allowlist
+(:func:`notebooklm._auth.browser_capture.filter_storage_state_cookies_by_domain_policy`)
+on the captured ``storage_state`` and widens neither credential storage nor
+logging (never logs a captured cookie value — only the typed outcome).
+
+**Honest, typed outcomes.** Unlike a sibling project that silently returns
+``None``, this layer distinguishes three states and NEVER reports success on
+dead tokens:
+
+* :attr:`HeadlessReauthStatus.UNAVAILABLE` — L3 could not even be attempted
+  (opt-in off, no reusable profile, or ``playwright`` not installed).
+* :attr:`HeadlessReauthStatus.FAILED` — L3 ran but the profile's Google
+  session is ALSO dead (the headless browser was redirected to the Google
+  login page), or the capture otherwise failed.
+* :attr:`HeadlessReauthStatus.SUCCESS` — fresh cookies were captured, filtered,
+  and atomically persisted to ``storage_state.json``.
+
+``playwright`` stays lazily imported (only the neutral capture core touches it);
+importing this module without the ``browser`` extra never fails.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from ..exceptions import HeadlessLoginRequiredError
+from .browser_capture import BrowserCapturePlan, run_browser_capture
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+logger = logging.getLogger("notebooklm.auth")
+
+# Opt-in env var that lets the mid-RPC auth cascade auto-fire L3. Read here and
+# in the client wiring. Set to ``"1"`` to allow a *mid-call* headless re-auth;
+# unset (or any other value) means L3 only fires via the explicit
+# ``client.refresh_auth(allow_headless=True)`` entry point. The locked design
+# decision: never auto-fire by default.
+NOTEBOOKLM_HEADLESS_REAUTH_ENV = "NOTEBOOKLM_HEADLESS_REAUTH"
+
+# Per-storage-path single-flight for the (blocking, sync) browser drive.
+#
+# The mid-RPC cascade already coalesces through
+# ``AuthRefreshCoordinator.await_refresh``, but the explicit
+# ``client.refresh_auth(allow_headless=True)`` entry point bypasses that
+# coordinator, and several clients (or processes-within-a-process) can target
+# the same profile. This registry guarantees that, within ONE process, at most
+# ONE browser drives a given ``storage_state.json`` at a time: concurrent
+# callers serialize on a per-resolved-path ``threading.Lock``, and a follower
+# that sees the storage file freshly rewritten by the leader while it waited
+# SKIPS its own browser (coalesces) instead of launching a redundant one.
+#
+# ``_DRIVE_REGISTRY_LOCK`` makes the get-or-create of a per-path lock atomic
+# across the worker threads ``asyncio.to_thread`` may use. This is a
+# best-effort, single-process guard; cross-process coordination (two CLI
+# invocations) is out of scope here — they each own their own browser, the same
+# way the interactive ``notebooklm login`` flow does.
+_DRIVE_REGISTRY_LOCK = threading.Lock()
+_DRIVE_LOCKS_BY_PATH: dict[str, threading.Lock] = {}
+
+
+def headless_reauth_env_enabled(env: dict[str, str] | None = None) -> bool:
+    """True when ``NOTEBOOKLM_HEADLESS_REAUTH=1`` opts into mid-RPC L3 auto-fire.
+
+    ``env`` defaults to :data:`os.environ`; injectable for deterministic tests.
+    Only the exact value ``"1"`` enables it, mirroring the strict opt-in
+    convention used by ``_REFRESH_ATTEMPTED_ENV`` and the keepalive env gates.
+    """
+    source = os.environ if env is None else env
+    return source.get(NOTEBOOKLM_HEADLESS_REAUTH_ENV) == "1"
+
+
+class HeadlessReauthStatus(Enum):
+    """Terminal classification of one L3 headless re-auth attempt.
+
+    Three mutually-exclusive states keep failure honest (a sibling project
+    collapsed all of these into a silent ``None``):
+
+    * ``UNAVAILABLE`` — the attempt was declined before driving a browser
+      (opt-in off, no reusable profile, or ``playwright`` missing). The caller
+      should fall through to the existing terminal "Run 'notebooklm login'"
+      message unchanged — L3 simply does not apply here.
+    * ``FAILED`` — a browser ran but re-auth did not succeed: most importantly
+      the profile's Google session is ALSO dead (headless landed on the Google
+      login page), or the capture/persist failed. NEVER reported on dead
+      tokens being healed; this means the operator genuinely must re-login.
+    * ``SUCCESS`` — fresh cookies were captured, domain-filtered, and persisted.
+    """
+
+    UNAVAILABLE = "unavailable"
+    FAILED = "failed"
+    SUCCESS = "success"
+
+
+@dataclass(frozen=True)
+class HeadlessReauthResult:
+    """Typed outcome of :func:`attempt_headless_reauth`.
+
+    Attributes:
+        status: The terminal :class:`HeadlessReauthStatus`.
+        reason: Short, human-readable, credential-free explanation (safe to
+            log / surface). Never contains a cookie value or token.
+        storage_path: The ``storage_state.json`` that was (re)written on
+            ``SUCCESS``; ``None`` otherwise.
+    """
+
+    status: HeadlessReauthStatus
+    reason: str
+    storage_path: Path | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """``True`` only for :attr:`HeadlessReauthStatus.SUCCESS`."""
+        return self.status is HeadlessReauthStatus.SUCCESS
+
+
+class _SilentRaisingCaptureIO:
+    """A ``BrowserCaptureIO`` sink for the unattended headless arm.
+
+    There is NO human in the L3 path, so the interactive niceties are inverted
+    to silent / raising behavior:
+
+    * ``emit`` swallows presentation lines (the neutral core emits a few
+      "Already logged in." style lines meant for an interactive console; under
+      headless re-auth they are noise). Lines are dropped, never logged, so a
+      future core change that put a credential in an ``emit`` line could not
+      leak through this sink.
+    * ``fail`` raises :class:`HeadlessLoginRequiredError` instead of exiting the
+      process — an unattended library call must never call ``sys.exit``. The
+      neutral core routes user-facing aborts through ``io.fail``; mapping them
+      to this exception lets :func:`attempt_headless_reauth` classify them as
+      :attr:`HeadlessReauthStatus.FAILED` rather than hanging or exiting.
+    * ``run_async`` is never reached on the capture path (the core only calls it
+      from the interactive adapter's account-metadata repair, which the
+      headless arm does not run); it raises if somehow invoked so a contract
+      drift is loud rather than silent.
+    """
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        # Intentionally silent: no human console, and never log emit content.
+        return None
+
+    def fail(self, code: int) -> NoReturn:
+        raise HeadlessLoginRequiredError(
+            "Headless re-auth aborted by the capture core "
+            f"(exit code {code}); the persisted browser profile's Google "
+            "session is likely dead. Run 'notebooklm login' to re-authenticate."
+        )
+
+    def run_async(self, coro: Awaitable[Any]) -> Any:
+        # Not reached on the headless capture path (no account-metadata repair).
+        raise RuntimeError(
+            "run_async is not supported on the headless re-auth IO sink "
+            "(the headless arm performs no account-metadata repair)."
+        )
+
+
+def _resolve_reusable_profile(
+    *,
+    browser_profile: Path | None,
+    profile: str | None,
+) -> Path | None:
+    """Resolve the persistent browser-profile dir, or ``None`` if not reusable.
+
+    The whole L3 layer rests on a reusable profile whose Google session
+    outlives the NotebookLM cookies. The profile is the persistent-context dir
+    ``notebooklm login`` launches against
+    (:func:`notebooklm.paths.get_browser_profile_dir`), so we resolve the same
+    path and require it to already exist and be a directory — a missing /
+    empty profile means there is no Google session to harvest and L3 declines.
+
+    Args:
+        browser_profile: Explicit profile dir (e.g. from a ``--storage`` flow);
+            takes precedence when supplied.
+        profile: Profile name to resolve via ``get_browser_profile_dir`` when
+            no explicit dir is given.
+
+    Returns:
+        The existing profile directory, or ``None`` when no reusable profile is
+        present on disk.
+    """
+    if browser_profile is not None:
+        candidate = browser_profile
+    else:
+        # Imported lazily to avoid a module-load edge with paths/config.
+        from ..paths import get_browser_profile_dir
+
+        candidate = get_browser_profile_dir(profile)
+
+    # A persistent context needs a populated profile dir to hold a live Google
+    # session. An absent or non-directory path has no session to harvest.
+    if not candidate.is_dir():
+        return None
+    # An empty dir (e.g. created by a path-prep step but never logged into) has
+    # no Chrome session state. ``next(iterdir)`` is cheap and avoids treating a
+    # freshly-mkdir'd profile as reusable.
+    try:
+        next(candidate.iterdir())
+    except StopIteration:
+        return None
+    except OSError as exc:  # unreadable dir — treat as no reusable profile
+        logger.debug("Headless re-auth: profile dir %s not readable: %s", candidate, exc)
+        return None
+    return candidate
+
+
+def attempt_headless_reauth(
+    *,
+    storage_path: Path,
+    allow_headless: bool,
+    browser_profile: Path | None = None,
+    profile: str | None = None,
+    browser: str = "chromium",
+    include_domains: set[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> HeadlessReauthResult:
+    """Attempt one layer-3 headless re-auth; return a typed, honest outcome.
+
+    Decision logic (the gate the locked design decision pins):
+
+    1. **Opt-in.** Proceed only when ``allow_headless`` is ``True`` OR
+       ``NOTEBOOKLM_HEADLESS_REAUTH=1`` is set. Otherwise return ``UNAVAILABLE``
+       — L3 NEVER fires by default. (Callers pass ``allow_headless=True`` for
+       the explicit ``client.refresh_auth(allow_headless=True)`` entry, and
+       gate the mid-RPC auto-fire on the env var via
+       :func:`headless_reauth_env_enabled`.)
+    2. **Reusable profile.** A persistent profile dir holding a (hopefully
+       live) Google session must exist on disk (:func:`_resolve_reusable_profile`).
+       No profile → ``UNAVAILABLE`` (fall through to the terminal message).
+    3. **Drive the headless browser** through the neutral capture core
+       (``headless=True, interactive=False``): launch the persistent context,
+       navigate to the NotebookLM base URL, classify the landing — authenticated
+       (lands on NotebookLM) → capture / domain-filter / atomically persist;
+       redirected to the Google login page → the profile's session is ALSO dead
+       → :class:`HeadlessLoginRequiredError` → ``FAILED`` (loud, never hangs).
+    4. **Playwright missing** → ``UNAVAILABLE`` (the ``browser`` extra is not
+       installed; nothing to drive).
+
+    This function performs the *recovery*, not the retry. On ``SUCCESS`` the
+    caller re-runs the normal auth path (L1 token refresh) which now finds the
+    freshly-persisted cookies. It is a recovery, not the hot path, and the
+    actual browser drive is single-flight-coalesced by the caller (the client
+    wiring routes concurrent failing calls through the existing refresh
+    single-flight so N failures spawn at most one browser).
+
+    Args:
+        storage_path: ``storage_state.json`` to (re)write on success.
+        allow_headless: Explicit opt-in (the ``refresh_auth(allow_headless=)``
+            value). When ``False``, only the env var can enable L3.
+        browser_profile: Explicit persistent-profile dir; defaults to the
+            profile's ``get_browser_profile_dir`` when ``None``.
+        profile: Profile name used to resolve the browser-profile dir.
+        browser: Playwright channel (``"chromium"`` / ``"chrome"`` / ``"msedge"``).
+        include_domains: Optional cookie-domain opt-in labels, forwarded to the
+            same allowlist filter the interactive login uses.
+        env: Environment mapping for the opt-in check; defaults to
+            :data:`os.environ`.
+
+    Returns:
+        A :class:`HeadlessReauthResult` with a distinct status for unavailable
+        / failed / success. NEVER ``SUCCESS`` unless cookies were persisted.
+    """
+    if not (allow_headless or headless_reauth_env_enabled(env)):
+        return HeadlessReauthResult(
+            HeadlessReauthStatus.UNAVAILABLE,
+            "headless re-auth not enabled "
+            "(pass allow_headless=True or set NOTEBOOKLM_HEADLESS_REAUTH=1)",
+        )
+
+    resolved_profile = _resolve_reusable_profile(browser_profile=browser_profile, profile=profile)
+    if resolved_profile is None:
+        return HeadlessReauthResult(
+            HeadlessReauthStatus.UNAVAILABLE,
+            "no reusable browser profile on disk (run 'notebooklm login' once "
+            "to create a persistent Google session)",
+        )
+
+    plan = BrowserCapturePlan(
+        browser=browser,
+        browser_profile=resolved_profile,
+        storage_path=storage_path,
+        include_domains=include_domains,
+    )
+
+    # Lazy-import probe: if the ``browser`` extra is absent, the neutral core's
+    # ``ensure_playwright_available`` routes through ``io.fail`` →
+    # ``HeadlessLoginRequiredError``. We want that case classified as
+    # UNAVAILABLE (nothing to drive), distinct from a genuine dead-session
+    # FAILED. Check import availability up front so the two are not conflated.
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        return HeadlessReauthResult(
+            HeadlessReauthStatus.UNAVAILABLE,
+            "playwright is not installed (install the 'browser' extra to enable headless re-auth)",
+        )
+
+    # Per-storage-path single-flight: within this process, at most one browser
+    # drives a given storage file at a time, and a follower that finds the file
+    # freshly rewritten while it waited coalesces (skips its own browser). This
+    # covers the explicit ``refresh_auth(allow_headless=True)`` entry and
+    # multi-client callers, which do NOT pass through the mid-RPC coordinator's
+    # single-flight.
+    return _drive_capture_coalesced(plan)
+
+
+def _get_drive_lock(storage_path: Path) -> threading.Lock:
+    """Return the per-resolved-storage-path single-flight lock for the browser drive."""
+    key = str(storage_path.expanduser().resolve())
+    with _DRIVE_REGISTRY_LOCK:
+        lock = _DRIVE_LOCKS_BY_PATH.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _DRIVE_LOCKS_BY_PATH[key] = lock
+        return lock
+
+
+def _storage_mtime(storage_path: Path) -> float | None:
+    """Best-effort mtime of the storage file, or ``None`` when absent/unreadable."""
+    try:
+        return storage_path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _drive_capture_coalesced(plan: BrowserCapturePlan) -> HeadlessReauthResult:
+    """Drive the headless capture under the per-path single-flight + freshness skip.
+
+    Captures the storage mtime BEFORE acquiring the lock. After acquiring it, a
+    follower whose storage file was rewritten by the leader while it waited
+    (mtime advanced) skips its own browser and reports SUCCESS — so N concurrent
+    callers spawn at most ONE browser per profile. The leader (and any follower
+    whose wait did not yield a fresh file) drives the real capture.
+    """
+    storage_path = plan.storage_path
+    pre_mtime = _storage_mtime(storage_path)
+    lock = _get_drive_lock(storage_path)
+    with lock:
+        post_mtime = _storage_mtime(storage_path)
+        if post_mtime is not None and (pre_mtime is None or post_mtime > pre_mtime):
+            # A sibling leader re-minted while we waited; coalesce on its result.
+            logger.info(
+                "Layer-3 headless re-auth coalesced onto a concurrent re-mint "
+                "(storage already refreshed); skipping a redundant browser."
+            )
+            return HeadlessReauthResult(
+                HeadlessReauthStatus.SUCCESS,
+                "coalesced onto a concurrent headless re-mint",
+                storage_path=storage_path,
+            )
+        return _drive_capture(plan)
+
+
+def _drive_capture(plan: BrowserCapturePlan) -> HeadlessReauthResult:
+    """Run one headless ``run_browser_capture`` and map it to a typed outcome."""
+    io = _SilentRaisingCaptureIO()
+    logger.info(
+        "Attempting layer-3 headless re-auth against persisted browser profile "
+        "(opt-in honored); no cookie values are logged."
+    )
+    try:
+        run_browser_capture(plan, io, headless=True, interactive=False)
+    except HeadlessLoginRequiredError as exc:
+        # The profile's Google session is also dead (redirected to login) or
+        # the core aborted via io.fail. Honest FAILED — never masked as success.
+        logger.warning("Layer-3 headless re-auth failed: %s", exc)
+        return HeadlessReauthResult(
+            HeadlessReauthStatus.FAILED,
+            "the persisted browser profile's Google session is also expired",
+        )
+    except Exception as exc:  # noqa: BLE001 - recovery is best-effort
+        # Any other capture failure (launch error, navigation failure,
+        # filesystem error) is a non-fatal recovery failure: surface FAILED so
+        # the caller falls back to the terminal message rather than crashing.
+        # The message is the exception *type/string* (already redacted by the
+        # exceptions layer); no cookie value reaches here.
+        logger.warning("Layer-3 headless re-auth errored: %s", exc)
+        return HeadlessReauthResult(
+            HeadlessReauthStatus.FAILED,
+            f"headless capture failed: {type(exc).__name__}",
+        )
+
+    logger.info("Layer-3 headless re-auth succeeded; re-minted cookies persisted.")
+    return HeadlessReauthResult(
+        HeadlessReauthStatus.SUCCESS,
+        "re-minted NotebookLM cookies from the live browser-profile session",
+        storage_path=plan.storage_path,
+    )
+
+
+__all__ = [
+    "NOTEBOOKLM_HEADLESS_REAUTH_ENV",
+    "HeadlessReauthResult",
+    "HeadlessReauthStatus",
+    "attempt_headless_reauth",
+    "headless_reauth_env_enabled",
+]

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from .._env import get_base_url
@@ -17,6 +19,8 @@ if TYPE_CHECKING:
     from .._runtime.auth import AuthRefreshCoordinator
     from .._runtime.lifecycle import ClientLifecycle
 
+logger = logging.getLogger("notebooklm.auth")
+
 
 async def refresh_auth_session(
     *,
@@ -25,6 +29,7 @@ async def refresh_auth_session(
     auth_coord: AuthRefreshCoordinator,
     lifecycle: ClientLifecycle,
     cookie_persistence: CookiePersistence,
+    allow_headless: bool = False,
 ) -> AuthTokens:
     """Refresh NotebookLM auth tokens through the raw homepage session path.
 
@@ -39,28 +44,61 @@ async def refresh_auth_session(
     in scope directly. The single production caller
     (:meth:`NotebookLMClient.refresh_auth`) sources the five
     collaborators from ``self._auth`` and ``self._collaborators``.
+
+    Layer-3 headless re-auth (the deepest recovery layer):
+
+    When the homepage GET 302s to the Google login page the first-party
+    NotebookLM cookies are fully dead, and neither this L1 token refresh nor
+    the L2 ``RotateCookies`` rotation can help. ``allow_headless`` (or the
+    ``NOTEBOOKLM_HEADLESS_REAUTH=1`` env opt-in) lets this function fall
+    through to :func:`notebooklm._auth.headless_reauth.attempt_headless_reauth`,
+    which drives an unattended headless browser against the persistent profile
+    to silently re-mint cookies. On a successful re-mint the fresh cookies are
+    reloaded into the live HTTP client and the homepage GET is retried ONCE; if
+    L3 is unavailable (no opt-in / no profile / playwright missing) or fails
+    (the profile's Google session is also dead) the original dead-cookie
+    ``ValueError`` stands unchanged — so default behavior with no opt-in and no
+    profile is byte-identical to before.
+
+    Coalescing: the mid-RPC cascade reaches this function through
+    :meth:`AuthRefreshCoordinator.await_refresh` (the bound ``client.refresh_auth``
+    callback), whose single-flight task creation means N concurrent failing
+    RPCs trigger at most ONE refresh — and therefore at most one browser. The
+    explicit ``client.refresh_auth(allow_headless=True)`` entry passes
+    ``allow_headless`` straight through.
     """
     http_client = kernel.get_http_client()
     url = f"{get_base_url()}/"
     if auth.account_email or auth.authuser:
         url = f"{url}?{authuser_query(auth.authuser, auth.account_email)}"
-    response = await http_client.get(url)
-    response.raise_for_status()
 
-    final_url = str(response.url)
-    if is_google_auth_redirect(final_url):
-        raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
+    async def _get_and_extract() -> tuple[str, str] | None:
+        """GET the homepage + extract tokens; ``None`` signals a dead-cookie 302."""
+        response = await http_client.get(url)
+        response.raise_for_status()
+        if is_google_auth_redirect(str(response.url)):
+            return None
+        try:
+            csrf_value = extract_wiz_field(response.text, "SNlM0e", strict=True)
+            sid_value = extract_wiz_field(response.text, "FdrFJe", strict=True)
+        except AuthExtractionError as exc:
+            label = {"SNlM0e": "CSRF token", "FdrFJe": "session ID"}.get(exc.key, exc.key)
+            raise ValueError(
+                f"Failed to extract {label} ({exc.key}). "
+                "Page structure may have changed or authentication expired. "
+                f"Preview: {exc.payload_preview!r}"
+            ) from exc
+        return csrf_value or "", sid_value or ""
 
-    try:
-        csrf = extract_wiz_field(response.text, "SNlM0e", strict=True)
-        sid = extract_wiz_field(response.text, "FdrFJe", strict=True)
-    except AuthExtractionError as exc:
-        label = {"SNlM0e": "CSRF token", "FdrFJe": "session ID"}.get(exc.key, exc.key)
-        raise ValueError(
-            f"Failed to extract {label} ({exc.key}). "
-            "Page structure may have changed or authentication expired. "
-            f"Preview: {exc.payload_preview!r}"
-        ) from exc
+    extracted = await _get_and_extract()
+    if extracted is None:
+        # Dead first-party cookies. Try layer-3 headless re-auth (opt-in /
+        # env-gated); on a successful re-mint, reload cookies and retry once.
+        if await _try_headless_reauth(auth=auth, kernel=kernel, allow_headless=allow_headless):
+            extracted = await _get_and_extract()
+        if extracted is None:
+            raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
+    csrf, sid = extracted
 
     # Keep the csrf/session mutation centralized so RPC snapshots cannot
     # observe a torn token pair while refresh is in flight.
@@ -75,3 +113,88 @@ async def refresh_auth_session(
     await lifecycle.save_cookies(cookie_persistence, http_client.cookies)
 
     return auth
+
+
+async def _try_headless_reauth(
+    *,
+    auth: AuthTokens,
+    kernel: Kernel,
+    allow_headless: bool,
+) -> bool:
+    """Drive layer-3 headless re-auth and reload cookies on success.
+
+    Returns ``True`` only when the headless re-auth succeeded AND the freshly
+    persisted ``storage_state.json`` cookies were reloaded into the live HTTP
+    client (so the caller's retry GET uses them). Returns ``False`` for every
+    honest non-success outcome (unavailable / failed), leaving the original
+    dead-cookie error to stand.
+
+    The browser drive in
+    :func:`notebooklm._auth.headless_reauth.attempt_headless_reauth` is a
+    blocking, ``playwright``-sync call, so it is offloaded to a worker thread
+    via :func:`asyncio.to_thread` and never stalls the event loop. The import
+    is function-local so the ``browser`` extra stays optional.
+
+    L3 requires a writeable on-disk storage path to (re)mint into. Env-var auth
+    (``NOTEBOOKLM_AUTH_JSON``, ``auth.storage_path is None``) has no backing
+    file, so L3 declines there — symmetric with the PSIDTS-recovery decline in
+    :func:`notebooklm._auth.psidts_recovery._resolve_recovery_path`.
+
+    Profile binding (CRITICAL): the headless browser is driven against the
+    persistent profile that is a sibling of THIS client's ``storage_state.json``
+    (``<storage_path>/../browser_profile``), NOT the ambient/default profile.
+    A ``from_storage(profile="work")`` or ``--storage <path>`` client therefore
+    re-mints from and into ITS OWN profile, never silently harvesting another
+    account's session or overwriting the wrong storage file. When no such
+    sibling profile exists, ``attempt_headless_reauth`` returns UNAVAILABLE.
+    """
+    storage_path = auth.storage_path
+    if storage_path is None:
+        logger.debug("Headless re-auth skipped: env-var auth has no writeable storage path.")
+        return False
+
+    from .cookies import _replace_cookie_jar, build_httpx_cookies_from_storage
+    from .headless_reauth import HeadlessReauthStatus, attempt_headless_reauth
+
+    # Bind the browser profile to the SAME profile as this storage file: the
+    # persistent profile dir is the ``browser_profile`` sibling of
+    # ``storage_state.json`` (see ``notebooklm.paths`` layout). Resolving it
+    # explicitly here — rather than letting ``attempt_headless_reauth`` fall
+    # back to the active/default profile — keeps a non-default client (custom
+    # ``--storage`` or ``profile="work"``) from re-minting against the wrong
+    # account's session.
+    browser_profile = storage_path.parent / "browser_profile"
+
+    result = await asyncio.to_thread(
+        attempt_headless_reauth,
+        storage_path=storage_path,
+        allow_headless=allow_headless,
+        browser_profile=browser_profile,
+    )
+    if result.status is not HeadlessReauthStatus.SUCCESS:
+        # UNAVAILABLE / FAILED — honest non-success; the dead-cookie error
+        # stands. ``reason`` is credential-free and safe to log at debug.
+        logger.debug(
+            "Headless re-auth did not succeed (%s): %s", result.status.value, result.reason
+        )
+        return False
+
+    # Re-mint succeeded: reload the freshly-persisted cookies into the live
+    # HTTP client's jar so the caller's retry GET authenticates with them. If
+    # the reload/validation fails — e.g. the domain filter dropped a required
+    # cookie, or the capture wrote a degenerate state the landing classifier
+    # didn't catch — treat it as a NON-success: do NOT claim a heal we can't
+    # back up. The caller's dead-cookie ``ValueError`` then stands honestly
+    # rather than being replaced by a lower-level cookie-load error.
+    try:
+        fresh_jar = await asyncio.to_thread(build_httpx_cookies_from_storage, storage_path)
+    except (ValueError, OSError) as exc:
+        logger.warning(
+            "Headless re-auth wrote storage but the re-minted cookies failed to "
+            "load/validate (%s); treating as a non-success.",
+            type(exc).__name__,
+        )
+        return False
+    _replace_cookie_jar(kernel.get_http_client().cookies, fresh_jar)
+    logger.info("Headless re-auth succeeded; reloaded re-minted cookies for retry.")
+    return True

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -147,6 +147,19 @@ async def _try_headless_reauth(
     re-mints from and into ITS OWN profile, never silently harvesting another
     account's session or overwriting the wrong storage file. When no such
     sibling profile exists, ``attempt_headless_reauth`` returns UNAVAILABLE.
+
+    Cookie-domain policy (LIMITATION): the re-mint captures only the DEFAULT
+    cookie-domain set (required Google cookies + regional ccTLDs). The optional
+    ``--include-domains`` labels a user may have passed at ``notebooklm login``
+    time are NOT persisted anywhere, so an L3 re-mint cannot reproduce them: a
+    profile originally logged in with ``--include-domains=gmail`` will, after a
+    headless re-auth, hold a ``storage_state.json`` WITHOUT those optional
+    sibling-product cookies. The re-auth still SUCCEEDS for NotebookLM itself
+    (the required cookies are present); only opt-in extras are dropped.
+    Operators relying on optional domains should re-run ``notebooklm login
+    --include-domains=...`` after an L3 re-mint, or inspect their cookie domains.
+    Persisting the login-time domain set (a small sidecar metadata file) is a
+    tracked follow-up, out of scope for P2.
     """
     storage_path = auth.storage_path
     if storage_path is None:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -683,7 +683,7 @@ class NotebookLMClient:
             on_rpc_event=on_rpc_event,
         )
 
-    async def refresh_auth(self) -> AuthTokens:
+    async def refresh_auth(self, *, allow_headless: bool = False) -> AuthTokens:
         """Refresh authentication tokens by fetching the NotebookLM homepage.
 
         This helps prevent 'Session Expired' errors by obtaining a fresh CSRF
@@ -703,11 +703,30 @@ class NotebookLMClient:
         constructor delegates to, so test shells observe the same
         resolution path.
 
+        Args:
+            allow_headless: Opt in to **layer-3 headless re-auth** when the
+                first-party NotebookLM cookies are fully dead (the homepage GET
+                302s to the Google login page) and neither L1 token refresh nor
+                L2 ``RotateCookies`` rotation can help. When ``True``, an
+                unattended **headless** browser is driven against the persistent
+                login profile to silently re-mint cookies from a still-live
+                Google session, then this refresh retries once. Defaults to
+                ``False`` — the locked design decision is that L3 NEVER fires by
+                default; with no opt-in and no profile the behavior is
+                byte-identical to before. (A *mid-RPC* auto-fire is separately
+                gated on ``NOTEBOOKLM_HEADLESS_REAUTH=1``.)
+
+                SECURITY: the persistent profile is an account-equivalent
+                credential (a live Google session). L3 is local-unattended-only
+                and must NOT be the auth path for a remote / hosted MCP server.
+
         Returns:
             Updated AuthTokens.
 
         Raises:
-            ValueError: If token extraction fails (page structure may have changed).
+            ValueError: If token extraction fails (page structure may have
+                changed), or if cookies are dead and L3 is unavailable / also
+                fails (the persisted profile's Google session is expired too).
         """
         return await refresh_auth_session(
             auth=self._auth,
@@ -715,6 +734,7 @@ class NotebookLMClient:
             auth_coord=self._collaborators.auth_coord,
             lifecycle=self._collaborators.lifecycle,
             cookie_persistence=self._collaborators.cookie_persistence,
+            allow_headless=allow_headless,
         )
 
 

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -75,6 +75,9 @@ __all__ = [
     # Validation/Config
     "ValidationError",
     "ConfigurationError",
+    # Headless re-auth (layer-3 auth recovery)
+    "HeadlessReauthError",
+    "HeadlessLoginRequiredError",
     # Network (NOT under RPC - happens before RPC)
     "NetworkError",
     # RPC Protocol
@@ -242,6 +245,34 @@ class ValidationError(NotebookLMError):
 
 class ConfigurationError(NotebookLMError):
     """Missing or invalid configuration (auth, storage)."""
+
+
+# =============================================================================
+# Headless re-auth (layer-3 auth recovery; not an RPC-protocol error)
+# =============================================================================
+
+
+class HeadlessReauthError(NotebookLMError):
+    """Base for layer-3 headless re-auth (silent browser re-mint) failures.
+
+    Raised by the headless arm of the browser-capture core and the
+    :mod:`notebooklm._auth.headless_reauth` decision layer. Distinct from
+    :class:`AuthError` (an RPC-protocol auth failure) because L3 is a *recovery*
+    step that drives a real browser, not a decoded batchexecute error.
+    """
+
+
+class HeadlessLoginRequiredError(HeadlessReauthError):
+    """The persisted browser profile's Google session is also dead.
+
+    Raised when the headless browser, launched against the persistent profile,
+    is redirected to the Google login page instead of landing on NotebookLM —
+    meaning even the longer-lived browser-profile session has expired and there
+    is no unattended path left. The unattended caller must surface this (it
+    never hangs waiting for a human) so the operator re-runs ``notebooklm
+    login``. Also raised when the unattended capture core aborts via its
+    ``io.fail`` sink (there is no interactive console to route an exit code to).
+    """
 
 
 # =============================================================================

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -71,7 +71,12 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # on existing methods (ruff one-param-per-line wraps each 6-param signature);
     # it is irreducible without splitting these modules, which is out of scope for
     # the bug fix. New ceilings are the measured post-fix LOC.
-    "exceptions.py": 1515,
+    # +31 LOC: the two public layer-3 headless re-auth exceptions
+    # (``HeadlessReauthError`` / ``HeadlessLoginRequiredError``) belong in the
+    # canonical exceptions module — that is where ``__all__`` and the
+    # public-surface manifest pin them, so they cannot live in a sibling file
+    # without forking the public exception home. Irreducible for this feature.
+    "exceptions.py": 1546,
     "_artifacts.py": 1451,
     "_source/upload.py": 1236,
     "_sources.py": 1007,

--- a/tests/e2e/test_headless_reauth.py
+++ b/tests/e2e/test_headless_reauth.py
@@ -43,11 +43,29 @@ def _profile_is_reusable() -> bool:
     return True
 
 
+def _playwright_available() -> bool:
+    """True when the ``browser`` extra is importable.
+
+    Without it ``attempt_headless_reauth`` returns ``UNAVAILABLE`` (nothing to
+    drive), which is NOT one of the SUCCESS/FAILED outcomes this test asserts —
+    so the gate must skip rather than let the test fail on a missing optional
+    dependency.
+    """
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 _GATE = pytest.mark.skipif(
-    os.environ.get("NOTEBOOKLM_HEADLESS_REAUTH") != "1" or not _profile_is_reusable(),
+    os.environ.get("NOTEBOOKLM_HEADLESS_REAUTH") != "1"
+    or not _profile_is_reusable()
+    or not _playwright_available(),
     reason=(
-        "headless re-auth e2e requires NOTEBOOKLM_HEADLESS_REAUTH=1 and a "
-        "non-empty persistent browser profile (run 'notebooklm login' first)"
+        "headless re-auth e2e requires NOTEBOOKLM_HEADLESS_REAUTH=1, a non-empty "
+        "persistent browser profile (run 'notebooklm login' first), and the "
+        "'browser' extra installed"
     ),
 )
 

--- a/tests/e2e/test_headless_reauth.py
+++ b/tests/e2e/test_headless_reauth.py
@@ -1,0 +1,82 @@
+"""E2E for layer-3 headless re-auth (gated on a real persistent profile).
+
+This test drives a REAL headless browser against the persistent login profile
+and is excluded from CI by default (``-m e2e`` + a profile/opt-in gate). It
+exists to exercise the one path the unit tests fake: the actual
+launch -> navigate -> classify -> capture -> persist sequence against a live
+Google session.
+
+Run locally, after ``notebooklm login`` has populated the profile, with::
+
+    NOTEBOOKLM_HEADLESS_REAUTH=1 pytest tests/e2e/test_headless_reauth.py -m e2e
+
+It is SKIPPED unless both:
+
+* the persistent browser profile exists and is non-empty (a real Google
+  session to harvest), and
+* the operator opted in via ``NOTEBOOKLM_HEADLESS_REAUTH=1`` (the same opt-in
+  the production mid-RPC path requires) — so the test never silently drives a
+  browser in an environment that did not ask for it.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from notebooklm._auth.headless_reauth import (
+    HeadlessReauthStatus,
+    attempt_headless_reauth,
+)
+from notebooklm.paths import get_browser_profile_dir, get_storage_path
+
+
+def _profile_is_reusable() -> bool:
+    profile = get_browser_profile_dir()
+    if not profile.is_dir():
+        return False
+    try:
+        next(profile.iterdir())
+    except (StopIteration, OSError):
+        return False
+    return True
+
+
+_GATE = pytest.mark.skipif(
+    os.environ.get("NOTEBOOKLM_HEADLESS_REAUTH") != "1" or not _profile_is_reusable(),
+    reason=(
+        "headless re-auth e2e requires NOTEBOOKLM_HEADLESS_REAUTH=1 and a "
+        "non-empty persistent browser profile (run 'notebooklm login' first)"
+    ),
+)
+
+
+@pytest.mark.e2e
+@_GATE
+def test_headless_reauth_against_live_profile() -> None:
+    """Drive a real headless re-auth and assert an honest, typed outcome.
+
+    A live profile session yields SUCCESS (cookies re-minted + persisted); an
+    expired profile session yields FAILED. UNAVAILABLE should not occur here
+    because the gate already proved opt-in + a reusable profile. Either way the
+    result is one of the three honest, typed outcomes — never a silent ``None``.
+    """
+    result = attempt_headless_reauth(
+        storage_path=get_storage_path(),
+        allow_headless=True,
+    )
+
+    assert result.status in {
+        HeadlessReauthStatus.SUCCESS,
+        HeadlessReauthStatus.FAILED,
+    }, f"unexpected status {result.status} (reason: {result.reason})"
+
+    if result.status is HeadlessReauthStatus.SUCCESS:
+        assert result.succeeded is True
+        assert result.storage_path == get_storage_path()
+        assert get_storage_path().exists()
+    else:
+        # Honest failure — the profile's Google session is also expired.
+        assert result.succeeded is False
+        assert result.storage_path is None

--- a/tests/unit/test_auth_headless_reauth.py
+++ b/tests/unit/test_auth_headless_reauth.py
@@ -283,7 +283,7 @@ def test_concurrent_explicit_attempts_coalesce_to_one_browser(tmp_path: Path, mo
         drives["count"] += 1
         time.sleep(0.05)  # hold the lock so followers pile up behind it
         # Simulate the real capture writing fresh storage (advances mtime).
-        plan.storage_path.write_text('{"cookies": [], "origins": []}')
+        plan.storage_path.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
 
     monkeypatch.setattr(hr, "run_browser_capture", _slow_capture)
     monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())

--- a/tests/unit/test_auth_headless_reauth.py
+++ b/tests/unit/test_auth_headless_reauth.py
@@ -262,9 +262,7 @@ def test_result_succeeded_property() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_concurrent_explicit_attempts_coalesce_to_one_browser(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_concurrent_explicit_attempts_coalesce_to_one_browser(tmp_path: Path, monkeypatch) -> None:
     """N concurrent ``attempt_headless_reauth`` calls drive ONE browser.
 
     The explicit ``refresh_auth(allow_headless=True)`` entry bypasses the

--- a/tests/unit/test_auth_headless_reauth.py
+++ b/tests/unit/test_auth_headless_reauth.py
@@ -1,0 +1,328 @@
+"""Unit tests for the layer-3 headless re-auth decision layer.
+
+Covers :mod:`notebooklm._auth.headless_reauth`:
+
+* the opt-in × profile-present × failure-class decision matrix,
+* the three typed honest outcomes (UNAVAILABLE / FAILED / SUCCESS) and that
+  SUCCESS is never reported on a dead/redirected session,
+* the env-var opt-in gate (``NOTEBOOKLM_HEADLESS_REAUTH=1``),
+* the default-unchanged behavior (no opt-in + no profile → UNAVAILABLE, the
+  browser is never launched).
+
+The browser drive is faked end-to-end via ``run_browser_capture`` so no real
+Playwright / network is needed; ``playwright`` stays lazily imported.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from notebooklm._auth import headless_reauth as hr
+from notebooklm._auth.headless_reauth import (
+    HeadlessReauthResult,
+    HeadlessReauthStatus,
+    attempt_headless_reauth,
+    headless_reauth_env_enabled,
+)
+from notebooklm.exceptions import HeadlessLoginRequiredError
+
+
+def _make_profile(tmp_path: Path) -> Path:
+    """Create (idempotently) a non-empty browser-profile dir on disk."""
+    profile = tmp_path / "browser_profile"
+    profile.mkdir(exist_ok=True)
+    (profile / "Default").mkdir(exist_ok=True)  # a populated profile dir
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# env opt-in gate
+# ---------------------------------------------------------------------------
+
+
+def test_env_enabled_only_for_exact_one() -> None:
+    assert headless_reauth_env_enabled({"NOTEBOOKLM_HEADLESS_REAUTH": "1"}) is True
+    assert headless_reauth_env_enabled({"NOTEBOOKLM_HEADLESS_REAUTH": "0"}) is False
+    assert headless_reauth_env_enabled({"NOTEBOOKLM_HEADLESS_REAUTH": "true"}) is False
+    assert headless_reauth_env_enabled({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Decision matrix: opt-in OFF → UNAVAILABLE, never launches a browser
+# ---------------------------------------------------------------------------
+
+
+def test_optin_off_is_unavailable_and_never_launches(tmp_path: Path, monkeypatch) -> None:
+    """No opt-in + no env → UNAVAILABLE; the capture core is never reached.
+
+    This pins the locked design decision: L3 NEVER fires by default.
+    """
+    profile = _make_profile(tmp_path)
+
+    def _boom(*_a, **_k):  # pragma: no cover - must not be called
+        raise AssertionError("run_browser_capture must not be called when opt-in is off")
+
+    monkeypatch.setattr(hr, "run_browser_capture", _boom)
+
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=False,
+        browser_profile=profile,
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.UNAVAILABLE
+    assert result.succeeded is False
+    assert "not enabled" in result.reason
+
+
+def test_optin_off_even_with_profile_is_unavailable(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(hr, "run_browser_capture", lambda *a, **k: None)
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=False,
+        browser_profile=_make_profile(tmp_path),
+        env={"NOTEBOOKLM_HEADLESS_REAUTH": "0"},
+    )
+    assert result.status is HeadlessReauthStatus.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Decision matrix: opt-in ON but no reusable profile → UNAVAILABLE
+# ---------------------------------------------------------------------------
+
+
+def test_optin_on_no_profile_dir_is_unavailable(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(hr, "run_browser_capture", lambda *a, **k: None)
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=True,
+        browser_profile=tmp_path / "does_not_exist",
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.UNAVAILABLE
+    assert "no reusable browser profile" in result.reason
+
+
+def test_optin_on_empty_profile_dir_is_unavailable(tmp_path: Path, monkeypatch) -> None:
+    """A freshly-mkdir'd but empty profile holds no Google session → decline."""
+    monkeypatch.setattr(hr, "run_browser_capture", lambda *a, **k: None)
+    empty = tmp_path / "browser_profile"
+    empty.mkdir()
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=True,
+        browser_profile=empty,
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Decision matrix: opt-in ON + profile present → drives the browser
+# ---------------------------------------------------------------------------
+
+
+def test_success_when_capture_succeeds(tmp_path: Path, monkeypatch) -> None:
+    """Capture returns normally → SUCCESS, storage_path carried out."""
+    storage = tmp_path / "storage_state.json"
+    captured: dict[str, object] = {}
+
+    def _fake_capture(plan, io, *, headless, interactive):
+        captured["headless"] = headless
+        captured["interactive"] = interactive
+        captured["profile"] = plan.browser_profile
+        return None
+
+    profile = _make_profile(tmp_path)
+    monkeypatch.setattr(hr, "run_browser_capture", _fake_capture)
+    # Ensure the playwright-import probe passes by faking it present.
+    monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())
+    monkeypatch.setitem(__import__("sys").modules, "playwright.sync_api", _DummyModule())
+
+    result = attempt_headless_reauth(
+        storage_path=storage,
+        allow_headless=True,
+        browser_profile=profile,
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.SUCCESS
+    assert result.succeeded is True
+    assert result.storage_path == storage
+    # The headless arm must be driven non-interactively, headless.
+    assert captured == {
+        "headless": True,
+        "interactive": False,
+        "profile": profile,
+    }
+
+
+def test_failed_when_profile_session_also_dead(tmp_path: Path, monkeypatch) -> None:
+    """Headless landed on the Google login page → FAILED, NEVER success."""
+
+    def _redirected(plan, io, *, headless, interactive):
+        raise HeadlessLoginRequiredError("redirected to login")
+
+    monkeypatch.setattr(hr, "run_browser_capture", _redirected)
+    monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())
+    monkeypatch.setitem(__import__("sys").modules, "playwright.sync_api", _DummyModule())
+
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=True,
+        browser_profile=_make_profile(tmp_path),
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.FAILED
+    assert result.succeeded is False
+    assert result.storage_path is None
+    assert "expired" in result.reason
+
+
+def test_failed_on_unexpected_capture_error(tmp_path: Path, monkeypatch) -> None:
+    """An unexpected capture exception → FAILED (best-effort recovery)."""
+
+    def _boom(plan, io, *, headless, interactive):
+        raise RuntimeError("launch blew up")
+
+    monkeypatch.setattr(hr, "run_browser_capture", _boom)
+    monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())
+    monkeypatch.setitem(__import__("sys").modules, "playwright.sync_api", _DummyModule())
+
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=True,
+        browser_profile=_make_profile(tmp_path),
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.FAILED
+    # Error TYPE only — never a cookie value.
+    assert "RuntimeError" in result.reason
+
+
+def test_env_optin_drives_browser_without_explicit_flag(tmp_path: Path, monkeypatch) -> None:
+    """``NOTEBOOKLM_HEADLESS_REAUTH=1`` enables L3 even with allow_headless=False."""
+    monkeypatch.setattr(hr, "run_browser_capture", lambda *a, **k: None)
+    monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())
+    monkeypatch.setitem(__import__("sys").modules, "playwright.sync_api", _DummyModule())
+
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=False,
+        browser_profile=_make_profile(tmp_path),
+        env={"NOTEBOOKLM_HEADLESS_REAUTH": "1"},
+    )
+    assert result.status is HeadlessReauthStatus.SUCCESS
+
+
+def test_unavailable_when_playwright_missing(tmp_path: Path, monkeypatch) -> None:
+    """Opt-in + profile, but the ``browser`` extra is absent → UNAVAILABLE.
+
+    Distinct from FAILED: there is nothing to drive, not a dead session.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_playwright(name, *args, **kwargs):
+        if name == "playwright.sync_api" or name == "playwright":
+            raise ImportError("No module named 'playwright'")
+        return real_import(name, *args, **kwargs)
+
+    def _must_not_run(*_a, **_k):  # pragma: no cover
+        raise AssertionError("capture must not run when playwright is missing")
+
+    monkeypatch.setattr(hr, "run_browser_capture", _must_not_run)
+    monkeypatch.setattr(builtins, "__import__", _no_playwright)
+
+    result = attempt_headless_reauth(
+        storage_path=tmp_path / "storage_state.json",
+        allow_headless=True,
+        browser_profile=_make_profile(tmp_path),
+        env={},
+    )
+    assert result.status is HeadlessReauthStatus.UNAVAILABLE
+    assert "playwright" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# HeadlessReauthResult convenience
+# ---------------------------------------------------------------------------
+
+
+def test_result_succeeded_property() -> None:
+    assert HeadlessReauthResult(HeadlessReauthStatus.SUCCESS, "ok").succeeded is True
+    assert HeadlessReauthResult(HeadlessReauthStatus.FAILED, "no").succeeded is False
+    assert HeadlessReauthResult(HeadlessReauthStatus.UNAVAILABLE, "no").succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# Explicit-path coalescing: concurrent attempts → ONE browser per profile
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_explicit_attempts_coalesce_to_one_browser(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """N concurrent ``attempt_headless_reauth`` calls drive ONE browser.
+
+    The explicit ``refresh_auth(allow_headless=True)`` entry bypasses the
+    mid-RPC coordinator's single-flight, so the per-storage-path drive lock +
+    freshness skip in ``attempt_headless_reauth`` is what prevents redundant
+    browsers. The leader writes the storage file (advancing its mtime); waiting
+    followers observe the fresh file and coalesce.
+    """
+    import threading
+    import time
+
+    storage = tmp_path / "storage_state.json"
+    profile = _make_profile(tmp_path)
+    drives = {"count": 0}
+    barrier = threading.Barrier(6)
+
+    def _slow_capture(plan, io, *, headless, interactive):
+        drives["count"] += 1
+        time.sleep(0.05)  # hold the lock so followers pile up behind it
+        # Simulate the real capture writing fresh storage (advances mtime).
+        plan.storage_path.write_text('{"cookies": [], "origins": []}')
+
+    monkeypatch.setattr(hr, "run_browser_capture", _slow_capture)
+    monkeypatch.setitem(__import__("sys").modules, "playwright", _DummyModule())
+    monkeypatch.setitem(__import__("sys").modules, "playwright.sync_api", _DummyModule())
+
+    results: list[HeadlessReauthResult] = []
+    results_lock = threading.Lock()
+
+    def _worker() -> None:
+        barrier.wait()
+        res = attempt_headless_reauth(
+            storage_path=storage, allow_headless=True, browser_profile=profile, env={}
+        )
+        with results_lock:
+            results.append(res)
+
+    threads = [threading.Thread(target=_worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one real browser drive; all six callers report SUCCESS (the
+    # leader drove, the followers coalesced onto the fresh storage).
+    assert drives["count"] == 1
+    assert len(results) == 6
+    assert all(r.status is HeadlessReauthStatus.SUCCESS for r in results)
+
+
+class _DummyModule:
+    """Stand-in for the ``playwright`` / ``playwright.sync_api`` modules.
+
+    Only used to satisfy the function-local ``import playwright.sync_api``
+    availability probe in :func:`attempt_headless_reauth` without installing
+    the real extra; the actual capture is faked via ``run_browser_capture``.
+    """
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_auth_session_headless_reauth.py
+++ b/tests/unit/test_auth_session_headless_reauth.py
@@ -1,0 +1,243 @@
+"""Unit tests for the layer-3 headless re-auth wiring in ``refresh_auth_session``.
+
+Covers the L3 hook on the dead-cookie path:
+
+* default-unchanged: dead cookies + no opt-in + no profile → the original
+  ``ValueError`` ("Run 'notebooklm login'") stands, and L3 is NOT attempted.
+* opt-in success: a successful headless re-mint reloads cookies and the
+  homepage GET is retried once, yielding fresh tokens.
+* opt-in failure: a FAILED/UNAVAILABLE L3 outcome leaves the dead-cookie
+  ``ValueError`` intact.
+* coalescing: N concurrent failing refreshes routed through the real
+  ``AuthRefreshCoordinator.await_refresh`` single-flight spawn at most ONE
+  browser drive.
+
+The browser drive (``attempt_headless_reauth``) is faked; no Playwright /
+network is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._auth.headless_reauth import HeadlessReauthResult, HeadlessReauthStatus
+from notebooklm._auth.session import refresh_auth_session
+from notebooklm._runtime.auth import AuthRefreshCoordinator
+from notebooklm.auth import AuthTokens
+
+REFRESH_HTML = '"SNlM0e":"new_csrf_token_123" "FdrFJe":"new_session_id_456"'
+LOGIN_REDIRECT = "https://accounts.google.com/signin/v2/identifier"
+
+
+def _auth(storage_path: Path | None = None) -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "dead_sid", "__Secure-1PSIDTS": "dead", "HSID": "h"},
+        csrf_token="old_csrf",
+        session_id="old_session",
+        storage_path=storage_path,
+    )
+
+
+class _RecordingKernel:
+    def __init__(self, http_client: httpx.AsyncClient) -> None:
+        self._http_client = http_client
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        return self._http_client
+
+
+class _RecordingLifecycle:
+    def __init__(self) -> None:
+        self.saved = 0
+
+    async def save_cookies(self, cookie_persistence: Any, jar: httpx.Cookies, path=None) -> None:
+        self.saved += 1
+
+
+class _RecordingAuthCoord:
+    def __init__(self) -> None:
+        self.ops: list[str] = []
+
+    async def update_auth_tokens(self, *, auth: AuthTokens, csrf: str, session_id: str) -> None:
+        self.ops.append("update")
+        auth.csrf_token = csrf
+        auth.session_id = session_id
+
+    def update_auth_headers(self, *, auth: AuthTokens, kernel: Any) -> None:
+        self.ops.append("headers")
+
+
+def _bundle(http_client: httpx.AsyncClient, auth: AuthTokens) -> dict[str, Any]:
+    return {
+        "auth": auth,
+        "kernel": _RecordingKernel(http_client),
+        "auth_coord": _RecordingAuthCoord(),
+        "lifecycle": _RecordingLifecycle(),
+        "cookie_persistence": object(),
+    }
+
+
+def _redirect_then_ok_handler(state: dict[str, int]):
+    """Homepage 302s to login until L3 'heals', then serves tokens.
+
+    ``state['healed']`` is flipped by the faked re-mint; before that the
+    homepage redirects to the Google login page (dead cookies).
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "accounts.google.com":
+            return httpx.Response(200, text="<html>sign in</html>", request=request)
+        if state.get("healed"):
+            return httpx.Response(200, text=REFRESH_HTML, request=request)
+        return httpx.Response(
+            302, headers={"Location": LOGIN_REDIRECT}, request=request
+        )
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Default-unchanged: dead cookies, no opt-in, no profile → ValueError, no L3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dead_cookies_no_optin_raises_and_skips_l3(monkeypatch) -> None:
+    state: dict[str, int] = {}
+    called = {"l3": 0}
+
+    def _spy(**kwargs):  # pragma: no cover - must not be called
+        called["l3"] += 1
+        return HeadlessReauthResult(HeadlessReauthStatus.UNAVAILABLE, "no")
+
+    # storage_path=None → ``_try_headless_reauth`` declines BEFORE reaching
+    # ``attempt_headless_reauth`` (env-var auth has no writeable backing store).
+    import notebooklm._auth.headless_reauth as hr
+
+    monkeypatch.setattr(hr, "attempt_headless_reauth", _spy)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_redirect_then_ok_handler(state)),
+        follow_redirects=True,
+    ) as http_client:
+        b = _bundle(http_client, _auth(storage_path=None))
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await refresh_auth_session(allow_headless=False, **b)
+
+    assert called["l3"] == 0  # env-var auth with no storage path never drives L3
+
+
+@pytest.mark.asyncio
+async def test_dead_cookies_optin_but_unavailable_raises(monkeypatch, tmp_path: Path) -> None:
+    state: dict[str, int] = {}
+    import notebooklm._auth.headless_reauth as hr
+
+    monkeypatch.setattr(
+        hr,
+        "attempt_headless_reauth",
+        lambda **k: HeadlessReauthResult(HeadlessReauthStatus.UNAVAILABLE, "no profile"),
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_redirect_then_ok_handler(state)),
+        follow_redirects=True,
+    ) as http_client:
+        b = _bundle(http_client, _auth(storage_path=tmp_path / "s.json"))
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await refresh_auth_session(allow_headless=True, **b)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in success: re-mint heals, retry yields fresh tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dead_cookies_optin_success_retries_and_refreshes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    storage = tmp_path / "storage_state.json"
+    storage.write_text('{"cookies": [], "origins": []}')
+    state: dict[str, int] = {}
+    import notebooklm._auth.headless_reauth as hr
+
+    def _fake_attempt(**kwargs):
+        # Simulate the headless re-mint "healing" the dead-cookie homepage.
+        state["healed"] = 1
+        assert kwargs["storage_path"] == storage
+        return HeadlessReauthResult(HeadlessReauthStatus.SUCCESS, "ok", storage_path=storage)
+
+    monkeypatch.setattr(hr, "attempt_headless_reauth", _fake_attempt)
+    # Avoid touching the real cookie reload (no real cookies on disk).
+    # ``_try_headless_reauth`` imports this function-locally from ``.cookies``,
+    # so patch the owning module, not ``session_mod``.
+    import notebooklm._auth.cookies as cookies_mod
+
+    monkeypatch.setattr(cookies_mod, "build_httpx_cookies_from_storage", lambda p: httpx.Cookies())
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_redirect_then_ok_handler(state)),
+        follow_redirects=True,
+    ) as http_client:
+        auth = _auth(storage_path=storage)
+        b = _bundle(http_client, auth)
+        result = await refresh_auth_session(allow_headless=True, **b)
+
+    assert result is auth
+    assert auth.csrf_token == "new_csrf_token_123"
+    assert auth.session_id == "new_session_id_456"
+
+
+# ---------------------------------------------------------------------------
+# Coalescing: N concurrent failing refreshes → at most ONE browser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refreshes_coalesce_to_one_browser(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """N concurrent refreshes via the real single-flight spawn ONE re-mint.
+
+    The mid-RPC cascade reaches ``refresh_auth_session`` through
+    ``AuthRefreshCoordinator.await_refresh``; its single-flight task creation
+    means concurrent failing callers join ONE refresh task — and therefore one
+    headless browser drive.
+    """
+    storage = tmp_path / "storage_state.json"
+    storage.write_text('{"cookies": [], "origins": []}')
+    state: dict[str, int] = {}
+    drives = {"count": 0}
+    import notebooklm._auth.headless_reauth as hr
+
+    def _fake_attempt(**kwargs):
+        drives["count"] += 1
+        state["healed"] = 1
+        return HeadlessReauthResult(HeadlessReauthStatus.SUCCESS, "ok", storage_path=storage)
+
+    monkeypatch.setattr(hr, "attempt_headless_reauth", _fake_attempt)
+    import notebooklm._auth.cookies as cookies_mod
+
+    monkeypatch.setattr(cookies_mod, "build_httpx_cookies_from_storage", lambda p: httpx.Cookies())
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_redirect_then_ok_handler(state)),
+        follow_redirects=True,
+    ) as http_client:
+        auth = _auth(storage_path=storage)
+        b = _bundle(http_client, auth)
+
+        async def _do_refresh() -> AuthTokens:
+            return await refresh_auth_session(allow_headless=True, **b)
+
+        # Route N concurrent callers through ONE coordinator single-flight.
+        coord = AuthRefreshCoordinator(refresh_callback=_do_refresh)
+        coord.set_bound_loop(asyncio.get_running_loop())
+        await asyncio.gather(*[coord.await_refresh() for _ in range(8)])
+
+    assert drives["count"] == 1

--- a/tests/unit/test_auth_session_headless_reauth.py
+++ b/tests/unit/test_auth_session_headless_reauth.py
@@ -94,9 +94,7 @@ def _redirect_then_ok_handler(state: dict[str, int]):
             return httpx.Response(200, text="<html>sign in</html>", request=request)
         if state.get("healed"):
             return httpx.Response(200, text=REFRESH_HTML, request=request)
-        return httpx.Response(
-            302, headers={"Location": LOGIN_REDIRECT}, request=request
-        )
+        return httpx.Response(302, headers={"Location": LOGIN_REDIRECT}, request=request)
 
     return handler
 
@@ -199,9 +197,7 @@ async def test_dead_cookies_optin_success_retries_and_refreshes(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_refreshes_coalesce_to_one_browser(
-    monkeypatch, tmp_path: Path
-) -> None:
+async def test_concurrent_refreshes_coalesce_to_one_browser(monkeypatch, tmp_path: Path) -> None:
     """N concurrent refreshes via the real single-flight spawn ONE re-mint.
 
     The mid-RPC cascade reaches ``refresh_auth_session`` through

--- a/tests/unit/test_auth_session_headless_reauth.py
+++ b/tests/unit/test_auth_session_headless_reauth.py
@@ -160,7 +160,7 @@ async def test_dead_cookies_optin_success_retries_and_refreshes(
     monkeypatch, tmp_path: Path
 ) -> None:
     storage = tmp_path / "storage_state.json"
-    storage.write_text('{"cookies": [], "origins": []}')
+    storage.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
     state: dict[str, int] = {}
     import notebooklm._auth.headless_reauth as hr
 
@@ -206,7 +206,7 @@ async def test_concurrent_refreshes_coalesce_to_one_browser(monkeypatch, tmp_pat
     headless browser drive.
     """
     storage = tmp_path / "storage_state.json"
-    storage.write_text('{"cookies": [], "origins": []}')
+    storage.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
     state: dict[str, int] = {}
     drives = {"count": 0}
     import notebooklm._auth.headless_reauth as hr

--- a/tests/unit/test_browser_capture_headless_arm.py
+++ b/tests/unit/test_browser_capture_headless_arm.py
@@ -136,7 +136,7 @@ def test_headless_authenticated_landing_persists_storage(tmp_path: Path) -> None
 
     # Persisted, and the domain allowlist filtered out the mail.google.com row.
     assert storage.exists()
-    persisted = json.loads(storage.read_text())
+    persisted = json.loads(storage.read_text(encoding="utf-8"))
     names = {c["name"] for c in persisted["cookies"]}
     assert "SID" in names
     assert "X" not in names

--- a/tests/unit/test_browser_capture_headless_arm.py
+++ b/tests/unit/test_browser_capture_headless_arm.py
@@ -1,0 +1,178 @@
+"""Unit tests for the headless arm of ``run_browser_capture`` (layer-3 re-auth).
+
+Covers the landing-URL classifier and the no-human contract:
+
+* authenticated landing (lands on the NotebookLM host) → capture / filter /
+  atomically persist ``storage_state.json`` (reusing the P1 path); NEVER waits
+  for a human.
+* redirected to the Google login page → raise
+  :class:`HeadlessLoginRequiredError` loudly (the profile's session is also
+  dead); NEVER hangs on ``wait_for_url``.
+* the ``(headless, interactive)`` mode guard: only the two sanctioned arms are
+  accepted.
+
+The Playwright context is faked via ``patch("playwright.sync_api.sync_playwright")``
+(the same shape the existing login-coverage suite uses), so no real browser /
+network is required and ``playwright`` stays lazily imported.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notebooklm._auth.browser_capture import (
+    BrowserCapturePlan,
+    _reject_unsupported_mode,
+    run_browser_capture,
+)
+from notebooklm.exceptions import HeadlessLoginRequiredError
+
+
+class _RaisingCaptureIO:
+    """``BrowserCaptureIO`` whose ``fail`` raises (mirrors the headless sink)."""
+
+    def __init__(self) -> None:
+        self.emitted: list[Any] = []
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        self.emitted.append(args)
+
+    def fail(self, code: int) -> Any:
+        raise HeadlessLoginRequiredError(f"io.fail({code})")
+
+    def run_async(self, coro: Any) -> Any:  # pragma: no cover - not reached
+        raise AssertionError("run_async not used in the headless arm")
+
+
+class _FakeSyncPlaywright:
+    def __init__(self, playwright: Any) -> None:
+        self._playwright = playwright
+
+    def __enter__(self) -> Any:
+        return self._playwright
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+def _fake_playwright_landing(url: str, *, cookies: list[dict] | None = None) -> Any:
+    """Build a fake playwright whose page lands on ``url``."""
+    page = MagicMock()
+    page.url = url
+    page.goto.return_value = None
+    page.content.return_value = "<html></html>"
+    context = MagicMock()
+    context.pages = [page]
+    context.storage_state.return_value = {
+        "cookies": cookies if cookies is not None else [],
+        "origins": [],
+    }
+    playwright = MagicMock()
+    playwright.chromium.launch_persistent_context.return_value = context
+    return playwright, context, page
+
+
+def _run_headless(plan: BrowserCapturePlan, io: Any, playwright: Any) -> Any:
+    with patch(
+        "playwright.sync_api.sync_playwright",
+        side_effect=lambda: _FakeSyncPlaywright(playwright),
+    ):
+        return run_browser_capture(plan, io, headless=True, interactive=False)
+
+
+# ---------------------------------------------------------------------------
+# Mode guard
+# ---------------------------------------------------------------------------
+
+
+def test_mode_guard_accepts_both_sanctioned_arms() -> None:
+    io = _RaisingCaptureIO()
+    # interactive login arm
+    _reject_unsupported_mode(headless=False, interactive=True, io=io)
+    # headless re-auth arm
+    _reject_unsupported_mode(headless=True, interactive=False, io=io)
+
+
+@pytest.mark.parametrize(
+    ("headless", "interactive"),
+    [(True, True), (False, False)],
+)
+def test_mode_guard_rejects_contradictory_combos(headless: bool, interactive: bool) -> None:
+    with pytest.raises(NotImplementedError, match="Unsupported browser-capture mode"):
+        _reject_unsupported_mode(
+            headless=headless, interactive=interactive, io=_RaisingCaptureIO()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authenticated landing → capture + persist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_playwright
+def test_headless_authenticated_landing_persists_storage(tmp_path: Path) -> None:
+    storage = tmp_path / "storage_state.json"
+    profile = tmp_path / "browser_profile"
+    profile.mkdir()
+
+    cookies = [
+        {"name": "SID", "value": "v", "domain": ".google.com", "path": "/"},
+        # A sibling-product cookie that the domain filter must DROP.
+        {"name": "X", "value": "y", "domain": "mail.google.com", "path": "/"},
+    ]
+    playwright, _context, _page = _fake_playwright_landing(
+        "https://notebooklm.google.com/", cookies=cookies
+    )
+    io = _RaisingCaptureIO()
+
+    result = _run_headless(
+        BrowserCapturePlan(
+            browser="chromium", browser_profile=profile, storage_path=storage
+        ),
+        io,
+        playwright,
+    )
+
+    # Persisted, and the domain allowlist filtered out the mail.google.com row.
+    assert storage.exists()
+    persisted = json.loads(storage.read_text())
+    names = {c["name"] for c in persisted["cookies"]}
+    assert "SID" in names
+    assert "X" not in names
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Redirected to login → loud failure, no hang
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_playwright
+def test_headless_redirected_to_login_raises_loudly(tmp_path: Path) -> None:
+    storage = tmp_path / "storage_state.json"
+    profile = tmp_path / "browser_profile"
+    profile.mkdir()
+
+    playwright, _context, page = _fake_playwright_landing(
+        "https://accounts.google.com/signin/v2/identifier"
+    )
+    io = _RaisingCaptureIO()
+
+    with pytest.raises(HeadlessLoginRequiredError, match="session is"):
+        _run_headless(
+            BrowserCapturePlan(
+                browser="chromium", browser_profile=profile, storage_path=storage
+            ),
+            io,
+            playwright,
+        )
+
+    # The headless arm must NOT wait for a human.
+    page.wait_for_url.assert_not_called()
+    # Nothing was persisted on the dead-session path.
+    assert not storage.exists()

--- a/tests/unit/test_browser_capture_headless_arm.py
+++ b/tests/unit/test_browser_capture_headless_arm.py
@@ -104,9 +104,7 @@ def test_mode_guard_accepts_both_sanctioned_arms() -> None:
 )
 def test_mode_guard_rejects_contradictory_combos(headless: bool, interactive: bool) -> None:
     with pytest.raises(NotImplementedError, match="Unsupported browser-capture mode"):
-        _reject_unsupported_mode(
-            headless=headless, interactive=interactive, io=_RaisingCaptureIO()
-        )
+        _reject_unsupported_mode(headless=headless, interactive=interactive, io=_RaisingCaptureIO())
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +129,7 @@ def test_headless_authenticated_landing_persists_storage(tmp_path: Path) -> None
     io = _RaisingCaptureIO()
 
     result = _run_headless(
-        BrowserCapturePlan(
-            browser="chromium", browser_profile=profile, storage_path=storage
-        ),
+        BrowserCapturePlan(browser="chromium", browser_profile=profile, storage_path=storage),
         io,
         playwright,
     )
@@ -165,9 +161,7 @@ def test_headless_redirected_to_login_raises_loudly(tmp_path: Path) -> None:
 
     with pytest.raises(HeadlessLoginRequiredError, match="session is"):
         _run_headless(
-            BrowserCapturePlan(
-                browser="chromium", browser_profile=profile, storage_path=storage
-            ),
+            BrowserCapturePlan(browser="chromium", browser_profile=profile, storage_path=storage),
             io,
             playwright,
         )


### PR DESCRIPTION
## Summary

P2 of the headless re-auth feature (P1 was #1512). Adds **layer-3** (deepest) auth recovery: when NotebookLM's first-party cookies are fully dead — the homepage GET 302s to the Google login page and neither L1 token refresh nor L2 `RotateCookies` rotation can help — a persisted browser profile may still hold a live Google SSO session that outlives `storage_state.json`. L3 drives an unattended **headless** browser against that profile to silently re-mint cookies, then retries the auth path once.

### What's wired

- **Headless arm of `run_browser_capture`** (`headless=True, interactive=False`): launches the persistent context headlessly, navigates, and **classifies the landing** — authenticated (on the NotebookLM host) → reuse the P1 capture/domain-filter/atomic-persist path; redirected to the Google login page → raise `HeadlessLoginRequiredError` **loudly** (there is no human — it NEVER waits/hangs).
- **`_auth/headless_reauth.py`** — the typed-outcome decision layer (opt-in × profile-present × failure-class). Honest, distinct outcomes (a sibling project silently returned `None`):
  - `UNAVAILABLE` — no opt-in / no reusable profile / playwright missing → fall through to the terminal "Run 'notebooklm login'" message unchanged.
  - `FAILED` — the profile's Google session is also dead, or capture/reload failed. **Never** reported on dead tokens.
  - `SUCCESS` — cookies captured, domain-filtered, atomically persisted.
- **L3 wiring** into `refresh_auth_session` on the dead-cookie wall: attempt L3 only when allowed; on success reload cookies into the live client and retry the homepage GET once; otherwise the original dead-cookie `ValueError` stands. **Default behavior is byte-identical when opt-in is off and no profile exists.**
- **Explicit entry:** `client.refresh_auth(allow_headless=False)` — additive, keyword-only (no api-compat allowlist entry needed; audit exits 0).
- **Opt-in mid-RPC auto-fire** only when `NOTEBOOKLM_HEADLESS_REAUTH=1`; never mid-call by default (the locked design decision from the P1 docstring).

### Coalescing (reuses the existing single-flight)

- The **mid-RPC cascade** reaches `refresh_auth_session` through `AuthRefreshCoordinator.await_refresh` (the bound `client.refresh_auth` callback), whose single-flight task creation means N concurrent failing RPCs trigger at most one refresh → one browser.
- The **explicit** `refresh_auth(allow_headless=True)` path bypasses that coordinator, so `attempt_headless_reauth` adds a **per-storage-path single-flight + freshness skip**: concurrent callers serialize on a per-path lock, and a follower that finds the storage file freshly re-minted while it waited **coalesces** (skips its own browser). N concurrent callers → ONE browser per profile.

### Profile binding

The headless browser is driven against the persistent profile that is a **sibling of THIS client's `storage_state.json`** (`<storage_path>/../browser_profile`), not the ambient/default profile — so a `from_storage(profile="work")` / `--storage <path>` client re-mints from and into **its own** profile and never harvests another account's session or overwrites the wrong file.

## SECURITY boundary (LOCAL-UNATTENDED-ONLY)

The persistent profile is an **account-equivalent credential**: a live Google session, longer-lived than `storage_state.json`. **L3 must NOT become the auth story for a remote / hosted MCP server** — it is for a local, unattended agent/worker on the operator's own machine. This PR:
- reuses the **existing cookie-domain allowlist** on the captured `storage_state` (no widening of credential storage);
- **never logs a captured cookie value** — only the typed outcome / credential-free `reason` (heeds redaction findings #1517/#1518);
- gates every drive behind explicit opt-in (`allow_headless=True` or `NOTEBOOKLM_HEADLESS_REAUTH=1`).

## Test plan

- **Unit** (no live auth/browser; faked playwright, lazy import preserved):
  - decision matrix (opt-in × profile × failure-class) incl. default-unchanged when opt-in is off / no profile;
  - landing classifier (authenticated → capture+persist, with the domain filter dropping `mail.google.com`; redirected → loud `HeadlessLoginRequiredError`, `wait_for_url` never called, nothing persisted);
  - typed honest outcomes incl. UNAVAILABLE-vs-FAILED separation (playwright missing → UNAVAILABLE, not FAILED);
  - coalescing — both the mid-RPC single-flight (8 concurrent → 1 browser) and the explicit per-path path (6 concurrent threads → 1 browser);
  - session wiring: dead cookies + opt-in success → reload + retry → fresh tokens; opt-in + UNAVAILABLE/FAILED → original `ValueError` stands.
- **E2E** (`@pytest.mark.e2e`, gated on `NOTEBOOKLM_HEADLESS_REAUTH=1` + a real non-empty profile; excluded from CI): drives a real headless re-auth and asserts an honest typed outcome.
- Gates: `mypy` clean, `ruff` clean, `audit_public_api_compat.py` exit 0 (additive), `check_claude_md_freshness.py` exit 0 (new module registered in `docs/architecture.md`), full suite green (`TZ=UTC pytest`).

## Out of scope (P3 — not built)

doctor-command diagnostics, `playwright.connect_over_cdp()` attach-to-running-Chrome, keepalive profile-"touch". Extension points/TODOs are noted in the docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in headless re-auth (enabled via allow_headless or NOTEBOOKLM_HEADLESS_REAUTH=1) to attempt silent cookie reminting with typed outcomes: SUCCESS, FAILED (session dead), or UNAVAILABLE.
  * Exposed a client option to trigger the headless fallback when interactive refresh fails.

* **Documentation**
  * Updated authentication architecture docs to describe the headless re-auth flow and constraints.

* **Tests**
  * Added unit and E2E tests covering outcomes, coalescing, and gating conditions.

* **Security**
  * Notes: persistent profiles are credential-equivalent and the flow is local-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->