### PR TITLE
fix(notebooks): detect quota exhaustion on Discovery Engine code 7/8, not just code 3 (#1546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Notebook-quota exhaustion is now detected on the "Discovery Engine" backend,
+  not just the legacy one** (#1546). `notebooks.create()` converts a quota-shaped
+  `CREATE_NOTEBOOK` failure into the actionable `NotebookLimitError`, but the
+  trigger was gated on a single gRPC status code (`3` / INVALID_ARGUMENT — the
+  legacy backend's quota code). Google's newer Discovery Engine backend reports
+  the same notebook-limit exhaustion as code `7` (PERMISSION_DENIED), so affected
+  accounts got a raw, confusing RPC error instead of the "delete old notebooks"
+  guidance. The detector now matches a set of quota-suspect codes —
+  `{3, 7, 8}` (3 = legacy INVALID_ARGUMENT, 7 = Discovery Engine
+  PERMISSION_DENIED, 8 = canonical gRPC RESOURCE_EXHAUSTED as insurance). This
+  cannot cause false positives: a matched code only *gates* the quota path, after
+  which the existing count-vs-limit verification (fetch the account's advertised
+  `notebook_limit`, raise only when the owned count is at/near it) is what
+  actually decides — a code-7 failure on an account well under its limit (a
+  genuine permission error) still propagates unchanged. The membership check also
+  normalizes the code to `int` first, so a string-form `rpc_code` (the field is
+  typed `str | int | None`) still matches.
+
 - **`notebooklm auth check` text mode now exits non-zero when an executed check
   fails, matching `--json` mode** (#1569). Previously the Rich-table renderer
   printed the failed checks but always exited `0`, so an unattended health check

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -255,6 +255,21 @@ unset (still truncated).
 - Check that notebook/source IDs are valid
 - Add delays between operations (see Rate Limiting section)
 
+**Notebook / source limits.** A quota-related `create` failure usually means the account is at its
+**notebooks-per-account** limit; a quota-related `source add` failure means a notebook is at its
+**sources-per-notebook** limit (these are two different caps — don't confuse them). For the notebook
+case `notebooklm-py` verifies your owned notebook count against the account's server-reported limit and
+raises a clear `NotebookLimitError` instead of an opaque RPC error; deleting old notebooks (or sources)
+frees the quota. Documented limits (per Google, **subject to change** — see the
+[official limits page](https://support.google.com/notebooklm/answer/16213268)):
+
+| Tier | Notebooks / account | Sources / notebook |
+|---|---|---|
+| Standard (free) | 100 | 50 |
+| Plus | 200 | 100 |
+| Pro | 500 | 300 |
+| AI Ultra | 500 | 500–600 |
+
 **If it only affects _write_ operations** (`create`, `source add`, `generate`) while reads (`list`, `ask`) keep working — **and the web UI still works** — the likely cause is that Google changed the request payload (wire format) for those RPCs and `notebooklm-py` is still sending the old shape. Google rolls these out gradually, so it can hit some accounts before others.
 
 > **First, rule out a mis-decoded success.** Re-run the failing action, then check `notebooklm list`: if the resource was actually **created** despite the error, it's a *response*-decoding issue (share the **Response** below). If it was **not** created, Google rejected our **request** (share the **Payload** below).

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -31,7 +31,44 @@ from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadat
 logger = logging.getLogger(__name__)
 
 
-CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
+# gRPC status codes under which a CREATE_NOTEBOOK failure *may* signal that the
+# account has exhausted its notebook quota. Different backend cohorts report the
+# same exhaustion under different codes:
+#   3 = INVALID_ARGUMENT  — the legacy backend's quota code (established in #328).
+#   7 = PERMISSION_DENIED — the "Discovery Engine" backend's code (#1546: the
+#                           reporter hit a notebook limit, the AzXHBd create
+#                           returned status=7, and freeing space fixed it).
+#   8 = RESOURCE_EXHAUSTED — the canonical gRPC quota code; insurance for if
+#                            Google ever adopts the "correct" one.
+# Membership here only *gates* the quota path — it never decides it. The actual
+# disambiguator is the count-vs-limit check in
+# :meth:`NotebooksAPI._raise_quota_error_if_detected`, which fetches the
+# account's advertised notebook limit and only raises ``NotebookLimitError``
+# when the owned count is at/near it. That gate is why this set can safely span
+# broad codes (3 also covers wire-format drift, 7 also covers genuine
+# permission errors) without risking a false ``NotebookLimitError``.
+CREATE_NOTEBOOK_QUOTA_RPC_CODES = frozenset({3, 7, 8})
+
+
+def _normalize_rpc_code(code: str | int | None) -> int | None:
+    """Coerce an ``RPCError.rpc_code`` to ``int`` for set membership tests.
+
+    ``RPCError.rpc_code`` is typed ``str | int | None`` — the decoder usually
+    populates the gRPC status as a bare integer, but a string (e.g. ``"7"``) or
+    a non-numeric sentinel (e.g. ``"USER_DISPLAYABLE_ERROR"``) is possible, and a
+    string ``"7"`` would silently fail an ``in {3, 7, 8}`` test against an
+    int-only set. This coerces a numeric code to ``int`` and maps anything
+    absent/non-numeric to ``None`` (no match) instead of raising. Mirrors
+    ``notebooklm._app.errors._normalized_rpc_code`` — duplicated rather than
+    imported because ``_app`` sits *above* this client-runtime module in the
+    layering (``tests/_guardrails/test_app_boundary.py``).
+    """
+    if code is None:
+        return None
+    try:
+        return int(code)
+    except (TypeError, ValueError):
+        return None
 
 
 def build_create_notebook_params(title: str) -> list[Any]:
@@ -501,16 +538,19 @@ class NotebooksAPI:
         )
 
     async def _raise_quota_error_if_detected(self, error: RPCError) -> None:
-        """Convert CREATE_NOTEBOOK invalid-argument failures into quota errors."""
+        """Convert a quota-shaped CREATE_NOTEBOOK failure into a quota error."""
         if (
             error.method_id != RPCMethod.CREATE_NOTEBOOK.value
-            or error.rpc_code != CREATE_NOTEBOOK_QUOTA_RPC_CODE
+            or _normalize_rpc_code(error.rpc_code) not in CREATE_NOTEBOOK_QUOTA_RPC_CODES
         ):
             return
 
-        # The backend reports quota exhaustion as code 3 rather than a typed
-        # limit error, so verify against the account's advertised limit before
-        # changing the exception type.
+        # A quota-suspect status code (see ``CREATE_NOTEBOOK_QUOTA_RPC_CODES``)
+        # only *gates* this path — those codes also cover unrelated failures, so
+        # verify against the account's advertised limit before changing the
+        # exception type. The count-vs-limit check below is the real
+        # disambiguator between true quota exhaustion and a same-coded non-quota
+        # error.
         try:
             account_limits = await self._get_account_limits()
         except Exception:

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -63,10 +63,12 @@ def _shared_notebooks(count: int) -> list[Notebook]:
 
 
 def _create_invalid_argument_error(
-    *, method_id: str = RPCMethod.CREATE_NOTEBOOK.value, rpc_code: int = 3
+    *, method_id: str = RPCMethod.CREATE_NOTEBOOK.value, rpc_code: str | int = 3
 ) -> RPCError:
+    # Mirror the code into the message so a failing assertion shows the real
+    # status (the helper is exercised with 3/7/8/"7"), not a hardcoded "3".
     return RPCError(
-        "RPC CCqFvf returned null result with status code 3 (Invalid argument).",
+        f"RPC CCqFvf returned null result with status code {rpc_code}.",
         method_id=method_id,
         rpc_code=rpc_code,
     )
@@ -359,6 +361,58 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value.limit == 100
 
     @pytest.mark.asyncio
+    async def test_create_permission_denied_at_limit_raises_limit_error(self):
+        # The "Discovery Engine" backend reports notebook-quota exhaustion as
+        # gRPC code 7 (PERMISSION_DENIED) instead of the legacy code 3 (#1546).
+        # With the owned count at the advertised limit, the count-vs-limit gate
+        # confirms quota and the raw RPCError is converted to NotebookLimitError.
+        original = _create_invalid_argument_error(rpc_code=7)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("Discovery Engine At Limit")
+
+        assert exc_info.value.current_count == 500
+        assert exc_info.value.limit == 500
+        assert exc_info.value.original_error is original
+
+    @pytest.mark.asyncio
+    async def test_create_string_form_quota_code_at_limit_raises_limit_error(self):
+        # ``RPCError.rpc_code`` is typed ``str | int | None``; a string-form code
+        # ("7") must still match the int-only quota set, so the membership check
+        # normalizes the code to int first. Without that coercion a string code
+        # would silently skip quota detection (gemini-code-assist on #1574).
+        original = _create_invalid_argument_error(rpc_code="7")
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("String Code At Limit")
+
+        assert exc_info.value.current_count == 500
+        assert exc_info.value.limit == 500
+        assert exc_info.value.original_error is original
+
+    @pytest.mark.asyncio
+    async def test_create_resource_exhausted_at_limit_raises_limit_error(self):
+        # Code 8 (RESOURCE_EXHAUSTED) is the canonical gRPC quota code; carried
+        # as insurance for if Google ever adopts the "correct" one (#1546).
+        original = _create_invalid_argument_error(rpc_code=8)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("Resource Exhausted At Limit")
+
+        assert exc_info.value.current_count == 500
+        assert exc_info.value.limit == 500
+        assert exc_info.value.original_error is original
+
+    @pytest.mark.asyncio
     async def test_create_invalid_argument_uses_account_limit_not_free_boundary(self):
         original = _create_invalid_argument_error()
         api = _make_api(rpc_call=AsyncMock(side_effect=original))
@@ -383,6 +437,41 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value is original
 
     @pytest.mark.asyncio
+    async def test_create_permission_denied_under_limit_preserves_rpc_error(self):
+        # The count-vs-limit gate still protects against false positives when a
+        # broad quota code is in play: a code-7 (PERMISSION_DENIED) failure on
+        # an account well under its limit is a *genuine* permission error, NOT
+        # quota exhaustion, so the raw RPCError must propagate unchanged. This
+        # mirrors the code-3 under-limit case above and is the critical guard
+        # added alongside the #1546 code-7/8 broadening.
+        original = _create_invalid_argument_error(rpc_code=7)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(20))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Genuine Permission Error")
+
+        assert exc_info.value is original
+        assert not isinstance(exc_info.value, NotebookLimitError)
+
+    @pytest.mark.asyncio
+    async def test_create_resource_exhausted_under_limit_preserves_rpc_error(self):
+        # Symmetrical to the code-7 under-limit guard: even the canonical quota
+        # code (8) does not convert when the account is well under its limit —
+        # the count-vs-limit gate, not the code, is what decides.
+        original = _create_invalid_argument_error(rpc_code=8)
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(20))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Genuine Exhausted Error")
+
+        assert exc_info.value is original
+        assert not isinstance(exc_info.value, NotebookLimitError)
+
+    @pytest.mark.asyncio
     async def test_non_quota_rpc_code_preserves_rpc_error_without_listing(self):
         original = _create_invalid_argument_error(rpc_code=13)
         api = _make_api(rpc_call=AsyncMock(side_effect=original))
@@ -396,9 +485,9 @@ class TestCreateNotebookQuotaDetection:
 
         assert exc_info.value is original
         api._get_account_limits.assert_not_awaited()
-        # baseline list runs once before CREATE_NOTEBOOK; no
-        # quota-check list because the RPC code (13) is not the
-        # quota-exhausted code (3).
+        # baseline list runs once before CREATE_NOTEBOOK; no quota-check list
+        # because RPC code 13 (INTERNAL) is not one of the quota-suspect codes
+        # ({3, 7, 8}), so the quota path is skipped before any limit lookup.
         assert api.list.await_count == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`notebooks.create()` converts a quota-shaped `CREATE_NOTEBOOK` RPC failure into the actionable `NotebookLimitError` ("delete old notebooks and try again"). The trigger was gated on a **single** gRPC status code — `CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3` (INVALID_ARGUMENT), established as the legacy backend's quota code in #328.

#1546 surfaced that Google's newer **"Discovery Engine"** backend reports notebook-quota exhaustion as gRPC code **7 (PERMISSION_DENIED)**, not 3. The reporter (`caichengle666`) confirmed: hit a notebook limit, the `AzXHBd` create returned `status=7`, and freeing space fixed it. The code-3-only filter misses that, so affected accounts get a raw, confusing RPC error instead of the clear limit guidance.

This widens the gate to a set of quota-suspect codes: `CREATE_NOTEBOOK_QUOTA_RPC_CODES = frozenset({3, 7, 8})`.

## Related Issue

Related to #1546.

## Changes

- **`src/notebooklm/_notebooks.py`**: replace the scalar `CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3` with `CREATE_NOTEBOOK_QUOTA_RPC_CODES = frozenset({3, 7, 8})` and switch the membership check in `_raise_quota_error_if_detected` from `!= ` to `not in`. Codes: **3** = legacy INVALID_ARGUMENT (#328), **7** = Discovery Engine PERMISSION_DENIED (#1546), **8** = canonical gRPC RESOURCE_EXHAUSTED (insurance for if Google ever adopts the "correct" code). Comments updated to explain the multi-cohort code situation and why the gate is safe.
- **`tests/unit/test_notebook_api.py`**: extend the `TestCreateNotebookQuotaDetection` cluster — code 7 at/over limit raises `NotebookLimitError`; code 8 at/over limit raises `NotebookLimitError`; **code 7 well under limit does NOT convert and the raw `RPCError` propagates** (the critical false-positive guard, mirroring the existing code-3 under-limit test). Existing code-3 behavior unchanged.
- **`CHANGELOG.md`**: entry under `### Fixed` (Unreleased).

## Why broadening the code set is safe (no false positives)

The code check only **gates** the quota path — it never decides it. After the code matches, `_raise_quota_error_if_detected` **verifies against the account's real limit**: it fetches `account_limits.notebook_limit` via `GET_USER_SETTINGS` and only raises `NotebookLimitError` when `owned_count >= max(notebook_limit - 1, 0)`. That count-vs-limit gate is the true disambiguator, so widening the code set cannot cause a false `NotebookLimitError` unless the account is genuinely at/near its limit.

Concretely, a code-7 failure on an account well under its limit (i.e. a *genuine* permission error, not quota) still propagates the raw `RPCError` unchanged — proven by the new `test_create_permission_denied_under_limit_preserves_rpc_error` regression test. The same protection covers code 3 (which also fires on wire-format drift) and code 8.

The renamed constant is private to the `_notebooks` module (not in `__all__`, not re-exported, not imported by tests), so the scalar→frozenset rename is not a public-API or test-seam break — confirmed by `scripts/audit_public_api_compat.py` (no new allowlist entries).

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (full `uv run pytest`: 10206 passed, 69 skipped, 1 xfailed)
- [x] Linting and formatting pass (`uv run ruff check .` + `uv run ruff format --check .`, whole tree)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] Public API compat audit passes with no new allowlist entries (`uv run python scripts/audit_public_api_compat.py`)
- [ ] If this PR changes architectural shape, an ADR has been added or updated. — N/A (behavioral bug fix, no architectural change)

## Notes

- **Hold note for maintainers:** inclusion of code **7** rests on the #1546 interpretation that "gRPC 7 = quota on the Discovery Engine backend," which is under verification on the issue (specifically: does a cookie-only `AzXHBd` create still return 7 after quota is freed?). Codes **3** (#328-confirmed) and **8** (canonical `RESOURCE_EXHAUSTED`) are not at risk. If 7 turns out not to be quota, it can be dropped from the set before merge; the change is a one-line edit to the `frozenset`. Marked "Related to" rather than "Closes" #1546 for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook quota exhaustion handling on both legacy and Discovery Engine backends by recognizing additional quota-related gRPC failures and showing user-friendly notebook limit guidance instead of raw RPC errors.
  * Continues to preserve the original RPC error when the account is still under its notebook limit (quota guidance is shown only when the owned-count meets the configured limit).
* **Tests**
  * Expanded unit coverage for quota detection when creating notebooks at and under quota, including numeric and string forms of the backend status codes.
* **Documentation**
  * Added troubleshooting guidance for notebook/source limits, including a tier table for each plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->