### PR TITLE
feat(rpc-health): bundle enum/quota/proto drift monitor + sqTeoe cohort tripwire

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -190,6 +190,86 @@ jobs:
         echo "## RPC Health Check Results" >> "$GITHUB_STEP_SUMMARY"
         grep -A 10 "^SUMMARY$" health-report.txt >> "$GITHUB_STEP_SUMMARY" || echo "No summary found" >> "$GITHUB_STEP_SUMMARY"
 
+    # Bundle-drift monitor (capture_rpc_registry.py). NOT a PR gate — it depends
+    # on Google's live external JS bundle, which can rotate at any time — so it
+    # rides the nightly/issue-filing track here. ``--check`` gates id rotation
+    # (ABSENT), ``--check-enums`` gates studio enum CHANGED/STALE (a selectable
+    # format renumbered/retired — the #1597 class). NEW/UNPARSED, quota codes and
+    # proto assertions print for visibility but never fail. ``continue-on-error``
+    # so a drift hit files an issue rather than red-failing the canary outright.
+    - name: Run bundle drift monitor
+      id: bundle
+      continue-on-error: true
+      shell: bash
+      env:
+        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
+      run: |
+        set +e
+        uv run python scripts/capture_rpc_registry.py --check --check-enums 2>&1 \
+          | tee bundle-drift-report.txt
+        exit_code=${PIPESTATUS[0]}
+        echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+        exit "$exit_code"
+
+    - name: Scrub secrets from bundle-drift-report.txt
+      # The bundle is public CDN content, but the discovery homepage read is
+      # authenticated and a transport error could echo a request URL; scrub
+      # before any downstream consumer reads the file (same posture as the
+      # health-report scrub above). Idempotent.
+      if: always()
+      shell: bash
+      run: |
+        if [ ! -f bundle-drift-report.txt ]; then
+          echo "::warning::bundle-drift-report.txt not produced; skipping scrub."
+          exit 0
+        fi
+        uv run python - <<'PY'
+        from pathlib import Path
+        from notebooklm._logging import scrub_secrets
+
+        report = Path("bundle-drift-report.txt")
+        original = report.read_text(encoding="utf-8", errors="replace")
+        scrubbed = scrub_secrets(original)
+        if scrubbed != original:
+            report.write_text(scrubbed, encoding="utf-8")
+            print(f"Scrubbed bundle-drift-report.txt (delta {abs(len(original) - len(scrubbed))} chars).")
+        else:
+            print("No secret-shaped substrings detected in bundle-drift-report.txt.")
+        PY
+
+    - name: Check for existing bundle drift issue
+      if: steps.bundle.outputs.exit_code != '0'
+      id: dup_bundle
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if ! count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open --label automated --label rpc-breakage \
+          --search 'in:title "Studio enum / RPC drift detected"' \
+          --json number --jq 'length'); then
+          echo "::warning::Bundle drift dedup probe failed; allowing issue creation"
+          count=0
+        fi
+        echo "open=${count}" >> "$GITHUB_OUTPUT"
+
+    - name: Create Issue on bundle drift
+      if: |
+        steps.bundle.outputs.exit_code != '0'
+        && steps.dup_bundle.outputs.open == '0'
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
+      with:
+        title: "Studio enum / RPC drift detected"
+        content-filepath: bundle-drift-report.txt
+        labels: rpc-breakage, automated
+
+    - name: Upload bundle drift report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: rpc-bundle-drift-report
+        path: bundle-drift-report.txt
+        retention-days: 30
+
     # Each issue-creating step is paired with a dedup probe that counts
     # open issues sharing the same title + automated label. Without this,
     # back-to-back failing runs (manual reruns, cron + workflow_dispatch)
@@ -298,6 +378,35 @@ jobs:
         title: "RPC Health Check: Non-transient ERROR detected"
         content-filepath: error-issue-body.md
         labels: rpc-error, bug, automated
+
+    # Exit code 4 = the ``sqTeoe`` cohort tripwire flipped (GetArtifactCustomization
+    # Choices returned non-null). Our account migrated to the new studio-customization
+    # surface; the VideoStyle / format codes in rpc/types.py must be re-captured.
+    # GATED-null is the expected steady state and never reaches this branch.
+    - name: Check for existing cohort-flip issue
+      if: steps.health.outputs.exit_code == '4'
+      id: dup_cohort
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if ! count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open --label automated --label rpc-breakage \
+          --search 'in:title "Studio customization cohort flipped"' \
+          --json number --jq 'length'); then
+          echo "::warning::Cohort-flip dedup probe failed; allowing issue creation"
+          count=0
+        fi
+        echo "open=${count}" >> "$GITHUB_OUTPUT"
+
+    - name: Create Issue on cohort flip
+      if: |
+        steps.health.outputs.exit_code == '4'
+        && steps.dup_cohort.outputs.open == '0'
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
+      with:
+        title: "Studio customization cohort flipped — re-capture VideoStyle codes"
+        content-filepath: health-report.txt
+        labels: rpc-breakage, automated
 
     - name: Upload Report
       if: always()

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -5,7 +5,12 @@ against ``src/notebooklm/rpc/types.py``.
 NotebookLM declares every ``batchexecute`` RPC in its (public, gstatic-served) JS
 bundle as::
 
-    _.uD("<rpc_id>", <ReqCtor>, <RespCtor>, [<flags>, "/<Service>.<Method>"])
+    _.fD("<rpc_id>", <ReqCtor>, <RespCtor>, [<flags>, "/<Service>.<Method>"])
+
+(The registration helper is currently minified to ``_.fD``; it was ``_.uD`` in an
+earlier bundle. The scraper does **not** depend on the helper name — it anchors on
+the quoted ``"/<Service>.<Method>"`` path — so a future rename of this helper does
+not blank the diff.)
 
 The obfuscated ``<rpc_id>`` values are this project's #1 breakage class — they
 rotate without notice and a stale id silently breaks the affected operation. This
@@ -23,6 +28,14 @@ ids we hardcode, surfacing four classes:
                     Agentspace surface on `discoveryengine.googleapis.com`, behind a
                     server-side VPC Service Controls perimeter; not consumer-callable,
                     not a consumer migration target), or **other**
+
+Beyond the rpc-id registry, the same bundle carries the studio-feature **enum
+maps** (``switch(code){case N:return "Label"}`` blocks for VideoFormat /
+AudioFormat / app-variants), the ``Yp`` **quota-code** map (a feature-rollout
+early-warning surface), and proto **required-field assertions** (schema-shape
+drift). ``--check-enums`` extracts and diffs the switch enums against the int
+enums in ``rpc/types.py`` with the same four-class spirit as the id diff, but a
+distinct taxonomy — see :func:`diff_enums` for why ``NEW`` is report-only.
 
 Auth: discovering the bundle URL needs **one authenticated homepage read** (an
 unauthenticated request only returns the login app); fetching the bundle itself is
@@ -42,6 +55,8 @@ Usage::
     python scripts/capture_rpc_registry.py                 # human-readable diff
     python scripts/capture_rpc_registry.py --json          # machine-readable snapshot
     python scripts/capture_rpc_registry.py --check         # exit 1 if any of our ids are ABSENT
+    python scripts/capture_rpc_registry.py --check-enums    # exit 1 on CHANGED/STALE studio enums
+    python scripts/capture_rpc_registry.py --check --check-enums  # both gates (combine freely)
     python scripts/capture_rpc_registry.py --bundle-file bundle.js   # offline, no auth
 """
 
@@ -174,6 +189,205 @@ def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, d
     }
 
 
+# ---------------------------------------------------------------------------
+# Studio enum drift (switch(code){case N:return "Label"} maps)
+# ---------------------------------------------------------------------------
+#
+# Beyond the rpc-id registry the bundle inlines the studio-feature enums as
+# minified ``switch`` statements mapping an integer code to a display label,
+# e.g. ``switch(a){case 1:return"Explainer";case 3:return"Cinematic";...}``.
+# These are the human-facing labels for VideoFormat / AudioFormat / the
+# app-variant picker — the same integers we hardcode in ``rpc/types.py`` and
+# send on the wire. If Google ever renumbers a *selectable* format (the #1597
+# alarm: the VideoStyle/format code an existing label maps to changes) every
+# generate-* call silently produces the wrong artifact, so we diff them.
+
+# A switch block: ``switch(<scrutinee>){ <case 1:return"X";case 2:return"Y";> }``.
+# ``<scrutinee>`` is a short minified expr (kept <=30 chars so we don't span a
+# huge unrelated ``switch``); the body is one-or-more ``case N:return"Label"``.
+_SWITCH_BLOCK_RE = re.compile(r'switch\([^)]{1,30}\)\{((?:case \d+:return"[^"]*";?\s*)+)')
+# A single ``case N:return"Label"`` arm inside a matched block.
+_SWITCH_CASE_RE = re.compile(r'case (\d+):return"([^"]*)"')
+
+# Label-anchoring registry: a recognizable *subset* of labels identifies which
+# of our enums a switch block is. A block whose label set is a SUPERSET of an
+# anchor set is attributed to that enum (so a block that gained an unreleased
+# label still matches). Anchors are deliberately a handful of stable,
+# distinctive labels — not the full set — so a NEW label never breaks
+# attribution. The keys are our ``rpc/types.py`` enum class names.
+_ENUM_LABEL_ANCHORS: dict[str, frozenset[str]] = {
+    "VideoFormat": frozenset({"Explainer", "Cinematic"}),
+    "AudioFormat": frozenset({"Deep Dive", "Critique", "Debate"}),
+}
+
+
+def _normalize_label(label: str) -> str:
+    """``"Deep Dive"`` -> ``"DEEP_DIVE"`` so a bundle label can be matched to an
+    enum *member* name (our members are ``UPPER_SNAKE``, the bundle labels are
+    ``Title Case`` with spaces). Used to pair a live ``code -> label`` with our
+    ``MEMBER_NAME -> value`` mapping when diffing.
+    """
+    return re.sub(r"[^A-Z0-9]+", "_", label.upper()).strip("_")
+
+
+def extract_switch_enums(bundle: str) -> dict[str, dict[int, str]]:
+    """Return ``{our_enum_name: {code: label}}`` for every switch block that a
+    label anchor attributes to one of our enums.
+
+    Each ``switch(code){case N:return "Label"}`` block is parsed into a
+    ``{code -> label}`` map, then attributed to one of our enums by
+    *label-anchoring*: if the block's label set is a superset of an anchor set
+    in :data:`_ENUM_LABEL_ANCHORS`, it is that enum. Unattributed blocks (the
+    bundle has many switches we don't care about) are dropped. If two blocks
+    attribute to the same enum their maps are merged (later wins), which is
+    harmless because the anchor guarantees they are the same logical enum.
+    """
+    out: dict[str, dict[int, str]] = {}
+    for block_match in _SWITCH_BLOCK_RE.finditer(bundle):
+        cases = {int(code): label for code, label in _SWITCH_CASE_RE.findall(block_match.group(1))}
+        if not cases:
+            continue
+        labels = set(cases.values())
+        for enum_name, anchor in _ENUM_LABEL_ANCHORS.items():
+            if anchor <= labels:
+                out.setdefault(enum_name, {}).update(cases)
+    return out
+
+
+def parse_enum_members_from_text(types_text: str, enum_name: str) -> dict[str, int]:
+    """Return ``{MEMBER_NAME: int_value}`` for an ``(int, Enum)`` class in types.py.
+
+    Mirrors :func:`parse_ids_from_text` but for the integer studio enums. Scoped
+    to the named class body so members of other enums don't bleed in. Aliases
+    (two names, same value — e.g. ``QUIZ_FLASHCARD = 4``) are all retained.
+    """
+    match = re.search(rf"class {re.escape(enum_name)}\b.*?(?=\nclass |\Z)", types_text, re.DOTALL)
+    if not match:
+        return {}
+    out: dict[str, int] = {}
+    for name, value in re.findall(
+        r"""^\s+([A-Z][A-Z0-9_]*)\s*=\s*(\d+)""", match.group(0), re.MULTILINE
+    ):
+        out[name] = int(value)
+    return out
+
+
+def diff_enums(
+    types_text: str, live_switch: dict[str, dict[int, str]]
+) -> dict[str, list[dict[str, object]]]:
+    """Diff our int enums against the bundle's switch maps into a FOUR-class taxonomy.
+
+    Mirroring the id ``diff`` but for the studio enums. For each enum the bundle
+    attributed (via label-anchoring), each of our members is paired to a live
+    ``code -> label`` by normalizing the label to ``UPPER_SNAKE`` and matching it
+    to a member name. The four buckets:
+
+    * ``CHANGED`` — a label present in BOTH our enum and the bundle but mapped to
+      a DIFFERENT integer (our ``EXPLAINER = 1`` but the bundle now returns
+      "Explainer" for ``case 2``). **This is the #1597 alarm**: an existing,
+      selectable format silently renumbered. Fails ``--check-enums``.
+    * ``STALE`` — our member's integer is not present in the bundle's code set
+      for that enum at all (the format we still send was retired). Also fails
+      ``--check-enums``.
+    * ``NEW`` — the bundle declares a code our enum lacks (a new display label).
+      **REPORT-ONLY, never an alarm**: a switch arm is only a *display label*; a
+      label can ship in the bundle long before the format is selectable on any
+      cohort (proven live — the bundle listed Short / Whiteboard Animation /
+      Lecture while they were not yet selectable). Adding the member eagerly off
+      a bundle label would encode an unreleased/non-functional code.
+    * ``UNPARSED`` — an enum we have a label anchor for but found no switch block
+      to attribute (a recognizable region didn't parse). "Widen the regex", NOT
+      an alarm — same posture as PRESENT-UNPARSED in the id diff.
+
+    Returns ``{class -> [records]}`` where each record carries the enum name and
+    the specifics needed to report and to drive the ``--check-enums`` exit code.
+    """
+    buckets: dict[str, list[dict[str, object]]] = {
+        "changed": [],
+        "stale": [],
+        "new": [],
+        "unparsed": [],
+    }
+    for enum_name in _ENUM_LABEL_ANCHORS:
+        live_map = live_switch.get(enum_name)
+        if not live_map:
+            # We know this enum (we hold an anchor) but no block parsed for it.
+            buckets["unparsed"].append({"enum": enum_name})
+            continue
+
+        ours = parse_enum_members_from_text(types_text, enum_name)
+        # live label (normalized) -> code, for matching our members by name.
+        live_by_norm_label = {_normalize_label(label): code for code, label in live_map.items()}
+        our_codes = set(ours.values())
+
+        for member, value in ours.items():
+            live_code = live_by_norm_label.get(member)
+            if live_code is None:
+                # The label our member name corresponds to is not in the bundle.
+                if value not in live_map:
+                    buckets["stale"].append(
+                        {"enum": enum_name, "member": member, "our_value": value}
+                    )
+                # else: our value is still a live code under a label that didn't
+                # normalize back to our member name — neither CHANGED nor STALE.
+            elif live_code != value:
+                buckets["changed"].append(
+                    {
+                        "enum": enum_name,
+                        "member": member,
+                        "label": live_map[live_code],
+                        "our_value": value,
+                        "live_value": live_code,
+                    }
+                )
+
+        for code, label in sorted(live_map.items()):
+            if code not in our_codes:
+                buckets["new"].append({"enum": enum_name, "code": code, "label": label})
+
+    return buckets
+
+
+# ---------------------------------------------------------------------------
+# Quota codes (Yp map) and proto required-field assertions
+# ---------------------------------------------------------------------------
+#
+# Two more drift surfaces the same bundle carries — extracted for *visibility*
+# (a report line + JSON), not gated. They are leading indicators, not contract
+# breaks: a new quota code means a feature is rolling out server-side (an
+# early-warning for "build support soon"), and a changed proto assertion means a
+# request shape we encode may have grown a newly-required field.
+
+# The ``Yp`` quota map: ``[<code>,{status:"...",result:{message:"...limits..."}}]``.
+# The ``...limits...`` anchor in the message keeps this off unrelated result
+# objects. Codes map to features (1 chat, 3 audio, 6 video, 7 reports, ...).
+_QUOTA_CODE_RE = re.compile(r'\[(\d+),\{status:"[^"]*",result:\{message:"([^"]*limits[^"]*)"')
+
+# Proto required-field assertions: ``"<Message> is missing field '<field>'"``.
+# A drift in this set means a request message grew/lost a required field.
+_PROTO_ASSERTION_RE = re.compile(r"\"(\w+) is missing field '(\w+)'\"")
+
+
+def extract_quota_codes(bundle: str) -> dict[int, str]:
+    """Return ``{quota_code: message}`` from the bundle's ``Yp`` quota map.
+
+    A feature-rollout early-warning surface: a code we have not seen before means
+    Google is provisioning quota for a feature that is rolling out. Report-only.
+    """
+    return {int(code): message for code, message in _QUOTA_CODE_RE.findall(bundle)}
+
+
+def extract_proto_assertions(bundle: str) -> set[tuple[str, str]]:
+    """Return ``{(message, field)}`` proto required-field assertions from the bundle.
+
+    A schema-shape drift surface: ``"ExplainerVideoArtifact is missing field
+    'generation_options'"`` means that proto requires ``generation_options``. A
+    new assertion can mean a request we build needs a field we don't send.
+    Report-only.
+    """
+    return set(_PROTO_ASSERTION_RE.findall(bundle))
+
+
 def fetch_bundle() -> str:
     """Fetch and concatenate the gstatic app-bundle chunks (which carry the registry).
 
@@ -292,11 +506,72 @@ def _print_report(
             print(f"    {rpc_id:<8} {method}")
 
 
+def _print_enum_report(
+    enum_buckets: dict[str, list[dict[str, object]]],
+    quota: dict[int, str],
+    proto: set[tuple[str, str]],
+) -> None:
+    """Print the studio-enum / quota / proto drift report (same style as the id diff).
+
+    ``CHANGED``/``STALE`` are the alarms (a selectable format renumbered or
+    retired); ``NEW`` and ``UNPARSED`` print but never alarm. Quota codes and
+    proto assertions are report-only visibility surfaces.
+    """
+    changed, stale, new, unparsed = (
+        enum_buckets["changed"],
+        enum_buckets["stale"],
+        enum_buckets["new"],
+        enum_buckets["unparsed"],
+    )
+    print("\n" + "=" * 60)
+    print("STUDIO ENUM DRIFT (switch code->label maps)")
+    print(
+        f"CHANGED: {len(changed)}  STALE: {len(stale)}  NEW: {len(new)}  UNPARSED: {len(unparsed)}"
+    )
+    if changed:
+        print("\nCHANGED — a label's integer differs from ours (the #1597 alarm):")
+        for r in changed:
+            print(
+                f"  {r['enum']}.{r['member']} ({r['label']!r}): "
+                f"ours={r['our_value']} live={r['live_value']}"
+            )
+    if stale:
+        print("\nSTALE — our member's value is no longer a live code (format retired):")
+        for r in stale:
+            print(f"  {r['enum']}.{r['member']} = {r['our_value']}")
+    if new:
+        print("\nNEW — bundle code we lack (REPORT-ONLY; a display label may be unreleased):")
+        for r in new:
+            print(f"  {r['enum']} case {r['code']} -> {r['label']!r}")
+    if unparsed:
+        print("\nUNPARSED — known enum with no switch block parsed (widen regex; not an alarm):")
+        for r in unparsed:
+            print(f"  {r['enum']}")
+
+    print("\nQUOTA CODES (Yp map — feature-rollout early-warning; report-only):")
+    if quota:
+        for code, message in sorted(quota.items()):
+            print(f"  {code:<3} {message}")
+    else:
+        print("  (none parsed)")
+
+    print("\nPROTO REQUIRED-FIELD ASSERTIONS (schema-shape; report-only):")
+    if proto:
+        for message, field in sorted(proto):
+            print(f"  {message} -> {field}")
+    else:
+        print("  (none parsed)")
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: load/fetch the bundle, diff vs rpc/types.py, report.
 
-    Returns the process exit code: ``1`` when ``--check`` is set and any of our
-    ids are ABSENT (a rotation/stale alarm), else ``0``.
+    Returns the process exit code: ``1`` when a gate fires —  ``--check`` with any
+    ABSENT id (id rotation), and/or ``--check-enums`` with any CHANGED/STALE
+    studio enum (a selectable format renumbered or retired). The two gates
+    combine (either firing exits ``1``); ``NEW``/``UNPARSED`` enum classes,
+    quota codes and proto assertions are report-only and never affect the exit
+    code. Without a gate flag the exit is always ``0`` (report mode).
     """
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
     parser.add_argument(
@@ -304,17 +579,28 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--check", action="store_true", help="exit 1 if any of our ids are ABSENT")
     parser.add_argument(
+        "--check-enums",
+        action="store_true",
+        help="exit 1 if any studio enum is CHANGED or STALE (NEW/UNPARSED never fail)",
+    )
+    parser.add_argument(
         "--bundle-file", type=Path, help="analyse a saved bundle file (no auth/network)"
     )
     parser.add_argument("--types", type=Path, default=_DEFAULT_TYPES, help="path to rpc/types.py")
     args = parser.parse_args(argv)
 
-    ours = parse_ids_from_text(args.types.read_text(encoding="utf-8"))
+    types_text = args.types.read_text(encoding="utf-8")
+    ours = parse_ids_from_text(types_text)
     bundle = args.bundle_file.read_text(encoding="utf-8") if args.bundle_file else fetch_bundle()
     live = extract_registry(bundle)
     buckets = diff(ours, live, bundle)
     # Services any CONFIRMED id resolves to are, empirically, serving our cohort.
     current_services = {_service_of(m) for m in buckets["confirmed"].values()}
+
+    live_switch = extract_switch_enums(bundle)
+    enum_buckets = diff_enums(types_text, live_switch)
+    quota = extract_quota_codes(bundle)
+    proto = extract_proto_assertions(bundle)
 
     if args.json:
         print(
@@ -332,7 +618,12 @@ def main(argv: list[str] | None = None) -> int:
                         }
                         for i, m in buckets["unmapped"].items()
                     },
-                    "counts": {k: len(v) for k, v in buckets.items()} | {"ours": len(ours)},
+                    "enums": enum_buckets,
+                    "quota_codes": {str(code): message for code, message in quota.items()},
+                    "proto_assertions": sorted(f"{m}.{f}" for m, f in proto),
+                    "counts": {k: len(v) for k, v in buckets.items()}
+                    | {"ours": len(ours)}
+                    | {f"enum_{k}": len(v) for k, v in enum_buckets.items()},
                 },
                 indent=2,
                 sort_keys=True,
@@ -340,14 +631,24 @@ def main(argv: list[str] | None = None) -> int:
         )
     else:
         _print_report(ours, live, buckets, current_services)
+        _print_enum_report(enum_buckets, quota, proto)
 
+    exit_code = 0
     if args.check and buckets["absent"]:
         print(
             f"\nFAIL: {len(buckets['absent'])} of our RPC ids are no longer registered.",
             file=sys.stderr,
         )
-        return 1
-    return 0
+        exit_code = 1
+    if args.check_enums and (enum_buckets["changed"] or enum_buckets["stale"]):
+        print(
+            f"\nFAIL: {len(enum_buckets['changed'])} CHANGED and "
+            f"{len(enum_buckets['stale'])} STALE studio enum value(s) — a selectable "
+            "format was renumbered or retired; re-capture rpc/types.py enums.",
+            file=sys.stderr,
+        )
+        exit_code = 1
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -205,9 +205,13 @@ def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, d
 # A switch block: ``switch(<scrutinee>){ <case 1:return"X";case 2:return"Y";> }``.
 # ``<scrutinee>`` is a short minified expr (kept <=30 chars so we don't span a
 # huge unrelated ``switch``); the body is one-or-more ``case N:return"Label"``.
-_SWITCH_BLOCK_RE = re.compile(r'switch\([^)]{1,30}\)\{((?:case \d+:return"[^"]*";?\s*)+)')
-# A single ``case N:return"Label"`` arm inside a matched block.
-_SWITCH_CASE_RE = re.compile(r'case (\d+):return"([^"]*)"')
+# Whitespace-tolerant so a minor minifier/pretty-printer change (spaces after
+# ``return``, around ``:``, between arms) doesn't yield a false UNPARSED.
+_SWITCH_BLOCK_RE = re.compile(
+    r'switch\([^)]{1,30}\)\{\s*((?:case\s+\d+\s*:\s*return\s*"[^"]*"\s*;?\s*)+)'
+)
+# A single ``case N:return "Label"`` arm inside a matched block.
+_SWITCH_CASE_RE = re.compile(r'case\s+(\d+)\s*:\s*return\s*"([^"]*)"')
 
 # Label-anchoring registry: a recognizable *subset* of labels identifies which
 # of our enums a switch block is. A block whose label set is a SUPERSET of an
@@ -324,12 +328,19 @@ def diff_enums(
             live_code = live_by_norm_label.get(member)
             if live_code is None:
                 # The label our member name corresponds to is not in the bundle.
-                if value not in live_map:
+                live_label = live_map.get(value)
+                norm_live_label = _normalize_label(live_label) if live_label else None
+                if value not in live_map or (norm_live_label in ours and norm_live_label != member):
+                    # STALE either because our integer code vanished from the
+                    # bundle entirely, OR it was repurposed: the code now maps to
+                    # a label that normalizes to a DIFFERENT member already in our
+                    # enum, so our member name still pointing at it is wrong.
                     buckets["stale"].append(
                         {"enum": enum_name, "member": member, "our_value": value}
                     )
                 # else: our value is still a live code under a label that didn't
-                # normalize back to our member name — neither CHANGED nor STALE.
+                # normalize back to any of our member names — neither CHANGED nor
+                # STALE (likely a renamed/aliased label we don't track yet).
             elif live_code != value:
                 buckets["changed"].append(
                     {

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -10,9 +10,14 @@ Exit codes:
     2 - Authentication or infrastructure failure (not an RPC problem)
     3 - One or more RPC methods returned a non-transient ERROR
         (timeouts, parse failures, unexpected HTTP errors)
+    4 - Studio-customization cohort flip: the ``sqTeoe`` tripwire
+        (GetArtifactCustomizationChoices) returned non-null, meaning our
+        account migrated to the new customization surface and the VideoStyle /
+        format codes must be re-captured. GATED-null is the expected steady
+        state and is NOT a failure.
 
 Priority order when multiple statuses are present:
-    MISMATCH (1) > AUTH (2) > non-transient ERROR (3) > OK (0)
+    MISMATCH (1) > AUTH (2) > non-transient ERROR (3) > cohort MIGRATED (4) > OK (0)
 
 Transient errors that still exit 0 are limited to rate-limit signals
 (HTTP 429, gRPC ``RESOURCE_EXHAUSTED``, and the decoder's user-displayable
@@ -91,6 +96,28 @@ class CheckStatus(str, Enum):
     MISMATCH = "MISMATCH"
     ERROR = "ERROR"
     SKIPPED = "SKIPPED"
+
+
+class CohortStatus(str, Enum):
+    """Result of the ``sqTeoe`` studio-customization cohort tripwire.
+
+    ``GetArtifactCustomizationChoices`` (rpc id ``sqTeoe``) is gated off for our
+    consumer cohort and returns ``null`` unconditionally today (``GATED`` — the
+    expected steady state, NOT a failure). The day it starts returning a
+    non-null payload our account has been migrated to the new studio-customization
+    surface (``MIGRATED`` — a loud signal: the VideoStyle/format codes must be
+    re-captured). ``UNKNOWN`` covers a transient/transport failure on the probe
+    itself (no cohort conclusion drawn — never an alarm).
+    """
+
+    GATED = "GATED"
+    MIGRATED = "MIGRATED"
+    UNKNOWN = "UNKNOWN"
+
+
+# Studio-customization cohort tripwire RPC. NOT in ``RPCMethod`` (it is gated off
+# for our consumer cohort, so there is no typed/public path), called by raw id.
+_CUSTOMIZATION_CHOICES_RPC_ID = "sqTeoe"
 
 
 @dataclass
@@ -822,6 +849,114 @@ async def check_chat_query(
     )
 
 
+def build_customization_choices_params(notebook_id: str) -> list[Any]:
+    """Build ``sqTeoe`` (GetArtifactCustomizationChoices) params for ``notebook_id``.
+
+    Reverse-engineered (live-verified) request shape: ``[nbctx, None, artifact_type]``
+    where ``nbctx`` is the standard notebook-context options wrapper and
+    ``artifact_type`` is ``3`` (video) — the surface whose VideoStyle/format codes
+    we most want an early migration signal for. Extracted as a helper so the wire
+    shape is testable without a live call.
+    """
+    nbctx = [
+        2,
+        None,
+        None,
+        [1, None, None, None, None, None, None, None, None, None, [1]],
+        [notebook_id],
+    ]
+    artifact_type = 3  # video
+    return [nbctx, None, artifact_type]
+
+
+async def make_raw_rpc_request(
+    client: httpx.AsyncClient,
+    auth: AuthTokens,
+    rpc_id: str,
+    params: list[Any],
+    source_path: str = "/",
+) -> tuple[str | None, str | None]:
+    """Issue a batchexecute call by *raw* rpc id (for methods not in ``RPCMethod``).
+
+    The cohort tripwire probes ``sqTeoe``, which has no ``RPCMethod`` member (it
+    is gated for our cohort), so it cannot go through ``make_rpc_request``. This
+    mirrors that function's wire assembly but threads the id straight into both
+    the ``rpcids=`` query param and ``encode_rpc_request``'s ``rpc_id_override``
+    (the two MUST stay in sync). It calls the executor directly — there is no
+    idempotency registry in this script, so no retries to disable.
+    """
+    query_params = {
+        "rpcids": rpc_id,
+        "source-path": source_path,
+        "f.sid": auth.session_id,
+        "hl": get_default_language(),
+        "rt": "c",
+    }
+    if auth.account_email or auth.authuser:
+        query_params["authuser"] = auth.account_route
+    url = f"{get_batchexecute_url()}?{urlencode(query_params)}"
+    # Any RPCMethod member works as the first arg — ``rpc_id_override`` is what
+    # actually lands in the body, kept identical to the ``rpcids=`` query param.
+    rpc_request = encode_rpc_request(RPCMethod.LIST_NOTEBOOKS, params, rpc_id_override=rpc_id)
+    body = build_request_body(rpc_request, auth.csrf_token)
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Cookie": auth.cookie_header,
+    }
+    try:
+        response = await client.post(url, content=body, headers=headers)
+        response.raise_for_status()
+        return response.text, None
+    except httpx.HTTPStatusError as e:
+        return None, f"HTTP {e.response.status_code}"
+    except httpx.RequestError as e:
+        return None, str(e) or type(e).__name__
+
+
+async def check_customization_cohort(
+    client: httpx.AsyncClient,
+    auth: AuthTokens,
+    notebook_id: str | None,
+) -> tuple[CohortStatus, str]:
+    """Probe ``sqTeoe`` to detect a studio-customization cohort flip.
+
+    ``GetArtifactCustomizationChoices`` returns ``null`` for our gated consumer
+    cohort. We decode with ``allow_null=True`` so a genuine null payload is
+    ``GATED`` (the steady state, not a failure) — but the *absent-id* drift guard
+    inside ``decode_response`` still fires if the id stopped being echoed (that
+    surfaces as a parse error here and is reported as ``UNKNOWN``, not silently
+    swallowed). A non-null payload means our account was migrated to the new
+    customization surface (``MIGRATED`` — re-capture VideoStyle codes).
+
+    Returns ``(status, detail)``. ``UNKNOWN`` is drawn for any transport/parse
+    failure so the tripwire never alarms on a transient flake; only a clean,
+    decoded non-null result is ``MIGRATED``.
+    """
+    if not notebook_id:
+        return CohortStatus.UNKNOWN, "No notebook ID provided (cohort tripwire needs one)"
+
+    response_text, error = await make_raw_rpc_request(
+        client,
+        auth,
+        _CUSTOMIZATION_CHOICES_RPC_ID,
+        build_customization_choices_params(notebook_id),
+        source_path=f"/notebook/{notebook_id}",
+    )
+    if error is not None:
+        return CohortStatus.UNKNOWN, error
+    if response_text is None:
+        return CohortStatus.UNKNOWN, "Empty response from server"
+
+    try:
+        data = decode_response(response_text, _CUSTOMIZATION_CHOICES_RPC_ID, allow_null=True)
+    except (json.JSONDecodeError, ValueError, IndexError, TypeError, RPCError) as e:
+        return CohortStatus.UNKNOWN, f"Parse error: {scrub_secrets(e)}"
+
+    if data is None:
+        return CohortStatus.GATED, "null (gated — expected steady state)"
+    return CohortStatus.MIGRATED, "non-null payload (cohort migrated)"
+
+
 async def setup_temp_resources(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1116,8 +1251,13 @@ async def cleanup_temp_resources(
         print(f"WARNING: Notebook {temp.notebook_id} may need manual cleanup", file=sys.stderr)
 
 
-async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
-    """Run health check on all RPC methods."""
+async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], CohortStatus]:
+    """Run health check on all RPC methods.
+
+    Returns ``(results, cohort_status)``: the per-method ``CheckResult`` list plus
+    the ``sqTeoe`` studio-customization cohort tripwire verdict (reported and
+    exit-coded separately from RPC drift; see :class:`CohortStatus`).
+    """
     storage_path = resolve_storage_path()
     cookies = load_auth()
 
@@ -1130,6 +1270,7 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
 
     results: list[CheckResult] = []
     temp_resources = TempResources()
+    cohort_status = CohortStatus.UNKNOWN
 
     print("Fetching auth tokens...")
     try:
@@ -1202,13 +1343,22 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
                 chat_line += f" - {scrub_secrets(chat_result.error)}"
             print(chat_line)
 
+            # Studio-customization cohort tripwire. Distinct from the RPC-drift
+            # probes: GATED-null is the expected steady state (NOT a failure),
+            # MIGRATED is a loud signal that the customization surface flipped and
+            # the VideoStyle/format codes must be re-captured.
+            cohort_status, cohort_detail = await check_customization_cohort(
+                client, auth, notebook_id
+            )
+            print(f"COHORT   sqTeoe customization choices: {cohort_status.value} - {cohort_detail}")
+
         finally:
             if full_mode and temp_resources.notebook_id:
                 print()
                 print("Testing DELETE operations during cleanup...")
                 await cleanup_temp_resources(client, auth, temp_resources, results)
 
-    return results
+    return results, cohort_status
 
 
 # Substrings that mark an ERROR as a transient signal. Keep this list
@@ -1278,6 +1428,7 @@ def partition_errors(
 def compute_exit_code(
     counts: Counter[CheckStatus],
     non_transient_errors: list[CheckResult],
+    cohort_status: CohortStatus = CohortStatus.UNKNOWN,
 ) -> int:
     """Compute the script exit code from result counts.
 
@@ -1285,16 +1436,26 @@ def compute_exit_code(
         1. MISMATCH  -> 1
         2. AUTH      -> 2 (signaled by the caller via sys.exit, never reached here)
         3. non-transient ERROR -> 3
-        4. OK        -> 0
+        4. cohort MIGRATED -> 4 (sqTeoe tripwire flipped; loud but not RPC drift)
+        5. OK        -> 0
+
+    The cohort flip sits *below* the RPC-drift codes so a run that has both real
+    drift AND a cohort flip still surfaces the higher-severity drift exit; the
+    flip is reported in the summary either way.
     """
     if counts[CheckStatus.MISMATCH] > 0:
         return 1
     if non_transient_errors:
         return 3
+    if cohort_status == CohortStatus.MIGRATED:
+        return 4
     return 0
 
 
-def print_summary(results: list[CheckResult]) -> int:
+def print_summary(
+    results: list[CheckResult],
+    cohort_status: CohortStatus = CohortStatus.UNKNOWN,
+) -> int:
     """Print summary and return exit code."""
     print()
     print("=" * 60)
@@ -1347,10 +1508,14 @@ def print_summary(results: list[CheckResult]) -> int:
             print(f"  [transient]     {r.method.name} ({r.expected_id}): {scrub_secrets(r.error)}")
         print()
 
+    # Cohort tripwire line. GATED-null is the expected steady state (a PASS, not
+    # a failure); MIGRATED is the loud flip the canary exists to surface.
+    print(f"COHORT:   sqTeoe customization choices = {cohort_status.value}")
+
     # Return exit code.
-    # Priority: MISMATCH (1) > non-transient ERROR (3) > OK (0).
+    # Priority: MISMATCH (1) > non-transient ERROR (3) > cohort MIGRATED (4) > OK (0).
     # AUTH (2) is signaled earlier via sys.exit(2) and never reaches here.
-    exit_code = compute_exit_code(counts, non_transient_errors)
+    exit_code = compute_exit_code(counts, non_transient_errors, cohort_status)
 
     if exit_code == 1:
         print("RESULT: FAIL - RPC ID mismatches detected")
@@ -1360,6 +1525,10 @@ def print_summary(results: list[CheckResult]) -> int:
         print(f"RESULT: FAIL - non-transient ERROR detected in methods: {affected}")
         print("       These are real failures (not rate-limit transients).")
         return 3
+    if exit_code == 4:
+        print("RESULT: COHORT FLIP - sqTeoe returned non-null (studio customization migrated)")
+        print("       Re-capture VideoStyle / format codes in src/notebooklm/rpc/types.py.")
+        return 4
     if transient_errors:
         print("RESULT: PASS - Only transient errors observed (rate-limits / ReadTimeouts)")
         print("       Review ERROR DETAILS above for affected methods.")
@@ -1385,8 +1554,8 @@ def main() -> int:
     print("=" * 60)
     print()
 
-    results = asyncio.run(run_health_check(full_mode=args.full))
-    return print_summary(results)
+    results, cohort_status = asyncio.run(run_health_check(full_mode=args.full))
+    return print_summary(results, cohort_status)
 
 
 if __name__ == "__main__":

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -910,7 +910,9 @@ async def make_raw_rpc_request(
     except httpx.HTTPStatusError as e:
         return None, f"HTTP {e.response.status_code}"
     except httpx.RequestError as e:
-        return None, str(e) or type(e).__name__
+        # httpx.RequestError subclasses can stringify the failed request URL,
+        # which carries f.sid; scrub before it reaches a live print site.
+        return None, scrub_secrets(str(e) or type(e).__name__)
 
 
 async def check_customization_cohort(
@@ -947,9 +949,15 @@ async def check_customization_cohort(
     if response_text is None:
         return CohortStatus.UNKNOWN, "Empty response from server"
 
+    # RPCError (incl. UnknownRPCMethodError from the absent-id drift guard) must
+    # propagate so the tripwire LOUDLY surfaces an id rotation / protocol break
+    # rather than degrading it to a quiet UNKNOWN. Bare ValueError likewise
+    # propagates — it signals a code bug (e.g. an invalid int() conversion), not
+    # API shape drift. Only a genuinely unreadable/malformed JSON root is caught
+    # and reported as UNKNOWN here.
     try:
         data = decode_response(response_text, _CUSTOMIZATION_CHOICES_RPC_ID, allow_null=True)
-    except (json.JSONDecodeError, ValueError, IndexError, TypeError, RPCError) as e:
+    except (json.JSONDecodeError, TypeError) as e:
         return CohortStatus.UNKNOWN, f"Parse error: {scrub_secrets(e)}"
 
     if data is None:
@@ -1350,7 +1358,10 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
             cohort_status, cohort_detail = await check_customization_cohort(
                 client, auth, notebook_id
             )
-            print(f"COHORT   sqTeoe customization choices: {cohort_status.value} - {cohort_detail}")
+            print(
+                "COHORT   sqTeoe customization choices: "
+                f"{cohort_status.value} - {scrub_secrets(cohort_detail)}"
+            )
 
         finally:
             if full_mode and temp_resources.notebook_id:

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -308,6 +308,33 @@ class VideoFormat(int, Enum):
     assert buckets["changed"] == []
 
 
+def test_diff_enums_stale_when_value_repurposed_to_another_member() -> None:
+    """Our member's value is still a live code but now labels a DIFFERENT member -> STALE.
+
+    The integer code wasn't retired — it was *repurposed*. Our ``BRIEF = 2`` still
+    sees code 2 in the bundle, but code 2 now returns "Cinematic", which normalizes
+    to ``CINEMATIC`` (a different member already in our enum). Leaving BRIEF
+    unflagged would silently keep our ``BRIEF`` name pointing at a code that now
+    means Cinematic, so it must be STALE.
+    """
+    # Anchors (Explainer, Cinematic) present so the block attributes to VideoFormat.
+    # No "Brief" label in the bundle; code 2 has been reused for "Cinematic".
+    bundle = 'switch(a){case 1:return"Explainer";case 2:return"Cinematic"}'
+    types = """
+class VideoFormat(int, Enum):
+    EXPLAINER = 1
+    BRIEF = 2
+    CINEMATIC = 2
+"""
+    live = extract_switch_enums(bundle)
+    buckets = diff_enums(types, live)
+
+    stale = {(r["enum"], r["member"], r["our_value"]) for r in buckets["stale"]}
+    assert ("VideoFormat", "BRIEF", 2) in stale
+    # CINEMATIC's name still matches the live label for code 2 -> not CHANGED.
+    assert buckets["changed"] == []
+
+
 def test_diff_enums_unparsed_when_no_block() -> None:
     """A known enum (we hold an anchor) with no switch block parsed -> UNPARSED."""
     # Only VideoFormat is present; AudioFormat has no block to attribute.

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -12,11 +12,17 @@ from pathlib import Path
 
 import pytest
 from scripts.capture_rpc_registry import (
+    _normalize_label,
     _service_of,
     classify_service,
     diff,
+    diff_enums,
+    extract_proto_assertions,
+    extract_quota_codes,
     extract_registry,
+    extract_switch_enums,
     main,
+    parse_enum_members_from_text,
     parse_ids_from_text,
 )
 
@@ -151,3 +157,203 @@ def test_main_json_includes_unmapped_family(
     # /Svc.Create), so empirical-first classification tags this family "current" — this
     # also exercises the empirical path through the --json output, not just the schema.
     assert payload["unmapped"]["NewOne"] == {"method": "/Svc.Brand", "family": "current"}
+
+
+# ---------------------------------------------------------------------------
+# Studio enum / quota / proto drift extractors + diff_enums
+# ---------------------------------------------------------------------------
+
+# Minimal int-enum fixtures mirroring rpc/types.py's VideoFormat / AudioFormat.
+_ENUM_TYPES = """
+class VideoFormat(int, Enum):
+    EXPLAINER = 1
+    BRIEF = 2
+    CINEMATIC = 3
+
+class AudioFormat(int, Enum):
+    DEEP_DIVE = 1
+    BRIEF = 2
+    CRITIQUE = 3
+    DEBATE = 4
+"""
+
+# A bundle with the two anchored switch blocks (each carries a NEW trailing label
+# our enums lack — Short / Whiteboard Animation / Lecture), the Yp quota map, and
+# a proto required-field assertion. Whitespace/quote style mirrors the live shapes.
+_ENUM_BUNDLE = (
+    'f=function(a){switch(a){case 1:return"Explainer";case 2:return"Brief";'
+    'case 3:return"Cinematic";case 4:return"Short";case 5:return"Whiteboard Animation"}};'
+    'g=function(b){switch(b){case 1:return"Deep Dive";case 2:return"Brief";'
+    'case 3:return"Critique";case 4:return"Debate";case 5:return"Lecture"}};'
+    'Yp=[[1,{status:"RESOURCE_EXHAUSTED",result:{message:"chat limits reached"}}],'
+    '[6,{status:"RESOURCE_EXHAUSTED",result:{message:"video limits reached"}}]];'
+    "e=\"ExplainerVideoArtifact is missing field 'generation_options'\";"
+)
+
+
+def test_normalize_label() -> None:
+    assert _normalize_label("Deep Dive") == "DEEP_DIVE"
+    assert _normalize_label("Whiteboard Animation") == "WHITEBOARD_ANIMATION"
+    assert _normalize_label("Explainer") == "EXPLAINER"
+
+
+def test_extract_switch_enums_label_anchoring() -> None:
+    enums = extract_switch_enums(_ENUM_BUNDLE)
+    # Both blocks are attributed to our enums purely by their anchor label subset.
+    assert enums["VideoFormat"] == {
+        1: "Explainer",
+        2: "Brief",
+        3: "Cinematic",
+        4: "Short",
+        5: "Whiteboard Animation",
+    }
+    assert enums["AudioFormat"] == {
+        1: "Deep Dive",
+        2: "Brief",
+        3: "Critique",
+        4: "Debate",
+        5: "Lecture",
+    }
+
+
+def test_extract_switch_enums_drops_unanchored_blocks() -> None:
+    # A switch block with no recognizable anchor label set is not attributed.
+    bundle = 'switch(x){case 1:return"Mango";case 2:return"Papaya"}'
+    assert extract_switch_enums(bundle) == {}
+
+
+def test_parse_enum_members_from_text() -> None:
+    assert parse_enum_members_from_text(_ENUM_TYPES, "VideoFormat") == {
+        "EXPLAINER": 1,
+        "BRIEF": 2,
+        "CINEMATIC": 3,
+    }
+    # Unknown class -> empty (scoped to the named class body).
+    assert parse_enum_members_from_text(_ENUM_TYPES, "Nonexistent") == {}
+
+
+def test_extract_quota_codes() -> None:
+    assert extract_quota_codes(_ENUM_BUNDLE) == {
+        1: "chat limits reached",
+        6: "video limits reached",
+    }
+
+
+def test_extract_proto_assertions() -> None:
+    assert extract_proto_assertions(_ENUM_BUNDLE) == {
+        ("ExplainerVideoArtifact", "generation_options"),
+    }
+
+
+def test_diff_enums_new_is_report_only() -> None:
+    """Our enums match the bundle's leading codes; the trailing codes are NEW only."""
+    live = extract_switch_enums(_ENUM_BUNDLE)
+    buckets = diff_enums(_ENUM_TYPES, live)
+
+    assert buckets["changed"] == []
+    assert buckets["stale"] == []
+    assert buckets["unparsed"] == []
+    # Short (4) / Whiteboard Animation (5) / Lecture (5) are bundle codes we lack.
+    new_pairs = {(r["enum"], r["code"], r["label"]) for r in buckets["new"]}
+    assert new_pairs == {
+        ("VideoFormat", 4, "Short"),
+        ("VideoFormat", 5, "Whiteboard Animation"),
+        ("AudioFormat", 5, "Lecture"),
+    }
+
+
+def test_diff_enums_changed_is_the_alarm() -> None:
+    """A label whose integer differs from ours is CHANGED (the #1597 alarm)."""
+    # Our EXPLAINER claims code 2, but the bundle returns "Explainer" for case 1.
+    types = """
+class VideoFormat(int, Enum):
+    EXPLAINER = 2
+    BRIEF = 1
+    CINEMATIC = 3
+
+class AudioFormat(int, Enum):
+    DEEP_DIVE = 1
+    BRIEF = 2
+    CRITIQUE = 3
+    DEBATE = 4
+"""
+    live = extract_switch_enums(_ENUM_BUNDLE)
+    buckets = diff_enums(types, live)
+
+    changed = {
+        (r["enum"], r["member"], r["our_value"], r["live_value"]) for r in buckets["changed"]
+    }
+    assert changed == {
+        ("VideoFormat", "EXPLAINER", 2, 1),
+        ("VideoFormat", "BRIEF", 1, 2),
+    }
+    assert buckets["stale"] == []
+
+
+def test_diff_enums_stale_when_value_not_a_live_code() -> None:
+    """Our member's value is no longer any live code for that enum -> STALE."""
+    # A trimmed VideoFormat bundle exposing only codes {1, 3}; our BRIEF = 2 is gone.
+    bundle = 'switch(a){case 1:return"Explainer";case 3:return"Cinematic"}'
+    types = """
+class VideoFormat(int, Enum):
+    EXPLAINER = 1
+    BRIEF = 2
+    CINEMATIC = 3
+"""
+    live = extract_switch_enums(bundle)
+    buckets = diff_enums(types, live)
+
+    stale = {(r["enum"], r["member"], r["our_value"]) for r in buckets["stale"]}
+    assert stale == {("VideoFormat", "BRIEF", 2)}
+    assert buckets["changed"] == []
+
+
+def test_diff_enums_unparsed_when_no_block() -> None:
+    """A known enum (we hold an anchor) with no switch block parsed -> UNPARSED."""
+    # Only VideoFormat is present; AudioFormat has no block to attribute.
+    bundle = 'switch(a){case 1:return"Explainer";case 2:return"Brief";case 3:return"Cinematic"}'
+    live = extract_switch_enums(bundle)
+    buckets = diff_enums(_ENUM_TYPES, live)
+
+    assert {r["enum"] for r in buckets["unparsed"]} == {"AudioFormat"}
+    assert buckets["changed"] == []
+    assert buckets["stale"] == []
+
+
+def test_check_enums_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--check-enums exits 1 on CHANGED/STALE only; NEW/UNPARSED stay 0. --check still works."""
+    types = tmp_path / "types.py"
+    bundle = tmp_path / "bundle.js"
+
+    # Clean baseline (our enums == bundle leading codes; only NEW trailing labels).
+    types.write_text(_ENUM_TYPES, encoding="utf-8")
+    bundle.write_text(_ENUM_BUNDLE, encoding="utf-8")
+    rc = main(["--bundle-file", str(bundle), "--types", str(types), "--check-enums"])
+    out = capsys.readouterr().out
+    assert rc == 0  # NEW labels never fail the enum gate
+    assert "STUDIO ENUM DRIFT" in out
+    assert "NEW: 3" in out
+
+    # CHANGED -> exit 1.
+    types.write_text(
+        "class VideoFormat(int, Enum):\n    EXPLAINER = 2\n    BRIEF = 1\n    CINEMATIC = 3\n"
+        "class AudioFormat(int, Enum):\n    DEEP_DIVE = 1\n    CRITIQUE = 3\n    DEBATE = 4\n",
+        encoding="utf-8",
+    )
+    assert main(["--bundle-file", str(bundle), "--types", str(types), "--check-enums"]) == 1
+
+
+def test_check_and_check_enums_combine(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--check (id rotation) and --check-enums combine; either firing exits 1."""
+    # _TYPES has an ABSENT id (ZZxxYY/GONE); _BUNDLE has no switch enums.
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    bundle = tmp_path / "bundle.js"
+    bundle.write_text(_BUNDLE, encoding="utf-8")
+
+    # --check alone fires on the ABSENT id even with no enum data present.
+    assert main(["--bundle-file", str(bundle), "--types", str(types), "--check"]) == 1
+    # Combining the flags still exits 1 (the id gate fires; enum gate sees nothing).
+    assert (
+        main(["--bundle-file", str(bundle), "--types", str(types), "--check", "--check-enums"]) == 1
+    )

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -723,3 +723,143 @@ def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch) -> No
     with pytest.raises(SystemExit) as excinfo:
         check_rpc_health.main()
     assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# sqTeoe studio-customization cohort tripwire
+# ---------------------------------------------------------------------------
+
+CohortStatus = check_rpc_health.CohortStatus
+build_customization_choices_params = check_rpc_health.build_customization_choices_params
+check_customization_cohort = check_rpc_health.check_customization_cohort
+make_raw_rpc_request = check_rpc_health.make_raw_rpc_request
+
+
+def _cohort_auth() -> check_rpc_health.AuthTokens:
+    return check_rpc_health.AuthTokens(
+        cookies={"SID": "sid"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+def test_build_customization_choices_params_shape() -> None:
+    """The reverse-engineered ``[nbctx, None, artifact_type]`` shape is verified."""
+    params = build_customization_choices_params("nb_42")
+    assert params == [
+        [
+            2,
+            None,
+            None,
+            [1, None, None, None, None, None, None, None, None, None, [1]],
+            ["nb_42"],
+        ],
+        None,
+        3,  # artifact_type = video
+    ]
+
+
+@pytest.mark.asyncio
+async def test_make_raw_rpc_request_threads_id_into_query_and_body() -> None:
+    """The raw id lands in BOTH the ``rpcids=`` query param and the ``f.req`` body."""
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+            captured["url"] = url
+            captured["content"] = content
+            return httpx.Response(200, text=")]}'\n\n[]", request=httpx.Request("POST", url))
+
+    text, error = await make_raw_rpc_request(
+        FakeClient(),
+        _cohort_auth(),
+        "sqTeoe",
+        [["x"]],
+        source_path="/notebook/nb_1",
+    )
+    assert error is None
+    assert text == ")]}'\n\n[]"
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["rpcids"] == ["sqTeoe"]
+    assert query["source-path"] == ["/notebook/nb_1"]
+    # The body's f.req carries the override id, kept in sync with the query param.
+    assert "sqTeoe" in captured["content"]
+    # The fallback RPCMethod (LIST_NOTEBOOKS) must NOT leak into the wire.
+    assert check_rpc_health.RPCMethod.LIST_NOTEBOOKS.value not in captured["content"]
+
+
+@pytest.mark.asyncio
+async def test_check_customization_cohort_gated_on_null() -> None:
+    """A genuine null payload is GATED (the expected steady state, NOT a failure)."""
+
+    class NullClient:
+        async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+            # wrb.fr frame whose payload is JSON null -> decode_response(..., allow_null) == None
+            body = ')]}\'\n\n[["wrb.fr","sqTeoe","null",null,null,null,"generic"]]'
+            return httpx.Response(200, text=body, request=httpx.Request("POST", url))
+
+    status, detail = await check_customization_cohort(NullClient(), _cohort_auth(), "nb_1")
+    assert status is CohortStatus.GATED
+    assert "gated" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_check_customization_cohort_migrated_on_non_null() -> None:
+    """A non-null payload is the loud MIGRATED signal (cohort flipped)."""
+
+    class MigratedClient:
+        async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+            body = ')]}\'\n\n[["wrb.fr","sqTeoe","[[1,2,3]]",null,null,null,"generic"]]'
+            return httpx.Response(200, text=body, request=httpx.Request("POST", url))
+
+    status, _ = await check_customization_cohort(MigratedClient(), _cohort_auth(), "nb_1")
+    assert status is CohortStatus.MIGRATED
+
+
+@pytest.mark.asyncio
+async def test_check_customization_cohort_unknown_on_transport_error() -> None:
+    """A transport failure never alarms; it draws UNKNOWN (no cohort conclusion)."""
+
+    class FailingClient:
+        async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+            raise httpx.ReadTimeout("")
+
+    status, detail = await check_customization_cohort(FailingClient(), _cohort_auth(), "nb_1")
+    assert status is CohortStatus.UNKNOWN
+    assert detail == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_check_customization_cohort_unknown_without_notebook() -> None:
+    status, _ = await check_customization_cohort(object(), _cohort_auth(), None)
+    assert status is CohortStatus.UNKNOWN
+
+
+def test_compute_exit_code_cohort_migrated_is_four() -> None:
+    """MIGRATED draws exit 4 when no higher-priority drift fired."""
+    clean = Counter({CheckStatus.OK: 3})
+    assert check_rpc_health.compute_exit_code(clean, [], CohortStatus.MIGRATED) == 4
+    assert check_rpc_health.compute_exit_code(clean, [], CohortStatus.GATED) == 0
+    # RPC drift outranks the cohort flip.
+    mismatch = Counter({CheckStatus.MISMATCH: 1})
+    assert check_rpc_health.compute_exit_code(mismatch, [], CohortStatus.MIGRATED) == 1
+    real_error = [_result("e", CheckStatus.ERROR, error="Parse error: boom")]
+    assert check_rpc_health.compute_exit_code(Counter(), real_error, CohortStatus.MIGRATED) == 3
+
+
+def test_print_summary_reports_cohort_flip(capsys: pytest.CaptureFixture[str]) -> None:
+    results = [_result("ok", CheckStatus.OK)]
+    rc = print_summary(results, CohortStatus.MIGRATED)
+    out = capsys.readouterr().out
+    assert rc == 4
+    assert "COHORT FLIP" in out
+    assert "sqTeoe customization choices = MIGRATED" in out
+
+
+def test_print_summary_gated_is_pass(capsys: pytest.CaptureFixture[str]) -> None:
+    results = [_result("ok", CheckStatus.OK)]
+    rc = print_summary(results, CohortStatus.GATED)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "sqTeoe customization choices = GATED" in out
+    assert "RESULT: PASS" in out


### PR DESCRIPTION
## What

Extends the RPC-bundle monitoring to detect new classes of drift in Google's live JS bundle beyond obfuscated RPC ids, and wires it into the nightly RPC-health job.

### 1. `scripts/capture_rpc_registry.py` — three new extractors + an enum diff

- **`extract_switch_enums`** — parses the bundle's inline `switch(code){case N:return "Label"}` maps and attributes each block to one of our enums by **label-anchoring**: a small registry maps a distinctive label *subset* (`{"Explainer","Cinematic"}` → `VideoFormat`, `{"Deep Dive","Critique","Debate"}` → `AudioFormat`) and any block whose labels are a superset of an anchor is attributed to that enum. Anchoring on a subset means a NEW label never breaks attribution.
- **`extract_quota_codes`** — the `Yp` quota map (`{code → message}`), a feature-rollout early-warning surface.
- **`extract_proto_assertions`** — `{(message, field)}` proto required-field assertions (`"ExplainerVideoArtifact is missing field 'generation_options'"`), a schema-shape drift surface.
- **`diff_enums`** — a FOUR-class taxonomy mirroring the existing id `diff`:
  - **CHANGED** — a label present in both our enum and the bundle but mapped to a different integer (the **#1597 alarm**: a selectable format silently renumbered). Fails `--check-enums`.
  - **STALE** — our member's integer is no longer any live code for that enum (format retired). Fails `--check-enums`.
  - **NEW** — the bundle declares a code we lack. **REPORT-ONLY, never an alarm** — a switch arm is only a *display label*, and a label can ship in the bundle long before the format is selectable on any cohort (**proven live**: the bundle lists `Short` / `Whiteboard Animation` / `Lecture` while they are not yet selectable). Encoding a member off a bundle label would bake in an unreleased/non-functional code.
  - **UNPARSED** — a known enum (we hold an anchor) with no switch block parsed: "widen the regex", not an alarm — same posture as PRESENT-UNPARSED in the id diff.

`--check-enums` exits 1 **only** on CHANGED/STALE; NEW/UNPARSED, quota codes and proto assertions print for visibility but exit 0. `--check` (id rotation) is unchanged and the two gates combine. Also fixed the stale `_.uD(...)` docstring example → `_.fD(...)` (the registration helper was renamed; the scraper is path-anchored, not helper-name-anchored, so it kept working).

### 2. `scripts/check_rpc_health.py` — `sqTeoe` cohort tripwire

`GetArtifactCustomizationChoices` (rpc id `sqTeoe`, not in our enum) returns `null` unconditionally for our gated consumer cohort. A new `check_customization_cohort` calls it by **raw id** (new `make_raw_rpc_request` threads the id into both the `rpcids=` query param and `encode_rpc_request`'s `rpc_id_override`, decode with `allow_null=True`) and classifies:

- **GATED** (null) — the expected steady state, **not** a failure.
- **MIGRATED** (non-null) — our account flipped to the new studio-customization surface → new **exit code 4** (`RESULT: COHORT FLIP`), priority below the RPC-drift codes (MISMATCH 1 > AUTH 2 > non-transient ERROR 3 > **MIGRATED 4** > OK 0).
- **UNKNOWN** — transport/parse failure on the probe; never alarms.

The absent-id drift guard inside `decode_response` still fires if the id stops being echoed, so a rotated `sqTeoe` surfaces as a parse error (UNKNOWN), not a silent GATED.

### 3. `.github/workflows/rpc-health.yml` — nightly wiring

- A `Run bundle drift monitor` step (authed `health-check` job, `continue-on-error`) runs `capture_rpc_registry.py --check --check-enums`, scrubs the report, dedups, and files an issue titled **"Studio enum / RPC drift detected"** (`rpc-breakage, automated`) on nonzero exit.
- A cohort-flip issue branch (`exit_code == '4'`) files **"Studio customization cohort flipped — re-capture VideoStyle codes"**.

Both stay on the nightly/issue-filing track — **NOT** a required PR gate (they depend on a live external bundle).

## Tests

`tests/unit/test_capture_rpc_registry.py` — extractors, `parse_enum_members_from_text`, `_normalize_label`, and `diff_enums` covering all four classes (CHANGED/STALE/NEW/UNPARSED), plus `--check-enums` exit codes and `--check`/`--check-enums` combining, all from inline bundle snippets (no network). `tests/unit/test_check_rpc_health.py` — the tripwire param shape, raw-rpc query/body id sync, GATED/MIGRATED/UNKNOWN classification, and the exit-4 path through `compute_exit_code`/`print_summary`.

## Verification

- `uv run pytest tests/unit tests/integration` — 9255 passed, 66 skipped.
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run ruff check .` + `uv run ruff format --check .` — clean over the whole tree.
- `python scripts/capture_rpc_registry.py --help` shows `--check-enums`; script imports cleanly; against the real `rpc/types.py` the live `Short`/`Whiteboard Animation`/`Lecture` formats land as NEW (report-only, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated bundle drift monitoring that produces a drift report, scrubs sensitive info, and opens a deduplicated issue when drift is detected.
  * Expanded RPC health checks with a studio customization cohort tripwire that surfaces “cohort flip” failures with dedicated messaging.

* **Bug Fixes**
  * Improved health check exit-status handling so cohort flips have a distinct failure category.

* **Tests**
  * Added unit tests covering enum/quota/proto drift detection, cohort classification, and combined exit-code behavior.

* **Chores**
  * Enhanced CI workflow reporting and uploads the drift report as a 30-day artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->