### PR TITLE
feat(scripts): group UNMAPPED RPCs by service family in capture report

### DIFF
--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -16,17 +16,26 @@ ids we hardcode, surfacing four classes:
 * ABSENT          — our id no longer appears in the bundle at all (rotation/stale — the alarm)
 * PRESENT-UNPARSED— our id string is in the bundle but its registration form wasn't
                     parsed (not a rotation; a parser gap to widen, not an alert)
-* UNMAPPED        — a live RPC the bundle declares that we don't expose (new
-                    capability or migration target)
+* UNMAPPED        — a live RPC the bundle declares that we don't expose, grouped by
+                    service family: **current** (old `LabsTailwind*` consumer backend
+                    — callable on our cohort now, just unexposed), **enterprise** (the
+                    Discovery-Engine domain services — the NotebookLM Enterprise /
+                    Agentspace surface on `discoveryengine.googleapis.com`, behind a
+                    server-side VPC Service Controls perimeter; not consumer-callable,
+                    not a consumer migration target), or **other**
 
 Auth: discovering the bundle URL needs **one authenticated homepage read** (an
 unauthenticated request only returns the login app); fetching the bundle itself is
 unauthenticated (public CDN). Run ``notebooklm login`` first, or pass
 ``--bundle-file`` to analyse a pre-saved bundle offline (no auth/network).
 
-Cohort note: the bundle reflects *your account's* cohort. New-generation ids
-(e.g. ``AzXHBd``/``NotebookService.*``) may be registered but gated for
-un-migrated accounts; the active ids are whichever the cohort is served.
+Cohort note: the bundle is shared between the consumer NotebookLM app and the
+enterprise (Agentspace / Vertex AI Search) surface, so it registers BOTH RPC
+generations. The Discovery-Engine ids (e.g. ``AzXHBd``/``NotebookService.*``) are
+the *enterprise* surface — gated off for consumer accounts by a server-side VPC
+Service Controls perimeter (live-probed 2026-06-16: grpc 7 ``VPC_SERVICE_CONTROLS``
+/ ``CONSUMER_INVALID`` on ``discoveryengine.googleapis.com``), not a consumer
+cohort that is "about to migrate".
 
 Usage::
 
@@ -70,6 +79,51 @@ _UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ch
 # Resolved relative to this file (scripts/ -> repo root) so the script runs from
 # any working directory, not just the repo root.
 _DEFAULT_TYPES = Path(__file__).resolve().parent.parent / "src" / "notebooklm" / "rpc" / "types.py"
+
+# --- Service-family classification: consumer backend vs enterprise (Discovery Engine) ---
+# "Current" (the consumer backend serving our cohort now) is detected *empirically*:
+# any service one of our CONFIRMED ids resolves to is, by definition, working for us.
+# Past that, the known Discovery-Engine domain services are tagged "enterprise" — they
+# are the NotebookLM Enterprise / Agentspace surface (discoveryengine.googleapis.com),
+# gated off for consumer accounts by a server-side VPC Service Controls perimeter, NOT a
+# pre-migration consumer cohort. The old NotebookLM family shares the ``LabsTailwind``
+# prefix (same consumer backend, callable on our cohort even where we don't expose it);
+# anything else is "other" — itself a useful drift signal (a new, unclassified service).
+_DISCOVERY_ENGINE_SERVICES = frozenset(
+    {
+        "NotebookService",
+        "SourceService",
+        "NoteService",
+        "ArtifactService",
+        "AudioOverviewService",
+        "AccountService",
+    }
+)
+
+
+def _service_of(method_path: str) -> str:
+    """``/LabsTailwindOrchestrationService.AddSources`` -> ``LabsTailwindOrchestrationService``."""
+    return method_path.lstrip("/").split(".", 1)[0]
+
+
+def classify_service(service: str, current_services: set[str]) -> str:
+    """Tag a service ``current`` / ``enterprise`` / ``other``.
+
+    ``current`` = the consumer backend, works on our cohort today; ``enterprise`` =
+    a Discovery-Engine domain service — the NotebookLM Enterprise / Agentspace
+    surface, gated off for consumer accounts by a VPC Service Controls perimeter
+    (NOT a consumer migration target); ``other`` = unclassified (investigate —
+    possibly a new service). Empirical first (a service our CONFIRMED ids use is
+    ``current``), then the known Discovery-Engine domain services, then the old
+    ``LabsTailwind*`` consumer family.
+    """
+    if service in current_services:
+        return "current"
+    if service in _DISCOVERY_ENGINE_SERVICES:
+        return "enterprise"
+    if service.startswith("LabsTailwind"):
+        return "current"
+    return "other"
 
 
 def parse_ids_from_text(types_text: str) -> dict[str, str]:
@@ -178,7 +232,10 @@ def fetch_bundle() -> str:
 
 
 def _print_report(
-    ours: dict[str, str], live: dict[str, str], buckets: dict[str, dict[str, str]]
+    ours: dict[str, str],
+    live: dict[str, str],
+    buckets: dict[str, dict[str, str]],
+    current_services: set[str],
 ) -> None:
     """Print the human-readable diff (counts + per-bucket id listings) to stdout."""
     confirmed, present, absent, unmapped = (
@@ -203,9 +260,31 @@ def _print_report(
         print("\nPRESENT-UNPARSED — id is in the bundle but registration not parsed (widen regex):")
         for rpc_id in sorted(present, key=lambda i: present[i]):
             print(f"  {rpc_id:<8} {present[rpc_id]}")
-    print(f"\nUNMAPPED — live RPCs we do not expose ({len(unmapped)}):")
-    for rpc_id in sorted(unmapped, key=lambda i: unmapped[i]):
-        print(f"  {rpc_id:<8} {unmapped[rpc_id]}")
+    # Group the unexposed RPCs by service family so "callable on our cohort now"
+    # (current) is visually separated from the gated Discovery-Engine surface.
+    fam_groups: dict[str, list[tuple[str, str]]] = {
+        "current": [],
+        "enterprise": [],
+        "other": [],
+    }
+    for rpc_id, method in unmapped.items():
+        fam_groups[classify_service(_service_of(method), current_services)].append((rpc_id, method))
+    fam_labels = {
+        "current": "UNMAPPED · consumer backend — callable on our cohort now, just not exposed",
+        "enterprise": (
+            "UNMAPPED · enterprise (Discovery Engine / Agentspace) — VPC-SC-gated, "
+            "not consumer-callable, not a migration target"
+        ),
+        "other": "UNMAPPED · other / unclassified services (investigate)",
+    }
+    print(f"\nUNMAPPED — live RPCs we do not expose ({len(unmapped)}), by service family:")
+    for fam in ("current", "enterprise", "other"):
+        items = fam_groups[fam]
+        if not items:
+            continue
+        print(f"\n  {fam_labels[fam]} ({len(items)}):")
+        for rpc_id, method in sorted(items, key=lambda x: x[1]):
+            print(f"    {rpc_id:<8} {method}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -229,6 +308,8 @@ def main(argv: list[str] | None = None) -> int:
     bundle = args.bundle_file.read_text(encoding="utf-8") if args.bundle_file else fetch_bundle()
     live = extract_registry(bundle)
     buckets = diff(ours, live, bundle)
+    # Services any CONFIRMED id resolves to are, empirically, serving our cohort.
+    current_services = {_service_of(m) for m in buckets["confirmed"].values()}
 
     if args.json:
         print(
@@ -239,7 +320,13 @@ def main(argv: list[str] | None = None) -> int:
                     },
                     "absent": buckets["absent"],
                     "present_unparsed": buckets["present_unparsed"],
-                    "unmapped": buckets["unmapped"],
+                    "unmapped": {
+                        i: {
+                            "method": m,
+                            "family": classify_service(_service_of(m), current_services),
+                        }
+                        for i, m in buckets["unmapped"].items()
+                    },
                     "counts": {k: len(v) for k, v in buckets.items()} | {"ours": len(ours)},
                 },
                 indent=2,
@@ -247,7 +334,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        _print_report(ours, live, buckets)
+        _print_report(ours, live, buckets, current_services)
 
     if args.check and buckets["absent"]:
         print(

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -237,7 +237,12 @@ def _print_report(
     buckets: dict[str, dict[str, str]],
     current_services: set[str],
 ) -> None:
-    """Print the human-readable diff (counts + per-bucket id listings) to stdout."""
+    """Print the human-readable diff (counts + per-bucket id listings) to stdout.
+
+    ``current_services`` is the empirically-derived set of services our CONFIRMED
+    ids resolve to; it drives the UNMAPPED service-family grouping
+    (``current`` / ``enterprise`` / ``other``) via :func:`classify_service`.
+    """
     confirmed, present, absent, unmapped = (
         buckets["confirmed"],
         buckets["present_unparsed"],

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -7,6 +7,7 @@ id that is present in the bundle but not parsed must NOT be reported as a rotati
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -126,3 +127,27 @@ def test_classify_service() -> None:
     assert classify_service("SourceService", current) == "enterprise"
     # Anything else is an unclassified drift signal -> other.
     assert classify_service("InteractionEventService", current) == "other"
+    # Empirical precedence: when a known DE service IS in the empirical current set,
+    # "current" wins over the DE-name rule — locks the documented empirical-first
+    # ordering (the ``in current_services`` check must precede the DE-set check).
+    assert classify_service("NotebookService", {"NotebookService"}) == "current"
+
+
+def test_main_json_includes_unmapped_family(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--json carries the per-id unmapped ``{method, family}`` schema (contract guard)."""
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    bundle = tmp_path / "bundle.js"
+    bundle.write_text(_BUNDLE, encoding="utf-8")
+
+    rc = main(["--bundle-file", str(bundle), "--types", str(types), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    # NewOne (/Svc.Brand) is bundle-declared but absent from our enum -> unmapped.
+    # ``Svc`` is the service our CONFIRMED ids resolve to (wXbhsf/CCqFvf -> /Svc.List,
+    # /Svc.Create), so empirical-first classification tags this family "current" — this
+    # also exercises the empirical path through the --json output, not just the schema.
+    assert payload["unmapped"]["NewOne"] == {"method": "/Svc.Brand", "family": "current"}

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from scripts.capture_rpc_registry import diff, extract_registry, main, parse_ids_from_text
+from scripts.capture_rpc_registry import (
+    _service_of,
+    classify_service,
+    diff,
+    extract_registry,
+    main,
+    parse_ids_from_text,
+)
 
 # Mixed quote styles on purpose — exercises the quote-agnostic parsing of both
 # the enum (CREATE is single-quoted) and the bundle (the CCqFvf registration).
@@ -92,3 +99,30 @@ def test_main_bundle_file_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str
 
     # --check turns the ABSENT id (ZZxxYY/GONE) into a non-zero exit
     assert main(["--bundle-file", str(bundle), "--types", str(types), "--check"]) == 1
+
+
+def test_service_of() -> None:
+    assert _service_of("/LabsTailwindOrchestrationService.AddSources") == (
+        "LabsTailwindOrchestrationService"
+    )
+    # Leading slash optional; only the segment before the first dot is the service.
+    assert _service_of("NotebookService.CreateNotebook") == "NotebookService"
+
+
+def test_classify_service() -> None:
+    # `current_services` is what the run discovered empirically (services our
+    # CONFIRMED ids resolve to) — it always wins, even for a name we'd otherwise
+    # bucket elsewhere.
+    current = {"LabsTailwindOrchestrationService", "DasherGrowthPromotionService"}
+
+    # Empirical hit -> current.
+    assert classify_service("LabsTailwindOrchestrationService", current) == "current"
+    # A current-hit on a non-LabsTailwind name still wins via the empirical set.
+    assert classify_service("DasherGrowthPromotionService", current) == "current"
+    # Old family by prefix (not in the empirical set this run) -> current.
+    assert classify_service("LabsTailwindSharingService", current) == "current"
+    # Known Discovery-Engine domain services -> enterprise (Agentspace/Vertex surface).
+    assert classify_service("NotebookService", current) == "enterprise"
+    assert classify_service("SourceService", current) == "enterprise"
+    # Anything else is an unclassified drift signal -> other.
+    assert classify_service("InteractionEventService", current) == "other"


### PR DESCRIPTION
Follow-up to #1585 (merged). That PR landed `capture_rpc_registry.py` with a **flat** UNMAPPED list — every live-but-unexposed RPC in one block. This PR groups them by service family so the report directly distinguishes "what's callable on our consumer cohort" from "what's the enterprise (Discovery Engine) surface."

## What changed

The UNMAPPED bucket mixed two operationally distinct populations registered in the same shared frontend bundle:

- the **old `LabsTailwind*` consumer backend** — callable on our cohort today, just not surfaced by the client, and
- the **Discovery-Engine domain services** (`NotebookService`, `SourceService`, `NoteService`, `ArtifactService`, `AudioOverviewService`, `AccountService`) — the **NotebookLM Enterprise / Agentspace** surface, gated off for consumer accounts.

Now each unexposed RPC is classified into three families:

| family | meaning |
|---|---|
| `current` | old `LabsTailwind*` consumer backend (+ any service a CONFIRMED id empirically resolves to) — works on our cohort now |
| `enterprise` | the Discovery-Engine domain services — NotebookLM Enterprise / Agentspace on `discoveryengine.googleapis.com`, behind a server-side VPC Service Controls perimeter; **not consumer-callable, not a migration target** |
| `other` | unclassified — a genuinely new service = drift signal to investigate |

Detection is **empirical-first**: any service one of our CONFIRMED ids maps to is tagged `current` even when it isn't `LabsTailwind*` (e.g. `DasherGrowthPromotionService`, which our `ozz5Z`/`GET_USER_TIER` uses). Then the known DE domain services → `enterprise`, then the `LabsTailwind` prefix, else `other`.

Both outputs carry it: the human report prints three grouped sections; `--json` adds a per-id `family` field.

## Why `enterprise`, not "gated until migration"

Grounded in a **live probe (2026-06-16)**: well-formed resource-name requests (`projects/670560280865/locations/global/notebooks/<id>...`) to `NotebookService.GetNotebook`, `SourceService.GetSource`, and `NoteService.BatchDeleteNotes` all return:

```
grpc 7 PERMISSION_DENIED
  google.rpc.PreconditionFailure -> VPC_SERVICE_CONTROLS
  google.rpc.ErrorInfo -> reason=SECURITY_POLICY_VIOLATED / CONSUMER_INVALID,
                          service=discoveryengine.googleapis.com
```

The code is **shape-dependent** (malformed -> 3 INVALID_ARGUMENT; well-formed -> 7 VPC-SC), proving the request authenticates and reaches server-side parsing — so the block is a **server-side enterprise perimeter**, not authentication and not a consumer cohort awaiting migration. `discoveryengine.googleapis.com` is Vertex AI Search / Agentspace (the enterprise product); the bundle is shared across consumer + enterprise (its logging allowlist includes `agentspace.google` / `vertexaisearch.cloud.google`). A consumer cookie-authed client cannot cross VPC-SC by construction.

## Live findings (today's bundle)

```
CONFIRMED: 46  ABSENT: 0  PRESENT-UNPARSED: 0  UNMAPPED: 67

UNMAPPED - consumer backend - callable on our cohort now, just not exposed (28)
  e.g. te3DCe /...CopyProject, Es3dTe /...DiscoverSources, AHyHrd /...CreateAudioOverview
UNMAPPED - enterprise (Discovery Engine / Agentspace) - VPC-SC-gated (37)
  the full new family: AzXHBd /NotebookService.CreateNotebook, rG2vCb, ZMz0Qe /NoteService.BatchDeleteNotes, ...
UNMAPPED - other / unclassified (investigate) (2)
  GJw9Bd /CompletionService.CompleteExternalIdentities, HpN0Ub /InteractionEventService.LogInteractionEvent
```

## Tests

Offline unit coverage for `_service_of` / `classify_service` (empirical-hit, old-family-by-prefix, enterprise-by-name, other). `uv run pytest tests/unit/test_capture_rpc_registry.py` -> 6 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RPC registry capture now groups previously unmapped live RPCs into service families: current, enterprise, and other.
  * Human-readable reports now display unmapped RPCs with per-family section headers and sorted listings.
  * Updated JSON output so unmapped RPC entries include the computed service family classification.

* **Tests**
  * Added unit tests covering service-name extraction, service family classification rules (including precedence), and the updated JSON schema for unmapped entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->