### PR TITLE
fix(rpc): align artifact CREATE payloads with live UI (backport #1583) — fixes #1594 for 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.2] - 2026-06-09
+## [0.7.2] - 2026-06-17
 
 Maintenance patch on the 0.7.x line. Backports fixes from `main`
 (cherry-picked ahead of the v0.8.0 breaking release).
 
 ### Fixed
+
+- **Video (and other artifact) generation no longer fails immediately on
+  cohorts that reject the legacy client-options shape** (#1594; backport of
+  #1583). `CREATE_ARTIFACT` sent a minimal param-0 of `[2]`; the live web
+  client sends the fuller capability envelope
+  (`[2, null, null, [1, …, [1]], [[1, 4, 8, 2, 3, 6]]]`). On some accounts the
+  backend began rejecting the short form for video generation specifically —
+  the artifact was created and then immediately marked failed, while audio and
+  infographic (which the backend still accepted) kept working. All artifact
+  builders (audio, video, cinematic video, report, quiz, flashcards) now send
+  the full envelope, matching the browser. The VCR body matcher normalizes the
+  old and new client-options shapes so existing generation cassettes still
+  replay.
 
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Any
 
 from ..rpc import (
     INTERACTIVE_MIND_MAP_VARIANT,
@@ -54,6 +54,23 @@ _STATIC_REPORT_CONFIGS: dict[ReportFormat, dict[str, str]] = {
 }
 
 
+def _artifact_client_options() -> list[Any]:
+    """Return the client-options block used by Studio artifact RPCs.
+
+    Live UI captures on 2026-06-15 for Data Table and interactive Mind Map send
+    this full capability envelope as ``CREATE_ARTIFACT`` param 0. Older captures
+    used the shorter ``[2]`` form, but the fuller envelope now matches the web
+    client and the in-place retry RPC.
+    """
+    return [
+        2,
+        None,
+        None,
+        [1, None, None, None, None, None, None, None, None, None, [1]],
+        [[1, 4, 8, 2, 3, 6]],
+    ]
+
+
 def build_audio_artifact_params(
     notebook_id: str,
     source_ids: list[str],
@@ -71,7 +88,7 @@ def build_audio_artifact_params(
     length_code = audio_length.value if audio_length is not None else AudioLength.DEFAULT.value
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -125,7 +142,7 @@ def build_video_artifact_params(
         video_config.append(style_prompt)
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -157,7 +174,7 @@ def build_cinematic_video_artifact_params(
     source_ids_double = nest_source_ids(source_ids, 1)
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -201,7 +218,7 @@ def build_report_artifact_params(
     source_ids_double = nest_source_ids(source_ids, 1)
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -242,7 +259,7 @@ def build_quiz_artifact_params(
     difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -285,7 +302,7 @@ def build_flashcards_artifact_params(
     difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -327,7 +344,7 @@ def build_interactive_mind_map_artifact_params(
     """
     source_ids_triple = nest_source_ids(source_ids, 2)
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -365,7 +382,7 @@ def build_infographic_artifact_params(
     style_code = style.value if style is not None else InfographicStyle.AUTO_SELECT.value
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -404,7 +421,7 @@ def build_slide_deck_artifact_params(
     length_code = slide_length.value if slide_length is not None else SlideDeckLength.DEFAULT.value
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,
@@ -437,24 +454,9 @@ def build_revise_slide_params(artifact_id: str, slide_index: int, prompt: str) -
     ]
 
 
-# Fixed client capability blob for ``RETRY_ARTIFACT``. Confirmed byte-identical
-# across video (UI DevTools capture), audio, and infographic retries
-# (issue #1319), so it is sent verbatim regardless of artifact type. The
-# trailing ``[[1, 4, 8, 2, 3, 6]]`` is a static artifact-type-code capability
-# list, not artifact-specific. If Google reshapes this, the RETRY_ARTIFACT call
-# fails loudly per the standard RPC policy rather than silently mis-retrying.
-_RETRY_OPTIONS: Final[list[Any]] = [
-    2,
-    None,
-    None,
-    [1, None, None, None, None, None, None, None, None, None, [1]],
-    [[1, 4, 8, 2, 3, 6]],
-]
-
-
 def build_retry_artifact_params(artifact_id: str) -> list[Any]:
     """Build ``RETRY_ARTIFACT`` params for an in-place failed-artifact retry."""
-    return [_RETRY_OPTIONS, artifact_id]
+    return [_artifact_client_options(), artifact_id]
 
 
 def build_data_table_artifact_params(
@@ -468,7 +470,7 @@ def build_data_table_artifact_params(
     source_ids_triple = nest_source_ids(source_ids, 2)
 
     return [
-        [2],
+        _artifact_client_options(),
         notebook_id,
         [
             None,

--- a/tests/unit/test_interactive_mind_map_payload.py
+++ b/tests/unit/test_interactive_mind_map_payload.py
@@ -1,18 +1,26 @@
 """Snapshot test for the interactive-mind-map CREATE_ARTIFACT payload builder.
 
 The expected shape is verified live against the captured GUI request (#1256):
-``[[2], nb, [None,None,4,<triple src ids>,None,None,None,None,None,[None,[4]]]]``.
+``[client_options, nb, [None,None,4,<triple src ids>,None,None,None,None,None,[None,[4]]]]``.
 """
 
 from __future__ import annotations
 
 from notebooklm._artifact.payloads import build_interactive_mind_map_artifact_params
 
+_ARTIFACT_CLIENT_OPTIONS = [
+    2,
+    None,
+    None,
+    [1, None, None, None, None, None, None, None, None, None, [1]],
+    [[1, 4, 8, 2, 3, 6]],
+]
+
 
 def test_single_source_exact_shape():
     params = build_interactive_mind_map_artifact_params("nb1", ["s1"])
     assert params == [
-        [2],
+        _ARTIFACT_CLIENT_OPTIONS,
         "nb1",
         [None, None, 4, [[["s1"]]], None, None, None, None, None, [None, [4]]],
     ]

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -83,6 +83,14 @@ from notebooklm.rpc.types import (
 
 FIXTURE_ROOT: Path = Path(__file__).parents[1] / "fixtures" / "rpc_golden"
 
+_ARTIFACT_CLIENT_OPTIONS: list[Any] = [
+    2,
+    None,
+    None,
+    [1, None, None, None, None, None, None, None, None, None, [1]],
+    [[1, 4, 8, 2, 3, 6]],
+]
+
 
 class _FixtureSchemaError(AssertionError):
     """Raised when a fixture is missing a required field or has the wrong type.
@@ -235,7 +243,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 audio_length=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -262,7 +270,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 audio_length=AudioLength.SHORT,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -298,7 +306,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 style_prompt=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -329,7 +337,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 style_prompt="blueprint line art",
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -365,7 +373,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 instructions=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -391,7 +399,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 extra_instructions=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -432,7 +440,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 extra_instructions="Ignored for custom reports.",
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -468,7 +476,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 difficulty=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -497,7 +505,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 difficulty=QuizDifficulty.HARD,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -526,7 +534,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 difficulty=QuizDifficulty.EASY,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -557,7 +565,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 style=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -590,7 +598,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 style=InfographicStyle.EDITORIAL,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -622,7 +630,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 slide_length=None,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -656,7 +664,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 slide_length=SlideDeckLength.SHORT,
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -688,7 +696,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                 instructions="Extract product comparisons",
             ),
             [
-                [2],
+                _ARTIFACT_CLIENT_OPTIONS,
                 "nb_payload",
                 [
                     None,
@@ -757,17 +765,9 @@ def test_revise_slide_payload_builder_matches_golden_envelope() -> None:
 def test_retry_artifact_payload_builder_matches_golden_envelope() -> None:
     params = build_retry_artifact_params("artifact_payload")
 
-    # The type-agnostic retry_options literal is sent verbatim (issue #1319).
-    assert params == [
-        [
-            2,
-            None,
-            None,
-            [1, None, None, None, None, None, None, None, None, None, [1]],
-            [[1, 4, 8, 2, 3, 6]],
-        ],
-        "artifact_payload",
-    ]
+    # The type-agnostic client-options literal is sent verbatim (issue #1319;
+    # also confirmed for CREATE_ARTIFACT on 2026-06-15).
+    assert params == [_ARTIFACT_CLIENT_OPTIONS, "artifact_payload"]
     encoded = encode_rpc_request(RPCMethod.RETRY_ARTIFACT, params)
     assert encoded == _expected_rpc_envelope(RPCMethod.RETRY_ARTIFACT, params)
     # The encoded envelope must carry the confirmed wire ID.

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -444,7 +444,7 @@ class TestArtifactsSourceSelection:
 
         # Video params structure:
         # [
-        #   [2], notebook_id,
+        #   client_options, notebook_id,
         #   [None, None, 3, source_ids_triple, None, None, None, None,
         #    [None, None, [source_ids_double, language, instructions, None, format_code, style_code]]]
         # ]
@@ -632,7 +632,7 @@ class TestArtifactsSourceSelection:
 
         # Report params structure:
         # [
-        #   [2], notebook_id,
+        #   client_options, notebook_id,
         #   [None, None, 2, source_ids_triple, None, None, None,
         #    [None, [title, desc, None, source_ids_double, language, prompt, None, True]]]
         # ]
@@ -725,7 +725,7 @@ class TestArtifactsSourceSelection:
 
         # Quiz params structure:
         # [
-        #   [2], notebook_id,
+        #   client_options, notebook_id,
         #   [None, None, 4, source_ids_triple, ...]
         # ]
         inner_params = params[2]

--- a/tests/unit/test_vcr_body_matcher.py
+++ b/tests/unit/test_vcr_body_matcher.py
@@ -62,6 +62,36 @@ _normalize_uuids: Callable[[str], str] = _vcr_config._normalize_uuids
 _FREQ_VOLATILE_KEYS: frozenset[str] = _vcr_config._FREQ_VOLATILE_KEYS
 _UUID_PLACEHOLDER: str = _vcr_config._UUID_PLACEHOLDER
 
+_OLD_CREATE_ARTIFACT_OPTIONS = [2]
+_LIVE_CREATE_ARTIFACT_OPTIONS = [
+    2,
+    None,
+    None,
+    [1, None, None, None, None, None, None, None, None, None, [1]],
+    [[1, 4, 8, 2, 3, 6]],
+]
+_DATA_TABLE_SPEC = [
+    None,
+    None,
+    9,
+    [[["source-id"]]],
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    [None, ["make a table", "en"]],
+]
+
 
 class _StubRequest:
     """Minimal stand-in for a ``vcr.request.Request`` carrying only ``body``."""
@@ -184,6 +214,62 @@ def test_batchexecute_null_vs_filled_slot_still_matches() -> None:
     body_a = _build_batchexecute_body("rpc", [None, None])
     body_b = _build_batchexecute_body("rpc", [2, 2])
     assert _freq_body_matcher(_StubRequest(body_a), _StubRequest(body_b)) is True
+
+
+def test_create_artifact_old_and_live_client_options_match() -> None:
+    """Old ``[2]`` and live client-options envelopes match for CREATE_ARTIFACT.
+
+    The production builder now follows the 2026-06-15 web UI shape at param 0,
+    while older generation cassettes recorded the compact ``[2]`` form. The VCR
+    matcher should treat only that client-options slot as equivalent and keep
+    the artifact spec itself structurally checked.
+    """
+    old_body = _build_batchexecute_body(
+        "R7cb6c",
+        [_OLD_CREATE_ARTIFACT_OPTIONS, "notebook-id", _DATA_TABLE_SPEC],
+    )
+    live_body = _build_batchexecute_body(
+        "R7cb6c",
+        [_LIVE_CREATE_ARTIFACT_OPTIONS, "notebook-id", _DATA_TABLE_SPEC],
+    )
+
+    assert _freq_body_matcher(_StubRequest(old_body), _StubRequest(live_body)) is True
+
+
+def test_create_artifact_spec_drift_still_fails_after_options_normalization() -> None:
+    """The R7cb6c compatibility rule does not hide real artifact-spec drift."""
+    truncated_spec = _DATA_TABLE_SPEC[:-1]
+    old_body = _build_batchexecute_body(
+        "R7cb6c",
+        [_OLD_CREATE_ARTIFACT_OPTIONS, "notebook-id", _DATA_TABLE_SPEC],
+    )
+    drift_body = _build_batchexecute_body(
+        "R7cb6c",
+        [_LIVE_CREATE_ARTIFACT_OPTIONS, "notebook-id", truncated_spec],
+    )
+
+    assert _freq_body_matcher(_StubRequest(old_body), _StubRequest(drift_body)) is False
+
+
+def test_create_artifact_unknown_client_options_shape_fails() -> None:
+    """Only the known old/live R7cb6c client-options envelopes are normalized."""
+    old_body = _build_batchexecute_body(
+        "R7cb6c",
+        [_OLD_CREATE_ARTIFACT_OPTIONS, "notebook-id", _DATA_TABLE_SPEC],
+    )
+
+    for unknown_options in (
+        [3],
+        [None],
+        ["unexpected"],
+        [2, None, None, [1], [[1, 4, 8, 2, 3, 6]]],
+    ):
+        unknown_body = _build_batchexecute_body(
+            "R7cb6c",
+            [unknown_options, "notebook-id", _DATA_TABLE_SPEC],
+        )
+
+        assert _freq_body_matcher(_StubRequest(old_body), _StubRequest(unknown_body)) is False
 
 
 def test_batchexecute_envelope_with_extra_top_level_slot_fails() -> None:

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -441,6 +441,63 @@ def _shape_only(node: Any) -> Any:
     return _LEAF
 
 
+_CREATE_ARTIFACT_RPC_ID = "R7cb6c"
+_CREATE_ARTIFACT_OPTIONS_SENTINEL = {"_CREATE_ARTIFACT_CLIENT_OPTIONS": True}
+_CREATE_ARTIFACT_OLD_CLIENT_OPTIONS = [2]
+_CREATE_ARTIFACT_LIVE_CLIENT_OPTIONS = [
+    2,
+    None,
+    None,
+    [1, None, None, None, None, None, None, None, None, None, [1]],
+    [[1, 4, 8, 2, 3, 6]],
+]
+
+
+def _is_create_artifact_client_options(node: Any) -> bool:
+    """Return whether ``node`` is a known CREATE_ARTIFACT options envelope.
+
+    Older cassettes recorded the compact ``[2]`` first param. Live UI captures
+    on 2026-06-15 send ``[2, None, None, ..., [[1, 4, 8, 2, 3, 6]]]`` instead.
+    Both identify the same client-options slot for matcher purposes; the actual
+    artifact spec remains matched structurally.
+    """
+    if not isinstance(node, list):
+        return False
+    return node in (
+        _CREATE_ARTIFACT_OLD_CLIENT_OPTIONS,
+        _CREATE_ARTIFACT_LIVE_CLIENT_OPTIONS,
+    )
+
+
+def _normalize_create_artifact_options(decoded_outer: Any) -> Any:
+    """Canonicalize old/new CREATE_ARTIFACT client-options shapes for VCR replay."""
+    if not isinstance(decoded_outer, list):
+        return decoded_outer
+
+    normalized_outer: list[Any] = []
+    for batch in decoded_outer:
+        if not isinstance(batch, list):
+            normalized_outer.append(batch)
+            continue
+        normalized_batch: list[Any] = []
+        for entry in batch:
+            if (
+                isinstance(entry, list)
+                and len(entry) >= 2
+                and entry[0] == _CREATE_ARTIFACT_RPC_ID
+                and isinstance(entry[1], list)
+                and entry[1]
+                and _is_create_artifact_client_options(entry[1][0])
+            ):
+                args = list(entry[1])
+                args[0] = _CREATE_ARTIFACT_OPTIONS_SENTINEL
+                normalized_batch.append([entry[0], args, *entry[2:]])
+            else:
+                normalized_batch.append(entry)
+        normalized_outer.append(normalized_batch)
+    return normalized_outer
+
+
 def _normalize_freq_string(body: str) -> str | None:
     """Extract and lightly-normalize the raw ``f.req`` value from a form body.
 
@@ -585,7 +642,7 @@ def _freq_body_matcher(r1: Any, r2: Any) -> bool:
                         else:
                             decoded_batch.append(entry)
                     decoded_outer.append(decoded_batch)
-                return f_req, ("batch", decoded_outer)
+                return f_req, ("batch", _normalize_create_artifact_options(decoded_outer))
             except (TypeError, IndexError):
                 return f_req, None
 


### PR DESCRIPTION
## What

Backport of #1583 ("align artifact generation payloads with live UI") to the 0.7.x line, targeted at the **video-generation-fails-immediately** report in #1594.

## Why

On v0.7.1, `CREATE_ARTIFACT` sends a minimal param-0 of `[2]`. The live NotebookLM web client sends the fuller capability envelope:

```
[2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[1, 4, 8, 2, 3, 6]]]
```

On some accounts/cohorts the backend began **rejecting the short `[2]` form for video generation specifically** — the artifact is created (returns a task id) and then immediately marked `failed`, while audio and infographic (still accepted) keep working. That matches #1594 exactly (reporter's decoded browser `f.req` is the envelope; their CLI on 0.7.1 sends `[2]`).

Note: this is cohort-dependent — it could not be reproduced on a test account that still accepts `[2]` for video across many languages. The reporter's own browser capture + the audio/video asymmetry are the evidence; confirmation via this build is requested on #1594.

## Scope (minimal backport)

Cherry-picked the essential payload alignment, **not** the full #1583 commit:

- ✅ `_artifact/payloads.py` — all builders (audio, video, cinematic video, report, quiz, flashcards) send the full client-options envelope.
- ✅ `tests/vcr_config.py` + `test_vcr_body_matcher.py` — normalize old/new client-options shapes so existing generation cassettes still replay.
- ✅ golden-payload / source-selection / interactive-mind-map test updates that came with the shape change.
- ❌ **Dropped** (don't belong on 0.7.x): `_idempotency_policy.py` and `test_mcp_desktop_extension.py` (newer files, absent on 0.7.x), the 590-line `rpc-reference.md` doc rewrite, and the `uv.lock` churn.

## Verification

- `uv run pytest` — full suite green
- `uv run ruff check` / `uv run mypy src/notebooklm` — clean
- `scripts/audit_public_api_compat.py` — no public-API break (allowlist untouched)

Targets the 0.7.2 maintenance release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

