### PR TITLE
docs(install): lead with uv tool / pipx; explain PEP 668 (macOS/Linux pip fails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,20 @@ These features are available via API/CLI but not exposed in NotebookLM's web int
 
 The full install guide — six personas (agent, end-user, library, headless, contributor, power-user), optional extras matrix, platform notes — lives in **[docs/installation.md](docs/installation.md)**.
 
-**Quickest start** (CLI users and AI agents):
+**Quickest start** (CLI users and AI agents) — install in an isolated tool environment, which also sidesteps the locked-down system Python on modern macOS/Linux ([PEP 668](https://peps.python.org/pep-0668/)):
 
 ```bash
-pip install "notebooklm-py[browser]"   # core + Playwright
-playwright install chromium             # ~170 MB; no progress bar — be patient (30–90 s)
-notebooklm login                        # opens browser for Google sign-in
-notebooklm auth check --test --json     # verify: expect "status": "ok"
+uv tool install "notebooklm-py[browser]"   # or: pipx install "notebooklm-py[browser]"
+notebooklm login                           # first run auto-downloads Chromium (~170 MB), then Google sign-in
+notebooklm auth check --test --json        # verify: expect "status": "ok"
 ```
+
+> Plain `pip install "notebooklm-py[browser]"` works **inside a virtualenv**. Outside one, modern macOS (Homebrew Python) and Debian/Ubuntu reject it with `error: externally-managed-environment` — use `uv tool` / `pipx` above, or a venv. (On Windows, python.org's Python is not externally-managed, so `pip install` is fine.)
 
 **As a library** (embedded in your app — no Playwright, no Chromium):
 
 ```bash
-pip install notebooklm-py               # ~10 MB; ship a pre-acquired storage_state.json
+uv add notebooklm-py                    # or, inside a virtualenv: pip install notebooklm-py
 ```
 
 If `playwright install chromium` fails on Linux with `TypeError: onExit is not a function`, see the [Linux workaround](docs/troubleshooting.md#linux). **Contributors:** see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These features are available via API/CLI but not exposed in NotebookLM's web int
 
 The full install guide — six personas (agent, end-user, library, headless, contributor, power-user), optional extras matrix, platform notes — lives in **[docs/installation.md](docs/installation.md)**.
 
-**Quickest start** (CLI users and AI agents) — install in an isolated tool environment, which also sidesteps the locked-down system Python on modern macOS/Linux ([PEP 668](https://peps.python.org/pep-0668/)):
+**Quickest start** (CLI users and AI agents) — install the CLI with `uv tool` (recommended) or `pipx`:
 
 ```bash
 uv tool install "notebooklm-py[browser]"   # or: pipx install "notebooklm-py[browser]"
@@ -98,7 +98,14 @@ notebooklm login                           # first run auto-downloads Chromium (
 notebooklm auth check --test --json        # verify: expect "status": "ok"
 ```
 
-> Plain `pip install "notebooklm-py[browser]"` works **inside a virtualenv**. Outside one, modern macOS (Homebrew Python) and Debian/Ubuntu reject it with `error: externally-managed-environment` — use `uv tool` / `pipx` above, or a venv. (On Windows, python.org's Python is not externally-managed, so `pip install` is fine.)
+**Why `uv tool` / `pipx`?** They install the CLI into its own isolated environment and put `notebooklm` on your `PATH` — no dependency clashes with other tools, a one-line upgrade (`uv tool upgrade notebooklm-py`) or uninstall, and, crucially, they work on modern macOS (Homebrew Python) and Debian/Ubuntu where a system-wide `pip install` is blocked with `error: externally-managed-environment` ([PEP 668](https://peps.python.org/pep-0668/)). No `uv` yet? `curl -LsSf https://astral.sh/uv/install.sh | sh` (or `brew install uv` / `winget install astral-sh.uv`).
+
+**Prefer plain `pip`?** It works the same **inside a virtualenv** (and directly on Windows, where Python isn't externally-managed):
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install "notebooklm-py[browser]"
+```
 
 **As a library** (embedded in your app — no Playwright, no Chromium):
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,14 +37,25 @@ This is the canonical installation guide for `notebooklm-py`. The README has a q
 
 ## Quick install (TL;DR by persona)
 
+> **Installing the CLI on macOS / Linux — use an isolated installer.** Plain
+> `pip install` into the *system* interpreter fails on modern macOS (Homebrew
+> Python) and Debian/Ubuntu with `error: externally-managed-environment`
+> ([PEP 668](https://peps.python.org/pep-0668/)). For CLI/app use, prefer
+> **`uv tool install`** or **`pipx install`** — they put `notebooklm` (and
+> `notebooklm-mcp` / `notebooklm-server`) on your PATH in a dedicated environment
+> without touching system Python. Plain `pip` still works **inside a virtualenv**
+> and on **Windows** (python.org's Python is not externally-managed). Library
+> users install into their own project's venv (`uv add` / `pip install`), so
+> PEP 668 never applies.
+
 | Persona | Install command |
 |---|---|
-| **A — AI Agent** | `pip install "notebooklm-py[browser]"` (then optionally `pip install "notebooklm-py[cookies]"` if Python < 3.13) |
-| **B — End user** | `pip install "notebooklm-py[browser]"` (or `pipx install "notebooklm-py[browser]"` for isolation) |
-| **C — Library user** | `pip install notebooklm-py` |
-| **D — Headless server / CI** | `pip install notebooklm-py` (no Playwright; ship a `storage_state.json`) |
+| **A — AI Agent** | `pip install "notebooklm-py[browser]"` in the user's active env (fall back to `uv tool install` / `pipx install` on an *externally-managed-environment* error) |
+| **B — End user** | `uv tool install "notebooklm-py[browser]"` or `pipx install "notebooklm-py[browser]"` (isolated; avoids the PEP 668 error) |
+| **C — Library user** | `uv add notebooklm-py` (or `pip install notebooklm-py` inside your project venv) |
+| **D — Headless server / CI** | `pip install notebooklm-py` inside a venv/container; ship a `storage_state.json` (no Playwright) |
 | **E — Contributor** | `uv sync --frozen --extra browser --extra dev --extra markdown && uv run playwright install chromium && uv run pre-commit install` |
-| **F — Power user** | `pip install "notebooklm-py[browser,cookies,markdown]"` (Python ≤ 3.12 only) |
+| **F — Power user** | `uv tool install "notebooklm-py[browser,cookies,markdown]"` (Python ≤ 3.12 only) |
 
 ---
 
@@ -73,6 +84,8 @@ else
     echo "Skipping [cookies] on Python 3.13+ (rookiepy unavailable). Use 'notebooklm login' interactively."
 fi
 ```
+
+> If `pip install` errors with `externally-managed-environment` (modern macOS / Debian system Python, [PEP 668](https://peps.python.org/pep-0668/)), retry with `uv tool install "notebooklm-py[browser]"` or `pipx install "notebooklm-py[browser]"` — isolated installs that don't touch system Python. Inside an active virtualenv, `pip` works as-is.
 
 **Why two separate calls (not `[browser,cookies]`):** the combined form is atomic — if `rookiepy` fails to compile, the whole install fails and the user gets **nothing**. Splitting means `[browser]` always succeeds; `[cookies]` is recoverable.
 
@@ -129,20 +142,22 @@ Occasional CLI use.
 
 **Prerequisites:** Python 3.10+ already installed.
 
-**Recommended (cross-platform default, including Windows):**
-
-<!-- not mirrored: end-user pip install (Persona B); CONTRIBUTING.md tracks the in-repo `uv sync` flow only -->
-```bash
-pip install "notebooklm-py[browser]"
-```
-
-For an isolated install (avoids polluting your env), use `pipx` or `uv tool`:
+**Recommended — isolated install (macOS / Linux / Windows):**
 
 <!-- not mirrored: end-user isolated install (pipx / uv tool); CONTRIBUTING.md targets in-repo contributors -->
 ```bash
-pipx install "notebooklm-py[browser]"
-# OR (if you already have uv: https://docs.astral.sh/uv/getting-started/installation/)
 uv tool install "notebooklm-py[browser]"
+# OR, with pipx:
+pipx install "notebooklm-py[browser]"
+```
+
+Both put `notebooklm` on your PATH in a dedicated environment, so they work even where the system Python is locked down — modern macOS (Homebrew) and Debian/Ubuntu reject a plain `pip install` into it with `error: externally-managed-environment` ([PEP 668](https://peps.python.org/pep-0668/)). (If you don't have `uv` yet: <https://docs.astral.sh/uv/getting-started/installation/>.)
+
+Plain `pip` is fine **inside a virtualenv**, or on Windows (python.org's Python is not externally-managed):
+
+<!-- not mirrored: end-user pip install in a venv (Persona B); CONTRIBUTING.md tracks the in-repo `uv sync` flow only -->
+```bash
+pip install "notebooklm-py[browser]"
 ```
 
 **Post-install:** Run `notebooklm login` once. The CLI auto-installs Chromium on first run (~170 MB, 30–90 s, **no progress bar — be patient**).
@@ -293,13 +308,14 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 
 ## REST API server
 
-> **⚠️ Experimental.** Like the drafted MCP adapter, the REST server is experimental: the `/v1` surface and behavior may change in a minor release, and it is excluded from the public-API compatibility gate. Pin a version before relying on it for automation. The server also logs an experimental warning on every startup.
+> **⚠️ Experimental.** Like the MCP adapter, the REST server is experimental: the `/v1` surface and behavior may change in a minor release, and it is excluded from the public-API compatibility gate. Pin a version before relying on it for automation. The server also logs an experimental warning on every startup.
 
 A single-tenant, localhost REST API over the same transport-neutral core as the CLI — the natural shape for scripting and agent automation (feed a notebook, generate an artifact, pull it down) without spawning a CLI process per call.
 
 <!-- not mirrored: the server extra is end-user/automation tooling, not part of the contributor `uv sync` flow; CONTRIBUTING.md tracks only browser/dev/markdown. -->
 ```bash
-pip install "notebooklm-py[server]"        # fastapi + uvicorn + python-multipart
+uv tool install "notebooklm-py[server]"    # fastapi + uvicorn + python-multipart
+# OR, with pipx:  pipx install "notebooklm-py[server]"   (or plain pip inside a venv)
 ```
 
 **Prerequisite:** a provisioned account (`storage_state.json`) from `notebooklm login`. The server holds one account for the process; it does not run browser login itself.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,7 @@ This is the canonical installation guide for `notebooklm-py`. The README has a q
 | **C — Library user** | `uv add notebooklm-py` (or `pip install notebooklm-py` inside your project venv) |
 | **D — Headless server / CI** | `pip install notebooklm-py` inside a venv/container; ship a `storage_state.json` (no Playwright) |
 | **E — Contributor** | `uv sync --frozen --extra browser --extra dev --extra markdown && uv run playwright install chromium && uv run pre-commit install` |
-| **F — Power user** | `uv tool install "notebooklm-py[browser,cookies,markdown]"` (Python ≤ 3.12 only) |
+| **F — Power user** | `uv tool install --python 3.12 "notebooklm-py[browser,cookies,markdown]"` (the `cookies` extra needs Python ≤ 3.12; `--python 3.12` makes uv provision a matching interpreter even if your default is 3.13+) |
 
 ---
 


### PR DESCRIPTION
## Problem
On modern macOS (Homebrew Python) and Debian/Ubuntu, installing a CLI with plain `pip install` into the **system** interpreter fails with `error: externally-managed-environment` ([PEP 668](https://peps.python.org/pep-0668/)). Our install docs led with exactly that (`pip install "notebooklm-py[browser]"`), so Mac/Linux users hit a wall on step one. (Learned from how [notebooklm-mcp-cli](https://github.com/jacob-bd/notebooklm-mcp-cli) leads with `uv tool install`.)

## Fix
Flip the **CLI/app** install guidance to isolated installers, which put `notebooklm` / `notebooklm-mcp` / `notebooklm-server` on PATH without touching system Python:

- **README quickstart** → leads with `uv tool install "notebooklm-py[browser]"` (or `pipx`), plus a note that plain `pip` works only inside a venv (or on Windows, where python.org Python isn't externally-managed). Library use → `uv add` / venv pip.
- **installation.md** → adds a PEP 668 callout under *Quick install*; updates the persona table (**B**/**F** → `uv tool`/`pipx`; **A** keeps the agent `pip` pattern with a fallback note; **C**/**D** clarified as project-venv/container); flips the Persona B detail to lead with the isolated installer; updates the REST-server `[server]` install command.
- Fixes a stale "drafted MCP adapter" reference (MCP is merged).

## Notes
- `pip` stays fully documented as the **in-venv / Windows** path — nothing removed, just re-ordered with the failure explained.
- **Windows** intentionally keeps `pip` (python.org Python is not externally-managed).
- SKILL.md's required agent `pip install "notebooklm-py[browser]"` line is untouched (the agent persona installs into the user's active env).
- Block-mirror parity (26 blocks) + `test_install_docs.py` (23) pass; no `notebooklm[...]`-without-`-py` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Recommend isolated CLI installs using `uv tool install` or `pipx` instead of plain `pip`
  * Added fallback flow for `pip` inside virtual environments and guidance for externally-managed (PEP 668) systems
  * Removed separate browser-driver install step and streamlined verification with `notebooklm auth check --test --json`
  * Clarified CLI, library (`uv add` option), and REST API server install paths and experimental warning text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->