### PR TITLE
fix(types): decode created_at as tz-aware UTC, not naive host-local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Decoded `created_at` timestamps are now tz-aware UTC instead of naive
+  host-local time** (#1519). The shared decoder `_datetime_from_timestamp`
+  (backing `Notebook`/`Source`/`Artifact`/`MindMap.created_at`) called
+  `datetime.fromtimestamp(value)` with no `tz`, producing a **naive** datetime in
+  the host's local zone — so the same epoch surfaced as a different wall-time
+  string per machine, and `created_at.isoformat()` / `--json` output, the
+  `strftime` table cells, etc. mis-stated the absolute instant (a notebook
+  created `13:40:05` UTC rendered as the offset-less `08:40:05` under
+  `America/New_York`). It now returns `datetime.fromtimestamp(value, tz=utc)`:
+  the value is tz-aware UTC and host-independent. `.timestamp()` round-trips
+  unchanged, so internal sort/dedup/download ordering is provably unaffected —
+  only the rendered string changes (now offset-aware, identical everywhere).
+  This is the production sibling of the timezone slip pinned out of the #1511
+  golden VCR test.
+
 - **Playwright login: closing the browser during the final storage-state
   capture now shows the browser-closed help instead of a bug-report prompt**
   (#1514, deferred from the #1512 review). Every in-flow Playwright call in

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from .research import ResearchSourceInput
@@ -145,8 +145,16 @@ class CitedSourceSelection:
 
 
 def _datetime_from_timestamp(value: Any) -> datetime | None:
-    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
+    """Convert an API seconds timestamp to a UTC ``datetime``, ``None`` if invalid.
+
+    Pinning ``tz=timezone.utc`` makes the result tz-aware and host-independent:
+    a naive ``fromtimestamp(value)`` would render in the host's local zone, so the
+    same epoch surfaced as a different wall-time string per CI runner / user box and
+    mis-stated the absolute instant. ``.timestamp()`` round-trips identically either
+    way, so internal sort/dedup/download ordering is unaffected — only the rendered
+    string changes (now offset-aware and identical everywhere).
+    """
     try:
-        return datetime.fromtimestamp(value)
+        return datetime.fromtimestamp(value, tz=timezone.utc)
     except (TypeError, ValueError, OSError, OverflowError):
         return None

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -138,12 +138,13 @@ class TestNotebooksGoldenDecoded:
         )
         # The created_at slot decodes to a real timestamp (not a fabricated
         # default) — pin the first row's to catch a timestamp-column slip.
-        # The decoder renders LOCAL wall time (``datetime.fromtimestamp``), so
-        # pin the round-tripped epoch — identical on every timezone/CI host —
-        # never the rendered wall-time string (that one varies with TZ and
-        # failed CI's UTC runners against a UTC-5 recording sandbox).
+        # The decoder now renders tz-aware UTC (``fromtimestamp(.., tz=utc)``,
+        # #1519), so the round-tripped epoch is identical on every timezone/CI
+        # host. We still pin the epoch (not a wall-time string), and additionally
+        # assert tz-awareness so a regression back to naive host-local time fails.
         first = notebooks[0]
         assert first.created_at is not None
+        assert first.created_at.tzinfo is not None
         assert_decoded_equals(
             int(first.created_at.timestamp()),
             1768311605,

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,7 +1,10 @@
 """Unit tests for types module dataclasses and parsing."""
 
+import os
 import pickle
+import time
 import warnings
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -57,6 +60,59 @@ class TestTimestampParsing:
         assert parsed is not None
         assert parsed.timestamp() == ts
 
+    def test_datetime_from_timestamp_is_tz_aware_utc(self):
+        """Decoded datetimes are tz-aware UTC, not naive host-local time (#1519).
+
+        The bug: a naive ``datetime.fromtimestamp(value)`` rendered the epoch in
+        the host's local zone, so the public ``created_at`` mis-stated the absolute
+        instant and serialized differently per box. The decoder must return a
+        tz-aware value pinned to UTC and equal to the correct absolute instant.
+
+        Red-first: against the unfixed (naive) decoder ``parsed.tzinfo`` is ``None``,
+        so the ``tzinfo is not None`` assertion fails (and the offset-aware equality
+        would compare unequal — a naive value never ``==`` an aware one).
+        """
+        from notebooklm.types import _datetime_from_timestamp
+
+        # 1768311605 == 2026-01-13T13:40:05+00:00 (the issue's illustrative instant).
+        parsed = _datetime_from_timestamp(1768311605)
+
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timedelta(0)
+        assert parsed == datetime(2026, 1, 13, 13, 40, 5, tzinfo=timezone.utc)
+
+    @pytest.mark.parametrize("tz_name", ["UTC", "America/New_York", "Asia/Kolkata"])
+    def test_datetime_from_timestamp_host_independent(self, tz_name):
+        """The decoded instant is identical regardless of the host timezone (#1519).
+
+        Exercises the original failure mode directly: under ``America/New_York`` a
+        notebook created 13:40:05 UTC used to serialize as the offset-less
+        ``08:40:05``. With the fix every host yields the same tz-aware UTC value.
+        ``time.tzset`` only honours ``$TZ`` on POSIX, so skip elsewhere.
+        """
+        if not hasattr(time, "tzset"):
+            pytest.skip("time.tzset is POSIX-only; cannot exercise host-TZ swap")
+
+        from notebooklm.types import _datetime_from_timestamp
+
+        # Swap the process-wide zone, then restore the host's real $TZ + tz table
+        # in ``finally`` so the swap never leaks into later tests in this process.
+        original_tz = os.environ.get("TZ")
+        os.environ["TZ"] = tz_name
+        time.tzset()
+        try:
+            parsed = _datetime_from_timestamp(1768311605)
+        finally:
+            if original_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = original_tz
+            time.tzset()
+
+        assert parsed == datetime(2026, 1, 13, 13, 40, 5, tzinfo=timezone.utc)
+        assert parsed.isoformat() == "2026-01-13T13:40:05+00:00"
+
     def test_datetime_from_timestamp_oserror(self, monkeypatch):
         """Platform-specific timestamp errors should normalize to None."""
         from unittest.mock import MagicMock
@@ -71,7 +127,8 @@ class TestTimestampParsing:
         parsed = _datetime_from_timestamp(1704067200)
 
         assert parsed is None
-        mock_datetime.fromtimestamp.assert_called_once_with(1704067200)
+        # Pinned to UTC so the rendered instant is host-independent (#1519).
+        mock_datetime.fromtimestamp.assert_called_once_with(1704067200, tz=timezone.utc)
 
     @pytest.mark.parametrize("value", ["bad", None, float("inf"), float("-inf")])
     def test_datetime_from_timestamp_invalid_value(self, value):


### PR DESCRIPTION
## Summary

Fixes #1519 (from the adversarially-verified audit). The shared decoder `_datetime_from_timestamp` (`src/notebooklm/_types/common.py`, behind `Notebook`/`Source`/`Artifact`/`MindMap.created_at`) called `datetime.fromtimestamp(value)` with **no `tz`** — producing a **naive** datetime in the host's local zone. The public `created_at: datetime | None` contract therefore mis-stated the absolute instant and rendered host-TZ-dependently: a notebook created `13:40:05` UTC serialized as the offset-less `08:40:05` under `America/New_York`, and `--json`/`isoformat`/`strftime` output varied per machine.

### Fix
`return datetime.fromtimestamp(value, tz=timezone.utc)` — tz-aware UTC, host-independent. `.timestamp()` round-trips identically, so internal sort/dedup/download ordering (which key on `.timestamp()` or the raw int) is provably unaffected; only the rendered string changes (now offset-aware, identical everywhere).

This is the **production sibling** of the timezone slip that was pinned out of the #1511 golden VCR test (that test was made TZ-invariant, but this production decoder still emitted host-dependent strings).

### Tests (red-first)
- tz-aware + host-independence unit tests (TZ-parametrized via `$TZ`/`time.tzset()`), proving the old naive behavior fails and the decoded instant is identical across zones.
- Updated the existing `fromtimestamp`-call-args assertion to expect `tz=utc`; hardened the #1511 golden VCR test with a `tzinfo` assertion.

### Verification
- Full `uv run pytest -m "not e2e"`: 9618+ passed (no failures)
- mypy clean · ruff clean · API-compat audit exit 0 (only rendered string changes; `.timestamp()` unchanged) · module-size ratchet green

Polish: claude implementer + codex independent review — codex SHIP. It independently confirmed this is the **only** production `fromtimestamp` site, found no naive/aware `created_at` comparison that would now raise, verified CLI/`_app.serialize`/MCP paths pin no offset-less strings, and that None/0/negative/huge timestamps keep their behavior. One Minor (CHANGELOG over-listed `Note.created_at`, which the decoder doesn't currently feed) fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `created_at` timestamp handling to return timezone-aware UTC datetimes instead of host-local times. This ensures consistent temporal representation across different environments and machines, improving accuracy for serialization and formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->