### PR TITLE
refactor: drain module-size ratchet to two monoliths (budget 1000)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -950,6 +950,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_source/listing.py` | Core service layer for listing notebook sources |
 | `_source/polling.py` | Poll coordination service for active source conversions |
 | `_source/upload.py` | Concurrency-gated upload pipeline for source files |
+| `_source/_upload_decode.py` | Pure decode/validation helpers for the upload pipeline (URL redaction, ADD_SOURCE_FILE source-id extraction, content-type policy), extracted from `upload.py` |
 | `_source/upload_payloads.py` | Stable source upload registration, rename, and resumable-upload request builders |
 | `_label/params.py` | Stable CREATE_LABEL / LIST_LABELS / UPDATE_LABEL / DELETE_LABEL request payload builders (with the shared `_opts()` request-options wrapper) |
 | `_notebook_metadata.py` | Metadata protocol schemas for sub-clients |
@@ -1084,6 +1085,7 @@ src/notebooklm/
 │   └── semaphore.py             # Concurrency semaphore middleware
 ├── _source/                     # Source-feature subpackage (promoted from flat _source_*.py, #1328)
 │   ├── __init__.py              # Re-exports the cluster's public service classes
+│   ├── _upload_decode.py        # Pure URL/source-id/content-type decode + validation helpers (extracted from upload.py)
 │   ├── add.py                   # Source addition coordinator
 │   ├── content.py               # Source content fetcher
 │   ├── listing.py               # Source listing helper

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -64,38 +64,19 @@ async def _await_writer_exit(
 ) -> None:
     """Wait for a download writer thread to actually exit.
 
-    Plain ``await asyncio.to_thread(thread.join)`` is unsafe under
-    cancellation: if our awaiting task is cancelled, the await raises
-    ``CancelledError`` and we unwind even though the underlying
-    ``thread.join`` is still blocked on the thread. The thread keeps
-    running, which means the outer cleanup (``temp_file.unlink``)
-    races with the writer's still-open file handle.
+    A plain ``await asyncio.to_thread(thread.join)`` is unsafe under cancellation:
+    the await raises ``CancelledError`` and we unwind while the underlying join is
+    still blocked, so outer cleanup (``temp_file.unlink``) races the writer's
+    still-open file handle. ``asyncio.shield`` alone doesn't help (the await still
+    raises). The fix is a shield-loop that re-awaits the same shielded join task
+    until it completes; repeated cancellations only delay our re-raise, never the
+    writer's exit.
 
-    ``asyncio.shield`` alone doesn't fix this: it keeps the *inner*
-    join task alive across cancellation, but the *await* still raises
-    ``CancelledError`` and we unwind anyway. The fix is a shield-loop
-    that keeps re-awaiting the same shielded join task until it
-    actually completes. Repeated cancellations only delay our
-    re-raise, never the writer's exit.
-
-    Cancellation handling:
-
-    * Only ``asyncio.CancelledError`` is caught inside the loop — any
-      other exception from the shielded join (currently none in
-      practice, since ``Thread.join`` doesn't raise) propagates
-      immediately so we don't accidentally hide a real bug.
-    * The most recent ``CancelledError`` (if any) is preserved.
-    * If ``re_raise_cancel=True``, the helper re-raises that
-      ``CancelledError`` after the writer has fully exited. Callers
-      on the success path want this so an in-flight cancellation
-      isn't lost when the writer happens to finish first. Callers on
-      a cleanup-path (the producer's ``except`` block, which already
-      has an exception to re-raise) leave it at the default
-      ``False`` so we don't mask the original error with a second
-      cancellation.
-
-    Handles both the original join-vs-unlink race AND the follow-up case
-    where an initial fix could silently absorb task cancellation.
+    Only ``CancelledError`` is caught (any other join exception propagates). The
+    most recent ``CancelledError`` is preserved and, when ``re_raise_cancel`` is
+    set, re-raised after the writer exits — success-path callers want this so an
+    in-flight cancellation isn't lost; cleanup-path callers leave it ``False`` so
+    the original error isn't masked by a second cancellation.
     """
     join_task = asyncio.ensure_future(asyncio.to_thread(writer_thread.join))
     cancelled_error: asyncio.CancelledError | None = None
@@ -837,32 +818,16 @@ class ArtifactDownloadService:
                                 "Authentication may have expired. Run 'notebooklm login'.",
                             )
 
-                        # Producer/consumer split: a single dedicated
-                        # writer thread drains a bounded queue and writes
-                        # to ``temp_file``. Compared to the legacy
-                        # per-chunk ``asyncio.to_thread(f.write, chunk)``,
-                        # this avoids thousands of thread-pool allocations
-                        # for multi-GB downloads.
-                        #
-                        # The writer runs on a dedicated ``threading.Thread``
-                        # rather than ``asyncio.to_thread`` so it does NOT
-                        # tie up a slot in asyncio's default executor pool.
-                        # With many concurrent downloads, default-executor
-                        # saturation by long-lived writers (each blocking
-                        # on ``chunk_q.get()``) could deadlock producers
-                        # trying to ``put`` via ``to_thread``.
-                        #
-                        # Producer puts use ``put_nowait`` first and only
-                        # fall back to ``to_thread(put, ...)`` when the
-                        # queue is full, minimizing default-executor
-                        # pressure during normal flow.
-                        #
-                        # End-of-stream is signalled with a ``None``
-                        # sentinel. Writer-side failures are surfaced via
-                        # ``writer_error`` and an early ``writer_failed``
-                        # ``threading.Event`` so the producer can short-
-                        # circuit BEFORE the writer's drain completes,
-                        # avoiding wasted network reads.
+                        # Producer/consumer split: one dedicated ``threading.Thread``
+                        # (not ``asyncio.to_thread``, which would tie up a default-
+                        # executor slot and risk deadlocking producers under many
+                        # concurrent downloads) drains a bounded queue to
+                        # ``temp_file``, avoiding per-chunk thread-pool churn on
+                        # multi-GB files. Producer puts use ``put_nowait`` first,
+                        # falling back to ``to_thread(put)`` only when full. EOF is a
+                        # ``None`` sentinel; writer failures surface via
+                        # ``writer_error`` + an early ``writer_failed`` Event so the
+                        # producer can short-circuit before the drain completes.
                         chunk_q: queue.Queue[bytes | None] = queue.Queue(
                             maxsize=_DOWNLOAD_WRITER_QUEUE_SIZE
                         )
@@ -870,23 +835,12 @@ class ArtifactDownloadService:
                         writer_error: list[BaseException] = []
 
                         def _writer_loop() -> None:
-                            # If the writer raises (e.g. OSError on
-                            # ``fh.write``), the bounded queue may have a
-                            # producer parked in ``q.put`` waiting for a
-                            # consumer. Without draining, that producer
-                            # hangs forever because we are the only
-                            # consumer. The ``finally`` drains pending
-                            # items via ``get_nowait`` so blocked puts
-                            # complete and the producer can observe the
-                            # failure signal on its next iteration.
-                            #
-                            # ``writer_failed`` is set in the ``except``
-                            # BEFORE the drain so the producer's
-                            # short-circuit check fires as early as
-                            # possible — the drain itself can run for a
-                            # few milliseconds clearing the queue, during
-                            # which the producer would otherwise read and
-                            # discard network bytes pointlessly.
+                            # On writer failure the bounded queue may have a producer
+                            # parked in ``q.put``; the ``finally`` drains via
+                            # ``get_nowait`` so those puts complete and the producer
+                            # can observe the failure. ``writer_failed`` is set in
+                            # ``except`` BEFORE the drain so the producer short-
+                            # circuits as early as possible.
                             try:
                                 with open(temp_file, "wb") as fh:
                                     while True:
@@ -922,19 +876,13 @@ class ArtifactDownloadService:
                         try:
                             async for chunk in response.aiter_bytes(chunk_size=65536):
                                 if writer_failed.is_set():
-                                    # Writer raised mid-stream. Stop
-                                    # reading — further network bytes
-                                    # would just be discarded by the
-                                    # drain. The original error is
-                                    # re-raised via ``writer_error[0]``
-                                    # below.
+                                    # Writer raised mid-stream: stop reading (further
+                                    # bytes would just be drained); error re-raised
+                                    # via ``writer_error`` below.
                                     break
-                                # ``put_nowait`` avoids a ``to_thread``
-                                # round-trip when the queue has space
-                                # (the common case under balanced flow);
-                                # fall back to ``to_thread`` only when
-                                # the queue is full so the loop suspends
-                                # cleanly under back-pressure.
+                                # ``put_nowait`` avoids a ``to_thread`` round-trip
+                                # when the queue has space; fall back only when full
+                                # so the loop suspends cleanly under back-pressure.
                                 try:
                                     chunk_q.put_nowait(chunk)
                                 except queue.Full:
@@ -945,30 +893,20 @@ class ArtifactDownloadService:
                                     chunk_q.put_nowait(None)
                                 except queue.Full:
                                     await asyncio.to_thread(chunk_q.put, None)
-                            # Join surfaces any exception the writer
-                            # captured. ``_await_writer_exit`` shield-
-                            # loops until the writer actually exits so
-                            # the outer cleanup never races with the
-                            # still-open file handle. ``re_raise_cancel
-                            # =True`` ensures a cancellation that
-                            # arrived while we were waiting for the
-                            # writer isn't lost when the writer happens
-                            # to finish first.
+                            # ``_await_writer_exit`` shield-loops until the writer
+                            # exits (so cleanup never races its file handle) and
+                            # surfaces any captured exception; ``re_raise_cancel``
+                            # preserves a cancellation that arrived mid-wait.
                             await _await_writer_exit(writer_thread, re_raise_cancel=True)
                             if writer_error:
                                 raise next(iter(writer_error))  # one-slot exception box
                         except BaseException:
-                            # On producer-side failure (network error,
-                            # cancellation, HTML payload), make sure the
-                            # writer sees a sentinel and exits — even if
-                            # the queue is currently saturated. A bare
-                            # ``put_nowait(None)`` would raise
-                            # ``queue.Full`` and leave the writer parked
-                            # in ``q.get`` forever; instead drop one item
-                            # to make room, then put the sentinel. At
-                            # most two iterations are needed: the writer
-                            # is the only consumer, so once a slot opens
-                            # nothing else refills it.
+                            # On producer-side failure, ensure the writer sees a
+                            # sentinel and exits even if the queue is saturated: a
+                            # bare ``put_nowait(None)`` would raise ``queue.Full`` and
+                            # leave the writer parked forever, so drop one item to
+                            # make room then put the sentinel (≤2 iterations — the
+                            # writer is the only consumer).
                             while True:
                                 try:
                                     chunk_q.put_nowait(None)
@@ -978,23 +916,11 @@ class ArtifactDownloadService:
                                 try:
                                     chunk_q.get_nowait()
                                 except queue.Empty:
-                                    # Writer drained between our put and
-                                    # get — the next put attempt will
-                                    # succeed.
                                     pass
-                            # MUST wait for the writer to actually exit
-                            # before unwinding: the outer ``except``
-                            # unlinks ``temp_file``, which would race
-                            # with the writer's still-open file handle
-                            # otherwise. A plain
-                            # ``contextlib.suppress(BaseException) +
-                            # await to_thread(.join)`` does NOT suffice
-                            # — the await itself can be re-cancelled and
-                            # unwind before the writer finishes. The
-                            # shield-loop in ``_await_writer_exit``
-                            # keeps re-awaiting the same shielded join
-                            # task across repeated cancellations until
-                            # the writer thread is actually dead.
+                            # MUST wait for the writer to fully exit before
+                            # unwinding: the outer ``except`` unlinks ``temp_file``,
+                            # which would race the writer's open file handle. See
+                            # ``_await_writer_exit`` for why a plain join doesn't do.
                             await _await_writer_exit(writer_thread)
                             raise
 

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -122,43 +122,28 @@ class ChatAPI(LoopBoundPrimitive):
     ):
         """Initialize the chat API.
 
-        Per ADR-0014 Rule 2 Corollary, ``ChatAPI`` depends on the
-        **direct** collaborators it actually exercises rather than a
-        chat-local Runtime Protocol that bundles them. ``ChatAPI`` takes
-        the four underlying collaborators (``rpc``, ``transport``,
-        ``reqid``, ``loop_guard``) by keyword argument.
+        Per ADR-0014 Rule 2 Corollary, ``ChatAPI`` depends on the **direct**
+        collaborators it exercises (``rpc``, ``transport``, ``reqid``,
+        ``loop_guard``) rather than a chat-local Runtime Protocol bundling them.
 
         Args:
-            rpc: RPC dispatch collaborator (the client's
-                ``internals.executor`` / ``RpcExecutor``) for the
-                ``get_conversation_*``, ``configure``,
-                ``delete_conversation``, and ``save_answer_as_note``
-                round-trips.
-            transport: :class:`RuntimeTransport` collaborator (the client's
-                ``_composed.transport``) that owns the authed-POST entry
-                point used by :meth:`ask` via
-                :func:`chat_aware_authed_post`.
-            reqid: :class:`ReqidCounter` collaborator (the client's
-                ``internals.collaborators.reqid``) that mints the
-                per-attempt ``_reqid`` query parameter for the streamed
-                chat request.
-            loop_guard: :class:`LoopGuard` collaborator (the client's
-                ``internals.collaborators.lifecycle``) whose
-                :meth:`assert_bound_loop` fires before :meth:`ask`
-                acquires the per-conversation lock so a cross-loop
-                follow-up doesn't hang on a lock bound to a dead loop.
-            chat_timeout: Per-read HTTP timeout, in seconds, for the streamed
-                chat endpoint. Defaults to the chat-specific shared-notebook
-                first-byte window. ``None`` inherits the underlying transport
-                timeout.
+            rpc: RPC dispatch collaborator for the ``get_conversation_*``,
+                ``configure``, ``delete_conversation``, and
+                ``save_answer_as_note`` round-trips.
+            transport: :class:`RuntimeTransport` owning the authed-POST entry
+                point used by :meth:`ask` via :func:`chat_aware_authed_post`.
+            reqid: :class:`ReqidCounter` minting the per-attempt ``_reqid``
+                query parameter for the streamed chat request.
+            loop_guard: :class:`LoopGuard` whose :meth:`assert_bound_loop` fires
+                before :meth:`ask` acquires the per-conversation lock, so a
+                cross-loop follow-up doesn't hang on a lock bound to a dead loop.
+            chat_timeout: Per-read HTTP timeout (seconds) for the streamed chat
+                endpoint. ``None`` inherits the underlying transport timeout.
             conversation_cache: Optional injected cache; defaults to a fresh
-                per-instance ``ConversationCache`` (chat-domain state, no
-                other consumer).
-            notebooks: Optional source-id resolver. Defaults to a
-                ``NotebooksAPI`` wrapper around ``rpc`` so a bare
-                ``ChatAPI(rpc=..., transport=..., reqid=..., loop_guard=...)``
-                still has a default source-id resolver without callers
-                wiring the full NotebooksAPI graph.
+                per-instance ``ConversationCache``.
+            notebooks: Optional source-id resolver; defaults to a
+                ``NotebooksAPI`` around ``rpc`` so a bare ``ChatAPI(...)`` still
+                resolves source ids without callers wiring the full graph.
         """
         self._rpc = rpc
         self._transport = transport
@@ -171,20 +156,14 @@ class ChatAPI(LoopBoundPrimitive):
             notebooks = NotebooksAPI(rpc)
         self._notebooks = notebooks
         self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
-        # Per-``conversation_id`` lock that serializes follow-up asks on the
-        # same conversation. Without this, two
-        # ``asyncio.gather``'d ``ask`` calls on the same conversation read
-        # identical pre-update history at the top, both POST that history,
-        # then race to append to ``self._cache`` — the server sees two
-        # follow-ups both claiming to be turn N+1 and the local cache loses
-        # one turn's lineage.
+        # Per-``conversation_id`` lock serializing follow-up asks on the same
+        # conversation. Without it, two ``asyncio.gather``'d asks read identical
+        # pre-update history, both POST it, then race to append to ``self._cache``
+        # — the server sees two turn N+1 follow-ups and the cache loses lineage.
         #
-        # ``WeakValueDictionary`` keeps the map bounded automatically:
-        # callers hold a strong reference to the lock while inside
-        # ``async with lock:``; once every waiter releases, the entry GCs
-        # itself and the key is removed. The cost is per-key churn for
-        # one-shot conversations, which is negligible compared to the
-        # round-trip we're protecting.
+        # ``WeakValueDictionary`` keeps the map bounded: a caller holds a strong
+        # ref while inside ``async with lock:``; once all waiters release, the
+        # entry GCs itself. Per-key churn for one-shot conversations is negligible.
         self._conversation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
@@ -196,14 +175,11 @@ class ChatAPI(LoopBoundPrimitive):
         self._new_conversation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
-        # Event-loop binding for the two lazy lock maps above. ``_bound_loop``
-        # and the ``set_bound_loop`` template method come from the
-        # :class:`~notebooklm._loop_bound.LoopBoundPrimitive` base; this API
-        # overrides :meth:`_on_loop_rebind` to clear the two lock maps on a
-        # loop change. Each lock in the maps binds to whichever loop is running
-        # the first time it is awaited; if the client is closed on loop A and
-        # reopened on loop B, a stale lock bound to the now-dead loop A must
-        # never be reused — see :meth:`_on_loop_rebind` / :meth:`reset_after_open`.
+        # Event-loop binding for the two lazy lock maps. ``set_bound_loop`` comes
+        # from :class:`~notebooklm._loop_bound.LoopBoundPrimitive`; this API
+        # overrides :meth:`_on_loop_rebind` to clear the maps on a loop change so
+        # a lock bound to a closed loop is never reused after a reopen — see
+        # :meth:`_on_loop_rebind` / :meth:`reset_after_open`.
 
     def _on_loop_rebind(
         self,
@@ -212,19 +188,12 @@ class ChatAPI(LoopBoundPrimitive):
     ) -> None:
         """Clear the lazy conversation lock maps when the bound loop changes.
 
-        Fires from :meth:`~notebooklm._loop_bound.LoopBoundPrimitive.set_bound_loop`
-        only on a real loop change (and before ``_bound_loop`` is updated), so
-        ``set_bound_loop`` is self-consistent even if called independently of
-        :meth:`reset_after_open` (e.g. directly in a test or a future caller):
-        a stale ``asyncio.Lock`` bound to the old loop must never be reused
-        after a rebind. The production ``open()`` path also calls
-        :meth:`reset_after_open` immediately after, so the clear is idempotent
-        there.
-
-        The cross-loop guard for :meth:`ask` is the injected
-        ``loop_guard.assert_bound_loop`` (already called at the top of
-        :meth:`ask` before any lock is acquired); this hook only governs when
-        the lazy locks are rebuilt.
+        Fires from ``LoopBoundPrimitive.set_bound_loop`` only on a real loop
+        change (before ``_bound_loop`` updates), so a stale ``asyncio.Lock``
+        bound to the old loop is never reused after a rebind even when called
+        independently of :meth:`reset_after_open`. The cross-loop guard for
+        :meth:`ask` is the injected ``loop_guard.assert_bound_loop``; this hook
+        only governs when the lazy locks are rebuilt.
         """
         self._conversation_locks.clear()
         self._new_conversation_locks.clear()
@@ -232,21 +201,13 @@ class ChatAPI(LoopBoundPrimitive):
     def reset_after_open(self) -> None:
         """Discard the lazy conversation locks so a reopened client rebinds them.
 
-        Called from :meth:`ClientLifecycle.open` (alongside the
-        per-collaborator ``set_bound_loop`` propagation) so a client that was
-        closed and reopened on a *different* event loop builds fresh
-        ``asyncio.Lock`` instances on the new loop instead of reusing stale
-        ones bound to the old (now-dead) loop. On Python 3.10/3.11 reusing a
-        stale lock can raise "bound to a different event loop" or mispark
-        waiters; on 3.12+ the breakage is largely masked, but resetting keeps
-        the behaviour consistent across versions.
-
-        Mirrors
-        :meth:`notebooklm._source.upload.SourceUploadPipeline.reset_after_open`.
-        Deliberately narrow: clearing the two ``WeakValueDictionary`` maps is
-        enough because each per-key lock is reconstructed lazily on the next
-        :meth:`_get_conversation_lock` / :meth:`_get_new_conversation_lock`
-        call from inside the new loop.
+        Called from :meth:`ClientLifecycle.open` so a client closed and reopened
+        on a *different* event loop builds fresh ``asyncio.Lock`` instances on
+        the new loop instead of reusing stale ones bound to the dead loop (which
+        on 3.10/3.11 can raise "bound to a different event loop" or mispark
+        waiters). Clearing the two ``WeakValueDictionary`` maps suffices — each
+        per-key lock is rebuilt lazily on the next ``_get_*_lock`` call. Mirrors
+        ``SourceUploadPipeline.reset_after_open``.
         """
         self._conversation_locks.clear()
         self._new_conversation_locks.clear()
@@ -254,17 +215,11 @@ class ChatAPI(LoopBoundPrimitive):
     def _get_conversation_lock(self, conversation_id: str) -> asyncio.Lock:
         """Return the (lazily created) lock for ``conversation_id``.
 
-        Single-threaded asyncio means ``WeakValueDictionary.get`` /
-        ``__setitem__`` are atomic w.r.t. coroutine interleaving — no
-        ``await`` between the lookup and the insert, so two concurrent
-        callers on the same conversation either both see the existing lock
-        or one creates it and the other reads it. Either way they share a
-        single lock instance.
-
-        Returning the bare lock (vs. an async-context-manager wrapper) so
-        callers use ``async with self._get_conversation_lock(cid):`` and
-        the strong reference to ``lock`` keeps the WeakValueDictionary
-        entry alive for the duration of the critical section.
+        Single-threaded asyncio makes the ``WeakValueDictionary`` get/set atomic
+        (no ``await`` between lookup and insert), so concurrent callers on the
+        same conversation share one lock instance. The bare lock is returned (not
+        a context-manager wrapper) so the caller's strong ref keeps the entry
+        alive for the critical section.
         """
         lock = self._conversation_locks.get(conversation_id)
         if lock is None:
@@ -318,17 +273,6 @@ class ChatAPI(LoopBoundPrimitive):
             NetworkError / ChatError: If the post-ask ``hPTbtc`` round-trip
                 itself fails (transient network or auth issue). Same
                 logging contract — answer is logged before the raise.
-
-        Example:
-            # New conversation — SDK fetches the real id post-ask via hPTbtc.
-            result = await client.chat.ask(notebook_id, "What is machine learning?")
-
-            # Follow-up — pass the real, hPTbtc-fetched conversation_id back.
-            result = await client.chat.ask(
-                notebook_id,
-                "How does it differ from deep learning?",
-                conversation_id=result.conversation_id
-            )
 
         Note:
             Repeated ``ask()`` calls without ``conversation_id`` all extend

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -53,34 +53,13 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-# Sentinel marking "the canonical ``initial_interval`` keyword was not passed"
-# in ``wait_for_completion``. The default stays this ``object()`` sentinel (not a
-# literal ``5.0``) so the public-API compatibility audit's default-repr check
-# sees no changed-default break; when the caller leaves it unset we resolve the
-# cadence to ``_DEFAULT_RESEARCH_POLL_INTERVAL`` below.
+# Sentinel for "``initial_interval`` not passed" in ``wait_for_completion``. Kept
+# as ``object()`` (not literal ``5.0``) so the public-API compat default-repr
+# check sees no changed-default break; unset resolves to the default below.
 _INITIAL_INTERVAL_UNSET: Any = object()
 
-# Default poll cadence (seconds between status checks) used when
-# ``initial_interval`` is left unset. Preserved verbatim so default-shape callers
-# keep the same behavior.
+# Default poll cadence (seconds) when ``initial_interval`` is unset.
 _DEFAULT_RESEARCH_POLL_INTERVAL = 5.0
-
-
-# ---------------------------------------------------------------------------
-# IMPORT_RESEARCH timeout-verification helpers
-#
-# IMPORT_RESEARCH is classified NON_IDEMPOTENT_NO_RETRY in IDEMPOTENCY_REGISTRY
-# (see #808): the executor will surface the first 5xx/timeout to the caller
-# rather than retry blindly, because the wire protocol has no client-token
-# slot and a naive retry duplicates every source. ``ResearchAPI``'s
-# verification path sidesteps that constraint by snapshotting baseline
-# sources before the call and matching post-call ``sources.list`` URLs
-# against the request — disambiguating "server already committed but the
-# response was lost" from "request truly failed". These helpers mirror the
-# CLI-only logic that originally landed in PR #321 / #327; they live in the
-# library now so Python API consumers get the same deep-research fix the
-# CLI does (issue #315).
-# ---------------------------------------------------------------------------
 
 
 def _normalize_import_verification_url(url: str) -> str:
@@ -450,26 +429,23 @@ class ResearchAPI:
             await self._poll_task_models(notebook_id),
             notebook_id=notebook_id,
             task_id=task_id,
-            # The ambiguity raise only applies to the unfiltered (task_id is
-            # None) path; when a discriminator is pinned, _select_polled_tasks
-            # filters before the raise branch. Gating it here matches
-            # wait_for_completion and keeps the intent explicit.
+            # Ambiguity raise applies only to the unfiltered (task_id is None)
+            # path; a pinned discriminator filters before the raise. Matches
+            # wait_for_completion.
             raise_on_ambiguous=task_id is None,
         )
 
         if parsed_tasks:
-            # ``parsed_tasks`` is a typed ``list[ResearchTask]`` (not a decoded RPC
-            # payload); ``first_task, *_ = parsed_tasks`` avoids a ``name[int]`` read.
-            first_task, *_ = parsed_tasks  # typed list[ResearchTask] head; unpack avoids name[int]
+            # ``parsed_tasks`` is a typed ``list[ResearchTask]``; the unpack avoids
+            # a ``name[int]`` positional read on a decoded payload.
+            first_task, *_ = parsed_tasks
             return self._public_poll_result(first_task, parsed_tasks)
 
-        # A concrete pinned ``task_id`` that matched nothing is a poll-observed
-        # absence of that specific task — a typed ``NOT_FOUND`` sentinel
-        # carrying the requested id. A falsy ``task_id`` (``None`` for the
-        # unfiltered poll, or the degenerate empty string) is not a meaningful
-        # discriminator, so it stays ``NO_RESEARCH`` ("nothing in flight") and
-        # preserves the legacy empty-poll dict shape. See ADR-0019 Rule 4
-        # (#1346).
+        # A pinned ``task_id`` that matched nothing is a poll-observed absence —
+        # a typed ``NOT_FOUND`` sentinel carrying the id. A falsy ``task_id``
+        # (``None`` or empty string) is no discriminator, so it stays
+        # ``NO_RESEARCH`` and preserves the legacy empty-poll shape (ADR-0019
+        # Rule 4, #1346).
         if task_id:
             return ResearchTask.not_found(task_id)
 
@@ -526,11 +502,9 @@ class ResearchAPI:
                 positive.
             TypeError: If the resolved poll interval is not a number.
         """
-        # The sentinel default means "``initial_interval`` was not supplied" —
-        # fall back to the default cadence. An *explicit* non-numeric value
-        # (e.g. initial_interval=None or initial_interval="1") is a caller bug;
-        # fail fast with TypeError rather than silently coercing it back to the
-        # default.
+        # Unset sentinel → default cadence. An *explicit* non-numeric value
+        # (``None``, ``"1"``) is a caller bug: fail fast with TypeError rather
+        # than silently coercing it back to the default.
         if initial_interval is _INITIAL_INTERVAL_UNSET:
             poll_interval = _DEFAULT_RESEARCH_POLL_INTERVAL
         elif isinstance(initial_interval, bool) or not isinstance(initial_interval, (int, float)):
@@ -554,7 +528,6 @@ class ResearchAPI:
                 task_id=pinned_task_id,
                 raise_on_ambiguous=pinned_task_id is None,
             )
-            # ``parsed_tasks`` is a typed ``list[ResearchTask]``: first or ``None``.
             selected_task = next(iter(parsed_tasks), None)
             if pinned_task_id is None and selected_task is not None:
                 pinned_task_id = selected_task.task_id
@@ -683,8 +656,7 @@ class ResearchAPI:
         )
         imported = []
         # ``unwrap_import_rows`` centralises the ``[[src1, ...]]`` envelope probe
-        # (the former ``result[0]`` / ``first[0]`` reads) behind the research row
-        # adapter; an unrecognised shape falls through to ``[]``/unchanged.
+        # behind the research row adapter; an unrecognised shape → ``[]``.
         for src_data in unwrap_import_rows(result):
             row = ImportedSourceRow(src_data)
             if not row.is_well_formed:
@@ -834,22 +806,14 @@ class ResearchAPI:
                                 source_inputs, source_models, strict=True
                             )
                         ]
-                        # Filter for retry: drop already-present URLs.
-                        # Additionally, when *any* URL was verified
-                        # committed, drop no-URL entries (deep-research
-                        # reports): reports are appended FIRST in the
-                        # IMPORT_RESEARCH payload (see
-                        # ``_build_report_import_entry`` usage in
-                        # ``import_sources``), so a URL newly observed after
-                        # this attempt implies the report committed too.
-                        # Pre-existing URLs only de-dupe URL entries; they do
-                        # not prove this request committed no-URL reports.
-                        # Without this guard,
-                        # each retry duplicates the report server-side.
-                        # When no URL committed, keep no-URL entries —
-                        # the report's fate is unknown and the
-                        # report-only attempt cap further down bounds
-                        # the worst case.
+                        # Filter for retry: drop already-present URLs. Also, when
+                        # *any* URL committed, drop no-URL entries (deep-research
+                        # reports are appended FIRST in the IMPORT_RESEARCH payload,
+                        # so a newly-observed URL implies the report committed too —
+                        # without this guard each retry duplicates it server-side).
+                        # Pre-existing URLs only de-dupe URL entries. When no URL
+                        # committed, keep no-URL entries (report fate unknown; the
+                        # report-only attempt cap below bounds the worst case).
                         drop_no_url_entries = bool(committed_urls_norm)
                         filtered_source_pairs = [
                             (source_input, source)

--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -1,0 +1,323 @@
+"""Pure decode/validation helpers for the source upload pipeline.
+
+Extracted from :mod:`notebooklm._source.upload` to keep that module under the
+size budget. These are side-effect-free helpers over the resumable-upload URL,
+the ``ADD_SOURCE_FILE`` register response (source-id extraction), and upload
+content-type policy. ``upload.py`` re-exports every name so the historical
+``notebooklm._source.upload.<helper>`` import/patch surface keeps resolving.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import SplitResult, parse_qsl, urlsplit
+
+from ..exceptions import ValidationError
+from ..rpc import get_upload_url
+
+_SOURCE_ID_UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_SOURCE_ID_FIELD_NAMES = frozenset({"SOURCE_ID", "source_id", "sourceId"})
+_CONTEXTUAL_SOURCE_ID_FIELD_NAMES = frozenset({"id"})
+_SOURCE_NAME_FIELD_NAMES = frozenset(
+    {"SOURCE_NAME", "source_name", "sourceName", "filename", "fileName", "name", "title"}
+)
+_SOURCE_ID_ENVELOPE_MAX_DEPTH = 8
+
+_MEDIA_CONTENT_TYPE_PREFIXES = ("audio/", "video/")
+_MEDIA_APPLICATION_CONTENT_TYPES = frozenset(
+    {
+        "application/mp4",
+        "application/ogg",
+        "application/x-matroska",
+    }
+)
+_MEDIA_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
+_STRICT_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = ()
+_HTML_UPLOAD_SUFFIXES = frozenset({".html", ".htm", ".xhtml", ".xht"})
+_HTML_UPLOAD_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
+
+
+def _normalize_upload_path(path: str) -> str:
+    return (path or "/").rstrip("/") + "/"
+
+
+def _default_port_for_scheme(scheme: str) -> int | None:
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    return None
+
+
+def _redacted_upload_authority(parsed: SplitResult) -> str | None:
+    host = parsed.hostname
+    if host is None:
+        return None
+
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    port = parsed.port
+    port_suffix = f":{port}" if port is not None else ""
+    return f"{host}{port_suffix}"
+
+
+def _redact_upload_url(upload_url: str) -> str:
+    """Return a log-safe representation of a resumable upload URL."""
+    try:
+        parsed = urlsplit(upload_url)
+        authority = _redacted_upload_authority(parsed)
+    except ValueError:
+        return "[REDACTED_UPLOAD_URL]"
+    if not parsed.scheme or authority is None:
+        return "[REDACTED_UPLOAD_URL]"
+    suffix = "?..." if parsed.query else ""
+    return f"{parsed.scheme}://{authority}{parsed.path}{suffix}"
+
+
+def _validate_resumable_upload_url(upload_url: str) -> str:
+    """Validate that a resumable upload URL targets the configured upload endpoint."""
+    try:
+        parsed = urlsplit(upload_url)
+        actual_port = parsed.port or _default_port_for_scheme(parsed.scheme)
+        expected = urlsplit(get_upload_url())
+        expected_port = expected.port or _default_port_for_scheme(expected.scheme)
+    except ValueError as exc:
+        raise ValidationError("Upload URL is not valid") from exc
+
+    if parsed.scheme != "https":
+        raise ValidationError("Upload URL must use https")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValidationError("Upload URL must not contain credentials")
+    if parsed.hostname is None:
+        raise ValidationError("Upload URL must include a host")
+    if parsed.hostname != expected.hostname or actual_port != expected_port:
+        raise ValidationError("Upload URL host is not trusted")
+    if _normalize_upload_path(parsed.path) != _normalize_upload_path(expected.path):
+        raise ValidationError("Upload URL path is not trusted")
+    upload_ids = [
+        value
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() == "upload_id"
+    ]
+    if len(upload_ids) != 1 or not next(iter(upload_ids)):  # next(iter): ratchet
+        raise ValidationError("Upload URL must include exactly one non-empty upload_id")
+
+    return upload_url
+
+
+def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
+    """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
+
+    Only trusted ADD_SOURCE_FILE shapes are accepted: explicit source-id fields
+    and the legacy singleton list envelope (``[[id]]`` / ``[[[[id]]]]``).
+    Arbitrary nested ids are intentionally ignored so ambiguous responses fall
+    through to the post-register source-list probe.
+    """
+    field_candidates = _extract_source_id_field_candidates(result, filename)
+    if len(field_candidates) == 1:
+        (candidate,) = field_candidates  # exactly one (guarded); unpack avoids name[int]
+        return candidate
+    if len(field_candidates) > 1:
+        return None
+
+    row_candidates = _extract_contextual_source_id_row_candidates(result, filename)
+    if len(row_candidates) == 1:
+        (candidate,) = row_candidates  # exactly one (guarded); unpack avoids name[int]
+        return candidate
+    if len(row_candidates) > 1:
+        return None
+
+    prefixed_candidate = _extract_prefixed_singleton_source_id_envelope(result, filename)
+    if prefixed_candidate is not None:
+        return prefixed_candidate
+
+    return _extract_singleton_source_id_envelope(result, filename)
+
+
+def _extract_source_id_field_candidates(result: Any, filename: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(value: Any) -> None:
+        candidate = _coerce_source_id_candidate(value, filename)
+        if candidate is not None and candidate not in seen:
+            candidates.append(candidate)
+            seen.add(candidate)
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
+            return
+        if isinstance(node, dict):
+            names = _source_context_names(node)
+            matched_context = bool(names) and any(
+                _coerce_filename_candidate(name) == filename for name in names
+            )
+            mismatched_context = bool(names) and not matched_context
+            for key, value in node.items():
+                if not isinstance(key, str):
+                    continue
+                if (
+                    key in _SOURCE_ID_FIELD_NAMES
+                    and not mismatched_context
+                    and (depth == 0 or matched_context)
+                ) or (key in _CONTEXTUAL_SOURCE_ID_FIELD_NAMES and matched_context):
+                    add_candidate(value)
+            for value in node.values():
+                walk(value, depth + 1)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child, depth + 1)
+
+    walk(result, 0)
+    return candidates
+
+
+def _extract_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
+    node, depth = _unwrap_singleton_envelope(result)
+    if depth == 0:
+        return None
+
+    return _coerce_source_id_candidate(node, filename)
+
+
+def _extract_prefixed_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
+    if not isinstance(result, list) or len(result) != 2:
+        return None
+    prefix, inner = result  # unpack ``[None, inner]``, not index it (ratchet)
+    if prefix is not None:
+        return None
+    return _extract_singleton_source_id_envelope(inner, filename)
+
+
+def _extract_contextual_source_id_row_candidates(result: Any, filename: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(value: Any) -> None:
+        candidate = _coerce_source_id_candidate(value, filename)
+        if candidate is not None and candidate not in seen:
+            candidates.append(candidate)
+            seen.add(candidate)
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
+            return
+        if isinstance(node, list):
+            if len(node) >= 2:
+                first, second, *_rest = node  # unpack pair, not index (ratchet)
+                if _coerce_filename_candidate(second) == filename:
+                    add_candidate(first)
+                if _coerce_filename_candidate(first) == filename:
+                    add_candidate(second)
+            for child in node:
+                walk(child, depth + 1)
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value, depth + 1)
+
+    walk(result, 0)
+    return candidates
+
+
+def _coerce_filename_candidate(value: Any) -> str | None:
+    value, _depth = _unwrap_singleton_envelope(value)
+    if not isinstance(value, str):
+        return None
+    return value.strip()
+
+
+def _coerce_source_id_candidate(value: Any, filename: str) -> str | None:
+    value, _depth = _unwrap_singleton_envelope(value)
+    if not isinstance(value, str):
+        return None
+    if len(value) > 1000:
+        return None
+    candidate = value.strip()
+    if not candidate or candidate == filename:
+        return None
+    if _SOURCE_ID_UUID_PATTERN.match(candidate) or _looks_like_id_string(candidate):
+        return candidate
+    return None
+
+
+def _source_context_names(node: dict[Any, Any]) -> list[Any]:
+    return [
+        value
+        for key, value in node.items()
+        if isinstance(key, str) and key in _SOURCE_NAME_FIELD_NAMES
+    ]
+
+
+def _unwrap_singleton_envelope(value: Any) -> tuple[Any, int]:
+    depth = 0
+    while isinstance(value, list) and len(value) == 1 and depth < _SOURCE_ID_ENVELOPE_MAX_DEPTH:
+        (value,) = value  # not ``value[0]`` (guard pins len 1): ratchet
+        depth += 1
+    return value, depth
+
+
+def _register_response_shape_label(result: Any) -> str:
+    if isinstance(result, dict):
+        return "object"
+    if isinstance(result, list):
+        return "array"
+    if isinstance(result, str):
+        return "string"
+    if result is None:
+        return "null"
+    return type(result).__name__
+
+
+def _looks_like_id_string(candidate: str) -> bool:
+    """Heuristic for the non-UUID fallback in file-source id extraction."""
+    if len(candidate) < 4:
+        return False
+    if any(c in candidate for c in " \t/"):
+        return False
+    return any(c.isdigit() or c in "-_" for c in candidate)
+
+
+def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
+    """Return the content type for the Scotty resumable-upload start request."""
+    if mime_type is not None:
+        content_type = mime_type.strip()
+        if not content_type:
+            raise ValidationError("mime_type cannot be empty or whitespace-only")
+        return content_type
+
+    guessed, _encoding = mimetypes.guess_type(file_path.name)
+    return guessed or "application/octet-stream"
+
+
+def _normalize_content_type(content_type: str) -> str:
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def _transient_error_types_for_upload(content_type: str) -> tuple[int | None, ...]:
+    """Return source status=ERROR transient policy for this upload."""
+    normalized = _normalize_content_type(content_type)
+    if (
+        normalized.startswith(_MEDIA_CONTENT_TYPE_PREFIXES)
+        or normalized in _MEDIA_APPLICATION_CONTENT_TYPES
+    ):
+        return _MEDIA_TRANSIENT_ERROR_TYPES
+    return _STRICT_TRANSIENT_ERROR_TYPES
+
+
+def _validate_upload_file_supported(file_path: Path, content_type: str) -> None:
+    """Reject local file types known to fail NotebookLM's upload endpoint."""
+    normalized = _normalize_content_type(content_type)
+    if (
+        file_path.suffix.lower() in _HTML_UPLOAD_SUFFIXES
+        or normalized in _HTML_UPLOAD_CONTENT_TYPES
+    ):
+        raise ValidationError(
+            "HTML file uploads are not supported by NotebookLM's upload endpoint: "
+            f"{file_path.name}. Convert the page to .txt, .md, or .pdf first, then retry."
+        )

--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -105,7 +105,10 @@ def _validate_resumable_upload_url(upload_url: str) -> str:
         for key, value in parse_qsl(parsed.query, keep_blank_values=True)
         if key.lower() == "upload_id"
     ]
-    if len(upload_ids) != 1 or not next(iter(upload_ids)):  # next(iter): ratchet
+    if len(upload_ids) != 1:
+        raise ValidationError("Upload URL must include exactly one non-empty upload_id")
+    (upload_id,) = upload_ids  # exactly one (guarded); unpack avoids next(iter()): ratchet
+    if not upload_id:
         raise ValidationError("Upload URL must include exactly one non-empty upload_id")
 
     return upload_url

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -44,7 +44,17 @@ from ..types import Source, SourceAddError
 # from ``_upload_decode``, so a test seam that patches such a global must target
 # ``_upload_decode`` — that is where the name is looked up — not this module.
 from ._upload_decode import (  # noqa: F401
+    _CONTEXTUAL_SOURCE_ID_FIELD_NAMES,
+    _HTML_UPLOAD_CONTENT_TYPES,
+    _HTML_UPLOAD_SUFFIXES,
+    _MEDIA_APPLICATION_CONTENT_TYPES,
+    _MEDIA_CONTENT_TYPE_PREFIXES,
+    _MEDIA_TRANSIENT_ERROR_TYPES,
+    _SOURCE_ID_ENVELOPE_MAX_DEPTH,
+    _SOURCE_ID_FIELD_NAMES,
     _SOURCE_ID_UUID_PATTERN,
+    _SOURCE_NAME_FIELD_NAMES,
+    _STRICT_TRANSIENT_ERROR_TYPES,
     _coerce_filename_candidate,
     _coerce_source_id_candidate,
     _default_port_for_scheme,

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import mimetypes
 import os
-import re
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import IO, TYPE_CHECKING, Any, Protocol, cast
-from urllib.parse import SplitResult, parse_qsl, urlsplit
 
 import httpx
 
@@ -39,6 +36,33 @@ from ..exceptions import (
 from ..rpc import RPCError, RPCMethod, get_upload_url
 from ..rpc.types import SourceStatus
 from ..types import Source, SourceAddError
+
+# Decode/validation helpers live in ``_upload_decode``; re-exported here so the
+# historical ``notebooklm._source.upload.<helper>`` import/patch surface (and the
+# ``SourceUploadPipeline`` body below) keep resolving them.
+from ._upload_decode import (  # noqa: F401
+    _SOURCE_ID_UUID_PATTERN,
+    _coerce_filename_candidate,
+    _coerce_source_id_candidate,
+    _default_port_for_scheme,
+    _extract_contextual_source_id_row_candidates,
+    _extract_prefixed_singleton_source_id_envelope,
+    _extract_register_file_source_id,
+    _extract_singleton_source_id_envelope,
+    _extract_source_id_field_candidates,
+    _looks_like_id_string,
+    _normalize_content_type,
+    _normalize_upload_path,
+    _redact_upload_url,
+    _redacted_upload_authority,
+    _register_response_shape_label,
+    _resolve_upload_content_type,
+    _source_context_names,
+    _transient_error_types_for_upload,
+    _unwrap_singleton_envelope,
+    _validate_resumable_upload_url,
+    _validate_upload_file_supported,
+)
 from .listing import SourceLister
 from .polling import SourcePoller
 from .upload_payloads import (
@@ -50,16 +74,6 @@ from .upload_payloads import (
 if TYPE_CHECKING:
     from .._runtime.lifecycle import ClientLifecycle
     from .._transport_drain import TransportDrainTracker
-
-_SOURCE_ID_UUID_PATTERN = re.compile(
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-)
-_SOURCE_ID_FIELD_NAMES = frozenset({"SOURCE_ID", "source_id", "sourceId"})
-_CONTEXTUAL_SOURCE_ID_FIELD_NAMES = frozenset({"id"})
-_SOURCE_NAME_FIELD_NAMES = frozenset(
-    {"SOURCE_NAME", "source_name", "sourceName", "filename", "fileName", "name", "title"}
-)
-_SOURCE_ID_ENVELOPE_MAX_DEPTH = 8
 
 
 class AuthMetadata(Protocol):
@@ -112,75 +126,6 @@ _TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
 # Preserve the historical ``notebooklm._sources`` log channel after moving
 # upload choreography into this module.
 module_logger = logging.getLogger("notebooklm").getChild("_sources")
-
-
-def _normalize_upload_path(path: str) -> str:
-    return (path or "/").rstrip("/") + "/"
-
-
-def _default_port_for_scheme(scheme: str) -> int | None:
-    if scheme == "https":
-        return 443
-    if scheme == "http":
-        return 80
-    return None
-
-
-def _redacted_upload_authority(parsed: SplitResult) -> str | None:
-    host = parsed.hostname
-    if host is None:
-        return None
-
-    if ":" in host and not host.startswith("["):
-        host = f"[{host}]"
-
-    port = parsed.port
-    port_suffix = f":{port}" if port is not None else ""
-    return f"{host}{port_suffix}"
-
-
-def _redact_upload_url(upload_url: str) -> str:
-    """Return a log-safe representation of a resumable upload URL."""
-    try:
-        parsed = urlsplit(upload_url)
-        authority = _redacted_upload_authority(parsed)
-    except ValueError:
-        return "[REDACTED_UPLOAD_URL]"
-    if not parsed.scheme or authority is None:
-        return "[REDACTED_UPLOAD_URL]"
-    suffix = "?..." if parsed.query else ""
-    return f"{parsed.scheme}://{authority}{parsed.path}{suffix}"
-
-
-def _validate_resumable_upload_url(upload_url: str) -> str:
-    """Validate that a resumable upload URL targets the configured upload endpoint."""
-    try:
-        parsed = urlsplit(upload_url)
-        actual_port = parsed.port or _default_port_for_scheme(parsed.scheme)
-        expected = urlsplit(get_upload_url())
-        expected_port = expected.port or _default_port_for_scheme(expected.scheme)
-    except ValueError as exc:
-        raise ValidationError("Upload URL is not valid") from exc
-
-    if parsed.scheme != "https":
-        raise ValidationError("Upload URL must use https")
-    if parsed.username is not None or parsed.password is not None:
-        raise ValidationError("Upload URL must not contain credentials")
-    if parsed.hostname is None:
-        raise ValidationError("Upload URL must include a host")
-    if parsed.hostname != expected.hostname or actual_port != expected_port:
-        raise ValidationError("Upload URL host is not trusted")
-    if _normalize_upload_path(parsed.path) != _normalize_upload_path(expected.path):
-        raise ValidationError("Upload URL path is not trusted")
-    upload_ids = [
-        value
-        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
-        if key.lower() == "upload_id"
-    ]
-    if len(upload_ids) != 1 or not next(iter(upload_ids)):  # next(iter): ratchet
-        raise ValidationError("Upload URL must include exactly one non-empty upload_id")
-
-    return upload_url
 
 
 async def _build_invalid_argument_source_limit_hint(
@@ -249,19 +194,6 @@ class AsyncClientFactory(Protocol):
 ListSources = Callable[[str], Awaitable[list[Source]]]
 QueueWaitRecorder = Callable[[float], None]
 
-_MEDIA_CONTENT_TYPE_PREFIXES = ("audio/", "video/")
-_MEDIA_APPLICATION_CONTENT_TYPES = frozenset(
-    {
-        "application/mp4",
-        "application/ogg",
-        "application/x-matroska",
-    }
-)
-_MEDIA_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
-_STRICT_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = ()
-_HTML_UPLOAD_SUFFIXES = frozenset({".html", ".htm", ".xhtml", ".xht"})
-_HTML_UPLOAD_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
-
 
 # Single-loop-per-client invariant per ADR-0004; not safe for multi-loop fan-out.
 _BACKGROUND_CANCEL_TASKS: set[asyncio.Task[None]] = set()
@@ -270,218 +202,6 @@ _BACKGROUND_CANCEL_TASKS: set[asyncio.Task[None]] = set()
 def _retain_background_cancel_task(task: asyncio.Task[None]) -> None:
     _BACKGROUND_CANCEL_TASKS.add(task)
     task.add_done_callback(_BACKGROUND_CANCEL_TASKS.discard)
-
-
-def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
-    """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
-
-    Only trusted ADD_SOURCE_FILE shapes are accepted: explicit source-id fields
-    and the legacy singleton list envelope (``[[id]]`` / ``[[[[id]]]]``).
-    Arbitrary nested ids are intentionally ignored so ambiguous responses fall
-    through to the post-register source-list probe.
-    """
-    field_candidates = _extract_source_id_field_candidates(result, filename)
-    if len(field_candidates) == 1:
-        (candidate,) = field_candidates  # exactly one (guarded); unpack avoids name[int]
-        return candidate
-    if len(field_candidates) > 1:
-        return None
-
-    row_candidates = _extract_contextual_source_id_row_candidates(result, filename)
-    if len(row_candidates) == 1:
-        (candidate,) = row_candidates  # exactly one (guarded); unpack avoids name[int]
-        return candidate
-    if len(row_candidates) > 1:
-        return None
-
-    prefixed_candidate = _extract_prefixed_singleton_source_id_envelope(result, filename)
-    if prefixed_candidate is not None:
-        return prefixed_candidate
-
-    return _extract_singleton_source_id_envelope(result, filename)
-
-
-def _extract_source_id_field_candidates(result: Any, filename: str) -> list[str]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-
-    def add_candidate(value: Any) -> None:
-        candidate = _coerce_source_id_candidate(value, filename)
-        if candidate is not None and candidate not in seen:
-            candidates.append(candidate)
-            seen.add(candidate)
-
-    def walk(node: Any, depth: int) -> None:
-        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
-            return
-        if isinstance(node, dict):
-            names = _source_context_names(node)
-            matched_context = bool(names) and any(
-                _coerce_filename_candidate(name) == filename for name in names
-            )
-            mismatched_context = bool(names) and not matched_context
-            for key, value in node.items():
-                if not isinstance(key, str):
-                    continue
-                if (
-                    key in _SOURCE_ID_FIELD_NAMES
-                    and not mismatched_context
-                    and (depth == 0 or matched_context)
-                ) or (key in _CONTEXTUAL_SOURCE_ID_FIELD_NAMES and matched_context):
-                    add_candidate(value)
-            for value in node.values():
-                walk(value, depth + 1)
-        elif isinstance(node, list):
-            for child in node:
-                walk(child, depth + 1)
-
-    walk(result, 0)
-    return candidates
-
-
-def _extract_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
-    node, depth = _unwrap_singleton_envelope(result)
-    if depth == 0:
-        return None
-
-    return _coerce_source_id_candidate(node, filename)
-
-
-def _extract_prefixed_singleton_source_id_envelope(result: Any, filename: str) -> str | None:
-    if not isinstance(result, list) or len(result) != 2:
-        return None
-    prefix, inner = result  # unpack ``[None, inner]``, not index it (ratchet)
-    if prefix is not None:
-        return None
-    return _extract_singleton_source_id_envelope(inner, filename)
-
-
-def _extract_contextual_source_id_row_candidates(result: Any, filename: str) -> list[str]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-
-    def add_candidate(value: Any) -> None:
-        candidate = _coerce_source_id_candidate(value, filename)
-        if candidate is not None and candidate not in seen:
-            candidates.append(candidate)
-            seen.add(candidate)
-
-    def walk(node: Any, depth: int) -> None:
-        if depth > _SOURCE_ID_ENVELOPE_MAX_DEPTH:
-            return
-        if isinstance(node, list):
-            if len(node) >= 2:
-                first, second, *_rest = node  # unpack pair, not index (ratchet)
-                if _coerce_filename_candidate(second) == filename:
-                    add_candidate(first)
-                if _coerce_filename_candidate(first) == filename:
-                    add_candidate(second)
-            for child in node:
-                walk(child, depth + 1)
-        elif isinstance(node, dict):
-            for value in node.values():
-                walk(value, depth + 1)
-
-    walk(result, 0)
-    return candidates
-
-
-def _coerce_filename_candidate(value: Any) -> str | None:
-    value, _depth = _unwrap_singleton_envelope(value)
-    if not isinstance(value, str):
-        return None
-    return value.strip()
-
-
-def _coerce_source_id_candidate(value: Any, filename: str) -> str | None:
-    value, _depth = _unwrap_singleton_envelope(value)
-    if not isinstance(value, str):
-        return None
-    if len(value) > 1000:
-        return None
-    candidate = value.strip()
-    if not candidate or candidate == filename:
-        return None
-    if _SOURCE_ID_UUID_PATTERN.match(candidate) or _looks_like_id_string(candidate):
-        return candidate
-    return None
-
-
-def _source_context_names(node: dict[Any, Any]) -> list[Any]:
-    return [
-        value
-        for key, value in node.items()
-        if isinstance(key, str) and key in _SOURCE_NAME_FIELD_NAMES
-    ]
-
-
-def _unwrap_singleton_envelope(value: Any) -> tuple[Any, int]:
-    depth = 0
-    while isinstance(value, list) and len(value) == 1 and depth < _SOURCE_ID_ENVELOPE_MAX_DEPTH:
-        (value,) = value  # not ``value[0]`` (guard pins len 1): ratchet
-        depth += 1
-    return value, depth
-
-
-def _register_response_shape_label(result: Any) -> str:
-    if isinstance(result, dict):
-        return "object"
-    if isinstance(result, list):
-        return "array"
-    if isinstance(result, str):
-        return "string"
-    if result is None:
-        return "null"
-    return type(result).__name__
-
-
-def _looks_like_id_string(candidate: str) -> bool:
-    """Heuristic for the non-UUID fallback in file-source id extraction."""
-    if len(candidate) < 4:
-        return False
-    if any(c in candidate for c in " \t/"):
-        return False
-    return any(c.isdigit() or c in "-_" for c in candidate)
-
-
-def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
-    """Return the content type for the Scotty resumable-upload start request."""
-    if mime_type is not None:
-        content_type = mime_type.strip()
-        if not content_type:
-            raise ValidationError("mime_type cannot be empty or whitespace-only")
-        return content_type
-
-    guessed, _encoding = mimetypes.guess_type(file_path.name)
-    return guessed or "application/octet-stream"
-
-
-def _normalize_content_type(content_type: str) -> str:
-    return content_type.split(";", 1)[0].strip().lower()
-
-
-def _transient_error_types_for_upload(content_type: str) -> tuple[int | None, ...]:
-    """Return source status=ERROR transient policy for this upload."""
-    normalized = _normalize_content_type(content_type)
-    if (
-        normalized.startswith(_MEDIA_CONTENT_TYPE_PREFIXES)
-        or normalized in _MEDIA_APPLICATION_CONTENT_TYPES
-    ):
-        return _MEDIA_TRANSIENT_ERROR_TYPES
-    return _STRICT_TRANSIENT_ERROR_TYPES
-
-
-def _validate_upload_file_supported(file_path: Path, content_type: str) -> None:
-    """Reject local file types known to fail NotebookLM's upload endpoint."""
-    normalized = _normalize_content_type(content_type)
-    if (
-        file_path.suffix.lower() in _HTML_UPLOAD_SUFFIXES
-        or normalized in _HTML_UPLOAD_CONTENT_TYPES
-    ):
-        raise ValidationError(
-            "HTML file uploads are not supported by NotebookLM's upload endpoint: "
-            f"{file_path.name}. Convert the page to .txt, .md, or .pdf first, then retry."
-        )
 
 
 class SourceUploadPipeline(LoopBoundPrimitive):

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -38,8 +38,11 @@ from ..rpc.types import SourceStatus
 from ..types import Source, SourceAddError
 
 # Decode/validation helpers live in ``_upload_decode``; re-exported here so the
-# historical ``notebooklm._source.upload.<helper>`` import/patch surface (and the
-# ``SourceUploadPipeline`` body below) keep resolving them.
+# historical ``notebooklm._source.upload.<helper>`` import surface (and the
+# ``SourceUploadPipeline`` body below) keep resolving them. Note: each helper
+# reads its module-level globals (e.g. ``urlsplit``, ``_SOURCE_ID_UUID_PATTERN``)
+# from ``_upload_decode``, so a test seam that patches such a global must target
+# ``_upload_decode`` — that is where the name is looked up — not this module.
 from ._upload_decode import (  # noqa: F401
     _SOURCE_ID_UUID_PATTERN,
     _coerce_filename_candidate,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -89,11 +89,10 @@ class SourcesAPI:
                 :meth:`add_file` uploads. The semaphore is owned by this
                 Sources upload pipeline, not by the shared core/session.
         """
-        # ``upload_timeout`` and ``max_concurrent_uploads`` are accepted for
-        # API stability — the actual upload pipeline that honors them is
-        # constructed by the :class:`NotebookLMClient` composition root and
-        # injected via ``uploader=``. They are stored here only as historical
-        # attributes for callers that introspect the instance.
+        # ``upload_timeout`` / ``max_concurrent_uploads`` are accepted for API
+        # stability but honored by the injected ``uploader=`` pipeline (built by
+        # the :class:`NotebookLMClient` composition root); stored here only as
+        # historical attributes for callers that introspect the instance.
         self._rpc = rpc
         self._adder = SourceAddService()
         self._content = SourceContentRenderer(self._rpc, logger=logger)
@@ -103,10 +102,10 @@ class SourcesAPI:
         self._max_concurrent_uploads = max_concurrent_uploads
         self._uploader = uploader
         self._uploader.configure_source_limit_lookup(self._get_source_limit)
-        # Single owner for the source-lifecycle verbs: the upload pipeline
-        # delegates its ``list_sources`` / ``get_source`` / ``wait_*`` verbs
-        # to the SAME ``SourceLister`` / ``SourcePoller`` instances this API
-        # uses, rather than re-constructing parallel copies (issue #1205).
+        # Single owner for the source-lifecycle verbs: the upload pipeline reuses
+        # the SAME ``SourceLister`` / ``SourcePoller`` instances this API uses for
+        # its ``list_sources`` / ``get_source`` / ``wait_*`` verbs rather than
+        # re-constructing parallel copies (issue #1205).
         self._uploader.configure_source_lifecycle(
             lister=self._lister,
             poller=self._poller,
@@ -367,13 +366,9 @@ class SourcesAPI:
             The created Source object. If wait=False, status may be PROCESSING.
 
         Example:
-            # Add and wait for processing
             source = await client.sources.add_url(nb_id, url, wait=True)
-
-            # Or add without waiting (for batch operations)
-            source = await client.sources.add_url(nb_id, url)
-            # ... add more sources ...
-            await client.sources.wait_for_sources(nb_id, [s.id for s in sources])
+            # ``wait=False`` returns immediately; poll later via
+            # ``wait_for_sources(nb_id, [s.id for s in sources])``.
         """
         return await self._adder.add_url(
             notebook_id,
@@ -453,81 +448,39 @@ class SourcesAPI:
         title: str | None = None,
         on_progress: Callable[[int, int], object] | None = None,
     ) -> Source:
-        """Add a file source to a notebook using resumable upload.
+        """Add a file source to a notebook using Google's resumable upload.
 
-        Uses Google's resumable upload protocol:
-        1. Register source intent with RPC → get SOURCE_ID
-        2. Start upload session with SOURCE_ID (get upload URL)
-        3. Stream upload file content (memory-efficient for large files)
-        4. Optionally rename the source if a custom ``title`` was supplied
-           (the file-add RPC has no title slot, so a follow-up
-           ``UPDATE_SOURCE`` is the only way to set one).
-
-        Concurrency / FD lifecycle:
-            ``add_file`` enters a drain-tracked ``operation_scope("upload:0")``
-            before waiting on the Sources-owned semaphore, so graceful
-            shutdown tracks both active and semaphore-queued uploads.
-            The upload section runs under the Sources-owned upload
-            pipeline semaphore, which bounds simultaneous in-flight
-            uploads at ``max_concurrent_uploads`` (default 4).
-            Each admitted upload holds **one open file descriptor**, so the cap
-            also guards FD exhaustion. The path is resolved/checked before
-            semaphore admission; once admitted, ``add_file`` opens that path
-            once, gets size with ``os.fstat()``, and streams the same file object
-            through registration/session/body POST. No second path-based open
-            occurs, so a later path swap cannot change the uploaded bytes. The
-            streaming helper closes the FD when finalize completes or unwinds.
+        Registers the source, opens an upload session, streams the file body
+        (memory-efficient for large files), and — if a custom ``title`` is given —
+        issues a follow-up ``UPDATE_SOURCE`` rename (the file-add RPC has no title
+        slot). Uploads run under the Sources-owned semaphore
+        (``max_concurrent_uploads``, default 4), which also caps open file
+        descriptors; the path is resolved before admission and opened exactly once.
 
         Args:
             notebook_id: The notebook ID.
             file_path: Path to the file to upload.
-            mime_type: Optional content type for the upload start handshake.
-                When omitted, the MIME type is inferred from the filename
-                extension. Supplying a value overrides inference.
-            title: Optional display title. When provided and different from the
-                source filename, a rename is issued after upload so the source
-                appears with this title in the UI and API responses. Leading and
-                trailing whitespace is stripped; empty titles are rejected. If
-                the post-upload rename fails, the upload is preserved, a warning
-                is logged, and the returned source keeps the filename title.
-
-                Important: supplying a non-default title forces a brief
-                registration wait (~seconds) for the source to become visible
-                server-side *before* the rename is issued, even when
-                ``wait=False``. The UPDATE_SOURCE RPC silently no-ops against
-                an unregistered source, so blocking here is the only way to
-                honor the caller's intent. This narrow wait completes once
-                the source's status is non-ERROR (or transient-ERROR for
-                audio); it does NOT wait for full processing. See #388.
-            wait: If True, wait for source to be fully ready before returning.
-                Note that supplying ``title`` also forces a narrow pre-rename
-                registration wait regardless of this flag — see the ``title``
-                parameter above.
-            wait_timeout: Maximum seconds to wait if ``wait=True``. Also bounds
-                the narrow registration wait triggered by a custom ``title``;
-                that wait returns on the first PROCESSING/READY poll so it
-                completes in seconds for typical sources regardless of this
-                value. Default: 120.
-            on_progress: Optional sync or async callback invoked as
-                ``on_progress(bytes_sent, total_bytes)`` during the streaming
-                upload body. Callback exceptions propagate and abort the
-                upload, matching normal application callback semantics.
+            mime_type: Content type for the upload handshake; inferred from the
+                filename extension when omitted.
+            title: Optional display title. When set and different from the
+                filename, a rename is issued after upload (whitespace stripped;
+                empty rejected). A non-default title forces a brief registration
+                wait before the rename even when ``wait=False`` — UPDATE_SOURCE
+                no-ops against an unregistered source (#388); a failed rename is
+                logged and the filename title is kept.
+            wait: If True, wait for the source to be fully ready before returning.
+            wait_timeout: Max seconds to wait if ``wait=True`` (also bounds the
+                narrow registration wait above). Default: 120.
+            on_progress: Optional sync/async ``on_progress(bytes_sent, total)``
+                callback during the upload body; its exceptions abort the upload.
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
 
-        Supported file types:
-            - PDF: application/pdf
-            - Text: text/plain
-            - Markdown: text/markdown
-            - EPUB: application/epub+zip
-            - Word: application/vnd.openxmlformats-officedocument.wordprocessingml.document
-
         Raises:
             ValidationError: If the path is not a regular file, the title is
-                empty, or the upload is an HTML-family file that NotebookLM's
-                upload endpoint rejects. Convert saved web pages to text,
-                Markdown, or PDF before calling this method.
+                empty, or the file is an HTML-family type the upload endpoint
+                rejects (convert to text/Markdown/PDF first).
         """
         return await self._uploader.add_file(
             notebook_id,
@@ -663,8 +616,7 @@ class SourcesAPI:
         if result and return_object:
             return Source.from_api_response(result, method_id=RPCMethod.UPDATE_SOURCE.value)
         # Null echo: hydrate via the internal lookup (never public ``get()`` —
-        # #1247) so a miss raises. ``False`` skips it only when existence is
-        # proven by the echo; v0.8.0 (#1362) runs it to detect a miss.
+        # #1247) so a miss raises; v0.8.0 (#1362) runs it to detect a miss.
         if not return_object and result:
             return None
         source = await self._get_or_none(notebook_id, source_id)
@@ -777,9 +729,7 @@ class SourcesAPI:
             output_format=output_format,
         )
 
-    # =========================================================================
-    # Private helper methods
-    # =========================================================================
+    # --- Private helper methods ---
 
     def _extract_all_text(self, data: builtins.list, max_depth: int = 100) -> builtins.list[str]:
         """Recursively extract all text strings from nested arrays.
@@ -854,11 +804,10 @@ class SourcesAPI:
         client sees a 5xx / network error. The probe-then-retry loop
         in ``add_url`` owns recovery via ``idempotent_create``.
         """
-        # allow_null=False mirrors _register_file_source — ADD_SOURCE on
-        # success returns the new source row. A null result with a status
-        # code at wrb.fr[5] is the #407 / #474 mode; allow_null=True would
-        # swallow that diagnostic. The decoder now raises RPCError with the
-        # status code so add_url can wrap it into SourceAddError with detail.
+        # allow_null=False (mirrors _register_file_source): ADD_SOURCE returns the
+        # new source row on success. A null result with a status code at wrb.fr[5]
+        # is the #407 / #474 mode; allow_null=True would swallow that diagnostic,
+        # so the decoder raises RPCError with the code for add_url to wrap.
         return await self._adder.add_youtube_source(
             notebook_id,
             url,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -455,7 +455,8 @@ class SourcesAPI:
         issues a follow-up ``UPDATE_SOURCE`` rename (the file-add RPC has no title
         slot). Uploads run under the Sources-owned semaphore
         (``max_concurrent_uploads``, default 4), which also caps open file
-        descriptors; the path is resolved before admission and opened exactly once.
+        descriptors; the path is resolved before admission and opened exactly once
+        (a single open pins the bytes, so a later path swap cannot alter the upload).
 
         Args:
             notebook_id: The notebook ID.

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -48,11 +48,9 @@ from ..exceptions import ValidationError
 from ..types import Source
 
 # Render/validation helpers live in ``_source_render``; re-exported here so the
-# historical ``source_cmd.<helper>`` import/patch surface (and the retained command
-# bodies below) keep resolving them. The F401 suppression marks every name an
-# intentional re-export — three (``_available_output_path``,
-# ``_exit_with_add_research_status``, ``_print_add_research_task_ids``) are used
-# only by sibling helpers in ``_source_render`` and have no caller here.
+# historical ``source_cmd.<helper>`` import/patch surface keeps resolving them
+# (F401: every name is an intentional re-export, some used only by sibling
+# ``_source_render`` helpers).
 from ._source_render import (  # noqa: F401
     _available_output_path,
     _classify_junk_sources,
@@ -565,11 +563,9 @@ def source_add_research(
     ``--prompt-file``.
     """
     query = resolve_prompt(query, prompt_file, "query", required=True)
-    # Flag-combination rules live in the neutral ``_app`` core as a pure
-    # ``validate_*`` raising ``ValidationError``; the command maps that to the
-    # CLI conflict contract (ADR-0015 §2): under --json route through the typed
-    # envelope, otherwise preserve Click's parser-style ``UsageError`` (exit 2
-    # with usage text) so interactive callers still see the canonical prose.
+    # Flag-combination rules live in the neutral ``_app`` core (pure ``validate_*``
+    # raising ``ValidationError``); the command maps that to the CLI conflict
+    # contract (ADR-0015 §2): --json → typed envelope, else Click ``UsageError``.
     try:
         validate_add_research_flags(import_all=import_all, cited_only=cited_only, no_wait=no_wait)
     except ValidationError as exc:
@@ -831,10 +827,9 @@ def source_clean(ctx, notebook_id, dry_run, yes, json_output, client_auth):
                 with cli_status("Fetching sources for cleanup...", ctx=ctx):
                     return await client.sources.list(notebook_id_inner)
 
-            # In --json mode, never prompt — automation cannot
-            # answer the question. Pass a non-interactive ``confirm_delete``
-            # that always declines; once the service returns ``cancelled`` we
-            # synthesize a structured ``CONFIRM_REQUIRED`` error below.
+            # In --json mode, never prompt: pass a ``confirm_delete`` that always
+            # declines, then synthesize a ``CONFIRM_REQUIRED`` error from the
+            # resulting ``cancelled`` status below.
             confirm_delete = (
                 (lambda count: False)
                 if json_output
@@ -939,11 +934,9 @@ def _dispatch_source_clean_result(
         return
 
     if result.failures:
-        # Failure summary is an error diagnostic, so it must remain visible
-        # under root ``--quiet`` (policy: errors are never silenced; see
-        # ``cli/rendering.py``). Use ``console.print`` directly here instead
-        # of ``cli_print`` so the diagnostic is not swallowed when the user
-        # passes ``--quiet``.
+        # Failure summary is an error diagnostic: use ``console.print`` (not
+        # ``cli_print``) so it stays visible under root ``--quiet`` — errors are
+        # never silenced (see ``cli/rendering.py``).
         console.print(
             f"[yellow]Cleaned {result.deleted_count} source(s). "
             f"{len(result.failures)} deletion(s) failed.[/yellow]",

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -44,12 +44,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
 
-# Any *new* module is forbidden from exceeding this many lines. Chosen to sit
-# just below the smallest currently-allowlisted module (``_research.py`` at
-# 936) so the allowlist is the *complete* set of modules over budget today and
-# the gate is green on main. New work must come in at or under this budget or
-# split before merge.
-MODULE_SIZE_BUDGET = 900
+# Any *new* module is forbidden from exceeding this many lines: a round 1000-line
+# cap that new work must come in at/under or split before merge. The allowlist
+# below is the *complete* set of modules over budget today, so the gate is green
+# on main. (Raised from 900 once the sub-1000 modules — ``_chat/api.py``,
+# ``_research.py``, ``cli/source_cmd.py`` — were trimmed below the round cap.)
+MODULE_SIZE_BUDGET = 1000
 
 # Every module currently over budget, pinned at its ratchet ceiling. These are
 # the only sanctioned exceedances; the map can only shrink and ceilings can only
@@ -59,56 +59,21 @@ MODULE_SIZE_BUDGET = 900
 # DO NOT raise a ceiling to make room for new code in a fat module — split it.
 # DO lower a ceiling when a module shrinks (the gate will tell you the value).
 ALLOWLISTED_CEILINGS: dict[str, int] = {
-    "cli/source_cmd.py": 964,
-    # _artifacts.py + _artifact/downloads.py: raised for the #1488 double-list
-    # fix, which threads an optional pre-fetched-list kwarg through every
-    # ``download_<x>`` method (and its public ``ArtifactsAPI`` delegate) plus the
-    # new ``_list_for_download`` seam so the download path issues ONE list RPC
-    # instead of two. The growth is the keyword-only params + ``is None`` guards
-    # on existing methods (ruff one-param-per-line wraps each 6-param signature);
-    # it is irreducible without splitting these modules, which is out of scope for
-    # the bug fix. New ceilings are the measured post-fix LOC.
-    # +31 LOC: the two public layer-3 headless re-auth exceptions
-    # (``HeadlessReauthError`` / ``HeadlessLoginRequiredError``) belong in the
-    # canonical exceptions module — that is where ``__all__`` and the
-    # public-surface manifest pin them, so they cannot live in a sibling file
-    # without forking the public exception home. Irreducible for this feature.
+    # The two remaining oversized modules, pinned at their measured LOC. Each is a
+    # cohesive unit whose split is a larger refactor than a line-count nudge
+    # warrants. ``_chat/api.py``, ``_research.py``, ``cli/source_cmd.py``,
+    # ``_sources.py``, ``_artifact/downloads.py``, and ``_source/upload.py`` were
+    # drained below the 1000-line budget and removed (one-way ratchet); ``client.py``
+    # dropped out earlier when its ``__init__`` body moved to ``_client_assembly.py``.
+    # ``_source/upload.py`` shed its pure decode/validation helpers to the sibling
+    # ``_source/_upload_decode.py``.
+    #
+    # ``exceptions.py`` is the canonical public exception home — ``__all__`` and
+    # the public-surface manifest pin every class to ``notebooklm.exceptions``, so
+    # the classes cannot move to sibling files without forking that home.
+    # ``_artifacts.py`` is the single ``ArtifactsAPI`` facade.
     "exceptions.py": 1546,
     "_artifacts.py": 1447,
-    # +3 LOC: the #1491 single-level positional-RPC drain for the sources domain
-    # replaced the file's raw ``name[int]`` reads (``result[0]`` / ``node[0]`` /
-    # ``value[0]`` / ``upload_ids[0]`` / ``matches[0]``) with unpack /
-    # ``next(iter(...))`` forms that lift the heuristic ADD_SOURCE_FILE id-envelope
-    # walks off the type-blind ratchet. The residual growth is irreducible
-    # in-place (an extra unpack-binding line in the two-element prefix and id/name
-    # pair reads); splitting the module for 3 lines is disproportionate. New
-    # ceiling is the measured post-drain LOC.
-    # +3 LOC: PR #1557 review (gemini) — the three guaranteed-single id picks
-    # switched from ``next(iter(x))`` to explicit ``(x,) = ...`` unpacking (one
-    # extra binding line each), which makes the single-element invariant explicit
-    # and sidesteps the PEP 479 ``StopIteration`` nuance. Irreducible in-place.
-    "_source/upload.py": 1242,
-    "_sources.py": 1007,
-    # _artifact/downloads.py: raised for the #1521 per-redirect-hop revalidation
-    # fix. The new *logic* (host+scheme hop guard + httpx event-hook factory) was
-    # *split out* into the sibling ``_artifact/_redirect_guard.py`` per this
-    # gate's "split out the new bulk" rule; the residual growth is irreducible
-    # in-place edits: call-site wiring (one import + the ``event_hooks=`` kwarg on
-    # each of the two ``httpx.AsyncClient(...)`` constructions) plus a security
-    # comment in ``_is_trusted_download_host`` documenting the percent-encode
-    # parser-differential bypass the re-review caught (dropping the ``unquote``
-    # decode + rejecting any ``%`` in the host). New ceiling is the measured
-    # post-fix LOC.
-    # +2 LOC: PR #1557 (the #1491 positional drain + its gemini-review unpacking
-    # of the typed ``completed``/``Artifact`` list heads). Irreducible in-place.
-    "_artifact/downloads.py": 1043,
-    # client.py dropped below the budget when its ``__init__`` body moved to
-    # ``_client_assembly.py`` (the shared constructor/test-factory seam), so
-    # its ceiling entry was removed per the one-way-ratchet rule.
-    # +1 LOC: PR #1557 (the #1491 positional drain + its gemini-review unpacking
-    # of the typed ``parsed_tasks``/``list[ResearchTask]`` head). Irreducible.
-    "_research.py": 934,
-    "_chat/api.py": 955,
 }
 
 

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -23,12 +23,13 @@ splits):
 3. **No stale allowlist entries.** Every allowlisted path must still exist (a
    rename/delete must update the allowlist).
 
-The ceilings below were *measured*, not estimated. To regenerate them::
+The ceilings below were *measured*, not estimated. To regenerate them (the
+``> 1000`` filter must track ``MODULE_SIZE_BUDGET`` below)::
 
     python -c "from pathlib import Path; src=Path('src/notebooklm'); \
         [print(f\"{len(p.read_text(encoding='utf-8').splitlines()):>6}  {p.relative_to(src).as_posix()}\") \
          for p in sorted(src.rglob('*.py')) \
-         if len(p.read_text(encoding='utf-8').splitlines()) > 900]"
+         if len(p.read_text(encoding='utf-8').splitlines()) > 1000]"
 
 Line counting uses ``str.splitlines()`` to match the diagnostic in
 ``scripts/audit_test_suite.py`` (``big_files``), so the two never disagree.

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -18,7 +18,7 @@ from urllib.parse import SplitResult, urlsplit
 import httpx
 import pytest
 
-import notebooklm._source.upload as _upload_mod
+import notebooklm._source._upload_decode as _upload_decode_mod
 from notebooklm._source.upload import (
     SourceUploadPipeline,
     _build_invalid_argument_source_limit_hint,
@@ -75,9 +75,10 @@ def test_redact_upload_url_value_error_returns_placeholder(
 ) -> None:
     """A urlsplit ValueError is swallowed into the redacted placeholder."""
     # ADR-0007 forbids string-target ``mock.patch`` on notebooklm internals;
-    # patch the module-level ``urlsplit`` seam object-form instead.
+    # patch the ``urlsplit`` seam object-form on ``_upload_decode`` (where the
+    # helper now resolves it after the extraction).
     fake_urlsplit = MagicMock(side_effect=ValueError("bad url"))
-    monkeypatch.setattr(_upload_mod, "urlsplit", fake_urlsplit)
+    monkeypatch.setattr(_upload_decode_mod, "urlsplit", fake_urlsplit)
     assert _redact_upload_url("https://example.com/x") == "[REDACTED_UPLOAD_URL]"
     fake_urlsplit.assert_called_once_with("https://example.com/x")
 
@@ -91,9 +92,10 @@ def test_validate_resumable_upload_url_value_error_wrapped(
         raise ValueError("malformed")
 
     # ADR-0007 forbids string-target ``mock.patch`` on notebooklm internals;
-    # patch the module-level ``urlsplit`` seam object-form instead.
+    # patch the ``urlsplit`` seam object-form on ``_upload_decode`` (where the
+    # helper now resolves it after the extraction).
     fake_urlsplit = MagicMock(side_effect=_boom)
-    monkeypatch.setattr(_upload_mod, "urlsplit", fake_urlsplit)
+    monkeypatch.setattr(_upload_decode_mod, "urlsplit", fake_urlsplit)
     with pytest.raises(ValidationError, match="Upload URL is not valid"):
         _validate_resumable_upload_url("https://example.com/?upload_id=x")
     fake_urlsplit.assert_called_once_with("https://example.com/?upload_id=x")


### PR DESCRIPTION
## What

Drains the module-size guardrail ratchet down to two remaining monoliths. Non-breaking internal refactor — public API and runtime behavior are unchanged (the API-compat audit exits 0 with no new allowlist entries).

### Budget change
- Raise `MODULE_SIZE_BUDGET` **900 → 1000** in `tests/_guardrails/test_module_size_ratchet.py`.

### Six modules drained below the new budget
- `_chat/api.py`, `_research.py`, `cli/source_cmd.py`, `_sources.py`, `_artifact/downloads.py` — drained purely via **comment/docstring trims** (no logic change). Load-bearing facts (ADR refs, contract notes, the download cancellation/race and `_is_trusted_download_host` rationale) were preserved.
- `_source/upload.py` — drained by **extracting pure, side-effect-free decode/validation helpers** into the new module `src/notebooklm/_source/_upload_decode.py` (resumable-upload URL validation/redaction, `ADD_SOURCE_FILE` source-id extraction, and upload content-type policy).

### Preserved re-export surface
`upload.py` re-exports every extracted name (`# noqa: F401`) so the historical `notebooklm._source.upload.<helper>` **import** surface keeps resolving (the `__all__` entries and the pipeline body still reference them).

### Repointed patch seams
The two `urlsplit` test seams in `tests/unit/test_source_upload_coverage.py` were repointed from the upload module to `_upload_decode` — that is where the moved helpers now look up the `urlsplit` global, so it's the correct patch target. A clarifying comment was added at the re-export site so future maintainers patch the right module.

### Docs
`docs/architecture.md` adds `_source/_upload_decode.py` to both the per-file index and the repo tree.

### Result
After this change, only `exceptions.py` and `_artifacts.py` remain on the module-size allowlist.

## Verification
- `uv run pytest` — full suite green (the only locally-skipped failures are two pre-existing Playwright-extra env checks in `test_auth_headless_reauth.py`, byte-identical to `main`, which pass in CI where the `browser` extra is installed).
- `uv run mypy src/notebooklm --ignore-missing-imports` — no issues (272 files).
- `uv run pre-commit run --all-files` — ruff lint + format pass.
- `uv run python scripts/audit_public_api_compat.py` — **exits 0**, no allowlist changes (confirms non-breaking).
- Guardrail suite (`tests/_guardrails/`, module-size ratchet, public-surface manifest, docs module-refs, CLAUDE.md freshness) — all pass.

## Polish
Ran the `/polish` pipeline (simplify → multi-model review → ultrathink) over the diff. The simplifier found nothing to change (clean drain). Review surfaced one documentation-precision point — that the *import* surface is preserved but a moved helper reads its globals from `_upload_decode` — which is now documented at the re-export site; the lost path-swap rationale in the `add_file` docstring was also restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified docs and inline comments across upload flow, chat/research APIs, cancellation behavior, and CLI usage examples.

* **Refactor**
  * Extracted and centralized upload decode/validation helpers into a distinct internal module and preserved public import surface.

* **Tests**
  * Updated unit tests to align with the refactor and relaxed the module-size budget with a narrowed allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->