### PR TITLE
refactor(rpc): de-bless internal notebooklm.rpc.* exports (keep RPCMethod + resolve_rpc_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the server and its dependencies (`fastmcp`) arrive only with the `mcp` extra.
   See [docs/mcp-guide.md](docs/mcp-guide.md).
 
+### Changed
+
+- **`notebooklm.rpc` public surface narrowed to the two documented power-user
+  imports** (#1589). `notebooklm.rpc.__all__` now lists only `RPCMethod` and
+  `resolve_rpc_id`; the ~47 other names it used to advertise (the batchexecute
+  wire helpers `encode_rpc_request` / `decode_response` / `extract_rpc_result` /
+  …, the endpoint URL constants and helpers, `safe_index`, and the enum /
+  exception **re-exports** that remain public under their canonical names —
+  most enums as `notebooklm.<X>` / `notebooklm.types.<X>`, the exceptions as
+  `notebooklm.<X>` / `notebooklm.exceptions.<X>`, with `ArtifactStatus` /
+  `artifact_status_to_str` `notebooklm.types`-only and `ArtifactTypeCode` having
+  no public alias) are no longer part of the
+  blessed, compat-gated public surface. This aligns the audited surface with
+  `docs/stability.md`, which has always marked `notebooklm.rpc.*` internal. **Not
+  a removal:** every name stays importable as `notebooklm.rpc.<name>` for
+  back-compat — only the public-API *advertisement* shrank. New code should
+  import the canonical public name (or `RPCMethod` / `resolve_rpc_id` for
+  raw-RPC power use). See [docs/deprecations.md](docs/deprecations.md).
+
 ### Fixed
 
 - **`notebooklm auth check` text mode now exits non-zero when an executed check

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -56,6 +56,25 @@ migration for each is in
 > `notebooklm source add --mime-type` are likewise **not** deprecated —
 > `mime_type` sets the resumable-upload content-type header.
 
+> **`notebooklm.rpc` public surface tightened — not a removal (v0.8.0,
+> [#1589](https://github.com/teng-lin/notebooklm-py/issues/1589)).**
+> `notebooklm.rpc.__all__` now advertises only the two documented power-user
+> imports, `RPCMethod` and `resolve_rpc_id`. The ~47 other names it used to list
+> — the batchexecute wire helpers (`encode_rpc_request`, `decode_response`,
+> `extract_rpc_result`, `safe_index`, …), the endpoint URL constants/helpers, and
+> the enum / exception **re-exports** — are **not removed**: they remain
+> importable as `notebooklm.rpc.<name>` for back-compat. They were never part of
+> the supported public API (`docs/stability.md` has always marked
+> `notebooklm.rpc.*` internal); this change only stops the compat gate from
+> advertising them. New code should import the canonical public name where one
+> exists: most enums as `notebooklm.<X>` / `notebooklm.types.<X>`, but
+> `ArtifactStatus` and `artifact_status_to_str` only as `notebooklm.types.<X>`;
+> the exceptions as `notebooklm.<X>` / `notebooklm.exceptions.<X>`. The wire
+> helpers, the endpoint URL constants/helpers, `safe_index`, `ArtifactTypeCode`,
+> and `RPCErrorCode` are internal with **no** blessed public alias and stay
+> importable only as `notebooklm.rpc.<name>`. For raw-RPC power use, import
+> `from notebooklm.rpc import RPCMethod, resolve_rpc_id`.
+
 
 ## Removed in v0.7.0
 

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -168,7 +168,9 @@ await client.refresh_auth()
 
 **Debug:**
 ```python
-from notebooklm.rpc import decode_response
+# decode_response is an internal RPC helper (notebooklm.rpc.* is internal per
+# docs/stability.md); import it from its defining module for contributor debugging.
+from notebooklm.rpc.decoder import decode_response
 
 raw_response = await http_client.post(...)
 print("Raw:", raw_response.text[:500])

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -180,7 +180,7 @@ from notebooklm.rpc import RPCMethod, resolve_rpc_id
 
 ### Strict decoding (the only mode since v0.7.0)
 
-Schema-drift helpers (notably :func:`notebooklm.rpc.safe_index`) **raise**
+Schema-drift helpers (notably the internal ``safe_index`` decode helper) **raise**
 :class:`~notebooklm.exceptions.UnknownRPCMethodError` when Google's
 batchexecute response shape does not match what the decoder expects. This is
 now the only behavior: the legacy ``NOTEBOOKLM_STRICT_DECODE=0`` warn-and-
@@ -230,7 +230,7 @@ The following v0.3-era deprecations completed their removal cycle in v0.5.0:
 | `notebooklm.rpc.types.StudioContentType` | `ArtifactType` | Internal raw code alias removed |
 | `notebooklm.rpc.StudioContentType` | `ArtifactType` | Internal re-export removed |
 | `notebooklm.rpc.RPCMethod.DISCOVER_SOURCES` | none | Unused raw RPC enum member, not exercised by client APIs |
-| `notebooklm.rpc.RPCMethod.QUERY_ENDPOINT` | `notebooklm.rpc.get_query_url()` | Endpoint URL path moved out of the RPC method enum |
+| `notebooklm.rpc.RPCMethod.QUERY_ENDPOINT` | `notebooklm.rpc.get_query_url()` (internal) | Endpoint URL path moved out of the RPC method enum; `get_query_url()` is itself internal plumbing (`notebooklm.rpc.*` is internal — see above) with no blessed public replacement |
 | `notebooklm.cli.language_cmd.save_config` | `_save_config` | Private low-level write primitive only |
 
 ### Deprecated for a future major release

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -296,6 +296,241 @@
       "code": "changed-signature",
       "object": "notebooklm.client.NotebookLMClient.research.wait_for_completion",
       "reason": "Same break as above; covers the audit dotted-module-path view of the same callable."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ArtifactStatus",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.types.ArtifactStatus. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ArtifactTypeCode",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal artifact type-code enum (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.AudioFormat",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.AudioFormat / notebooklm.types.AudioFormat. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.AudioLength",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.AudioLength / notebooklm.types.AudioLength. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.AuthError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.AuthError / notebooklm.exceptions.AuthError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.BATCHEXECUTE_URL",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ChatGoal",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.ChatGoal / notebooklm.types.ChatGoal. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ChatResponseLength",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.ChatResponseLength / notebooklm.types.ChatResponseLength. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ClientError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.ClientError / notebooklm.exceptions.ClientError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.DriveMimeType",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.DriveMimeType / notebooklm.types.DriveMimeType. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ExportType",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.ExportType / notebooklm.types.ExportType. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.FLASHCARDS_VARIANT",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal artifact-variant constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.INTERACTIVE_MIND_MAP_VARIANT",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal artifact-variant constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.InfographicDetail",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.InfographicDetail / notebooklm.types.InfographicDetail. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.InfographicOrientation",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.InfographicOrientation / notebooklm.types.InfographicOrientation. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.InfographicStyle",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.InfographicStyle / notebooklm.types.InfographicStyle. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.NetworkError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.NetworkError / notebooklm.exceptions.NetworkError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.QUERY_URL",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.QUIZ_VARIANT",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal artifact-variant constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.QuizDifficulty",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.QuizDifficulty / notebooklm.types.QuizDifficulty. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.QuizQuantity",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.QuizQuantity / notebooklm.types.QuizQuantity. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.RPCError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.RPCError / notebooklm.exceptions.RPCError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.RPCErrorCode",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal RPC error-code helper (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.RPCTimeoutError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.RPCTimeoutError / notebooklm.exceptions.RPCTimeoutError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.RateLimitError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.RateLimitError / notebooklm.exceptions.RateLimitError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ReportFormat",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.ReportFormat / notebooklm.types.ReportFormat. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.ServerError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.ServerError / notebooklm.exceptions.ServerError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.SlideDeckFormat",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.SlideDeckFormat / notebooklm.types.SlideDeckFormat. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.SlideDeckLength",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.SlideDeckLength / notebooklm.types.SlideDeckLength. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.UPLOAD_URL",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint constant (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.UnknownRPCMethodError",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Exception re-export; the canonical public import is notebooklm.UnknownRPCMethodError / notebooklm.exceptions.UnknownRPCMethodError. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.VideoFormat",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.VideoFormat / notebooklm.types.VideoFormat. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.VideoStyle",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Enum re-export; the canonical public import is notebooklm.VideoStyle / notebooklm.types.VideoStyle. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.artifact_status_to_str",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Helper re-export; the canonical public import is notebooklm.types.artifact_status_to_str. Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.build_request_body",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.collect_rpc_ids",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.decode_response",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.encode_rpc_request",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.extract_rpc_result",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.get_batchexecute_url",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint helper (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.get_error_message_for_code",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal RPC error-code helper (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.get_query_url",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint helper (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.get_upload_url",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute endpoint helper (no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.nest_source_ids",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.parse_chunked_response",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.safe_index",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute decode helper (defined in notebooklm.rpc._safe_index, re-exported via notebooklm.rpc.decoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.rpc.strip_anti_xssi",
+      "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
     }
   ]
 }

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -1,6 +1,17 @@
 """RPC protocol implementation for NotebookLM batchexecute API."""
 
-from .decoder import (
+# ``notebooklm.rpc.*`` is internal (see docs/stability.md). Only ``RPCMethod`` and
+# ``resolve_rpc_id`` are blessed public power-user imports; they alone appear in
+# ``__all__`` below.
+#
+# Every other imported name stays importable as a module attribute, because
+# first-party code imports several through this facade (e.g. ``safe_index``) and
+# external callers may already do ``from notebooklm.rpc import <name>``. But they
+# are deliberately kept OUT of ``__all__`` so the public-API compat gate stops
+# advertising them (#1589; one ``removed-export`` allowance each in
+# scripts/api-compat-allowlist.json). The ``noqa: F401`` directives suppress the
+# resulting "unused import" warnings on these re-export groups.
+from .decoder import (  # noqa: F401
     AuthError,
     ClientError,
     NetworkError,
@@ -18,9 +29,9 @@ from .decoder import (
     safe_index,
     strip_anti_xssi,
 )
-from .encoder import build_request_body, encode_rpc_request, nest_source_ids
+from .encoder import build_request_body, encode_rpc_request, nest_source_ids  # noqa: F401
 from .overrides import resolve_rpc_id
-from .types import (
+from .types import (  # noqa: F401
     BATCHEXECUTE_URL,
     FLASHCARDS_VARIANT,
     INTERACTIVE_MIND_MAP_VARIANT,
@@ -52,56 +63,9 @@ from .types import (
     get_upload_url,
 )
 
+# Blessed public power-user surface only; see the banner comment above for why
+# every other importable name is intentionally omitted.
 __all__ = [
     "RPCMethod",
-    "BATCHEXECUTE_URL",
-    "QUERY_URL",
-    "UPLOAD_URL",
-    "get_batchexecute_url",
-    "get_query_url",
-    "get_upload_url",
     "resolve_rpc_id",
-    "ArtifactTypeCode",
-    "FLASHCARDS_VARIANT",
-    "QUIZ_VARIANT",
-    "INTERACTIVE_MIND_MAP_VARIANT",
-    "ArtifactStatus",
-    "artifact_status_to_str",
-    "AudioFormat",
-    "AudioLength",
-    "VideoFormat",
-    "VideoStyle",
-    "QuizQuantity",
-    "QuizDifficulty",
-    "InfographicOrientation",
-    "InfographicDetail",
-    "InfographicStyle",
-    "SlideDeckFormat",
-    "SlideDeckLength",
-    "ReportFormat",
-    "ChatGoal",
-    "ChatResponseLength",
-    "DriveMimeType",
-    "ExportType",
-    "encode_rpc_request",
-    "build_request_body",
-    "nest_source_ids",
-    "strip_anti_xssi",
-    "parse_chunked_response",
-    "extract_rpc_result",
-    "collect_rpc_ids",
-    "decode_response",
-    "safe_index",
-    # Exceptions
-    "RPCError",
-    "AuthError",
-    "NetworkError",
-    "RPCTimeoutError",
-    "RateLimitError",
-    "ServerError",
-    "ClientError",
-    "UnknownRPCMethodError",
-    # Error handling utilities
-    "RPCErrorCode",
-    "get_error_message_for_code",
 ]

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -218,6 +218,9 @@ def test_rpc_legacy_reexports_stay_importable_but_unblessed() -> None:
     import notebooklm.rpc as public_rpc
 
     assert len(_RPC_LEGACY_REEXPORTS) == 47
+    assert len(_RPC_LEGACY_REEXPORTS) == len(set(_RPC_LEGACY_REEXPORTS)), (
+        "_RPC_LEGACY_REEXPORTS must not contain duplicate names (a dup could mask a drop)"
+    )
     missing = [name for name in _RPC_LEGACY_REEXPORTS if not hasattr(public_rpc, name)]
     assert missing == [], f"de-blessed names must stay importable from notebooklm.rpc: {missing}"
     re_blessed = [name for name in _RPC_LEGACY_REEXPORTS if name in public_rpc.__all__]

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -75,6 +75,7 @@ _DOCUMENTED_PUBLIC_IMPORTS = {
         "select_cited_sources",
     ],
     "notebooklm.rpc": [
+        "resolve_rpc_id",
         "RPCMethod",
     ],
     "notebooklm.types": [
@@ -134,6 +135,93 @@ def test_public_facade_imports_are_identity_reexports() -> None:
     assert notebooklm.ConnectionLimits is public_types.ConnectionLimits
     assert public_rpc.RPCMethod is rpc_types.RPCMethod
     assert public_rpc.resolve_rpc_id is rpc_overrides.resolve_rpc_id
+
+
+# The names de-blessed from ``notebooklm.rpc.__all__`` in #1589. They were
+# removed from ``__all__`` (so the compat gate no longer advertises them) but
+# remain importable as module attributes for back-compat — see
+# ``scripts/api-compat-allowlist.json`` and ``docs/deprecations.md``.
+_RPC_LEGACY_REEXPORTS = [
+    # batchexecute endpoint URL constants + helpers
+    "BATCHEXECUTE_URL",
+    "QUERY_URL",
+    "UPLOAD_URL",
+    "get_batchexecute_url",
+    "get_query_url",
+    "get_upload_url",
+    # artifact-variant constants
+    "FLASHCARDS_VARIANT",
+    "QUIZ_VARIANT",
+    "INTERACTIVE_MIND_MAP_VARIANT",
+    # artifact type-code + status helpers
+    "ArtifactTypeCode",
+    "ArtifactStatus",
+    "artifact_status_to_str",
+    # enum re-exports (also public via notebooklm / notebooklm.types)
+    "AudioFormat",
+    "AudioLength",
+    "VideoFormat",
+    "VideoStyle",
+    "QuizQuantity",
+    "QuizDifficulty",
+    "InfographicOrientation",
+    "InfographicDetail",
+    "InfographicStyle",
+    "SlideDeckFormat",
+    "SlideDeckLength",
+    "ReportFormat",
+    "ChatGoal",
+    "ChatResponseLength",
+    "DriveMimeType",
+    "ExportType",
+    # batchexecute wire helpers
+    "encode_rpc_request",
+    "build_request_body",
+    "nest_source_ids",
+    "strip_anti_xssi",
+    "parse_chunked_response",
+    "extract_rpc_result",
+    "collect_rpc_ids",
+    "decode_response",
+    "safe_index",
+    # exception re-exports (also public via notebooklm / notebooklm.exceptions)
+    "RPCError",
+    "AuthError",
+    "NetworkError",
+    "RPCTimeoutError",
+    "RateLimitError",
+    "ServerError",
+    "ClientError",
+    "UnknownRPCMethodError",
+    # error-code utilities
+    "RPCErrorCode",
+    "get_error_message_for_code",
+]
+
+
+def test_rpc_all_is_minimized_to_documented_power_user_imports() -> None:
+    """``notebooklm.rpc.__all__`` stays frozen to the two blessed imports (#1589).
+
+    Catches a name being re-blessed into ``__all__`` directly (the compat audit
+    only catches this indirectly, via a now-stale allowlist entry).
+    """
+    import notebooklm.rpc as public_rpc
+
+    assert public_rpc.__all__ == ["RPCMethod", "resolve_rpc_id"]
+
+
+def test_rpc_legacy_reexports_stay_importable_but_unblessed() -> None:
+    """The de-blessed RPC names remain importable as attributes (back-compat),
+    while staying out of ``__all__``. Freezes the promise made in #1589 that this
+    is a de-advertisement, not a removal — no existing gate covers importability.
+    """
+    import notebooklm.rpc as public_rpc
+
+    assert len(_RPC_LEGACY_REEXPORTS) == 47
+    missing = [name for name in _RPC_LEGACY_REEXPORTS if not hasattr(public_rpc, name)]
+    assert missing == [], f"de-blessed names must stay importable from notebooklm.rpc: {missing}"
+    re_blessed = [name for name in _RPC_LEGACY_REEXPORTS if name in public_rpc.__all__]
+    assert re_blessed == [], f"de-blessed names must not return to __all__: {re_blessed}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Tighten the public API: de-bless internal `notebooklm.rpc.*` exports

Closes #1589.

`notebooklm.rpc.__all__` advertised **49** names as public, but `docs/stability.md`
has always declared `notebooklm.rpc.*` **internal** except the two documented
power-user imports:

```python
from notebooklm.rpc import RPCMethod, resolve_rpc_id
```

So the compat-gate-enforced public surface (`scripts/audit_public_api_compat.py`
reads each module's `__all__`) **contradicted** the documented stability
contract — it exposed RPC wire helpers, batchexecute URL constants/helpers,
`safe_index`, and enum/exception **re-exports** that are already public via the
top-level package / `notebooklm.types` / `notebooklm.exceptions`.

### What changed

- **`rpc/__all__` shrunk 49 → 2** (`RPCMethod`, `resolve_rpc_id`). The other 47
  names stay **defined and importable** as `notebooklm.rpc.<name>` (the imports
  remain in `rpc/__init__.py` with `# noqa: F401`, matching the existing
  re-export convention in `_source/upload.py` / `cli/source_cmd.py`) — only the
  *blessed / audited* surface shrinks. First-party code that imports several of
  these via the facade (e.g. `from ..rpc import safe_index`) is unaffected.
- **47 `removed-export` allowances** added to `scripts/api-compat-allowlist.json`
  (baseline **v0.7.0** — all 47 are present there, so every entry matches a real
  break and none is stale). Reasons are per-name: enums/exceptions point at their
  canonical public import; genuinely-internal helpers note they have no public
  alias. To be pruned at the next release tag (`--check-stale` enforces this).
- **`resolve_rpc_id` documented** alongside `RPCMethod` in the public-import
  manifest (`tests/_guardrails/test_public_surface_manifest.py`).
- **Two new guardrails**: one freezes `rpc.__all__ == ["RPCMethod",
  "resolve_rpc_id"]` (catches re-blessing directly, not just via the audit's
  stale-allowance path); one asserts the 47 de-blessed names stay importable as
  `notebooklm.rpc.<name>` — the back-compat promise no existing gate covered.
- **`safe_index` clarified as internal** in `docs/stability.md` (dropped the
  `:func:` import-looking cross-ref).
- **Docs:** CHANGELOG `### Changed` entry, a `docs/deprecations.md` note (worded
  as a surface-tightening, **not** a removal — the names stay importable), and a
  one-line fix in `docs/rpc-development.md` to import `decode_response` from its
  defining module rather than the facade.

### Back-compat

Not a removal. Every de-blessed name remains importable as
`notebooklm.rpc.<name>`; only the public-API *advertisement* shrank. mypy is
unaffected (implicit re-export is allowed — no `no_implicit_reexport`).

### Out of scope (deliberately)

- **`auth.__all__`** — cannot be shrunk by an `__all__` edit (a guardrail pins it
  as a superset of first-party imports, and `_app/auth_check.py` must import
  those names from the public `auth` module). A real auth tightening is a
  separate "relocate internals to `_auth`" project.
- The top-level typed API (110 names) — that *is* the public API.

### Verification

- `scripts/audit_public_api_compat.py --check-stale` → **0 unapproved, 0 stale**, exit 0
- `ruff check .` + `ruff format --check .` → clean
- `mypy src/notebooklm` → clean (273 files)
- full `pytest` suite → green

Plan reviewed to convergence by momus + oracle across three models before
execution; the diff then went through `/polish` (claude + codex). Codex caught
two reason/doc-accuracy bugs a single reviewer missed — `artifact_status_to_str`
*is* public via `notebooklm.types` (not "no alias"), and the enum-alternative
prose over-generalized (`ArtifactStatus` is `types`-only; `ArtifactTypeCode` has
no public alias) — both fixed here, and the importability guardrail was added on
codex's suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated stability/deprecation materials to clarify which `notebooklm.rpc` imports are officially public versus internal.
  * Refreshed the RPC development guide to point to the correct internal decoder reference for debugging.

* **Tests**
  * Added/updated guardrail checks to ensure `notebooklm.rpc.__all__` advertises only the supported power-user imports, while legacy symbols remain importable but unlisted.

* **Chores**
  * Tightened the `notebooklm.rpc` public export surface to reduce officially advertised RPC APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->