### PR TITLE
pre-commit: drive ruff via uv run to remove version-pin drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: uv run ruff check --fix
+        entry: uv run ruff check --force-exclude --fix
         language: system
         types_or: [python, pyi]
         require_serial: true
       - id: ruff-format
         name: ruff-format
-        entry: uv run ruff format
+        entry: uv run ruff format --force-exclude
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,19 @@
+# Ruff is pinned once in pyproject.toml ([project.optional-dependencies].dev:
+# `ruff==…`).
+# These local hooks invoke that same interpreter's ruff via `uv run`, so the
+# pre-commit version can never drift from the version used by CI and locally.
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+  - repo: local
     hooks:
       - id: ruff
-        args: [--fix]
+        name: ruff
+        entry: uv run ruff check --fix
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
       - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]
+        require_serial: true


### PR DESCRIPTION
## Problem

Ruff was pinned in two independent places:

- `pyproject.toml` → `ruff==0.15.15` (dev extra, resolved via `uv.lock`)
- `.pre-commit-config.yaml` → `rev: v0.15.15` (the `astral-sh/ruff-pre-commit` mirror)

They happen to match today, but nothing keeps them in sync: `pre-commit autoupdate` bumps the `rev` without touching `pyproject.toml`, and a dependency bump won't touch the config. Drift means the pre-commit hook runs a different ruff than CI and local `uv run ruff`.

## Fix

Replace the `ruff-pre-commit` mirror with `repo: local` hooks that invoke the project's own ruff through `uv run`. `pyproject.toml`'s dev pin (resolved against `uv.lock`) becomes the **single source of truth**, so the pre-commit ruff version can no longer drift.

```yaml
repos:
  - repo: local
    hooks:
      - id: ruff
        entry: uv run ruff check --fix
        language: system
        types_or: [python, pyi]
        require_serial: true
      - id: ruff-format
        entry: uv run ruff format
        language: system
        types_or: [python, pyi]
        require_serial: true
```

## Tradeoff

The hooks now use `language: system`, so they require the project venv (ruff installed via the `dev` extra) rather than pre-commit's isolated mirror environment. This matches the canonical contributor setup documented in `CLAUDE.md` (`uv sync ... --extra dev`).

## Verification

- `uv run ruff --version` → `0.15.15` (the pinned version)
- `uv run pre-commit run --all-files` → both `ruff` and `ruff-format` pass

https://claude.ai/code/session_01Gts3g294Socp3WN8JVv4Sh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gts3g294Socp3WN8JVv4Sh)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling setup to run code-quality checks using local ruff and ruff-format hooks via the pinned tooling environment, replacing the previous externally sourced configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->