### PR TITLE
fix(cli): profile delete/list/create/rename honor the CLI error contract instead of escaping as a traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer-id prefix match (and is not treated as a partial expansion, so no
   "Matched:" prose is emitted). Genuine prefix ambiguity (two strict prefixes,
   no exact match) and the not-found / title-instead-of-id paths are unchanged.
+- **`profile` filesystem commands now surface a friendly error + exit 1
+  instead of a raw traceback** (#1520). The `profile delete` (`shutil.rmtree`),
+  `profile create` (directory materialization), `profile rename` (`os.rename`),
+  and text-mode `profile list` paths performed their pure-filesystem operations
+  unguarded, so an `OSError` — a half-deleted or locked profile directory, a
+  read-only mount, or a browser-profile file held by AV/the browser on Windows
+  — escaped `SectionedGroup.main` (which only catches `ClickException`/`Abort`)
+  and printed a Python traceback. Each now mirrors `profile switch`'s existing
+  `except OSError -> click.ClickException` idiom, yielding the documented
+  friendly-message + exit-1 CLI contract. The `--json profile list` path keeps
+  its existing `handle_errors` envelope (an unexpected `OSError` there stays the
+  `UNEXPECTED_ERROR` / exit-2 contract automation relies on).
 - **Playwright login: closing the browser during the final storage-state
   capture now shows the browser-closed help instead of a bug-report prompt**
   (#1514, deferred from the #1512 review). Every in-flow Playwright call in

--- a/src/notebooklm/cli/profile_cmd.py
+++ b/src/notebooklm/cli/profile_cmd.py
@@ -112,7 +112,17 @@ def list_cmd(json_output):
         with handle_errors(json_output=True):
             _run_list_cmd(json_output=True)
         return
-    _run_list_cmd(json_output=False)
+    # The text path was previously unwrapped, so a filesystem failure while
+    # enumerating profiles escaped as a raw traceback. Mirror ``switch_cmd``'s
+    # OSError handling for a friendly message + exit 1. (The ``--json`` path
+    # above keeps its ``handle_errors`` envelope, which classifies an unexpected
+    # OSError as the exit-2 ``UNEXPECTED_ERROR`` contract automation relies on.)
+    try:
+        _run_list_cmd(json_output=False)
+    except OSError as e:
+        raise click.ClickException(  # cli-input-validation: profile list filesystem failure
+            f"Failed to list profiles: {e}"
+        ) from None
 
 
 def _run_list_cmd(*, json_output: bool) -> None:
@@ -191,7 +201,15 @@ def create_cmd(name):
             f"Profile '{name}' already exists."
         )
 
-    get_profile_dir(name, create=True)
+    # Mirror ``switch_cmd``'s OSError handling: a filesystem failure while
+    # materializing the profile directory (read-only mount, permissions) yields
+    # a friendly message + exit 1 via Click, never a raw traceback.
+    try:
+        get_profile_dir(name, create=True)
+    except OSError as e:
+        raise click.ClickException(  # cli-input-validation: profile create filesystem failure
+            f"Failed to create profile '{name}': {e}"
+        ) from None
     console.print(f"[green]Profile '{name}' created.[/green]")
     console.print(f"[dim]Run 'notebooklm -p {name} login' to authenticate.[/dim]")
 
@@ -293,7 +311,16 @@ def delete_cmd(name, yes, confirm):
             console.print("[dim]Cancelled.[/dim]")
             return
 
-    shutil.rmtree(profile_dir)
+    # Mirror ``switch_cmd``'s OSError handling: a pure-filesystem failure (a
+    # locked or half-deleted profile directory — common on Windows when the
+    # browser profile is held by AV/the browser) yields a friendly message +
+    # exit 1 via Click, never a raw traceback.
+    try:
+        shutil.rmtree(profile_dir)
+    except OSError as e:
+        raise click.ClickException(  # cli-input-validation: profile delete filesystem failure
+            f"Failed to delete profile '{name}': {e}"
+        ) from None
     console.print(f"[green]Profile '{name}' deleted.[/green]")
 
 
@@ -326,7 +353,18 @@ def rename_cmd(old_name, new_name):
             f"Profile '{new_name}' already exists."
         )
 
-    os.rename(old_dir, new_dir)
+    # Mirror ``switch_cmd``'s OSError handling: a failure moving the profile
+    # directory (a locked browser-profile file held by AV/the browser on
+    # Windows, a cross-device rename) yields a friendly message + exit 1 via
+    # Click, never a raw traceback. The config retarget below only runs once the
+    # directory move succeeded, so a failed rename never leaves a dangling
+    # ``default_profile`` pointer.
+    try:
+        os.rename(old_dir, new_dir)
+    except OSError as e:
+        raise click.ClickException(  # cli-input-validation: profile rename filesystem failure
+            f"Failed to rename profile '{old_name}': {e}"
+        ) from None
 
     # Update config if renamed profile was the effective default. This is
     # always serialized through the locked mutator — there is NO pre-read

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -3,9 +3,10 @@
 import importlib
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -146,6 +147,22 @@ class TestProfileListAccountMetadata:
         }
         assert result.stderr == ""
 
+    def test_text_reports_filesystem_error(self, runner, tmp_path):
+        # The text-mode list path used to be unwrapped (the --json path above is
+        # already routed through handle_errors), so a filesystem failure escaped
+        # as a raw traceback. It must now surface a friendly error + exit 1.
+        with patch.object(profile_module, "list_profiles", side_effect=OSError("denied")):
+            result = runner.invoke(
+                cli,
+                ["profile", "list"],
+                env=notebooklm_env(tmp_path),
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 1, result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Failed to list profiles: denied" in result.output
+
 
 class TestProfileCreateCommand:
     @pytest.mark.parametrize("name", [".", "-work", "_work", "work/team", "../work"])
@@ -163,6 +180,26 @@ class TestProfileCreateCommand:
 
         assert result.exit_code == 1
         assert "Profile 'work' already exists." in result.output
+
+    def test_create_reports_mkdir_failure(self, runner, tmp_path):
+        # A filesystem failure while materializing the profile directory must
+        # yield a friendly error + exit 1, not a raw traceback / exit 2.
+        def fake_get_profile_dir(name, create=False):
+            if create:
+                raise OSError("read-only filesystem")
+            return tmp_path / "profiles" / name
+
+        with patch.object(profile_module, "get_profile_dir", side_effect=fake_get_profile_dir):
+            result = runner.invoke(
+                cli,
+                ["profile", "create", "work"],
+                env=notebooklm_env(tmp_path),
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 1, result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Failed to create profile 'work': read-only filesystem" in result.output
 
 
 class TestProfileSwitchCommand:
@@ -299,6 +336,31 @@ class TestProfileDeleteCommand:
         assert "Profile 'old' deleted." in result.output
         assert not (tmp_path / "profiles" / "old").exists()
 
+    def test_delete_reports_rmtree_failure(self, runner, tmp_path, monkeypatch):
+        # A locked/partially-deleted profile directory (common on Windows when
+        # the browser profile is held by AV/the browser) must yield a friendly
+        # error + exit 1, not a raw traceback or the exit-2 bug-report path.
+        make_profile(tmp_path, "old")
+
+        # Patch the consumer-side binding (profile_module.shutil) rather than the
+        # global shutil module: wrap the real module and override only rmtree, so
+        # the simulated failure stays isolated to this command and never mutates
+        # the process-wide shutil (ADR-0007 object-target form on the consumer).
+        fake_shutil = MagicMock(wraps=shutil)
+        fake_shutil.rmtree.side_effect = OSError("locked")
+        monkeypatch.setattr(profile_module, "shutil", fake_shutil)
+        result = runner.invoke(
+            cli,
+            ["profile", "delete", "old", "--confirm"],
+            env=notebooklm_env(tmp_path),
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code == 1, result.output
+        # Friendly Click error path — never an uncaught traceback.
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Failed to delete profile 'old': locked" in result.output
+
 
 class TestProfileRenameCommand:
     def test_rename_profile_success(self, runner, tmp_path):
@@ -315,6 +377,30 @@ class TestProfileRenameCommand:
         assert "Profile renamed: work" in result.output
         assert not (tmp_path / "profiles" / "work").exists()
         assert (tmp_path / "profiles" / "client" / "context.json").exists()
+
+    def test_rename_reports_move_failure(self, runner, tmp_path, monkeypatch):
+        # A failure moving the profile directory (e.g. a locked browser-profile
+        # file held by AV/the browser on Windows) must yield a friendly error +
+        # exit 1, not a raw traceback / exit 2.
+        make_profile(tmp_path, "work")
+
+        # Patch the consumer-side binding (profile_module.os) rather than the
+        # global os module: wrap the real module and override only rename, so
+        # the simulated failure stays isolated to this command and never mutates
+        # the process-wide os (ADR-0007 object-target form on the consumer).
+        fake_os = MagicMock(wraps=os)
+        fake_os.rename.side_effect = OSError("locked")
+        monkeypatch.setattr(profile_module, "os", fake_os)
+        result = runner.invoke(
+            cli,
+            ["profile", "rename", "work", "client"],
+            env=notebooklm_env(tmp_path),
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code == 1, result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Failed to rename profile 'work': locked" in result.output
 
     def test_rename_updates_configured_default_profile(self, runner, tmp_path):
         make_profile(tmp_path, "work")


### PR DESCRIPTION
## Summary

Fixes #1520 (from the adversarially-verified audit). The CLI contract converts failures to a friendly message + defined exit code (1 user / 2 unexpected) — never a raw Python traceback. But `profile delete`'s `shutil.rmtree` (`src/notebooklm/cli/profile_cmd.py`) and the text-mode `list`/`create`/`rename` paths had no error handling, and `SectionedGroup.main` catches only `ClickException`/`Abort` — so a generic `OSError` (permission denied, file held open — common on Windows where browser-profile files are locked by AV/the browser, read-only FS, partial deletion) propagated uncaught as a traceback. The `--json list` path was already wrapped; these pure-filesystem paths were the gap.

### Fix
Wrapped the four unguarded paths in `except OSError → click.ClickException` (exit 1), mirroring the existing `switch_cmd` idiom exactly:
- `delete_cmd` (`rmtree`), `create_cmd` (`get_profile_dir(create=True)`), `rename_cmd` (`os.rename`), and the text-path `list_cmd` — each emits `"Failed to <verb> profile '<name>': <e>"` + exit 1.
- Each `ClickException` site carries the `# cli-input-validation:` marker the error-handler allowlist guardrail requires.
- `--json list` is untouched — it keeps its `handle_errors` exit-2 envelope (pinned by an existing test).

**Why `except OSError`, not `handle_errors`:** routing an `OSError` through `handle_errors` hits its generic `except Exception` → **exit 2** (UNEXPECTED_ERROR), contradicting the contract's exit-1-for-user-error requirement. `switch_cmd`'s explicit `except OSError → ClickException` (exit 1) is the correct sibling to mirror. (`shutil.Error` is an `OSError` subclass across 3.10–3.14, so `rmtree`'s failure surface is covered.)

### Tests (red-first)
`test_delete_reports_rmtree_failure`, `test_create_reports_mkdir_failure`, `test_rename_reports_move_failure`, `test_text_reports_filesystem_error` — all failed pre-fix (raw `OSError`, not `SystemExit`); all assert exit 1 + friendly message post-fix. Reuse the existing `CliRunner` + `patch.object` harness.

### Verification
- Full `uv run pytest -m "not e2e"`: 9621 passed, 137 skipped, 1 xfailed
- mypy clean (236 files) · ruff clean · API-compat audit exit 0 · module-size ratchet + error-handler-allowlist guardrails green

Polish: claude implementer + codex independent review — codex SHIP, no Critical/Important; it independently confirmed `shutil.Error <: OSError` (the one bypass worth checking) and that `ClickException` yields exit 1 with no traceback through `SectionedGroup.main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile commands (create, delete, rename, and text-mode list) now catch filesystem errors and present clear, user-facing error messages, exiting with code 1 instead of showing internal tracebacks.
  * JSON-mode profile list behavior is unchanged and continues to preserve its existing error-envelope semantics.
* **Tests**
  * Added/updated tests to verify friendly error messages and correct exit-code behavior for profile commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->