### PR TITLE
fix(artifacts): match live video style encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Video Overview visual-style values now match the live NotebookLM Web UI**
+  (#1594). `VideoStyle` previously used stale numeric values, so several named
+  styles could serialize as the wrong style on the wire. `CUSTOM` now reflects
+  the UI's `0` value and is encoded the same way the Web UI sends it: the style
+  enum slot is omitted/defaulted and the custom visual-style prompt is appended
+  to the video config. Preset styles such as Whiteboard, Anime, Kawaii,
+  Watercolor, Heritage, and Paper-craft now use the current Web UI values.
+
 - **`notebooklm auth check` text mode now exits non-zero when an executed check
   fails, matching `--json` mode** (#1569). Previously the Rich-table renderer
   printed the failed checks but always exited `0`, so an unattended health check

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2298,15 +2298,15 @@ class VideoFormat(Enum):
 
 class VideoStyle(Enum):
     AUTO_SELECT = 1
-    CUSTOM = 2
-    CLASSIC = 3
-    WHITEBOARD = 4
-    KAWAII = 5
-    ANIME = 6
-    WATERCOLOR = 7
+    CUSTOM = 0
+    CLASSIC = 2
+    WHITEBOARD = 3
+    KAWAII = 9
+    ANIME = 7
+    WATERCOLOR = 6
     RETRO_PRINT = 8
-    HERITAGE = 9
-    PAPER_CRAFT = 10
+    HERITAGE = 4
+    PAPER_CRAFT = 5
 ```
 
 ### Quiz/Flashcards

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1,7 +1,7 @@
 # RPC & UI Reference
 
 **Status:** Active
-**Last Updated:** 2026-06-15
+**Last Updated:** 2026-06-17
 **Source of Truth:** `src/notebooklm/rpc/types.py` for method IDs; payload builders in `src/notebooklm/` and golden tests under `tests/unit/`
 **Purpose:** Complete reference for RPC methods, UI selectors, and payload structures
 
@@ -1169,7 +1169,7 @@ video_config = [
     format_code,          # 1=EXPLAINER, 2=BRIEF, 3=CINEMATIC
     style_code,           # None=CUSTOM, 1=AUTO_SELECT, 2=CLASSIC, 3=WHITEBOARD, ...
 ]
-if style_prompt:          # Optional 7th element; CUSTOM style only
+if video_style == VideoStyle.CUSTOM and style_prompt:
     video_config.append(style_prompt)
 
 params = [

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1159,15 +1159,15 @@ params = [
 **Source:** `_artifacts.py::generate_video()`
 
 ```python
-# Build the inner video config; style_prompt is appended ONLY when set
-# (which the builder allows only for video_style=VideoStyle.CUSTOM).
+# Build the inner video config. Explainer and Brief expose visual styles;
+# Cinematic hides the visual-style selector.
 video_config = [
     source_ids_double,
     language,             # "en"
-    instructions,
+    instructions,          # Focus/customization prompt
     None,
     format_code,          # 1=EXPLAINER, 2=BRIEF, 3=CINEMATIC
-    style_code,           # 1=AUTO_SELECT, 2=CUSTOM, 3=CLASSIC, 4=WHITEBOARD, ...
+    style_code,           # None=CUSTOM, 1=AUTO_SELECT, 2=CLASSIC, 3=WHITEBOARD, ...
 ]
 if style_prompt:          # Optional 7th element; CUSTOM style only
     video_config.append(style_prompt)
@@ -1186,6 +1186,25 @@ params = [
         None,                         # [7]
         [None, None, video_config],   # [8]
     ],
+]
+```
+
+Live Web UI capture on 2026-06-17 showed these visual-style radio values:
+`AUTO_SELECT=1`, `CUSTOM=0`, `CLASSIC=2`, `WHITEBOARD=3`,
+`KAWAII=9`, `ANIME=7`, `WATERCOLOR=6`, `RETRO_PRINT=8`,
+`HERITAGE=4`, and `PAPER_CRAFT=5`. Because `CUSTOM=0` is the protobuf
+default, the Web UI's JSON array omits that field as `null` and appends the
+custom visual-style prompt in the 7th slot:
+
+```python
+[
+    source_ids_double,
+    "en",
+    "Focus prompt",
+    None,
+    2,                    # VideoFormat.BRIEF
+    None,                 # VideoStyle.CUSTOM omitted/defaulted
+    "Custom visual style",
 ]
 ```
 

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -8,6 +8,86 @@
   },
   "allowed_breaks": [
     {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.ANIME",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.CLASSIC",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.CUSTOM",
+      "reason": "v0.8.0 #1594: CUSTOM is the live Web UI's proto-default video style value (0) and is encoded by omitting/defaulting the style slot plus appending the custom style prompt. See CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.HERITAGE",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.KAWAII",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.PAPER_CRAFT",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.WATERCOLOR",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.WHITEBOARD",
+      "reason": "v0.8.0 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures; see CHANGELOG.md and docs/rpc-reference.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.ANIME",
+      "reason": "Same break as notebooklm.VideoStyle.ANIME above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.CLASSIC",
+      "reason": "Same break as notebooklm.VideoStyle.CLASSIC above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.CUSTOM",
+      "reason": "Same break as notebooklm.VideoStyle.CUSTOM above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.HERITAGE",
+      "reason": "Same break as notebooklm.VideoStyle.HERITAGE above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.KAWAII",
+      "reason": "Same break as notebooklm.VideoStyle.KAWAII above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.PAPER_CRAFT",
+      "reason": "Same break as notebooklm.VideoStyle.PAPER_CRAFT above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.WATERCOLOR",
+      "reason": "Same break as notebooklm.VideoStyle.WATERCOLOR above; this entry covers the notebooklm.types re-export."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.WHITEBOARD",
+      "reason": "Same break as notebooklm.VideoStyle.WHITEBOARD above; this entry covers the notebooklm.types re-export."
+    },
+    {
       "code": "removed-member",
       "object": "notebooklm.NotebookLMClient.notebooks.share",
       "reason": "v0.8.0 #1363: removed the v0.5.0-deprecated NotebooksAPI.share() no-behavior-change wrapper over client.sharing.set_public. Use client.sharing.set_public(notebook_id, public) for the public-sharing toggle and client.notebooks.get_share_url(notebook_id, artifact_id) for the deep-link URL (get_share_url stays). See CHANGELOG.md and docs/deprecations.md."

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -128,7 +128,12 @@ def build_video_artifact_params(
     source_ids_double = nest_source_ids(source_ids, 1)
 
     format_code = video_format.value if video_format is not None else VideoFormat.EXPLAINER.value
-    style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
+    if video_style == VideoStyle.CUSTOM:
+        # Live Web UI serializes the CUSTOM enum's proto-default value (0) as
+        # an omitted/null field and carries the custom visual prompt in slot 6.
+        style_code = None
+    else:
+        style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
 
     video_config = [
         source_ids_double,

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -143,7 +143,7 @@ def build_video_artifact_params(
         format_code,
         style_code,
     ]
-    if style_prompt:
+    if video_style == VideoStyle.CUSTOM and style_prompt:
         video_config.append(style_prompt)
 
     return [

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -267,15 +267,15 @@ class VideoStyle(int, Enum):
     """Video visual style options."""
 
     AUTO_SELECT = 1
-    CUSTOM = 2
-    CLASSIC = 3
-    WHITEBOARD = 4
-    KAWAII = 5
-    ANIME = 6
-    WATERCOLOR = 7
+    CUSTOM = 0
+    CLASSIC = 2
+    WHITEBOARD = 3
+    KAWAII = 9
+    ANIME = 7
+    WATERCOLOR = 6
     RETRO_PRINT = 8
-    HERITAGE = 9
-    PAPER_CRAFT = 10
+    HERITAGE = 4
+    PAPER_CRAFT = 5
 
 
 class QuizQuantity(int, Enum):

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -813,6 +813,22 @@ def test_video_style_values_match_live_web_ui() -> None:
     }
 
 
+def test_video_style_prompt_slot_is_custom_only() -> None:
+    """Preset styles must not emit the Web UI's custom visual-style prompt slot."""
+    params = build_video_artifact_params(
+        "nb_payload",
+        ["src_alpha"],
+        language="en",
+        instructions="Make it playful",
+        video_format=VideoFormat.EXPLAINER,
+        video_style=VideoStyle.WHITEBOARD,
+        style_prompt="ignored outside custom style",
+    )
+
+    video_config = params[2][8][2]
+    assert video_config == [[["src_alpha"]], "en", "Make it playful", None, 1, 3]
+
+
 def test_revise_slide_payload_builder_matches_golden_envelope() -> None:
     params = build_revise_slide_params("artifact_payload", 2, "Tighten the summary")
 

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -371,7 +371,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                             "Summarize visually",
                             None,
                             1,
-                            2,
+                            None,
                             "blueprint line art",
                         ],
                     ],
@@ -399,6 +399,37 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                     None,
                     None,
                     [None, None, [[["src_alpha"]], "de", None, None, 3]],
+                ],
+            ],
+        ),
+        (
+            "video_non_contiguous_preset_style",
+            build_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions="Make it playful",
+                video_format=VideoFormat.BRIEF,
+                video_style=VideoStyle.KAWAII,
+                style_prompt=None,
+            ),
+            [
+                _ARTIFACT_CLIENT_OPTIONS,
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        None,
+                        [[["src_alpha"]], "en", "Make it playful", None, 2, 9],
+                    ],
                 ],
             ],
         ),
@@ -764,6 +795,22 @@ def test_artifact_payload_builders_match_golden_rpc_envelopes(
 
     assert params == expected
     assert encode_rpc_request(method, params) == _expected_rpc_envelope(method, expected)
+
+
+def test_video_style_values_match_live_web_ui() -> None:
+    """Guard against drift in the Web UI's Video Overview style radio values."""
+    assert {style: style.value for style in VideoStyle} == {
+        VideoStyle.AUTO_SELECT: 1,
+        VideoStyle.CUSTOM: 0,
+        VideoStyle.CLASSIC: 2,
+        VideoStyle.WHITEBOARD: 3,
+        VideoStyle.KAWAII: 9,
+        VideoStyle.ANIME: 7,
+        VideoStyle.WATERCOLOR: 6,
+        VideoStyle.RETRO_PRINT: 8,
+        VideoStyle.HERITAGE: 4,
+        VideoStyle.PAPER_CRAFT: 5,
+    }
 
 
 def test_revise_slide_payload_builder_matches_golden_envelope() -> None:

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -488,7 +488,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_prompt_encoding(
         self, mock_core, mock_mind_map_service
     ):
-        """Test custom video style prompt is encoded after the style code."""
+        """Test custom video style prompt is encoded like the live Web UI."""
         api = ArtifactsAPI(
             rpc=mock_core,
             drain=mock_core,
@@ -507,7 +507,7 @@ class TestArtifactsSourceSelection:
 
         params = mock_core.rpc_executor.rpc_call.call_args.args[1]
         video_config = params[2][8][2]
-        assert video_config[5] == VideoStyle.CUSTOM.value
+        assert video_config[5] is None
         assert video_config[6] == "Use hand-drawn diagrams"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update `VideoStyle` wire values to match the live NotebookLM Web UI (the old numeric codes were stale — e.g. whiteboard was `4`, the live value is `3` — so presets could serialize as the *wrong* style)
- encode custom video styles like the UI: omit/default the style enum slot and append the custom visual-style prompt
- add golden coverage for custom and non-contiguous preset video styles, plus docs and changelog notes

## Scope vs #1594 — this does NOT close #1594
This corrects the **video style wire encoding** — a real bug *surfaced by* #1594, and verified live (the corrected preset codes generate on our cohort; they previously serialized as the wrong style).

It does **not** fix the core of #1594. That failure is the **custom / free-text style path**, which is **cohort-gated** by Google's gradual rollout:
- On our (un-migrated) cohort, `CUSTOM` + prompt **still fails** even with this PR's UI-matched encoding (live-tested).
- We could **not verify** it succeeds on a migrated cohort (we don't have a migrated account).

So **#1594 stays open** pending the reporter testing this branch. Merge this for the wire-code correctness fix; the #1594 custom-video path is tracked separately.

## Test plan
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
