### PR TITLE
fix(notebooks): created_at now reflects creation (was last-modified); expose modified_at (#1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Notebook.created_at` now reflects the true creation time instead of the
+  last-modified time; `Notebook.modified_at` is newly exposed.** The notebook
+  metadata block carries two timestamps — the creation instant at
+  `data[5][8][0]` (pinned across edits) and the last-modified instant at
+  `data[5][5][0]` (advances on every modification). `Notebook.from_api_response`
+  read the *modified* slot (`data[5][5]`) and labeled it `created_at`, so the
+  field — and everything built on it (`--json` output, `metadata` export, the
+  `Created` table column) — silently reported the last edit time. `created_at`
+  now reads the creation slot (`data[5][8]`), and the last-modified time is
+  surfaced additively as `Notebook.modified_at` (new field, defaults to `None`,
+  appended at the end so positional construction is unaffected; also added to
+  `NotebookMetadata.to_dict()` and the notebook `--json` envelopes). This
+  applies to both `notebooks.get()` and `notebooks.list()` (the homepage/recent
+  feed), which share the decode path. No signature change — `created_at` keeps
+  its type, only its source value is corrected — so this is a behavioral fix,
+  not an API-compat break, and `modified_at` is purely additive.
 - **Decoded `created_at` timestamps are now tz-aware UTC instead of naive
   host-local time** (#1519). The shared decoder `_datetime_from_timestamp`
   (backing `Notebook`/`Source`/`Artifact`/`MindMap.created_at`) called

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1896,9 +1896,10 @@ await client.labels.delete(nb_id, papers.id)
 class Notebook:
     id: str
     title: str
-    created_at: Optional[datetime]
+    created_at: Optional[datetime]   # creation time (tz-aware UTC)
     sources_count: int
     is_owner: bool
+    modified_at: Optional[datetime]  # last-modified time (tz-aware UTC)
 ```
 
 ### Source

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -46,6 +46,9 @@ class Notebook:
     created_at: datetime | None = None
     sources_count: int = 0
     is_owner: bool = True
+    # ``modified_at`` is appended at the END of the field list so positional
+    # construction stays unaffected (additive, defaults to ``None``).
+    modified_at: datetime | None = None
 
     @classmethod
     def from_api_response(cls, data: list[Any]) -> Notebook:
@@ -78,11 +81,24 @@ class Notebook:
         # ``data[5][...]`` (the legitimately-absent block defaults below).
         meta = data[5] if len(data) > 5 and isinstance(data[5], list) else None
 
+        # ``meta[8]`` (``data[5][8][0]``) is the CREATION instant: a controlled
+        # probe (create → add source @T0 → add source @T1) showed this slot
+        # stayed pinned at the creation time across modifications, while
+        # ``meta[5]`` advanced on each edit. The two slots were historically
+        # swapped — ``created_at`` read ``meta[5]`` and so exposed the
+        # last-modified time. ``meta[5]`` (``data[5][5][0]``) is now correctly
+        # surfaced as ``modified_at``.
         created_at = None
+        if meta is not None and len(meta) > 8:
+            created_ts = meta[8]
+            if isinstance(created_ts, list) and len(created_ts) > 0:
+                created_at = _datetime_from_timestamp(created_ts[0])
+
+        modified_at = None
         if meta is not None and len(meta) > 5:
-            ts_data = meta[5]
-            if isinstance(ts_data, list) and len(ts_data) > 0:
-                created_at = _datetime_from_timestamp(ts_data[0])
+            modified_ts = meta[5]
+            if isinstance(modified_ts, list) and len(modified_ts) > 0:
+                modified_at = _datetime_from_timestamp(modified_ts[0])
 
         is_owner = True
         if meta is not None and len(meta) > 1:
@@ -95,6 +111,7 @@ class Notebook:
             created_at=created_at,
             sources_count=sources_count,
             is_owner=is_owner,
+            modified_at=modified_at,
         )
 
 
@@ -149,6 +166,11 @@ class NotebookMetadata:
         return self.notebook.created_at
 
     @property
+    def modified_at(self) -> datetime | None:
+        """Get last-modified timestamp."""
+        return self.notebook.modified_at
+
+    @property
     def is_owner(self) -> bool:
         """Get owner status."""
         return self.notebook.is_owner
@@ -159,6 +181,7 @@ class NotebookMetadata:
             "id": self.id,
             "title": self.title,
             "created_at": self.created_at.isoformat() if self.created_at else None,
+            "modified_at": self.modified_at.isoformat() if self.modified_at else None,
             "is_owner": self.is_owner,
             "sources": [s.to_dict() for s in self.sources],
         }

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -57,6 +57,7 @@ def register_notebook_commands(cli):
                         "title": nb.title,
                         "is_owner": nb.is_owner,
                         "created_at": nb.created_at.isoformat() if nb.created_at else None,
+                        "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                     },
                     columns=["ID", "Title", "Owner", "Created"],
                     row=lambda nb: [
@@ -112,6 +113,7 @@ def register_notebook_commands(cli):
                             "id": nb.id,
                             "title": nb.title,
                             "created_at": nb.created_at.isoformat() if nb.created_at else None,
+                            "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                         }
                     }
                     # When --use switched the active context, surface the new

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -483,6 +483,7 @@ def register_session_commands(cli):
                         "title": nb.title,
                         "is_owner": nb.is_owner,
                         "created_at": nb.created_at.isoformat() if nb.created_at else None,
+                        "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                     },
                 }
             )

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -136,20 +136,32 @@ class TestNotebooksGoldenDecoded:
         assert_decoded_equals(
             actual_head, _NOTEBOOKS_LIST_GOLDEN_HEAD, field="notebooks_list[:3] rows"
         )
-        # The created_at slot decodes to a real timestamp (not a fabricated
-        # default) — pin the first row's to catch a timestamp-column slip.
-        # The decoder now renders tz-aware UTC (``fromtimestamp(.., tz=utc)``,
+        # The created_at / modified_at slots decode to real timestamps (not
+        # fabricated defaults) — pin the first row's to catch a timestamp-column
+        # slip. ``created_at`` is the CREATION instant (``data[5][8][0]``) and
+        # ``modified_at`` is the LAST-MODIFIED instant (``data[5][5][0]``); the
+        # two were historically swapped (created_at exposed the modified time).
+        # The decoder renders tz-aware UTC (``fromtimestamp(.., tz=utc)``,
         # #1519), so the round-tripped epoch is identical on every timezone/CI
-        # host. We still pin the epoch (not a wall-time string), and additionally
-        # assert tz-awareness so a regression back to naive host-local time fails.
+        # host. We pin the epoch (not a wall-time string) and assert tz-awareness
+        # so a regression back to naive host-local time fails.
         first = notebooks[0]
         assert first.created_at is not None
         assert first.created_at.tzinfo is not None
         assert_decoded_equals(
             int(first.created_at.timestamp()),
-            1768311605,
+            1768174413,  # data[5][8][0] — true creation instant
             field="notebooks_list[0].created_at (epoch seconds)",
         )
+        assert first.modified_at is not None
+        assert first.modified_at.tzinfo is not None
+        assert_decoded_equals(
+            int(first.modified_at.timestamp()),
+            1768311605,  # data[5][5][0] — last-modified instant
+            field="notebooks_list[0].modified_at (epoch seconds)",
+        )
+        # Creation precedes last modification in the recorded row.
+        assert first.created_at < first.modified_at
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -169,6 +181,24 @@ class TestNotebooksGoldenDecoded:
         )
         assert_decoded_equals(notebook.sources_count, 2, field="notebooks_get.sources_count")
         assert_decoded_equals(notebook.is_owner, True, field="notebooks_get.is_owner")
+        # created_at is the CREATION instant (``data[5][8][0]``); modified_at is
+        # the LAST-MODIFIED instant (``data[5][5][0]``). Pin both epochs (TZ-
+        # invariant per #1511/#1519) to lock the previously-swapped slots.
+        assert notebook.created_at is not None
+        assert notebook.created_at.tzinfo is not None
+        assert_decoded_equals(
+            int(notebook.created_at.timestamp()),
+            1767921609,  # data[5][8][0] — true creation instant
+            field="notebooks_get.created_at (epoch seconds)",
+        )
+        assert notebook.modified_at is not None
+        assert notebook.modified_at.tzinfo is not None
+        assert_decoded_equals(
+            int(notebook.modified_at.timestamp()),
+            1768963937,  # data[5][5][0] — last-modified instant
+            field="notebooks_get.modified_at (epoch seconds)",
+        )
+        assert notebook.created_at < notebook.modified_at
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
@@ -870,6 +900,12 @@ def test_golden_values_visible_in_cassette_bytes() -> None:
         ("notes_create.yaml", "1768312234"),
         ("notes_list.yaml", "1768311078"),
         ("generate_mind_map_chain.yaml", "1778851315"),
+        # Notebook created_at/modified_at epochs (swapped-slot fix): created_at
+        # comes from data[5][8][0], modified_at from data[5][5][0].
+        ("notebooks_list.yaml", "1768174413"),  # list[0].created_at
+        ("notebooks_list.yaml", "1768311605"),  # list[0].modified_at
+        ("notebooks_get.yaml", "1767921609"),  # get.created_at
+        ("notebooks_get.yaml", "1768963937"),  # get.modified_at
         ("settings_get_user_tier.yaml", "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"),
         ("artifacts_export_report.yaml", "1bAgBGlybk82LZfbz6IPCwpQ12E4hlDQsuWTVWJVEHfM"),
         ("research_poll.yaml", "32b1e6c3-863f-4502-8509-fe9d5801db14"),

--- a/tests/unit/app/test_app_serialize.py
+++ b/tests/unit/app/test_app_serialize.py
@@ -135,6 +135,7 @@ def test_real_notebooklm_type_round_trips() -> None:
         "created_at": "2026-06-08T00:00:00+00:00",
         "sources_count": 3,
         "is_owner": True,
+        "modified_at": None,
     }
     json.dumps(result)
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -119,6 +119,7 @@ class TestNotebookList:
             "title",
             "is_owner",
             "created_at",
+            "modified_at",
         ]
         assert data["notebooks"][0]["id"] == "nb_1"
 

--- a/tests/unit/cli/test_session_characterization.py
+++ b/tests/unit/cli/test_session_characterization.py
@@ -259,6 +259,7 @@ class TestUseCharacterization:
                 "title": "JSON Char Notebook",
                 "is_owner": False,
                 "created_at": "2024-02-01T00:00:00",
+                "modified_at": None,
             },
         }
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -351,22 +351,110 @@ class TestNotebook:
         assert notebook.sources_count == 0
 
     def test_from_api_response_with_timestamp(self):
-        """Test parsing notebook with timestamp."""
-        ts = 1704067200  # 2024-01-01 00:00:00 UTC
+        """Test parsing notebook with timestamp.
+
+        ``created_at`` is read from ``meta[8]`` (the creation slot), so the
+        creation epoch is placed there. ``meta[5]`` carries the now-distinct
+        last-modified slot.
+        """
+        created_ts = 1704067200  # 2024-01-01 00:00:00 UTC
+        modified_ts = 1704153600  # 2024-01-02 00:00:00 UTC
         data = [
             "Timestamped Notebook",
             [],
             "nb_456",
             "📘",
             None,
-            [None, None, None, None, None, [ts, 0]],
+            # meta[5] = modified slot, meta[8] = creation slot
+            [None, None, None, None, None, [modified_ts, 0], None, None, [created_ts, 0]],
         ]
         notebook = Notebook.from_api_response(data)
 
         assert notebook.id == "nb_456"
         assert notebook.created_at is not None
         # Check timestamp value rather than year (timezone-independent)
-        assert notebook.created_at.timestamp() == ts
+        assert notebook.created_at.timestamp() == created_ts
+        assert notebook.modified_at is not None
+        assert notebook.modified_at.timestamp() == modified_ts
+
+    def test_from_api_response_created_modified_not_swapped(self):
+        """``created_at`` is ``meta[8]`` and ``modified_at`` is ``meta[5]``.
+
+        Regression pin for the swapped-slots bug: the metadata block exposes the
+        creation instant at ``data[5][8][0]`` (pinned across edits) and the
+        last-modified instant at ``data[5][5][0]`` (advances on each edit). The
+        pre-fix code read ``meta[5]`` for ``created_at`` and so surfaced the
+        last-modified time as the creation time.
+        """
+        created_ts = 1767921609  # 2026-01-09 — earlier (true creation)
+        modified_ts = 1768963937  # 2026-01-21 — later (last edit)
+        data = [
+            "Swap Probe Notebook",
+            [],
+            "nb_swap",
+            "📓",
+            None,
+            [None, None, None, None, None, [modified_ts, 1], None, None, [created_ts, 2]],
+        ]
+        notebook = Notebook.from_api_response(data)
+
+        # created_at == the meta[8] instant (NOT meta[5])
+        assert notebook.created_at is not None
+        assert notebook.created_at.timestamp() == created_ts
+        # modified_at == the meta[5] instant
+        assert notebook.modified_at is not None
+        assert notebook.modified_at.timestamp() == modified_ts
+        # The two are distinct and ordered created < modified (sanity).
+        assert notebook.created_at < notebook.modified_at
+
+    def test_from_api_response_short_meta_leaves_both_timestamps_none(self):
+        """A ``meta`` block too short to carry the slots soft-degrades to None.
+
+        ``meta[8]`` is absent (len 6) so ``created_at`` is None; ``meta[5]`` is
+        also degraded here (None payload) so ``modified_at`` is None too.
+        """
+        data = [
+            "Short Meta Notebook",
+            [],
+            "nb_short",
+            "📓",
+            None,
+            [None, None, None, None, None, None],  # len 6: meta[8] absent, meta[5] None
+        ]
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.created_at is None
+        assert notebook.modified_at is None
+
+    def test_from_api_response_short_meta_keeps_modified_but_not_created(self):
+        """A ``meta`` block carrying ``meta[5]`` but too short for ``meta[8]``.
+
+        Locks the length-guard policy: ``created_at`` (``meta[8]``) soft-degrades
+        to None rather than falling back to ``meta[5]`` (which would re-introduce
+        the swap bug), while ``modified_at`` (``meta[5]``) is still populated.
+        """
+        modified_ts = 1768311605
+        data = [
+            "Modified-Only Notebook",
+            [],
+            "nb_modonly",
+            "📓",
+            None,
+            [None, None, None, None, None, [modified_ts, 0]],  # len 6: meta[5] set, meta[8] absent
+        ]
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.created_at is None
+        assert notebook.modified_at is not None
+        assert notebook.modified_at.timestamp() == modified_ts
+
+    def test_from_api_response_missing_meta_leaves_both_timestamps_none(self):
+        """No metadata block at all → both timestamps None."""
+        data = ["No Meta Notebook", [], "nb_nometa", "📓"]
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.created_at is None
+        assert notebook.modified_at is None
 
     def test_from_api_response_strips_thought_prefix(self):
         """Test that 'thought\\n' prefix is stripped from title."""
@@ -399,18 +487,23 @@ class TestNotebook:
         assert notebook.is_owner is True
 
     def test_from_api_response_invalid_timestamp(self):
-        """Test parsing with invalid timestamp data."""
+        """Test parsing with invalid timestamp data.
+
+        ``created_at`` reads ``meta[8]`` and ``modified_at`` reads ``meta[5]``;
+        both invalid payloads soft-degrade to ``None``.
+        """
         data = [
             "Notebook",
             [],
             "nb_123",
             "📓",
             None,
-            [None, None, None, None, None, ["invalid", 0]],
+            [None, None, None, None, None, ["invalid", 0], None, None, ["invalid", 0]],
         ]
         notebook = Notebook.from_api_response(data)
 
         assert notebook.created_at is None
+        assert notebook.modified_at is None
 
     def test_from_api_response_out_of_range_timestamp(self):
         """Platform timestamp range errors should not escape notebook parsing."""
@@ -420,13 +513,16 @@ class TestNotebook:
             "nb_123",
             "📓",
             None,
-            [None, None, None, None, None, [1704067200, 0]],
+            [None, None, None, None, None, [1704067200, 0], None, None, [1704067200, 0]],
         ]
 
+        # Both the creation slot (meta[8]) and modified slot (meta[5]) overflow.
+        data[5][8][0] = float("inf")
         data[5][5][0] = float("inf")
         notebook = Notebook.from_api_response(data)
 
         assert notebook.created_at is None
+        assert notebook.modified_at is None
 
     def test_from_api_response_non_string_title(self):
         """Test parsing when title is not a string."""
@@ -1980,6 +2076,7 @@ class TestNotebookMetadata:
             title="Test Notebook",
             created_at=datetime(2024, 1, 1, 12, 0),
             is_owner=True,
+            modified_at=datetime(2024, 1, 2, 9, 30),
         )
         metadata = NotebookMetadata(
             notebook=notebook,
@@ -1994,6 +2091,7 @@ class TestNotebookMetadata:
             "id": "nb_123",
             "title": "Test Notebook",
             "created_at": "2024-01-01T12:00:00",
+            "modified_at": "2024-01-02T09:30:00",
             "is_owner": True,
             "sources": [
                 {"type": "pdf", "title": "test.pdf", "url": None},
@@ -2012,12 +2110,14 @@ class TestNotebookMetadata:
             title="Proxy Test",
             created_at=datetime(2024, 2, 1),
             is_owner=False,
+            modified_at=datetime(2024, 3, 1),
         )
         metadata = NotebookMetadata(notebook=notebook)
 
         assert metadata.id == "nb_456"
         assert metadata.title == "Proxy Test"
         assert metadata.created_at == datetime(2024, 2, 1)
+        assert metadata.modified_at == datetime(2024, 3, 1)
         assert metadata.is_owner is False
 
     def test_to_dict_with_none_created_at(self):


### PR DESCRIPTION
## Summary

Fixes #1535. `Notebook.created_at` exposed the notebook's **last-modified** time, not its creation time — confirmed by a controlled e2e probe **and** the recorded cassette corpus.

`Notebook.from_api_response` read the timestamp from `data[5][5]`, but that slot *advances on every modification*; the stable creation instant lives at `data[5][8]`. The e2e probe (create → add source @T0 → wait → add source @T1 → diff every epoch in the raw response) showed `data[5][5]` jumping to the second source-add time while `data[5][8]` stayed at creation. Both recorded cassettes agree (modified slot is always later than created):

| Cassette | `data[5][5]` (modified) | `data[5][8]` (created) |
|---|---|---|
| `notebooks_list.yaml` row 0 | `1768311605` (Jan 13) | `1768174413` (Jan 11) |
| `notebooks_get.yaml` | `1768963937` (Jan 21) | `1767921609` (Jan 9) |

### What changed
- **`created_at` now reads `data[5][8]`** (the true creation slot) — and only when `len(meta) > 8`, so a too-short block soft-degrades to `None` rather than falling back to the wrong slot (which would re-introduce the bug). codex decoded all 558 notebook rows in the cassette corpus: metadata lengths are only 13/16/19, never `meta[5]`-present-but-`meta[8]`-absent.
- **`Notebook.modified_at: datetime | None`** newly exposed from `data[5][5]` (additive field, appended last, default `None`).
- Both route through the (tz-aware UTC since #1519) `_datetime_from_timestamp`; covers `notebooks.list` (homepage feed `wXbhsf`) + `get` (both go through `from_api_response`).
- `modified_at` added to every Notebook JSON serialization site (`list/create --json`, `use --json`, `NotebookMetadata.to_dict()`); `_app.serialize.to_jsonable` picks it up via dataclass fields.

### Tests (red-first)
- `test_from_api_response_created_modified_not_swapped` — proven red against the old code (returned `meta[5]` as `created_at`).
- Length-guard policy: `len(meta)==6` with `meta[5]` set, `meta[8]` absent → `created_at` None, `modified_at` populated (no wrong-slot fallback).
- Golden-decoded pins corrected to the `data[5][8]`/`data[5][5]` epochs + a cassette-bytes sanity check. **Zero cassette re-records.**

### Verification
- Full `uv run pytest -m "not e2e"`: 9794 passed (2 pre-existing env failures needing the `browser` extra, identical on main)
- mypy clean (239 files) · ruff clean · API-compat audit exit 0 (additive `modified_at`, no signature change) · full `tests/_guardrails/` green

### Review
claude implementer + codex independent review (positional-decode + shipped-field scrutiny) → **SHIP**, no Critical/Important. codex empirically ruled out the length-guard regression across the whole cassette corpus.

Closes #1535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected `created_at` timestamp source in notebook data for improved accuracy.

* **New Features**
  * Added `modified_at` field to notebook data objects.
  * Updated `notebooks.get()`, `notebooks.list()`, and all notebook CLI commands (`--json` outputs) to include `modified_at`.
  * Extended metadata serialization to include the new `modified_at` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->