### PR TITLE
ci: retry `uv sync` to absorb transient dep-resolution flakes

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -37,10 +37,10 @@ jobs:
         # absorbs flakes — it never masks a genuine resolution error.
         shell: bash
         run: |
-          attempt=1
+          attempt=1; max=3
           until uv sync --frozen --extra browser --extra dev --extra markdown; do
-            if [ "$attempt" -ge 3 ]; then
-              echo "::error::uv sync failed after 3 attempts" >&2
+            if [ "$attempt" -ge "$max" ]; then
+              echo "::error::uv sync failed after $max attempts" >&2
               exit 1
             fi
             echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -32,7 +32,21 @@ jobs:
           enable-cache: true
 
       - name: Sync locked env (browser + dev + markdown)
-        run: uv sync --frozen --extra browser --extra dev --extra markdown
+        # Retried to ride out transient registry/network blips: a real
+        # lockfile problem fails all 3 attempts identically, so this only
+        # absorbs flakes — it never masks a genuine resolution error.
+        shell: bash
+        run: |
+          attempt=1
+          until uv sync --frozen --extra browser --extra dev --extra markdown; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::uv sync failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+            sleep $((attempt * 15))
+            attempt=$((attempt + 1))
+          done
 
       - name: Install pip-audit into the locked env
         # Pin pip-audit on the current major (2.x) so two consecutive nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,7 +122,21 @@ jobs:
       # (same as the contributor workflow in docs/installation.md). Extras
       # cover the full E2E surface: `browser` = playwright, `dev` = pytest +
       # plugins, `markdown` = markdownify (used by source-conversion tests).
-      run: uv sync --frozen --extra browser --extra dev --extra markdown
+      # Retried to ride out transient registry/network blips: a real lockfile
+      # problem fails all 3 attempts identically, so this only absorbs flakes
+      # — it never masks a genuine resolution error.
+      shell: bash
+      run: |
+        attempt=1
+        until uv sync --frozen --extra browser --extra dev --extra markdown; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     - name: Get Playwright version
       id: playwright-version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,10 +127,10 @@ jobs:
       # — it never masks a genuine resolution error.
       shell: bash
       run: |
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen --extra browser --extra dev --extra markdown; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -95,7 +95,21 @@ jobs:
       # `uv sync --frozen` reproduces the lockfile-pinned dep tree. The RPC
       # health script (`scripts/check_rpc_health.py`) only needs the core
       # runtime deps — no `[browser]`/`[dev]`/`[markdown]` extras required.
-      run: uv sync --frozen
+      # Retried to ride out transient registry/network blips: a real lockfile
+      # problem fails all 3 attempts identically, so this only absorbs flakes
+      # — it never masks a genuine resolution error.
+      shell: bash
+      run: |
+        attempt=1
+        until uv sync --frozen; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     # Fail-fast preflight. The script itself rejects empty
     # NOTEBOOKLM_AUTH_JSON downstream, but checking at the workflow layer

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -100,10 +100,10 @@ jobs:
       # — it never masks a genuine resolution error.
       shell: bash
       run: |
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,10 @@ jobs:
         # `uv sync` has no internal retry across the full resolve+download.
         # A real lockfile problem fails all 3 attempts identically, so this
         # only absorbs flakes — it never masks a genuine resolution error.
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen --extra browser --extra dev --extra markdown; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
@@ -167,10 +167,10 @@ jobs:
       # job has flaked on the `Install uv` / dep-resolution network hop.)
       shell: bash
       run: |
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen --extra dev --extra mcp; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
@@ -218,10 +218,10 @@ jobs:
       # — it never masks a genuine resolution error.
       shell: bash
       run: |
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen --extra dev --extra server; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
@@ -277,10 +277,10 @@ jobs:
         # has no internal retry across the full resolve+download. A real
         # lockfile problem fails all 3 attempts identically, so this only
         # absorbs flakes — it never masks a genuine resolution error.
-        attempt=1
+        attempt=1; max=3
         until uv sync --frozen --extra browser --extra dev --extra markdown; do
-          if [ "$attempt" -ge 3 ]; then
-            echo "::error::uv sync failed after 3 attempts" >&2
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
             exit 1
           fi
           echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,23 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv sync --frozen --extra browser --extra dev --extra markdown
+      shell: bash
+      run: |
+        # Retry to ride out transient registry/network blips during dep
+        # resolution: a single PyPI/GitHub hiccup was hard-failing the leg.
+        # `uv sync` has no internal retry across the full resolve+download.
+        # A real lockfile problem fails all 3 attempts identically, so this
+        # only absorbs flakes — it never masks a genuine resolution error.
+        attempt=1
+        until uv sync --frozen --extra browser --extra dev --extra markdown; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     - name: Run pre-commit checks
       run: uv run pre-commit run --all-files
@@ -145,7 +161,22 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies (mcp extra)
-      run: uv sync --frozen --extra dev --extra mcp
+      # Retried to ride out transient registry/network blips: a real lockfile
+      # problem fails all 3 attempts identically, so this only absorbs flakes
+      # — it never masks a genuine resolution error. (The windows leg of this
+      # job has flaked on the `Install uv` / dep-resolution network hop.)
+      shell: bash
+      run: |
+        attempt=1
+        until uv sync --frozen --extra dev --extra mcp; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     - name: Run MCP suite
       run: uv run pytest tests/unit/mcp tests/integration/mcp_vcr -q
@@ -182,7 +213,21 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies (server extra)
-      run: uv sync --frozen --extra dev --extra server
+      # Retried to ride out transient registry/network blips: a real lockfile
+      # problem fails all 3 attempts identically, so this only absorbs flakes
+      # — it never masks a genuine resolution error.
+      shell: bash
+      run: |
+        attempt=1
+        until uv sync --frozen --extra dev --extra server; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     - name: Run REST server suite
       run: uv run pytest tests/server -q
@@ -224,7 +269,24 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv sync --frozen --extra browser --extra dev --extra markdown
+      shell: bash
+      run: |
+        # Retry to ride out transient registry/network blips during dep
+        # resolution: a single PyPI/GitHub hiccup on one matrix entry was
+        # hard-failing the whole leg while the other 14 passed. `uv sync`
+        # has no internal retry across the full resolve+download. A real
+        # lockfile problem fails all 3 attempts identically, so this only
+        # absorbs flakes — it never masks a genuine resolution error.
+        attempt=1
+        until uv sync --frozen --extra browser --extra dev --extra markdown; do
+          if [ "$attempt" -ge 3 ]; then
+            echo "::error::uv sync failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
 
     - name: Get Playwright version
       id: playwright-version


### PR DESCRIPTION
## What

Wrap every regularly-running CI dependency-install step in a bounded **3-attempt backoff** (15s, 30s) around `uv sync`.

## Why

The install step had **no retry**, so a single transient PyPI/GitHub network blip during `uv sync` hard-failed the whole job. Surveying ~200 `Test` runs, this was the dominant infra-flake class on `main`:

- 2× `Install dependencies` failing on a **single matrix entry** (windows, macos) while the other 14 passed — classic network blip.
- 1× windows **MCP suite** `Install uv` / dep-resolution network hop (fetch from `raw.githubusercontent.com`).

(The remaining `main` failures in that window were *real* — API-compat gate, deterministic all-platform test failures — and are out of scope here. The many `cancelled` runs are expected `concurrency: cancel-in-progress` behavior, not flakes.)

## How it's safe

The loop **fails closed**: a real lockfile/resolution problem fails all three attempts identically, so this only absorbs transient flakes and never masks a genuine error. Each retry emits a `::warning::`; exhaustion emits `::error::` and exits non-zero.

The canonical `uv sync --frozen --extra browser --extra dev --extra markdown` string is preserved **verbatim**, so `scripts/check_ci_install_parity.py` still passes.

## Scope

| Workflow | Install sites hardened |
|---|---|
| `test.yml` | quality + MCP suite + REST server + test matrix |
| `nightly.yml` | E2E install |
| `dependency-audit.yml` | locked-env sync |
| `rpc-health.yml` | core-runtime sync |

Release-path workflows (`verify-package.yml`, `verify-artifacts.yml`) are **intentionally untouched** — they run rarely and a manual re-run is cheap; keeping the publish pipeline change-free is the safer trade.

## Verification

- All Code-Quality workflow gates pass locally: install-parity, workflow-permissions, secret-gates, action-pinning.
- YAML parses for all four files; `shell: bash` added where the matrix runs on windows.
- Retry logic unit-checked: fast on success, retries+succeeds on mid-failure, exits 1 after 3 real failures.
- 75 workflow-related unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by adding retry logic with progressive backoff to dependency installation steps across multiple workflows. Install steps now retry up to three times with increasing delays and report a failure after the final attempt, reducing flakiness from transient network or registry issues during builds and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->