### PR TITLE
fix(rpc): migrate GET_NOTEBOOK read path to nested template block (#1549)

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -43,6 +43,20 @@ def build_create_notebook_params(title: str) -> list[Any]:
     return [title, None, None, build_template_block()]
 
 
+def build_get_notebook_params(notebook_id: str) -> list[Any]:
+    """Return the canonical GET_NOTEBOOK (``rLM1Ne``) RPC payload.
+
+    The Gemini-3.5 rollout migrated the read path's trailing template block from
+    the flat ``[2]`` to the same nested :func:`build_template_block` wrapper the
+    write path adopted in #1548 (issue #1549). Live-verified forward-compatible:
+    the nested shape returns a byte-identical decoded notebook (notebook id /
+    title and every ``SourceRow``) as the flat ``[2]`` on an un-migrated account,
+    so it is safe across cohorts. The trailing ``None, 0`` is unchanged — only
+    the template block at position 2 is migrated (the narrow scope #1549 tracks).
+    """
+    return [notebook_id, None, build_template_block(), None, 0]
+
+
 def _extract_summary(outer: Any) -> str:
     """Extract the summary string from a SUMMARIZE ``result[0]`` payload.
 
@@ -571,7 +585,7 @@ class NotebooksAPI:
                 ``title``) for unknown IDs rather than a proper RPC error, so
                 this method post-validates the parsed response.
         """
-        params = [notebook_id, None, [2], None, 0]
+        params = build_get_notebook_params(notebook_id)
         result = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,
@@ -774,7 +788,7 @@ class NotebooksAPI:
         Returns:
             Raw API response data.
         """
-        params = [notebook_id, None, [2], None, 0]
+        params = build_get_notebook_params(notebook_id)
         return await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,

--- a/src/notebooklm/_source/listing.py
+++ b/src/notebooklm/_source/listing.py
@@ -11,6 +11,7 @@ from .._row_adapters.sources import SourceRow
 from .._runtime.contracts import RpcCaller
 from ..rpc import RPCError, RPCMethod, safe_index
 from ..types import Source
+from .upload_payloads import build_template_block
 
 # Keep source-list warnings on the historical logger so existing log filters
 # continue to see the same channel after the service extraction.
@@ -35,7 +36,12 @@ class SourceLister:
         ``NOTEBOOKLM_STRICT_DECODE=0`` opt-out into warn-and-return-``[]``
         was retired in v0.7.0; strict decoding is now the only mode.
         """
-        params = [notebook_id, None, [2], None, 0]
+        # GET_NOTEBOOK read-path tail migrated to the nested template block
+        # (#1549; live-verified forward-compatible). Mirrors
+        # ``_notebooks.build_get_notebook_params`` — inlined here because
+        # importing ``_notebooks`` from this module would cycle (``_notebooks``
+        # imports ``_source.upload_payloads``, which runs ``_source/__init__``).
+        params = [notebook_id, None, build_template_block(), None, 0]
         notebook = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,

--- a/tests/cassettes/artifacts_generate_flashcards.yaml
+++ b/tests/cassettes/artifacts_generate_flashcards.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312251394&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312251394&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_quiz.yaml
+++ b/tests/cassettes/artifacts_generate_quiz.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312248942&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312248942&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_report.yaml
+++ b/tests/cassettes/artifacts_generate_report.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312243895&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312243895&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_study_guide.yaml
+++ b/tests/cassettes/artifacts_generate_study_guide.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312246464&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312246464&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list.yaml
+++ b/tests/cassettes/artifacts_list.yaml
@@ -2381,7 +2381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list_data_tables.yaml
+++ b/tests/cassettes/artifacts_list_data_tables.yaml
@@ -2238,7 +2238,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list_infographics.yaml
+++ b/tests/cassettes/artifacts_list_infographics.yaml
@@ -2238,7 +2238,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/chat_ask.yaml
+++ b/tests/cassettes/chat_ask.yaml
@@ -1861,7 +1861,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934741655&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934741655&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/chat_ask_with_references.yaml
+++ b/tests/cassettes/chat_ask_with_references.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934754822&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934754822&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/cli_notebook_rename.yaml
+++ b/tests/cassettes/cli_notebook_rename.yaml
@@ -1956,7 +1956,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22ea4da50c-7138-47e1-a760-80dbf4f3535f%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780267425032&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22ea4da50c-7138-47e1-a760-80dbf4f3535f%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780267425032&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/generate_mind_map_interactive.yaml
+++ b/tests/cassettes/generate_mind_map_interactive.yaml
@@ -1858,7 +1858,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f7d1e2b6-2334-4016-b81d-aded7b3fa9b6%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780152877667&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f7d1e2b6-2334-4016-b81d-aded7b3fa9b6%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780152877667&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/label_list.yaml
+++ b/tests/cassettes/label_list.yaml
@@ -1858,7 +1858,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831541460&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831541460&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/label_sources.yaml
+++ b/tests/cassettes/label_sources.yaml
@@ -2032,7 +2032,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831545959&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831545959&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebook_zero_sources.yaml
+++ b/tests/cassettes/notebook_zero_sources.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%224d79940d-5f20-4d77-a918-5d04d08ce789%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778873027933&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%224d79940d-5f20-4d77-a918-5d04d08ce789%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778873027933&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_get.yaml
+++ b/tests/cassettes/notebooks_get.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963936973&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963936973&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_get_raw.yaml
+++ b/tests/cassettes/notebooks_get_raw.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312218683&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312218683&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_rename.yaml
+++ b/tests/cassettes/notebooks_rename.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'
@@ -1788,7 +1788,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'
@@ -2021,7 +2021,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/real_api_get_notebook.yaml
+++ b/tests/cassettes/real_api_get_notebook.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914367&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914367&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/real_api_list_sources.yaml
+++ b/tests/cassettes/real_api_list_sources.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914818&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914818&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/research_import_verification.yaml
+++ b/tests/cassettes/research_import_verification.yaml
@@ -2931,7 +2931,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%222f172482-c667-484f-beff-b7150d5795e7%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781273619630&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%222f172482-c667-484f-beff-b7150d5795e7%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781273619630&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/server_add_file.yaml
+++ b/tests/cassettes/server_add_file.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781132188780&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781132188780&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/server_generate_quiz.yaml
+++ b/tests/cassettes/server_generate_quiz.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781131847330&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1781131847330&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/source_list_label.yaml
+++ b/tests/cassettes/source_list_label.yaml
@@ -2032,7 +2032,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831547126&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831547126&
     headers:
       Accept:
       - '*/*'
@@ -2142,7 +2142,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831547126&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22be2a98a8-5897-4634-bc7c-05d29e493ae8%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780831547126&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_check_freshness.yaml
+++ b/tests/cassettes/sources_check_freshness.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963669810&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963669810&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_check_freshness_drive.yaml
+++ b/tests/cassettes/sources_check_freshness_drive.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%225bb31d9f-a2cb-4a9e-9249-41629c7dcb64%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1769105994268&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%225bb31d9f-a2cb-4a9e-9249-41629c7dcb64%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1769105994268&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_get_fulltext.yaml
+++ b/tests/cassettes/sources_get_fulltext.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312222253&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312222253&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_get_guide.yaml
+++ b/tests/cassettes/sources_get_guide.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_list.yaml
+++ b/tests/cassettes/sources_list.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312220727&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312220727&
     headers:
       Accept:
       - '*/*'
@@ -1648,7 +1648,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_refresh.yaml
+++ b/tests/cassettes/sources_refresh.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963703846&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963703846&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_rename.yaml
+++ b/tests/cassettes/sources_rename.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963681446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963681446&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/workflow_tracer_bullet.yaml
+++ b/tests/cassettes/workflow_tracer_bullet.yaml
@@ -2566,7 +2566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'
@@ -2665,7 +2665,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'
@@ -3479,7 +3479,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from notebooklm._notebooks import NotebooksAPI, build_create_notebook_params
+from notebooklm._notebooks import (
+    NotebooksAPI,
+    build_create_notebook_params,
+    build_get_notebook_params,
+)
 from notebooklm._source.listing import SourceLister
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -79,6 +83,20 @@ def test_build_create_notebook_params_matches_live_payload() -> None:
         None,
         None,
         [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+    ]
+
+
+def test_build_get_notebook_params_matches_live_payload() -> None:
+    # #1549: the read-path tail also migrated to the nested template block.
+    # Live-verified forward-compatible (decoded notebook + sources byte-identical
+    # to the old flat ``[2]`` on an un-migrated account). The trailing ``None, 0``
+    # is unchanged — only position 2 migrates.
+    assert build_get_notebook_params("nb_abc") == [
+        "nb_abc",
+        None,
+        [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+        None,
+        0,
     ]
 
 

--- a/tests/unit/test_notebook_metadata.py
+++ b/tests/unit/test_notebook_metadata.py
@@ -180,7 +180,14 @@ async def test_default_source_lister_uses_phase8_listing_service() -> None:
     assert rpc.calls == [
         (
             RPCMethod.GET_NOTEBOOK,
-            ["nb_123", None, [2], None, 0],
+            # #1549: GET_NOTEBOOK tail migrated to the nested template block.
+            [
+                "nb_123",
+                None,
+                [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+                None,
+                0,
+            ],
             "/notebook/nb_123",
         )
     ]

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -58,7 +58,14 @@ async def test_list_uses_exact_get_notebook_rpc_shape() -> None:
     assert rpc.calls == [
         (
             RPCMethod.GET_NOTEBOOK,
-            ["nb_123", None, [2], None, 0],
+            # #1549: GET_NOTEBOOK tail migrated to the nested template block.
+            [
+                "nb_123",
+                None,
+                [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+                None,
+                0,
+            ],
             "/notebook/nb_123",
         )
     ]


### PR DESCRIPTION
Closes #1549.

## What this does

Migrates the **read-path** `GET_NOTEBOOK` (`rLM1Ne`) trailing template block from the flat `[2]` to the same nested `build_template_block()` wrapper the write path adopted in #1548 (the Gemini-3.5 rollout). Reads weren't failing yet — migrated backends still accept the old `[2]` — but this proactively aligns the read path so it stays valid as cohorts migrate, closing the long-tracked #1549.

```
old: [notebook_id, None, [2],                                  None, 0]
new: [notebook_id, None, [2, None, None, [1, None×9, [1]]],    None, 0]
                          └─ build_template_block() ─┘
```

## Live verification (our account)

Re-verified forward-compatibility against the live API on a source-bearing notebook (8 sources), using a **control-repeat baseline** + **decoded-object compare** (GET_NOTEBOOK has read-to-read volatile fields, so raw-byte equality false-alarms):

- control: two OLD-shape reads → identical stable fingerprint ✓
- **NEW shape accepted** (HTTP 200, no `status=3`/`5`) ✓
- **NEW decode == OLD decode** — notebook id/title and all 8 `SourceRow` decodes (id, title, type, status) byte-identical ✓

## Change surface

- **All 3 GET_NOTEBOOK call sites** migrated: `notebooks.get()` + `notebooks.get_raw()` via a new `build_get_notebook_params()` helper (next to `build_create_notebook_params`), and the source-listing path (`_source/listing.py`) inlined with `build_template_block()` — importing `_notebooks` there would cycle via `_source/__init__`, documented in a comment.
- **31 cassettes**: the recorded `GET_NOTEBOOK` request bodies are updated to the new shape (the `freq` VCR matcher compares request-body *shape*; the recorded **response is unchanged** — verified identical live, so this is a request-shape refresh, not a re-record).
- **Tests**: `build_get_notebook_params` live-payload pin (mirrors the create-params test) + updated request-shape assertions in the metadata/source-listing service tests.

## Test plan

- `uv run pytest` green (unit + integration; the 823 VCR integration tests replay against the migrated cassettes).
- `mypy` + `ruff` (check + format) clean.
- No user-facing behavior change — internal wire-format hardening (same posture as the #1548 write-path migration, which likewise wasn't changelogged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed internal API request formatting for notebook operations to ensure compatibility with all account types using the updated parameter format.

* **Tests**
  * Updated test fixtures and unit tests to reflect the new request format for notebook retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->