### PR TITLE
fix(settings): map NOTEBOOKLM_TIER_PRO_CONSUMER_USER to "Google AI Pro"

### DIFF
--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -19,6 +19,9 @@ _TIER_PLAN_NAMES = {
     "NOTEBOOKLM_TIER_STANDARD": "Standard",
     "NOTEBOOKLM_TIER_PLUS": "Google AI Plus",
     "NOTEBOOKLM_TIER_PRO": "Google AI Pro",
+    # Consumer Google AI Pro reports this variant (live-observed on a real Pro
+    # account, 2026-06-16); without it get_account_tier() returns plan_name=None.
+    "NOTEBOOKLM_TIER_PRO_CONSUMER_USER": "Google AI Pro",
     "NOTEBOOKLM_TIER_PRO_DASHER_END_USER": "Google Workspace Pro",
     "NOTEBOOKLM_TIER_ULTRA": "Google AI Ultra",
 }

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -19,8 +19,7 @@ _TIER_PLAN_NAMES = {
     "NOTEBOOKLM_TIER_STANDARD": "Standard",
     "NOTEBOOKLM_TIER_PLUS": "Google AI Plus",
     "NOTEBOOKLM_TIER_PRO": "Google AI Pro",
-    # Consumer Google AI Pro reports this variant (live-observed on a real Pro
-    # account, 2026-06-16); without it get_account_tier() returns plan_name=None.
+    # Consumer Google AI Pro reports this variant (live-observed 2026-06-16); same plan.
     "NOTEBOOKLM_TIER_PRO_CONSUMER_USER": "Google AI Pro",
     "NOTEBOOKLM_TIER_PRO_DASHER_END_USER": "Google Workspace Pro",
     "NOTEBOOKLM_TIER_ULTRA": "Google AI Ultra",

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -660,7 +660,11 @@ class TestSettingsGoldenDecoded:
             "NOTEBOOKLM_TIER_PRO_CONSUMER_USER",
             field="settings_get_user_tier.tier",
         )
-        assert_decoded_equals(tier.plan_name, None, field="settings_get_user_tier.plan_name")
+        # The recorded token is a real consumer Pro account; it now maps to a plan
+        # name (previously decoded to None — the bug this change fixes).
+        assert_decoded_equals(
+            tier.plan_name, "Google AI Pro", field="settings_get_user_tier.plan_name"
+        )
 
 
 # =============================================================================

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -120,6 +120,7 @@ def test_extract_account_tier_preserves_unknown_tier_string():
         ("NOTEBOOKLM_TIER_STANDARD", "Standard"),
         ("NOTEBOOKLM_TIER_PLUS", "Google AI Plus"),
         ("NOTEBOOKLM_TIER_PRO", "Google AI Pro"),
+        ("NOTEBOOKLM_TIER_PRO_CONSUMER_USER", "Google AI Pro"),
         ("NOTEBOOKLM_TIER_PRO_DASHER_END_USER", "Google Workspace Pro"),
         ("NOTEBOOKLM_TIER_ULTRA", "Google AI Ultra"),
     ],


### PR DESCRIPTION
## Bug (live-verified)

A real consumer **Google AI Pro** account reports its tier string as `NOTEBOOKLM_TIER_PRO_CONSUMER_USER`, which was **missing** from `_TIER_PLAN_NAMES`. So `extract_account_tier()` / `get_account_tier()` returned `plan_name=None` for a genuine Pro account — the raw `tier` was still surfaced, but the friendly plan name was lost.

Verified live on 2026-06-16:

```
client.settings.get_account_tier()
  -> tier='NOTEBOOKLM_TIER_PRO_CONSUMER_USER'  plan_name=None   # before
```

## Fix

Add the mapping `NOTEBOOKLM_TIER_PRO_CONSUMER_USER -> "Google AI Pro"` (same plan name as the existing `NOTEBOOKLM_TIER_PRO`) and extend the parametrized `test_extract_account_tier_maps_all_known_plan_names` round-trip test that locks `_TIER_PLAN_NAMES` against the parser.

## Scope / safety

- **No public-API change**: `_TIER_PLAN_NAMES` is private; `extract_account_tier`/`AccountTier` signatures unchanged; `scripts/api-compat-allowlist.json` untouched (compat audit passes clean).
- ruff + mypy clean; `tests/unit/test_user_settings_api.py` → 47 passed.

## Context

Surfaced while live-validating #1587 (the Rosetta-Stone RPC-semantics pass). #1587 is comment-only and does not fix this real behavioral gap, so it ships as its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **Google AI Pro** account tier so account tier resolution correctly maps this subscription to the friendly plan name and recognizes it consistently across the service.
* **Bug Fixes**
  * Fixed tier decoding so previously returned tier information no longer results in an unknown/empty plan name.
* **Tests**
  * Updated unit and integration tests to cover the new tier-to-plan-name mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->