### PR TITLE
docs(changelog): complete v0.7.2 entry (#1548, compare links, date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.2] - 2026-06-17
+## [0.7.2] - 2026-06-18
 
 Maintenance patch on the 0.7.x line. Backports fixes from `main`
 (cherry-picked ahead of the v0.8.0 breaking release).
@@ -36,6 +36,19 @@ Maintenance patch on the 0.7.x line. Backports fixes from `main`
   the full envelope, matching the browser. The VCR body matcher normalizes the
   old and new client-options shapes so existing generation cassettes still
   replay.
+
+- **`notebooks.create()` and `sources.add_url()` no longer fail on
+  already-migrated cohorts** (#1548; backport of #1546). Google migrated the
+  `CREATE_NOTEBOOK` (CCqFvf) and URL `ADD_SOURCE` (izAoDd) payloads to a nested
+  wire shape during the gradual rollout: the flat trailing template block
+  (`[2],[1]` for create; `[2],None,None` for url-add) collapsed into a nested
+  `[2, None, None, [1, …, [1]]]` block, and the URL source spec gained a
+  trailing `1`. Backends on already-migrated accounts began rejecting the old
+  flat shape (`status=3` for create, `5`/`9` for add-source), while read paths
+  were unaffected. Both payload builders now emit the nested shape, which is
+  forward-compatible across migrated and un-migrated cohorts (verified live).
+  Scope is limited to the create + add-url RPCs with exact Web-UI captures; the
+  youtube/text/drive/file `ADD_SOURCE` variants are unchanged.
 
 - **Empty notebook summary no longer raises `UnknownRPCMethodError`** (#1485).
   A brand-new, source-less notebook has no summary yet, so the `SUMMARIZE` RPC
@@ -1181,7 +1194,9 @@ This is the initial public release of `notebooklm-py`. While core functionality 
 - **Authentication expiry**: CSRF tokens expire after some time. Re-run `notebooklm login` if you encounter auth errors.
 - **Large file uploads**: Files over 50MB may fail or timeout. Split large documents if needed.
 
-[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.4.1...v0.5.0


### PR DESCRIPTION
Pre-release CHANGELOG completeness pass for **v0.7.2**, surfaced by a thorough pre-release audit of \`release/v0.7.1\`.

## What

1. **Document the backported #1548 fix** — the CREATE_NOTEBOOK + ADD_SOURCE(url) nested-wire-shape migration (backport of #1546) shipped on this branch (\`0ad9d631\`) but was **missing from the \`[0.7.2]\` changelog section**. It's a core RPC-breakage fix (notebook create / add-URL fail on already-migrated Google cohorts), so it warrants an entry.
2. **Fix comparison links** — \`[Unreleased]\` pointed at \`v0.7.0\`; the \`[0.7.2]\` and (previously-missing) \`[0.7.1]\` links are now present and correct.
3. **Bump the release date** to the actual release day (2026-06-18).

## Why now

This must land on \`release/v0.7.1\` **before** the \`v0.7.2\` tag so the tagged commit ships a complete, accurate changelog.

## Audit result (for context)

Release branch is otherwise clean and green: ruff/format/mypy clean, full suite 8425 passed, E2E (ubuntu+windows) passed, API-compat audit compatible with v0.7.1 (24 VideoStyle breaks allowlisted + documented). No code changes in this PR — changelog only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

