### PR TITLE
test(cli_vcr): cover research + auth groups, drain stale exemptions

### DIFF
--- a/tests/_guardrails/test_cli_vcr_coverage.py
+++ b/tests/_guardrails/test_cli_vcr_coverage.py
@@ -38,7 +38,10 @@ command module for a ``NotebookLMClient`` / ``run_client_workflow`` RPC path):
 
 * ``"Phase-3: needs maintainer recording (#1452)"`` — the group hits the RPC API
   but has no cassettes yet; it flips on when a maintainer records (issue #1452
-  Phase 3). These are the only entries expected to drain.
+  Phase 3). No group currently carries this reason (``research`` / ``auth`` drained
+  out of it once their cassettes were wired up — see ``test_research.py`` /
+  ``test_auth.py``); it is kept as a sanctioned reason for any future RPC-path
+  group that lands before its cassette does.
 * ``"local-only, no RPC path"`` — the group never builds a client (filesystem /
   package-data only), so a VCR cassette would record nothing. These are
   permanent by design.
@@ -70,28 +73,27 @@ _REASON_LOCAL_ONLY = "local-only, no RPC path"
 # name), so the mapping is explicit. Each path is relative to ``CLI_VCR_DIR``.
 GROUP_COVERAGE: dict[str, str] = {
     "artifact": "test_artifacts.py",
+    "auth": "test_auth.py",  # `auth check`/`refresh` token-fetch paths over reused cassettes
     "download": "test_downloads.py",
     "generate": "test_generate.py",
     "label": "test_label.py",
     "language": "test_settings.py",  # `language` commands live in test_settings.py
     "note": "test_notes.py",
     "profile": "test_profile.py",
+    "research": "test_research.py",  # `research status`/`wait` over reused poll cassettes
     "share": "test_share.py",
     "source": "test_sources.py",
 }
 
 # Groups with no cli_vcr coverage today → reason. Shrink-only: a group leaves
 # this map ONLY by gaining real coverage (move it to GROUP_COVERAGE). Verified
-# by reading each command module:
-#   * ``research``/``auth`` build a NotebookLMClient (RPC path) but have no
-#     cassettes yet — they flip on when a maintainer records (#1452 Phase 3).
-#   * ``agent``/``skill``/``mcp`` never touch the RPC API (``agent show`` prints
-#     packaged prompt templates; ``skill`` reads/writes skill files on disk;
-#     ``mcp install`` reads/writes the MCP client's config file on disk), so a VCR
-#     cassette would capture nothing — permanently local-only.
+# by reading each command module: ``agent``/``skill``/``mcp`` never touch the RPC
+# API (``agent show`` prints packaged prompt templates; ``skill`` reads/writes
+# skill files on disk; ``mcp install`` reads/writes the MCP client's config file
+# on disk), so a VCR cassette would capture nothing — permanently local-only.
+# (``research`` / ``auth`` left this map for GROUP_COVERAGE once their cassettes
+# were wired up; see the module docstring for the now-unused needs-recording reason.)
 COVERAGE_EXEMPT: dict[str, str] = {
-    "research": _REASON_NEEDS_RECORDING,
-    "auth": _REASON_NEEDS_RECORDING,
     "agent": _REASON_LOCAL_ONLY,
     "skill": _REASON_LOCAL_ONLY,
     "mcp": _REASON_LOCAL_ONLY,

--- a/tests/cassettes/README.md
+++ b/tests/cassettes/README.md
@@ -37,7 +37,7 @@ synthetic error recordings used by error-replay tests, and
 | `chat`         | `chat_ask.yaml`, `chat_ask_with_references.yaml` |
 | `notes`        | `notes_create.yaml`, `notes_list_mind_maps.yaml` |
 | `auth`         | `auth_rotate_cookies_refresh.yaml` |
-| `cli`          | `cli_doctor.yaml`, `cli_login_browser_cookies_check.yaml` |
+| `cli`          | `cli_doctor.yaml`, `cli_auth.yaml`, `cli_login_browser_cookies_check.yaml` |
 
 `<operation>` is the method or CLI verb being exercised (`list`, `add`,
 `download`, `generate`, `rename`, etc.).

--- a/tests/cassettes/cli_auth.yaml
+++ b/tests/cassettes/cli_auth.yaml
@@ -1,0 +1,15 @@
+# VCR cassette for the local `notebooklm auth check` CLI integration tests.
+#
+# The default `auth check` path is a local-only diagnostic — it reads the
+# profile's storage_state.json and validates the cookie jar, making NO HTTP
+# requests. This cassette is therefore intentionally empty: the matched tests
+# exist to guard that the no-network `auth check` path never starts emitting
+# HTTP traffic in a future refactor (VCR in record_mode='none' raises on any
+# unmatched request). If a network call is ever added to the default path, the
+# cli_vcr test fails loudly with a CannotOverwriteExistingCassetteException and
+# forces the author to re-record this cassette intentionally.
+#
+# The token-fetch (`auth check --test`) and `auth refresh` paths DO make HTTP
+# and reuse `auth_rotate_cookies_refresh.yaml` instead.
+interactions: []
+version: 1

--- a/tests/integration/cli_vcr/test_auth.py
+++ b/tests/integration/cli_vcr/test_auth.py
@@ -1,0 +1,226 @@
+"""CLI integration tests for ``notebooklm auth`` (VCR replay).
+
+The ``auth`` group mixes local-only subcommands (``inspect`` / ``logout`` --
+filesystem and browser-cookie only) with RPC-path subcommands:
+
+* ``auth check``   -- local cookie validation by default (no HTTP); with
+  ``--test`` it also exercises the token-fetch round-trip (a homepage GET to
+  re-mint CSRF / session).
+* ``auth refresh`` -- the one-shot keepalive: loads the profile's
+  ``storage_state.json``, fetches CSRF + session from ``notebooklm.google.com``
+  (a homepage GET; their side effect is the rotated cookie jar), and persists
+  the jar back to disk.
+
+These tests drive the RPC-path subcommands through Click's ``CliRunner`` while
+VCR replays recorded traffic from ``tests/cassettes`` -- no live auth, no new
+recording. They close the ``auth`` cli_vcr coverage gap (issue #1452 Phase 3):
+the gate's ``COVERAGE_EXEMPT`` reason for ``auth`` was stale -- the cassette the
+token-fetch path needs (``auth_rotate_cookies_refresh.yaml``) already existed,
+so the group is exercisable without a maintainer recording.
+
+Cassettes reused:
+
+* ``cli_auth.yaml`` -- intentionally empty (``interactions: []``). Pins the
+  *local* ``auth check`` path so that if a future refactor makes the no-network
+  validation start issuing HTTP, VCR's ``record_mode="none"`` trips a loud
+  ``CannotOverwriteExistingCassetteException`` (the doctor / profile idiom).
+* ``auth_rotate_cookies_refresh.yaml`` -- the recorded refresh handshake. Its
+  homepage ``GET https://notebooklm.google.com/`` (interaction 2) is exactly the
+  request the token-fetch path makes; the two ``wXbhsf`` batchexecute POSTs it
+  also carries are left unplayed (VCR tolerates unplayed cassette interactions,
+  erroring only on UNMATCHED requests). Cross-referenced against
+  ``tests/integration/test_auth_refresh_vcr.py``, which drives the same cassette
+  through the client API.
+
+Why ``auth refresh`` / ``auth check --test`` deliberately do NOT use
+``mock_auth_for_vcr``: that fixture patches ``notebooklm.auth.fetch_tokens_with_domains``
+to a stub, which would short-circuit the very token-fetch round-trip these tests
+mean to replay. Instead they run the real fetch against an isolated profile with
+a real ``storage_state.json`` so the homepage GET reaches the cassette. The
+autouse ``_disable_keepalive_poke_for_vcr`` fixture (in
+``tests/integration/conftest.py``) suppresses the layer-1 ``RotateCookies`` poke
+for every ``@pytest.mark.vcr`` test, so no un-recorded ``accounts.google.com``
+POST escapes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from notebooklm import paths
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# A storage_state.json with the cookies the token-fetch path needs. SID is the
+# load-bearing cookie for ``auth check``'s ``sid_cookie`` probe; the rest round
+# out a realistic Google auth jar. Values are obviously synthetic -- VCR matches
+# on request shape, never on cookie values, so the recorded homepage GET replays
+# regardless of what is sent.
+_STORAGE_COOKIES = [
+    {"name": "SID", "value": "fixture-sid", "domain": ".google.com", "path": "/"},
+    {"name": "HSID", "value": "fixture-hsid", "domain": ".google.com", "path": "/"},
+    {"name": "SSID", "value": "fixture-ssid", "domain": ".google.com", "path": "/"},
+    {"name": "APISID", "value": "fixture-apisid", "domain": ".google.com", "path": "/"},
+    {"name": "SAPISID", "value": "fixture-sapisid", "domain": ".google.com", "path": "/"},
+    {
+        "name": "__Secure-1PSIDTS",
+        "value": "fixture-1psidts",
+        "domain": ".google.com",
+        "path": "/",
+    },
+]
+
+
+@pytest.fixture
+def isolated_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``NOTEBOOKLM_HOME`` into ``tmp_path`` with a seeded default profile.
+
+    Writes a real ``storage_state.json`` under the default profile so the
+    token-fetch path loads genuine on-disk cookies (the keepalive needs a
+    writable storage file). Clears ``notebooklm.paths`` module caches before and
+    after so the sandbox env var actually takes effect, mirroring the
+    ``isolated_home`` fixtures in ``test_doctor.py`` / ``test_profile.py``.
+
+    Returns the resolved ``storage_state.json`` path so tests can assert the
+    keepalive persisted the rotated jar back to it.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+
+    profile_dir = tmp_path / "profiles" / "default"
+    profile_dir.mkdir(parents=True)
+    try:
+        profile_dir.chmod(0o700)
+    except (OSError, NotImplementedError):
+        pass
+    storage_path = profile_dir / "storage_state.json"
+    # Seed valid in-band account metadata (``notebooklm.account``) so the
+    # keepalive's post-fetch ``_is_valid_account_metadata`` check passes and the
+    # "Identifying Google account..." repair path (which would issue a SECOND,
+    # un-recorded homepage GET) is skipped -- the cassette records exactly ONE
+    # homepage GET, so the keepalive must make exactly one.
+    storage_path.write_text(
+        json.dumps(
+            {
+                "cookies": _STORAGE_COOKIES,
+                "notebooklm": {"account": {"authuser": 0, "email": "fixture@example.com"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps({"default_profile": "default"}), encoding="utf-8"
+    )
+
+    yield storage_path
+
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+
+
+class TestAuthCheckCommand:
+    """``notebooklm auth check`` -- local cookie validation (+ optional --test)."""
+
+    @notebooklm_vcr.use_cassette("cli_auth.yaml")
+    def test_check_local_passes(self, runner, isolated_profile: Path) -> None:
+        """Default ``auth check`` validates the seeded jar with NO HTTP.
+
+        The empty ``cli_auth.yaml`` cassette would trip on any request, so a
+        clean exit 0 also proves the no-network contract of the default path.
+        """
+        result = runner.invoke(cli, ["auth", "check", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["checks"]["storage_exists"] is True
+        assert data["checks"]["sid_cookie"] is True
+
+    @notebooklm_vcr.use_cassette("cli_auth.yaml")
+    def test_check_missing_storage_fails(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``auth check`` on a profile with no ``storage_state.json`` reports failure.
+
+        Still makes no HTTP request (the empty cassette guards that), and exits
+        non-zero because the storage-exists probe fails.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+        monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+        monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+        paths.set_active_profile(None)
+        paths._reset_config_cache()
+        try:
+            result = runner.invoke(cli, ["auth", "check", "--json"])
+        finally:
+            paths.set_active_profile(None)
+            paths._reset_config_cache()
+
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output)
+        assert data["checks"]["storage_exists"] is False
+
+    def test_check_test_fetch_round_trip(self, runner, isolated_profile: Path) -> None:
+        """``auth check --test`` replays the homepage token-fetch GET and reports pass.
+
+        Reuses the refresh cassette's homepage GET (interaction 2). The
+        ``--test`` path mints CSRF + session from the recorded HTML; a
+        ``token_fetch == True`` check proves the extractor ran against real
+        recorded page chrome, and ``play_count == 1`` proves the round-trip
+        actually hit the cassette rather than short-circuiting.
+        """
+        with notebooklm_vcr.use_cassette("auth_rotate_cookies_refresh.yaml") as cassette:
+            result = runner.invoke(cli, ["auth", "check", "--test", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["checks"]["token_fetch"] is True
+        assert cassette.play_count == 1, "expected exactly one recorded homepage GET to replay"
+
+
+class TestAuthRefreshCommand:
+    """``notebooklm auth refresh`` -- one-shot keepalive token fetch."""
+
+    def test_refresh_keepalive(self, runner, isolated_profile: Path) -> None:
+        """``auth refresh`` replays the homepage GET and reports the refreshed path.
+
+        The keepalive loads the seeded jar, performs the homepage GET (replayed
+        from the cassette), re-mints CSRF / session, and persists the jar back
+        to ``storage_state.json``. Asserts exit 0, the success line naming the
+        storage path, and ``play_count == 1`` -- the recorded GET is what makes
+        the fetch succeed offline, and the count proves it was actually issued.
+        """
+        with notebooklm_vcr.use_cassette("auth_rotate_cookies_refresh.yaml") as cassette:
+            result = runner.invoke(cli, ["auth", "refresh"])
+
+        assert result.exit_code == 0, result.output
+        assert "refreshed" in result.output
+        assert cassette.play_count == 1, "expected exactly one recorded homepage GET to replay"
+        # The keepalive's whole point is a writable storage file; it must still
+        # exist (and remain valid JSON) after the rotated jar is persisted.
+        assert isolated_profile.exists()
+        json.loads(isolated_profile.read_text(encoding="utf-8"))
+
+    def test_refresh_quiet_suppresses_success_line(self, runner, isolated_profile: Path) -> None:
+        """``auth refresh --quiet`` runs the same fetch but prints no output at all.
+
+        The quiet keepalive still issues (and consumes) the recorded homepage GET
+        -- ``play_count == 1`` -- but suppresses the success line entirely, so
+        stdout/stderr come back empty.
+        """
+        with notebooklm_vcr.use_cassette("auth_rotate_cookies_refresh.yaml") as cassette:
+            result = runner.invoke(cli, ["auth", "refresh", "--quiet"])
+
+        assert result.exit_code == 0, result.output
+        assert not result.output.strip(), (
+            f"quiet refresh must print nothing, got: {result.output!r}"
+        )
+        assert cassette.play_count == 1, "expected exactly one recorded homepage GET to replay"

--- a/tests/integration/cli_vcr/test_research.py
+++ b/tests/integration/cli_vcr/test_research.py
@@ -1,0 +1,171 @@
+"""CLI integration tests for ``notebooklm research`` (VCR replay).
+
+The ``research`` group (``status`` / ``wait``) is an RPC-backed command set: it
+opens a real :class:`~notebooklm.client.NotebookLMClient` and polls the research
+session over ``batchexecute``. These tests drive the full CLI -> Client -> RPC
+path through Click's ``CliRunner`` while VCR replays the recorded poll traffic
+from ``tests/cassettes`` -- no live auth, no new recording.
+
+Cassettes reused (recorded against the python-API / research suite; the
+``cli_vcr`` suite shares ``cassette_library_dir`` so they replay directly):
+
+* ``research_poll.yaml``       -- a poll that classifies to an active/terminal
+  verdict (rpcids ``Ljjv0c`` then ``e3bVqc``); drives the populated
+  ``research status`` path.
+* ``research_poll_empty.yaml`` -- a poll against a notebook with no research
+  task (single ``e3bVqc``); drives both the ``no_research`` ``research status``
+  path and the single-poll terminal ``research wait`` path.
+
+These close the ``research`` cli_vcr coverage gap (issue #1452 Phase 3): the
+gate's ``COVERAGE_EXEMPT`` reason for ``research`` was stale -- the cassettes
+already existed, so the group is exercisable without a maintainer recording.
+
+Why this matters beyond the gate: ``research status``/``wait`` resolve the
+notebook, poll the session, classify the result, and project the ``--json``
+envelope -- a path no other cli_vcr test touches. The matcher keys on
+``rpcids`` + decoded body shape (never the notebook id), so the placeholder id
+``mock_context`` injects replays cleanly against cassettes recorded elsewhere.
+
+The poll/``status`` commands only enter the RPC layer; the leading homepage GET
+some cassettes carry (auth bootstrap) is simply left unplayed, which VCR's
+``record_mode="none"`` tolerates -- it errors only on UNMATCHED requests the
+cassette lacks, never on unplayed cassette interactions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+
+class TestResearchStatusCommand:
+    """``notebooklm research status`` -- single non-blocking poll."""
+
+    def test_status_text(self, runner, mock_auth_for_vcr, mock_context) -> None:
+        """Text-mode status against a populated poll exits 0 and prints a verdict.
+
+        The recorded poll classifies to the ``in_progress`` branch, which prints
+        a non-empty status line. The ``cassette.play_count == 1`` assertion pins
+        that the command actually issued (and consumed) the recorded poll RPC --
+        without it, a regression that short-circuited to a local default would
+        still satisfy the exit-0 / output-present checks.
+        """
+        with notebooklm_vcr.use_cassette("research_poll.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "status"])
+
+        assert result.exit_code == 0, result.output
+        assert result.output.strip(), "expected a status line"
+        # A traceback in the output means the command crashed rather than
+        # rendering a classified result.
+        assert "Traceback" not in result.output
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
+
+    def test_status_json_envelope(self, runner, mock_auth_for_vcr, mock_context) -> None:
+        """``research status --json`` emits the canonical ``to_public_dict`` payload.
+
+        Asserts the envelope *shape* (a JSON object carrying a ``status`` key
+        whose value is a string) plus the populated-cassette invariant that the
+        status is NOT ``no_research`` -- catching a short-circuit / wrong-cassette
+        regression where the command never reached the recorded in-flight poll.
+        The recorded value happens to be ``in_progress``; the floor assertion
+        (``!= "no_research"``) is the re-record-safe part, the equality is a
+        tighter pin on today's recording.
+        """
+        with notebooklm_vcr.use_cassette("research_poll.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, dict), f"expected a JSON object, got: {result.output!r}"
+        assert isinstance(data.get("status"), str), f"missing/invalid status: {data!r}"
+        assert data["status"] != "no_research", f"populated poll must not be no_research: {data!r}"
+        assert data["status"] == "in_progress", f"recorded poll is in_progress: {data!r}"
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
+
+    def test_status_no_research_text(self, runner, mock_auth_for_vcr, mock_context) -> None:
+        """A poll with no research task reports the ``no_research`` branch.
+
+        ``research status`` (unlike ``research wait``) exits 0 even when no
+        research is running -- it is a non-blocking status probe. The text
+        render prints the "No research running" line. ``play_count == 1`` proves
+        the verdict came from the recorded empty poll, not a skipped RPC.
+        """
+        with notebooklm_vcr.use_cassette("research_poll_empty.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "status"])
+
+        assert result.exit_code == 0, result.output
+        assert "No research running" in result.output
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
+
+    def test_status_no_research_json(self, runner, mock_auth_for_vcr, mock_context) -> None:
+        """``research status --json`` on an idle notebook reports ``no_research``."""
+        with notebooklm_vcr.use_cassette("research_poll_empty.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, dict), f"expected a JSON object, got: {result.output!r}"
+        assert data.get("status") == "no_research", f"expected no_research, got: {data!r}"
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
+
+
+class TestResearchWaitCommand:
+    """``notebooklm research wait`` -- blocking poll loop.
+
+    ``wait`` drives ``ResearchAPI.wait_for_completion``, which polls until a
+    *terminal* status (``completed`` / ``failed`` / ``no_research``) or the
+    timeout fires. ``research_poll_empty.yaml`` returns ``no_research`` on its
+    single recorded ``e3bVqc`` poll, so ``wait_for_completion`` returns after
+    exactly one interaction -- a deterministic terminal path that exercises the
+    full CLI ``wait`` -> resolve -> poll-loop -> render -> exit-code chain
+    without needing a cassette that records a multi-tick progression.
+
+    ``fast_sleep`` no-ops ``asyncio.sleep`` so that if the poll loop ever sleeps
+    before reaching its verdict the test still runs at full speed; on the
+    single-poll terminal path the terminal check short-circuits before any
+    sleep, so it is belt-and-braces here.
+    """
+
+    def test_wait_no_research_text(
+        self, runner, mock_auth_for_vcr, mock_context, fast_sleep
+    ) -> None:
+        """``research wait`` on an idle notebook exits 1 with a no-research message.
+
+        Unlike ``research status`` (a non-blocking probe that exits 0), ``wait``
+        treats "nothing to wait for" as a failure outcome and exits 1 per the
+        handler's ``no_research`` branch. ``play_count == 1`` proves the verdict
+        came from the recorded poll, not a loop that short-circuited before
+        issuing any RPC.
+        """
+        with notebooklm_vcr.use_cassette("research_poll_empty.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "wait", "--interval", "1"])
+
+        assert result.exit_code == 1, result.output
+        assert "No research running" in result.output
+        assert "Traceback" not in result.output
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
+
+    def test_wait_no_research_json(
+        self, runner, mock_auth_for_vcr, mock_context, fast_sleep
+    ) -> None:
+        """``research wait --json`` on an idle notebook emits the ``no_research`` envelope.
+
+        Shape-only: a JSON object whose ``status`` is ``no_research`` and which
+        carries an ``error`` string -- never a recorded value, so re-record-safe.
+        """
+        with notebooklm_vcr.use_cassette("research_poll_empty.yaml") as cassette:
+            result = runner.invoke(cli, ["research", "wait", "--json", "--interval", "1"])
+
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, dict), f"expected a JSON object, got: {result.output!r}"
+        assert data.get("status") == "no_research", f"expected no_research, got: {data!r}"
+        assert isinstance(data.get("error"), str), f"missing error string: {data!r}"
+        assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"

--- a/tests/integration/cli_vcr/test_research.py
+++ b/tests/integration/cli_vcr/test_research.py
@@ -39,10 +39,20 @@ import json
 import pytest
 
 from notebooklm.notebooklm_cli import cli
+from notebooklm.types import ResearchStatus
 
 from .conftest import notebooklm_vcr, skip_no_cassettes
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# Allowed ``status`` values for a *populated* research poll -- every canonical
+# ``ResearchStatus`` value except ``no_research`` (which is the empty-poll
+# sentinel). Derived from the enum as a set-membership floor, NOT a pin on the
+# recorded value, so the assertion survives a re-record into any populated state
+# (issue #1452 re-record-safe convention).
+_POPULATED_STATUS_VALUES = frozenset(
+    member.value for member in ResearchStatus if member is not ResearchStatus.NO_RESEARCH
+)
 
 
 class TestResearchStatusCommand:
@@ -72,11 +82,12 @@ class TestResearchStatusCommand:
 
         Asserts the envelope *shape* (a JSON object carrying a ``status`` key
         whose value is a string) plus the populated-cassette invariant that the
-        status is NOT ``no_research`` -- catching a short-circuit / wrong-cassette
-        regression where the command never reached the recorded in-flight poll.
-        The recorded value happens to be ``in_progress``; the floor assertion
-        (``!= "no_research"``) is the re-record-safe part, the equality is a
-        tighter pin on today's recording.
+        status is a known *active-or-terminal* :class:`ResearchStatus` value (NOT
+        ``no_research``). That catches a short-circuit / wrong-cassette regression
+        where the command never reached the recorded in-flight poll, while staying
+        re-record-safe: it is a set-membership check against the canonical enum
+        (not a pin on the recorded value), so a re-record that lands in any
+        populated state (today it is ``in_progress``) still passes.
         """
         with notebooklm_vcr.use_cassette("research_poll.yaml") as cassette:
             result = runner.invoke(cli, ["research", "status", "--json"])
@@ -85,8 +96,9 @@ class TestResearchStatusCommand:
         data = json.loads(result.output)
         assert isinstance(data, dict), f"expected a JSON object, got: {result.output!r}"
         assert isinstance(data.get("status"), str), f"missing/invalid status: {data!r}"
-        assert data["status"] != "no_research", f"populated poll must not be no_research: {data!r}"
-        assert data["status"] == "in_progress", f"recorded poll is in_progress: {data!r}"
+        assert data["status"] in _POPULATED_STATUS_VALUES, (
+            f"populated poll status must be a known non-no_research value: {data!r}"
+        )
         assert cassette.play_count == 1, "expected exactly one recorded poll RPC to replay"
 
     def test_status_no_research_text(self, runner, mock_auth_for_vcr, mock_context) -> None:


### PR DESCRIPTION
## Summary
- Add cli_vcr (VCR-replay CLI integration) coverage for the `research` and `auth` command groups by **reusing existing cassettes** — no live auth, no new recording.
- Drain both groups from the shrink-only-ratchet `COVERAGE_EXEMPT` set in `tests/_guardrails/test_cli_vcr_coverage.py`; their `_REASON_NEEDS_RECORDING` exemption was stale (the cassettes already existed under `tests/cassettes`, which the cli_vcr suite shares via `cassette_library_dir`).

## What's covered
- **`tests/integration/cli_vcr/test_research.py`** — `research status` (populated `in_progress` + `no_research`, text + `--json`) over `research_poll.yaml` / `research_poll_empty.yaml`; `research wait` (deterministic `no_research` terminal, text + `--json`). The deep cassette (`research_deep_poll_long.yaml`) is intentionally NOT used for `wait`: it records only in-progress polls and never reaches a terminal state, so it would exhaust mid-loop.
- **`tests/integration/cli_vcr/test_auth.py`** — local `auth check` (new empty-cassette pin `cli_auth.yaml`, doctor/profile idiom), `auth check --test`, and `auth refresh` (+ `--quiet`) over the existing `auth_rotate_cookies_refresh.yaml` homepage GET. Seeds in-band account metadata so the keepalive's "Identifying Google account" repair path (a second, un-recorded GET) is skipped.
- Every RPC-path test asserts `cassette.play_count == 1` so a short-circuit regression that skips the intended RPC fails loudly (not just "exit 0").
- Guardrail: moved `research`/`auth` into `GROUP_COVERAGE`, removed from `COVERAGE_EXEMPT`, refreshed the now-accurate docstring/comments. `_REASON_NEEDS_RECORDING` kept (still sanctioned by `_VALID_REASONS` for future groups). Added `cli_auth.yaml` to `tests/cassettes/README.md`.

## Test plan
- [x] `uv run pytest tests/integration/cli_vcr/test_research.py tests/integration/cli_vcr/test_auth.py -v` → 11 passed
- [x] `uv run pytest tests/_guardrails/test_cli_vcr_coverage.py -v` → green (ratchet flips automatically)
- [x] `uv run pytest tests/_guardrails/ tests/integration/cli_vcr/ tests/integration/test_auth_refresh_vcr.py` → 1138 passed, 2 skipped, 1 xfailed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → clean
- [x] `uv run pre-commit run --all-files` (ruff + format over whole tree) → passed

## Polish
Ran `/polish` (claude + codex; agy excluded per project policy). Code-simplifier consolidated duplicated guardrail prose. Triple review found one Important item (RPC-path tests didn't assert cassette consumption) — addressed by adding `cassette.play_count == 1` to all RPC-path tests plus a `status != "no_research"` floor on the populated case — and one minor (quiet-refresh assertion tightened to `not result.output.strip()`).

## Deferred polish findings
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration VCR-based tests for the `auth` CLI (check, refresh, quiet mode) and for the `research` CLI (status and wait, text and JSON modes).

* **Documentation**
  * Expanded cassette examples in test docs to include an auth cassette and clarified auth cassette behavior (local-only vs networked flows).

* **Chores**
  * Updated CLI coverage classification and exemption rationale so only permanently local-only groups remain exempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->