### PR TITLE
fix(rpc): correct VideoStyle wire values to match live Web UI (backport #1597) for 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Maintenance patch on the 0.7.x line. Backports fixes from `main`
 
 ### Fixed
 
+- **Video Overview visual-style values corrected to match the live Web UI**
+  (#1594; backport of #1597). `VideoStyle` used stale numeric wire values, so
+  several named styles (Whiteboard, Kawaii, Anime, Watercolor, Heritage,
+  Paper-craft, Classic, Custom) serialized as the *wrong* style on the wire.
+  Values now match live Web UI captures, and `CUSTOM` is encoded the Web-UI way
+  (the style enum slot is omitted/defaulted and the custom visual-style prompt
+  is appended). **Note:** this changes the integer values of `VideoStyle`
+  members — code that passed the raw ints must update; passing the enum members
+  (`VideoStyle.WHITEBOARD`, …) is unaffected.
+
 - **Video (and other artifact) generation no longer fails immediately on
   cohorts that reject the legacy client-options shape** (#1594; backport of
   #1583). `CREATE_ARTIFACT` sent a minimal param-0 of `[2]`; the live web

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2187,15 +2187,15 @@ class VideoFormat(Enum):
 
 class VideoStyle(Enum):
     AUTO_SELECT = 1
-    CUSTOM = 2
-    CLASSIC = 3
-    WHITEBOARD = 4
-    KAWAII = 5
-    ANIME = 6
-    WATERCOLOR = 7
+    CUSTOM = 0
+    CLASSIC = 2
+    WHITEBOARD = 3
+    KAWAII = 9
+    ANIME = 7
+    WATERCOLOR = 6
     RETRO_PRINT = 8
-    HERITAGE = 9
-    PAPER_CRAFT = 10
+    HERITAGE = 4
+    PAPER_CRAFT = 5
 ```
 
 ### Quiz/Flashcards

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -596,15 +596,15 @@ params = [
 **Source:** `_artifacts.py::generate_video()`
 
 ```python
-# Build the inner video config; style_prompt is appended ONLY when set
-# (which the builder allows only for video_style=VideoStyle.CUSTOM).
+# Build the inner video config. Explainer and Brief expose visual styles;
+# Cinematic hides the visual-style selector.
 video_config = [
     source_ids_double,
     language,             # "en"
-    instructions,
+    instructions,          # Focus/customization prompt
     None,
     format_code,          # 1=EXPLAINER, 2=BRIEF, 3=CINEMATIC
-    style_code,           # 1=AUTO_SELECT, 2=CUSTOM, 3=CLASSIC, 4=WHITEBOARD, ...
+    style_code,           # None=CUSTOM, 1=AUTO_SELECT, 2=CLASSIC, 3=WHITEBOARD, ...
 ]
 if style_prompt:          # Optional 7th element; CUSTOM style only
     video_config.append(style_prompt)
@@ -623,6 +623,25 @@ params = [
         None,                         # [7]
         [None, None, video_config],   # [8]
     ],
+]
+```
+
+Live Web UI capture on 2026-06-17 showed these visual-style radio values:
+`AUTO_SELECT=1`, `CUSTOM=0`, `CLASSIC=2`, `WHITEBOARD=3`,
+`KAWAII=9`, `ANIME=7`, `WATERCOLOR=6`, `RETRO_PRINT=8`,
+`HERITAGE=4`, and `PAPER_CRAFT=5`. Because `CUSTOM=0` is the protobuf
+default, the Web UI's JSON array omits that field as `null` and appends the
+custom visual-style prompt in the 7th slot:
+
+```python
+[
+    source_ids_double,
+    "en",
+    "Focus prompt",
+    None,
+    2,                    # VideoFormat.BRIEF
+    None,                 # VideoStyle.CUSTOM omitted/defaulted
+    "Custom visual style",
 ]
 ```
 

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -65,7 +65,7 @@
     {
       "code": "removed-member",
       "object": "notebooklm.Note.from_api_response",
-      "reason": "Dead positional parser removed (#1389). Note rows are decoded through notebooklm._row_adapters.notes.NoteRow; the classmethod had no production callers (only test_types.py exercised it). Construct Note(...) directly from NoteRow's named properties — see NotesAPI._parse_note."
+      "reason": "Dead positional parser removed (#1389). Note rows are decoded through notebooklm._row_adapters.notes.NoteRow; the classmethod had no production callers (only test_types.py exercised it). Construct Note(...) directly from NoteRow's named properties \u2014 see NotesAPI._parse_note."
     },
     {
       "code": "removed-member",
@@ -316,6 +316,126 @@
       "code": "changed-return",
       "object": "notebooklm.client.NotebookLMClient.sources.rename",
       "reason": "Same break as notebooklm.NotebookLMClient.sources.rename above; this entry covers the audit's dotted-module-path view of the same callable."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.CUSTOM",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.CLASSIC",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.WHITEBOARD",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.KAWAII",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.ANIME",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.WATERCOLOR",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.HERITAGE",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.VideoStyle.PAPER_CRAFT",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.CUSTOM",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.CLASSIC",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.WHITEBOARD",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.KAWAII",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.ANIME",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.WATERCOLOR",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.HERITAGE",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.rpc.VideoStyle.PAPER_CRAFT",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.CUSTOM",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.CLASSIC",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.WHITEBOARD",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.KAWAII",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.ANIME",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.WATERCOLOR",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.HERITAGE",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.VideoStyle.PAPER_CRAFT",
+      "reason": "v0.7.2 #1594: VideoStyle wire values were stale and generated the wrong NotebookLM video style. Updated to match live Web UI captures (backport of #1597); see CHANGELOG.md."
     }
   ]
 }

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -128,7 +128,12 @@ def build_video_artifact_params(
     source_ids_double = nest_source_ids(source_ids, 1)
 
     format_code = video_format.value if video_format is not None else VideoFormat.EXPLAINER.value
-    style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
+    if video_style == VideoStyle.CUSTOM:
+        # Live Web UI serializes the CUSTOM enum's proto-default value (0) as
+        # an omitted/null field and carries the custom visual prompt in slot 6.
+        style_code = None
+    else:
+        style_code = video_style.value if video_style is not None else VideoStyle.AUTO_SELECT.value
 
     video_config = [
         source_ids_double,

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -216,15 +216,15 @@ class VideoStyle(int, Enum):
     """Video visual style options."""
 
     AUTO_SELECT = 1
-    CUSTOM = 2
-    CLASSIC = 3
-    WHITEBOARD = 4
-    KAWAII = 5
-    ANIME = 6
-    WATERCOLOR = 7
+    CUSTOM = 0
+    CLASSIC = 2
+    WHITEBOARD = 3
+    KAWAII = 9
+    ANIME = 7
+    WATERCOLOR = 6
     RETRO_PRINT = 8
-    HERITAGE = 9
-    PAPER_CRAFT = 10
+    HERITAGE = 4
+    PAPER_CRAFT = 5
 
 
 class QuizQuantity(int, Enum):

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -357,7 +357,7 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                             "Summarize visually",
                             None,
                             1,
-                            2,
+                            None,
                             "blueprint line art",
                         ],
                     ],
@@ -385,6 +385,37 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                     None,
                     None,
                     [None, None, [[["src_alpha"]], "de", None, None, 3]],
+                ],
+            ],
+        ),
+        (
+            "video_non_contiguous_preset_style",
+            build_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions="Make it playful",
+                video_format=VideoFormat.BRIEF,
+                video_style=VideoStyle.KAWAII,
+                style_prompt=None,
+            ),
+            [
+                _ARTIFACT_CLIENT_OPTIONS,
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [
+                        None,
+                        None,
+                        [[["src_alpha"]], "en", "Make it playful", None, 2, 9],
+                    ],
                 ],
             ],
         ),
@@ -750,6 +781,22 @@ def test_artifact_payload_builders_match_golden_rpc_envelopes(
 
     assert params == expected
     assert encode_rpc_request(method, params) == _expected_rpc_envelope(method, expected)
+
+
+def test_video_style_values_match_live_web_ui() -> None:
+    """Guard against drift in the Web UI's Video Overview style radio values."""
+    assert {style: style.value for style in VideoStyle} == {
+        VideoStyle.AUTO_SELECT: 1,
+        VideoStyle.CUSTOM: 0,
+        VideoStyle.CLASSIC: 2,
+        VideoStyle.WHITEBOARD: 3,
+        VideoStyle.KAWAII: 9,
+        VideoStyle.ANIME: 7,
+        VideoStyle.WATERCOLOR: 6,
+        VideoStyle.RETRO_PRINT: 8,
+        VideoStyle.HERITAGE: 4,
+        VideoStyle.PAPER_CRAFT: 5,
+    }
 
 
 def test_revise_slide_payload_builder_matches_golden_envelope() -> None:

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -488,7 +488,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_prompt_encoding(
         self, mock_core, mock_mind_map_service
     ):
-        """Test custom video style prompt is encoded after the style code."""
+        """Test custom video style prompt is encoded like the live Web UI."""
         api = ArtifactsAPI(
             rpc=mock_core,
             drain=mock_core,
@@ -507,7 +507,7 @@ class TestArtifactsSourceSelection:
 
         params = mock_core.rpc_executor.rpc_call.call_args.args[1]
         video_config = params[2][8][2]
-        assert video_config[5] == VideoStyle.CUSTOM.value
+        assert video_config[5] is None
         assert video_config[6] == "Use hand-drawn diagrams"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Backport of #1597 to the 0.7.x (0.7.2) line, as requested.

## What
- Corrects `VideoStyle` numeric wire values to match the live NotebookLM Web UI (the old values were stale — e.g. whiteboard was `4`, live is `3` — so named styles serialized as the **wrong** style).
- Encodes `CUSTOM` the Web-UI way: the style enum slot is omitted/defaulted and the custom visual-style prompt is appended.
- Adds `changed-enum-value` api-compat allowlist entries for the public `VideoStyle` members across the `notebooklm` / `notebooklm.rpc` / `notebooklm.types` views (3 paths × 8 changed members).
- Adds golden coverage + docs + a `[0.7.2]` changelog entry.

## Heads-up: this is a breaking enum-value change in a patch
Per your decision to backport #1597 to 0.7.2. The integer values of `VideoStyle` members change — **breaking** for code that passed the raw ints, but it corrects wrong behavior (the old codes produced the wrong style). Enum-member usage (`VideoStyle.WHITEBOARD`, …) is unaffected. The api-compat gate passes via the sanctioned allowlist entries.

## Scope vs #1594 — does NOT close it
This corrects the **preset style wire codes** (validated live on our cohort). It does **not** close #1594: the custom-style path is **cohort-gated** and unverified on a migrated account. #1594 stays open pending the reporter's test of the fix branch.

## Verification
- `uv run pytest tests/unit/test_rpc_golden_payloads.py tests/unit/test_source_selection.py` → 248 passed
- `uv run ruff check` / `ruff format --check` / `uv run mypy src/notebooklm` → clean
- `scripts/audit_public_api_compat.py` → passes (allowlist entries cover all 24 changed-enum-value breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

