### PR TITLE
test(rpc): wire decoder→dataclass mappers into golden fixtures + add ratchet

### DIFF
--- a/tests/fixtures/rpc_golden/ADD_SOURCE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE.json
@@ -140,5 +140,14 @@
         ]
       ]
     }
-  ]
+  ],
+  "mapper": "tests.unit._golden_mappers:add_source",
+  "mapper_expected": {
+    "id": "SCRUBBED_SRC_NEW_001",
+    "title": null,
+    "url": null,
+    "_type_code": null,
+    "created_at": null,
+    "status": 2
+  }
 }

--- a/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
@@ -29,7 +29,7 @@
         [
           "wrb.fr",
           "rLM1Ne",
-          "[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",[[[\"SCRUBBED_SRC_001\"],\"Scrubbed Source\",[2,null]]]]",
+          "[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]]]",
           null,
           null,
           null,
@@ -39,20 +39,43 @@
     ],
     "allow_null": false,
     "expected_decoded": [
-      "SCRUBBED_NB_001",
-      "Scrubbed Notebook One",
       [
+        "Scrubbed Notebook One",
         [
           [
             "SCRUBBED_SRC_001"
-          ],
-          "Scrubbed Source",
+          ]
+        ],
+        "SCRUBBED_NB_001",
+        "📓",
+        null,
+        [
+          null,
+          false,
+          null,
+          null,
+          null,
           [
-            2,
-            null
+            1704153600,
+            0
+          ],
+          null,
+          null,
+          [
+            1704067200,
+            0
           ]
         ]
       ]
     ]
+  },
+  "mapper": "tests.unit._golden_mappers:get_notebook",
+  "mapper_expected": {
+    "id": "SCRUBBED_NB_001",
+    "title": "Scrubbed Notebook One",
+    "created_at": "2024-01-01T00:00:00+00:00",
+    "sources_count": 1,
+    "is_owner": true,
+    "modified_at": "2024-01-02T00:00:00+00:00"
   }
 }

--- a/tests/fixtures/rpc_golden/GET_SHARE_STATUS.json
+++ b/tests/fixtures/rpc_golden/GET_SHARE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "method_name": "GET_SHARE_STATUS",
   "method_id": "JFMDGd",
-  "description": "Get notebook share settings (production shape [notebook_id, [2]]).",
+  "description": "Get notebook share settings (restricted, two shared users).",
   "request": {
     "params": [
       "SCRUBBED_NB_001",
@@ -26,7 +26,7 @@
         [
           "wrb.fr",
           "JFMDGd",
-          "[1,0,[]]",
+          "[[[\"scrubbed.alice@example.invalid\",2,[],[\"Scrubbed Alice\",\"https://scrubbed.example.com/avatar/alice.png\"]],[\"scrubbed.bob@example.invalid\",3,[],[\"Scrubbed Bob\",\"https://scrubbed.example.com/avatar/bob.png\"]]],null,1000]",
           null,
           null,
           null,
@@ -36,9 +36,50 @@
     ],
     "allow_null": false,
     "expected_decoded": [
-      1,
-      0,
-      []
+      [
+        [
+          "scrubbed.alice@example.invalid",
+          2,
+          [],
+          [
+            "Scrubbed Alice",
+            "https://scrubbed.example.com/avatar/alice.png"
+          ]
+        ],
+        [
+          "scrubbed.bob@example.invalid",
+          3,
+          [],
+          [
+            "Scrubbed Bob",
+            "https://scrubbed.example.com/avatar/bob.png"
+          ]
+        ]
+      ],
+      null,
+      1000
     ]
+  },
+  "mapper": "tests.unit._golden_mappers:get_share_status",
+  "mapper_expected": {
+    "notebook_id": "SCRUBBED_NB_001",
+    "is_public": false,
+    "access": 0,
+    "view_level": 0,
+    "shared_users": [
+      {
+        "email": "scrubbed.alice@example.invalid",
+        "permission": 2,
+        "display_name": "Scrubbed Alice",
+        "avatar_url": "https://scrubbed.example.com/avatar/alice.png"
+      },
+      {
+        "email": "scrubbed.bob@example.invalid",
+        "permission": 3,
+        "display_name": "Scrubbed Bob",
+        "avatar_url": "https://scrubbed.example.com/avatar/bob.png"
+      }
+    ],
+    "share_url": null
   }
 }

--- a/tests/fixtures/rpc_golden/GET_SUGGESTED_REPORTS.json
+++ b/tests/fixtures/rpc_golden/GET_SUGGESTED_REPORTS.json
@@ -1,7 +1,7 @@
 {
   "method_name": "GET_SUGGESTED_REPORTS",
   "method_id": "ciyUvf",
-  "description": "Fetch AI-suggested report formats for a notebook.",
+  "description": "Fetch AI-suggested report formats (wrapped [[row,...]] envelope).",
   "request": {
     "params": [
       "SCRUBBED_NB_001"
@@ -23,7 +23,7 @@
         [
           "wrb.fr",
           "ciyUvf",
-          "[[\"Scrubbed Briefing Doc\",\"Briefing doc on scrubbed topic.\"],[\"Scrubbed Study Guide\",\"Study guide on scrubbed topic.\"]]",
+          "[[[\"Scrubbed Briefing Doc\",\"Briefing doc on scrubbed topic.\",null,null,\"Write a briefing doc on the scrubbed topic.\",2],[\"Scrubbed Study Guide\",\"Study guide on scrubbed topic.\",null,null,\"Write a study guide on the scrubbed topic.\",1]]]",
           null,
           null,
           null,
@@ -34,13 +34,38 @@
     "allow_null": false,
     "expected_decoded": [
       [
-        "Scrubbed Briefing Doc",
-        "Briefing doc on scrubbed topic."
-      ],
-      [
-        "Scrubbed Study Guide",
-        "Study guide on scrubbed topic."
+        [
+          "Scrubbed Briefing Doc",
+          "Briefing doc on scrubbed topic.",
+          null,
+          null,
+          "Write a briefing doc on the scrubbed topic.",
+          2
+        ],
+        [
+          "Scrubbed Study Guide",
+          "Study guide on scrubbed topic.",
+          null,
+          null,
+          "Write a study guide on the scrubbed topic.",
+          1
+        ]
       ]
     ]
-  }
+  },
+  "mapper": "tests.unit._golden_mappers:get_suggested_reports",
+  "mapper_expected": [
+    {
+      "title": "Scrubbed Briefing Doc",
+      "description": "Briefing doc on scrubbed topic.",
+      "prompt": "Write a briefing doc on the scrubbed topic.",
+      "audience_level": 2
+    },
+    {
+      "title": "Scrubbed Study Guide",
+      "description": "Study guide on scrubbed topic.",
+      "prompt": "Write a study guide on the scrubbed topic.",
+      "audience_level": 1
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
+++ b/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
@@ -54,5 +54,26 @@
         ]
       ]
     ]
-  }
+  },
+  "mapper": "tests.unit._golden_mappers:list_artifacts",
+  "mapper_expected": [
+    {
+      "id": "SCRUBBED_ARTIFACT_001",
+      "title": "Scrubbed Audio Overview",
+      "_artifact_type": 1,
+      "status": 3,
+      "created_at": null,
+      "url": null,
+      "_variant": null
+    },
+    {
+      "id": "SCRUBBED_ARTIFACT_002",
+      "title": "Scrubbed Briefing Doc",
+      "_artifact_type": 2,
+      "status": 3,
+      "created_at": null,
+      "url": null,
+      "_variant": null
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/LIST_LABELS.json
+++ b/tests/fixtures/rpc_golden/LIST_LABELS.json
@@ -69,5 +69,18 @@
         ]
       ]
     ]
-  }
+  },
+  "mapper": "tests.unit._golden_mappers:list_labels",
+  "mapper_expected": [
+    {
+      "id": "SCRUBBED_LABEL_001",
+      "name": "Scrubbed Topic A",
+      "notebook_id": "SCRUBBED_NB_001",
+      "emoji": null,
+      "source_ids": [
+        "SCRUBBED_SRC_001",
+        "SCRUBBED_SRC_002"
+      ]
+    }
+  ]
 }

--- a/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
+++ b/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
@@ -28,7 +28,7 @@
         [
           "wrb.fr",
           "wXbhsf",
-          "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0],[\"SCRUBBED_NB_002\",\"Scrubbed Notebook Two\",null,null,null,null,0]]]",
+          "[[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]],[\"Scrubbed Notebook Two\",[],\"SCRUBBED_NB_002\",\"\\ud83d\\udcd8\",null,[null,true,null,null,null,[1704240000,0],null,null,[1704067200,0]]]]]",
           null,
           null,
           null,
@@ -40,22 +40,56 @@
     "expected_decoded": [
       [
         [
-          "SCRUBBED_NB_001",
           "Scrubbed Notebook One",
+          [
+            [
+              "SCRUBBED_SRC_001"
+            ]
+          ],
+          "SCRUBBED_NB_001",
+          "📓",
           null,
-          null,
-          null,
-          null,
-          0
+          [
+            null,
+            false,
+            null,
+            null,
+            null,
+            [
+              1704153600,
+              0
+            ],
+            null,
+            null,
+            [
+              1704067200,
+              0
+            ]
+          ]
         ],
         [
-          "SCRUBBED_NB_002",
           "Scrubbed Notebook Two",
+          [],
+          "SCRUBBED_NB_002",
+          "📘",
           null,
-          null,
-          null,
-          null,
-          0
+          [
+            null,
+            true,
+            null,
+            null,
+            null,
+            [
+              1704240000,
+              0
+            ],
+            null,
+            null,
+            [
+              1704067200,
+              0
+            ]
+          ]
         ]
       ]
     ]
@@ -107,7 +141,7 @@
           [
             "wrb.fr",
             "ZZdrift",
-            "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0]]]",
+            "[[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]]]]",
             null,
             null,
             null,
@@ -137,7 +171,7 @@
           [
             "wrb.fr",
             "wXbhsf",
-            "[[[\"SCRUBBED_NB_001\",\"Scrubbed Notebook One\",null,null,null,null,0]]]",
+            "[[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]]]]",
             null,
             null,
             null,
@@ -148,16 +182,54 @@
       "expected_decoded": [
         [
           [
-            "SCRUBBED_NB_001",
             "Scrubbed Notebook One",
+            [
+              [
+                "SCRUBBED_SRC_001"
+              ]
+            ],
+            "SCRUBBED_NB_001",
+            "📓",
             null,
-            null,
-            null,
-            null,
-            0
+            [
+              null,
+              false,
+              null,
+              null,
+              null,
+              [
+                1704153600,
+                0
+              ],
+              null,
+              null,
+              [
+                1704067200,
+                0
+              ]
+            ]
           ]
         ]
       ]
+    }
+  ],
+  "mapper": "tests.unit._golden_mappers:list_notebooks",
+  "mapper_expected": [
+    {
+      "id": "SCRUBBED_NB_001",
+      "title": "Scrubbed Notebook One",
+      "created_at": "2024-01-01T00:00:00+00:00",
+      "sources_count": 1,
+      "is_owner": true,
+      "modified_at": "2024-01-02T00:00:00+00:00"
+    },
+    {
+      "id": "SCRUBBED_NB_002",
+      "title": "Scrubbed Notebook Two",
+      "created_at": "2024-01-01T00:00:00+00:00",
+      "sources_count": 0,
+      "is_owner": false,
+      "modified_at": "2024-01-03T00:00:00+00:00"
     }
   ]
 }

--- a/tests/fixtures/rpc_golden/README.md
+++ b/tests/fixtures/rpc_golden/README.md
@@ -62,8 +62,25 @@ ID changes without renaming the file.
 whose payload is consumed by inline feature-level extraction
 (`safe_index`-based) rather than a centralised mapper. When present, the
 mapper is imported via `module.path:attribute` form and applied to
-`expected_decoded`; the returned value (or its `to_public_dict()` form for
-dataclasses) is compared against `mapper_expected`.
+`expected_decoded`; the returned value is then projected to its
+fixture-comparable shape (`to_public_dict()` when the mapped object exposes
+it, otherwise the transport-neutral `to_jsonable()` projection used by the
+public `--json` / MCP / HTTP envelopes) and compared against
+`mapper_expected`.
+
+Because the golden harness calls the mapper with a single positional argument
+(`expected_decoded`), most fixtures point at a thin adapter in
+`tests/unit/_golden_mappers.py` that mirrors the extraction-then-factory path
+the feature layer runs — routing through the same production helpers where one
+exists (e.g. `LIST_ARTIFACTS` / `GET_SUGGESTED_REPORTS` reuse
+`unwrap_artifact_rows`; `LIST_NOTEBOOKS` extracts the `[[row, ...]]` envelope and
+maps each row through `Notebook.from_api_response`). Methods whose
+feature path has no clean single-payload mapper — fire-and-forget mutations
+that decode to `None`, inline `safe_index` reads, or `UPDATE_SOURCE` (decodes to
+`null`) — deliberately omit the pair and stay skipped. The wired set is pinned
+by `_MAPPER_COVERED_METHODS` + `test_mapper_covered_methods_have_mappers`, which
+fails loudly if a fixture loses its mapper rather than letting the row silently
+regress to a skip.
 
 `drift_cases` is **optional** — present only on the drift-prone methods
 (`CREATE_ARTIFACT`, `ADD_SOURCE`, `START_FAST_RESEARCH`, `LIST_NOTEBOOKS`)

--- a/tests/unit/_golden_mappers.py
+++ b/tests/unit/_golden_mappers.py
@@ -1,0 +1,155 @@
+"""Single-argument golden mappers for ``test_rpc_golden_payloads``.
+
+Each function here takes exactly one argument — a fixture's
+``response.expected_decoded`` payload — and returns the feature-level
+domain object(s) that the production code builds from that same decoded
+payload. The golden test (``test_mapper_output_shape_when_documented``)
+imports these via the fixture's ``"mapper": "tests.unit._golden_mappers:<fn>"``
+field, runs the function on ``expected_decoded``, projects the result into its
+public shape (``to_public_dict()`` when present, else the transport-neutral
+:func:`notebooklm._app.serialize.to_jsonable`), and pins it against the
+fixture's recorded ``mapper_expected`` shape.
+
+Why a dedicated test-side module rather than wiring the production factories
+directly?
+
+* The golden harness calls the mapper with a single positional argument, but
+  several production factories take extra arguments
+  (``Source.from_api_response(data, *, method_id=...)``,
+  ``ShareStatus.from_api_response(data, notebook_id)``,
+  ``Label.from_api_response(data, *, notebook_id=..., method_id=...)``), and
+  some methods return a *list* of rows that the feature layer extracts before
+  mapping (``LIST_NOTEBOOKS`` / ``LIST_ARTIFACTS`` / ``LIST_LABELS`` /
+  ``GET_SUGGESTED_REPORTS``).
+* These thin adapters mirror the **exact** extraction-then-factory path the
+  feature layer runs (see the cross-references in each docstring), so the
+  golden seam exercises the real decode->dataclass boundary without leaking
+  test-only logic into ``src/``.
+
+Methods whose feature path has no clean single-payload mapper (inline
+``safe_index`` extraction, fire-and-forget ``None`` returns, or a
+``SourceFulltext`` built field-by-field) are deliberately left without a
+mapper entry and remain honestly skipped (see ``_MAPPER_COVERED_METHODS`` in
+the test module for the exemption rationale).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from notebooklm._row_adapters.artifacts import ReportSuggestionRow, unwrap_artifact_rows
+from notebooklm._types.artifacts import Artifact, ReportSuggestion
+from notebooklm._types.labels import Label
+from notebooklm._types.notebooks import Notebook
+from notebooklm._types.sharing import ShareStatus
+from notebooklm._types.sources import Source
+from notebooklm.rpc.types import RPCMethod
+
+# Fixed notebook id used by the share-status / label mappers below. The
+# ``GET_SHARE_STATUS`` / ``LIST_LABELS`` decoded payloads carry no notebook
+# reference (the id is supplied by the caller at the feature layer), so the
+# golden mapper pins a synthetic, scrubbed id that matches the one used in the
+# corresponding fixtures' request params.
+_NOTEBOOK_ID = "SCRUBBED_NB_001"
+
+
+def list_notebooks(decoded: Any) -> list[Notebook]:
+    """``LIST_NOTEBOOKS`` -> one :class:`Notebook` per row.
+
+    Mirrors ``NotebooksAPI.list`` (``_notebooks.py``): the decoded payload is
+    the ``[[row, ...]]`` wrapped envelope, and each inner row is handed to
+    :meth:`Notebook.from_api_response`.
+    """
+    return [Notebook.from_api_response(row) for row in decoded[0]]
+
+
+def get_notebook(decoded: Any) -> Notebook:
+    """``GET_NOTEBOOK`` -> a single :class:`Notebook`.
+
+    Mirrors ``NotebooksAPI.get`` (``_notebooks.py``): ``decoded[0]`` is the
+    notebook-info row passed to :meth:`Notebook.from_api_response`.
+    """
+    return Notebook.from_api_response(decoded[0])
+
+
+def add_source(decoded: Any) -> Source:
+    """``ADD_SOURCE`` -> the created :class:`Source`.
+
+    Mirrors ``_source/add.py``: the decoded payload is handed straight to
+    :meth:`Source.from_api_response` tagged with the ``ADD_SOURCE`` method id.
+    """
+    return Source.from_api_response(decoded, method_id=RPCMethod.ADD_SOURCE.value)
+
+
+def list_artifacts(decoded: Any) -> list[Artifact]:
+    """``LIST_ARTIFACTS`` -> one :class:`Artifact` per studio row.
+
+    Mirrors ``ArtifactsAPI`` studio-row filtering
+    (``_artifact/listing.py::_filter_studio_artifacts``): the decoded payload
+    is routed through the production ``unwrap_artifact_rows`` wrap-probe — which
+    accepts both the wrapped ``[[row, ...]]`` envelope and an already-flat list —
+    and each non-empty list row is built via :meth:`Artifact.from_api_response`.
+    (Mind-map rows come from a separate ``GET_NOTES_AND_MIND_MAPS`` fetch and are
+    not part of this payload.)
+    """
+    rows = unwrap_artifact_rows(
+        decoded,
+        method_id=RPCMethod.LIST_ARTIFACTS.value,
+        source="golden.list_artifacts",
+    )
+    return [
+        Artifact.from_api_response(row) for row in rows if isinstance(row, list) and len(row) > 0
+    ]
+
+
+def list_labels(decoded: Any) -> list[Label]:
+    """``LIST_LABELS`` -> one :class:`Label` per 4-tuple.
+
+    Mirrors ``LabelsAPI`` parsing (``_labels.py``): the decoded payload is the
+    ``[[tuple, ...]]`` envelope and each tuple is parsed via
+    :meth:`Label.from_api_response` with the notebook id and method id the
+    feature layer threads through.
+    """
+    return [
+        Label.from_api_response(
+            tuple_,
+            notebook_id=_NOTEBOOK_ID,
+            method_id=RPCMethod.LIST_LABELS.value,
+        )
+        for tuple_ in decoded[0]
+    ]
+
+
+def get_share_status(decoded: Any) -> ShareStatus:
+    """``GET_SHARE_STATUS`` -> a :class:`ShareStatus`.
+
+    Mirrors ``SharingAPI`` (``_sharing.py``): the decoded payload and the
+    notebook id are handed to :meth:`ShareStatus.from_api_response`.
+    """
+    return ShareStatus.from_api_response(decoded, _NOTEBOOK_ID)
+
+
+def get_suggested_reports(decoded: Any) -> list[ReportSuggestion]:
+    """``GET_SUGGESTED_REPORTS`` -> one :class:`ReportSuggestion` per row.
+
+    Mirrors ``ArtifactsAPI.suggest_reports`` (``_artifacts.py``): the decoded
+    payload is routed through the production ``unwrap_artifact_rows`` wrap-probe
+    (accepting both the wrapped ``[[row, ...]]`` envelope and a flat list), then
+    each well-formed row is wrapped in a :class:`ReportSuggestionRow` (the
+    position adapter) before constructing the public :class:`ReportSuggestion`.
+    """
+    rows = unwrap_artifact_rows(
+        decoded,
+        method_id=RPCMethod.GET_SUGGESTED_REPORTS.value,
+        source="golden.get_suggested_reports",
+    )
+    return [
+        ReportSuggestion(
+            title=row.title,
+            description=row.description,
+            prompt=row.prompt,
+            audience_level=row.audience_level,
+        )
+        for row in map(ReportSuggestionRow, rows)
+        if row.is_well_formed
+    ]

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -25,6 +25,7 @@ Fixture schema is documented in ``tests/fixtures/rpc_golden/README.md``.
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
 import json
 import warnings
@@ -33,6 +34,7 @@ from typing import Any, cast
 
 import pytest
 
+from notebooklm._app.serialize import to_jsonable
 from notebooklm._artifact.payloads import (
     build_audio_artifact_params,
     build_cinematic_video_artifact_params,
@@ -1058,6 +1060,21 @@ def test_response_decoder_returns_expected_payload(method: RPCMethod) -> None:
     )
 
 
+def _mapper_item_repr(item: Any) -> Any:
+    """Project one mapped item into its fixture-comparable shape.
+
+    ``to_public_dict()`` wins when present (research-task models expose it);
+    otherwise a dataclass instance is run through the transport-neutral
+    :func:`to_jsonable` (the same serializer the public ``--json`` / MCP / HTTP
+    envelopes use), and anything else passes through unchanged.
+    """
+    if hasattr(item, "to_public_dict"):
+        return item.to_public_dict()
+    if dataclasses.is_dataclass(item) and not isinstance(item, type):
+        return to_jsonable(item)
+    return item
+
+
 @pytest.mark.parametrize("method", ALL_METHODS, ids=lambda m: m.name)
 def test_mapper_output_shape_when_documented(method: RPCMethod) -> None:
     """Methods that document a downstream mapper must also pin its output.
@@ -1087,17 +1104,74 @@ def test_mapper_output_shape_when_documented(method: RPCMethod) -> None:
     # Mappers commonly return dataclass instances or lists thereof; compare
     # via the fixture-recorded shape (typically the public dict form or a
     # list of public dicts). The fixture decides the representation.
-    if isinstance(mapped, list) and mapped and hasattr(mapped[0], "to_public_dict"):
-        mapped_repr: Any = [item.to_public_dict() for item in mapped]
-    elif hasattr(mapped, "to_public_dict"):
-        mapped_repr = mapped.to_public_dict()
+    #
+    # Resolution order, per item:
+    #   1. ``to_public_dict()`` when present (research-task models expose it);
+    #   2. otherwise the transport-neutral :func:`to_jsonable` projection for a
+    #      dataclass instance — the same serializer the CLI/MCP/HTTP adapters
+    #      use, so the golden shape matches the public ``--json`` envelope;
+    #   3. otherwise the raw return value (primitives / dicts / lists).
+    if isinstance(mapped, list) and mapped:
+        mapped_repr: Any = [_mapper_item_repr(item) for item in mapped]
     else:
-        mapped_repr = mapped
+        mapped_repr = _mapper_item_repr(mapped)
 
     assert mapped_repr == expected, (
         f"Mapper {mapper_ref!r} for {method.name} returned a shape that "
         f"does not match the fixture's mapper_expected.\n"
         f"Got: {mapped_repr!r}\nExpected: {expected!r}"
+    )
+
+
+# Methods whose fixtures are expected to carry a wired ``mapper`` /
+# ``mapper_expected`` pair so the decoder->dataclass seam is golden-pinned (not
+# merely skipped). The guard below fails loudly if any of them loses its mapper
+# wiring, converting the historical silent skip into a zero-cost ratchet.
+#
+# Only methods whose feature path has a CLEAN single-payload mapper are listed.
+# The remaining methods stay honestly skipped because their feature path either:
+#   * returns ``None`` on success (fire-and-forget mutations: CREATE_NOTE,
+#     DELETE_*, RENAME_*, SHARE_*, SET_USER_SETTINGS, REMOVE_RECENTLY_VIEWED,
+#     RETRY_ARTIFACT, REVISE_SLIDE, the *_RESEARCH starters, …);
+#   * extracts inline via ``safe_index`` with no centralised mapper
+#     (GET_SOURCE's field-by-field ``SourceFulltext`` build, GET_SOURCE_GUIDE,
+#     conversation/user-settings/tier reads, GET_INTERACTIVE_HTML, …);
+#   * has no decoded payload to map (UPDATE_SOURCE decodes to ``null``); or
+#   * reconciles the raw decode against client-side state rather than returning
+#     it directly (CREATE_NOTEBOOK feeds the payload to ``Notebook.from_api_response``
+#     but the feature return comes from a baseline-id-diff + ``_probe`` step, so
+#     the raw-decode shape is not the public return the fixture would pin).
+# Wiring those would require contorting the harness or adding production code
+# for tests, so they are deliberately exempt rather than forced.
+_MAPPER_COVERED_METHODS: tuple[RPCMethod, ...] = (
+    RPCMethod.POLL_RESEARCH,
+    RPCMethod.LIST_NOTEBOOKS,
+    RPCMethod.GET_NOTEBOOK,
+    RPCMethod.ADD_SOURCE,
+    RPCMethod.LIST_ARTIFACTS,
+    RPCMethod.LIST_LABELS,
+    RPCMethod.GET_SHARE_STATUS,
+    RPCMethod.GET_SUGGESTED_REPORTS,
+)
+
+
+def test_mapper_covered_methods_have_mappers() -> None:
+    """Methods listed as mapper-covered must keep their wired mapper goldens.
+
+    Mirrors ``test_drift_prone_methods_have_drift_cases``: if a future edit
+    drops the ``mapper`` / ``mapper_expected`` pair from one of these fixtures,
+    the suite fails loudly here rather than silently degrading the
+    ``test_mapper_output_shape_when_documented`` row back into a skip.
+    """
+    missing = []
+    for method in _MAPPER_COVERED_METHODS:
+        fixture = _load_fixture(method)
+        if not fixture.get("mapper") or "mapper_expected" not in fixture:
+            missing.append(method.name)
+    assert not missing, (
+        f"Mapper-covered methods missing a 'mapper' / 'mapper_expected' pair: "
+        f"{missing}. Restore the decoder->dataclass golden for each (see "
+        f"tests/unit/_golden_mappers.py)."
     )
 
 


### PR DESCRIPTION
## Why

`tests/unit/test_rpc_golden_payloads.py` had **45 skipped tests**, all from one parametrized test, `test_mapper_output_shape_when_documented`. It self-skips whenever a fixture omits the optional `mapper` / `mapper_expected` fields — and only `POLL_RESEARCH` declared them. The skip was the *silent default*, with no guard (unlike the sibling `drift_cases` mechanism) preventing a mapper-bearing method from quietly regressing back into a skip.

## What

- **`tests/unit/_golden_mappers.py` (new)** — single-argument wrappers that mirror each feature-layer parse path, so the golden harness (which calls a mapper with one positional arg = `expected_decoded`) can pin the decoder→dataclass seam. Artifact mappers route through the **production** `unwrap_artifact_rows` helper rather than re-implementing the envelope probe.
- **7 fixtures wired** with `mapper` / `mapper_expected` (`LIST_NOTEBOOKS`, `GET_NOTEBOOK`, `ADD_SOURCE`, `LIST_ARTIFACTS`, `LIST_LABELS`, `GET_SHARE_STATUS`, `GET_SUGGESTED_REPORTS`). Every `mapper_expected` was computed by **running the real mapper** on the fixture's `expected_decoded`, not hand-authored. A few fixtures' `expected_decoded` were enriched to realistic shapes (e.g. `GET_SHARE_STATUS` now carries two scrubbed shared-user rows; `GET_SUGGESTED_REPORTS` uses the wrapped `[[row,...]]` envelope matching real captures) so the assertions exercise real parsing rather than degenerate empties.
- **Ratchet guard** — `_MAPPER_COVERED_METHODS` + `test_mapper_covered_methods_have_mappers`, mirroring `_DRIFT_COVERED_METHODS` / `test_drift_prone_methods_have_drift_cases`. Any covered method that loses its mapper now fails loudly instead of silently skipping.

**Skips: 45 → 38.** The remaining 38 are honest exemptions (fire-and-forget mutations that decode to `None`, inline `safe_index` reads, `UPDATE_SOURCE` decoding to `null`, and `CREATE_NOTEBOOK`'s baseline-diff reconciliation) — documented inline on `_MAPPER_COVERED_METHODS`.

## Verification

- `uv run pytest tests/unit/test_rpc_golden_payloads.py` → `275 passed, 38 skipped`
- Full unit suite → `8295 passed` (the 2 `test_auth_headless_reauth` failures are pre-existing browser/playwright-env, not from this change)
- `mypy src/notebooklm` clean · `ruff check .` + `ruff format --check .` clean

Test-only; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated golden RPC fixtures across multiple endpoints to reflect richer response shapes and decoding expectations
  * Added mapper-based validations that project decoded payloads into public-facing shapes and enforce mapper coverage for listed methods
  * Adjusted test assertions to serialize mapper outputs consistently for comparison

* **Documentation**
  * Expanded fixture README to document the mapper mechanism and expected serialization/projection behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->