### PR TITLE
docs(architecture): _app hub + three thin adapters (CLI/MCP/REST)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ exactly one client runtime and one RPC stack:
 | --- | --- | --- | --- | --- | --- |
 | **CLI** | `cli/` | terminal (Click) | `notebooklm` | base | exit codes + the byte-stable `--json` error envelope (ADR-0015) |
 | **MCP** | `mcp/` | Model Context Protocol (FastMCP) | `notebooklm-mcp` | `mcp` extra · experimental | MCP tool error content (`CODE: message`) |
-| **REST** | `server/` | HTTP (FastAPI) | `notebooklm-server` | `server` extra · experimental | HTTP status + `{"error": {"category", "message"}}` |
+| **REST** | `server/` | HTTP (FastAPI) | `notebooklm-server` | `server` extra · experimental | HTTP status + `{"error": {"category": "...", "message": "..."}}` |
 
 ### Transport-neutral application layer (`_app/`)
 
@@ -667,7 +667,7 @@ The MCP server is a second thin adapter beside `cli/`, opt-in behind the `mcp`
 extra and **experimental** (preview). `create_server()` builds a FastMCP server
 that exposes the `_app/` cores as MCP tools driving a single long-lived
 `NotebookLMClient`; run it with the `notebooklm-mcp` console script (stdio or
-loopback HTTP). Like the CLI it imports no `click` / `rich` / `cli` — it is built
+loopback HTTP). It imports no `click` / `rich` / `cli` — like the CLI, it is built
 on the `_app/` cores only (enforced by `tests/_guardrails/test_mcp_boundary.py`).
 Failures surface as `CODE: message` strings projected from `_app.errors.classify`,
 and mutating tools are confirmation-gated (they return a `needs_confirmation`
@@ -689,7 +689,7 @@ surface is disabled. Long-running work (source ingest, artifact generation) uses
 the **poll-the-resource** model — the create call returns immediately and the
 matching `GET` reports `pending` / `200` / `404` / `409` / `410`. Failures project
 from `_app.errors.classify` onto an HTTP status plus the
-`{"error": {"category", "message"}}` envelope. It imports no `click` / `rich` /
+`{"error": {"category": "...", "message": "..."}}` envelope. It imports no `click` / `rich` /
 `cli` (enforced by `tests/_guardrails/test_server_boundary.py`). Launch and
 configuration: [`docs/installation.md`](./installation.md#rest-api-server).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,30 +8,38 @@ the historical narrative lives in
 ## Layered overview
 
 ```text
+            three thin, transport-specific adapters
++----------------+  +----------------+  +----------------+
+| CLI    (cli/)  |  | MCP    (mcp/)  |  | REST (server/) |
+| Click commands |  | FastMCP tools  |  | FastAPI routes |
++----------------+  +----------------+  +----------------+
+         \                  |                  /
+          \                 |                 /
+           +----------------+----------------+
+                            ▼
 +----------------------------------------------------------+
-| CLI Layer (src/notebooklm/cli/*)                         |
-|   Top-level commands (login, use, status, list, ask,     |
-|   doctor, completion, ...) registered by the session/    |
-|   notebook/chat/doctor modules; plus subcommand groups   |
-|   (source, artifact, agent, generate, download, note,    |
-|   share, skill, research, language, profile). Pure       |
-|   adapter — no RPC logic.                                |
+| Application Layer  (src/notebooklm/_app/*)               |
+|   Transport-neutral business logic shared by all three   |
+|   adapters: id validation/resolution, plan-building,     |
+|   status projection, retry/wait orchestration,           |
+|   errors.classify (the single failure-category source),  |
+|   diagnostics. Imports no click / rich / fastmcp /       |
+|   fastapi (boundary lint-enforced; ADR-0021).            |
 +----------------------------------------------------------+
-                          ▼
+                            ▼
 +----------------------------------------------------------+
 | Client Layer (client.py + feature APIs)                  |
 |   NotebookLMClient + namespaced sub-clients:             |
 |     .notebooks  .sources  .artifacts  .chat              |
 |     .notes      .research  .settings  .sharing           |
 +----------------------------------------------------------+
-                          ▼
+                            ▼
 +----------------------------------------------------------+
 | Runtime Layer (client-owned collaborators)               |
-|   NotebookLMClient owns ClientComposed plus focused       |
-|   collaborators such as RpcExecutor, RuntimeTransport,   |
-|   ClientLifecycle, and Kernel.                           |
+|   ClientComposed + RpcExecutor, RuntimeTransport,        |
+|   ClientLifecycle, Kernel.                               |
 +----------------------------------------------------------+
-                          ▼
+                            ▼
 +----------------------------------------------------------+
 | RPC Layer (src/notebooklm/rpc/*)                         |
 |   types.py    method IDs + enums (source of truth)       |
@@ -40,20 +48,34 @@ the historical narrative lives in
 +----------------------------------------------------------+
 ```
 
+Three thin **transport adapters** fan into that one shared core; everything below
+`_app/` is then identical regardless of which adapter drove the call — there is
+exactly one client runtime and one RPC stack:
+
+| Adapter | Package | Transport | Console script | Install | Failures render as |
+| --- | --- | --- | --- | --- | --- |
+| **CLI** | `cli/` | terminal (Click) | `notebooklm` | base | exit codes + the byte-stable `--json` error envelope (ADR-0015) |
+| **MCP** | `mcp/` | Model Context Protocol (FastMCP) | `notebooklm-mcp` | `mcp` extra · experimental | MCP tool error content (`CODE: message`) |
+| **REST** | `server/` | HTTP (FastAPI) | `notebooklm-server` | `server` extra · experimental | HTTP status + `{"error": {"category", "message"}}` |
+
 ### Transport-neutral application layer (`_app/`)
 
-The CLI is a thin adapter over `src/notebooklm/_app/` — transport-neutral
-business logic (id validation/resolution, plan-building, status projection,
-retry/wait orchestration, error classification, diagnostics) shared by the CLI
-and other front-ends (a FastMCP server, a future HTTP surface). Each adapter
-parses its own inputs into typed `Request`/`Plan`/`Result` dataclasses, calls
-the neutral core, and renders the typed result into its own envelope vocabulary
-(the CLI builds the byte-stable `--json` envelope; ADR-0015). The package imports
-no `click`/`rich`/`cli`/`fastmcp` — the boundary is lint-enforced — and raises
-only the public `notebooklm.exceptions` hierarchy, with `_app.errors.classify`
-as the single neutral source of the failure-category decision each adapter
-projects onto its own codes. See ADR-0021. The per-module index and the full
-tree are in [File map](#file-map) below.
+The CLI, the MCP server (`mcp/`), and the REST server (`server/`) are each thin
+adapters over `src/notebooklm/_app/` — transport-neutral business logic (id
+validation/resolution, plan-building, status projection, retry/wait
+orchestration, error classification, diagnostics) shared by all three
+front-ends. Each adapter parses its transport's inputs into typed
+`Request`/`Plan`/`Result` dataclasses, calls the neutral core (which receives the
+live client), and renders the typed result into its own envelope vocabulary;
+simple reads/mutations call the `client.*` namespaces directly, while multi-step
+flows go through the `_app/` cores. The package imports no transport framework —
+`click` / `rich` / `fastmcp` / `fastapi`, nor the `cli` / `server` / `rpc`
+sibling packages — with the boundary lint-enforced
+(`tests/_guardrails/test_app_boundary.py`). It raises only the public
+`notebooklm.exceptions` hierarchy, with `_app.errors.classify` as the single
+neutral source of the failure-category decision each adapter projects onto its
+own codes (CLI exit codes, MCP error shapes, REST HTTP statuses). See ADR-0021.
+The per-module index and the full tree are in [File map](#file-map) below.
 
 ## Library call flows
 
@@ -71,7 +93,7 @@ Most public methods (`client.notebooks.list()`, `client.sources.rename()`,
 
 ```text
 +----------------------------------------------------------------+
-| CLI command or user code                                       |
+| CLI command / MCP tool / REST route / library call             |
 +----------------------------------------------------------------+
                                  |
                                  v
@@ -639,6 +661,38 @@ the CLI — the rest stays behind the `auth.py` facade. The same test keeps
 low-level helpers (`runtime`, `context`, `resolve`, `rendering`,
 `auth_runtime`, `options`) from growing upward dependencies on command modules
 or the `cli.helpers` compatibility facade.
+
+## MCP adapter (`mcp/`)
+
+The MCP server is a second thin adapter beside `cli/`, opt-in behind the `mcp`
+extra and **experimental** (preview). `create_server()` builds a FastMCP server
+that exposes the `_app/` cores as MCP tools driving a single long-lived
+`NotebookLMClient`; run it with the `notebooklm-mcp` console script (stdio or
+loopback HTTP). Like the CLI it imports no `click` / `rich` / `cli` — it is built
+on the `_app/` cores only (enforced by `tests/_guardrails/test_mcp_boundary.py`).
+Failures surface as `CODE: message` strings projected from `_app.errors.classify`,
+and mutating tools are confirmation-gated (they return a `needs_confirmation`
+preview unless called with `confirm=true`). `notebooklm mcp install <client>`
+wires it into Claude Desktop/Code, Cursor, or Windsurf, and `desktop-extension/`
+packages a one-click `.mcpb` bundle. Full guide:
+[`docs/mcp-guide.md`](./mcp-guide.md).
+
+## REST server (`server/`)
+
+The single-tenant REST server is the third adapter (ADR-0021), opt-in behind the
+`server` extra and **experimental**. A FastAPI app maps `/v1` routes onto the
+`_app/` cores and the public client namespaces, with one `NotebookLMClient` opened
+once at the ASGI lifespan inside the server loop (honoring the ADR-0004 loop-
+affinity contract). Every `/v1` request requires a static bearer token
+(constant-time compare) plus a loopback `Host` literal (a DNS-rebinding guard);
+`/healthz` is the one public route, and the `/docs` / `/openapi.json` schema
+surface is disabled. Long-running work (source ingest, artifact generation) uses
+the **poll-the-resource** model — the create call returns immediately and the
+matching `GET` reports `pending` / `200` / `404` / `409` / `410`. Failures project
+from `_app.errors.classify` onto an HTTP status plus the
+`{"error": {"category", "message"}}` envelope. It imports no `click` / `rich` /
+`cli` (enforced by `tests/_guardrails/test_server_boundary.py`). Launch and
+configuration: [`docs/installation.md`](./installation.md#rest-api-server).
 
 ## Middleware chain (ADR-0009)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,8 @@
-# Architecture (post-v0.5.0)
+# Architecture
 
-This document describes the runtime shape of `notebooklm-py` after the
-v0.5.0 refactor program closed. It is the canonical post-refactor map;
-the historical narrative lives in
-[`docs/refactor-history.md`](./refactor-history.md).
+This document is the canonical map of `notebooklm-py`'s current runtime shape.
+The historical refactor narrative (including the program that first established
+this layering) lives in [`docs/refactor-history.md`](./refactor-history.md).
 
 ## Layered overview
 
@@ -1277,7 +1276,7 @@ src/notebooklm/
 - [ADR-0010](./adr/0010-session-kernel-split.md) — Session/Kernel split (Superseded by ADR-0013).
 - [ADR-0011](./adr/0011-schema-validation-policy.md) — Schema validation policy (Accepted; `safe_index` is the canonical decode helper).
 - [ADR-0012](./adr/0012-implementation-surface-convention.md) — Implementation surface convention (Accepted; underscore-prefix = unsupported import surface).
-- [ADR-0013](./adr/0013-composable-session-capabilities.md) — Composable Session Capabilities (the post-v0.5.0 capability model).
+- [ADR-0013](./adr/0013-composable-session-capabilities.md) — Composable Session Capabilities (the composable session-capability model).
 - [ADR-0014](./adr/0014-feature-local-runtime-adapters.md) — Feature-local runtime adapters (Accepted; features receive direct collaborators instead of `Session`).
 - [ADR-0015](./adr/0015-json-envelope-contract-for-post-parse-click-exceptions.md) — Typed JSON error envelope for post-parse CLI failures (Accepted).
 - [ADR-0021](./adr/0021-transport-neutral-app-layer.md) — Transport-neutral application layer (`_app/`) (Accepted; boundary enforced by `tests/_guardrails/test_app_boundary.py`, classify↔error_handler agreement by `tests/_guardrails/test_classify_error_handler_consistency.py`).


### PR DESCRIPTION
The architecture doc's layered overview still framed the system as CLI-only and called MCP/REST "a FastMCP server, a future HTTP surface" — both are now shipped (MCP #1484, REST #1538). This updates `docs/architecture.md` to the current shape.

## Changes (docs-only)
- **Layered overview diagram** rewritten: three thin transport adapters (`cli/`, `mcp/`, `server/`) fan into the transport-neutral `_app/` core → client → runtime → rpc. One client runtime + one RPC stack below the fan-in.
- **Adapter table** added — package · transport · console script · install/extra · how failures render — making the triad explicit.
- **`_app/` prose** refreshed: names all three shipped adapters, the lint-enforced boundary (no `click`/`rich`/`fastmcp`/`fastapi`, no `cli`/`server`/`rpc`), and the simple-op-via-`client.*` vs multi-step-via-`_app`-core nuance.
- Added **`## MCP adapter`** and **`## REST server`** sections parallel to the existing `## CLI layer`.
- Generalized the typed-RPC call-flow top box: `CLI command / MCP tool / REST route / library call`.

## Verification
- All inline module/file refs resolve (`test_mcp_boundary.py`, `test_server_boundary.py`, `mcp-guide.md`, `installation.md#rest-api-server`).
- `check_docs_module_refs.py` ✅ · `check_claude_md_freshness.py` ✅
- Every claim cross-checked against source (boundary lint set, console scripts, extras, experimental status, `_app.errors.classify` projection in all three adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked architecture docs to present CLI, MCP, and REST as thin transport adapters over a shared core; updated diagrams and adapter-to-core boundary descriptions to clarify request/plan/result parsing and envelope rendering.
  * Added an adapter comparison table and new sections describing the MCP adapter and an experimental single-tenant REST server, covering routing, long-lived client handling, error envelope formats, and confirmation/polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->