### PR TITLE
fix(auth): split-state PSIDTS recovery no longer writes a duplicate SIDTS row to storage_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-product `OSID` cookie on `notebooklm.google.com` and
   `myaccount.google.com` as distinct jar entries.
 
+- **Split-state PSIDTS recovery no longer writes a duplicate
+  `__Secure-3PSIDTS` row to `storage_state.json`** (#1523). On the
+  `--browser-cookies` path, when `__Secure-1PSIDTS` is missing/expired (so
+  recovery fires) but a fresh `__Secure-3PSIDTS` is already in the source jar,
+  Google's `RotateCookies` POST returns both rotated SIDTS cookies and the
+  in-memory recovery append loop emitted a second `__Secure-3PSIDTS` (and a
+  stale `__Secure-1PSIDTS` twin) entry with no analog in any real browser jar.
+  Auth still worked (the row is deduped on load), but the on-disk artifact
+  diverged from the true cookie set. `recover_psidts_in_memory` now keys the
+  source jar by RFC 6265 identity `(name, domain, path)` (path normalized via
+  `or "/"`, matching every loader) and overwrites the existing row in place
+  with the rotated occurrence instead of appending — exactly one row per key,
+  carrying the fresh value, mirroring the last-occurrence-wins dedup added to
+  `filter_storage_state_cookies_by_domain_policy` in #1513.
+
 - **`sources.add_text` no longer swallows typed transport errors into
   `SourceAddError`.** Its bare `except RPCError` wrapped *everything* —
   including the `RPCError` subclasses `RateLimitError`, `AuthError`, and

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -524,9 +524,14 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
        expired — see :func:`_psidts_needs_recovery`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``).
 
-    On success, mutates ``rookiepy_cookies`` to append the rotated
-    ``__Secure-1PSIDTS`` (and ``__Secure-3PSIDTS``) entries in rookiepy's
-    snake_case format. Downstream
+    On success, mutates ``rookiepy_cookies`` so the rotated
+    ``__Secure-1PSIDTS`` (and ``__Secure-3PSIDTS``) entries are present in
+    rookiepy's snake_case format. A rotated cookie that shares its
+    ``(name, domain, path)`` identity with an existing row REPLACES that row
+    in place (the rotation is the value we want to persist); otherwise it is
+    appended. This keeps exactly one row per identity so split-state recovery
+    cannot write a duplicate ``__Secure-3PSIDTS`` row to ``storage_state.json``
+    (issue #1523). Downstream
     :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
     picks them up on re-conversion.
 
@@ -589,22 +594,51 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         )
         return False
 
+    # Index the source jar by RFC 6265 identity so a rotated cookie that
+    # already has a same-(name, domain, path) row REPLACES it in place rather
+    # than appending a second occurrence. Split-state recovery (#1523) hits
+    # this: __Secure-1PSIDTS is missing/expired (so recovery fires) while a
+    # fresh __Secure-3PSIDTS is already present — RotateCookies rotates BOTH,
+    # and a blind append leaves a duplicate __Secure-3PSIDTS (and a stale
+    # __Secure-1PSIDTS twin) row with no analog in any real browser jar. The
+    # rotation is the value we want to persist, so the rotated occurrence wins
+    # — mirroring the last-occurrence-wins dedup in
+    # ``filter_storage_state_cookies_by_domain_policy`` (#1513). ``path or "/"``
+    # matches the normalization the loaders and save_cookies_to_storage use.
+    index_by_identity: dict[tuple[str, str, str], int] = {}
+    for pos, entry in enumerate(rookiepy_cookies):
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        domain = entry.get("domain")
+        if not isinstance(name, str) or not isinstance(domain, str):
+            continue
+        path = entry.get("path")
+        index_by_identity[(name, domain, (path if isinstance(path, str) else "") or "/")] = pos
+
     for cookie in rotated_cookies:
         if cookie.name not in {_PSIDTS_COOKIE, "__Secure-3PSIDTS"}:
             continue
         if not cookie.value or not cookie.domain:
             continue
-        rookiepy_cookies.append(
-            {
-                "name": cookie.name,
-                "value": cookie.value,
-                "domain": cookie.domain,
-                "path": cookie.path or "/",
-                "expires": cookie.expires,
-                "secure": True,
-                "http_only": True,
-            }
-        )
+        rotated_entry = {
+            "name": cookie.name,
+            "value": cookie.value,
+            "domain": cookie.domain,
+            "path": cookie.path or "/",
+            "expires": cookie.expires,
+            "secure": True,
+            "http_only": True,
+        }
+        identity = (cookie.name, cookie.domain, cookie.path or "/")
+        existing = index_by_identity.get(identity)
+        if existing is None:
+            index_by_identity[identity] = len(rookiepy_cookies)
+            rookiepy_cookies.append(rotated_entry)
+        else:
+            # Same (name, domain, path) already present — overwrite with the
+            # rotated occurrence so exactly one row carries the fresh value.
+            rookiepy_cookies[existing] = rotated_entry
 
     logger.info(
         "Recovered %s via in-memory RotateCookies POST (browser-cookies extraction)",
@@ -627,8 +661,10 @@ def validate_with_recovery(
     retry through :func:`recover_psidts_in_memory` (issue #990). When the
     recovery preconditions hold (SID present, PSIDTS absent or expired,
     secondary binding intact — see :func:`_psidts_needs_recovery`), the
-    rotated cookies are appended to ``rookiepy_cookies`` in place so
-    downstream persistence picks them up.
+    rotated cookies are merged into ``rookiepy_cookies`` in place by
+    ``(name, domain, path)`` identity — overwriting an existing same-identity
+    row, else appended — so downstream persistence picks them up without
+    duplicating a SIDTS entry.
 
     Lives in the auth subpackage rather than the CLI login package so both
     CLI call sites can route through ``notebooklm.auth`` without adding a

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -326,6 +326,65 @@ class TestPsidtsExpiryGate:
         assert len(fresh) == 1
 
     @pytest.mark.no_default_keepalive_mock
+    def test_in_memory_split_state_emits_one_row_per_sidts(self, httpx_mock: HTTPXMock):
+        """Split-state recovery must not write a DUPLICATE SIDTS row (issue #1523).
+
+        Trigger: ``__Secure-1PSIDTS`` missing/expired so recovery fires, but a
+        fresh ``__Secure-3PSIDTS`` is already in the source jar. RotateCookies
+        rotates BOTH; the append loop must end with EXACTLY ONE row per
+        ``(name, domain, path)`` carrying the ROTATED value — no second
+        ``__Secure-3PSIDTS`` (or ``__Secure-1PSIDTS``) row that has no analog in
+        any real browser jar.
+        """
+        now = time.time()
+        cookies = [
+            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
+            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            # __Secure-1PSIDTS expired → recovery fires.
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "stale_1psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": now - 3600,
+            },
+            # __Secure-3PSIDTS fresh and already present → would duplicate.
+            {
+                "name": "__Secure-3PSIDTS",
+                "value": "stale_3psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": now + 3600,
+            },
+        ]
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+
+        for name, rotated in (
+            ("__Secure-1PSIDTS", "fresh_psidts_value"),
+            ("__Secure-3PSIDTS", "fresh_3psidts_value"),
+        ):
+            rows = [c for c in cookies if c["name"] == name]
+            assert len(rows) == 1, f"{name} duplicated: {rows}"
+            assert rows[0]["value"] == rotated, f"{name} did not carry the rotated value"
+
+        # The resulting storage_state must likewise hold exactly one row each.
+        from notebooklm._auth import cookies as _auth_cookies
+
+        state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(cookies)
+        for name in ("__Secure-1PSIDTS", "__Secure-3PSIDTS"):
+            state_rows = [c for c in state["cookies"] if c["name"] == name]
+            assert len(state_rows) == 1, f"{name} duplicated on disk: {state_rows}"
+
+        # Auth-relevant binding cookies are all still present and correct.
+        names = {c["name"]: c["value"] for c in cookies}
+        assert names["SID"] == "s"
+        assert names["APISID"] == "a"
+        assert names["SAPISID"] == "sa"
+
+    @pytest.mark.no_default_keepalive_mock
     def test_in_memory_present_and_fresh_skips_recovery(self, httpx_mock: HTTPXMock):
         now = time.time()
         cookies = [


### PR DESCRIPTION
## Summary

Fixes #1523 (from the adversarially-verified audit; Low/cosmetic — auth was never broken). Split-state PSIDTS recovery (`recover_psidts_in_memory` in `src/notebooklm/_auth/psidts_recovery.py`) appended rotated SIDTS cookies to `rookiepy_cookies` unconditionally, so when Google's `RotateCookies` returned a fresh `__Secure-3PSIDTS` that already existed in the source jar, the persisted `storage_state.json` gained a **duplicate** row with no analog in any real browser jar. It's deduped on load (`build_httpx_cookies_from_storage` keys `(name, domain, path)`), so auth worked — but the on-disk artifact drifted from the true cookie set, in the file the rest of the system treats as canonical.

### Fix
Before appending rotated cookies, index `rookiepy_cookies` by RFC 6265 identity `(name, domain, path or "/")`; a rotated cookie whose identity already exists **overwrites that row in place** (rotated/last wins), else appends. This emits exactly one row per identity and guarantees the persisted value is the *rotated* one even if a stale-but-present same-identity row existed. Path normalization (`or "/"`) mirrors the loaders, `save_cookies_to_storage`, and the #1513 `filter_storage_state_cookies_by_domain_policy` dedup. Scoped to `psidts_recovery.py`; deliberately did **not** dedup the public-API `convert_rookiepy_cookies_to_storage_state` (wider blast radius).

The file-based recovery path is unaffected — it writes through `save_cookies_to_storage`, which already merges by `(name, domain, path)` and never produced the on-disk duplicate.

### Tests (red-first)
`test_in_memory_split_state_emits_one_row_per_sidts` — failed pre-fix (`__Secure-1PSIDTS duplicated: 2 == 1`); asserts exactly one `__Secure-1PSIDTS` and one `__Secure-3PSIDTS` row both in `rookiepy_cookies` and the resulting `storage_state`, each carrying the rotated value, with SID/APISID/SAPISID binding cookies intact.

### Verification
- Full `uv run pytest -m "not e2e"`: 9618 passed, 137 skipped, 1 xfailed
- mypy clean (236 files) · ruff clean · API-compat audit exit 0 (signature unchanged) · module-size ratchet green

Polish: claude implementer + codex independent review — codex SHIP, no Critical/Important; one Minor (docstring still said "appended") fixed in the final commit. Codex independently probed empty/absent-path cases and the existing-fresh-but-different/stale/no-existing branches — all collapse to one rotated row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PSIDTS cookie recovery to properly deduplicate cookies by identity when using browser cookies extraction, preventing duplicate entries in storage state.

* **Tests**
  * Added regression test for split-state PSIDTS recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->