### PR TITLE
docs(rpc): correct RPC method semantics from live registry (Rosetta-Stone pass)

### DIFF
--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -201,7 +201,11 @@ class ArtifactDownloadService:
         )
 
     async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
-        """Fetch interactive artifact HTML through the runtime RPC seam."""
+        """Fetch interactive artifact HTML through the runtime RPC seam.
+
+        ``GET_INTERACTIVE_HTML`` is the live generic ``GetArtifact`` getter; here
+        we read the HTML body at ``[0][9][0]`` (quiz / flashcard content).
+        """
         result = await self._rpc.rpc_call(
             RPCMethod.GET_INTERACTIVE_HTML,
             [artifact_id],

--- a/src/notebooklm/_artifact/generation.py
+++ b/src/notebooklm/_artifact/generation.py
@@ -465,10 +465,11 @@ class ArtifactGenerationService:
             instructions=instructions,
         )
 
-        # GENERATE_MIND_MAP is classified PROBE_THEN_CREATE in
-        # ``_idempotency.py``. ``operation_variant=None`` is passed
-        # explicitly to document this call site as the no-variant default
-        # (the registry resolves the same entry either way; the explicit
+        # GENERATE_MIND_MAP is the live ``ActOnSources`` — a generic
+        # source-action op we drive with mind-map params; it is classified
+        # PROBE_THEN_CREATE in ``_idempotency.py``. ``operation_variant=None``
+        # is passed explicitly to document this call site as the no-variant
+        # default (the registry resolves the same entry either way; the explicit
         # kwarg is a future-proofing marker for a possible variant table).
         result = await self._rpc.rpc_call(
             RPCMethod.GENERATE_MIND_MAP,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -832,7 +832,7 @@ class ArtifactsAPI:
         title: str = "Export",
         export_type: ExportType = ExportType.DOCS,
     ) -> Any:
-        """Export any artifact to Google Docs/Sheets (generic; ``export_type`` selects)."""
+        """Export any artifact to Google Drive (live ``ExportToDrive``; ``export_type`` picks Docs/Sheets)."""
         params = [None, artifact_id, content, title, int(export_type)]
         return await self._rpc.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -671,6 +671,9 @@ class ChatAPI(LoopBoundPrimitive):
         # so a concurrent follow-up can't read pre-delete history then POST it
         # after the delete cleared both server-side state and the local cache.
         async with self._get_conversation_lock(conversation_id):
+            # DELETE_CONVERSATION is the live ``DeleteChatTurns``: it deletes the
+            # conversation's chat turns (the "Delete history" action), not a
+            # standalone conversation entity.
             # Param shape from web-UI traffic; trailing 1 is a fixed flag.
             params: list[Any] = [[], conversation_id, None, 1]
             await self._rpc.rpc_call(

--- a/src/notebooklm/_idempotency_policy.py
+++ b/src/notebooklm/_idempotency_policy.py
@@ -122,7 +122,9 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
         ),
     )
 
-    # GENERATE_MIND_MAP — generation RPC with no client-token slot.
+    # GENERATE_MIND_MAP (live method ``ActOnSources``, a generic source-action
+    # op we drive to generate a mind map) — generation RPC with no client-token
+    # slot.
     # Params are ``[source_ids_nested, None, None, None, None,
     # ["interactive_mindmap", [["[CONTEXT]", instructions]], language], None,
     # [2, None, [1]]]`` (see ``ArtifactsAPI.generate_mind_map`` in
@@ -320,8 +322,11 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
     # default because transport retries remain enabled.
 
     _IDEMPOTENT_READ_OR_SET_OP_NOTES: dict[RPCMethod, str] = {
-        RPCMethod.LIST_NOTEBOOKS: "read-only list; replay does not mutate notebook state",
+        # Live method ListRecentlyViewedProjects: a read-only recents list.
+        RPCMethod.LIST_NOTEBOOKS: "read-only recents list; replay does not mutate notebook state",
         RPCMethod.GET_NOTEBOOK: "read-only notebook fetch; replay does not mutate notebook state",
+        # Live method MutateProject (generic notebook mutator; covers title plus
+        # chat-config and view-level via different params).
         RPCMethod.RENAME_NOTEBOOK: (
             "set notebook title/settings to caller-supplied values; replay leaves the same state"
         ),
@@ -332,8 +337,10 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
         RPCMethod.UPDATE_SOURCE: (
             "set source metadata/title to caller-supplied values; replay leaves the same state"
         ),
+        # Live method GenerateNotebookGuide: generates the notebook guide
+        # (summary + suggested questions); response-only, persists nothing.
         RPCMethod.SUMMARIZE: (
-            "response-only notebook summary generation; no persisted resource is created by replay"
+            "response-only notebook guide generation; no persisted resource is created by replay"
         ),
         RPCMethod.GET_SOURCE_GUIDE: (
             "response-only source guide fetch/generation; no persisted resource is created by replay"
@@ -348,10 +355,16 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
         RPCMethod.SHARE_ARTIFACT: (
             "legacy public share-link state update; replay leaves the same share state"
         ),
+        # Live method GetArtifact: a generic single-artifact getter (we use it
+        # to fetch interactive-artifact HTML / mind-map tree). Read-only.
         RPCMethod.GET_INTERACTIVE_HTML: (
-            "read-only artifact HTML fetch; replay does not mutate artifact state"
+            "read-only artifact fetch; replay does not mutate artifact state"
         ),
+        # Live method ListDiscoverSourcesJob (the research family is the
+        # DiscoverSources pipeline).
         RPCMethod.POLL_RESEARCH: "read-only research task poll; replay does not start a task",
+        # Live method GetNotes: mind maps come back as JSON-bodied notes, so a
+        # single GetNotes read returns both.
         RPCMethod.GET_NOTES_AND_MIND_MAPS: (
             "read-only notes/mind-maps list; replay does not mutate note state"
         ),
@@ -365,18 +378,32 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
         RPCMethod.GET_CONVERSATION_TURNS: (
             "read-only conversation history fetch; replay does not mutate chat state"
         ),
+        # Live method DeleteChatTurns: deletes the conversation's chat turns
+        # (the web UI "Delete history" action), idempotent set-op.
         RPCMethod.DELETE_CONVERSATION: (
-            "server-side conversation delete is idempotent (set-op semantics)"
+            "server-side chat-turn delete is idempotent (set-op semantics)"
         ),
         RPCMethod.GET_SHARE_STATUS: "read-only share status fetch; replay does not mutate ACL state",
         RPCMethod.REMOVE_RECENTLY_VIEWED: (
             "remove notebook from recents is idempotent; replay leaves it absent"
         ),
-        RPCMethod.GET_USER_SETTINGS: "read-only settings fetch; replay does not mutate settings",
+        # Live method GetOrCreateAccount: the first call may create the account
+        # server-side, but every call (including replay) converges to the same
+        # account state, so replay creates no *additional* resource.
+        RPCMethod.GET_USER_SETTINGS: (
+            "GetOrCreateAccount settings fetch; replay converges to the same account state"
+        ),
+        # Live method MutateAccount (generic account mutator; we use it only for
+        # the output-language setting).
         RPCMethod.SET_USER_SETTINGS: (
             "set user settings to caller-supplied values; replay leaves the same state"
         ),
-        RPCMethod.GET_USER_TIER: "read-only account tier fetch; replay does not mutate account state",
+        # Live method FetchRecommendations on DasherGrowthPromotionService — a
+        # read-only promotions/recommendations fetch, not a tier lookup (the
+        # "tier" is scraped from the recommendations payload). Replay-safe.
+        RPCMethod.GET_USER_TIER: (
+            "read-only promotions/recommendations fetch; replay does not mutate account state"
+        ),
         RPCMethod.LIST_LABELS: "read-only label list; replay does not mutate label state",
         RPCMethod.UPDATE_LABEL: (
             "default (rename / set-emoji) sets label fields to caller-supplied values; "

--- a/src/notebooklm/_mind_maps_api.py
+++ b/src/notebooklm/_mind_maps_api.py
@@ -37,9 +37,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The interactive (studio-artifact) mind map exposes its ``{"name", "children"}``
-# node tree at ``[0][9][3]`` of the ``GET_INTERACTIVE_HTML`` response (vs the HTML
-# body at ``[0][9][0]``). The leaf at ``[3]`` is the only position that may be
+# ``GET_INTERACTIVE_HTML`` is the live ``GetArtifact`` — a generic
+# single-artifact getter, not an interactive-HTML-specific endpoint. For an
+# interactive (studio-artifact) mind map its response carries the
+# ``{"name", "children"}`` node tree at ``[0][9][3]`` (vs the HTML body at
+# ``[0][9][0]``). The leaf at ``[3]`` is the only position that may be
 # legitimately absent during the brief window after completion before the
 # options block is fully populated.
 _INTERACTIVE_TREE_LEAF_POS = 3

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -354,10 +354,11 @@ class NotebooksAPI:
         """List notebooks (most-recently-viewed first).
 
         .. note::
-            The backing RPC is ``ListRecentlyViewedProjects``, so this returns
-            the account's *recently viewed* notebooks rather than a guaranteed
-            exhaustive inventory. In practice this is the same set the
-            NotebookLM home page shows.
+            The backing RPC is ``ListRecentlyViewedProjects`` — results are
+            ordered most-recently-viewed first (live-observed). It is not
+            independently confirmed whether this can ever omit an *owned*
+            notebook; in practice it matches the set shown on the NotebookLM
+            home page.
 
         Returns:
             List of Notebook objects.

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -351,7 +351,13 @@ class NotebooksAPI:
         return source_ids
 
     async def list(self) -> list[Notebook]:
-        """List all notebooks.
+        """List notebooks (most-recently-viewed first).
+
+        .. note::
+            The backing RPC is ``ListRecentlyViewedProjects``, so this returns
+            the account's *recently viewed* notebooks rather than a guaranteed
+            exhaustive inventory. In practice this is the same set the
+            NotebookLM home page shows.
 
         Returns:
             List of Notebook objects.
@@ -658,6 +664,8 @@ class NotebooksAPI:
             no longer enters its block.
         """
         logger.debug("Deleting notebook: %s", notebook_id)
+        # DELETE_NOTEBOOK is the live ``DeleteProjects`` (batch-capable: the
+        # leading slot is a list of ids); we delete a single notebook per call.
         params = [[notebook_id], [2]]
         await self._rpc.rpc_call(RPCMethod.DELETE_NOTEBOOK, params)
 
@@ -672,6 +680,10 @@ class NotebooksAPI:
             The renamed Notebook object (fetched after rename).
         """
         logger.debug("Renaming notebook %s to: %s", notebook_id, new_title)
+        # RENAME_NOTEBOOK is the live ``MutateProject``, a generic notebook
+        # mutator: the same RPC sets the title here, chat config in
+        # ``ChatAPI.configure``, and the share view-level in
+        # ``SharingAPI.set_view_level`` — each with a different params shape.
         # Payload format discovered via browser traffic capture:
         # [notebook_id, [[null, null, null, [null, new_title]]]]
         params = [notebook_id, [[None, None, None, [None, new_title]]]]
@@ -720,6 +732,12 @@ class NotebooksAPI:
 
         This provides a high-level overview of what the notebook contains,
         similar to what's shown in the Chat panel when opening a notebook.
+
+        .. note::
+            The backing RPC is ``GenerateNotebookGuide`` — it produces the
+            notebook *guide*: a short summary plus suggested starter questions
+            (each ``SuggestedTopic`` carries the question and its chat prompt),
+            rather than a freeform summary alone.
 
         Args:
             notebook_id: The notebook ID.

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -341,6 +341,10 @@ class ResearchAPI:
         # 1 = Web, 2 = Drive
         source_type = 1 if source_lower == "web" else 2
 
+        # The whole research feature is Google's "DiscoverSources" pipeline:
+        # fast -> DiscoverSourcesManifold, deep -> DiscoverSourcesAsync,
+        # POLL_RESEARCH -> ListDiscoverSourcesJob, IMPORT_RESEARCH ->
+        # FinishDiscoverSourcesRun. "Research" is our label for that pipeline.
         if mode_lower == "fast":
             params = [[query, source_type], None, 1, notebook_id]
             rpc_id = RPCMethod.START_FAST_RESEARCH

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -72,10 +72,10 @@ MIND_MAP_LEAF_ABSENT: Any = object()
 def unwrap_mind_map_generation_leaf(result: Any, *, method_id: str, source: str) -> Any:
     """Return the JSON leaf at ``result[0][0]`` of a ``GENERATE_MIND_MAP`` reply.
 
-    The ``GENERATE_MIND_MAP`` (``cu1Hbf``) reply nests the mind-map JSON payload
-    two levels deep (``[[mind_map_json]]``). This centralises the ``result[0]`` /
-    ``inner[0]`` descent ``ArtifactsAPI.generate_mind_map`` previously open-coded
-    (issue #1491).
+    The ``GENERATE_MIND_MAP`` (``yyryJe``, live method ``ActOnSources``) reply
+    nests the mind-map JSON payload two levels deep (``[[mind_map_json]]``). This
+    centralises the ``result[0]`` / ``inner[0]`` descent
+    ``ArtifactsAPI.generate_mind_map`` previously open-coded (issue #1491).
 
     The descent is **soft** (preserving the historical contract): a short /
     non-list payload, or a short / non-list inner list, returns the

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -25,7 +25,13 @@ _TIER_PLAN_NAMES = {
 
 
 def build_get_user_settings_params() -> list[Any]:
-    """Build GET_USER_SETTINGS params without sharing a mutable list."""
+    """Build GET_USER_SETTINGS params without sharing a mutable list.
+
+    The live endpoint is ``GetOrCreateAccount``: it returns the account record
+    (output-language settings and account-level limits) and may create the
+    account server-side on the first call, so it is account-level rather than a
+    pure settings read.
+    """
     return [
         None,
         [1, None, None, None, None, None, None, None, None, None, [1]],
@@ -33,7 +39,14 @@ def build_get_user_settings_params() -> list[Any]:
 
 
 def build_get_user_tier_params() -> list[Any]:
-    """Build GET_USER_TIER params for the NotebookLM homepage context."""
+    """Build GET_USER_TIER params for the NotebookLM homepage context.
+
+    Despite the ``GET_USER_TIER`` enum name, the live endpoint is
+    ``FetchRecommendations`` on ``DasherGrowthPromotionService`` — a
+    promotions/growth recommendations fetch scoped to the homepage context,
+    not a subscription-tier lookup. We read the tier off the recommendations
+    payload as a best-effort signal (see :func:`extract_account_tier`).
+    """
     return [
         [
             [
@@ -144,7 +157,12 @@ def extract_account_limits(data: list | None) -> AccountLimits:
 
 
 def _find_tier_string(value: Any) -> str | None:
-    """Find the first NotebookLM tier string in a nested response."""
+    """Find the first ``NOTEBOOKLM_TIER_*`` string in a nested response.
+
+    The response is a promotions/recommendations payload (the live endpoint is
+    ``FetchRecommendations``), so the tier string is embedded at an unstable
+    depth — hence the stack-walk rather than a fixed index path.
+    """
     stack = [value]
     while stack:
         item = stack.pop()
@@ -156,7 +174,15 @@ def _find_tier_string(value: Any) -> str | None:
 
 
 def extract_account_tier(data: list | None) -> AccountTier:
-    """Extract the NotebookLM subscription tier from GET_USER_TIER response data."""
+    """Extract the NotebookLM tier signal from GET_USER_TIER response data.
+
+    GET_USER_TIER is the live ``FetchRecommendations`` promotions endpoint, so
+    ``data`` is a recommendations payload rather than an account record. The
+    returned ``AccountTier.tier`` is the ``NOTEBOOKLM_TIER_*`` string embedded
+    in that payload — a promotion-eligibility signal that tracks the plan, not
+    an authoritative subscription-tier field. Returns an empty ``AccountTier``
+    when no such string is present.
+    """
     tier = _find_tier_string(data)
     return AccountTier(tier=tier, plan_name=_TIER_PLAN_NAMES.get(tier) if tier else None)
 
@@ -285,7 +311,15 @@ class SettingsAPI:
         return limits
 
     async def get_account_tier(self) -> AccountTier:
-        """Get the NotebookLM subscription tier for the current account.
+        """Get the NotebookLM tier signal for the current account.
+
+        .. note::
+            This calls the homepage promotions endpoint (live method
+            ``FetchRecommendations`` on ``DasherGrowthPromotionService``), not a
+            dedicated tier API. The returned tier is a ``NOTEBOOKLM_TIER_*``
+            string scraped from the recommendations payload — a best-effort
+            signal that tracks the subscription plan rather than an
+            authoritative tier field. It may be absent even for a paid account.
 
         Returns:
             AccountTier with the raw tier string and a friendly plan name when known.

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -52,76 +52,116 @@ class RPCMethod(str, Enum):
 
     These are obfuscated method identifiers used by the batchexecute API.
     Reverse-engineered from network traffic analysis.
+
+    Many members carry a ``-> <Method>`` comment (trailing, or on the line
+    above when it would overflow) naming the live
+    ``/LabsTailwindOrchestrationService.<Method>`` endpoint the obfuscated id
+    resolves to (recovered from Google's own id registry; entries on a
+    *different* service spell out the service prefix). That backend name is the
+    source of truth for what the RPC *actually does* — our enum member name is a
+    reverse-engineered label that is sometimes narrower or older than the real
+    method. Where the two diverge (e.g. ``LIST_NOTEBOOKS -> ListRecentlyViewedProjects``,
+    ``GENERATE_MIND_MAP -> ActOnSources``, ``GET_USER_TIER -> FetchRecommendations``
+    on a *promotions* service), the comment is the authoritative semantics and
+    the divergence is documented at the call site too. The member names
+    themselves are part of the internal RPC contract and are intentionally left
+    unchanged; only the clarifying comments were corrected.
     """
 
     # Notebook operations
-    LIST_NOTEBOOKS = "wXbhsf"
-    CREATE_NOTEBOOK = "CCqFvf"
-    GET_NOTEBOOK = "rLM1Ne"
-    RENAME_NOTEBOOK = "s0tc2d"
-    DELETE_NOTEBOOK = "WWINqb"
+    LIST_NOTEBOOKS = "wXbhsf"  # -> ListRecentlyViewedProjects (recents, NOT all notebooks)
+    CREATE_NOTEBOOK = "CCqFvf"  # -> CreateProject
+    GET_NOTEBOOK = "rLM1Ne"  # -> GetProject
+    RENAME_NOTEBOOK = "s0tc2d"  # -> MutateProject (generic notebook mutator; see note below)
+    DELETE_NOTEBOOK = "WWINqb"  # -> DeleteProjects (batch-capable; we send a single id)
 
     # Source operations
-    ADD_SOURCE = "izAoDd"
-    ADD_SOURCE_FILE = "o4cbdc"  # Register uploaded file as source
-    DELETE_SOURCE = "tGMBJ"
-    GET_SOURCE = "hizoJc"
-    REFRESH_SOURCE = "FLmJqe"
-    CHECK_SOURCE_FRESHNESS = "yR9Yof"
-    UPDATE_SOURCE = "b7Wfje"
+    ADD_SOURCE = "izAoDd"  # -> AddSources (batch-capable; we send a single source)
+    # NOTE: the live registry path-extractor paired o4cbdc with ``AddTentativeSources``,
+    # but that is almost certainly a mis-pairing — this id is the upload-register
+    # step for a file already staged via the upload endpoint, whereas
+    # AddTentativeSources is a discover-sources op. Treat the real method as
+    # unconfirmed; do not relabel from the suspect pairing.
+    ADD_SOURCE_FILE = "o4cbdc"  # Register uploaded file as source (live /Method unconfirmed)
+    DELETE_SOURCE = "tGMBJ"  # -> DeleteSources (batch-capable; we send a single source)
+    GET_SOURCE = "hizoJc"  # -> LoadSource
+    REFRESH_SOURCE = "FLmJqe"  # -> RefreshSource
+    CHECK_SOURCE_FRESHNESS = "yR9Yof"  # -> CheckSourceFreshness
+    UPDATE_SOURCE = "b7Wfje"  # -> MutateSource
 
     # Source label operations (AI topic grouping)
-    CREATE_LABEL = "agX4Bc"  # Multi-mode: AI auto-group (generate) AND manual create
-    LIST_LABELS = "I3xc3c"
-    UPDATE_LABEL = "le8sX"  # Rename / set emoji / add sources (fieldmask)
-    DELETE_LABEL = "GyzE7e"  # Batch delete by id
+    # -> CreateLabel. Multi-mode: AI auto-group (generate) AND manual create
+    CREATE_LABEL = "agX4Bc"
+    LIST_LABELS = "I3xc3c"  # -> GetLabels
+    UPDATE_LABEL = "le8sX"  # -> MutateLabel. Rename / set emoji / add sources (fieldmask)
+    DELETE_LABEL = "GyzE7e"  # -> DeleteLabels. Batch delete by id
 
     # Summary and query
-    SUMMARIZE = "VfAZjd"
-    GET_SOURCE_GUIDE = "tr032e"
-    GET_SUGGESTED_REPORTS = "ciyUvf"  # AI-suggested report formats
+    SUMMARIZE = "VfAZjd"  # -> GenerateNotebookGuide (guide w/ summary + suggested questions)
+    GET_SOURCE_GUIDE = "tr032e"  # -> GenerateDocumentGuides
+    GET_SUGGESTED_REPORTS = "ciyUvf"  # -> GenerateReportSuggestions. AI-suggested report formats
 
     # Artifact operations
-    CREATE_ARTIFACT = "R7cb6c"  # Generate any artifact (audio, video, report, quiz, etc.)
-    LIST_ARTIFACTS = "gArtLc"  # List all artifacts in a notebook
-    DELETE_ARTIFACT = "V5N4be"
+    # -> CreateArtifact. Generate any artifact (audio, video, report, quiz, etc.)
+    CREATE_ARTIFACT = "R7cb6c"
+    LIST_ARTIFACTS = "gArtLc"  # -> ListArtifacts. List all artifacts in a notebook
+    DELETE_ARTIFACT = "V5N4be"  # -> DeleteArtifact
+    # -> UpdateArtifact (generic artifact updater; we only set the title)
     RENAME_ARTIFACT = "rc3d8d"
+    # -> ExportToDrive (Google Drive only; Docs/Sheets are Drive destinations)
     EXPORT_ARTIFACT = "Krh3pd"
-    SHARE_ARTIFACT = "RGP97b"
-    GET_INTERACTIVE_HTML = "v9rmvd"  # Fetch quiz/flashcard HTML content (also serves interactive mind map data at [0][9][3])
-    REVISE_SLIDE = "KmcKPe"  # Revise individual slide with prompt
-    RETRY_ARTIFACT = "Rytqqe"  # Retry a failed Studio artifact in place (UI "Retry")
+    SHARE_ARTIFACT = "RGP97b"  # -> LabsTailwindSharingService.ShareAudio
+    # -> GetArtifact. A GENERIC single-artifact getter, not interactive-HTML-specific:
+    # for type-4 artifacts it returns the quiz/flashcard HTML at [0][9][0] and the
+    # interactive mind map node tree at [0][9][3]. The enum name reflects only the
+    # interactive-HTML use we expose.
+    GET_INTERACTIVE_HTML = "v9rmvd"
+    REVISE_SLIDE = "KmcKPe"  # -> DeriveArtifact (generic derive op; we use it to revise a slide)
+    # -> GenerateArtifact. Retry a failed Studio artifact in place (UI "Retry")
+    RETRY_ARTIFACT = "Rytqqe"
 
-    # Research
-    START_FAST_RESEARCH = "Ljjv0c"
-    START_DEEP_RESEARCH = "QA9ei"
-    POLL_RESEARCH = "e3bVqc"
-    IMPORT_RESEARCH = "LBwxtb"
+    # Research — the whole family is backed by Google's "DiscoverSources" pipeline
+    START_FAST_RESEARCH = "Ljjv0c"  # -> DiscoverSourcesManifold
+    START_DEEP_RESEARCH = "QA9ei"  # -> DiscoverSourcesAsync
+    POLL_RESEARCH = "e3bVqc"  # -> ListDiscoverSourcesJob
+    IMPORT_RESEARCH = "LBwxtb"  # -> FinishDiscoverSourcesRun
 
     # Note and mind map operations
-    GENERATE_MIND_MAP = "yyryJe"  # Generate mind map from sources
-    CREATE_NOTE = "CYK0Xb"
-    GET_NOTES_AND_MIND_MAPS = "cFji9"  # Returns both notes and mind maps
-    UPDATE_NOTE = "cYAfTb"
-    DELETE_NOTE = "AH0mwd"
+    # -> ActOnSources (generic source-action op; we use it to generate a mind map)
+    GENERATE_MIND_MAP = "yyryJe"
+    CREATE_NOTE = "CYK0Xb"  # -> CreateNote
+    # -> GetNotes (mind maps come back as JSON-bodied notes; see _note_service)
+    GET_NOTES_AND_MIND_MAPS = "cFji9"
+    UPDATE_NOTE = "cYAfTb"  # -> MutateNote
+    DELETE_NOTE = "AH0mwd"  # -> DeleteNotes (batch-capable; we send a single note)
 
     # Conversation
-    GET_LAST_CONVERSATION_ID = "hPTbtc"  # Returns only the most recent conversation ID
-    GET_CONVERSATION_TURNS = "khqZz"  # Returns full Q&A turns for a conversation
-    DELETE_CONVERSATION = "J7Gthc"  # Delete a conversation (web UI's "Delete history" action)
+    # -> ListChatSessions (we read only the most recent session id)
+    GET_LAST_CONVERSATION_ID = "hPTbtc"
+    GET_CONVERSATION_TURNS = "khqZz"  # -> ListChatTurns. Returns full Q&A turns for a conversation
+    # -> DeleteChatTurns (deletes the chat turns; web UI's "Delete history")
+    DELETE_CONVERSATION = "J7Gthc"
 
     # Sharing operations (notebook-level)
-    SHARE_NOTEBOOK = "QDyure"  # Set notebook visibility (restricted/anyone with link)
-    GET_SHARE_STATUS = "JFMDGd"  # Get notebook share settings
+    SHARE_NOTEBOOK = "QDyure"  # -> LabsTailwindSharingService.ShareProject. Set notebook visibility
+    # -> LabsTailwindSharingService.GetProjectDetails. Get notebook share settings
+    GET_SHARE_STATUS = "JFMDGd"
     # Note: SET_SHARE_ACCESS uses RENAME_NOTEBOOK (s0tc2d) with different params
 
     # Additional notebook operations
-    REMOVE_RECENTLY_VIEWED = "fejl7e"
+    REMOVE_RECENTLY_VIEWED = "fejl7e"  # -> RemoveRecentlyViewedProject
 
     # User settings
-    GET_USER_SETTINGS = "ZwVcOc"  # Get user settings including output language
-    SET_USER_SETTINGS = "hT54vc"  # Set user settings (e.g., output language)
-    GET_USER_TIER = "ozz5Z"  # Get NotebookLM subscription tier from homepage context
+    # -> GetOrCreateAccount (account-level; may create the account on first call)
+    GET_USER_SETTINGS = "ZwVcOc"
+    # -> MutateAccount (generic account mutator; we only set the output language)
+    SET_USER_SETTINGS = "hT54vc"
+    # -> DasherGrowthPromotionService.FetchRecommendations. WARNING: this is a
+    # *promotions/growth* recommendations endpoint on a DIFFERENT service, NOT a
+    # subscription-tier lookup. The "tier" we surface is a NOTEBOOKLM_TIER_* string
+    # scraped from the recommendations payload (a promotion-eligibility signal that
+    # tracks the plan), not an authoritative tier field. See _settings.extract_account_tier.
+    GET_USER_TIER = "ozz5Z"
 
 
 class ArtifactTypeCode(int, Enum):

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -69,7 +69,10 @@ class RPCMethod(str, Enum):
     """
 
     # Notebook operations
-    LIST_NOTEBOOKS = "wXbhsf"  # -> ListRecentlyViewedProjects (recents, NOT all notebooks)
+    # -> ListRecentlyViewedProjects. Recency-ordered (most-recently-viewed first,
+    # live-observed); whether it can omit an owned notebook (full vs recents) is
+    # not independently confirmed.
+    LIST_NOTEBOOKS = "wXbhsf"
     CREATE_NOTEBOOK = "CCqFvf"  # -> CreateProject
     GET_NOTEBOOK = "rLM1Ne"  # -> GetProject
     RENAME_NOTEBOOK = "s0tc2d"  # -> MutateProject (generic notebook mutator; see note below)


### PR DESCRIPTION
## docs(rpc): correct RPC method semantics from live registry (Rosetta-Stone pass)

We recovered Google's own id registry mapping each obfuscated `batchexecute` method id to its live `/LabsTailwindOrchestrationService.<Method>` name. Those clean names are a **Rosetta Stone** for what each old-service RPC *actually does*. This PR uses that map to fix places where our code's **labeling/documentation** of the OLD monolith service was wrong or misleading.

**Scope guarantee:** comment / docstring / internal-naming only. **Zero public-API change** — `scripts/audit_public_api_compat.py` still reports `OK ... (58 reviewed break(s) allowlisted)` (exit 0) with **no new allowlist entries** (the allowlist file has a zero-byte diff). No enum *values*, method names, type names, signatures, or return types changed; no runtime logic changed. This does **not** touch the new domain services or any migration.

Findings are tagged by the agreed taxonomy:
- **(1a) internal-only** — misleading comment/docstring/internal name → **APPLIED**.
- **(1b) value-correctness** — possible wrong-position/wrong-interpretation decode → **PARKED** (behavior change; needs your approval).
- **(2) additive** — the method does more than we expose → **PARKED** (opportunity, not implemented).
- **(3) contract** — a *public* field/return whose type/semantics is arguably wrong → **PARKED** (needs an ADR-0019 deprecation runway).

The id→method map was treated as a strong hint and verified against the code. One pairing was rejected as a likely mis-pairing (see the suspect note).

---

## (1a) Internal-only fixes — APPLIED

### Central enum annotations — `src/notebooklm/rpc/types.py`
Added a `-> <Method>` comment to (almost) every `RPCMethod` member naming the live endpoint, plus a class-docstring paragraph explaining the convention and that member names are intentionally unchanged. Highlights of corrected/added comments:

| id | enum (unchanged) | old comment | corrected to live method |
|----|------------------|-------------|--------------------------|
| `wXbhsf` | `LIST_NOTEBOOKS` | *(none)* | `-> ListRecentlyViewedProjects` (recents, NOT all) |
| `s0tc2d` | `RENAME_NOTEBOOK` | *(none)* | `-> MutateProject` (generic notebook mutator) |
| `WWINqb` | `DELETE_NOTEBOOK` | *(none)* | `-> DeleteProjects` (batch-capable) |
| `VfAZjd` | `SUMMARIZE` | *(none)* | `-> GenerateNotebookGuide` |
| `v9rmvd` | `GET_INTERACTIVE_HTML` | "Fetch quiz/flashcard HTML content" | `-> GetArtifact` (GENERIC single-artifact getter) |
| `yyryJe` | `GENERATE_MIND_MAP` | "Generate mind map from sources" | `-> ActOnSources` (generic source-action op) |
| `cFji9` | `GET_NOTES_AND_MIND_MAPS` | "Returns both notes and mind maps" | `-> GetNotes` (mind maps come back as JSON-bodied notes) |
| `J7Gthc` | `DELETE_CONVERSATION` | "Delete a conversation" | `-> DeleteChatTurns` (deletes turns) |
| `khqZz` | `GET_CONVERSATION_TURNS` | *(partial)* | `-> ListChatTurns` |
| `hPTbtc` | `GET_LAST_CONVERSATION_ID` | *(partial)* | `-> ListChatSessions` |
| `rc3d8d` | `RENAME_ARTIFACT` | *(none)* | `-> UpdateArtifact` (generic; we only set title) |
| `Krh3pd` | `EXPORT_ARTIFACT` | *(none)* | `-> ExportToDrive` (Drive only) |
| `Rytqqe` | `RETRY_ARTIFACT` | "Retry a failed Studio artifact" | `-> GenerateArtifact` |
| `KmcKPe` | `REVISE_SLIDE` | "Revise individual slide" | `-> DeriveArtifact` (generic derive) |
| `ZwVcOc` | `GET_USER_SETTINGS` | "Get user settings…" | `-> GetOrCreateAccount` (may create on first call) |
| `hT54vc` | `SET_USER_SETTINGS` | "Set user settings…" | `-> MutateAccount` (generic account mutator) |
| `ozz5Z` | `GET_USER_TIER` | "Get NotebookLM subscription tier…" | `-> DasherGrowthPromotionService.FetchRecommendations` (**different service; promotions, not tier**) |
| research family | `START_FAST/DEEP_RESEARCH`, `POLL_RESEARCH`, `IMPORT_RESEARCH` | *(none)* | `-> DiscoverSourcesManifold / DiscoverSourcesAsync / ListDiscoverSourcesJob / FinishDiscoverSourcesRun` |
| labels / sharing / sources / notes | (see file) | partial | full `-> <Method>` annotations added (incl. `LabsTailwindSharingService.*` for share ops) |

### Wrong RPC id in a docstring — `src/notebooklm/_row_adapters/artifacts.py:75`
`unwrap_mind_map_generation_leaf` claimed `GENERATE_MIND_MAP (``cu1Hbf``)`. **`cu1Hbf` is not the GENERATE_MIND_MAP id** — it is `yyryJe` (confirmed by `types.py`, cassettes, golden fixtures, and the registry; `cu1Hbf` appears nowhere else). Corrected to `yyryJe`, live method `ActOnSources`.

### `GET_USER_TIER` is a promotions endpoint — `src/notebooklm/_settings.py`
The richest finding. `get_account_tier()` extracts a `NOTEBOOKLM_TIER_*` string by stack-walking the response — but the live endpoint is `FetchRecommendations` on `DasherGrowthPromotionService` (a growth/promotions service, a *different* service). Clarified (no signature/return change) on `build_get_user_tier_params`, `_find_tier_string`, `extract_account_tier`, and the **public** `get_account_tier()` docstring (a `.. note::` that this is a promotions endpoint and the "tier" is a best-effort scraped signal, not an authoritative field).

### `GET_USER_SETTINGS` is `GetOrCreateAccount` — `src/notebooklm/_settings.py`
Clarified `build_get_user_settings_params` docstring: account-level, may create the account on first call.

### Idempotency-policy notes — `src/notebooklm/_idempotency_policy.py`
Reworded the human-readable `notes=` strings only — **classification buckets unchanged** — for `LIST_NOTEBOOKS`, `RENAME_NOTEBOOK`, `SUMMARIZE`, `GET_INTERACTIVE_HTML`, `POLL_RESEARCH`, `GET_NOTES_AND_MIND_MAPS`, `DELETE_CONVERSATION`, `GET_USER_SETTINGS`, `SET_USER_SETTINGS`, `GET_USER_TIER`, plus the `GENERATE_MIND_MAP` comment block. Notably `GET_USER_TIER` now reads "promotions/recommendations fetch" not "account tier fetch", and `GET_USER_SETTINGS` notes GetOrCreate-on-first-call (still replay-safe → bucket unchanged).

### Call-site clarifications
- `src/notebooklm/_notebooks.py` — `list()` docstring `.. note::` (recents via `ListRecentlyViewedProjects`); `rename()` comment (generic `MutateProject`, also drives chat-config + view-level); `get_description()` docstring `.. note::` (`GenerateNotebookGuide` = guide, not freeform summary); `delete()` comment (`DeleteProjects`, batch-capable, single-id usage).
- `src/notebooklm/_mind_maps_api.py` + `src/notebooklm/_artifact/downloads.py` — `GET_INTERACTIVE_HTML` is the generic `GetArtifact`.
- `src/notebooklm/_chat/api.py` — `delete_conversation` comment (`DeleteChatTurns`).
- `src/notebooklm/_artifacts.py` — `export()` docstring (`ExportToDrive`; Docs/Sheets are Drive doc kinds). _Folded into the existing docstring line to keep the module at exactly its 1000-line ADR-0008 ratchet ceiling._
- `src/notebooklm/_artifact/generation.py` — `generate_mind_map` comment (`ActOnSources`).
- `src/notebooklm/_research.py` — research family is the DiscoverSources pipeline.

---

## (1b) Value-correctness — PARKED (needs your approval)

### `GET_USER_TIER` "tier" may not be a real subscription tier
`src/notebooklm/_settings.py` `extract_account_tier` / `_find_tier_string`. Because the source is `FetchRecommendations` (promotions), the `NOTEBOOKLM_TIER_*` string is plausibly a **promotion-eligibility signal** rather than an authoritative subscription tier. It empirically tracks the plan, so it is usually "right", but it could diverge (a promo-eligible account, or a paid account with no promo string → tier reported absent). **No code change** — flagging the value semantics. Decision: keep as best-effort (docstring now says so), or source the tier from a real account field (e.g. the `GetOrCreateAccount` payload) instead.

---

## (2) Additive — PARKED (opportunities, not implemented)

1. **`RENAME_NOTEBOOK` is the generic `MutateProject`.** Already used internally for three things (title via `NotebooksAPI.rename`, chat config via `ChatAPI.configure`, share view-level via `SharingAPI.set_view_level`) — no single generic "mutate notebook" entry point. Consolidation opportunity.
2. **`RENAME_ARTIFACT` is the generic `UpdateArtifact`** with a field-mask (`[["title"]]`); we only set the title. Could expose other artifact fields.
3. **`SET_USER_SETTINGS` is the generic `MutateAccount`**; we only set output-language.
4. **`GET_INTERACTIVE_HTML` is the generic `GetArtifact`.** We only use it for interactive-artifact HTML / mind-map tree; it is a generic single-artifact getter.
5. **Batch ops.** `AddSources` / `DeleteSources` / `DeleteNotes` / `DeleteProjects` are all plural/batch-capable server-side; we expose single-item operations only.
6. **`SUMMARIZE` (`GenerateNotebookGuide`) prompt field under-surfaced.** `SuggestedTopic` decodes both `question` and `prompt` (`src/notebooklm/_types/notebooks.py:167-168`), but the CLI only emits `topic.question` (`src/notebooklm/cli/notebook_cmd.py:308`). The chat prompts are decoded into the public type but not shown in CLI output.

---

## (3) Contract — PARKED (needs a deliberate ADR-0019 runway)

1. **`GET_USER_TIER` public surface naming.** `client.settings.get_account_tier()` and the exported `AccountTier` type (`notebooklm/__init__.py:120,195`) are named around "subscription tier", but the endpoint is a promotions/recommendations fetch. A rename would be a public-contract break — **not changed**; the docstring now clarifies. Matching the names to the semantics needs a deprecation cycle.
2. **`notebooks.list()` "all notebooks" expectation.** The backing RPC is `ListRecentlyViewedProjects` (recents), not a guaranteed exhaustive inventory. The public docstring previously said "List all notebooks"; corrected to "recently-viewed". A true list-all is a behavior/contract decision, not a doc fix.

---

## Suspect / rejected mapping (did NOT act on)

- **`o4cbdc ADD_SOURCE_FILE -> AddTentativeSources` — REJECTED as likely mis-pairing.** `ADD_SOURCE_FILE` is the register-an-already-uploaded-file step; `AddTentativeSources` is a discover-sources op. The path-anchored extractor almost certainly mis-paired these. The enum comment records the real `/Method` as **unconfirmed** rather than relabeling from the suspect pairing.

---

## Verification

- `uv run python scripts/audit_public_api_compat.py` → `OK: public API is compatible with v0.7.0 (58 reviewed break(s) allowlisted)`, exit 0. **Allowlist file diff is empty (0 new entries).**
- `uv run --extra dev mypy src/notebooklm --ignore-missing-imports` → `Success: no issues found in 273 source files`.
- `uv run ruff format --check .` and `uv run ruff check .` → clean.
- Full `uv run pytest` → green (10251 passed, 69 skipped, 1 xfailed), including the ADR-0008 module-size ratchet (`_artifacts.py` held at exactly 1000 lines).
- Polish gate run with **claude + codex only** (agy not used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved SDK docstrings to clearly describe the behavior and semantics of artifact export/download, interactive mind maps, research start/polling, notebook listing/deletion/renaming/description generation, and chat history deletion.
  * Refined settings/tier documentation to better reflect how tier data is derived.
  * Expanded RPC method mapping notes and response-shape descriptions for more accurate understanding of the underlying flows.
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->