### PR TITLE
refactor: extract ArtifactGenerationService to drain _artifacts.py below budget

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,7 +222,7 @@ Some feature workflows intentionally combine RPC with non-RPC HTTP work:
 |------|---------------|
 | Source file upload | `SourcesAPI.add_file()` delegates to `SourceUploadPipeline.add_file()`. The pipeline opens an `operation_scope`, takes its own upload semaphore, registers the file source through `runtime.rpc_call(ADD_SOURCE_FILE)`, then uses a dedicated `httpx.AsyncClient` and live Kernel cookies for the Scotty resumable-upload start/finalize calls. Optional wait/rename steps return to `rpc_call`. |
 | Source URL/text/Drive add | `SourceAddService` wraps URL and Drive mutating RPCs in `idempotent_create(...)` because those flows have stable probes. Text-source adds are intentionally non-idempotent unless the caller handles dedupe externally. |
-| Artifact generation | `ArtifactsAPI` builds `CREATE_ARTIFACT` params (via the `_artifact/payloads.py` builders) and uses the normal `rpc_call` path directly — the former `ArtifactGenerationService` was folded into the facade (#1205). `ArtifactPollingService` owns leader/follower polling with `operation_scope(...)` and a feature-local `PollRegistry`; `ArtifactsAPI` registers a close-time drain hook for poll cleanup. |
+| Artifact generation | `ArtifactsAPI` delegates the `generate_*` / `revise_slide` / `retry_failed` kickoff paths to `ArtifactGenerationService` (`_artifact/generation.py`), which builds `CREATE_ARTIFACT` params (via the `_artifact/payloads.py` builders) and uses the normal `rpc_call` path; the facade keeps thin signature-preserving delegators. `ArtifactPollingService` owns leader/follower polling with `operation_scope(...)` and a feature-local `PollRegistry`; `ArtifactsAPI` registers a close-time drain hook for poll cleanup. |
 | Artifact download | `ArtifactDownloadService` lists/selects artifacts through `RpcCaller`, but media downloads use a separate streaming `httpx.AsyncClient` with storage cookies, trusted-host checks, and a producer/writer split. They do not go through `RpcExecutor` or `Kernel.post`. |
 | Notes and mind maps | `NoteService` owns note-row CRUD/classification through `RpcCaller`. `NoteBackedMindMapService` adapts those note rows for artifact-facing mind-map behavior so notes and artifacts do not import each other. |
 
@@ -502,6 +502,7 @@ Beyond the client-owned runtime graph, several feature APIs are implemented via 
 | `NoteService` | [`_note_service.py`](../src/notebooklm/_note_service.py) | Service layer managing note CRUD, note-backed content generation, and sync. |
 | `NoteBackedMindMapService` | [`_mind_map.py`](../src/notebooklm/_mind_map.py) | Specific adapter service representing mind-maps, backed by standard notebook notes. |
 | `ArtifactDownloadService` | [`_artifact/downloads.py`](../src/notebooklm/_artifact/downloads.py) | Asynchronous download coordinator for finished artifacts. |
+| `ArtifactGenerationService` | [`_artifact/generation.py`](../src/notebooklm/_artifact/generation.py) | Generation kickoff service (`generate_*`, `revise_slide`, `retry_failed`) extracted from `ArtifactsAPI`. |
 | `_artifact_formatters` | [`_artifact/formatters.py`](../src/notebooklm/_artifact/formatters.py) | Markdown, HTML, and plain text formatters for artifacts. |
 | `_artifact/listing` | [`_artifact/listing.py`](../src/notebooklm/_artifact/listing.py) | Listing and filtering operations for notebook artifacts. |
 | `_row_adapters*` | [`_row_adapters/artifacts.py`](../src/notebooklm/_row_adapters/artifacts.py), [`_row_adapters/chat.py`](../src/notebooklm/_row_adapters/chat.py), [`_row_adapters/labels.py`](../src/notebooklm/_row_adapters/labels.py), [`_row_adapters/notes.py`](../src/notebooklm/_row_adapters/notes.py), [`_row_adapters/research.py`](../src/notebooklm/_row_adapters/research.py), [`_row_adapters/sources.py`](../src/notebooklm/_row_adapters/sources.py) | Wire-shape adapters that wrap raw batchexecute rows (`ArtifactRow`, `LabelRow`, `NoteRow`, `SourceRow`, the `POLL_RESEARCH` rows) and the streamed-chat rows (`AnswerRow`/`CitationRow`/…) behind named accessors so downloads, polling, listing, labels, research, and the chat parser don't open-code positional indices. Strict decode behavior is pinned in `tests/unit/test_row_adapters.py`, `tests/unit/test_chat_row_adapter.py`, and `tests/unit/test_research_row_adapter.py`. |
@@ -943,6 +944,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_artifact/_redirect_guard.py` | Per-redirect-hop host/scheme revalidation for downloads — rejects off-allowlist / non-HTTPS redirect targets before the request is sent (#1521) |
 | `_artifact/formatters.py` | Markdown, HTML, and plain text formatters for artifacts |
 | `_artifact/payloads.py` | Stable CREATE_ARTIFACT / GENERATE_MIND_MAP request payload builders |
+| `_artifact/generation.py` | Generation kickoff service (`generate_*`, `revise_slide`, `retry_failed`) extracted from `ArtifactsAPI`; the facade keeps thin delegators |
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact/polling.py` | Poll coordination service for artifact generation tasks |
 | `_source/add.py` | Core service layer for adding text, URL, or Google Drive sources |
@@ -1097,6 +1099,7 @@ src/notebooklm/
 │   ├── _redirect_guard.py       # Per-redirect-hop host/scheme revalidation for downloads (#1521)
 │   ├── downloads.py             # Artifact download coordinator
 │   ├── formatters.py            # Artifact formatting helpers
+│   ├── generation.py            # Artifact generation kickoff service (generate_*, revise_slide, retry_failed)
 │   ├── payloads.py              # Stable artifact request payload builders
 │   ├── listing.py               # Artifact listing helper
 │   └── polling.py               # Artifact polling coordinator

--- a/src/notebooklm/_artifact/generation.py
+++ b/src/notebooklm/_artifact/generation.py
@@ -1,0 +1,580 @@
+"""Private artifact generation service implementation.
+
+Holds the ``generate_*`` / ``revise_slide`` / ``retry_failed`` kickoff paths
+extracted from :class:`~notebooklm._artifacts.ArtifactsAPI` (the facade keeps
+thin delegators preserving the public signatures). This service owns only the
+RPC dispatch surface, the source-id resolver, and the note-row primitives — no
+polling/status state lives here.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json as json_module
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .._env import get_default_language
+from .._row_adapters import artifacts as _artifact_rows
+from .._types.artifacts import _status_from_code
+from .._types.research import MindMapResult
+from ..exceptions import (
+    ArtifactFeatureUnavailableError,
+    DecodingError,
+    ValidationError,
+)
+from ..rpc import (
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    RPCMethod,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+    safe_index,
+)
+from ..types import GenerationStatus
+from .payloads import (
+    build_audio_artifact_params,
+    build_cinematic_video_artifact_params,
+    build_data_table_artifact_params,
+    build_flashcards_artifact_params,
+    build_infographic_artifact_params,
+    build_mind_map_params,
+    build_quiz_artifact_params,
+    build_report_artifact_params,
+    build_retry_artifact_params,
+    build_revise_slide_params,
+    build_slide_deck_artifact_params,
+    build_video_artifact_params,
+)
+
+if TYPE_CHECKING:
+    from .._note_service import NoteService
+    from .._notebook_metadata import NotebookSourceIdProvider
+    from .._runtime.contracts import RpcCaller
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactGenerationService:
+    """Generation kickoff operations extracted from :class:`ArtifactsAPI`.
+
+    Peer to :class:`~notebooklm._artifact.downloads.ArtifactDownloadService`
+    and :class:`~notebooklm._artifact.polling.ArtifactPollingService`. Injected
+    with the RPC caller, the source-id resolver, and the note-row service so the
+    generate paths carry no other facade state.
+    """
+
+    def __init__(
+        self,
+        *,
+        rpc: RpcCaller,
+        notebooks: NotebookSourceIdProvider,
+        note_service: NoteService,
+    ) -> None:
+        self._rpc = rpc
+        self._notebooks = notebooks
+        self._note_service = note_service
+
+    async def generate_audio(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+        audio_format: AudioFormat | None = None,
+        audio_length: AudioLength | None = None,
+    ) -> GenerationStatus:
+        """Generate an Audio Overview (podcast)."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_audio_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+            audio_format=audio_format,
+            audio_length=audio_length,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="audio",
+        )
+
+    async def generate_video(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+        video_format: VideoFormat | None = None,
+        video_style: VideoStyle | None = None,
+        style_prompt: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a Video Overview."""
+        if language is None:
+            language = get_default_language()
+        normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
+        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
+            raise ValidationError("style_prompt is not supported for cinematic videos")
+        if video_style == VideoStyle.CUSTOM and not normalized_style_prompt:
+            raise ValidationError("style_prompt is required when video_style is CUSTOM")
+        if normalized_style_prompt and video_style != VideoStyle.CUSTOM:
+            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
+
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_video_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+            video_format=video_format,
+            video_style=video_style,
+            style_prompt=normalized_style_prompt,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="video",
+        )
+
+    async def generate_cinematic_video(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a Cinematic Video Overview."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_cinematic_video_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="cinematic video",
+        )
+
+    async def generate_report(
+        self,
+        notebook_id: str,
+        report_format: ReportFormat = ReportFormat.BRIEFING_DOC,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        custom_prompt: str | None = None,
+        extra_instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a report artifact."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_report_artifact_params(
+            notebook_id,
+            source_ids,
+            report_format=report_format,
+            language=language,
+            custom_prompt=custom_prompt,
+            extra_instructions=extra_instructions,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="report",
+        )
+
+    async def generate_study_guide(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        extra_instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a study guide report."""
+        if language is None:
+            language = get_default_language()
+        return await self.generate_report(
+            notebook_id,
+            report_format=ReportFormat.STUDY_GUIDE,
+            source_ids=source_ids,
+            language=language,
+            extra_instructions=extra_instructions,
+        )
+
+    async def generate_quiz(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        instructions: str | None = None,
+        quantity: QuizQuantity | None = None,
+        difficulty: QuizDifficulty | None = None,
+    ) -> GenerationStatus:
+        """Generate a quiz."""
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_quiz_artifact_params(
+            notebook_id,
+            source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="quiz",
+        )
+
+    async def generate_flashcards(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        instructions: str | None = None,
+        quantity: QuizQuantity | None = None,
+        difficulty: QuizDifficulty | None = None,
+    ) -> GenerationStatus:
+        """Generate flashcards."""
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_flashcards_artifact_params(
+            notebook_id,
+            source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="flashcards",
+        )
+
+    async def generate_infographic(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+        orientation: InfographicOrientation | None = None,
+        detail_level: InfographicDetail | None = None,
+        style: InfographicStyle | None = None,
+    ) -> GenerationStatus:
+        """Generate an infographic."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_infographic_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+            orientation=orientation,
+            detail_level=detail_level,
+            style=style,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="infographic",
+        )
+
+    async def generate_slide_deck(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+        slide_format: SlideDeckFormat | None = None,
+        slide_length: SlideDeckLength | None = None,
+    ) -> GenerationStatus:
+        """Generate a slide deck."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_slide_deck_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+            slide_format=slide_format,
+            slide_length=slide_length,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="slide deck",
+        )
+
+    async def revise_slide(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        slide_index: int,
+        prompt: str,
+    ) -> GenerationStatus:
+        """Revise an individual slide in a completed slide deck using a prompt."""
+        if slide_index < 0:
+            raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
+
+        params = build_revise_slide_params(artifact_id, slide_index, prompt)
+        # v0.8.0 (#1342): a synchronous refusal (``RPCError``) propagates rather
+        # than being swallowed into a soft ``status="failed"`` return.
+        result = await self._rpc.rpc_call(
+            RPCMethod.REVISE_SLIDE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if result is None:
+            logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
+            raise ArtifactFeatureUnavailableError(
+                "slide revision",
+                method_id=RPCMethod.REVISE_SLIDE.value,
+            )
+        return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
+
+    async def retry_failed(self, notebook_id: str, artifact_id: str) -> GenerationStatus:
+        """Retry a failed Studio artifact in place (the UI "Retry" action).
+
+        Re-runs generation for an already-failed artifact *without* deleting it
+        first. The same ``artifact_id`` is preserved and returned as the task
+        id, so existing ``poll_status`` / ``wait_for_completion`` flows keep
+        working — an accepted retry comes back as
+        ``GenerationStatus(status="in_progress")``.
+
+        Follows the ADR-0019 "async kickoff" contract: a synchronous server
+        refusal (``USER_DISPLAYABLE_ERROR`` — rate limit, quota, or a
+        non-retryable artifact) **raises** ``RateLimitError`` / ``RPCError``
+        rather than returning ``status="failed"``, matching the v0.8.0 behavior
+        of the sibling ``generate_*`` / ``revise_slide`` methods (#1342).
+
+        ``notebook_id`` is routing-only — it sets the ``source_path`` header;
+        the artifact is identified solely by ``artifact_id`` (same trait as
+        ``revise_slide``).
+        """
+        params = build_retry_artifact_params(artifact_id)
+        # A USER_DISPLAYABLE_ERROR refusal propagates as RateLimitError/RPCError
+        # per ADR-0019 "async kickoff", matching _call_generate / revise_slide
+        # after v0.8.0 (#1342).
+        #
+        # ``allow_null=True`` lets a null decode through to the explicit
+        # ``result is None`` guard below (the golden fixture pins the
+        # normal-success row, so it records ``allow_null: false`` for that
+        # happy-path decode — the two are not in conflict).
+        result = await self._rpc.rpc_call(
+            RPCMethod.RETRY_ARTIFACT,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if result is None:
+            logger.warning("RETRY_ARTIFACT returned null result for artifact %s", artifact_id)
+            raise ArtifactFeatureUnavailableError(
+                "retry",
+                method_id=RPCMethod.RETRY_ARTIFACT.value,
+            )
+        # This matches revise_slide / generate_* after v0.8.0 (#1342):
+        # no-task rows raise instead of being reported as started-then-failed.
+        # A structurally-short row still raises ``UnknownRPCMethodError`` from
+        # ``safe_index`` inside ``_parse_generation_result``.
+        status = self._parse_generation_result(result, method_id=RPCMethod.RETRY_ARTIFACT.value)
+        if not status.task_id:
+            logger.warning("RETRY_ARTIFACT returned a row with no artifact id: %r", result)
+            raise ArtifactFeatureUnavailableError(
+                "retry",
+                method_id=RPCMethod.RETRY_ARTIFACT.value,
+            )
+        return status
+
+    async def generate_data_table(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a data table."""
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_data_table_artifact_params(
+            notebook_id,
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
+        return await self._call_generate(
+            notebook_id,
+            params,
+            null_result_artifact_type="data table",
+        )
+
+    async def generate_mind_map(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = "en",
+        instructions: str | None = None,
+    ) -> MindMapResult:
+        """Generate a note-backed mind map and persist it as a note.
+
+        Returns:
+            A :class:`~notebooklm._types.research.MindMapResult` with
+            ``mind_map`` (the parsed mind-map structure, or ``None`` on an
+            empty response) and ``note_id`` (the persisted note id, or
+            ``None``). Use attribute access (``result.mind_map``).
+        """
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
+
+        params = build_mind_map_params(
+            source_ids,
+            language=language,
+            instructions=instructions,
+        )
+
+        # GENERATE_MIND_MAP is classified PROBE_THEN_CREATE in
+        # ``_idempotency.py``. ``operation_variant=None`` is passed
+        # explicitly to document this call site as the no-variant default
+        # (the registry resolves the same entry either way; the explicit
+        # kwarg is a future-proofing marker for a possible variant table).
+        result = await self._rpc.rpc_call(
+            RPCMethod.GENERATE_MIND_MAP,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+            operation_variant=None,
+        )
+
+        # The two-level ``[[mind_map_json]]`` leaf descent is centralised behind
+        # ``unwrap_mind_map_generation_leaf`` (#1491); the sentinel marks absence
+        # (a present leaf, incl. ``None``, is processed as before).
+        mind_map_json = _artifact_rows.unwrap_mind_map_generation_leaf(
+            result, method_id=RPCMethod.GENERATE_MIND_MAP.value, source="ArtifactsAPI"
+        )
+        if mind_map_json is not _artifact_rows.MIND_MAP_LEAF_ABSENT:
+            if isinstance(mind_map_json, str):
+                try:
+                    mind_map_data = json_module.loads(mind_map_json)
+                except json_module.JSONDecodeError:
+                    mind_map_data = mind_map_json
+                    mind_map_json = str(mind_map_json)
+            else:
+                mind_map_data = mind_map_json
+                mind_map_json = json_module.dumps(mind_map_json)
+
+            # Only accept ``name`` when it is a non-empty ``str`` — a
+            # malformed tree with a ``null``/numeric ``name`` would otherwise
+            # flow into the note title and frozen ``MindMap.title: str``
+            # (issue #1270).
+            title = "Mind Map"
+            if isinstance(mind_map_data, dict):
+                name = mind_map_data.get("name")
+                if isinstance(name, str) and name:
+                    title = name
+
+            # ``NoteService.create_note`` raises ``RPCError`` when the
+            # server omits a usable row id (issue #1162); on success it
+            # always returns a ``Note`` with a non-empty id. The
+            # ``note.id or None`` below is therefore defensive only —
+            # it preserves the public dict contract ("note_id is None
+            # means persistence failed") for any future degenerate
+            # shape, but the empty-id case now surfaces as an error
+            # rather than a silent ``{"note_id": None}``.
+            note = await self._note_service.create_note(
+                notebook_id, title=title, content=mind_map_json
+            )
+            return MindMapResult(
+                mind_map=mind_map_data,
+                note_id=note.id or None,
+                created_at=note.created_at,
+            )
+
+        return MindMapResult(mind_map=None, note_id=None)
+
+    async def _call_generate(
+        self,
+        notebook_id: str,
+        params: builtins.list[Any],
+        *,
+        null_result_artifact_type: str | None = None,
+    ) -> GenerationStatus:
+        """Make a generation RPC call with error handling."""
+        # Best-effort debug label over the OUTGOING request body; the ``[2:3]``
+        # slice-pick keeps it off ``name[int]`` (== old guarded ``params[2]``).
+        descriptor = next(iter(params[2:3]), None)
+        artifact_type = (
+            next(iter(descriptor[2:3]), "unknown") if isinstance(descriptor, list) else "unknown"
+        )
+        logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
+        # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
+        # ``operation_variant=None`` marks this call site as the no-variant
+        # default (a future-proofing marker; the registry resolves the same).
+        # v0.8.0 (#1342): a synchronous refusal (couldn't-start, ``RPCError``)
+        # propagates rather than being swallowed into a soft
+        # ``status="failed"`` return.
+        result = await self._rpc.rpc_call(
+            RPCMethod.CREATE_ARTIFACT,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+            operation_variant=None,
+        )
+        if result is None and null_result_artifact_type is not None:
+            raise ArtifactFeatureUnavailableError(
+                null_result_artifact_type,
+                method_id=RPCMethod.CREATE_ARTIFACT.value,
+            )
+        return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
+
+    def _parse_generation_result(
+        self,
+        result: Any,
+        *,
+        method_id: str,
+        source: str = "_parse_generation_result",
+    ) -> GenerationStatus:
+        """Parse generation API result into GenerationStatus."""
+        artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
+
+        if artifact_id:
+            status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
+            return GenerationStatus(task_id=artifact_id, status=_status_from_code(status_code))
+
+        # v0.8.0 (#1342): a missing id means no task was created — raise.
+        # Null id (feature gated) -> ArtifactFeatureUnavailableError; else drift.
+        if artifact_id is None:
+            raise ArtifactFeatureUnavailableError("artifact", method_id=method_id)
+        raise DecodingError(f"No artifact id (source={source})", method_id=method_id)

--- a/src/notebooklm/_artifact/generation.py
+++ b/src/notebooklm/_artifact/generation.py
@@ -534,10 +534,14 @@ class ArtifactGenerationService:
         """Make a generation RPC call with error handling."""
         # Best-effort debug label over the OUTGOING request body; the ``[2:3]``
         # slice-pick keeps it off ``name[int]`` (== old guarded ``params[2]``).
-        descriptor = next(iter(params[2:3]), None)
-        artifact_type = (
-            next(iter(descriptor[2:3]), "unknown") if isinstance(descriptor, list) else "unknown"
-        )
+        # Unpack the at-most-one-element slice rather than ``next(iter(...))`` so
+        # the single-element invariant is explicit (no StopIteration path).
+        descriptor = None
+        if params[2:3]:
+            (descriptor,) = params[2:3]
+        artifact_type = "unknown"
+        if isinstance(descriptor, list) and descriptor[2:3]:
+            (artifact_type,) = descriptor[2:3]
         logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
         # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
         # ``operation_variant=None`` marks this call site as the no-variant

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -6,38 +6,22 @@ Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 """
 
 import builtins
-import json as json_module
 import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 # ``_mind_map`` is re-exported as ``_artifacts._mind_map`` so legacy patch
-# seams can still resolve the module via the artifacts facade. The runtime code
-# path in this module talks to the injected ``NoteBackedMindMapService`` /
-# ``NoteService`` instances; the bare module re-export is for monkeypatch
-# convenience only.
+# seams can still resolve the module via the artifacts facade (monkeypatch
+# convenience only). Runtime code talks to the injected
+# ``NoteBackedMindMapService`` / ``NoteService`` instances.
 from . import _mind_map  # noqa: F401 — re-exported as facade attribute
 from ._artifact import formatters as _artifact_formatters
 from ._artifact import polling as _artifact_polling
 from ._artifact.downloads import ArtifactDownloadService, DownloadResult
+from ._artifact.generation import ArtifactGenerationService
 from ._artifact.listing import ArtifactListingService
-from ._artifact.payloads import (
-    build_audio_artifact_params,
-    build_cinematic_video_artifact_params,
-    build_data_table_artifact_params,
-    build_flashcards_artifact_params,
-    build_infographic_artifact_params,
-    build_mind_map_params,
-    build_quiz_artifact_params,
-    build_report_artifact_params,
-    build_retry_artifact_params,
-    build_revise_slide_params,
-    build_slide_deck_artifact_params,
-    build_suggest_reports_params,
-    build_video_artifact_params,
-)
-from ._env import get_default_language
+from ._artifact.payloads import build_suggest_reports_params
 from ._lookup import unwrap_or_raise
 from ._mind_map import NoteBackedMindMapService
 from ._note_service import NoteService
@@ -45,14 +29,8 @@ from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
 from ._row_adapters import artifacts as _artifact_rows
 from ._runtime.contracts import RpcCaller
-from ._types.artifacts import _status_from_code
 from ._types.research import MindMapResult
-from .exceptions import (
-    ArtifactFeatureUnavailableError,
-    ArtifactNotFoundError,
-    DecodingError,
-    ValidationError,
-)
+from .exceptions import ArtifactNotFoundError
 
 if TYPE_CHECKING:
     from ._runtime.lifecycle import ClientLifecycle
@@ -73,7 +51,6 @@ from .rpc import (
     SlideDeckLength,
     VideoFormat,
     VideoStyle,
-    safe_index,
 )
 from .types import (
     Artifact,
@@ -88,19 +65,15 @@ logger = logging.getLogger(__name__)
 class ArtifactsAPI:
     """Operations on NotebookLM artifacts (studio content).
 
-    Artifacts are AI-generated content including Audio Overviews, Video Overviews,
-    Reports, Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
+    Artifacts are AI-generated content: Audio/Video Overviews, Reports,
+    Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 
-    Usage:
+    Usage::
+
         async with NotebookLMClient.from_storage() as client:
-            # Generate
             status = await client.artifacts.generate_audio(notebook_id)
             await client.artifacts.wait_for_completion(notebook_id, status.task_id)
-
-            # Download
             await client.artifacts.download_audio(notebook_id, "output.mp4")
-
-            # List and manage
             artifacts = await client.artifacts.list(notebook_id)
             await client.artifacts.rename(notebook_id, artifact_id, "New Title")
     """
@@ -119,29 +92,23 @@ class ArtifactsAPI:
         """Initialize the artifacts API.
 
         Args:
-            rpc: RPC dispatch surface (:class:`RpcCaller`). Used for
-                direct artifact RPCs (delete, rename, export, list_raw)
-                and threaded into the generation and download services.
-            drain: Transport drain coordinator. Owns ``operation_scope``
-                (used by the polling service) and ``register_drain_hook``
-                (used here to register the polling-service close-time
-                cleanup hook).
-            lifecycle: Client lifecycle seam. Owns ``assert_bound_loop``
-                used by the polling service before it touches loop-bound
-                state.
+            rpc: RPC dispatch surface (:class:`RpcCaller`) — used for direct
+                artifact RPCs (delete, rename, export, list_raw) and threaded
+                into the generation and download services.
+            drain: Transport drain coordinator — owns ``operation_scope`` (used
+                by the polling service) and ``register_drain_hook`` (used here
+                to register the polling-service close-time cleanup hook).
+            lifecycle: Client lifecycle seam — owns ``assert_bound_loop`` used
+                by the polling service before it touches loop-bound state.
             notebooks: Source-id resolver. Required — wire from
-                ``NotebookLMClient`` (no implicit fallback).
-            mind_maps: Note-backed mind-map facade. Owns the
-                ``list_mind_maps`` / ``extract_content`` paths consumed
-                by ``_artifact.downloads.download_mind_map``. Renamed
-                from ``mind_map_service`` to reflect the
-                concrete adapter type (:class:`NoteBackedMindMapService`).
-            note_service: Backend note-row primitives. Owns the
-                ``create_note`` call site that this API's
-                ``generate_mind_map`` uses to persist generated mind
-                maps. The generation path no longer
-                reaches into a module-level ``_mind_map.create_note``
-                shim.
+                ``NotebookLMClient`` (no implicit fallback). Threaded into the
+                generation service.
+            mind_maps: Note-backed mind-map facade (:class:`NoteBackedMindMapService`)
+                — owns the ``list_mind_maps`` / ``extract_content`` paths
+                consumed by ``_artifact.downloads.download_mind_map``.
+            note_service: Backend note-row primitives — owns the ``create_note``
+                call site that the generation service's ``generate_mind_map``
+                uses to persist generated mind maps.
             storage_path: Path to storage state file for loading download cookies.
         """
         self._rpc = rpc
@@ -157,6 +124,11 @@ class ArtifactsAPI:
             listing=self._listing,
             mind_maps=self._mind_maps,
             storage_path=storage_path,
+        )
+        self._generation = ArtifactGenerationService(
+            rpc=self._rpc,
+            notebooks=self._notebooks,
+            note_service=self._note_service,
         )
         self._polling = _artifact_polling.ArtifactPollingService(
             loop_guard=self._lifecycle,
@@ -174,22 +146,11 @@ class ArtifactsAPI:
     ) -> list[Artifact]:
         """List all artifacts in a notebook, including mind maps.
 
-        This returns all AI-generated content: Audio Overviews, Video Overviews,
-        Reports, Quizzes, Flashcards, Infographics, Slide Decks, Data Tables,
-        and Mind Maps.
-
-        Note: Note-backed mind maps are stored in the notes collection, while
-        interactive mind maps are studio artifacts (type 4 / variant 4). This
-        listing merges both backings under ``ArtifactType.MIND_MAP`` because
-        both are AI-generated mind-map content.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_type: Optional ArtifactType to filter by.
-                Use ArtifactType.MIND_MAP to get only mind maps.
-
-        Returns:
-            List of Artifact objects.
+        Returns all AI-generated content. Note-backed mind maps live in the
+        notes collection while interactive mind maps are studio artifacts
+        (type 4 / variant 4); this listing merges both backings under
+        ``ArtifactType.MIND_MAP``. Pass ``artifact_type`` to filter (e.g.
+        ``ArtifactType.MIND_MAP`` for mind maps only).
         """
         logger.debug("Listing artifacts in notebook %s", notebook_id)
         return await self._listing.list_artifacts(
@@ -214,20 +175,13 @@ class ArtifactsAPI:
     async def get(self, notebook_id: str, artifact_id: str) -> Artifact:
         """Get a specific artifact by ID.
 
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The artifact ID.
-
-        Returns:
-            The :class:`~notebooklm.types.Artifact`.
-
         Raises:
             ArtifactNotFoundError: If no artifact with ``artifact_id`` exists
                 (matches ``notebooks.get``; issue #1247). Use :meth:`get_or_none`
                 for the sanctioned ``None``-on-miss lookup.
         """
-        # ``unwrap_or_raise`` single-sources the raise-on-miss decision (#1247).
-        # Internal callers needing the silent lookup use get_or_none.
+        # ``unwrap_or_raise`` single-sources the raise-on-miss decision (#1247);
+        # internal callers needing the silent lookup use get_or_none.
         return unwrap_or_raise(
             await self.get_or_none(notebook_id, artifact_id),
             ArtifactNotFoundError(artifact_id),
@@ -237,25 +191,14 @@ class ArtifactsAPI:
         """Get an artifact by ID, returning ``None`` when it does not exist.
 
         The sanctioned ``None``-on-miss lookup (ADR-0019): unlike :meth:`get`
-        — which now raises
-        :class:`~notebooklm.exceptions.ArtifactNotFoundError` on a miss
-        (#1247) — this returns ``None`` for a genuine absence and
-        emits no deprecation warning. This method neither catches nor synthesizes
-        a miss itself; it lists once and id-matches, inheriting :meth:`list`'s
-        behavior unchanged. (Per ADR-0019 Rule 3, ``list`` keeps its deliberate
-        *partial-availability* policy: a transport failure of the mind-map
-        sub-fetch logs a warning and yields the studio artifacts that did load,
-        so a note-backed mind-map id can read absent while that sub-fetch is
-        down. That cross-namespace policy is decided separately and is not
-        re-litigated here.) Faults raised by the primary studio-artifact listing
-        propagate unchanged.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The artifact ID.
-
-        Returns:
-            The :class:`~notebooklm.types.Artifact`, or ``None`` if not found.
+        — which raises ``ArtifactNotFoundError`` on a miss (#1247) — this
+        returns ``None`` for a genuine absence with no deprecation warning. It
+        lists once and id-matches, inheriting :meth:`list`'s behavior. (Per
+        ADR-0019 Rule 3, ``list`` keeps its deliberate *partial-availability*
+        policy: a mind-map sub-fetch transport failure logs a warning and
+        yields the studio artifacts that loaded, so a note-backed mind-map id
+        can read absent while that sub-fetch is down.) Faults from the primary
+        studio-artifact listing propagate unchanged.
         """
         logger.debug("Getting artifact %s from notebook %s", artifact_id, notebook_id)
         return await self._listing.get(notebook_id, artifact_id, list_artifacts=self.list)
@@ -310,23 +253,13 @@ class ArtifactsAPI:
         audio_length: AudioLength | None = None,
     ) -> GenerationStatus:
         """Generate an Audio Overview (podcast)."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_audio_artifact_params(
+        return await self._generation.generate_audio(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
             audio_format=audio_format,
             audio_length=audio_length,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="audio",
         )
 
     async def generate_video(
@@ -340,32 +273,14 @@ class ArtifactsAPI:
         style_prompt: str | None = None,
     ) -> GenerationStatus:
         """Generate a Video Overview."""
-        if language is None:
-            language = get_default_language()
-        normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
-        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
-            raise ValidationError("style_prompt is not supported for cinematic videos")
-        if video_style == VideoStyle.CUSTOM and not normalized_style_prompt:
-            raise ValidationError("style_prompt is required when video_style is CUSTOM")
-        if normalized_style_prompt and video_style != VideoStyle.CUSTOM:
-            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
-
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_video_artifact_params(
+        return await self._generation.generate_video(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
             video_format=video_format,
             video_style=video_style,
-            style_prompt=normalized_style_prompt,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="video",
+            style_prompt=style_prompt,
         )
 
     async def generate_cinematic_video(
@@ -376,21 +291,11 @@ class ArtifactsAPI:
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a Cinematic Video Overview."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_cinematic_video_artifact_params(
+        return await self._generation.generate_cinematic_video(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="cinematic video",
         )
 
     async def generate_report(
@@ -403,23 +308,13 @@ class ArtifactsAPI:
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a report artifact."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_report_artifact_params(
+        return await self._generation.generate_report(
             notebook_id,
-            source_ids,
             report_format=report_format,
+            source_ids=source_ids,
             language=language,
             custom_prompt=custom_prompt,
             extra_instructions=extra_instructions,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="report",
         )
 
     async def generate_study_guide(
@@ -430,11 +325,8 @@ class ArtifactsAPI:
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a study guide report."""
-        if language is None:
-            language = get_default_language()
-        return await self.generate_report(
+        return await self._generation.generate_study_guide(
             notebook_id,
-            report_format=ReportFormat.STUDY_GUIDE,
             source_ids=source_ids,
             language=language,
             extra_instructions=extra_instructions,
@@ -449,20 +341,12 @@ class ArtifactsAPI:
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
         """Generate a quiz."""
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_quiz_artifact_params(
+        return await self._generation.generate_quiz(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             instructions=instructions,
             quantity=quantity,
             difficulty=difficulty,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="quiz",
         )
 
     async def generate_flashcards(
@@ -474,20 +358,12 @@ class ArtifactsAPI:
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
         """Generate flashcards."""
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_flashcards_artifact_params(
+        return await self._generation.generate_flashcards(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             instructions=instructions,
             quantity=quantity,
             difficulty=difficulty,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="flashcards",
         )
 
     async def generate_infographic(
@@ -501,24 +377,14 @@ class ArtifactsAPI:
         style: InfographicStyle | None = None,
     ) -> GenerationStatus:
         """Generate an infographic."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_infographic_artifact_params(
+        return await self._generation.generate_infographic(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
             orientation=orientation,
             detail_level=detail_level,
             style=style,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="infographic",
         )
 
     async def generate_slide_deck(
@@ -531,23 +397,13 @@ class ArtifactsAPI:
         slide_length: SlideDeckLength | None = None,
     ) -> GenerationStatus:
         """Generate a slide deck."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_slide_deck_artifact_params(
+        return await self._generation.generate_slide_deck(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
             slide_format=slide_format,
             slide_length=slide_length,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="slide deck",
         )
 
     async def revise_slide(
@@ -558,99 +414,26 @@ class ArtifactsAPI:
         prompt: str,
     ) -> GenerationStatus:
         """Revise an individual slide in a completed slide deck using a prompt."""
-        if slide_index < 0:
-            raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
-
-        params = build_revise_slide_params(artifact_id, slide_index, prompt)
-        # v0.8.0 (#1342): a synchronous refusal (``RPCError``) propagates rather
-        # than being swallowed into a soft ``status="failed"`` return.
-        result = await self._rpc.rpc_call(
-            RPCMethod.REVISE_SLIDE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        if result is None:
-            logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
-            raise ArtifactFeatureUnavailableError(
-                "slide revision",
-                method_id=RPCMethod.REVISE_SLIDE.value,
-            )
-        return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
+        return await self._generation.revise_slide(notebook_id, artifact_id, slide_index, prompt)
 
     async def retry_failed(self, notebook_id: str, artifact_id: str) -> GenerationStatus:
         """Retry a failed Studio artifact in place (the UI "Retry" action).
 
-        Re-runs generation for an already-failed artifact *without* deleting it
-        first. The same ``artifact_id`` is preserved and returned as the task
-        id, so existing :meth:`poll_status` / :meth:`wait_for_completion` flows
-        keep working — an accepted retry comes back as
-        ``GenerationStatus(status="in_progress")``.
+        Re-runs generation for an already-failed artifact without deleting it
+        first; the same ``artifact_id`` is preserved as the task id, so existing
+        :meth:`poll_status` / :meth:`wait_for_completion` flows keep working. An
+        accepted retry returns ``GenerationStatus(status="in_progress")``.
 
-        A single retry may itself fail again provider-side; this is a single
-        in-place operation, so callers decide whether to re-invoke after a
-        later terminal ``failed`` status (observed by polling).
-
-        This method follows the ADR-0019 "async kickoff" contract: a
-        synchronous server refusal (``USER_DISPLAYABLE_ERROR`` - e.g. rate
-        limit, quota, or a non-retryable artifact) **raises** the underlying
-        :class:`~notebooklm.exceptions.RateLimitError` /
-        :class:`~notebooklm.exceptions.RPCError` rather than returning
-        ``status="failed"``. This now matches the v0.8.0 behavior of the
-        sibling ``generate_*`` / :meth:`revise_slide` methods (#1342).
-
-        Args:
-            notebook_id: The notebook ID. Routing-only — it sets the
-                ``source_path`` header; the artifact is identified solely by
-                ``artifact_id`` in the RPC payload (same trait as
-                :meth:`revise_slide`).
-            artifact_id: The ID of the failed artifact to retry.
-
-        Returns:
-            A :class:`~notebooklm.types.GenerationStatus` whose ``task_id`` is
-            the same ``artifact_id`` and whose ``status`` is ``"in_progress"``
-            once the retry is accepted.
-
-        Raises:
-            RateLimitError: The server refused the retry with a rate-limit /
-                quota ``USER_DISPLAYABLE_ERROR``.
-            RPCError: Any other synchronous server refusal.
-            ArtifactFeatureUnavailableError: The RPC returned a null /
-                missing-id result (no generation task was created).
+        Follows the ADR-0019 "async kickoff" contract: a synchronous
+        ``USER_DISPLAYABLE_ERROR`` refusal (rate limit, quota, non-retryable
+        artifact) **raises** ``RateLimitError`` / ``RPCError`` rather than
+        returning ``status="failed"``, matching the sibling ``generate_*`` /
+        :meth:`revise_slide` methods after v0.8.0 (#1342). A null / missing-id
+        result raises :class:`ArtifactFeatureUnavailableError`. ``notebook_id``
+        is routing-only (sets the ``source_path`` header); the artifact is
+        identified solely by ``artifact_id``.
         """
-        params = build_retry_artifact_params(artifact_id)
-        # A USER_DISPLAYABLE_ERROR refusal propagates as RateLimitError/RPCError
-        # per ADR-0019 "async kickoff", matching _call_generate / revise_slide
-        # after v0.8.0 (#1342).
-        #
-        # ``allow_null=True`` lets a null decode through to the explicit
-        # ``result is None`` guard below (the golden fixture pins the
-        # normal-success row, so it records ``allow_null: false`` for that
-        # happy-path decode — the two are not in conflict).
-        result = await self._rpc.rpc_call(
-            RPCMethod.RETRY_ARTIFACT,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        if result is None:
-            logger.warning("RETRY_ARTIFACT returned null result for artifact %s", artifact_id)
-            raise ArtifactFeatureUnavailableError(
-                "retry",
-                method_id=RPCMethod.RETRY_ARTIFACT.value,
-            )
-        # This matches revise_slide / generate_* after v0.8.0 (#1342):
-        # no-task rows raise instead of being reported as started-then-failed.
-        # A structurally-short row still raises ``UnknownRPCMethodError`` from
-        # ``safe_index`` inside ``_parse_generation_result``.
-        status = self._parse_generation_result(result, method_id=RPCMethod.RETRY_ARTIFACT.value)
-        if not status.task_id:
-            logger.warning("RETRY_ARTIFACT returned a row with no artifact id: %r", result)
-            raise ArtifactFeatureUnavailableError(
-                "retry",
-                method_id=RPCMethod.RETRY_ARTIFACT.value,
-            )
-        return status
+        return await self._generation.retry_failed(notebook_id, artifact_id)
 
     async def generate_data_table(
         self,
@@ -660,21 +443,11 @@ class ArtifactsAPI:
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a data table."""
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_data_table_artifact_params(
+        return await self._generation.generate_data_table(
             notebook_id,
-            source_ids,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
-        )
-        return await self._call_generate(
-            notebook_id,
-            params,
-            null_result_artifact_type="data table",
         )
 
     async def generate_mind_map(
@@ -686,81 +459,16 @@ class ArtifactsAPI:
     ) -> MindMapResult:
         """Generate a note-backed mind map and persist it as a note.
 
-        Returns:
-            A :class:`~notebooklm._types.research.MindMapResult` with
-            ``mind_map`` (the parsed mind-map structure, or ``None`` on an
-            empty response) and ``note_id`` (the persisted note id, or
-            ``None``). Use attribute access (``result.mind_map``).
+        Returns a :class:`~notebooklm._types.research.MindMapResult` with
+        ``mind_map`` (parsed structure, or ``None`` on an empty response) and
+        ``note_id`` (the persisted note id, or ``None``).
         """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._notebooks.get_source_ids(notebook_id)
-
-        params = build_mind_map_params(
-            source_ids,
+        return await self._generation.generate_mind_map(
+            notebook_id,
+            source_ids=source_ids,
             language=language,
             instructions=instructions,
         )
-
-        # GENERATE_MIND_MAP is classified PROBE_THEN_CREATE in
-        # ``_idempotency.py``. ``operation_variant=None`` is passed
-        # explicitly to document this call site as the no-variant default
-        # (the registry resolves the same entry either way; the explicit
-        # kwarg is a future-proofing marker for a possible variant table).
-        result = await self._rpc.rpc_call(
-            RPCMethod.GENERATE_MIND_MAP,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-            operation_variant=None,
-        )
-
-        # The two-level ``[[mind_map_json]]`` leaf descent is centralised behind
-        # ``unwrap_mind_map_generation_leaf`` (#1491); the sentinel marks absence
-        # (a present leaf, incl. ``None``, is processed as before).
-        mind_map_json = _artifact_rows.unwrap_mind_map_generation_leaf(
-            result, method_id=RPCMethod.GENERATE_MIND_MAP.value, source="ArtifactsAPI"
-        )
-        if mind_map_json is not _artifact_rows.MIND_MAP_LEAF_ABSENT:
-            if isinstance(mind_map_json, str):
-                try:
-                    mind_map_data = json_module.loads(mind_map_json)
-                except json_module.JSONDecodeError:
-                    mind_map_data = mind_map_json
-                    mind_map_json = str(mind_map_json)
-            else:
-                mind_map_data = mind_map_json
-                mind_map_json = json_module.dumps(mind_map_json)
-
-            # Only accept ``name`` when it is a non-empty ``str`` — a
-            # malformed tree with a ``null``/numeric ``name`` would otherwise
-            # flow into the note title and frozen ``MindMap.title: str``
-            # (issue #1270).
-            title = "Mind Map"
-            if isinstance(mind_map_data, dict):
-                name = mind_map_data.get("name")
-                if isinstance(name, str) and name:
-                    title = name
-
-            # ``NoteService.create_note`` raises ``RPCError`` when the
-            # server omits a usable row id (issue #1162); on success it
-            # always returns a ``Note`` with a non-empty id. The
-            # ``note.id or None`` below is therefore defensive only —
-            # it preserves the public dict contract ("note_id is None
-            # means persistence failed") for any future degenerate
-            # shape, but the empty-id case now surfaces as an error
-            # rather than a silent ``{"note_id": None}``.
-            note = await self._note_service.create_note(
-                notebook_id, title=title, content=mind_map_json
-            )
-            return MindMapResult(
-                mind_map=mind_map_data,
-                note_id=note.id or None,
-                created_at=note.created_at,
-            )
-
-        return MindMapResult(mind_map=None, note_id=None)
 
     # =========================================================================
     # Download Operations
@@ -842,18 +550,7 @@ class ArtifactsAPI:
         html_content: str,
         is_quiz: bool,
     ) -> str:
-        """Format quiz or flashcard content for output.
-
-        Args:
-            app_data: Parsed data from HTML.
-            title: Artifact title.
-            output_format: Output format - json, markdown, or html.
-            html_content: Original HTML content.
-            is_quiz: True for quiz, False for flashcards.
-
-        Returns:
-            Formatted content string.
-        """
+        """Format quiz (``is_quiz=True``) or flashcard content as json/markdown/html."""
         return _artifact_formatters._format_interactive_content(
             app_data,
             title,
@@ -945,10 +642,6 @@ class ArtifactsAPI:
         ``None``) and never raises ``ArtifactNotFoundError``. Real failures
         (``403``/``5xx``/auth/transport) still propagate.
 
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The artifact ID to delete.
-
         .. versionchanged:: 0.7.0
             **Breaking change:** previously returned a hardcoded ``True``;
             now returns ``None`` (issue #1211). ``if await artifacts.delete(...):``
@@ -973,20 +666,10 @@ class ArtifactsAPI:
     ) -> Artifact | None:
         """Rename an artifact.
 
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The artifact ID to rename.
-            new_title: The new title.
-            return_object: When ``True`` (default), re-fetch (a full
-                ``LIST_ARTIFACTS`` call) and return the renamed
-                :class:`~notebooklm.types.Artifact`; when ``False``, return
-                ``None`` without re-fetching. Miss-detection runs in both modes
-                (``False`` still returns ``None`` on success but raises on a
-                miss — see ``Raises``).
-
-        Returns:
-            The renamed :class:`~notebooklm.types.Artifact`, or ``None`` when
-            ``return_object=False``.
+        ``return_object=True`` (default) re-fetches (a full ``LIST_ARTIFACTS``
+        call) and returns the renamed :class:`~notebooklm.types.Artifact`;
+        ``False`` returns ``None`` on success. Miss-detection runs in both
+        modes.
 
         Raises:
             ArtifactNotFoundError: if the artifact does not exist (detected via
@@ -1027,21 +710,15 @@ class ArtifactsAPI:
     async def poll_status(self, notebook_id: str, task_id: str) -> GenerationStatus:
         """Poll the status of a generation task.
 
-        Args:
-            notebook_id: The notebook ID.
-            task_id: The task/artifact ID to check.
-
-        Returns:
-            GenerationStatus with current status.  When the artifact is not
-            found in the list, ``status`` is set to ``"not_found"`` so that
-            callers can distinguish "genuinely pending" from "removed by the
-            server" (e.g. after a quota rejection).
+        Returns a ``GenerationStatus``; when the artifact is absent from the
+        list, ``status`` is ``"not_found"`` so callers can distinguish
+        "genuinely pending" from "removed by the server" (e.g. after a quota
+        rejection).
 
         .. versionchanged:: 0.4.0
-            **Breaking change:** Previously returned ``status="pending"``
-            when an artifact was absent from the list.  Now returns
-            ``status="not_found"`` to allow callers to distinguish a
-            genuinely pending artifact from one that was removed.
+            **Breaking change:** Previously returned ``status="pending"`` when
+            an artifact was absent from the list; now returns
+            ``status="not_found"``.
         """
         return await self._polling.poll_status(
             notebook_id,
@@ -1063,60 +740,32 @@ class ArtifactsAPI:
         min_not_found_window: float = 10.0,
         on_status_change: Callable[[GenerationStatus], object] | None = None,
     ) -> GenerationStatus:
-        """Wait for a generation task to complete.
-
-        Uses exponential backoff for polling to reduce API load.
+        """Wait for a generation task to complete (exponential-backoff polling).
 
         Concurrent callers for the same ``(notebook_id, task_id)`` share a
-        single underlying poll loop through this API's feature-owned
-        ``PollRegistry``. The first caller is the *leader* and drives the poll
-        loop; subsequent *followers* attach to the leader's future without
-        issuing their own ``LIST_ARTIFACTS`` requests. Cancellation is
-        per-caller — only the cancelled caller's ``await`` raises
-        ``CancelledError``; the underlying poll continues and remaining
-        followers still receive the result.
+        single poll loop via this API's feature-owned ``PollRegistry``. The
+        first caller is the *leader* and drives the loop; *followers* attach to
+        the leader's future without issuing their own ``LIST_ARTIFACTS``
+        requests. Cancellation is per-caller — only the cancelled caller's
+        ``await`` raises ``CancelledError``; the poll continues and remaining
+        followers still receive the result. Only the *leader's* interval /
+        timeout / not-found knobs apply to the shared loop; followers' values
+        are ignored once they attach. Distinct waiters that genuinely need
+        distinct timeouts should serialize their calls instead.
 
-        Because followers attach to the leader's already-running poll,
-        only the *leader's* ``initial_interval`` / ``max_interval`` /
-        ``timeout`` / ``max_not_found`` / ``min_not_found_window`` apply
-        to the shared poll loop. Followers' values for these parameters
-        are ignored once they attach. This is acceptable for the
-        intended use case (deduping accidental fan-out from the same
-        application) — distinct waiters that genuinely need distinct
-        timeouts should serialize their calls instead.
-
-        Args:
-            notebook_id: The notebook ID.
-            task_id: The task/artifact ID to wait for.
-            initial_interval: Initial seconds between status checks
-                (leader only — see note above).
-            max_interval: Maximum seconds between status checks
-                (leader only).
-            timeout: Maximum seconds to wait (leader only).
-            max_not_found: Consecutive "not found" polls before treating
-                the task as *removed*.  When the API removes an artifact
-                from the list (e.g. after a daily-quota rejection), the
-                poller would otherwise spin until *timeout*.  The returned
-                status is ``"removed"`` (see :attr:`GenerationStatus.is_removed`),
-                kept distinct from ``"failed"`` so a delisted artifact is not
-                conflated with one the server actually marked terminal-FAILED.
-                Defaults to 5 to tolerate brief replication lag and slow
-                networks. (Leader only.)
-            min_not_found_window: Minimum seconds that must have elapsed
-                since the *first* not-found response before a consecutive
-                run triggers failure.  This avoids false positives on
-                slow or unreliable networks.  Defaults to 10.0.
-                (Leader only.)
-            on_status_change: Optional sync or async callback invoked with a
-                ``GenerationStatus`` when the leader observes a new status.
-                Followers that attach to an existing poll receive only the
-                final status through this callback.
-
-        Returns:
-            Final GenerationStatus.
+        ``max_not_found`` (default 5) is the consecutive "not found" poll count
+        before the task is treated as *removed* — the returned status is
+        ``"removed"`` (see :attr:`GenerationStatus.is_removed`), kept distinct
+        from ``"failed"`` so a delisted artifact (e.g. after a daily-quota
+        rejection) is not conflated with a server terminal-FAILED.
+        ``min_not_found_window`` (default 10.0) is the minimum elapsed seconds
+        since the *first* not-found before a consecutive run triggers failure,
+        avoiding false positives on slow networks. ``on_status_change`` is an
+        optional sync/async callback invoked when the leader observes a new
+        status (followers receive only the final status).
 
         Raises:
-            TimeoutError: If task doesn't complete within timeout.
+            TimeoutError: If task doesn't complete within ``timeout``.
         """
         return await self._polling.wait_for_completion(
             notebook_id,
@@ -1141,17 +790,7 @@ class ArtifactsAPI:
         title: str = "Export",
         export_type: ExportType = ExportType.DOCS,
     ) -> Any:
-        """Export a report to Google Docs.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The report artifact ID.
-            title: Title for the exported document.
-            export_type: ExportType.DOCS (default) or ExportType.SHEETS.
-
-        Returns:
-            Export result with document URL.
-        """
+        """Export a report to Google Docs (``export_type`` selects DOCS/SHEETS)."""
         params = [None, artifact_id, None, title, int(export_type)]
         return await self._rpc.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
@@ -1166,16 +805,7 @@ class ArtifactsAPI:
         artifact_id: str,
         title: str = "Export",
     ) -> Any:
-        """Export a data table to Google Sheets.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The data table artifact ID.
-            title: Title for the exported spreadsheet.
-
-        Returns:
-            Export result with spreadsheet URL.
-        """
+        """Export a data table to Google Sheets."""
         params = [None, artifact_id, None, title, int(ExportType.SHEETS)]
         return await self._rpc.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
@@ -1192,20 +822,7 @@ class ArtifactsAPI:
         title: str = "Export",
         export_type: ExportType = ExportType.DOCS,
     ) -> Any:
-        """Export an artifact to Google Docs/Sheets.
-
-        Generic export method for any artifact type.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The artifact ID (optional).
-            content: Content to export (optional).
-            title: Title for the exported document.
-            export_type: ExportType.DOCS (default) or ExportType.SHEETS.
-
-        Returns:
-            Export result with document URL.
-        """
+        """Export any artifact to Google Docs/Sheets (generic; ``export_type`` selects)."""
         params = [None, artifact_id, content, title, int(export_type)]
         return await self._rpc.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
@@ -1263,33 +880,16 @@ class ArtifactsAPI:
         *,
         null_result_artifact_type: str | None = None,
     ) -> GenerationStatus:
-        """Make a generation RPC call with error handling."""
-        # Best-effort debug label over the OUTGOING request body; the ``[2:3]``
-        # slice-pick keeps it off ``name[int]`` (== old guarded ``params[2]``).
-        descriptor = next(iter(params[2:3]), None)
-        artifact_type = (
-            next(iter(descriptor[2:3]), "unknown") if isinstance(descriptor, list) else "unknown"
-        )
-        logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
-        # CREATE_ARTIFACT is PROBE_THEN_CREATE (``_idempotency.py``).
-        # ``operation_variant=None`` marks this call site as the no-variant
-        # default (a future-proofing marker; the registry resolves the same).
-        # v0.8.0 (#1342): a synchronous refusal (couldn't-start, ``RPCError``)
-        # propagates rather than being swallowed into a soft
-        # ``status="failed"`` return.
-        result = await self._rpc.rpc_call(
-            RPCMethod.CREATE_ARTIFACT,
+        """Make a generation RPC call with error handling.
+
+        Facade hop: tests call ``api._call_generate(...)`` directly; the
+        implementation lives on :class:`ArtifactGenerationService`.
+        """
+        return await self._generation._call_generate(
+            notebook_id,
             params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-            operation_variant=None,
+            null_result_artifact_type=null_result_artifact_type,
         )
-        if result is None and null_result_artifact_type is not None:
-            raise ArtifactFeatureUnavailableError(
-                null_result_artifact_type,
-                method_id=RPCMethod.CREATE_ARTIFACT.value,
-            )
-        return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw mind-map rows via the injected mind-map facade."""
@@ -1310,45 +910,23 @@ class ArtifactsAPI:
         *,
         type_code: ArtifactTypeCode,
     ) -> Any:
-        """Select an artifact from candidates by ID or return latest completed.
+        """Select an artifact from candidates by ID, or return latest completed.
 
-        This is the single point where completed-artifact selection happens.
-        Callers pass the raw artifact list from ``_list_raw``; the helper
-        filters it down to entries matching ``type_code`` with status
-        ``COMPLETED`` before applying the explicit-ID or latest-timestamp
-        rules.
+        Single point of completed-artifact selection: filters the raw
+        ``_list_raw`` list to entries matching ``type_code`` with status
+        ``COMPLETED``, then applies the explicit-ID or latest-timestamp rule.
 
-        Note on the length guard: the filter only requires ``len(a) > 4`` —
-        the minimum needed to read ``a[2]`` (type) and ``a[4]`` (status). The
-        old inline filters in ``download_report`` and ``download_data_table``
-        used stricter length checks (``> 7`` / ``> 18``). A completed-but-too-
-        short artifact now passes this filter and surfaces as
-        ``ArtifactParseError`` from the downstream extractor instead of
-        ``ArtifactNotReadyError`` from the candidate filter. In practice the
-        API returns consistent structures, and downstream paths already wrap
-        ``IndexError``/``TypeError`` into ``ArtifactParseError``.
-
-        Args:
-            candidates: Raw artifact list (typically from ``_list_raw``).
-            artifact_id: Specific artifact ID to select, or None for latest.
-            type_name: Display name (e.g., "Audio", "Slide deck"). Used for
-                the explicit-id-miss error key — lowercased with spaces turned
-                into underscores (e.g., "Slide deck" -> "slide_deck").
-            no_result_error_key: Error key used when no candidate survives
-                filtering. Most callers pass ``type_name.lower()`` but some
-                (e.g. ``download_video``) intentionally pass a distinct key
-                (``"video_overview"``) to preserve historical exception keys.
-                Named ``no_result_error_key`` (rather than something like
-                ``type_name_lower``) because it is not in general the
-                lowercase of ``type_name`` — see ``download_video``.
-            type_code: ArtifactTypeCode used to filter candidates by type.
-
-        Returns:
-            Selected artifact data.
+        The length guard requires only ``len(a) > 4`` — the minimum to read
+        ``a[2]`` (type) and ``a[4]`` (status). A completed-but-too-short
+        artifact passes here and surfaces as ``ArtifactParseError`` from the
+        downstream extractor rather than ``ArtifactNotReadyError`` from this
+        filter (downstream wraps ``IndexError``/``TypeError`` into
+        ``ArtifactParseError``). ``no_result_error_key`` is *not* in general
+        ``type_name.lower()`` — ``download_video`` passes ``"video_overview"``
+        to preserve historical exception keys.
 
         Raises:
-            ArtifactNotReadyError: If artifact not found or no candidates
-                available after filtering.
+            ArtifactNotReadyError: If no candidate is found after filtering.
         """
         return self._listing.select_artifact(
             candidates,
@@ -1375,73 +953,38 @@ class ArtifactsAPI:
         method_id: str,
         source: str = "_parse_generation_result",
     ) -> GenerationStatus:
-        """Parse generation API result into GenerationStatus."""
-        artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
+        """Parse a generation result into GenerationStatus.
 
-        if artifact_id:
-            status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
-            return GenerationStatus(task_id=artifact_id, status=_status_from_code(status_code))
-
-        # v0.8.0 (#1342): a missing id means no task was created — raise.
-        # Null id (feature gated) -> ArtifactFeatureUnavailableError; else drift.
-        if artifact_id is None:
-            raise ArtifactFeatureUnavailableError("artifact", method_id=method_id)
-        raise DecodingError(f"No artifact id (source={source})", method_id=method_id)
+        Facade hop: tests call ``api._parse_generation_result(...)`` directly;
+        the implementation lives on :class:`ArtifactGenerationService`.
+        """
+        return self._generation._parse_generation_result(result, method_id=method_id, source=source)
 
     @staticmethod
     def _extract_artifact_error(art: builtins.list[Any]) -> str | None:
-        """Try to extract a human-readable error from a failed artifact.
+        """Extract a human-readable error from a failed artifact, or ``None``.
 
-        Google's batchexecute responses embed error information in varying
-        positions depending on the artifact type.  This method walks through
-        known locations and returns the first non-empty string it finds.
-
-        Known error locations (reverse-engineered):
-        - art[3]: Sometimes contains an error reason string.
-        - art[5]: May contain a nested error payload similar to the
-          UserDisplayableError structure in RPC responses.
-
-        Args:
-            art: Raw artifact data from ``_list_raw()``.
-
-        Returns:
-            A human-readable error string, or ``None`` if no error detail
-            could be extracted.
+        Google's batchexecute responses embed error info in varying positions;
+        this walks known (reverse-engineered) locations and returns the first
+        non-empty string. ``art[3]`` sometimes holds an error reason string;
+        ``art[5]`` may hold a nested UserDisplayableError-style payload.
         """
         return _artifact_polling._extract_artifact_error(art)
 
     def _get_artifact_type_name(self, artifact_type: int) -> str:
-        """Get human-readable name for an artifact type.
-
-        Args:
-            artifact_type: The ArtifactTypeCode enum value.
-
-        Returns:
-            The enum name if valid, otherwise the raw integer as string.
-        """
+        """Human-readable name for an ``ArtifactTypeCode``, else the raw int as str."""
         return _artifact_polling._get_artifact_type_name(artifact_type)
 
     def _is_media_ready(self, art: builtins.list[Any], artifact_type: int) -> bool:
-        """Check if media artifact has URLs populated.
+        """Check if a media artifact's download URLs are populated.
 
-        For media artifacts (audio, video, infographic, slide deck), the API may
-        set status=COMPLETED before the actual media URLs are populated. This
-        method verifies that URLs are available for download.
+        For media artifacts (audio, video, infographic, slide deck) the API may
+        set status=COMPLETED before the URLs are populated; this verifies they
+        are available. Returns ``True`` for non-media types and (defensively)
+        on unexpected structure.
 
-        Artifact array structure (from BATCHEXECUTE responses):
-        - art[0]: artifact_id
-        - art[2]: artifact_type (ArtifactTypeCode enum value)
-        - art[4]: status_code (ArtifactStatus enum value)
-        - art[6][5]: audio media URL list
-        - art[8][i][0][0]: video media URL string (within nested variants and entries)
-        - art[16][3]: slide deck PDF URL
-
-        Args:
-            art: Raw artifact data from _list_raw().
-            artifact_type: The ArtifactTypeCode enum value.
-
-        Returns:
-            True if media URLs are available, or if artifact is non-media type.
-            Returns True on unexpected structure (defensive fallback).
+        Positional URL locations (BATCHEXECUTE rows): ``art[6][5]`` audio URL
+        list, ``art[8][i][0][0]`` video URL string (nested variants/entries),
+        ``art[16][3]`` slide-deck PDF URL.
         """
         return _artifact_polling._is_media_ready(art, artifact_type)

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -60,21 +60,20 @@ MODULE_SIZE_BUDGET = 1000
 # DO NOT raise a ceiling to make room for new code in a fat module — split it.
 # DO lower a ceiling when a module shrinks (the gate will tell you the value).
 ALLOWLISTED_CEILINGS: dict[str, int] = {
-    # The two remaining oversized modules, pinned at their measured LOC. Each is a
-    # cohesive unit whose split is a larger refactor than a line-count nudge
-    # warrants. ``_chat/api.py``, ``_research.py``, ``cli/source_cmd.py``,
-    # ``_sources.py``, ``_artifact/downloads.py``, and ``_source/upload.py`` were
-    # drained below the 1000-line budget and removed (one-way ratchet); ``client.py``
-    # dropped out earlier when its ``__init__`` body moved to ``_client_assembly.py``.
+    # The single remaining oversized module, pinned at its measured LOC.
+    # ``_chat/api.py``, ``_research.py``, ``cli/source_cmd.py``, ``_sources.py``,
+    # ``_artifact/downloads.py``, and ``_source/upload.py`` were drained below the
+    # 1000-line budget and removed (one-way ratchet); ``client.py`` dropped out
+    # earlier when its ``__init__`` body moved to ``_client_assembly.py``.
     # ``_source/upload.py`` shed its pure decode/validation helpers to the sibling
-    # ``_source/_upload_decode.py``.
+    # ``_source/_upload_decode.py``. ``_artifacts.py`` dropped out once its
+    # ``generate_*`` / ``revise_slide`` / ``retry_failed`` kickoff paths moved to
+    # the sibling ``_artifact/generation.py`` (``ArtifactGenerationService``).
     #
     # ``exceptions.py`` is the canonical public exception home — ``__all__`` and
     # the public-surface manifest pin every class to ``notebooklm.exceptions``, so
     # the classes cannot move to sibling files without forking that home.
-    # ``_artifacts.py`` is the single ``ArtifactsAPI`` facade.
     "exceptions.py": 1546,
-    "_artifacts.py": 1447,
 }
 
 

--- a/tests/_guardrails/test_no_facade_reach_in.py
+++ b/tests/_guardrails/test_no_facade_reach_in.py
@@ -56,6 +56,7 @@ _ARTIFACT_SERVICE_MODULES = [
     "_artifact/formatters.py",
     "_artifact/listing.py",
     "_artifact/downloads.py",
+    "_artifact/generation.py",
     "_artifact/polling.py",
 ]
 
@@ -264,6 +265,7 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 
 _REACH_IN_MIGRATED_MODULES: list[str] = [
     "_artifact/downloads.py",
+    "_artifact/generation.py",
 ]
 
 
@@ -288,10 +290,10 @@ class _ApiReachInVisitor(ast.NodeVisitor):
 
     ``_REACH_IN_MIGRATED_MODULES`` enumerates helpers already migrated to
     constructor injection; this guard is actively enforced for those
-    modules. The remaining artifact-service helper
-    (``_artifact/downloads.py``) is currently migrated;
-    ``_artifact_generation.py`` was folded into the ``ArtifactsAPI``
-    facade (issue #1205) so it is no longer a separate guarded module.
+    modules. The migrated artifact-service helpers are
+    ``_artifact/downloads.py`` and ``_artifact/generation.py`` (the latter
+    re-extracted from the ``ArtifactsAPI`` facade as a constructor-injected
+    ``ArtifactGenerationService``).
     """
 
     def __init__(self, module_name: str) -> None:


### PR DESCRIPTION
## Summary

Extracts the artifact **generation kickoff** paths from the 1447-line `ArtifactsAPI` facade into a new `ArtifactGenerationService` (`src/notebooklm/_artifact/generation.py`) — a peer to the existing `ArtifactDownloadService` and `ArtifactPollingService`. Combined with aggressive docstring/comment trimming on the facade, this drains `_artifacts.py` to **990 lines**, below the 1000-line module-size budget, and removes its `ALLOWLISTED_CEILINGS` entry (one-way ratchet) — leaving `exceptions.py` as the sole allowlisted module.

> **Stacked on #1564** (`refactor: drain module-size ratchet to two monoliths`). This PR targets `refactor/drain-module-size-ceilings`; once #1564 merges, retarget the base to `main`.

## What moved

Into `ArtifactGenerationService(rpc=…, notebooks=…, note_service=…)`:
- `generate_audio/video/cinematic_video/report/study_guide/quiz/flashcards/infographic/slide_deck/data_table/mind_map`
- `revise_slide`, `retry_failed`
- private `_call_generate`, `_parse_generation_result`

The facade keeps **thin, signature-preserving delegators** for every public method. `_call_generate` and `_parse_generation_result` also keep facade hops because tests call them directly on the API instance.

## Why it's seam-safe

- No test does `setattr` / `patch.object` on `_call_generate` / `_parse_generation_result`; they're called directly (preserved by the delegators) or exercised via a mocked RPC.
- The RPC is injected at construction; tests mutate the **same shared object** (`mock_core.rpc_executor.rpc_call`) via `.side_effect` / `.return_value`, so the extracted service sees it.
- All `generate_*` patch-seam tests pass unchanged — no seam repoints needed.

## What did NOT move

`_is_media_ready`, `_extract_artifact_error`, `_get_artifact_type_name` stay on the facade (status/polling concerns delegating to `_artifact_polling`). Their verbose docstrings were trimmed but the positional RPC-shape rationale (`art[3]`/`art[5]`/`art[6][5]`/…) was kept. Every issue/ADR ref (#1342, #1270, #1491, #1247, #1362, ADR-0019, …) was preserved.

## Verification

- `pytest tests/unit tests/integration -k "artifact or generation or mind_map or generate"` → 1543 passed
- `pytest tests/_guardrails/test_module_size_ratchet.py test_public_surface_manifest.py tests/unit/test_claude_md_freshness.py` → 309 passed
- Full suite green (the only 2 failures observed were a missing `browser` extra in the sandbox, unrelated; green once installed)
- `mypy src/notebooklm --ignore-missing-imports` → clean
- `pre-commit run --all-files` → pass
- `scripts/audit_public_api_compat.py` → exit 0 (non-breaking; no allowlist entries added)

## Docs

`docs/architecture.md` updated: class-index table, file-index table, repo tree, and the artifact-generation call-flow row (which previously said the service "was folded into the facade").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by restructuring artifact generation services for better maintainability and separation of concerns. All public APIs and functionality remain unchanged.

* **Chores**
  * Updated architecture documentation and test configurations to reflect internal service refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->