### PR TITLE
test(upload): make upload-timeout tests network-free (fix CI flake)

### DIFF
--- a/tests/integration/concurrency/test_upload_timeout_config.py
+++ b/tests/integration/concurrency/test_upload_timeout_config.py
@@ -48,8 +48,17 @@ def _make_capturing_async_client(
     """Build an ``httpx.AsyncClient`` subclass that records the ``timeout`` kwarg.
 
     Returns a class so ``async with httpx.AsyncClient(...)`` continues to
-    work — replacing only the constructor argument capture, not the
-    instance behavior.
+    work and ``super().__init__`` builds a fully valid client — replacing
+    only request *dispatch*, not construction.
+
+    Crucially, ``__init__`` always runs to completion for **every**
+    construction (so all timeouts are captured — the finalize POST asserts
+    ``captured[-1]``), but ``send`` is overridden to raise a transport error
+    **before any socket I/O**. The upload helpers fail fast and
+    deterministically regardless of CI network egress: there is no real
+    ``connect()``/``read()`` to race ``pytest-timeout``. (``httpx``'s
+    ``post``/``request`` funnel through ``send``, so this intercepts the
+    one request path the upload sites use without opening a connection.)
     """
     real_async_client = httpx.AsyncClient
 
@@ -57,6 +66,12 @@ def _make_capturing_async_client(
         def __init__(self, *args: object, **kwargs: object) -> None:
             captured.append(kwargs.get("timeout"))  # type: ignore[arg-type]
             super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+
+        async def send(self, *args: object, **kwargs: object) -> httpx.Response:
+            # Fail before any network I/O. ``httpx.ConnectError`` is an
+            # ``httpx.HTTPError`` subclass, satisfying the ``pytest.raises``
+            # below without ever opening a socket.
+            raise httpx.ConnectError("network disabled in upload-timeout test")
 
     return CapturingClient
 
@@ -72,9 +87,9 @@ async def test_custom_upload_timeout_propagates_to_start(
     async with NotebookLMClient(auth_tokens, upload_timeout=custom) as client:
         with patch.object(httpx, "AsyncClient", capturing):
             # Call the helper directly — exercises the start-resumable-upload
-            # site in isolation. The actual network call will fail (no real
-            # server), but we only care that the timeout kwarg was captured
-            # at construction time, before any I/O.
+            # site in isolation. The patched client raises in ``send`` before
+            # opening a socket, so the POST fails fast and network-free; we
+            # only care that the timeout kwarg was captured at construction.
             with pytest.raises((httpx.HTTPError, OSError)):
                 await client.sources._start_resumable_upload(
                     notebook_id="nb-test",


### PR DESCRIPTION
## Problem

`tests/integration/concurrency/test_upload_timeout_config.py` intermittently times out in CI (`Failed: Timeout (>60.0s) from pytest-timeout`) on the start/finalize upload-timeout assertions, while passing in ~0.1s locally.

## Real root cause (not an `__init__` deadlock)

`httpx.AsyncClient.__init__` does **no** network I/O, so it cannot hang. The actual cause:

The tests patch `httpx.AsyncClient` with a capturing subclass that calls a **real** `super().__init__()`, then drive the upload helpers (`SourcesAPI._start_resumable_upload` / `_upload_file_streaming`). Those helpers issue a **real** `client.post(...)` to a `notebooklm.google.com` URL and rely on it failing *fast*.

- On a GitHub runner (egress to google.com), the connect can succeed and the **read blocks up to the real 60s read timeout**, racing pytest-timeout's 60s → flaky hang.
- In a no-egress sandbox the POST fails instantly → green locally.

## Fix

Keep `super().__init__(*args, **kwargs)` so every client is fully constructed and **every** `timeout` kwarg is captured, but override **`send`** to raise `httpx.ConnectError` **before any socket I/O**. httpx's `post`/`request` funnel through `send`, so this intercepts the one request path the upload sites use with zero network. `httpx.ConnectError` is an `httpx.HTTPError` subclass, so the existing `pytest.raises((httpx.HTTPError, OSError))` guards are unchanged.

### Finalize `captured[-1]` pitfall handled

The start tests assert `captured[0]`; the **finalize tests assert `captured[-1]`** (the finalize POST's 300.0 timeout). A naive "raise inside `__init__` on the first construction" would prevent the finalize client from being constructed at all, so `captured[-1]` would silently point at the wrong client. Because this fix intercepts only **dispatch** (`send`), construction proceeds normally: the start site captures `captured[0]` and the finalize site captures `captured[-1]`, exactly as before.

## Verification

- `uv run pytest tests/integration/concurrency/test_upload_timeout_config.py -p no:randomly -q` → 5 passed in 0.10s.
- **Stability:** 20/20 loop runs pass, each ~0.10s.
- **Network-free proof:** re-ran the file with `socket.connect`, `socket.create_connection`, and the event loop's `getaddrinfo` all patched to raise on use — all 5 still pass, proving no real connection is ever opened.
- `uv run ruff check` + `ruff format --check` clean; `uv run mypy src/notebooklm --ignore-missing-imports` → no issues.
- All existing assertions preserved: start 10.0/60.0 & 5.0/10.0, finalize 10.0/300.0 & 5.0/10.0.

Only `tests/integration/concurrency/test_upload_timeout_config.py` is touched; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened upload-timeout regression test coverage with improved failure simulation scenarios
  * Enhanced test documentation to clarify timeout handling and assertion behavior during uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->