### PR TITLE
fix(auth): reliable auth-check exit codes + passive validation contract (#1569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Passive auth validation for unattended monitors** (#1569). New
+  `notebooklm.auth.fetch_tokens_passive(...)` validates the cookies on disk with
+  a strictly read-only token fetch — it never runs `NOTEBOOKLM_REFRESH_CMD`,
+  never fires the layer-1 keepalive rotation poke, and never writes
+  `storage_state.json` (additive public symbol; the active
+  `fetch_tokens_with_domains` is unchanged). `notebooklm auth check --test
+  --passive` routes the token probe through it, so a systemd/cron health check
+  can answer "do the cookies currently authenticate?" without mutating state,
+  spawning a subprocess, or racing real work. The transport-neutral
+  `run_auth_check(AuthCheckPlan(..., passive=True))` exposes the same probe to
+  the MCP/HTTP adapters.
+
+- **`notebooklm auth refresh --verify`** (#1569). After a refresh completes,
+  runs the passive token probe to confirm the resulting cookies actually
+  authenticate, exiting non-zero if they still redirect to sign-in. A successful
+  refresh command alone does not prove the post-refresh cookies work — this is
+  especially valuable with `--browser-cookies`, which rewrites the cookie jar
+  but does not otherwise verify it.
+
+- **macOS login recovery hint.** When the bundled-Chromium interactive login
+  times out (`Login not detected within 5 minutes`), the message now suggests
+  retrying with `notebooklm login --browser chrome` to reuse an already
+  signed-in system Chrome session — which often detects immediately and sidesteps
+  bundled-Chromium issues on macOS.
+
 - **Layer-3 headless re-auth: `client.refresh_auth(allow_headless=True)`** (#1525,
   P2; P1 was #1512). When NotebookLM's first-party cookies are fully dead — the
   homepage GET 302s to the Google login page and neither token refresh (L1) nor
@@ -76,6 +101,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [docs/mcp-guide.md](docs/mcp-guide.md).
 
 ### Fixed
+
+- **`notebooklm auth check` text mode now exits non-zero when an executed check
+  fails, matching `--json` mode** (#1569). Previously the Rich-table renderer
+  printed the failed checks but always exited `0`, so an unattended health check
+  using `auth check --test` (without `--json`) silently treated expired auth as
+  healthy — text and JSON modes had different process contracts. Both modes now
+  exit `0` only when every *executed* check passes (skipped checks — e.g. the
+  token fetch without `--test` — do not count as failures) and non-zero (`1`)
+  otherwise. Behavioral fix to the CLI exit-code contract; no API change.
 
 - **`Notebook.created_at` now reflects the true creation time instead of the
   last-modified time; `Notebook.modified_at` is newly exposed.** The notebook

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -644,6 +644,7 @@ notebooklm auth check [OPTIONS]
 
 **Options:**
 - `--test` - Also test token fetch from NotebookLM (makes network request)
+- `--passive` - With `--test`, validate read-only: never run `NOTEBOOKLM_REFRESH_CMD`, rotate cookies, or write to disk. Use for unattended readiness/health checks that must not mutate state or race real work. No effect without `--test`.
 - `--json` - Output as JSON (useful for scripts)
 
 **Examples:**
@@ -653,6 +654,9 @@ notebooklm auth check
 
 # Full validation with network test
 notebooklm auth check --test
+
+# Read-only readiness probe (no refresh cmd, no cookie write) for a health check
+notebooklm auth check --test --passive
 
 # JSON output for automation
 notebooklm auth check --json
@@ -677,6 +681,14 @@ notebooklm auth check --json
 - Check if cookies are from correct domain (regional vs .google.com)
 - Diagnose NOTEBOOKLM_AUTH_JSON environment variable issues
 
+**Exit codes:** `auth check` exits `0` only when every *executed* check passes
+and non-zero (`1`) when any executed check fails — in **both** text and `--json`
+modes. A skipped check does not count as a failure: without `--test`, the token
+fetch is skipped, so the exit status reflects only the local cookie checks.
+Unattended monitors should therefore rely on the exit code (not on parsing the
+table). To gate readiness on a real token fetch, run `notebooklm auth check
+--test` and check the exit status. See [CLI Exit-Code Convention](cli-exit-codes.md).
+
 ### Authentication: `auth refresh`
 
 One-shot keepalive: open a session, trigger the layer-1 SIDTS rotation poke against `accounts.google.com`, persist the rotated cookies to `storage_state.json`, and exit. When a file-backed Playwright storage state has cookies but lacks in-band `notebooklm.account` metadata, `auth refresh` also repairs that metadata if account discovery is unambiguous. It does not replace existing metadata; use `login --browser-cookies <browser> --account EMAIL` to re-bind a profile that already points at the wrong account. Designed to be invoked by the OS scheduler (launchd / systemd / cron / Task Scheduler / k8s CronJob) so an otherwise-idle profile does not stale out between user-driven calls.
@@ -689,6 +701,7 @@ notebooklm auth refresh [OPTIONS]
 - `--browser-cookies <browser>`, `--browser-cookie <browser>` - Re-extract cookies from an installed browser and match the current profile's account from `context.json`. This repairs account routing when browser account order changes after another account logs out. Accepts the same scoped syntax as `login`: `chrome::<profile-name-or-directory>` for one Chromium profile, and `firefox::<container-name>` or `firefox::none` for one Firefox container.
 - `--include-domains LABEL[,LABEL...]` - Forward to the browser-cookie reader (only meaningful with `--browser-cookies`). Same syntax as `notebooklm login --include-domains`.
 - `--quiet`, `-q` - Suppress success output; print only on error (cron-friendly)
+- `--verify` - After refreshing, run a read-only passive token fetch to confirm the resulting cookies actually authenticate; exit non-zero if they still fail. A successful refresh command alone does not prove the post-refresh cookies work — they may still redirect to sign-in. Especially valuable with `--browser-cookies`, which rewrites the cookie jar but does not otherwise verify it.
 
 **Cadence:** 15-20 minutes is the recommended interval. Tighter is wasteful (the 60 s mtime guard would skip it anyway); significantly looser may cross the `__Secure-1PSIDTS` server-side validity window for your account/region.
 
@@ -696,7 +709,7 @@ notebooklm auth refresh [OPTIONS]
 
 **Exit codes:**
 - `0` - the auth path completed without raising. The rotation POST is **best-effort**: exit 0 also covers (a) the 60 s mtime guard skipping the POST, (b) `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1` being set, (c) another process holding the cross-process rotate lock, and (d) a transient `httpx` error during the POST being caught and logged at DEBUG. Treat exit 0 as "no error" rather than "rotation occurred." For verification, enable `NOTEBOOKLM_LOG_LEVEL=DEBUG` and check for the `RotateCookies` log line.
-- `1` - a fatal error reached the CLI layer (e.g. `NOTEBOOKLM_AUTH_JSON` set, missing `storage_state.json`, invalid profile, `httpx.RequestError` not swallowed by the rotate guard). The OS scheduler's next firing is the retry mechanism; this command does not retry in-process.
+- `1` - a fatal error reached the CLI layer (e.g. `NOTEBOOKLM_AUTH_JSON` set, missing `storage_state.json`, invalid profile, `httpx.RequestError` not swallowed by the rotate guard), **or** `--verify` was passed and the post-refresh passive token fetch failed. The OS scheduler's next firing is the retry mechanism; this command does not retry in-process.
 
 **Examples:**
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,6 +131,18 @@ Or re-run `notebooklm login` if session cookies are also expired. If the failure
 3. Complete any CAPTCHA or security challenges Google presents
 4. Ensure you're using a real mouse/keyboard (not pasting credentials via script)
 
+#### "Login not detected within 5 minutes" (especially on macOS)
+
+**Cause:** The bundled Chromium that `notebooklm login` launches by default opened a fresh, signed-out browser, and its login-detection wait timed out — common on macOS where bundled Chromium can also be flaky (macOS 15+).
+
+**Solution:** If you are already signed in to Google in **system Chrome**, retry with that browser so the existing session is reused instead of starting a fresh sign-in:
+
+```bash
+notebooklm login --browser chrome --storage <path>
+```
+
+`--browser chrome` drives your installed Google Chrome (with its signed-in profile), which usually detects the account immediately and sidesteps bundled-Chromium issues. `--browser msedge` is the equivalent for organizations that require Microsoft Edge for SSO.
+
 ### RPC Errors
 
 #### "RPCError: No result found for RPC ID: XyZ123"

--- a/src/notebooklm/_app/auth_check.py
+++ b/src/notebooklm/_app/auth_check.py
@@ -60,6 +60,13 @@ class AuthCheckPlan:
             and propagate non-zero exit on failure. Carried on the plan so the
             renderer (in the adapter) picks the right shape without re-resolving
             the flag.
+        passive: When ``True``, the optional ``test_fetch`` token round-trip uses
+            the strictly read-only :func:`~notebooklm.auth.fetch_tokens_passive`
+            path — it never runs ``NOTEBOOKLM_REFRESH_CMD``, never fires the
+            keepalive rotation poke, and never writes cookies back to disk. This
+            is what an unattended readiness probe wants (issue #1569). No effect
+            without ``test_fetch`` (the local cookie checks are already
+            side-effect-free).
     """
 
     storage_path: Path
@@ -69,6 +76,7 @@ class AuthCheckPlan:
     auth_source_label: str
     test_fetch: bool
     json_output: bool
+    passive: bool = False
 
 
 @dataclass
@@ -191,13 +199,16 @@ async def run_auth_check(
         details["error"] = str(exc)
         return AuthCheckResult(plan=plan, checks=checks, details=details)
 
-    # Check 4: optional token-fetch round-trip.
+    # Check 4: optional token-fetch round-trip. ``passive`` selects the
+    # strictly read-only fetch (no refresh cmd, no rotation poke, no save) so a
+    # readiness probe never mutates state or spawns a subprocess (issue #1569).
     if plan.test_fetch:
         try:
-            from ..auth import fetch_tokens_with_domains
+            from ..auth import fetch_tokens_passive, fetch_tokens_with_domains
 
+            fetch = fetch_tokens_passive if plan.passive else fetch_tokens_with_domains
             token_path = None if plan.has_env_auth else plan.storage_path
-            csrf, session_id = await fetch_tokens_with_domains(token_path, plan.profile)
+            csrf, session_id = await fetch(token_path, plan.profile)
             checks["token_fetch"] = True
             details["csrf_length"] = len(csrf)
             details["session_id_length"] = len(session_id)

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -612,7 +612,11 @@ def run_browser_capture(
                 except PlaywrightTimeout:
                     io.emit(
                         "[red]Login not detected within 5 minutes.[/red]\n"
-                        "Try again with: notebooklm login"
+                        "Try again with: notebooklm login\n"
+                        "Already signed in to Google in Chrome? Retry with "
+                        "[cyan]notebooklm login --browser chrome[/cyan] to reuse that "
+                        "session (often detects immediately; also avoids "
+                        "bundled-Chromium issues on macOS)."
                     )
                     io.fail(1)
                 except PlaywrightError as exc:

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -46,6 +46,11 @@ logger = logging.getLogger("notebooklm.auth")
 # need to substitute one of these dependencies should patch the alias on
 # ``notebooklm._auth.refresh`` directly.
 build_httpx_cookies_from_storage = _auth_cookies.build_httpx_cookies_from_storage
+# No-recovery loader: validates and raises on missing cookies, but never fires
+# the inline ``RotateCookies`` PSIDTS recovery (network POST + disk write) that
+# ``build_httpx_cookies_from_storage`` does. Used by the passive probe so it
+# stays strictly read-only (issue #1569).
+_build_httpx_cookies_from_storage_strict = _auth_cookies._build_httpx_cookies_from_storage_strict
 _replace_cookie_jar = _auth_cookies._replace_cookie_jar
 _cookie_map_from_jar = _auth_cookies._cookie_map_from_jar
 build_cookie_jar = _auth_cookies.build_cookie_jar
@@ -684,6 +689,7 @@ async def _fetch_tokens_with_jar(
     authuser: int = 0,
     account_email: str | None = None,
     force_authuser_query: bool = False,
+    poke: bool = True,
 ) -> tuple[str, str]:
     """Internal: fetch CSRF and session tokens using a pre-built cookie jar.
 
@@ -706,6 +712,11 @@ async def _fetch_tokens_with_jar(
         force_authuser_query: Append ``?authuser=0`` when callers explicitly
             requested account index 0. Implicit default-account calls leave the
             URL byte-identical to pre-multi-account behavior.
+        poke: When ``False``, skip the layer-1 ``_poke_session`` rotation POST
+            entirely. The passive read-only validation path
+            (:func:`fetch_tokens_passive`) sets this so a readiness probe does
+            not rotate ``__Secure-1PSIDTS`` server-side without persisting the
+            result (which would stale the on-disk jar).
 
     Returns:
         Tuple of (csrf_token, session_id)
@@ -717,7 +728,8 @@ async def _fetch_tokens_with_jar(
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
 
     async with httpx.AsyncClient(cookies=cookie_jar) as client:
-        await _poke_session(client, storage_path)
+        if poke:
+            await _poke_session(client, storage_path)
 
         url = f"{get_base_url()}/"
         if account_email or authuser or force_authuser_query:
@@ -853,3 +865,59 @@ async def fetch_tokens_with_domains(
     # slow filesystems.
     await asyncio.to_thread(save_cookies_to_storage, jar, path, original_snapshot=snapshot)
     return csrf, session_id
+
+
+async def fetch_tokens_passive(
+    path: Path | None = None,
+    profile: str | None = None,
+    *,
+    authuser: int | None = None,
+    account_email: str | None = None,
+) -> tuple[str, str]:
+    """Validate the auth cookies on disk without any side effects.
+
+    Performs the same token-fetch round-trip (a homepage GET that re-mints
+    CSRF / session) as :func:`fetch_tokens_with_domains`, but is strictly
+    read-only. Unlike that function it:
+
+    * never runs ``NOTEBOOKLM_REFRESH_CMD`` (no re-auth hook / subprocess);
+    * never fires the layer-1 keepalive poke that rotates ``__Secure-1PSIDTS``
+      server-side;
+    * never fires the inline ``RotateCookies`` PSIDTS recovery (it loads the jar
+      with the no-recovery strict loader, so a missing/expired PSIDTS surfaces as
+      a plain ``ValueError`` instead of a network POST + disk write); and
+    * never writes rotated cookies back to ``storage_state.json``.
+
+    This is the readiness probe an unattended monitor (systemd / cron health
+    check) wants: it answers "do the cookies currently on disk authenticate?"
+    without mutating state, spawning a refresh subprocess, or racing concurrent
+    real work (issue #1569). Pair it with a passive ``auth check --test`` or
+    ``auth refresh --verify``.
+
+    Args:
+        path: Path to storage_state.json. If provided, takes precedence over env vars.
+        profile: Optional profile name used to resolve the storage path.
+        authuser: Optional explicit Google account index. Defaults to the
+            persisted profile value, or 0 when none exists.
+        account_email: Optional explicit Google account email. When provided,
+            it is used as the auth routing value instead of the integer index.
+
+    Returns:
+        Tuple of (csrf_token, session_id)
+
+    Raises:
+        FileNotFoundError: If storage file doesn't exist.
+        httpx.HTTPError: If request fails.
+        ValueError: If tokens cannot be extracted (e.g. redirected to sign-in).
+    """
+    if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
+        path = get_storage_path(profile=profile)
+    # Strict (no-recovery) loader: a missing/expired PSIDTS raises ``ValueError``
+    # here rather than triggering the inline ``RotateCookies`` rotation + save
+    # that ``build_httpx_cookies_from_storage`` would. A readiness probe reports
+    # "not authenticated" — it does not heal cookies.
+    jar = _build_httpx_cookies_from_storage_strict(path)
+    route_kwargs = _resolve_token_route_kwargs(path, authuser=authuser, account_email=account_email)
+    # poke=False + no save_cookies_to_storage ⇒ zero side effects on disk or
+    # on the server-side cookie rotation state.
+    return await _fetch_tokens_with_jar(jar, path, poke=False, **route_kwargs)

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -139,6 +139,7 @@ __all__ = [
     "extract_session_id_from_html",
     "extract_wiz_field",
     "fetch_tokens",
+    "fetch_tokens_passive",
     "fetch_tokens_with_domains",
     "format_authuser_value",
     "get_account_email_for_storage",
@@ -329,3 +330,4 @@ _fetch_tokens_with_refresh = _auth_refresh._fetch_tokens_with_refresh
 _fetch_tokens_with_jar = _auth_refresh._fetch_tokens_with_jar
 fetch_tokens = _auth_refresh.fetch_tokens
 fetch_tokens_with_domains = _auth_refresh.fetch_tokens_with_domains
+fetch_tokens_passive = _auth_refresh.fetch_tokens_passive

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -284,6 +284,13 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
             "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
         )
 
+    # Exit non-zero when any executed check failed so text mode shares the
+    # same process contract as --json mode. Unattended automation (systemd /
+    # cron health checks) relies on the exit code, not on parsing the table
+    # (issue #1569). Skipped (``None``) checks do not count as failures.
+    if not all_passed:
+        exit_with_code(1)
+
 
 def _render_auth_inspect(
     browser_name: str,

--- a/src/notebooklm/cli/services/auth_diagnostics.py
+++ b/src/notebooklm/cli/services/auth_diagnostics.py
@@ -66,7 +66,9 @@ def format_auth_source(plan: AuthCheckPlan) -> str:
     )
 
 
-def plan_from_click_context(ctx, *, test_fetch: bool, json_output: bool) -> AuthCheckPlan:
+def plan_from_click_context(
+    ctx, *, test_fetch: bool, json_output: bool, passive: bool = False
+) -> AuthCheckPlan:
     """Build an :class:`AuthCheckPlan` from a Click context + flags.
 
     The profile + storage path come from the same :class:`AuthSource` resolver
@@ -90,6 +92,7 @@ def plan_from_click_context(ctx, *, test_fetch: bool, json_output: bool) -> Auth
         ),
         test_fetch=test_fetch,
         json_output=json_output,
+        passive=passive,
     )
 
 

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -109,6 +109,36 @@ async def fetch_tokens_with_domains(*args: Any, **kwargs: Any) -> Any:
     return await auth_fetch_tokens_with_domains(*args, **kwargs)
 
 
+async def fetch_tokens_passive(*args: Any, **kwargs: Any) -> Any:
+    """Patch-compatible forwarding wrapper for the read-only passive token fetch."""
+    from ..auth import fetch_tokens_passive as auth_fetch_tokens_passive
+
+    return await auth_fetch_tokens_passive(*args, **kwargs)
+
+
+def _verify_token_fetch_after_refresh(
+    storage_path: Path, profile: str | None, *, quiet: bool
+) -> None:
+    """Confirm a token fetch actually succeeds after ``auth refresh``.
+
+    Runs the strictly read-only passive probe (no NOTEBOOKLM_REFRESH_CMD, no
+    cookie rotation, no write). A successful ``auth refresh`` — especially the
+    ``--browser-cookies`` rewrite — does not by itself prove the resulting
+    cookies authenticate; ``--verify`` makes that an explicit, fail-loud gate
+    so unattended schedulers can rely on the exit code (issue #1569).
+    """
+    try:
+        run_async(fetch_tokens_passive(storage_path, profile))
+    except Exception as exc:  # noqa: BLE001 — surface any failure as a clean exit 1
+        click.echo(
+            f"Error: refresh completed but the post-refresh token fetch failed: {exc}",
+            err=True,
+        )
+        exit_with_code(1)
+    if not quiet:
+        console.print("[green]ok[/green] verified: token fetch succeeds after refresh")
+
+
 def _click_exception_from(exc: LoginConfigurationError) -> click.ClickException:
     """Translate a login-service ``LoginConfigurationError`` into a Click error.
 
@@ -618,9 +648,17 @@ def register_session_commands(cli):
     @click.option(
         "--test", "test_fetch", is_flag=True, help="Test token fetch (makes network request)"
     )
+    @click.option(
+        "--passive",
+        is_flag=True,
+        help=(
+            "With --test, validate read-only: never run NOTEBOOKLM_REFRESH_CMD, "
+            "rotate cookies, or write to disk. For unattended health checks."
+        ),
+    )
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.pass_context
-    def auth_check(ctx, test_fetch, json_output):
+    def auth_check(ctx, test_fetch, passive, json_output):
         """Check authentication status and diagnose issues.
 
         Validates that authentication is properly configured by checking:
@@ -630,15 +668,32 @@ def register_session_commands(cli):
         - Cookie domains are correct
 
         Use --test to also verify tokens can be fetched from NotebookLM
-        (requires network access).
+        (requires network access). Add --passive so that token test is strictly
+        read-only — it never triggers NOTEBOOKLM_REFRESH_CMD, rotates cookies,
+        or writes storage, which is what a passive readiness probe wants.
+
+        Exits 0 only when every executed check passes; non-zero otherwise, in
+        both text and --json modes.
 
         \b
         Examples:
-          notebooklm auth check           # Quick local validation
-          notebooklm auth check --test    # Full validation with network test
-          notebooklm auth check --json    # Machine-readable output
+          notebooklm auth check                  # Quick local validation
+          notebooklm auth check --test           # Full validation with network test
+          notebooklm auth check --test --passive # Read-only probe (no refresh/no write)
+          notebooklm auth check --json           # Machine-readable output
         """
-        plan = plan_from_click_context(ctx, test_fetch=test_fetch, json_output=json_output)
+        if passive and not test_fetch:
+            # The local cookie checks are already side-effect-free, so --passive
+            # only changes the optional --test token fetch. Warn (don't fail) so
+            # a caller does not mistake a local-only run for a network probe.
+            click.echo(
+                "Note: --passive has no effect without --test "
+                "(the local cookie checks never run a refresh command or write to disk).",
+                err=True,
+            )
+        plan = plan_from_click_context(
+            ctx, test_fetch=test_fetch, json_output=json_output, passive=passive
+        )
         result = run_async(run_auth_check(plan))
         _render_auth_check_result(result)
 
@@ -672,8 +727,16 @@ def register_session_commands(cli):
     @click.option(
         "--quiet", "-q", is_flag=True, help="Suppress success output (only print on error)"
     )
+    @click.option(
+        "--verify",
+        is_flag=True,
+        help=(
+            "After refreshing, confirm a token fetch actually succeeds (read-only "
+            "passive probe). Exit non-zero if the post-refresh cookies still fail."
+        ),
+    )
     @click.pass_context
-    def auth_refresh(ctx, browser_cookies, include_domains_raw, quiet):
+    def auth_refresh(ctx, browser_cookies, include_domains_raw, quiet, verify):
         """Refresh stored cookies by exercising the auth path once or reading browser cookies.
 
         Default mode is a one-shot keepalive: opens a session, runs the
@@ -698,10 +761,16 @@ def register_session_commands(cli):
         are surfaced as exit 1 rather than retried in-process; the OS
         scheduler's next firing is the retry mechanism.
 
+        With ``--verify``, after the refresh completes a read-only passive token
+        fetch confirms the resulting cookies actually authenticate, exiting
+        non-zero if not. A successful refresh command alone does not prove the
+        post-refresh cookies work (they may still redirect to sign-in).
+
         \b
         Examples:
           notebooklm auth refresh                 # one-shot, exit 0/1
-          notebooklm auth refresh --browser-cookies chrome
+          notebooklm auth refresh --verify        # refresh, then confirm token fetch works
+          notebooklm auth refresh --browser-cookies chrome --verify
           notebooklm --profile work auth refresh  # against a named profile
           watch -n 1200 notebooklm auth refresh   # quick in-terminal loop
 
@@ -740,19 +809,21 @@ def register_session_commands(cli):
                     quiet=quiet,
                     include_domains=include_domains,
                 )
-                return
+            else:
+                run_async(fetch_tokens_with_domains(storage_path, profile))
 
-            run_async(fetch_tokens_with_domains(storage_path, profile))
+                from ..auth import read_account_metadata
 
-            from ..auth import read_account_metadata
+                if storage_path.exists():
+                    metadata = read_account_metadata(storage_path)
+                    if not _is_valid_account_metadata(metadata):
+                        repair_after_refresh(storage_path, quiet=quiet)
 
-            if storage_path.exists():
-                metadata = read_account_metadata(storage_path)
-                if not _is_valid_account_metadata(metadata):
-                    repair_after_refresh(storage_path, quiet=quiet)
+                if not quiet:
+                    console.print(f"[green]ok[/green] refreshed: {storage_path}")
 
-            if not quiet:
-                console.print(f"[green]ok[/green] refreshed: {storage_path}")
+            if verify:
+                _verify_token_fetch_after_refresh(storage_path, profile, quiet=quiet)
 
 
 # Backward-compat constant kept at module scope for tests that import it

--- a/tests/_guardrails/test_public_surface.py
+++ b/tests/_guardrails/test_public_surface.py
@@ -72,6 +72,7 @@ EXPECTED_AUTH_ALL: list[str] = [
     "extract_session_id_from_html",
     "extract_wiz_field",
     "fetch_tokens",
+    "fetch_tokens_passive",
     "fetch_tokens_with_domains",
     "format_authuser_value",
     "get_account_email_for_storage",

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -1087,6 +1087,24 @@
           "default": false,
           "envvar": null,
           "has_custom_shell_complete": false,
+          "help": "With --test, validate read-only: never run NOTEBOOKLM_REFRESH_CMD, rotate cookies, or write to disk. For unattended health checks.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "passive",
+          "opts": [
+            "--passive"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -1240,6 +1258,24 @@
           "opts": [
             "--quiet",
             "-q"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "After refreshing, confirm a token fetch actually succeeds (read-only passive probe). Exit non-zero if the post-refresh cookies still fail.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "verify",
+          "opts": [
+            "--verify"
           ],
           "required": false,
           "secondary_opts": [],

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -43,7 +43,8 @@ class TestAuthCheckCommand:
 
         result = runner.invoke(cli, ["auth", "check"])
 
-        assert result.exit_code == 0
+        # Failed check ⇒ non-zero exit in text mode too (issue #1569).
+        assert result.exit_code != 0
         assert "Storage exists" in result.output
         assert "fail" in result.output.lower() or "✗" in result.output
 
@@ -70,7 +71,8 @@ class TestAuthCheckCommand:
 
         result = runner.invoke(cli, ["auth", "check"])
 
-        assert result.exit_code == 0
+        # Failed check ⇒ non-zero exit in text mode too (issue #1569).
+        assert result.exit_code != 0
         assert "JSON valid" in result.output
         assert "fail" in result.output.lower() or "✗" in result.output
 
@@ -104,8 +106,9 @@ class TestAuthCheckCommand:
         directory as text raises ``IsADirectoryError``, a subclass of
         ``OSError``.
 
-        Contract: text mode shows the checks table (no traceback) and
-        exits 0 just like the existing invalid-JSON case.
+        Contract: text mode shows the checks table (no traceback) and exits
+        non-zero on the failed ``json_valid`` check, matching --json mode and
+        the invalid-JSON case (issue #1569).
         """
         # The fixture yields a path under tmp_path but does not create the
         # file. Make the path a directory so `read_text` raises
@@ -116,9 +119,10 @@ class TestAuthCheckCommand:
 
         result = runner.invoke(cli, ["auth", "check"])
 
-        # No traceback should leak.
-        assert result.exit_code == 0, (
-            f"unexpected traceback / non-zero text-mode exit: "
+        # Failed check ⇒ non-zero exit, but via a clean SystemExit — no
+        # traceback should leak to the caller.
+        assert result.exit_code != 0, (
+            f"expected non-zero text-mode exit on failed check: "
             f"stdout={result.output!r} exc={result.exception!r}"
         )
         assert result.exception is None or isinstance(result.exception, SystemExit), (
@@ -191,7 +195,8 @@ class TestAuthCheckCommand:
 
         result = runner.invoke(cli, ["auth", "check"])
 
-        assert result.exit_code == 0
+        # Missing SID cookie is a failed check ⇒ non-zero exit (issue #1569).
+        assert result.exit_code != 0
         assert "SID" in result.output or "cookie" in result.output.lower()
 
     def test_auth_check_valid_storage(self, runner, mock_storage_path):
@@ -301,7 +306,9 @@ class TestAuthCheckCommand:
 
             result = runner.invoke(cli, ["auth", "check", "--test"])
 
-        assert result.exit_code == 0
+        # Text mode must exit non-zero on a failed executed check, matching
+        # --json mode, so unattended automation can fail-fast (issue #1569).
+        assert result.exit_code != 0
         assert "Token fetch" in result.output
         assert "fail" in result.output.lower() or "✗" in result.output
         assert "expired" in result.output.lower() or "refresh" in result.output.lower()
@@ -329,6 +336,78 @@ class TestAuthCheckCommand:
         assert output["checks"]["token_fetch"] is True
         assert output["details"]["csrf_length"] == 10
         assert output["details"]["session_id_length"] == 10
+
+    def test_auth_check_passive_uses_passive_fetch(self, runner, mock_storage_path):
+        """``--test --passive`` routes through the read-only passive fetch.
+
+        The passive path must NOT touch ``fetch_tokens_with_domains`` (which
+        runs NOTEBOOKLM_REFRESH_CMD, rotates cookies, and persists to disk).
+        Issue #1569: a readiness probe must be side-effect-free.
+        """
+        storage_data = {
+            "cookies": [
+                {"name": "SID", "value": "test_sid", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
+            ]
+        }
+        mock_storage_path.write_text(json.dumps(storage_data))
+
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_active,
+        ):
+            mock_passive.return_value = ("csrf_token_abc", "session_id_xyz")
+
+            result = runner.invoke(cli, ["auth", "check", "--test", "--passive"])
+
+        assert result.exit_code == 0
+        mock_passive.assert_awaited_once()
+        mock_active.assert_not_called()
+        assert "Token fetch" in result.output
+        assert "pass" in result.output.lower() or "✓" in result.output
+
+    def test_auth_check_passive_failure_exits_nonzero(self, runner, mock_storage_path):
+        """``--test --passive`` still fails loud (non-zero) when the probe fails."""
+        storage_data = {
+            "cookies": [
+                {"name": "SID", "value": "test_sid", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
+            ]
+        }
+        mock_storage_path.write_text(json.dumps(storage_data))
+
+        with patch.object(
+            auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+        ) as mock_passive:
+            mock_passive.side_effect = ValueError("Authentication expired")
+
+            result = runner.invoke(cli, ["auth", "check", "--test", "--passive", "--json"])
+
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["checks"]["token_fetch"] is False
+
+    def test_auth_check_passive_without_test_warns_no_effect(self, runner, mock_storage_path):
+        """``--passive`` without ``--test`` is a no-op on already-passive local
+        checks; warn (not fail) so the caller is not misled."""
+        storage_data = {
+            "cookies": [
+                {"name": "SID", "value": "test_sid", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
+            ]
+        }
+        mock_storage_path.write_text(json.dumps(storage_data))
+
+        result = runner.invoke(cli, ["auth", "check", "--passive"])
+
+        # Still succeeds (local checks all pass), but the note is surfaced.
+        assert result.exit_code == 0
+        assert "no effect without --test" in result.output
 
     def test_auth_check_env_var_takes_precedence(self, runner, mock_storage_path, monkeypatch):
         """Test auth check uses NOTEBOOKLM_AUTH_JSON when set."""
@@ -1275,6 +1354,59 @@ class TestAuthRefreshCommand:
         # Friendly Unexpected-error message + the original detail.
         assert "Unexpected error" in result.output
         assert "rookiepy could not read cookies" in result.output
+
+    def test_auth_refresh_verify_success(self, runner, mock_storage_path):
+        """``--verify`` runs a passive token fetch after refresh; exit 0 on success."""
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            mock_passive.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh", "--verify"])
+        assert result.exit_code == 0
+        mock_passive.assert_awaited_once()
+        assert "verified" in result.output.lower()
+
+    def test_auth_refresh_verify_failure_exits_nonzero(self, runner, mock_storage_path):
+        """Refresh can succeed while the post-refresh token fetch still fails.
+
+        ``--verify`` makes that fail loud (exit 1) so a scheduler can rely on
+        the exit code rather than trusting refresh success alone (issue #1569).
+        """
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            mock_passive.side_effect = ValueError("Authentication expired or invalid.")
+            result = runner.invoke(cli, ["auth", "refresh", "--verify"])
+        assert result.exit_code == 1
+        assert "post-refresh token fetch failed" in result.output.lower()
+        assert "Traceback (most recent call last)" not in result.output
+
+    def test_auth_refresh_verify_after_browser_cookies(self, runner, mock_storage_path):
+        """``--verify`` also gates the ``--browser-cookies`` rewrite path."""
+        with (
+            patch_session_login_dual("_refresh_from_browser_cookies"),
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+        ):
+            mock_passive.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(
+                cli, ["auth", "refresh", "--browser-cookies", "chrome", "--verify"]
+            )
+        assert result.exit_code == 0
+        mock_passive.assert_awaited_once()
 
     def test_auth_refresh_rejects_env_var_auth(self, runner, monkeypatch, mock_storage_path):
         """NOTEBOOKLM_AUTH_JSON has no writable backing store; refreshing it

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -350,7 +350,7 @@ class TestAuthCheckCommand:
                 {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
             ]
         }
-        mock_storage_path.write_text(json.dumps(storage_data))
+        mock_storage_path.write_text(json.dumps(storage_data), encoding="utf-8")
 
         with (
             patch.object(
@@ -378,7 +378,7 @@ class TestAuthCheckCommand:
                 {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
             ]
         }
-        mock_storage_path.write_text(json.dumps(storage_data))
+        mock_storage_path.write_text(json.dumps(storage_data), encoding="utf-8")
 
         with patch.object(
             auth_module, "fetch_tokens_passive", new_callable=AsyncMock
@@ -401,7 +401,7 @@ class TestAuthCheckCommand:
                 {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
             ]
         }
-        mock_storage_path.write_text(json.dumps(storage_data))
+        mock_storage_path.write_text(json.dumps(storage_data), encoding="utf-8")
 
         result = runner.invoke(cli, ["auth", "check", "--passive"])
 
@@ -429,6 +429,35 @@ class TestAuthCheckCommand:
         output = json.loads(result.output)
         assert output["status"] == "ok"
         assert output["details"]["auth_source"] == "NOTEBOOKLM_AUTH_JSON"
+
+    def test_auth_check_passive_with_env_auth_passes_none_path(
+        self, runner, mock_storage_path, monkeypatch
+    ):
+        """``--test --passive`` under NOTEBOOKLM_AUTH_JSON routes the passive
+        probe with ``token_path=None`` (read-from-env), like the active path."""
+        if mock_storage_path.exists():
+            mock_storage_path.unlink()
+        env_storage = {
+            "cookies": [
+                {"name": "SID", "value": "env_sid", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "test_1psidts", "domain": ".google.com"},
+            ]
+        }
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(env_storage))
+
+        with patch.object(
+            auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+        ) as mock_passive:
+            mock_passive.return_value = ("csrf_env", "session_env")
+
+            result = runner.invoke(cli, ["auth", "check", "--test", "--passive", "--json"])
+
+        assert result.exit_code == 0
+        # has_env_auth ⇒ token_path is None (the env-var read signal), profile arg follows.
+        mock_passive.assert_awaited_once()
+        assert mock_passive.await_args.args[0] is None
+        output = json.loads(result.output)
+        assert output["checks"]["token_fetch"] is True
 
     def test_auth_check_shows_cookie_domains(self, runner, mock_storage_path):
         """Test auth check displays cookie domains."""

--- a/tests/unit/cli/test_playwright_login_render_contract.py
+++ b/tests/unit/cli/test_playwright_login_render_contract.py
@@ -731,6 +731,10 @@ class TestLoginErrorRender:
             "Waiting for login (up to 5 minutes)...\n"
             "Login not detected within 5 minutes.\n"
             "Try again with: notebooklm login\n"
+            "Already signed in to Google in Chrome? Retry with "
+            "notebooklm login --browser chrome to reuse that session "
+            "(often detects immediately; also avoids bundled-Chromium "
+            "issues on macOS).\n"
         )
 
     @pytest.mark.requires_playwright

--- a/tests/unit/cli/test_session_characterization.py
+++ b/tests/unit/cli/test_session_characterization.py
@@ -473,7 +473,7 @@ class TestAuthCheckCharacterization:
         mode exits non-zero (cleanly, no traceback) like --json (issue #1569).
         """
         # File exists but read raises OSError (permission denied simulation).
-        char_storage_file.write_text("{}")
+        char_storage_file.write_text("{}", encoding="utf-8")
         with patch("pathlib.Path.read_text", side_effect=OSError("Permission denied")):
             result = char_runner.invoke(cli, ["auth", "check"])
         assert result.exit_code == 1

--- a/tests/unit/cli/test_session_characterization.py
+++ b/tests/unit/cli/test_session_characterization.py
@@ -419,7 +419,7 @@ class TestAuthCheckCharacterization:
     def test_auth_check_text_storage_missing(self, char_runner, char_storage_file):
         # storage file does not exist
         result = char_runner.invoke(cli, ["auth", "check"])
-        assert result.exit_code == 0  # text mode does not exit non-zero
+        assert result.exit_code == 1  # failed check ⇒ non-zero, matches --json (issue #1569)
         assert "Authentication Check" in result.output
         assert "Storage file not found" in result.output
 
@@ -467,12 +467,17 @@ class TestAuthCheckCharacterization:
         assert data["checks"]["json_valid"] is False
 
     def test_auth_check_oserror_text_p1t3(self, char_runner, char_storage_file):
-        """P1.T3 regression: OSError on read does not raise; reports error gracefully."""
+        """P1.T3 regression: OSError on read does not raise; reports error gracefully.
+
+        The read failure surfaces as a failed ``json_valid`` check, so text
+        mode exits non-zero (cleanly, no traceback) like --json (issue #1569).
+        """
         # File exists but read raises OSError (permission denied simulation).
         char_storage_file.write_text("{}")
         with patch("pathlib.Path.read_text", side_effect=OSError("Permission denied")):
             result = char_runner.invoke(cli, ["auth", "check"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
         assert "Storage unreadable" in result.output or "Permission denied" in result.output
 
     def test_auth_check_oserror_json_p1t3(self, char_runner, char_storage_file):

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -336,7 +336,8 @@ class TestFetchTokensPassive:
                         },
                     ]
                 }
-            )
+            ),
+            encoding="utf-8",
         )
         return storage_file
 
@@ -419,7 +420,8 @@ class TestFetchTokensPassive:
         storage_file.write_text(
             json.dumps(
                 {"cookies": [{"name": "SID", "value": "sid_value", "domain": ".google.com"}]}
-            )
+            ),
+            encoding="utf-8",
         )
 
         recovery_calls = 0
@@ -438,7 +440,7 @@ class TestFetchTokensPassive:
 
         assert recovery_calls == 0
         # The stored cookies are untouched (no rotated PSIDTS written back).
-        assert "__Secure-1PSIDTS" not in storage_file.read_text()
+        assert "__Secure-1PSIDTS" not in storage_file.read_text(encoding="utf-8")
 
     @pytest.mark.asyncio
     async def test_passive_does_not_run_refresh_cmd(
@@ -450,7 +452,7 @@ class TestFetchTokensPassive:
 
         marker = tmp_path / "refresh_ran.marker"
         refresh_script = tmp_path / "refresh.py"
-        refresh_script.write_text(f"open({str(marker)!r}, 'w').close()\n")
+        refresh_script.write_text(f"open({str(marker)!r}, 'w').close()\n", encoding="utf-8")
         cmd = (
             shlex.join([sys.executable, str(refresh_script)])
             if os.name != "nt"

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -22,6 +22,7 @@ from notebooklm.auth import (
     AuthTokens,
     extract_cookies_with_domains,
     fetch_tokens,
+    fetch_tokens_passive,
     fetch_tokens_with_domains,
     save_cookies_to_storage,
     snapshot_cookie_jar,
@@ -310,6 +311,169 @@ class TestFetchTokens:
             if c["name"] == "SID" and c["domain"] == ".google.com"
         )
         assert sid_cookie["value"] == "new"
+
+
+class TestFetchTokensPassive:
+    """``fetch_tokens_passive`` is the strictly read-only readiness probe.
+
+    It must validate the cookies on disk without any side effect: no
+    ``_poke_session`` rotation, no ``NOTEBOOKLM_REFRESH_CMD`` subprocess, and
+    no write back to ``storage_state.json`` (issue #1569).
+    """
+
+    @staticmethod
+    def _storage_with_sid(tmp_path: Path) -> Path:
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                        {
+                            "name": "__Secure-1PSIDTS",
+                            "value": "test_1psidts",
+                            "domain": ".google.com",
+                        },
+                    ]
+                }
+            )
+        )
+        return storage_file
+
+    @pytest.mark.asyncio
+    async def test_passive_fetch_success(self, tmp_path, httpx_mock: HTTPXMock):
+        """Happy path: returns the tokens from the homepage GET."""
+        storage_file = self._storage_with_sid(tmp_path)
+        html = '"SNlM0e":"csrf_passive" "FdrFJe":"sess_passive"'
+        httpx_mock.add_response(url="https://notebooklm.google.com/", content=html.encode())
+
+        csrf, session_id = await fetch_tokens_passive(storage_file)
+
+        assert csrf == "csrf_passive"
+        assert session_id == "sess_passive"
+
+    @pytest.mark.asyncio
+    async def test_passive_skips_keepalive_poke(self, tmp_path, monkeypatch, httpx_mock: HTTPXMock):
+        """The layer-1 rotation poke must never fire on the passive path."""
+        storage_file = self._storage_with_sid(tmp_path)
+        html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
+        httpx_mock.add_response(url="https://notebooklm.google.com/", content=html.encode())
+
+        poke_calls = 0
+
+        async def spy_poke(client, storage_path=None):
+            nonlocal poke_calls
+            poke_calls += 1
+
+        # Seam-aliased patch (ADR-0007): patch the owning ``_auth.refresh``
+        # module so the bare-name call inside ``_fetch_tokens_with_jar`` is seen.
+        monkeypatch.setattr(_auth_refresh, "_poke_session", spy_poke)
+
+        await fetch_tokens_passive(storage_file)
+
+        assert poke_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_passive_does_not_write_storage(self, tmp_path, httpx_mock: HTTPXMock):
+        """A rotated redirect cookie must NOT be persisted (read-only)."""
+        storage_file = self._storage_with_sid(tmp_path)
+        before = storage_file.read_bytes()
+
+        html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
+        # Redirect through accounts.google.com with a Set-Cookie rotation, just
+        # like the active path's persistence test — but passive must drop it.
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/start"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/start",
+            status_code=302,
+            headers={
+                "Location": "https://notebooklm.google.com/",
+                "Set-Cookie": "__Secure-1PSIDTS=rotated; Domain=.google.com; Path=/",
+            },
+        )
+        httpx_mock.add_response(url="https://notebooklm.google.com/", content=html.encode())
+
+        await fetch_tokens_passive(storage_file)
+
+        assert storage_file.read_bytes() == before
+
+    @pytest.mark.asyncio
+    async def test_passive_does_not_trigger_psidts_recovery(self, tmp_path, monkeypatch):
+        """A missing PSIDTS must NOT fire inline RotateCookies recovery.
+
+        ``build_httpx_cookies_from_storage`` heals a missing/expired
+        ``__Secure-1PSIDTS`` with a ``RotateCookies`` POST + disk write. The
+        passive probe must instead surface a plain ``ValueError`` (no network,
+        no write) — it uses the no-recovery strict loader. Regression guard for
+        the side-effect leak through the loader (issue #1569).
+        """
+        from notebooklm._auth import psidts_recovery
+
+        # SID present but __Secure-1PSIDTS absent ⇒ recoverable on the active
+        # path, must stay read-only on the passive path.
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(
+            json.dumps(
+                {"cookies": [{"name": "SID", "value": "sid_value", "domain": ".google.com"}]}
+            )
+        )
+
+        recovery_calls = 0
+
+        def spy_recover(path):
+            nonlocal recovery_calls
+            recovery_calls += 1
+            return False
+
+        monkeypatch.setattr(psidts_recovery, "_recover_psidts_inline", spy_recover)
+
+        # No httpx_mock fixture here: if a RotateCookies POST escaped, the real
+        # network call would fail loudly rather than silently "pass".
+        with pytest.raises(ValueError):
+            await fetch_tokens_passive(storage_file)
+
+        assert recovery_calls == 0
+        # The stored cookies are untouched (no rotated PSIDTS written back).
+        assert "__Secure-1PSIDTS" not in storage_file.read_text()
+
+    @pytest.mark.asyncio
+    async def test_passive_does_not_run_refresh_cmd(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Even with NOTEBOOKLM_REFRESH_CMD set, the passive path never runs it."""
+        storage_file = self._storage_with_sid(tmp_path)
+        monkeypatch.setattr(_auth_refresh, "get_storage_path", lambda profile=None: storage_file)
+
+        marker = tmp_path / "refresh_ran.marker"
+        refresh_script = tmp_path / "refresh.py"
+        refresh_script.write_text(f"open({str(marker)!r}, 'w').close()\n")
+        cmd = (
+            shlex.join([sys.executable, str(refresh_script)])
+            if os.name != "nt"
+            else subprocess.list2cmdline([sys.executable, str(refresh_script)])
+        )
+        monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", cmd)
+
+        # Homepage redirects to sign-in → auth is expired.
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin",
+            content=b"<html>Login</html>",
+        )
+
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await fetch_tokens_passive(storage_file)
+
+        # The refresh subprocess must never have spawned.
+        assert not marker.exists()
 
 
 class TestFetchTokensAutoRefresh:


### PR DESCRIPTION
## Summary

Implements the full auth-verification contract requested in #1569 for unattended automation (systemd/cron health checks). Four coordinated changes, one coherent theme: *make auth verification a reliable, side-effect-aware contract*.

### 1. `auth check` text mode exits non-zero on failure (the bug)
The Rich-table renderer (`cli/_session_render.py`) printed failed checks but always exited `0`, while `--json` exited non-zero — so a health check using `auth check --test` **without** `--json` silently treated expired auth as healthy. Both modes now share one process contract: exit `0` only when every *executed* check passes; non-zero otherwise. Skipped (`None`) checks (e.g. the token fetch without `--test`) do not count as failures.

### 2. Passive validation mode (`--passive` + `fetch_tokens_passive`)
`auth check --test` runs `fetch_tokens_with_domains`, which on auth expiry **runs `NOTEBOOKLM_REFRESH_CMD`, fires the keepalive rotation poke, can trigger inline PSIDTS `RotateCookies` recovery, and writes `storage_state.json`** — none of which a passive readiness probe should do. New public `notebooklm.auth.fetch_tokens_passive` is strictly read-only:
- never runs `NOTEBOOKLM_REFRESH_CMD`;
- never fires the layer-1 keepalive poke (`poke=False`);
- never fires inline PSIDTS recovery — it uses the **no-recovery strict loader**, so a missing/expired PSIDTS surfaces as a `ValueError` instead of a network POST + disk write;
- never persists cookies.

`auth check --test --passive` routes the token probe through it. The transport-neutral `run_auth_check(AuthCheckPlan(..., passive=True))` exposes the same probe to the MCP/HTTP adapters (the Python-API ask in the issue).

### 3. `auth refresh --verify`
A successful refresh command does not prove the resulting cookies authenticate (they may still redirect to sign-in). `--verify` runs the passive probe after refresh and exits non-zero if it fails — especially valuable with `--browser-cookies`, which rewrites the jar but does not otherwise verify it.

### 4. macOS login recovery hint
The `Login not detected within 5 minutes` timeout now suggests `notebooklm login --browser chrome` to reuse an already signed-in system Chrome session (often detects immediately; sidesteps bundled-Chromium issues on macOS).

## Contract

`auth check` (both text and `--json`) exits `0` iff all executed checks pass. `auth check --test --passive` and `auth refresh --verify` give automation a fail-loud, side-effect-free readiness signal.

## Testing
- Full suite green: **9177 passed, 66 skipped**; `mypy` + `ruff` clean.
- New tests assert *passivity*, not just happy path: no keepalive poke, no disk write, no `NOTEBOOKLM_REFRESH_CMD`, and **no inline PSIDTS recovery** (a regression test proven to fail on the non-strict loader).
- Updated the exit-code contract tests, CLI contract baseline, and `auth.__all__` public-surface guardrail.

## Compatibility
Additive public API (`fetch_tokens_passive`); `scripts/audit_public_api_compat.py` exits 0 with **no** new allowlist entries — not an API-breaking change. Docs updated: `cli-reference.md`, `troubleshooting.md`, `CHANGELOG.md`.

Closes #1569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--passive` to `auth check` for read-only credential validation and `--verify` to `auth refresh` to confirm cookies after refresh

* **Bug Fixes**
  * `auth check` text mode now exits non‑zero on failures (matches JSON behavior)
  * Improved macOS login timeout guidance suggesting `--browser chrome`

* **Documentation**
  * Updated CLI reference and troubleshooting for new flags and exit semantics

* **Tests**
  * Expanded tests/fixtures to cover passive/verify behaviors and exit-code contracts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->