### PR TITLE
fix(mcp): flatten notebook_create output shape (#1540)

### DIFF
--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -47,7 +47,15 @@ def register(mcp: Any) -> None:
         client = get_client(ctx)
         with mcp_errors():
             result = await core.execute_notebook_create(client, title)
-            return to_jsonable(result)
+            # Flatten the created notebook to a top-level shape consistent with
+            # the sibling create tool (``note_create``) and ``notebook_delete``,
+            # which key the notebook by ``notebook_id`` rather than nesting the
+            # record under a ``notebook`` key (#1540). The remaining Notebook
+            # fields (title, created_at, sources_count, is_owner, modified_at)
+            # stay at the top level so no metadata is dropped.
+            notebook = to_jsonable(result.notebook)
+            notebook_id = notebook.pop("id")
+            return {"notebook_id": notebook_id, **notebook}
 
     @mcp.tool(annotations=READ_ONLY)
     async def notebook_describe(ctx: Context, notebook: str) -> dict[str, Any]:

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -157,10 +157,9 @@ class TestMcpLifecycle:
 
         # Create via MCP.
         created = await _call(client, "notebook_create", {"title": title})
-        notebook = created["notebook"]
-        nb_id = notebook["id"]
+        nb_id = created["notebook_id"]
         assert nb_id
-        assert notebook["title"] == title
+        assert created["title"] == title
         created_notebooks.append(nb_id)
 
         # Describe via MCP (resolves the full id directly — read path).
@@ -193,7 +192,7 @@ class TestMcpNameResolution:
         """A notebook created with a unique title is reachable by that title."""
         title = f"E2E-MCP-Name-{uuid4().hex[:8]}"
         created = await _call(client, "notebook_create", {"title": title})
-        nb_id = created["notebook"]["id"]
+        nb_id = created["notebook_id"]
         created_notebooks.append(nb_id)
 
         # Drive describe with the TITLE (not the id) — the MCP resolver must

--- a/tests/integration/mcp_vcr/test_notebooks.py
+++ b/tests/integration/mcp_vcr/test_notebooks.py
@@ -15,8 +15,8 @@ value is decorative — reusing the recorded id keeps intent obvious.
 The point of these tests is to PIN the serialized ``structured_content`` wire
 shape an MCP client actually receives — which differs per tool:
 
-* ``notebook_create`` nests the created notebook under a ``notebook`` key
-  (``to_jsonable(NotebookCreateResult(notebook=...))``).
+* ``notebook_create`` is flat: the created notebook's fields at the top level
+  with its id exposed as ``notebook_id`` (#1540) — matching ``note_create``.
 * ``notebook_describe`` is flat: ``{"notebook_id", "description": {...}}``.
 * ``notebook_rename`` is flat: ``{"notebook_id", "new_title"}``.
 * ``notebook_delete`` (confirmed) is flat: ``{"status", "notebook_id"}``.
@@ -51,26 +51,32 @@ async def test_mcp_notebook_create_over_vcr() -> None:
     ``execute_notebook_create`` -> ``client.notebooks.create`` -> recorded
     ``CREATE_NOTEBOOK`` (``CCqFvf``) RPC.
 
-    Pins the *nested* wire shape: the tool serializes
-    ``NotebookCreateResult(notebook=...)`` via ``to_jsonable``, so the created
-    notebook lands UNDER a ``notebook`` key (NOT flat) — the asymmetry with
-    ``note_create`` (flat) this suite exists to catch.
+    Pins the *flat* wire shape: the created notebook's fields land at the top
+    level with its id exposed as ``notebook_id`` (matching ``note_create`` and
+    ``notebook_delete``), NOT nested under a ``notebook`` key (#1540).
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool("notebook_create", {"title": CREATE_TITLE})
 
     structured = result.structured_content
     assert isinstance(structured, dict)
-    # Nested under "notebook" — the load-bearing asymmetry vs. flat note_create.
-    assert "notebook" in structured
-    notebook = structured["notebook"]
-    assert isinstance(notebook, dict)
-    # The Notebook dataclass fields the RPC row decodes to.
-    assert notebook.get("id"), "created notebook is missing an id"
-    assert "title" in notebook
-    assert "created_at" in notebook
-    assert "sources_count" in notebook
-    assert "is_owner" in notebook
+    # Flat: the id is exposed as ``notebook_id`` and the record is NOT nested.
+    assert structured.get("notebook_id"), "created notebook is missing a notebook_id"
+    # Pin the EXACT flat key set — every ``Notebook`` dataclass field, with
+    # ``id`` renamed to ``notebook_id``. Asserting the exact set (not just
+    # ``in`` checks) is the load-bearing guard: it catches BOTH a regression
+    # back to the nested ``{"notebook": ...}`` shape AND a silently dropped
+    # field such as ``modified_at`` ("no metadata is dropped"). A new Notebook
+    # field will fail this assertion by design, forcing a conscious wire-shape
+    # decision.
+    assert set(structured) == {
+        "notebook_id",
+        "title",
+        "created_at",
+        "sources_count",
+        "is_owner",
+        "modified_at",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/integration/mcp_vcr/test_notes.py
+++ b/tests/integration/mcp_vcr/test_notes.py
@@ -12,12 +12,11 @@ notebook/note ids, decoded from each ``f.req`` body) so :func:`resolve_notebook`
 body matcher is shape-only for batchexecute requests, so the id value itself is
 decorative.
 
-The point is to PIN the serialized ``structured_content`` wire shape — which is
-INCONSISTENT with the notebook tools:
+The point is to PIN the serialized ``structured_content`` wire shape — each note
+tool builds its dict BY HAND (not ``to_jsonable`` over a result dataclass):
 
 * ``note_create`` is FLAT with a ``created: true`` flag
-  (``{"notebook_id", "title", "note_id", "created"}``) — note the contrast with
-  ``notebook_create``, which nests under a ``notebook`` key.
+  (``{"notebook_id", "title", "note_id", "created"}``).
 * ``note_list`` is ``{"notebook_id", "notes": [...]}``.
 * ``note_delete`` (confirmed) is ``{"status", "notebook_id", "note_id"}``.
 
@@ -57,10 +56,9 @@ async def test_mcp_note_create_over_vcr() -> None:
     ``CREATE_NOTE`` (``CYK0Xb``) THEN finalizes title/content via ``UPDATE_NOTE``
     (``cYAfTb``) — both recorded in ``notes_create.yaml``.
 
-    Pins the FLAT ``created``-flag wire shape — the load-bearing asymmetry vs.
-    ``notebook_create``, which nests under a ``notebook`` key. The note tool
-    builds its dict by hand (not ``to_jsonable`` over a result dataclass), so the
-    shape is hand-authored and worth pinning verbatim.
+    Pins the FLAT ``created``-flag wire shape. The note tool builds its dict by
+    hand (not ``to_jsonable`` over a result dataclass), so the shape is
+    hand-authored and worth pinning verbatim.
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -48,7 +48,9 @@ async def test_notebook_list(mcp_call, mock_client) -> None:
 async def test_notebook_create(mcp_call, mock_client) -> None:
     mock_client.notebooks.create = AsyncMock(return_value=FakeNotebook(id=NB_ID, title="New"))
     result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {"notebook": {"id": NB_ID, "title": "New"}}
+    # Flat shape with the id exposed as ``notebook_id`` (#1540), matching
+    # ``note_create`` / ``notebook_delete`` rather than nesting under "notebook".
+    assert result.structured_content == {"notebook_id": NB_ID, "title": "New"}
     mock_client.notebooks.create.assert_awaited_once_with("New")
 
 


### PR DESCRIPTION
## Summary

Normalizes the MCP `notebook_create` tool's output shape. It previously returned the created notebook **nested** under a `notebook` key (`to_jsonable(NotebookCreateResult(notebook=...))`), while every sibling create/mutation tool — `note_create`, `notebook_delete` — exposes the notebook id **flat** as `notebook_id`. An agent therefore had to special-case `notebook_create` (`result["notebook"]["id"]`) where every other tool is flat.

Now `notebook_create` returns the flat shape:

```json
{ "notebook_id": "...", "title": "...", "created_at": "...", "sources_count": 0, "is_owner": true, "modified_at": null }
```

(the `Notebook` dataclass fields with `id` renamed to `notebook_id` — no metadata is dropped).

Fixes #1540.

## Why this is safe

The MCP server (`src/notebooklm/mcp/`) is newly merged to `main` and **unreleased**, so there is no backward-compatibility constraint — this is the moment to settle on the consistent shape. The CLI's separate `--json` envelope (which legitimately uses a `notebook` key) is untouched; this only affects the MCP wire surface.

## Changes

- `src/notebooklm/mcp/tools/notebooks.py` — `notebook_create` flattens `to_jsonable(result.notebook)`, exposing `id` as top-level `notebook_id`.
- `tests/unit/mcp/test_notebooks.py` — assertion updated to the flat shape.
- `tests/integration/mcp_vcr/test_notebooks.py` — docstrings updated; the VCR test now pins the **exact** flat key set, so a regression back to the nested shape *or* a silently dropped field (e.g. `modified_at`) fails loudly.
- `tests/integration/mcp_vcr/test_notes.py` — comment-only: removes the now-stale "`notebook_create` nests" contrast.
- `tests/e2e/test_mcp.py` — two read sites updated from `created["notebook"]["id"]` to `created["notebook_id"]`.

## Verification

- Whole-tree audit (both reviewers, src/tests/docs/desktop-extension): **no remaining readers of the old nested shape** would break.
- `uv run pytest` (affected unit + mcp_vcr + manifest), `uv run mypy src/notebooklm --ignore-missing-imports`, `uv run ruff check . && uv run ruff format --check .` — all green.
- Polished (code-simplifier + claude + codex review); the one consensus Minor (test didn't assert `modified_at`) is fixed via the exact-key-set assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the notebook creation response format to expose notebook ID and properties at the top level, aligning with other notebook tools for consistent API behavior.

* **Tests**
  * Updated integration and unit tests to validate the new response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->