### PR TITLE
test(ci): gate mcp + server coverage in their dedicated jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,17 @@ jobs:
         done
 
     - name: Run MCP suite
-      run: uv run pytest tests/unit/mcp tests/integration/mcp_vcr -q
+      # The MCP package is invisible to the main coverage job: that job installs
+      # only browser+dev+markdown (no `mcp` extra), so every `tests/unit/mcp`
+      # test is skipped there and `src/notebooklm/mcp/**` lands in coverage.json
+      # at 0%. This job is the only one that exercises the adapter, so it owns
+      # the coverage gate too. The threshold is the project-wide 90% floor (the
+      # same value `scripts/check_coverage_thresholds.py` pins everywhere — keep
+      # it identical or that drift guard fails); the adapter currently sits at
+      # ~96%, so this gate catches a regression back toward the old 0% blind spot.
+      run: >-
+        uv run pytest tests/unit/mcp tests/integration/mcp_vcr -q
+        --cov=src/notebooklm/mcp --cov-report=term-missing --cov-fail-under=90
 
   server:
     # The REST server ships behind the optional ``server`` extra, so the
@@ -230,7 +240,15 @@ jobs:
         done
 
     - name: Run REST server suite
-      run: uv run pytest tests/server -q
+      # Same blind spot as the MCP job: the main coverage job omits the `server`
+      # extra, so `tests/server` is skipped there and `src/notebooklm/server/**`
+      # registers 0% in coverage.json. This dedicated job owns the server
+      # coverage gate. The threshold is the project-wide 90% floor (kept
+      # identical everywhere so `check_coverage_thresholds.py` stays green); the
+      # adapter currently sits at ~92%, so this catches a slide back toward 0%.
+      run: >-
+        uv run pytest tests/server -q
+        --cov=src/notebooklm/server --cov-report=term-missing --cov-fail-under=90
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -161,9 +161,20 @@ class FakeArtifacts:
         *,
         artifacts_data: Any = None,
     ) -> str:
+        return await self._do_download(output_path)
+
+    async def download_slide_deck(
+        self, notebook_id: str, output_path: str, artifact_id: str | None = None, **kwargs: Any
+    ) -> str:
+        # A format-bearing download kind (output_format → pdf/pptx).
+        return await self._do_download(output_path)
+
+    async def _do_download(self, output_path: str) -> str:
         with open(output_path, "wb") as fh:
             fh.write(self._s.download_bytes)
-        return output_path
+        # download_return_path lets a test force a path OUTSIDE the server's temp
+        # dir, exercising the route's served-path safety guard.
+        return self._s.download_return_path or output_path
 
 
 class FakeClient:
@@ -178,6 +189,7 @@ class FakeClient:
         self.new_source_status: SourceStatus = SourceStatus.PROCESSING
         self.hide_new_sources: bool = False
         self.download_bytes: bytes = b"FAKE-ARTIFACT-BYTES"
+        self.download_return_path: str | None = None
         self.chat_error: Exception | None = None
 
         self.next_task = 1

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
+
 from fastapi.testclient import TestClient
 
+from notebooklm._app.generate import GenerationExecutionResult
+from notebooklm._app.generate_retry import GenerationOutcome
 from notebooklm._types.artifacts import GenerationState
+from notebooklm.server._pending import PendingRegistry
+from notebooklm.server.routes import artifacts as artifacts_route
 from notebooklm.server.routes.artifacts import DOWNLOAD_SPECS, GENERATE_TYPES
 
 from .fakes import FakeClient, make_artifact
@@ -98,6 +105,122 @@ def test_list_artifacts(authed_client: TestClient, fake_client: FakeClient) -> N
     resp = authed_client.get("/v1/notebooks/nb-1/artifacts")
     assert resp.status_code == 200
     assert resp.json()["artifacts"][0]["title"] == "Pod"
+
+
+# --- generate: input validation (400s) --------------------------------------
+
+
+def test_generate_unknown_type_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts", json={"type": "bogus"})
+    assert resp.status_code == 400
+
+
+def test_generate_unsupported_language_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "audio", "language": "zz-bogus"}
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_invalid_option_choice_is_400(authed_client: TestClient) -> None:
+    # A provided per-kind option is validated up front (clean 400, not a raw
+    # KeyError deeper in generate-core).
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "audio", "audio_format": "bogus"}
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_explicit_valid_option_is_202(authed_client: TestClient) -> None:
+    # An explicit valid option flows through to the generation plan.
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "audio", "audio_format": "brief"}
+    )
+    assert resp.status_code == 202
+
+
+# --- download: input validation + format axis --------------------------------
+
+
+def test_download_unknown_type_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "bogus"})
+    assert resp.status_code == 400
+
+
+def test_download_output_format_on_unsupported_type_is_400(authed_client: TestClient) -> None:
+    # audio has no format axis, so an output_format is a clean 400.
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts/download",
+        json={"type": "audio", "output_format": "mp3"},
+    )
+    assert resp.status_code == 400
+
+
+def test_download_with_output_format_streams(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.artifacts_store["nb-1"] = {"d1": make_artifact("d1", "slide-deck")}
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts/download",
+        json={"type": "slide-deck", "output_format": "pdf"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == fake_client.download_bytes
+
+
+def test_download_unexpected_output_path_is_rejected(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # If the core resolves a served path OUTSIDE the server's private temp dir,
+    # the route refuses to stream it (path-traversal safety guard).
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    outside = os.path.join(tempfile.gettempdir(), "nblm-outside-artifact.mp3")
+    fake_client.download_return_path = outside
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})
+    assert resp.status_code == 400
+
+
+# --- helpers: _cleanup + _generation_payload ---------------------------------
+
+
+def test_cleanup_unlinks_a_file(tmp_path: object) -> None:
+    target = os.path.join(str(tmp_path), "leftover.bin")
+    with open(target, "wb") as fh:
+        fh.write(b"x")
+    artifacts_route._cleanup(target)
+    assert not os.path.exists(target)
+
+
+def test_cleanup_missing_path_is_noop() -> None:
+    # Already-gone path must not raise.
+    artifacts_route._cleanup(os.path.join(tempfile.gettempdir(), "nblm-does-not-exist-xyz"))
+
+
+def test_generation_payload_mind_map_returns_inline() -> None:
+    # A mind-map renders synchronously: no task_id, the map is inlined.
+    result = GenerationExecutionResult(
+        kind="mind-map", display_name="Mind map", mind_map={"root": 1}
+    )
+    payload = artifacts_route._generation_payload("nb-1", result, PendingRegistry())
+    assert payload["mind_map"] == {"root": 1}
+    assert "task_id" not in payload
+
+
+def test_generation_payload_without_outcome() -> None:
+    # No generation outcome and no mind map → bare {notebook_id, kind}.
+    result = GenerationExecutionResult(kind="audio", display_name="Audio", generation=None)
+    payload = artifacts_route._generation_payload("nb-1", result, PendingRegistry())
+    assert payload == {"notebook_id": "nb-1", "kind": "audio"}
+
+
+def test_generation_payload_outcome_without_task_id_is_not_recorded() -> None:
+    # A falsy task_id is projected but never recorded in the pending registry.
+    pending = PendingRegistry()
+    outcome = GenerationOutcome(status="ok", artifact_type="audio", task_id="")
+    result = GenerationExecutionResult(kind="audio", display_name="Audio", generation=outcome)
+    payload = artifacts_route._generation_payload("nb-1", result, pending)
+    assert payload["task_id"] == ""
+    assert not pending.knows("nb-1", "")
 
 
 def test_download_spec_exhaustiveness() -> None:

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -158,8 +159,6 @@ def test_main_seeds_token_env_from_flag(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
     launcher.main(["--host", "127.0.0.1", "--token", "flag-token"])
     # The --token flag seeds the env the auth dependency later reads.
-    import os
-
     assert os.environ[SERVER_TOKEN_ENV] == "flag-token"
 
 

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from notebooklm.server import __main__ as launcher
@@ -55,3 +57,120 @@ def test_out_of_range_port_fails_clean(raw: str) -> None:
 @pytest.mark.parametrize("raw,expected", [("0", 0), ("65535", 65535)])
 def test_boundary_ports_accepted(raw: str, expected: int) -> None:
     assert launcher._resolve_port(raw) == expected
+
+
+def test_is_loopback_rejects_non_ip_hostname() -> None:
+    # A hostname that is neither in _LOOPBACK_HOSTNAMES nor a numeric IP literal
+    # is treated as non-loopback (the ipaddress.ip_address ValueError branch).
+    assert launcher._is_loopback("example.com") is False
+
+
+# --- _build_parser: defaults, env-derived defaults, flag overrides -----------
+
+
+def test_build_parser_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("NOTEBOOKLM_SERVER_HOST", "NOTEBOOKLM_SERVER_PORT", "NOTEBOOKLM_LOG_LEVEL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
+    args = launcher._build_parser().parse_args([])
+    assert args.host == "127.0.0.1"
+    assert args.port == "8000"  # kept as a string; converted later by _resolve_port
+    assert args.token is None
+    assert args.log_level == "INFO"
+
+
+def test_build_parser_reads_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_HOST", "::1")
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_PORT", "9001")
+    monkeypatch.setenv("NOTEBOOKLM_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
+    args = launcher._build_parser().parse_args([])
+    assert args.host == "::1"
+    assert args.port == "9001"
+    assert args.token == "env-secret"
+    assert args.log_level == "DEBUG"
+
+
+def test_build_parser_flags_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_HOST", "::1")
+    args = launcher._build_parser().parse_args(["--host", "127.0.0.1", "--port", "8123"])
+    assert args.host == "127.0.0.1"
+    assert args.port == "8123"
+
+
+# --- _configure_logging: maps the level name, falls back to INFO ------------
+
+
+def test_configure_logging_maps_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(launcher.logging, "basicConfig", lambda **kw: captured.update(kw))
+    launcher._configure_logging("debug")
+    assert captured["level"] == logging.DEBUG
+    launcher._configure_logging("not-a-level")  # unknown names fall back to INFO
+    assert captured["level"] == logging.INFO
+
+
+# --- main(): full launch path with uvicorn.run stubbed out ------------------
+
+
+def _stub_uvicorn_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Stub out ``main()``'s side effects and capture the ``uvicorn.run`` call.
+
+    Replaces ``uvicorn.run`` (so no server actually binds), ``create_app`` (so no
+    real app is built), and ``basicConfig`` (so ``main()`` does not mutate the
+    process-global logging config). Returns the dict the run call is captured into.
+    """
+    import uvicorn
+
+    captured: dict[str, object] = {}
+
+    def _capture(app: object, **kwargs: object) -> None:
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, "run", _capture)
+    monkeypatch.setattr(launcher, "create_app", lambda: "APP")
+    monkeypatch.setattr(launcher.logging, "basicConfig", lambda **_kwargs: None)
+    return captured
+
+
+def test_main_runs_server_with_resolved_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _stub_uvicorn_run(monkeypatch)
+    launcher.main(
+        ["--host", "127.0.0.1", "--port", "8123", "--token", "secret", "--log-level", "WARNING"]
+    )
+    assert captured["app"] == "APP"
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 8123  # _resolve_port converts the string to an int
+    assert captured["log_level"] == "warning"  # uvicorn wants a lowercase level
+
+
+def test_main_seeds_token_env_from_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
+    launcher.main(["--host", "127.0.0.1", "--token", "flag-token"])
+    # The --token flag seeds the env the auth dependency later reads.
+    import os
+
+    assert os.environ[SERVER_TOKEN_ENV] == "flag-token"
+
+
+def test_main_refuses_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
+    with pytest.raises(SystemExit):
+        launcher.main(["--host", "127.0.0.1"])
+
+
+def test_main_refuses_non_loopback_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.delenv(launcher.ALLOW_EXTERNAL_BIND_ENV, raising=False)
+    with pytest.raises(SystemExit):
+        launcher.main(["--host", "0.0.0.0", "--token", "secret"])
+
+
+def test_main_allows_external_bind_with_optin(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _stub_uvicorn_run(monkeypatch)
+    monkeypatch.setenv(launcher.ALLOW_EXTERNAL_BIND_ENV, "1")
+    launcher.main(["--host", "0.0.0.0", "--token", "secret"])
+    assert captured["host"] == "0.0.0.0"

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -117,8 +118,10 @@ def _stub_uvicorn_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     """Stub out ``main()``'s side effects and capture the ``uvicorn.run`` call.
 
     Replaces ``uvicorn.run`` (so no server actually binds), ``create_app`` (so no
-    real app is built), and ``basicConfig`` (so ``main()`` does not mutate the
-    process-global logging config). Returns the dict the run call is captured into.
+    real app is built), and the consumer-side ``logging`` binding with a wrapper
+    whose ``basicConfig`` is a no-op (so ``main()`` does not reconfigure logging
+    — without mutating the real ``logging`` module). Returns the dict the
+    ``uvicorn.run`` call is captured into.
     """
     import uvicorn
 
@@ -128,9 +131,14 @@ def _stub_uvicorn_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
         captured["app"] = app
         captured.update(kwargs)
 
+    # Wrap the real module so getLogger()/level constants still work, but swallow
+    # basicConfig — patching launcher's binding, not the global logging module.
+    mock_logging = MagicMock(wraps=logging)
+    mock_logging.basicConfig = lambda **_kwargs: None
+
     monkeypatch.setattr(uvicorn, "run", _capture)
-    monkeypatch.setattr(launcher, "create_app", lambda: "APP")
-    monkeypatch.setattr(launcher.logging, "basicConfig", lambda **_kwargs: None)
+    monkeypatch.setattr(launcher, "create_app", MagicMock(return_value="APP"))
+    monkeypatch.setattr(launcher, "logging", mock_logging)
     return captured
 
 


### PR DESCRIPTION
## Problem

The mcp and server adapters were **invisible to the coverage gate** — a regression to 0% real coverage would have shipped green.

- The only job with `--cov-fail-under` (the main **Test** job) installs just `browser,dev,markdown` — not `mcp`/`server`. `check_ci_install_parity.py` deliberately pins it to that 3-extra string (broader forms drag in `cookies`, which breaks on Py 3.13/3.14).
- So `tests/unit/mcp` and `tests/server` are **skipped** there (`importorskip`), and `src/notebooklm/{mcp,server}/**` lands in `coverage.json` at **0%**.
- The global 90% still passed (those packages are a small slice of the tree) and `check_coverage_thresholds.py` had **no per-file floor** guarding them.
- The dedicated **MCP suite** and **REST server** jobs *do* run the tests — but with **no `--cov`**, so they contributed nothing to coverage.

Net: ~3.7k lines of adapter code with zero enforced coverage.

## Fix

1. **`.github/workflows/test.yml`** — add `--cov=src/notebooklm/{mcp,server} --cov-report=term-missing --cov-fail-under=90` to the two dedicated jobs that already run those tests. `90` is the project-wide floor; `check_coverage_thresholds.py` asserts every `--cov-fail-under` equals pyproject's `fail_under=90`, so the value is kept identical (the drift guard stays green). MCP currently sits at **~96%**, server at **~92%**, so the gate has headroom and now catches any slide back toward the old blind spot.
2. **`tests/server/test_main.py`** — raise `server/__main__.py` from **67% → 97%** by testing the launch path: `main()` (happy path, token-from-flag seeding, no-token refusal, non-loopback refusal, external-bind opt-in), `_build_parser()`, `_configure_logging` level mapping, and the `_is_loopback` non-IP branch — with `uvicorn.run`/`create_app`/`basicConfig` stubbed. Lifts the server suite **88% → 92%**.

## Verification

- MCP gate: 95.9% ✓ (202 passed) · Server gate: 91.9% ✓ (123 passed)
- `check_coverage_thresholds.py`: OK (3 occurrences, all 90%) · `check_ci_install_parity.py`: OK
- Forbidden-monkeypatch lint: 60 passed (patches target stdlib/third-party/public names only)
- `ruff check`/`format` clean across the tree · 121 relevant guardrails pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded server launcher tests (argument parsing, logging, env handling, token/security guardrails, external bind rules), expanded artifacts API tests (input validation, generation/download flows, streaming downloads, path-traversal rejection), added unit tests for artifact helpers, and enhanced fake client download behavior for test control.

* **Chores**
  * CI workflow: added per-suite coverage reporting and enforced 90% coverage gates for relevant server test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

