### PR TITLE
fix(research): disambiguate import source rows

### DIFF
--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -676,14 +676,11 @@ class ResearchAPI:
             self._build_web_import_entry(src.url, src.title) for src in valid_sources
         )
 
-        params = [None, [1], effective_task_id, notebook_id, source_array]
-
         result = await self._rpc.rpc_call(
             RPCMethod.IMPORT_RESEARCH,
-            params,
+            [None, [1], effective_task_id, notebook_id, source_array],
             source_path=f"/notebook/{notebook_id}",
         )
-
         imported = []
         # ``unwrap_import_rows`` centralises the ``[[src1, ...]]`` envelope probe
         # (the former ``result[0]`` / ``first[0]`` reads) behind the research row

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -360,6 +360,17 @@ class ResearchStartRow:
 # envelope probe + per-row reads ``import_sources`` previously open-coded.
 _IMPORT_ENVELOPE_OUTER_POS = 0
 _IMPORT_ENVELOPE_PROBE_POS = 0
+_IMPORT_ROW_ID_ENVELOPE_POS = 0
+_IMPORT_ROW_TITLE_POS = 1
+_IMPORT_ROW_MIN_LEN = 2
+
+
+def _looks_like_import_row(value: Any) -> bool:
+    """Whether ``value`` has the leading slots of an ``IMPORT_RESEARCH`` row."""
+    if not isinstance(value, list) or len(value) < _IMPORT_ROW_MIN_LEN:
+        return False
+    id_envelope = value[_IMPORT_ROW_ID_ENVELOPE_POS]
+    return id_envelope is None or isinstance(id_envelope, list)
 
 
 def unwrap_import_rows(result: Any) -> list[Any]:
@@ -369,9 +380,10 @@ def unwrap_import_rows(result: Any) -> list[Any]:
     already-flat list of rows. This centralises the ``result[0]`` / ``result[0][0]``
     envelope probe so ``import_sources`` stops open-coding it; the reads are soft
     (an unrecognised shape falls through to ``result`` unchanged or ``[]``),
-    preserving the historical inline-unwrap contract exactly — the wrap is
-    recognised only when ``result[0]`` is a non-empty list whose own first
-    element is also a list.
+    with one extra disambiguation: the wrap is recognised only when
+    ``result[0][0]`` itself looks like an imported-source row. That preserves
+    flat single-row responses like ``[[[id], title]]`` instead of mistaking the
+    row's id envelope for a wrapper.
     """
     if not result or not isinstance(result, list):
         return []
@@ -379,7 +391,7 @@ def unwrap_import_rows(result: Any) -> list[Any]:
     if (
         isinstance(first, list)
         and len(first) > 0
-        and isinstance(first[_IMPORT_ENVELOPE_PROBE_POS], list)
+        and _looks_like_import_row(first[_IMPORT_ENVELOPE_PROBE_POS])
     ):
         return first
     return result
@@ -401,12 +413,12 @@ class ImportedSourceRow:
 
     _raw: Any = field(repr=False)
 
-    _ID_ENVELOPE_POS: ClassVar[int] = 0
+    _ID_ENVELOPE_POS: ClassVar[int] = _IMPORT_ROW_ID_ENVELOPE_POS
     _ID_POS: ClassVar[int] = 0
-    _TITLE_POS: ClassVar[int] = 1
+    _TITLE_POS: ClassVar[int] = _IMPORT_ROW_TITLE_POS
     # A usable row must carry at least ``[id_envelope, title]`` — mirrors the
     # historical ``len(src_data) >= 2`` guard.
-    _MIN_LEN: ClassVar[int] = 2
+    _MIN_LEN: ClassVar[int] = _IMPORT_ROW_MIN_LEN
 
     @property
     def is_well_formed(self) -> bool:

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -107,7 +107,7 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # its ceiling entry was removed per the one-way-ratchet rule.
     # +1 LOC: PR #1557 (the #1491 positional drain + its gemini-review unpacking
     # of the typed ``parsed_tasks``/``list[ResearchTask]`` head). Irreducible.
-    "_research.py": 937,
+    "_research.py": 934,
     "_chat/api.py": 955,
 }
 

--- a/tests/unit/test_research_api.py
+++ b/tests/unit/test_research_api.py
@@ -656,23 +656,9 @@ class TestImportSourcesEdgeCases:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """result[0][0] is not a list — no unwrap, loop runs on original result.
-        The unwrap condition requires result[0][0] to be a list. When result[0][0] is a
-        non-list value (e.g. None), the if-block is skipped and the for loop runs directly.
-        """
-        # result[0] = [None, "Flat Title"] so result[0][0] = None (not a list) → no unwrap
-        # The loop then processes each item in the original result directly.
-        # [None, "Flat Title"] has src_data[0]=None → src_id = None → skipped (covers 270->265)
-        # So we also include a valid entry to verify the loop ran:
-        # However, we need result[0][0] to NOT be a list to avoid unwrap.
-        # A valid entry looks like [["src_id"], "Title"] but result[0][0]=["src_id"] IS a list.
-        # The only way to avoid unwrap AND get results is if result[0] is a list but
-        # result[0][0] is not a list. Use result = ["not_a_list_entry", [["src_nw"], "Title"]].
-        # result[0] = "not_a_list_entry" → isinstance(result[0], list) is False → no unwrap.
+        """A non-list head skips envelope unwrapping and still parses later rows."""
         response = build_rpc_response(
             RPCMethod.IMPORT_RESEARCH,
-            # result[0] is a string, not a list → isinstance(result[0], list) is False
-            # condition fails → no unwrap → loop runs on the original result
             ["string_not_list", [["src_nw"], "No-Wrap Title"]],
         )
         httpx_mock.add_response(content=response.encode())
@@ -686,6 +672,48 @@ class TestImportSourcesEdgeCases:
         assert len(result) == 1
         assert result[0]["id"] == "src_nw"
         assert result[0]["title"] == "No-Wrap Title"
+
+    @pytest.mark.asyncio
+    async def test_import_sources_flat_single_row_with_id_envelope(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Regression for #1558: flat ``[[id], title]`` rows are not wrappers."""
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            [[["src_flat"], "Flat Title"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"url": "https://flat.example.com", "title": "Flat Title"}],
+            )
+        assert result == [{"id": "src_flat", "title": "Flat Title"}]
+
+    @pytest.mark.asyncio
+    async def test_import_sources_wrapped_single_row_still_unwraps(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Matches ``research_import_sources_direct.yaml``'s one-row wrapper."""
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            [[[["src_wrapped"], "Wrapped Title"]]],
+        )
+        httpx_mock.add_response(content=response.encode())
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"url": "https://wrapped.example.com", "title": "Wrapped Title"}],
+            )
+        assert result == [{"id": "src_wrapped", "title": "Wrapped Title"}]
 
     @pytest.mark.asyncio
     async def test_import_sources_src_data_too_short_skipped(

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -267,11 +267,27 @@ class TestUnwrapImportRows:
         assert unwrap_import_rows([rows]) == rows
 
     def test_single_wrapped_row_is_unwrapped(self) -> None:
-        # ``[[["id"], "t"]]``: ``result[0] = [["id"], "t"]`` is a non-empty list
-        # whose first element ``["id"]`` is itself a list, so the historical
-        # probe treats it as a one-level envelope and unwraps to ``result[0]``.
-        wrapped = [[["id"], "t"]]
-        assert unwrap_import_rows(wrapped) == [["id"], "t"]
+        # Matches ``research_import_sources_direct.yaml``: the recorded single
+        # imported row still arrives under a one-element ``[[row]]`` envelope.
+        wrapped = [[[["id"], "t"]]]
+        assert unwrap_import_rows(wrapped) == [[["id"], "t"]]
+
+    def test_flat_single_row_with_id_envelope_is_returned_unchanged(self) -> None:
+        # Regression for #1558: flat ``[row]`` where row is ``[[id], title]``
+        # must not mistake the row's id envelope for a wrapper.
+        flat = [[["id"], "t"]]
+        assert unwrap_import_rows(flat) == flat
+
+    def test_flat_populated_row_with_metadata_is_returned_unchanged(self) -> None:
+        # Real imported rows may carry metadata arrays after the title. The
+        # envelope probe must look only at ``result[0][0]`` as a row candidate;
+        # scanning the whole row could mistake metadata arrays for rows.
+        flat = [[["id"], "Title", [None, 1, [2]], [None, 2]]]
+        assert unwrap_import_rows(flat) == flat
+
+    def test_wrapped_row_with_absent_id_envelope_is_unwrapped(self) -> None:
+        rows = [[None, "Missing id"], [["id_2"], "Imported"]]
+        assert unwrap_import_rows([rows]) == rows
 
     def test_flat_list_with_non_list_head_returned_unchanged(self) -> None:
         # ``result[0]`` is a list but its first element is NOT a list, so the


### PR DESCRIPTION
## Summary
- fix IMPORT_RESEARCH envelope detection so flat single-row results like `[[["id"], "title"]]` are parsed as one row instead of mistaken for a wrapper
- preserve the cassette-backed wrapped shape from `research_import_sources_direct.yaml` / `research_import_sources_populated.yaml`
- update import-source edge tests and trim stale comments

Fixes #1558

## Verification
- `uv run --extra dev pytest tests/unit/test_research_api.py -k 'import_sources'`
- `uv run --extra dev pytest tests/unit/test_research.py::TestResearch::test_import_research tests/integration/test_rpc_gap_backfill_vcr.py::test_import_research_rpc_has_cassette_coverage`
- `uv run --extra dev pytest tests/_guardrails/test_module_size_ratchet.py tests/_guardrails/test_no_raw_positional_rpc_indexing.py`
- `uv run --extra dev pytest -n auto --dist=worksteal tests/unit/test_research_api.py tests/unit/test_research.py tests/integration/test_rpc_gap_backfill_vcr.py tests/_guardrails/test_module_size_ratchet.py tests/_guardrails/test_no_raw_positional_rpc_indexing.py`
- `uv run --extra dev mypy src/notebooklm/_research.py`
- `uv run --extra dev ruff check src/notebooklm/_research.py tests/unit/test_research_api.py`
- `uv run --extra dev ruff format --check src/notebooklm/_research.py tests/unit/test_research_api.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust source-import handling: avoids misclassifying already-flat responses as wrapped and preserves envelope structure when appropriate.

* **Tests**
  * Added/updated edge-case tests to validate flat vs. wrapped import responses, single-row shapes, absent id envelopes, and regression scenarios to prevent double-unwrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->