### PR TITLE
refactor(auth): de-bless 23 internal notebooklm.auth.* re-exports (PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   import the canonical public name (or `RPCMethod` / `resolve_rpc_id` for
   raw-RPC power use). See [docs/deprecations.md](docs/deprecations.md).
 
+- **`notebooklm.auth` public surface narrowed (PR-1)** (#1592). `auth.__all__`
+  drops 23 internal re-exports that only first-party `src`/tests imported (the
+  cookie-snapshot/storage helpers `save_cookies_to_storage` / `snapshot_cookie_jar`
+  / `CookieSnapshot*` / `CookieSaveResult` / `advance_cookie_snapshot_after_save`,
+  the WIZ-extraction helpers `extract_csrf_from_html` / `extract_session_id_from_html`
+  / `extract_wiz_field`, `authuser_query` / `format_authuser_value`,
+  `load_httpx_cookies` / `normalize_cookie_map`, `ALLOWED_COOKIE_DOMAINS` /
+  `MINIMUM_REQUIRED_COOKIES`, the env/URL constants `KEEPALIVE_ROTATE_URL` /
+  `NOTEBOOKLM_REFRESH_CMD_ENV` / `NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV` /
+  `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV`, `load_auth_from_storage`, `fetch_tokens`,
+  and `recover_psidts_in_memory`). These were migration leftovers from the
+  `_auth/*` extraction (ADR-0003 → ADR-0014); `docs/stability.md` has always marked
+  `notebooklm.auth.*` internal. **Not a removal:** every name stays importable as
+  `notebooklm.auth.<name>` for back-compat — first-party code now imports them from
+  their `notebooklm._auth.<sub>` home. The documented imports (`AuthTokens`,
+  `convert_rookiepy_cookies_to_storage_state`, the cookie-domain constants) and the
+  cohesive operations (`enumerate_accounts`, `fetch_tokens_with_domains`,
+  `fetch_tokens_passive`, …) are unchanged. See
+  [docs/deprecations.md](docs/deprecations.md).
+
 ### Fixed
 
 - **`notebooklm auth check` text mode now exits non-zero when an executed check

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -75,6 +75,23 @@ migration for each is in
 > importable only as `notebooklm.rpc.<name>`. For raw-RPC power use, import
 > `from notebooklm.rpc import RPCMethod, resolve_rpc_id`.
 
+> **`notebooklm.auth` public surface tightened — not a removal (v0.8.0,
+> [#1592](https://github.com/teng-lin/notebooklm-py/issues/1592)).**
+> `auth.__all__` no longer advertises 23 internal re-exports that only first-party
+> `src`/tests imported (cookie-snapshot/storage helpers, the WIZ-extraction helpers,
+> `authuser_query`/`format_authuser_value`, `load_httpx_cookies`/`normalize_cookie_map`,
+> `ALLOWED_COOKIE_DOMAINS`/`MINIMUM_REQUIRED_COOKIES`, the keepalive/refresh env +
+> URL constants, `load_auth_from_storage`, `fetch_tokens`, `recover_psidts_in_memory`).
+> These were migration leftovers from the `_auth/*` extraction (ADR-0003 → ADR-0014).
+> They are **not removed**: each remains importable as `notebooklm.auth.<name>` for
+> back-compat — first-party code now imports them from their `notebooklm._auth.<sub>`
+> home. `notebooklm.auth.*` has always been internal (`docs/stability.md`) except the
+> documented imports (`AuthTokens`, `convert_rookiepy_cookies_to_storage_state`, the
+> cookie-domain constants) and the cohesive operations (`enumerate_accounts`,
+> `fetch_tokens_with_domains`, `fetch_tokens_passive`, …), which are unchanged. A
+> deeper service-interface refactor of the remaining cli/_app-forced names was
+> evaluated and deferred (limited encapsulation payoff while names stay importable).
+
 
 ## Removed in v0.7.0
 

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -531,6 +531,121 @@
       "code": "removed-export",
       "object": "notebooklm.rpc.strip_anti_xssi",
       "reason": "v0.8.0 #1589: de-bless internal RPC export from notebooklm.rpc.__all__ (notebooklm.rpc.* is internal per docs/stability.md, except RPCMethod/resolve_rpc_id). Internal batchexecute wire helper (defined in notebooklm.rpc.decoder / notebooklm.rpc.encoder; no blessed public alias). Still importable explicitly for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.ALLOWED_COOKIE_DOMAINS",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.cookie_policy.ALLOWED_COOKIE_DOMAINS; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.CookieSaveResult",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.CookieSaveResult; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.CookieSnapshot",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.CookieSnapshot; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.CookieSnapshotKey",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.CookieSnapshotKey; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.CookieSnapshotValue",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.CookieSnapshotValue; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.KEEPALIVE_ROTATE_URL",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.keepalive.KEEPALIVE_ROTATE_URL; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.MINIMUM_REQUIRED_COOKIES",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.cookie_policy.MINIMUM_REQUIRED_COOKIES; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.paths.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.NOTEBOOKLM_REFRESH_CMD_ENV",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.paths.NOTEBOOKLM_REFRESH_CMD_ENV; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.paths.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.advance_cookie_snapshot_after_save",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.advance_cookie_snapshot_after_save; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.authuser_query",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.account.authuser_query; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_csrf_from_html",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.extraction.extract_csrf_from_html; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_session_id_from_html",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.extraction.extract_session_id_from_html; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_wiz_field",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.extraction.extract_wiz_field; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.fetch_tokens",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.refresh.fetch_tokens; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.format_authuser_value",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.account.format_authuser_value; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.load_auth_from_storage",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.tokens.load_auth_from_storage; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.load_httpx_cookies",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.cookies.load_httpx_cookies; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.normalize_cookie_map",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.cookies.normalize_cookie_map; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.recover_psidts_in_memory",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.psidts_recovery.recover_psidts_in_memory; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.save_cookies_to_storage",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.save_cookies_to_storage; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.snapshot_cookie_jar",
+      "reason": "v0.8.0 #1592: de-bless internal auth re-export from notebooklm.auth.__all__ (notebooklm.auth.* is internal per docs/stability.md). Canonical home notebooklm._auth.storage.snapshot_cookie_jar; no blessed public alias. Still importable from notebooklm.auth for back-compat. See CHANGELOG.md and docs/deprecations.md."
     }
   ]
 }

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -18,9 +18,9 @@ from urllib.parse import ParseResult, urlparse
 
 import httpx
 
+from .._auth.cookies import load_httpx_cookies
 from .._mind_maps_api import extract_interactive_tree_leaf
 from .._row_adapters.notes import NoteRow
-from ..auth import load_httpx_cookies
 from ..exceptions import UnknownRPCMethodError, ValidationError
 from ..rpc import ArtifactTypeCode, RPCMethod, safe_index
 from ..types import (

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, replace
 from typing import Any, NoReturn, Protocol
 from urllib.parse import quote, urlencode
 
+from .._auth.account import format_authuser_value
 from .._env import get_default_bl, get_default_language
 from .._row_adapters.chat import (
     AnswerRow,
@@ -26,7 +27,6 @@ from .._row_adapters.chat import (
     StreamFrameRow,
     TextLeafRow,
 )
-from ..auth import format_authuser_value
 from ..exceptions import ChatError, ChatResponseParseError, UnknownRPCMethodError
 from ..rpc._safe_index import safe_index
 from ..rpc.decoder import strip_anti_xssi

--- a/src/notebooklm/_cookie_persistence.py
+++ b/src/notebooklm/_cookie_persistence.py
@@ -11,13 +11,13 @@ from typing import Protocol
 
 import httpx
 
-from .auth import (
-    AuthTokens,
+from ._auth.storage import (
     CookieSaveResult,
     CookieSnapshot,
     advance_cookie_snapshot_after_save,
     snapshot_cookie_jar,
 )
+from .auth import AuthTokens
 
 
 class SaveCookiesToStorage(Protocol):

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode
 
 import httpx
 
+from ._auth.account import format_authuser_value
 from ._auth_refresh_retry import RefreshBudget, refresh_and_count
 from ._deadline import RuntimeDeadline
 from ._env import get_default_language
@@ -29,7 +30,6 @@ from ._transport_errors import (
     TransportServerError,
     parse_retry_after,
 )
-from .auth import format_authuser_value
 from .exceptions import DecodingError
 from .rpc import (
     ClientError,

--- a/src/notebooklm/_runtime/lifecycle.py
+++ b/src/notebooklm/_runtime/lifecycle.py
@@ -78,13 +78,13 @@ from ..auth import AuthTokens
 from .config import CORE_LOGGER_NAME
 
 if TYPE_CHECKING:
+    from .._auth.storage import CookieSaveResult
     from .._chat import ChatAPI
     from .._client_composed import ClientComposed
     from .._cookie_persistence import CookiePersistence
     from .._reqid_counter import ReqidCounter
     from .._source.upload import SourceUploadPipeline
     from .._transport_drain import TransportDrainTracker
-    from ..auth import CookieSaveResult
     from ..types import ConnectionLimits
     from .auth import AuthRefreshCoordinator
 

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -13,6 +13,7 @@ from typing import IO, TYPE_CHECKING, Any, Protocol, cast
 
 import httpx
 
+from .._auth.account import authuser_query, format_authuser_value
 from .._callbacks import maybe_await_callback
 from .._env import get_base_url
 from .._idempotency import idempotent_create
@@ -25,7 +26,6 @@ from .._runtime.contracts import (
     Kernel,
     RpcCaller,
 )
-from ..auth import authuser_query, format_authuser_value
 from ..exceptions import (
     AuthError,
     NetworkError,

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -17,10 +17,9 @@ Usage:
     async with NotebookLMClient(auth) as client:
         ...
 
-    # For authenticated downloads
-    cookies = load_httpx_cookies()
-    async with httpx.AsyncClient(cookies=cookies) as client:
-        response = await client.get(url)
+    # For authenticated artifact downloads, use the client's download methods
+    # (e.g. ``await client.artifacts.download_audio(...)``) rather than building
+    # an httpx client by hand.
 
 Security Notes:
     - Storage state files contain sensitive session cookies
@@ -107,60 +106,41 @@ _is_allowed_cookie_domain = _cookie_policy._is_allowed_cookie_domain
 
 
 # Public surface for ``from notebooklm.auth import *`` and for downstream
-# static-analysis tools (mypy, ruff F401 checks). This is the audited set of
-# names externally imported by the package, tests, docs, and the CLI as of
-# 2026-05-17. Underscore-prefixed names remain accessible on the module — some
-# tests reach for them as whitebox affordances — but are intentionally NOT
-# blessed here. See ``tests/_guardrails/test_public_surface.py``: two complementary
-# tests pin this list — ``test_auth_module_has_expected_all`` snapshot-checks
-# the exact ordering, and ``test_auth_all_matches_external_imports_audit``
-# AST-scans ``src/``, ``tests/``, ``docs/`` to fail if a new public name is
-# imported externally without being added here.
+# static-analysis tools (mypy, ruff F401 checks). ``notebooklm.auth.*`` is internal
+# (docs/stability.md) except the documented power-user imports plus the cohesive
+# operations the CLI/_app need across the public boundary. The 23 core/test-only
+# re-exports de-blessed in #1592 were removed from this list but remain importable
+# as module attributes for back-compat — first-party code now imports them from
+# their ``notebooklm._auth.<sub>`` home, and one ``removed-export`` allowance each
+# lives in scripts/api-compat-allowlist.json. Underscore-prefixed names remain
+# accessible on the module as whitebox test affordances but are intentionally NOT
+# blessed here. See ``tests/_guardrails/test_public_surface.py``:
+# ``test_auth_module_has_expected_all`` snapshot-checks the exact ordering, and
+# ``test_auth_all_matches_external_imports_audit`` AST-scans ``src/``/``tests/``/
+# ``docs/`` to fail if a public name is imported externally from ``notebooklm.auth``
+# without being added here.
 __all__ = [
     "Account",
-    "advance_cookie_snapshot_after_save",
-    "ALLOWED_COOKIE_DOMAINS",
     "AuthTokens",
-    "authuser_query",
     "build_cookie_jar",
     "build_httpx_cookies_from_storage",
     "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
     "cookie_names_from_storage",
-    "CookieSaveResult",
-    "CookieSnapshot",
-    "CookieSnapshotKey",
-    "CookieSnapshotValue",
     "enumerate_accounts",
     "extract_cookies_from_storage",
     "extract_cookies_with_domains",
-    "extract_csrf_from_html",
     "extract_email_from_html",
-    "extract_session_id_from_html",
-    "extract_wiz_field",
-    "fetch_tokens",
     "fetch_tokens_passive",
     "fetch_tokens_with_domains",
-    "format_authuser_value",
     "get_account_email_for_storage",
     "get_authuser_for_storage",
     "GOOGLE_REGIONAL_CCTLDS",
-    "KEEPALIVE_ROTATE_URL",
-    "load_auth_from_storage",
-    "load_httpx_cookies",
-    "MINIMUM_REQUIRED_COOKIES",
     "missing_cookies_hint",
-    "normalize_cookie_map",
-    "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
-    "NOTEBOOKLM_REFRESH_CMD_ENV",
-    "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
     "OPTIONAL_COOKIE_DOMAINS",
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "read_account_metadata",
-    "recover_psidts_in_memory",
     "REQUIRED_COOKIE_DOMAINS",
-    "save_cookies_to_storage",
-    "snapshot_cookie_jar",
     "validate_with_recovery",
     "write_account_metadata",
 ]
@@ -184,10 +164,11 @@ _validate_required_cookies = _cookie_policy._validate_required_cookies
 
 
 # WIZ field token extraction (CSRF, session ID, generic WIZ data) lives in
-# ``notebooklm._auth.extraction``. Re-exported here so the public surface
-# (``notebooklm.auth.extract_csrf_from_html`` etc., listed in ``__all__``) and
-# white-box test affordances (``_safe_url``, ``_build_wiz_field_patterns``)
-# keep resolving against ``notebooklm.auth``.
+# ``notebooklm._auth.extraction``. Re-exported here so ``extract_csrf_from_html``
+# / ``extract_session_id_from_html`` / ``extract_wiz_field`` (de-blessed from
+# ``__all__`` in #1592 but kept importable) and white-box test affordances
+# (``_safe_url``, ``_build_wiz_field_patterns``) keep resolving against
+# ``notebooklm.auth``.
 _build_wiz_field_patterns = _auth_extraction._build_wiz_field_patterns
 _safe_url = _auth_extraction._safe_url
 extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
@@ -228,16 +209,16 @@ async def enumerate_accounts(
 
 
 # ``load_auth_from_storage`` lives in ``_auth/tokens.py`` (see ADR-0014).
-# This module re-exports it so ``notebooklm.auth.load_auth_from_storage``
-# stays a stable public import.
+# Re-exported so ``notebooklm.auth.load_auth_from_storage`` stays importable
+# (de-blessed from ``__all__`` in #1592; first-party callers use ``_auth.tokens``).
 load_auth_from_storage = _auth_tokens.load_auth_from_storage
 
 
-# Env-var name constants live in ``notebooklm._auth.paths``. Re-exported so
-# both the public surface (``NOTEBOOKLM_REFRESH_CMD_ENV``,
-# ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV`` — listed in ``__all__``) and the
-# white-box surface (``_REFRESH_ATTEMPTED_ENV``, used by tests) keep resolving
-# against ``notebooklm.auth``.
+# Env-var name constants live in ``notebooklm._auth.paths``. Re-exported so both
+# ``NOTEBOOKLM_REFRESH_CMD_ENV`` / ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV``
+# (de-blessed from ``__all__`` in #1592 but kept importable) and the white-box
+# surface (``_REFRESH_ATTEMPTED_ENV``, used by tests) keep resolving against
+# ``notebooklm.auth``.
 NOTEBOOKLM_REFRESH_CMD_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_ENV
 NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV
 _REFRESH_ATTEMPTED_ENV = _auth_paths._REFRESH_ATTEMPTED_ENV
@@ -247,8 +228,8 @@ _REFRESH_ATTEMPTED_ENV = _auth_paths._REFRESH_ATTEMPTED_ENV
 # Rotation throttle + ``RotateCookies`` POST bodies live in
 # ``notebooklm._auth.keepalive``. Re-exported here so every name that was
 # previously module-level on ``notebooklm.auth`` (constants, the per-loop /
-# per-profile lock registry, the public ``KEEPALIVE_ROTATE_URL`` listed in
-# ``__all__``, and white-box helpers like ``_poke_session`` /
+# per-profile lock registry, ``KEEPALIVE_ROTATE_URL`` (de-blessed from ``__all__``
+# in #1592 but kept importable), and white-box helpers like ``_poke_session`` /
 # ``_rotate_cookies``) keeps resolving against this module. Tests that
 # need to substitute a moved body should patch the canonical home directly
 # (``_auth.keepalive.X``) — production code no longer mirrors writes
@@ -282,9 +263,9 @@ _rotate_cookies = _auth_keepalive._rotate_cookies
 # ``notebooklm._auth.psidts_recovery._recover_psidts_inline``.
 _recover_psidts_inline = _auth_psidts_recovery._recover_psidts_inline
 # In-memory variant for the browser-cookies extraction path (issue #990).
-# Public because CLI services (which must not import underscore-prefixed names
-# from notebooklm public modules) need access. Mutates the caller's rookiepy
-# cookie list in place; no file lock / throttle.
+# De-blessed from ``__all__`` in #1592 (kept importable); it has no first-party
+# importer today. Mutates the caller's rookiepy cookie list in place; no file
+# lock / throttle.
 recover_psidts_in_memory = _auth_psidts_recovery.recover_psidts_in_memory
 # Validate-with-recovery convenience: convert + validate rookiepy cookies and
 # transparently retry through ``recover_psidts_in_memory`` on the recoverable
@@ -304,11 +285,11 @@ _rotation_lock_path = _auth_paths._rotation_lock_path
 
 
 # --- Refresh-cmd + token-fetch entry points ---------------------------------
-# All refresh coordination and the public ``fetch_tokens`` /
-# ``fetch_tokens_with_domains`` entry points live in
-# ``notebooklm._auth.refresh``. Re-exported so the public surface
-# (``fetch_tokens`` + ``fetch_tokens_with_domains`` listed in ``__all__``) and
-# the white-box surface (lock registries, ContextVar, ``_run_refresh_cmd``
+# All refresh coordination and the token-fetch entry points live in
+# ``notebooklm._auth.refresh``. Re-exported so the kept public
+# ``fetch_tokens_with_domains`` / ``fetch_tokens_passive`` entry points,
+# ``fetch_tokens`` (de-blessed from ``__all__`` in #1592 but kept importable),
+# and the white-box surface (lock registries, ContextVar, ``_run_refresh_cmd``
 # carrying the redaction logic, etc.) keep resolving against
 # ``notebooklm.auth``. Tests that need to substitute a moved body should
 # patch the canonical home directly (``_auth.refresh.X``) — production

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
 #   names are exactly the previously-importable names the annotations no
 #   longer reference.
 from ._artifacts import ArtifactsAPI
+from ._auth.account import authuser_query as authuser_query
+from ._auth.extraction import extract_wiz_field as extract_wiz_field
 from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
 from ._client_assembly import _assemble_client
@@ -80,8 +82,6 @@ from ._source.upload import SourceUploadPipeline
 from ._sources import SourcesAPI
 from ._url_utils import is_google_auth_redirect as is_google_auth_redirect
 from .auth import AuthTokens
-from .auth import authuser_query as authuser_query
-from .auth import extract_wiz_field as extract_wiz_field
 from .exceptions import AuthExtractionError as AuthExtractionError
 
 __all__ = ["NotebookLMClient"]

--- a/tests/_guardrails/test_public_surface.py
+++ b/tests/_guardrails/test_public_surface.py
@@ -51,51 +51,59 @@ EXPECTED_CLIENT_ALL: list[str] = ["NotebookLMClient"]
 
 EXPECTED_AUTH_ALL: list[str] = [
     "Account",
-    "advance_cookie_snapshot_after_save",
-    "ALLOWED_COOKIE_DOMAINS",
     "AuthTokens",
-    "authuser_query",
     "build_cookie_jar",
     "build_httpx_cookies_from_storage",
     "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
     "cookie_names_from_storage",
+    "enumerate_accounts",
+    "extract_cookies_from_storage",
+    "extract_cookies_with_domains",
+    "extract_email_from_html",
+    "fetch_tokens_passive",
+    "fetch_tokens_with_domains",
+    "get_account_email_for_storage",
+    "get_authuser_for_storage",
+    "GOOGLE_REGIONAL_CCTLDS",
+    "missing_cookies_hint",
+    "OPTIONAL_COOKIE_DOMAINS",
+    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+    "read_account_metadata",
+    "REQUIRED_COOKIE_DOMAINS",
+    "validate_with_recovery",
+    "write_account_metadata",
+]
+
+# Names de-blessed from ``auth.__all__`` in PR-1 (#1592): removed from the
+# advertised surface but kept importable as module attributes for back-compat
+# (the rpc-tranche mechanism — see scripts/api-compat-allowlist.json). The freeze
+# test below locks that promise so a future change can't silently drop importability
+# or re-bless a name.
+_AUTH_DEBLESSED_KEEP_IMPORTABLE: list[str] = [
+    "advance_cookie_snapshot_after_save",
+    "ALLOWED_COOKIE_DOMAINS",
+    "authuser_query",
     "CookieSaveResult",
     "CookieSnapshot",
     "CookieSnapshotKey",
     "CookieSnapshotValue",
-    "enumerate_accounts",
-    "extract_cookies_from_storage",
-    "extract_cookies_with_domains",
     "extract_csrf_from_html",
-    "extract_email_from_html",
     "extract_session_id_from_html",
     "extract_wiz_field",
     "fetch_tokens",
-    "fetch_tokens_passive",
-    "fetch_tokens_with_domains",
     "format_authuser_value",
-    "get_account_email_for_storage",
-    "get_authuser_for_storage",
-    "GOOGLE_REGIONAL_CCTLDS",
     "KEEPALIVE_ROTATE_URL",
     "load_auth_from_storage",
     "load_httpx_cookies",
     "MINIMUM_REQUIRED_COOKIES",
-    "missing_cookies_hint",
     "normalize_cookie_map",
     "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
     "NOTEBOOKLM_REFRESH_CMD_ENV",
     "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
-    "OPTIONAL_COOKIE_DOMAINS",
-    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
-    "read_account_metadata",
     "recover_psidts_in_memory",
-    "REQUIRED_COOKIE_DOMAINS",
     "save_cookies_to_storage",
     "snapshot_cookie_jar",
-    "validate_with_recovery",
-    "write_account_metadata",
 ]
 
 
@@ -266,6 +274,22 @@ def test_auth_all_matches_external_imports_audit() -> None:
         "Add them to __all__ (and to EXPECTED_AUTH_ALL above) so the public "
         "surface stays explicit."
     )
+
+
+def test_auth_deblessed_names_stay_importable_but_unblessed() -> None:
+    """PR-1 (#1592): de-blessed auth names stay importable for back-compat but are
+    absent from ``__all__`` — the rpc-tranche freeze guard, applied to auth."""
+    assert len(_AUTH_DEBLESSED_KEEP_IMPORTABLE) == 23
+    assert len(_AUTH_DEBLESSED_KEEP_IMPORTABLE) == len(set(_AUTH_DEBLESSED_KEEP_IMPORTABLE)), (
+        "_AUTH_DEBLESSED_KEEP_IMPORTABLE must not contain duplicates"
+    )
+    declared = set(auth_module.__all__)
+    sentinel = object()
+    for name in _AUTH_DEBLESSED_KEEP_IMPORTABLE:
+        assert getattr(auth_module, name, sentinel) is not sentinel, (
+            f"de-blessed {name!r} must stay importable from notebooklm.auth"
+        )
+        assert name not in declared, f"de-blessed {name!r} must not be back in auth.__all__"
 
 
 def test_client_all_matches_external_imports_audit() -> None:

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -836,6 +836,13 @@ def test_auth_cookie_domain_constants_are_facade_exports() -> None:
 # ---------------------------------------------------------------------------
 
 
+# NOTE: 22 of the 23 names de-blessed from ``auth.__all__`` in PR-1 (#1592) were
+# removed from this manifest as a deliberate change (the docstring above sanctions
+# removal via a dedicated plan); the 23rd, ``recover_psidts_in_memory``, was never
+# in this list. First-party code now imports the de-blessed names from
+# ``notebooklm._auth.<sub>``; they stay importable from ``notebooklm.auth`` for
+# back-compat, guarded by ``test_auth_deblessed_names_stay_importable_but_unblessed``
+# in ``tests/_guardrails/test_public_surface.py``.
 _AUTH_FIRST_PARTY_COMPATIBILITY_NAMES = [
     "_auth_domain_priority",
     "_EXTRACTION_HINT",
@@ -851,45 +858,23 @@ _AUTH_FIRST_PARTY_COMPATIBILITY_NAMES = [
     "_update_cookie_input",
     "_validate_required_cookies",
     "Account",
-    "advance_cookie_snapshot_after_save",
-    "ALLOWED_COOKIE_DOMAINS",
-    "authuser_query",
     "AuthTokens",
     "build_cookie_jar",
     "build_httpx_cookies_from_storage",
     "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
-    "CookieSaveResult",
-    "CookieSnapshot",
-    "CookieSnapshotKey",
-    "CookieSnapshotValue",
     "enumerate_accounts",
     "extract_cookies_from_storage",
     "extract_cookies_with_domains",
-    "extract_csrf_from_html",
     "extract_email_from_html",
-    "extract_session_id_from_html",
-    "extract_wiz_field",
-    "fetch_tokens",
     "fetch_tokens_with_domains",
-    "format_authuser_value",
     "get_account_email_for_storage",
     "get_authuser_for_storage",
     "GOOGLE_REGIONAL_CCTLDS",
-    "KEEPALIVE_ROTATE_URL",
-    "load_auth_from_storage",
-    "load_httpx_cookies",
-    "MINIMUM_REQUIRED_COOKIES",
-    "normalize_cookie_map",
-    "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
-    "NOTEBOOKLM_REFRESH_CMD_ENV",
-    "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
     "OPTIONAL_COOKIE_DOMAINS",
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "read_account_metadata",
     "REQUIRED_COOKIE_DOMAINS",
-    "save_cookies_to_storage",
-    "snapshot_cookie_jar",
     "write_account_metadata",
 ]
 
@@ -957,7 +942,8 @@ def test_auth_paths_facade_delegates_to_private_module() -> None:
     import notebooklm.auth as auth
     from notebooklm._auth import paths
 
-    # Public-surface env-var names (listed in notebooklm.auth.__all__).
+    # Env-var names de-blessed from notebooklm.auth.__all__ in #1592; kept
+    # importable via the facade.
     assert auth.NOTEBOOKLM_REFRESH_CMD_ENV == paths.NOTEBOOKLM_REFRESH_CMD_ENV
     assert auth.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV == paths.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV
     assert auth.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV == paths.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV
@@ -972,7 +958,8 @@ def test_auth_extraction_facade_delegates_to_private_module() -> None:
     import notebooklm.auth as auth
     from notebooklm._auth import extraction
 
-    # Public-surface (listed in notebooklm.auth.__all__).
+    # WIZ extractors de-blessed from notebooklm.auth.__all__ in #1592; kept
+    # importable via the facade.
     assert auth.extract_csrf_from_html is extraction.extract_csrf_from_html
     assert auth.extract_session_id_from_html is extraction.extract_session_id_from_html
     assert auth.extract_wiz_field is extraction.extract_wiz_field

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,6 +19,10 @@ except ImportError:
     pass  # python-dotenv not installed, rely on shell environment
 
 from notebooklm import NotebookLMClient
+
+# ``load_auth_from_storage`` was de-blessed from ``notebooklm.auth.__all__`` in
+# #1592 (still importable there for back-compat); first-party code — including
+# these e2e fixtures — imports it from its canonical ``_auth.tokens`` home.
 from notebooklm._auth.tokens import load_auth_from_storage
 from notebooklm.auth import AuthTokens
 from notebooklm.exceptions import ChatError, RateLimitError

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,7 +19,8 @@ except ImportError:
     pass  # python-dotenv not installed, rely on shell environment
 
 from notebooklm import NotebookLMClient
-from notebooklm.auth import AuthTokens, load_auth_from_storage
+from notebooklm._auth.tokens import load_auth_from_storage
+from notebooklm.auth import AuthTokens
 from notebooklm.exceptions import ChatError, RateLimitError
 from notebooklm.paths import get_profile_dir
 

--- a/tests/unit/test_auth_cookie_policy.py
+++ b/tests/unit/test_auth_cookie_policy.py
@@ -12,14 +12,13 @@ from typing import Any
 import httpx
 import pytest
 
+from notebooklm._auth.cookies import load_httpx_cookies
+from notebooklm._auth.storage import save_cookies_to_storage, snapshot_cookie_jar
 from notebooklm.auth import (
     build_httpx_cookies_from_storage,
     convert_rookiepy_cookies_to_storage_state,
     extract_cookies_from_storage,
     extract_cookies_with_domains,
-    load_httpx_cookies,
-    save_cookies_to_storage,
-    snapshot_cookie_jar,
 )
 
 
@@ -990,7 +989,7 @@ class TestPathAwareCookieIdentity:
         """Pre-#369 callers built ``{(name, domain): value}`` dicts by hand;
         those keep working — :func:`normalize_cookie_map` widens the missing
         path to ``/`` so the rest of the pipeline sees the canonical shape."""
-        from notebooklm.auth import normalize_cookie_map
+        from notebooklm._auth.cookies import normalize_cookie_map
 
         result = normalize_cookie_map(
             {
@@ -1008,7 +1007,7 @@ class TestPathAwareCookieIdentity:
         'missing required cookies' error. Surface it via ``logger.warning``."""
         import logging
 
-        from notebooklm.auth import normalize_cookie_map
+        from notebooklm._auth.cookies import normalize_cookie_map
 
         with caplog.at_level(logging.WARNING, logger="notebooklm.auth"):
             result = normalize_cookie_map(
@@ -1087,7 +1086,7 @@ class TestRookiepyDomainsCoverage:
         validation purposes (e.g. ``cli.session`` historically) keep
         seeing the same domains. Only the runtime gate has tightened.
         """
-        from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
+        from notebooklm._auth.cookie_policy import ALLOWED_COOKIE_DOMAINS
 
         for domain in (
             ".youtube.com",
@@ -1298,7 +1297,7 @@ class TestMinimumRequiredCookies:
 
     def test_minimum_required_cookies_contains_sid(self):
         """Test MINIMUM_REQUIRED_COOKIES contains SID."""
-        from notebooklm.auth import MINIMUM_REQUIRED_COOKIES
+        from notebooklm._auth.cookie_policy import MINIMUM_REQUIRED_COOKIES
 
         assert "SID" in MINIMUM_REQUIRED_COOKIES
 
@@ -1314,8 +1313,8 @@ class TestAllowedCookieDomains:
         REQUIRED/OPTIONAL constants — see the cookie-domain split
         migration note in ``src/notebooklm/auth.py``.
         """
+        from notebooklm._auth.cookie_policy import ALLOWED_COOKIE_DOMAINS
         from notebooklm.auth import (
-            ALLOWED_COOKIE_DOMAINS,
             OPTIONAL_COOKIE_DOMAINS,
             REQUIRED_COOKIE_DOMAINS,
         )
@@ -1351,8 +1350,8 @@ class TestAllowedCookieDomains:
 
     def test_required_is_frozenset(self):
         """REQUIRED must be a frozenset so it cannot be mutated at runtime."""
+        from notebooklm._auth.cookie_policy import ALLOWED_COOKIE_DOMAINS
         from notebooklm.auth import (
-            ALLOWED_COOKIE_DOMAINS,
             OPTIONAL_COOKIE_DOMAINS,
             REQUIRED_COOKIE_DOMAINS,
         )

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -31,15 +31,17 @@ import notebooklm._atomic_io as _atomic_io
 import notebooklm._auth.refresh as _auth_refresh
 import notebooklm._auth.storage as _auth_storage
 import notebooklm._runtime.lifecycle as _lifecycle
-from notebooklm.auth import (
-    AuthTokens,
+from notebooklm._auth.storage import (
     CookieSaveResult,
     CookieSnapshotKey,
     CookieSnapshotValue,
     advance_cookie_snapshot_after_save,
-    build_httpx_cookies_from_storage,
     save_cookies_to_storage,
     snapshot_cookie_jar,
+)
+from notebooklm.auth import (
+    AuthTokens,
+    build_httpx_cookies_from_storage,
 )
 from tests._helpers.client_factory import build_client_shell_for_tests
 

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -10,16 +10,17 @@ import json
 
 import pytest
 
-from notebooklm._auth.extraction import _safe_url
+from notebooklm._auth.cookies import load_httpx_cookies
+from notebooklm._auth.extraction import (
+    _safe_url,
+    extract_csrf_from_html,
+    extract_session_id_from_html,
+)
+from notebooklm._auth.storage import save_cookies_to_storage, snapshot_cookie_jar
 from notebooklm.auth import (
     AuthTokens,
     build_httpx_cookies_from_storage,
     extract_cookies_from_storage,
-    extract_csrf_from_html,
-    extract_session_id_from_html,
-    load_httpx_cookies,
-    save_cookies_to_storage,
-    snapshot_cookie_jar,
 )
 
 

--- a/tests/unit/test_auth_keepalive.py
+++ b/tests/unit/test_auth_keepalive.py
@@ -18,10 +18,10 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import auth as auth_module
+from notebooklm._auth.keepalive import KEEPALIVE_ROTATE_URL
+from notebooklm._auth.paths import NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV
+from notebooklm._auth.refresh import fetch_tokens
 from notebooklm.auth import (
-    KEEPALIVE_ROTATE_URL,
-    NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV,
-    fetch_tokens,
     fetch_tokens_with_domains,
 )
 

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -18,14 +18,13 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm._auth import refresh as _auth_refresh
+from notebooklm._auth.refresh import fetch_tokens
+from notebooklm._auth.storage import save_cookies_to_storage, snapshot_cookie_jar
 from notebooklm.auth import (
     AuthTokens,
     extract_cookies_with_domains,
-    fetch_tokens,
     fetch_tokens_passive,
     fetch_tokens_with_domains,
-    save_cookies_to_storage,
-    snapshot_cookie_jar,
 )
 
 

--- a/tests/unit/test_auth_repr_redaction.py
+++ b/tests/unit/test_auth_repr_redaction.py
@@ -124,7 +124,7 @@ def test_repr_handles_empty_cookies_and_no_jar() -> None:
 
 def test_repr_does_not_leak_cookie_snapshot_values() -> None:
     """``cookie_snapshot`` mirrors the live jar and must also be redacted."""
-    from notebooklm.auth import snapshot_cookie_jar
+    from notebooklm._auth.storage import snapshot_cookie_jar
 
     auth = _build_auth_with_secrets()
     snapshot = snapshot_cookie_jar(auth.cookie_jar)  # type: ignore[arg-type]

--- a/tests/unit/test_auth_storage.py
+++ b/tests/unit/test_auth_storage.py
@@ -11,10 +11,10 @@ import json
 import pytest
 from pytest_httpx import HTTPXMock
 
+from notebooklm._auth.cookies import load_httpx_cookies
+from notebooklm._auth.tokens import load_auth_from_storage
 from notebooklm.auth import (
     AuthTokens,
-    load_auth_from_storage,
-    load_httpx_cookies,
 )
 
 

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -627,7 +627,7 @@ class TestCrossProcessFileLock:
 
         import fcntl
 
-        from notebooklm.auth import save_cookies_to_storage
+        from notebooklm._auth.storage import save_cookies_to_storage
 
         storage_path = tmp_path / "storage_state.json"
         storage_path.write_text(
@@ -644,7 +644,7 @@ class TestCrossProcessFileLock:
 
         monkeypatch.setattr("fcntl.flock", spy_flock)
 
-        from notebooklm.auth import snapshot_cookie_jar
+        from notebooklm._auth.storage import snapshot_cookie_jar
 
         jar = httpx.Cookies()
         empty_snapshot = snapshot_cookie_jar(jar)
@@ -662,7 +662,7 @@ class TestCrossProcessFileLock:
     def test_save_cookies_to_storage_creates_lock_sentinel(self, tmp_path):
         """The lock file is a sibling of the storage file with a `.lock` suffix
         so the storage file itself is free for the atomic temp-rename."""
-        from notebooklm.auth import save_cookies_to_storage, snapshot_cookie_jar
+        from notebooklm._auth.storage import save_cookies_to_storage, snapshot_cookie_jar
 
         storage_path = tmp_path / "storage_state.json"
         storage_path.write_text(

--- a/tests/unit/test_cookie_domain_split.py
+++ b/tests/unit/test_cookie_domain_split.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from notebooklm._auth.cookie_policy import ALLOWED_COOKIE_DOMAINS
 from notebooklm._auth.cookie_policy import (
     build_cookie_domain_allowlist as _neutral_build_cookie_domain_allowlist,
 )
@@ -34,7 +35,6 @@ from notebooklm._auth.cookie_policy import (
     resolve_optional_cookie_domains as _neutral_resolve_optional_cookie_domains,
 )
 from notebooklm.auth import (
-    ALLOWED_COOKIE_DOMAINS,
     OPTIONAL_COOKIE_DOMAINS,
     OPTIONAL_COOKIE_DOMAINS_BY_LABEL,
     REQUIRED_COOKIE_DOMAINS,
@@ -467,7 +467,7 @@ class TestTokenVerificationStillWorksAfterMinimumSet:
 
     def test_minimum_required_set_round_trips_through_load_httpx_cookies(self, tmp_path: Path):
         """The httpx jar (used by downloads + refresh) is non-empty for REQUIRED-only state."""
-        from notebooklm.auth import load_httpx_cookies
+        from notebooklm._auth.cookies import load_httpx_cookies
 
         storage_state = {
             "cookies": [

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -11,13 +11,15 @@ import pytest
 
 import notebooklm._cookie_persistence as persistence_module
 import notebooklm._runtime.lifecycle as lifecycle_module
-from notebooklm._cookie_persistence import CookiePersistence
-from notebooklm.auth import (
-    AuthTokens,
+from notebooklm._auth.storage import (
     CookieSaveResult,
     CookieSnapshot,
     CookieSnapshotKey,
     snapshot_cookie_jar,
+)
+from notebooklm._cookie_persistence import CookiePersistence
+from notebooklm.auth import (
+    AuthTokens,
 )
 from tests._helpers.client_factory import build_client_shell_for_tests
 

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -18,9 +18,11 @@ import pytest
 
 import notebooklm._auth.refresh as refresh_mod
 from notebooklm import auth as auth_mod
-from notebooklm.auth import (
+from notebooklm._auth.paths import (
     NOTEBOOKLM_REFRESH_CMD_ENV,
     NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV,
+)
+from notebooklm.auth import (
     _run_refresh_cmd,
     _split_refresh_cmd,
 )

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -46,8 +46,8 @@ def mock_core():
     # ``core.auth.authuser`` / ``core.auth.account_email`` at call time so
     # tests that mutate ``mock_core.auth.authuser`` mid-test still observe
     # the updated routing.
-    from notebooklm.auth import authuser_query as _authuser_query
-    from notebooklm.auth import format_authuser_value as _authuser_header
+    from notebooklm._auth.account import authuser_query as _authuser_query
+    from notebooklm._auth.account import format_authuser_value as _authuser_header
 
     core.authuser_query = MagicMock(
         side_effect=lambda: _authuser_query(core.auth.authuser, core.auth.account_email)

--- a/tests/unit/test_token_regex.py
+++ b/tests/unit/test_token_regex.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from notebooklm.auth import extract_wiz_field
+from notebooklm._auth.extraction import extract_wiz_field
 from notebooklm.exceptions import AuthExtractionError, RPCError
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "notebooklm_html.html"


### PR DESCRIPTION
## Tighten the public `auth` surface — PR-1: de-bless 23 internal re-exports

Closes #1592 (PR-1 of the auth tightening; sibling to the merged rpc tranche #1589/#1591).

`auth.__all__` advertised **46** names, but `docs/stability.md` has always marked
`notebooklm.auth.*` internal except a documented few. Most of the surplus are
**migration leftovers**: when auth internals moved into `_auth/*` (ADR-0003 →
ADR-0014), the facade kept the old `notebooklm.auth.X` import paths working.

### What this PR does (the cheap, zero-risk ratchet)

De-blesses the **23** names imported only by core-`src`/tests (never by `cli/`
or `_app/`, so no public-boundary pressure). `auth.__all__` **46 → 23**.

- **Mechanism = same as the rpc tranche:** names leave `__all__` but **stay
  importable** as `notebooklm.auth.<name>` (the facade re-exports by assignment) —
  back-compat preserved. First-party `src`/tests now import them from their
  canonical `notebooklm._auth.<sub>` home. One `removed-export` allowance each
  (baseline v0.7.0 — all 23 present there; `--check-stale` guards regrowth and
  forces prune at the next release).
- **Flips:** 8 core-`src` import sites (7 files) + the 23 names across 14 test
  files → `_auth.<sub>`.
- **Guardrails:** shrink `EXPECTED_AUTH_ALL` to match; remove the 22 de-blessed
  names from the move-safety manifest (`_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES`) —
  a deliberate change its own docstring sanctions; **add a freeze test**
  (`test_auth_deblessed_names_stay_importable_but_unblessed`) locking that the 23
  stay importable but absent from `__all__`.
- **Docs:** CHANGELOG `### Changed`, a `deprecations.md` surface-tightening note
  (de-advertisement, not removal), and an `auth.py` docstring fix (the
  `load_httpx_cookies` example pointed at a now-internal helper).

The 23: `advance_cookie_snapshot_after_save`, `ALLOWED_COOKIE_DOMAINS`,
`authuser_query`, `CookieSaveResult`, `CookieSnapshot`, `CookieSnapshotKey`,
`CookieSnapshotValue`, `extract_csrf_from_html`, `extract_session_id_from_html`,
`extract_wiz_field`, `fetch_tokens`, `format_authuser_value`, `KEEPALIVE_ROTATE_URL`,
`load_auth_from_storage`, `load_httpx_cookies`, `MINIMUM_REQUIRED_COOKIES`,
`normalize_cookie_map`, `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV`,
`NOTEBOOKLM_REFRESH_CMD_ENV`, `NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV`,
`recover_psidts_in_memory`, `save_cookies_to_storage`, `snapshot_cookie_jar`.

### Unchanged

Documented imports (`AuthTokens`, `convert_rookiepy_cookies_to_storage_state`,
the cookie-domain constants) and cohesive operations (`Account`,
`enumerate_accounts`, `fetch_tokens_with_domains`, `fetch_tokens_passive`, …) stay
public. No runtime behavior change; mypy unaffected (implicit re-export).

### Deliberately deferred

The ~14 names forced public by `cli/`+`_app/` (boundary-forbidden from `_auth`)
stay public. Hiding them needs cohesive service ops + a CLI-login refactor; a
momus+oracle review (claude+codex, two rounds) judged that encapsulation payoff
**limited** for auth — the move-safety policy keeps names importable regardless —
so the expensive ops/`refresh.py` refactor are **not** pursued here. Revisit only
with a genuine-removal mandate.

### Verification

- `scripts/audit_public_api_compat.py --check-stale` → **0 unapproved, 0 stale**
- `ruff check .` + `ruff format --check .` → clean
- `mypy src/notebooklm` → clean (273 files)
- full `pytest` → green (pre-existing untracked-file failures excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Tightened the `notebooklm.auth` public surface by removing 23 internal re-exports from `notebooklm.auth.__all__`. The removed symbols remain importable via `notebooklm.auth.<name>` for backward compatibility.
  * Updated internal auth wiring to use the more specific internal auth locations while preserving behavior.

* **Documentation**
  * Updated the changelog and deprecation guidance to clarify what changed and where to import from going forward.

* **Tests**
  * Refreshed public-surface guardrails to enforce the new `__all__` contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->