### PR TITLE
fix(security): re-validate every download redirect hop against the trusted-host allowlist (#1521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only the rendered string changes (now offset-aware, identical everywhere).
   This is the production sibling of the timezone slip pinned out of the #1511
   golden VCR test.
+- **Artifact downloads re-validate every redirect hop against the trusted-host
+  allowlist (SSRF-adjacent)** (#1521). Both download clients
+  (`download_url` single + `download_urls_batch`) use
+  `follow_redirects=True`, but the host-allowlist + HTTPS gate validated only
+  the *initial* URL. A trusted Google URL whose `Location` pointed
+  off-allowlist — a non-HTTPS hop, or a private/link-local host such as
+  `169.254.169.254` / `localhost` — was followed and its body written to the
+  caller's `output_path`, defeating the explicit allowlist. (Google session
+  cookies were already not leaked to a non-Google redirect host — the stdlib
+  cookie policy is domain-scoped — so this never exposed credentials; the
+  residual harm was attacker-influenced bytes landing on the filesystem.) Both
+  clients now attach an httpx `request` event hook that re-checks every hop's
+  host + scheme **before the request is sent**, raising `ArtifactDownloadError`
+  on the first off-allowlist or non-HTTPS hop so the untrusted host never
+  receives a connection. Legitimate trusted→trusted redirects (Google
+  signed-URL CDNs already on the allowlist) are unaffected. The host-allowlist
+  check (`_is_trusted_download_host`) also no longer percent-decodes the host
+  before matching: decoding created a parser differential where
+  `evil%2egoogleapis.com` (`%2e`→`.`) was judged trusted while httpx connected
+  to the raw, non-Google host — the guard now matches the exact host httpx
+  connects to and rejects any host containing `%`.
 
 - **`source delete` now honors exact-id-wins over prefix matching, in lockstep
   with `source get` / `rename` / `refresh`** (#1522). The delete-path resolver

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -881,6 +881,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_mind_map.py` | Specific adapter service representing mind-maps, backed by standard notes |
 | `_mind_maps_api.py` | `client.mind_maps` API — unified surface over both mind-map backends (note-backed JSON + interactive studio-artifact), dispatching each op to the correct RPC family (#1256) |
 | `_artifact/downloads.py` | Asynchronous download coordinator for finished artifacts |
+| `_artifact/_redirect_guard.py` | Per-redirect-hop host/scheme revalidation for downloads — rejects off-allowlist / non-HTTPS redirect targets before the request is sent (#1521) |
 | `_artifact/formatters.py` | Markdown, HTML, and plain text formatters for artifacts |
 | `_artifact/payloads.py` | Stable CREATE_ARTIFACT / GENERATE_MIND_MAP request payload builders |
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
@@ -1030,6 +1031,7 @@ src/notebooklm/
 │   └── upload_payloads.py       # Source upload request payload builders
 ├── _artifact/                   # Artifact-feature subpackage (promoted from flat _artifact_*.py, #1328)
 │   ├── __init__.py              # Re-exports the cluster's public service classes/builders
+│   ├── _redirect_guard.py       # Per-redirect-hop host/scheme revalidation for downloads (#1521)
 │   ├── downloads.py             # Artifact download coordinator
 │   ├── formatters.py            # Artifact formatting helpers
 │   ├── payloads.py              # Stable artifact request payload builders

--- a/src/notebooklm/_artifact/_redirect_guard.py
+++ b/src/notebooklm/_artifact/_redirect_guard.py
@@ -1,0 +1,70 @@
+"""Per-redirect-hop allowlist + HTTPS revalidation for artifact downloads.
+
+Both artifact-download clients (the single ``download_url`` stream and the
+``download_urls_batch`` loop in :mod:`notebooklm._artifact.downloads`) use
+``follow_redirects=True``. The initial host + scheme allowlist gate validates
+only the URL the caller passed, so a *trusted* Google URL whose ``Location``
+points off-allowlist — a non-HTTPS hop, or a private/link-local host such as
+``169.254.169.254`` — would otherwise be followed and its body written to the
+caller's ``output_path``. That is an SSRF-style fetch that defeats the
+explicit allowlist (issue #1521).
+
+This module supplies an httpx ``request`` event hook that re-checks every
+hop's host + scheme *before the request is sent*, so an untrusted host never
+receives a connection. The host-trust predicate is injected (rather than
+imported) to keep this module free of a circular dependency on
+``downloads.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from ..exceptions import ArtifactDownloadError
+
+if TYPE_CHECKING:
+    import httpx
+
+# Host-trust predicate signature: ``(hostname | None) -> bool``.
+_HostPredicate = Callable[[str | None], bool]
+
+
+def _assert_trusted_download_request(
+    request: httpx.Request, is_trusted_host: _HostPredicate
+) -> None:
+    """Reject an off-allowlist / non-HTTPS request hop.
+
+    Runs for every hop (the initial request and each redirect target).
+    Legitimate trusted→trusted redirects (Google signed-URL CDNs already on
+    the allowlist) pass through untouched.
+
+    Raises:
+        ArtifactDownloadError: on the first hop whose scheme is not HTTPS or
+            whose host is not on the trusted allowlist.
+    """
+    host = request.url.host or None
+    if request.url.scheme != "https":
+        raise ArtifactDownloadError(
+            "media",
+            details=f"Untrusted redirect to non-HTTPS hop: {host or '<unknown>'}",
+        )
+    if not is_trusted_host(host):
+        raise ArtifactDownloadError(
+            "media",
+            details=f"Untrusted download domain: {host or '<unknown>'}",
+        )
+
+
+def redirect_revalidation_hooks(is_trusted_host: _HostPredicate) -> dict[str, list[Any]]:
+    """Build httpx ``event_hooks`` re-validating every redirect hop (#1521).
+
+    ``is_trusted_host`` is the download module's host-allowlist predicate; it
+    is injected so this guard module has no import dependency on
+    ``downloads.py`` (which imports *this* module).
+    """
+
+    async def _on_request(request: httpx.Request) -> None:
+        _assert_trusted_download_request(request, is_trusted_host)
+
+    return {"request": [_on_request]}

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -13,7 +13,7 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import ParseResult, unquote, urlparse
+from urllib.parse import ParseResult, urlparse
 
 import httpx
 
@@ -30,6 +30,7 @@ from ..types import (
     ArtifactParseError,
     ArtifactType,
 )
+from ._redirect_guard import redirect_revalidation_hooks
 from .formatters import _extract_app_data, _format_interactive_content, _parse_data_table
 
 if TYPE_CHECKING:
@@ -143,8 +144,13 @@ def _load_httpx_cookies(storage_path: Any) -> Any:
 def _is_trusted_download_host(hostname: str | None) -> bool:
     if hostname is None:
         return False
-    hostname = unquote(hostname).lower()
-    if "\\" in hostname or "/" in hostname:
+    # Match the EXACT host httpx connects to. httpx does NOT percent-decode
+    # ``request.url.host``, so the guard must not either: decoding made
+    # ``evil%2egoogleapis.com`` (%2e -> '.') read as trusted while the
+    # connection went to the raw non-Google host (#1521). A real Google host
+    # never contains ``%``, so reject any (defense-in-depth w/ the slash guards).
+    hostname = hostname.lower()
+    if "%" in hostname or "\\" in hostname or "/" in hostname:
         return False
     return any(
         hostname == domain.lstrip(".") or hostname.endswith(domain)
@@ -714,6 +720,7 @@ class ArtifactDownloadService:
             cookies=cookies,
             follow_redirects=True,
             timeout=60.0,
+            event_hooks=redirect_revalidation_hooks(_is_trusted_download_host),  # #1521
         ) as client:
             for url, output_path in urls_and_paths:
                 display_host = ""
@@ -815,6 +822,7 @@ class ArtifactDownloadService:
                     cookies=cookies,
                     follow_redirects=True,
                     timeout=timeout,
+                    event_hooks=redirect_revalidation_hooks(_is_trusted_download_host),  # #1521
                 ) as client:
                     async with client.stream("GET", url) as response:
                         response.raise_for_status()

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -80,7 +80,17 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     "_artifacts.py": 1451,
     "_source/upload.py": 1236,
     "_sources.py": 1007,
-    "_artifact/downloads.py": 1033,
+    # _artifact/downloads.py: raised for the #1521 per-redirect-hop revalidation
+    # fix. The new *logic* (host+scheme hop guard + httpx event-hook factory) was
+    # *split out* into the sibling ``_artifact/_redirect_guard.py`` per this
+    # gate's "split out the new bulk" rule; the residual growth is irreducible
+    # in-place edits: call-site wiring (one import + the ``event_hooks=`` kwarg on
+    # each of the two ``httpx.AsyncClient(...)`` constructions) plus a security
+    # comment in ``_is_trusted_download_host`` documenting the percent-encode
+    # parser-differential bypass the re-review caught (dropping the ``unquote``
+    # decode + rejecting any ``%`` in the host). New ceiling is the measured
+    # post-fix LOC.
+    "_artifact/downloads.py": 1041,
     # client.py dropped below the budget when its ``__init__`` body moved to
     # ``_client_assembly.py`` (the shared constructor/test-factory seam), so
     # its ceiling entry was removed per the one-way-ratchet rule.

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -77,6 +77,40 @@ def test_is_trusted_download_host_none_returns_false():
     assert _is_trusted_download_host(None) is False
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "evil%2egoogleapis.com",  # %2e decodes to '.' -> evil.googleapis.com
+        "evil%2Egoogleapis.com",  # uppercase variant
+        "storage.googleapis.com%2eevil.example",  # encoded dot mid-host
+        "storage.googleapis.com%00",  # any percent-escape is suspect
+    ],
+)
+def test_is_trusted_download_host_rejects_percent_encoded(host):
+    """Percent-encoded hosts are never trusted (parser-differential bypass, #1521).
+
+    httpx connects to the RAW host; the guard must validate that same raw
+    string and never percent-decode it, or ``evil%2egoogleapis.com`` would be
+    judged trusted while the connection goes to a non-Google host.
+    """
+    assert _is_trusted_download_host(host) is False
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "storage.googleapis.com",
+        "lh3.googleusercontent.com",
+        "www.google.com",
+        "google.com",
+        "googleapis.com",
+    ],
+)
+def test_is_trusted_download_host_accepts_legitimate_google_hosts(host):
+    """Removing the percent-decode must not reject any real Google download host."""
+    assert _is_trusted_download_host(host) is True
+
+
 def test_download_display_host_falls_back_to_netloc():
     """Line 149: with no parsed hostname, strip userinfo from netloc."""
     from urllib.parse import urlparse

--- a/tests/unit/test_download_redirect_revalidation.py
+++ b/tests/unit/test_download_redirect_revalidation.py
@@ -1,0 +1,427 @@
+"""Per-redirect-hop host/scheme revalidation for artifact downloads (#1521).
+
+Both download clients (``download_url`` single + ``download_urls_batch``)
+use ``follow_redirects=True``. The initial host+scheme allowlist gate only
+checks the URL the caller passed, so a *trusted* Google URL whose
+``Location`` points off-allowlist — a non-HTTPS hop, or a private/link-local
+host such as ``169.254.169.254`` — would otherwise be followed and its body
+written to ``output_path``. That is an SSRF-style fetch that defeats the
+allowlist.
+
+These tests drive a *real* ``httpx.AsyncClient`` wired to an
+``httpx.MockTransport`` so the production ``event_hooks`` run against
+httpx's own redirect machinery. They assert:
+
+* a trusted→off-allowlist 30x is rejected with ``ArtifactDownloadError`` and
+  nothing is written (covers ``169.254.169.254`` and ``evil.example``),
+* a trusted→non-HTTPS (https→http downgrade) hop is rejected,
+* an open-redirect that stays on a *trusted* host still succeeds,
+* a multi-hop trusted→trusted→off-allowlist chain is rejected on the bad hop,
+* a legitimate trusted→trusted redirect still downloads.
+
+Covers BOTH the single-download and the batch surfaces.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+import notebooklm._artifact.downloads as _downloads_mod
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm.types import ArtifactDownloadError
+
+
+@pytest.fixture
+def mock_artifacts_api(tmp_path):
+    """ArtifactsAPI wired to mocks -- no real network, real httpx clients."""
+    from _fixtures.fake_core import make_fake_core
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
+
+    mock_core = make_fake_core(
+        rpc_call=AsyncMock(),
+        get_source_ids=AsyncMock(return_value=[]),
+    )
+    api = ArtifactsAPI(
+        rpc=mock_core,
+        drain=mock_core,
+        lifecycle=mock_core,
+        notebooks=AsyncMock(),
+        mind_maps=AsyncMock(spec=NoteBackedMindMapService),
+        note_service=AsyncMock(spec=NoteService),
+        storage_path=tmp_path / "storage.json",
+    )
+    return api
+
+
+def _patch_real_client_with_transport(handler: Callable[[httpx.Request], httpx.Response]):
+    """Patch the seams so a *real* ``httpx.AsyncClient`` runs over a MockTransport.
+
+    The production code constructs ``httpx.AsyncClient(..., event_hooks=...)``;
+    we forward every real kwarg (crucially ``event_hooks`` and
+    ``follow_redirects``) and only inject ``transport=MockTransport(handler)``
+    so the actual redirect machinery + the production request hook execute.
+    """
+    real_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", httpx.MockTransport(handler))
+        return real_cls(*args, **kwargs)
+
+    return (
+        patch.object(httpx, "AsyncClient", side_effect=_factory),
+        # Freeze the PUBLIC ``load_httpx_cookies`` import, not the private
+        # ``_load_httpx_cookies`` wrapper: both the single (downloads.py:717) and
+        # batch (:817) paths call ``_load_httpx_cookies``, which delegates to this
+        # name — so patching it here covers BOTH surfaces. Patching the private
+        # ``_load_httpx_cookies`` alias directly would trip the ADR-0007
+        # private-attribute monkeypatch guardrail.
+        patch.object(_downloads_mod, "load_httpx_cookies", return_value=httpx.Cookies()),
+    )
+
+
+# A trusted host accepted by ``_is_trusted_download_host``.
+_TRUSTED_HOST = "storage.googleapis.com"
+_TRUSTED_URL = f"https://{_TRUSTED_HOST}/start"
+
+
+def _redirect_handler(
+    *,
+    location: str,
+    body: bytes = b"PAYLOAD",
+    content_type: str = "video/mp4",
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a transport handler: trusted ``/start`` 302s to ``location``."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == _TRUSTED_HOST and request.url.path == "/start":
+            return httpx.Response(302, headers={"location": location})
+        # Any other (the redirect target) serves a body. If the hop is
+        # off-allowlist the production hook must have already aborted, so
+        # reaching here for an untrusted host is itself a test failure.
+        return httpx.Response(200, content=body, headers={"content-type": content_type})
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Single-download path: download_url
+# ---------------------------------------------------------------------------
+
+
+class TestSingleDownloadRedirectRevalidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "evil_location",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://evil.example/payload",
+            "https://localhost/payload",
+        ],
+    )
+    async def test_offallowlist_redirect_rejected_nothing_written(
+        self, mock_artifacts_api, tmp_path, evil_location
+    ):
+        """trusted→off-allowlist 30x → ArtifactDownloadError, no file/temp left."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=evil_location)
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_non_https_redirect_hop_rejected(self, mock_artifacts_api, tmp_path):
+        """https→http downgrade to a same-host hop is rejected (no plaintext fetch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"http://{_TRUSTED_HOST}/payload")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "non-HTTPS" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_multihop_trusted_then_offallowlist_rejected(self, mock_artifacts_api, tmp_path):
+        """trusted→trusted→evil: rejected on the off-allowlist hop, nothing written."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == _TRUSTED_HOST and request.url.path == "/start":
+                # First hop -> another trusted host (a CDN already on the
+                # allowlist).
+                return httpx.Response(
+                    302, headers={"location": "https://cdn.googleusercontent.com/hop2"}
+                )
+            if request.url.host == "cdn.googleusercontent.com":
+                # Second (trusted) hop -> an off-allowlist host.
+                return httpx.Response(302, headers={"location": "https://evil.example/payload"})
+            return httpx.Response(200, content=b"EVIL", headers={"content-type": "video/mp4"})
+
+        client_patch, cookies_patch = _patch_real_client_with_transport(handler)
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted download domain" in str(exc_info.value)
+        assert "evil.example" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_trusted_to_trusted_redirect_still_succeeds(self, mock_artifacts_api, tmp_path):
+        """A legitimate signed-URL CDN redirect (trusted→trusted) downloads fine."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        # storage.googleapis.com -> googleusercontent.com signed CDN (both trusted).
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location="https://lh3.googleusercontent.com/signed/file.mp4",
+                body=b"REAL MEDIA BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert result == str(output_path)
+        assert output_path.read_bytes() == b"REAL MEDIA BYTES"
+
+    @pytest.mark.asyncio
+    async def test_open_redirect_staying_on_trusted_host_succeeds(
+        self, mock_artifacts_api, tmp_path
+    ):
+        """An open-redirect that stays on a trusted host is not over-blocked."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location=f"https://{_TRUSTED_HOST}/redirected/file.mp4",
+                body=b"SAME HOST BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert result == str(output_path)
+        assert output_path.read_bytes() == b"SAME HOST BYTES"
+
+
+# ---------------------------------------------------------------------------
+# Batch path: download_urls_batch
+# ---------------------------------------------------------------------------
+
+
+class TestBatchDownloadRedirectRevalidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "evil_location",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://evil.example/payload",
+        ],
+    )
+    async def test_offallowlist_redirect_aggregated_into_failed_nothing_written(
+        self, mock_artifacts_api, tmp_path, evil_location
+    ):
+        """trusted→off-allowlist 30x → failed entry, no file written for it."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=evil_location)
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == _TRUSTED_URL
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_non_https_redirect_hop_rejected(self, mock_artifacts_api, tmp_path):
+        """https→http downgrade hop aggregated into ``failed`` for the batch."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"http://{_TRUSTED_HOST}/payload")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        _, failed_exc = result.failed[0]
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "non-HTTPS" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_bad_redirect_isolated_from_good_sibling(self, mock_artifacts_api, tmp_path):
+        """A redirect-to-evil URL fails while a clean sibling still succeeds."""
+        api = mock_artifacts_api
+        bad_url = f"https://{_TRUSTED_HOST}/start"
+        good_url = f"https://{_TRUSTED_HOST}/clean.mp4"
+        bad_path = tmp_path / "bad.mp4"
+        good_path = tmp_path / "good.mp4"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "https://evil.example/payload"})
+            if request.url.path == "/clean.mp4":
+                return httpx.Response(
+                    200, content=b"GOOD BYTES", headers={"content-type": "video/mp4"}
+                )
+            return httpx.Response(200, content=b"EVIL", headers={"content-type": "video/mp4"})
+
+        client_patch, cookies_patch = _patch_real_client_with_transport(handler)
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch(
+                [(bad_url, str(bad_path)), (good_url, str(good_path))]
+            )
+
+        assert result.succeeded == [str(good_path)]
+        assert good_path.read_bytes() == b"GOOD BYTES"
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == bad_url
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert not bad_path.exists()
+        assert result.partial
+
+    @pytest.mark.asyncio
+    async def test_trusted_to_trusted_redirect_still_succeeds(self, mock_artifacts_api, tmp_path):
+        """A legitimate trusted→trusted redirect downloads in the batch path too."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location="https://lh3.googleusercontent.com/signed/file.mp4",
+                body=b"REAL MEDIA BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == [str(output_path)]
+        assert result.failed == []
+        assert output_path.read_bytes() == b"REAL MEDIA BYTES"
+
+
+# ---------------------------------------------------------------------------
+# Percent-encoded host parser-differential bypass (#1521 re-review)
+# ---------------------------------------------------------------------------
+
+# ``_is_trusted_download_host`` previously percent-decoded the hostname before
+# matching, so ``evil%2egoogleapis.com`` decoded to ``evil.googleapis.com`` and
+# was judged TRUSTED — but httpx connects to the RAW host
+# ``evil%2egoogleapis.com``. The guard validated a *different* host than the
+# one actually connected to (a parser differential), letting the body land on
+# disk. These hosts must be rejected at every gate: the initial URL and any
+# redirect target, single and batch.
+_PERCENT_ENCODED_HOSTS = [
+    "evil%2egoogleapis.com",  # %2e -> '.' under the old unquote()
+    "evil%2Egoogleapis.com",  # uppercase variant
+    "storage.googleapis.com%2eevil.example",  # encoded dot mid-host
+]
+
+
+class TestPercentEncodedHostBypass:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_single_initial_url_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A percent-encoded host as the INITIAL url is rejected (single)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        # No redirect needed: the bad host is the initial URL itself.
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            lambda request: httpx.Response(200, content=b"EVIL")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(f"https://{host}/payload", str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_single_redirect_target_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A trusted URL redirecting to a percent-encoded host is rejected (single)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"https://{host}/payload")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_batch_initial_url_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A percent-encoded host as the INITIAL url is rejected (batch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        url = f"https://{host}/payload"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            lambda request: httpx.Response(200, content=b"EVIL")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(url, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == url
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_batch_redirect_target_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A trusted URL redirecting to a percent-encoded host is rejected (batch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"https://{host}/payload")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        _, failed_exc = result.failed[0]
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()


### PR DESCRIPTION
## Summary

Fixes #1521 (from the adversarially-verified audit; SSRF-adjacent). `src/notebooklm/_artifact/downloads.py` applied `_is_trusted_download_host` + the https gate to the **initial** URL only; both httpx clients used `follow_redirects=True` with no per-hop revalidation. A 30x from a trusted Google URL whose `Location` points off-allowlist (incl. non-https or a private/link-local host like `169.254.169.254`/`localhost`) was followed and its body written to `output_path` — an SSRF-style fetch defeating the explicit allowlist.

(The credential-leak path was already closed — cookies are domain-scoped, so Google session cookies aren't sent to a non-Google redirect host. Residual harm was attacker-influenced bytes landing on disk.)

### What changed
- **Per-hop revalidation** via an httpx **`request` event hook** (new `src/notebooklm/_artifact/_redirect_guard.py`) attached to both download clients. It fires *before every hop's request is sent* (initial URL + each redirect target) and re-applies `_is_trusted_download_host` + https, raising the module's existing `ArtifactDownloadError` on the first off-allowlist/non-https hop — so the untrusted host never receives a connection. Applied to **both** the single (`download_url`) and batch (`download_urls_batch`) paths.
- **Closed a percent-decode parser-differential** (caught in review): `_is_trusted_download_host` used to `unquote()` the host, so `https://evil%2egoogleapis.com/…` decoded to `evil.googleapis.com` and *passed* the allowlist while httpx connected to the **raw** host. Removed the decode (the guard now validates the exact host httpx connects to) and reject any host containing `%`/`\`/`/`.

### Tests (red-first)
- Off-allowlist redirect (`169.254.169.254` / `evil.example` / `localhost`), https→http downgrade, multi-hop `trusted→trusted→evil`, and the batch equivalents — all rejected with nothing written; legitimate `trusted→trusted` CDN redirects still succeed. (9 of 12 proven red.)
- `TestPercentEncodedHostBypass` + host-predicate tests for `evil%2egoogleapis.com` / `%2E` / `%00`, as initial URL and redirect target, single and batch (proven red).

### Verification
- Full `uv run pytest -m "not e2e"`: 9650 passed
- mypy clean (237 files) · ruff clean · API-compat audit exit 0 (fully private) · module-size ratchet green

### Review
claude implementer + **codex** independent security review (two passes). Codex caught the percent-decode bypass (`evil%2egoogleapis.com`); the fix closed it. Final codex verdict: **SHIP** — bypass closed, no regression, encoded path/query doesn't affect host validation.

Closes #1521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact downloads now re-validate every HTTP redirect hop to ensure hosts remain on the trusted allowlist and use HTTPS; untrusted or non-HTTPS hops are rejected.
  * Hostname checks no longer percent-decode input, preventing encoded hostnames from bypassing allowlist matching.

* **Tests**
  * Added comprehensive unit tests covering redirect revalidation, percent-encoded-host rejection, and batch/single-download behaviors.

* **Documentation**
  * Updated architecture docs to describe the new redirect revalidation guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->