### PR TITLE
feat(scripts): live RPC id-registry diff (capture_rpc_registry.py)

### DIFF
--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -52,9 +52,10 @@ _BUNDLE_URL_RE = re.compile(rf'https://www\.gstatic\.com/_/mss/{_APP}/_/js/[^"\\
 # A registration's two stable, quoted anchors: the ``/Service.Method`` path and
 # the rpc id. We anchor on the path and scan *backward* for the nearest id, which
 # is robust to nested ``[...]`` in the options array (a single forward regex
-# spanning to the path breaks on the inner ``]``).
-_METHOD_PATH_RE = re.compile(r'"(/[A-Za-z][\w]*\.[A-Za-z][\w]*)"')
-_ID_TOKEN_RE = re.compile(r'"([A-Za-z0-9]{5,8})"')
+# spanning to the path breaks on the inner ``]``). Quote-agnostic (``"`` or
+# ``'``) so a change in the bundle minifier's quote style doesn't blank the diff.
+_METHOD_PATH_RE = re.compile(r"""["'](/[A-Za-z][\w]*\.[A-Za-z][\w]*)["']""")
+_ID_TOKEN_RE = re.compile(r"""["']([A-Za-z0-9]{5,8})["']""")
 # How far back from a path string to look for its registration id.
 _ID_LOOKBACK = 160
 
@@ -64,7 +65,9 @@ _RPC_ID_RE = re.compile(r"[A-Za-z0-9]{5,8}")
 
 _UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138 Safari/537.36"
 
-_DEFAULT_TYPES = Path("src/notebooklm/rpc/types.py")
+# Resolved relative to this file (scripts/ -> repo root) so the script runs from
+# any working directory, not just the repo root.
+_DEFAULT_TYPES = Path(__file__).resolve().parent.parent / "src" / "notebooklm" / "rpc" / "types.py"
 
 
 def parse_ids_from_text(types_text: str) -> dict[str, str]:
@@ -72,7 +75,9 @@ def parse_ids_from_text(types_text: str) -> dict[str, str]:
     match = re.search(r"class RPCMethod\b.*?(?=\nclass |\Z)", types_text, re.DOTALL)
     body = match.group(0) if match else types_text
     out: dict[str, str] = {}
-    for name, value in re.findall(r'^\s+([A-Z][A-Z0-9_]*)\s*=\s*"([^"]+)"', body, re.MULTILINE):
+    for name, value in re.findall(
+        r"""^\s+([A-Z][A-Z0-9_]*)\s*=\s*["']([^"']+)["']""", body, re.MULTILINE
+    ):
         if _RPC_ID_RE.fullmatch(value):
             out[value] = name
     return out
@@ -97,9 +102,13 @@ def extract_registry(bundle: str) -> dict[str, str]:
 
 def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, dict[str, str]]:
     """Classify our ids vs the live registry into the four reporting buckets."""
+
+    def _in_bundle(rpc_id: str) -> bool:
+        return f'"{rpc_id}"' in bundle or f"'{rpc_id}'" in bundle
+
     confirmed = {i: live[i] for i in ours if i in live}
-    present_unparsed = {i: ours[i] for i in ours if i not in live and f'"{i}"' in bundle}
-    absent = {i: ours[i] for i in ours if i not in live and f'"{i}"' not in bundle}
+    present_unparsed = {i: ours[i] for i in ours if i not in live and _in_bundle(i)}
+    absent = {i: ours[i] for i in ours if i not in live and not _in_bundle(i)}
     unmapped = {i: live[i] for i in live if i not in ours}
     return {
         "confirmed": confirmed,
@@ -110,32 +119,49 @@ def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, d
 
 
 def fetch_bundle() -> str:
-    """Fetch the largest gstatic app-bundle chunk (the one carrying the registry).
+    """Fetch and concatenate the gstatic app-bundle chunks (which carry the registry).
 
-    One authenticated homepage read discovers the bundle URLs; the bundle itself
-    is then fetched unauthenticated from the public CDN.
+    One authenticated homepage read discovers the bundle URLs; the chunks are then
+    fetched unauthenticated from the public CDN, **sequentially** (to avoid rate
+    limiting) and **concatenated**, so the scan covers the whole frontend surface
+    regardless of how Google splits the registry across chunks.
     """
     import httpx
 
     from notebooklm._env import get_base_url
     from notebooklm.auth import authuser_query, load_auth_from_storage
 
+    def _get(
+        url: str,
+        *,
+        cookies: dict[str, str] | None = None,
+        follow_redirects: bool = False,
+        timeout: float = 60.0,
+    ) -> str:
+        response = httpx.get(
+            url,
+            headers={"User-Agent": _UA},
+            cookies=cookies,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return response.text
+
     cookies = load_auth_from_storage()
-    html = httpx.get(
+    html = _get(
         f"{get_base_url()}/?{authuser_query(0)}",
         cookies=cookies,
-        headers={"User-Agent": _UA},
         follow_redirects=True,
-        timeout=30,
-    ).text
+        timeout=30.0,
+    )
     urls = sorted(set(_BUNDLE_URL_RE.findall(html)))
     if not urls:
         raise SystemExit(
             f"No {_APP} bundle URL found in the homepage — not authenticated for "
             "NotebookLM? Run `notebooklm login` (or pass --bundle-file)."
         )
-    bodies = [httpx.get(u, headers={"User-Agent": _UA}, timeout=60).text for u in urls]
-    return max(bodies, key=len)
+    return "\n".join(_get(url) for url in urls)
 
 
 def _print_report(

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Capture NotebookLM's live RPC id registry from the web bundle and diff it
+against ``src/notebooklm/rpc/types.py``.
+
+NotebookLM declares every ``batchexecute`` RPC in its (public, gstatic-served) JS
+bundle as::
+
+    _.uD("<rpc_id>", <ReqCtor>, <RespCtor>, [<flags>, "/<Service>.<Method>"])
+
+The obfuscated ``<rpc_id>`` values are this project's #1 breakage class — they
+rotate without notice and a stale id silently breaks the affected operation. This
+script extracts the live ``id -> /Service.Method`` map and diffs it against the
+ids we hardcode, surfacing four classes:
+
+* CONFIRMED       — our id is still registered (shown with its decoded method name)
+* ABSENT          — our id no longer appears in the bundle at all (rotation/stale — the alarm)
+* PRESENT-UNPARSED— our id string is in the bundle but its registration form wasn't
+                    parsed (not a rotation; a parser gap to widen, not an alert)
+* UNMAPPED        — a live RPC the bundle declares that we don't expose (new
+                    capability or migration target)
+
+Auth: discovering the bundle URL needs **one authenticated homepage read** (an
+unauthenticated request only returns the login app); fetching the bundle itself is
+unauthenticated (public CDN). Run ``notebooklm login`` first, or pass
+``--bundle-file`` to analyse a pre-saved bundle offline (no auth/network).
+
+Cohort note: the bundle reflects *your account's* cohort. New-generation ids
+(e.g. ``AzXHBd``/``NotebookService.*``) may be registered but gated for
+un-migrated accounts; the active ids are whichever the cohort is served.
+
+Usage::
+
+    python scripts/capture_rpc_registry.py                 # human-readable diff
+    python scripts/capture_rpc_registry.py --json          # machine-readable snapshot
+    python scripts/capture_rpc_registry.py --check         # exit 1 if any of our ids are ABSENT
+    python scripts/capture_rpc_registry.py --bundle-file bundle.js   # offline, no auth
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# The NotebookLM web app's gstatic JS namespace. If Google renames the app this
+# pattern must be updated (the script will then report "no bundle URL").
+_APP = "boq-labs-tailwind"
+_BUNDLE_URL_RE = re.compile(rf'https://www\.gstatic\.com/_/mss/{_APP}/_/js/[^"\\\s<>]+')
+
+# A registration's two stable, quoted anchors: the ``/Service.Method`` path and
+# the rpc id. We anchor on the path and scan *backward* for the nearest id, which
+# is robust to nested ``[...]`` in the options array (a single forward regex
+# spanning to the path breaks on the inner ``]``).
+_METHOD_PATH_RE = re.compile(r'"(/[A-Za-z][\w]*\.[A-Za-z][\w]*)"')
+_ID_TOKEN_RE = re.compile(r'"([A-Za-z0-9]{5,8})"')
+# How far back from a path string to look for its registration id.
+_ID_LOOKBACK = 160
+
+# Real obfuscated rpc ids are short alphanumerics; this filter keeps non-id enum
+# constants (e.g. ``blog_post``) out of the diff.
+_RPC_ID_RE = re.compile(r"[A-Za-z0-9]{5,8}")
+
+_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138 Safari/537.36"
+
+_DEFAULT_TYPES = Path("src/notebooklm/rpc/types.py")
+
+
+def parse_ids_from_text(types_text: str) -> dict[str, str]:
+    """Return ``{rpc_id: ENUM_NAME}`` for the ``RPCMethod`` enum members."""
+    match = re.search(r"class RPCMethod\b.*?(?=\nclass |\Z)", types_text, re.DOTALL)
+    body = match.group(0) if match else types_text
+    out: dict[str, str] = {}
+    for name, value in re.findall(r'^\s+([A-Z][A-Z0-9_]*)\s*=\s*"([^"]+)"', body, re.MULTILINE):
+        if _RPC_ID_RE.fullmatch(value):
+            out[value] = name
+    return out
+
+
+def extract_registry(bundle: str) -> dict[str, str]:
+    """Return ``{rpc_id: /Service.Method}`` for every registration in the bundle.
+
+    Anchored on each ``"/Service.Method"`` path: the rpc id is the nearest
+    preceding quoted short token (the registration's first argument). Scanning
+    backward from the path tolerates nested brackets in the options array that a
+    single forward regex cannot span.
+    """
+    out: dict[str, str] = {}
+    for match in _METHOD_PATH_RE.finditer(bundle):
+        window = bundle[max(0, match.start() - _ID_LOOKBACK) : match.start()]
+        ids = _ID_TOKEN_RE.findall(window)
+        if ids:
+            out[ids[-1]] = match.group(1)
+    return out
+
+
+def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, dict[str, str]]:
+    """Classify our ids vs the live registry into the four reporting buckets."""
+    confirmed = {i: live[i] for i in ours if i in live}
+    present_unparsed = {i: ours[i] for i in ours if i not in live and f'"{i}"' in bundle}
+    absent = {i: ours[i] for i in ours if i not in live and f'"{i}"' not in bundle}
+    unmapped = {i: live[i] for i in live if i not in ours}
+    return {
+        "confirmed": confirmed,
+        "present_unparsed": present_unparsed,
+        "absent": absent,
+        "unmapped": unmapped,
+    }
+
+
+def fetch_bundle() -> str:
+    """Fetch the largest gstatic app-bundle chunk (the one carrying the registry).
+
+    One authenticated homepage read discovers the bundle URLs; the bundle itself
+    is then fetched unauthenticated from the public CDN.
+    """
+    import httpx
+
+    from notebooklm._env import get_base_url
+    from notebooklm.auth import authuser_query, load_auth_from_storage
+
+    cookies = load_auth_from_storage()
+    html = httpx.get(
+        f"{get_base_url()}/?{authuser_query(0)}",
+        cookies=cookies,
+        headers={"User-Agent": _UA},
+        follow_redirects=True,
+        timeout=30,
+    ).text
+    urls = sorted(set(_BUNDLE_URL_RE.findall(html)))
+    if not urls:
+        raise SystemExit(
+            f"No {_APP} bundle URL found in the homepage — not authenticated for "
+            "NotebookLM? Run `notebooklm login` (or pass --bundle-file)."
+        )
+    bodies = [httpx.get(u, headers={"User-Agent": _UA}, timeout=60).text for u in urls]
+    return max(bodies, key=len)
+
+
+def _print_report(
+    ours: dict[str, str], live: dict[str, str], buckets: dict[str, dict[str, str]]
+) -> None:
+    confirmed, present, absent, unmapped = (
+        buckets["confirmed"],
+        buckets["present_unparsed"],
+        buckets["absent"],
+        buckets["unmapped"],
+    )
+    print(f"our ids: {len(ours)} | live registrations parsed: {len(live)}")
+    print(
+        f"CONFIRMED: {len(confirmed)}  ABSENT: {len(absent)}  "
+        f"PRESENT-UNPARSED: {len(present)}  UNMAPPED: {len(unmapped)}\n"
+    )
+    print("CONFIRMED (our id -> live /Service.Method):")
+    for rpc_id in sorted(confirmed, key=lambda i: ours[i]):
+        print(f"  {rpc_id:<8} {ours[rpc_id]:<26} {confirmed[rpc_id]}")
+    if absent:
+        print("\nABSENT — id no longer in the bundle (rotation/stale; investigate):")
+        for rpc_id in sorted(absent, key=lambda i: absent[i]):
+            print(f"  {rpc_id:<8} {absent[rpc_id]}")
+    if present:
+        print("\nPRESENT-UNPARSED — id is in the bundle but registration not parsed (widen regex):")
+        for rpc_id in sorted(present, key=lambda i: present[i]):
+            print(f"  {rpc_id:<8} {present[rpc_id]}")
+    print(f"\nUNMAPPED — live RPCs we do not expose ({len(unmapped)}):")
+    for rpc_id in sorted(unmapped, key=lambda i: unmapped[i]):
+        print(f"  {rpc_id:<8} {unmapped[rpc_id]}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    parser.add_argument(
+        "--json", action="store_true", help="emit a JSON snapshot instead of a report"
+    )
+    parser.add_argument("--check", action="store_true", help="exit 1 if any of our ids are ABSENT")
+    parser.add_argument(
+        "--bundle-file", type=Path, help="analyse a saved bundle file (no auth/network)"
+    )
+    parser.add_argument("--types", type=Path, default=_DEFAULT_TYPES, help="path to rpc/types.py")
+    args = parser.parse_args(argv)
+
+    ours = parse_ids_from_text(args.types.read_text(encoding="utf-8"))
+    bundle = args.bundle_file.read_text(encoding="utf-8") if args.bundle_file else fetch_bundle()
+    live = extract_registry(bundle)
+    buckets = diff(ours, live, bundle)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "confirmed": {
+                        i: {"name": ours[i], "method": m} for i, m in buckets["confirmed"].items()
+                    },
+                    "absent": buckets["absent"],
+                    "present_unparsed": buckets["present_unparsed"],
+                    "unmapped": buckets["unmapped"],
+                    "counts": {k: len(v) for k, v in buckets.items()} | {"ours": len(ours)},
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        _print_report(ours, live, buckets)
+
+    if args.check and buckets["absent"]:
+        print(
+            f"\nFAIL: {len(buckets['absent'])} of our RPC ids are no longer registered.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -56,7 +56,9 @@ _BUNDLE_URL_RE = re.compile(rf'https://www\.gstatic\.com/_/mss/{_APP}/_/js/[^"\\
 # ``'``) so a change in the bundle minifier's quote style doesn't blank the diff.
 _METHOD_PATH_RE = re.compile(r"""["'](/[A-Za-z][\w]*\.[A-Za-z][\w]*)["']""")
 _ID_TOKEN_RE = re.compile(r"""["']([A-Za-z0-9]{5,8})["']""")
-# How far back from a path string to look for its registration id.
+# How far back from a path string to scan for its registration id. The
+# ``_.uD(id, ReqCtor, RespCtor, [flags, path])`` form fits well within ~100 chars;
+# 160 leaves headroom for longer minified constructor names.
 _ID_LOOKBACK = 160
 
 # Real obfuscated rpc ids are short alphanumerics; this filter keeps non-id enum
@@ -131,13 +133,13 @@ def fetch_bundle() -> str:
     from notebooklm._env import get_base_url
     from notebooklm.auth import authuser_query, load_auth_from_storage
 
-    def _get(
+    def _fetch(
         url: str,
         *,
         cookies: dict[str, str] | None = None,
         follow_redirects: bool = False,
         timeout: float = 60.0,
-    ) -> str:
+    ) -> httpx.Response:
         response = httpx.get(
             url,
             headers={"User-Agent": _UA},
@@ -146,27 +148,39 @@ def fetch_bundle() -> str:
             timeout=timeout,
         )
         response.raise_for_status()
-        return response.text
+        return response
 
     cookies = load_auth_from_storage()
-    html = _get(
+    html = _fetch(
         f"{get_base_url()}/?{authuser_query(0)}",
         cookies=cookies,
         follow_redirects=True,
         timeout=30.0,
-    )
+    ).text
     urls = sorted(set(_BUNDLE_URL_RE.findall(html)))
     if not urls:
         raise SystemExit(
             f"No {_APP} bundle URL found in the homepage — not authenticated for "
             "NotebookLM? Run `notebooklm login` (or pass --bundle-file)."
         )
-    return "\n".join(_get(url) for url in urls)
+    # Keep only genuine JS responses: raise_for_status rejects non-200, and this
+    # rejects a 200 served with the wrong content-type (e.g. an HTML login/error
+    # page), which would otherwise be parsed as a bundle and make every id ABSENT.
+    bodies: list[str] = []
+    for url in urls:
+        response = _fetch(url)
+        content_type = response.headers.get("content-type", "")
+        if "javascript" in content_type or "text/plain" in content_type:
+            bodies.append(response.text)
+    if not bodies:
+        raise SystemExit(f"No readable JS bundle content fetched from the {_APP} URLs.")
+    return "\n".join(bodies)
 
 
 def _print_report(
     ours: dict[str, str], live: dict[str, str], buckets: dict[str, dict[str, str]]
 ) -> None:
+    """Print the human-readable diff (counts + per-bucket id listings) to stdout."""
     confirmed, present, absent, unmapped = (
         buckets["confirmed"],
         buckets["present_unparsed"],
@@ -195,6 +209,11 @@ def _print_report(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: load/fetch the bundle, diff vs rpc/types.py, report.
+
+    Returns the process exit code: ``1`` when ``--check`` is set and any of our
+    ids are ABSENT (a rotation/stale alarm), else ``0``.
+    """
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
     parser.add_argument(
         "--json", action="store_true", help="emit a JSON snapshot instead of a report"

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 from scripts.capture_rpc_registry import diff, extract_registry, parse_ids_from_text
 
+# Mixed quote styles on purpose — exercises the quote-agnostic parsing of both
+# the enum (CREATE is single-quoted) and the bundle (the CCqFvf registration).
 _TYPES = """
 class RPCMethod(str, Enum):
     LIST = "wXbhsf"
-    CREATE = "CCqFvf"
+    CREATE = 'CCqFvf'
     GONE = "ZZxxYY"
     UNPARSED = "PuPpY1"
     NOT_AN_ID = "blog_post"
@@ -25,9 +27,9 @@ class SomethingElse(str, Enum):
 # present only as a bare string (not in registration form).
 _BUNDLE = (
     'x=new _.uD("wXbhsf",kF,csb,[_.Ue,!1,_.Se,"/Svc.List"]);'
-    'y=new _.uD("CCqFvf",a.b,c,[_.Ue,!0,_.Se,"/Svc.Create"]);'
+    "y=new _.uD('CCqFvf',a.b,c,[_.Ue,!0,_.Se,'/Svc.Create']);"
     'z=new _.uD("NewOne",p,q,[_.Ue,!1,_.Se,"/Svc.Brand"]);'
-    'log("PuPpY1");'
+    "log('PuPpY1');"
 )
 
 

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -7,7 +7,10 @@ id that is present in the bundle but not parsed must NOT be reported as a rotati
 
 from __future__ import annotations
 
-from scripts.capture_rpc_registry import diff, extract_registry, parse_ids_from_text
+from pathlib import Path
+
+import pytest
+from scripts.capture_rpc_registry import diff, extract_registry, main, parse_ids_from_text
 
 # Mixed quote styles on purpose — exercises the quote-agnostic parsing of both
 # the enum (CREATE is single-quoted) and the bundle (the CCqFvf registration).
@@ -42,6 +45,9 @@ def test_parse_ids_filters_non_ids_and_other_enums() -> None:
         "ZZxxYY": "GONE",
         "PuPpY1": "UNPARSED",
     }
+    # "abcdef" passes the _RPC_ID_RE filter on its own; it is excluded *only* by
+    # the class-scope regex (it lives in SomethingElse). Assert that explicitly.
+    assert "abcdef" not in ids
 
 
 def test_extract_registry() -> None:
@@ -65,3 +71,24 @@ def test_diff_buckets() -> None:
     assert set(buckets["present_unparsed"]) == {"PuPpY1"}
     # NewOne is declared by the bundle but absent from our enum
     assert set(buckets["unmapped"]) == {"NewOne"}
+
+
+def test_main_bundle_file_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """End-to-end offline run of main() via --bundle-file / --types (no network/auth).
+
+    Also exercises the __file__-independent path handling and the --check exit code.
+    """
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    bundle = tmp_path / "bundle.js"
+    bundle.write_text(_BUNDLE, encoding="utf-8")
+
+    rc = main(["--bundle-file", str(bundle), "--types", str(types)])
+    out = capsys.readouterr().out
+    assert rc == 0  # no --check -> 0 even though an id is ABSENT
+    assert "CONFIRMED: 2" in out
+    assert "ABSENT: 1" in out
+    assert "NewOne" in out  # an unmapped live RPC is listed
+
+    # --check turns the ABSENT id (ZZxxYY/GONE) into a non-zero exit
+    assert main(["--bundle-file", str(bundle), "--types", str(types), "--check"]) == 1

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -1,0 +1,65 @@
+"""Unit tests for ``scripts/capture_rpc_registry.py`` (offline; no network/auth).
+
+Covers the pure parse/extract/diff logic, including the edge cases that bit the
+original prototype: non-id enum constants (``blog_post``) must be filtered, and an
+id that is present in the bundle but not parsed must NOT be reported as a rotation.
+"""
+
+from __future__ import annotations
+
+from scripts.capture_rpc_registry import diff, extract_registry, parse_ids_from_text
+
+_TYPES = """
+class RPCMethod(str, Enum):
+    LIST = "wXbhsf"
+    CREATE = "CCqFvf"
+    GONE = "ZZxxYY"
+    UNPARSED = "PuPpY1"
+    NOT_AN_ID = "blog_post"
+
+class SomethingElse(str, Enum):
+    OTHER = "abcdef"
+"""
+
+# Two well-formed registrations, one unmapped registration, and the UNPARSED id
+# present only as a bare string (not in registration form).
+_BUNDLE = (
+    'x=new _.uD("wXbhsf",kF,csb,[_.Ue,!1,_.Se,"/Svc.List"]);'
+    'y=new _.uD("CCqFvf",a.b,c,[_.Ue,!0,_.Se,"/Svc.Create"]);'
+    'z=new _.uD("NewOne",p,q,[_.Ue,!1,_.Se,"/Svc.Brand"]);'
+    'log("PuPpY1");'
+)
+
+
+def test_parse_ids_filters_non_ids_and_other_enums() -> None:
+    ids = parse_ids_from_text(_TYPES)
+    # blog_post (underscore) filtered out; SomethingElse.OTHER excluded (different class)
+    assert ids == {
+        "wXbhsf": "LIST",
+        "CCqFvf": "CREATE",
+        "ZZxxYY": "GONE",
+        "PuPpY1": "UNPARSED",
+    }
+
+
+def test_extract_registry() -> None:
+    assert extract_registry(_BUNDLE) == {
+        "wXbhsf": "/Svc.List",
+        "CCqFvf": "/Svc.Create",
+        "NewOne": "/Svc.Brand",
+    }
+
+
+def test_diff_buckets() -> None:
+    ours = parse_ids_from_text(_TYPES)
+    live = extract_registry(_BUNDLE)
+    buckets = diff(ours, live, _BUNDLE)
+
+    assert set(buckets["confirmed"]) == {"wXbhsf", "CCqFvf"}
+    assert buckets["confirmed"]["wXbhsf"] == "/Svc.List"
+    # GONE is nowhere in the bundle -> a real rotation/stale alarm
+    assert set(buckets["absent"]) == {"ZZxxYY"}
+    # UNPARSED appears as a string but not as a parsed registration -> not an alarm
+    assert set(buckets["present_unparsed"]) == {"PuPpY1"}
+    # NewOne is declared by the bundle but absent from our enum
+    assert set(buckets["unmapped"]) == {"NewOne"}


### PR DESCRIPTION
## What

Adds `scripts/capture_rpc_registry.py` — a tool that extracts NotebookLM's **live RPC id registry** from the web app's JS bundle and diffs it against the 46 ids hardcoded in `src/notebooklm/rpc/types.py`.

The obfuscated rpc ids are this project's documented **#1 breakage class** (they rotate without notice; a stale id silently breaks the operation). Today we only find out when a user files a bug. This turns that into a watchable signal.

## How it works

- **Discovery** needs **one authenticated homepage read** — an unauthenticated request only returns the login (`boq-identity`) app; the NotebookLM (`boq-labs-tailwind`) bundle URL appears only when logged in.
- **Fetching** the bundle is **unauthenticated** (public gstatic CDN).
- **Parsing** is *path-anchored*: it finds each `"/Service.Method"` string and takes the nearest preceding quoted id, which is robust to nested `[...]` in the registration's options array (a single forward regex breaks on the inner `]`).
- Buckets each of our ids as **CONFIRMED / ABSENT (rotation) / PRESENT-UNPARSED / UNMAPPED**.
- `--check` exits non-zero on any ABSENT id (for a nightly canary); `--json` emits a snapshot; `--bundle-file` runs fully offline (no auth/network — the mode the unit test uses).

## Findings (run live against the current bundle)

```
our ids: 46 | live registrations parsed: 111
CONFIRMED: 46  ABSENT: 0  PRESENT-UNPARSED: 0  UNMAPPED: 65
```

**1. No rotations on this cohort** — all 46 of our ids are still registered. (This is the green-path; a future `CCqFvf → AzXHBd`-style flip would show up as ABSENT.)

**2. Full deobfuscation of our ids → backend `/Service.Method`** (these names live only in Google's minified JS):

| id | enum | live method |
|---|---|---|
| `CCqFvf` | CREATE_NOTEBOOK | `…OrchestrationService.CreateProject` |
| `rLM1Ne` | GET_NOTEBOOK | `…OrchestrationService.GetProject` |
| `izAoDd` | ADD_SOURCE | `…OrchestrationService.AddSources` |
| `wXbhsf` | LIST_NOTEBOOKS | `…OrchestrationService.ListRecentlyViewedProjects` |
| `ozz5Z` | GET_USER_TIER | `DasherGrowthPromotionService.FetchRecommendations` |

> The `ozz5Z` mapping incidentally resolves a long-standing open question (whether `ozz5Z` was ADD_SOURCE_V2): it is **GET_USER_TIER → FetchRecommendations**, unrelated to ADD_SOURCE.

**3. 65 unmapped live RPCs we don't expose**, across 10 services:

| service | count | examples |
|---|---|---|
| LabsTailwindOrchestrationService (old) | 25 | `CopyProject`, `DiscoverSources`, `GetProjectAnalytics`, `SubmitFeedback` |
| NotebookService (new) | 13 | `CreateNotebook` (`AzXHBd`), `GetNotebook` (`tHcQ6c`), `ShareNotebook`, `InteractSources` |
| SourceService (new) | 8 | `BatchCreateSources`, `AddTentativeSources`, `RefreshSource` |
| AudioOverviewService (new) | 5 | `CreateAudioOverview`, `GetIceConfig`/`SendSdpOffer` (WebRTC) |
| ArtifactService (new) | 5 | `Create/Get/List/Update/DeleteArtifact` |
| NoteService (new) | 4 | `BatchGetNotes`, `BatchDeleteNotes` |
| AccountService / Sharing / Interaction / DasherGrowth | 4 | account mgmt, `CreateAccessRequest`, … |

This doubles as **migration radar** — our (un-migrated) bundle already registers the entire new-generation `NotebookService`/`SourceService`/… surface (incl. `AzXHBd`), so a cohort flip would be visible here before it breaks anything, and as a **feature backlog** (sharing, discover-sources, copy, batch ops, analytics).

## Value

1. **Id-rotation early warning** for the #1 breakage class (wire it into the nightly canary with `--check`).
2. **Living deobfuscation** of `rpc/types.py` (id ↔ backend method name).
3. **Feature/migration discovery** (the 65 unexposed RPCs).

## Testing

- `tests/unit/test_capture_rpc_registry.py` — offline (no network/auth), exercises parse/extract/diff including the edge cases that bit the prototype (non-id constants like `blog_post` filtered; present-but-unparsed ≠ rotation).
- `ruff` clean; full `tests/_guardrails/` green (1027 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to compare expected RPC method IDs against the live served registry using online bundle retrieval or offline bundle-file input.
  * Produces categorized reports (confirmed, absent, present but not fully parsed, and unmapped extras), optional JSON snapshots, and a CI-friendly `--check` mode that fails when expected IDs are missing.
* **Tests**
  * Added unit and end-to-end offline tests covering extraction, diff bucketing behavior, and `--check` exit-code and reporting expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->