### PR TITLE
test(server): use tmp_path for _cleanup/download-guard temp paths

### DIFF
--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 
 from fastapi.testclient import TestClient
 
@@ -169,13 +168,13 @@ def test_download_with_output_format_streams(
 
 
 def test_download_unexpected_output_path_is_rejected(
-    authed_client: TestClient, fake_client: FakeClient
+    authed_client: TestClient, fake_client: FakeClient, tmp_path: object
 ) -> None:
     # If the core resolves a served path OUTSIDE the server's private temp dir,
-    # the route refuses to stream it (path-traversal safety guard).
+    # the route refuses to stream it (path-traversal safety guard). tmp_path is a
+    # distinct tree from the server's mkdtemp dir, so the guard fires.
     fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
-    outside = os.path.join(tempfile.gettempdir(), "nblm-outside-artifact.mp3")
-    fake_client.download_return_path = outside
+    fake_client.download_return_path = os.path.join(str(tmp_path), "nblm-outside-artifact.mp3")
     resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})
     assert resp.status_code == 400
 
@@ -191,9 +190,10 @@ def test_cleanup_unlinks_a_file(tmp_path: object) -> None:
     assert not os.path.exists(target)
 
 
-def test_cleanup_missing_path_is_noop() -> None:
-    # Already-gone path must not raise.
-    artifacts_route._cleanup(os.path.join(tempfile.gettempdir(), "nblm-does-not-exist-xyz"))
+def test_cleanup_missing_path_is_noop(tmp_path: object) -> None:
+    # Already-gone path must not raise. tmp_path is unique per test, so the path
+    # is guaranteed absent (no risk of deleting unrelated state).
+    artifacts_route._cleanup(os.path.join(str(tmp_path), "nblm-does-not-exist-xyz"))
 
 
 def test_generation_payload_mind_map_returns_inline() -> None:


### PR DESCRIPTION
## Follow-up to #1556

#1556 was merged before this CodeRabbit fix landed, so it's shipped as a small follow-up.

CodeRabbit flagged (Minor / Quick win) that two server artifact tests hard-coded filenames in the **shared system temp dir** via `tempfile.gettempdir()`:
- `test_cleanup_missing_path_is_noop` — if that path happened to exist (leftover, or a concurrent run), `_cleanup` would **delete unrelated state** instead of exercising the missing-path branch.
- `test_download_unexpected_output_path_is_rejected` — same hard-coded-temp-path smell.

This switches both to the per-test **`tmp_path`** fixture (unique, guaranteed-absent, isolated) and drops the now-unused `tempfile` import. `routes/artifacts.py` stays at 100%; server suite at 97%.

## Verification

- `pytest tests/server` → 136 passed
- `ruff check` / `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated artifact route tests to use isolated temporary directories for improved test reliability and cleaner test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->