### PR TITLE
feat(cli): re-land suggest-prompts command (#1616 stranded on orphaned branch)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -140,6 +140,7 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 - `notebooklm use <id>` - set context (⚠️ SINGLE-AGENT ONLY - use `-n` flag in parallel workflows)
 - `notebooklm create` - create notebook
 - `notebooklm ask "..."` - chat queries (without `--save-as-note`)
+- `notebooklm suggest-prompts` - AI-suggested prompts for a notebook (read-only, no state change)
 - `notebooklm history` - display conversation history (read-only)
 - `notebooklm source add` - add sources
 - `notebooklm profile list` - list profiles
@@ -200,6 +201,7 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 | Check research status | `notebooklm research status` |
 | Wait for research | `notebooklm research wait --import-all` |
 | Cancel research | `notebooklm research cancel <run_id>` (run_id = the `task_id` from `research status`) |
+| Suggest questions to ask | `notebooklm suggest-prompts` |
 | Chat | `notebooklm ask "question"` |
 | Chat (long prompt from file) | `notebooklm ask --prompt-file question.txt` |
 | Chat (specific sources) | `notebooklm ask "question" -s src_id1 -s src_id2` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -127,6 +127,11 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `ask --request-timeout N` | Per-invocation HTTP request/read timeout in seconds for chat. Defaults to the library chat timeout. `--timeout` is a back-compat alias for the same flag. | `notebooklm ask "long prompt" --request-timeout 120` |
 | `ask --save-as-note` | Save response as a note. When the answer contains `[N]` citations, the saved note preserves interactive hover-anchored citation links matching the NotebookLM web UI's "Save to note" behavior ([issue #660](https://github.com/teng-lin/notebooklm-py/issues/660)). Answers without citations fall back to a plain-text note. | `notebooklm ask "Explain X" --save-as-note` |
 | `ask --save-as-note --note-title` | Save response with custom note title. The NotebookLM server may apply smart-title generation for citation-rich saves and override the requested title; the success message reflects what the server actually stored. | `notebooklm ask "Explain X" --save-as-note --note-title "Title"` |
+| `suggest-prompts` | Get AI-suggested prompts for the notebook (each a title plus a ready-to-send instruction for `ask`) | `notebooklm suggest-prompts` |
+| `suggest-prompts --mode N` | Select the suggestion surface (1-9, default 4): 4=chat questions, 5=critique, 6=audio/debate, 8=quiz, 9=flashcards. Out-of-range exits 1. | `notebooklm suggest-prompts --mode 8` |
+| `suggest-prompts --query TEXT` | Free-text steer for the kind of prompts to suggest | `notebooklm suggest-prompts --query "key risks"` |
+| `suggest-prompts -s <id>` | Limit to specific source IDs (repeatable; defaults to all sources) | `notebooklm suggest-prompts -s src1 -s src2` |
+| `suggest-prompts --json` | Machine-readable output (`{notebook_id, suggestions, count}`) | `notebooklm suggest-prompts --json` |
 | `configure --mode` | Set predefined chat mode (`default`, `learning-guide`, `concise`, `detailed`) | `notebooklm configure --mode learning-guide` |
 | `configure --persona` | Set custom persona prompt (up to 10,000 chars) | `notebooklm configure --persona "Act as a tutor"` |
 | `configure --response-length` | Response verbosity (`default`, `longer`, `shorter`) | `notebooklm configure --response-length longer` |

--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -1,9 +1,10 @@
 """Chat and conversation CLI commands.
 
 Commands:
-    ask        Ask a notebook a question
-    configure  Configure chat persona and response settings
-    history    Get conversation history or clear local cache
+    ask             Ask a notebook a question
+    suggest-prompts Get AI-suggested prompts for a notebook
+    configure       Configure chat persona and response settings
+    history         Get conversation history or clear local cache
 """
 
 import logging
@@ -41,6 +42,14 @@ from .rendering import (
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_ids
 
 logger = logging.getLogger(__name__)
+
+# Inclusive ``--mode`` range for ``suggest-prompts``. Mirrors the canonical 1..9
+# bound that ``NotebooksAPI.suggest_prompts`` enforces (the CLI boundary forbids
+# importing the runtime layer's private constant, so this is a deliberate copy);
+# the method re-validates server-side-bound, so a drift here only changes which
+# layer reports the same out-of-range error, never correctness.
+_SUGGEST_PROMPTS_MODE_MIN = 1
+_SUGGEST_PROMPTS_MODE_MAX = 9
 
 
 def _configure_json_payload(config: ConfigureResult) -> dict[str, Any]:
@@ -424,6 +433,108 @@ def register_chat_commands(cli):
                         if note_save_error is not None:
                             data["note_save_error"] = note_save_error
                     json_output_response(data)
+
+        return _run()
+
+    @cli.command("suggest-prompts")
+    @notebook_option
+    @click.option(
+        "--mode",
+        default=4,
+        type=int,
+        help=(
+            "Suggestion surface to target (1-9, default 4). 4=default chat "
+            "questions, 5=critique, 6=audio/debate, 8=quiz, 9=flashcards. "
+            "Out-of-range values exit 1 with a validation error."
+        ),
+    )
+    @click.option(
+        "--query",
+        default=None,
+        help="Free-text steer for the kind of prompts to suggest.",
+    )
+    @click.option(
+        "--source",
+        "-s",
+        "source_ids",
+        multiple=True,
+        help="Limit to specific source IDs (can be repeated). Defaults to all sources.",
+        shell_complete=_complete_sources,
+    )
+    @json_option
+    @with_client
+    def suggest_prompts_cmd(
+        ctx,
+        notebook_id,
+        mode,
+        query,
+        source_ids,
+        json_output,
+        client_auth,
+    ):
+        """Get AI-suggested prompts for a notebook.
+
+        Returns a short list of suggested prompts (each a title plus a
+        ready-to-send instruction) that you can pass to ``notebooklm ask``.
+        ``--mode`` selects the product surface the prompts are written for:
+        4 (default) = chat questions, 5 = critique, 6 = audio/debate,
+        8 = quiz, 9 = flashcards. A mode outside 1-9 exits 1.
+
+        \b
+        Example:
+          notebooklm suggest-prompts
+          notebooklm suggest-prompts --mode 8           # quiz prompts
+          notebooklm suggest-prompts --query "key risks"
+          notebooklm suggest-prompts -s src_001 -s src_002
+          notebooklm suggest-prompts --json
+        """
+        nb_id = require_notebook(notebook_id)
+        # Validate ``mode`` up front -- BEFORE any notebook/source resolution --
+        # so an out-of-range value always surfaces the mode error (exit 1) and
+        # never pays for a ``sources.list`` resolution RPC. ``suggest_prompts``
+        # re-validates the same 1..9 range before its own RPC; this mirror keeps
+        # the bad-mode failure deterministic regardless of how ``-s`` resolves.
+        # Raises the public ``ValidationError`` so the shared error envelope
+        # (``@with_client``) maps it to a VALIDATION_ERROR exit-1 / JSON envelope.
+        if not _SUGGEST_PROMPTS_MODE_MIN <= mode <= _SUGGEST_PROMPTS_MODE_MAX:
+            raise ValidationError(
+                f"mode must be in the inclusive range "
+                f"{_SUGGEST_PROMPTS_MODE_MIN}..{_SUGGEST_PROMPTS_MODE_MAX}, got {mode!r}"
+            )
+
+        async def _run():
+            async with resolve_client_factory(ctx)(client_auth) as client:
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                sources = await resolve_source_ids(
+                    client, nb_id_resolved, source_ids, json_output=json_output
+                )
+                suggestions = await client.notebooks.suggest_prompts(
+                    nb_id_resolved,
+                    source_ids=sources,
+                    mode=mode,
+                    query=query,
+                )
+
+                if json_output:
+                    json_output_response(
+                        {
+                            "notebook_id": nb_id_resolved,
+                            "suggestions": [
+                                {"title": s.title, "prompt": s.prompt} for s in suggestions
+                            ],
+                            "count": len(suggestions),
+                        }
+                    )
+                    return
+
+                if not suggestions:
+                    console.print("[yellow]No prompt suggestions returned[/yellow]")
+                    return
+
+                console.print("[bold cyan]Suggested prompts:[/bold cyan]")
+                for i, suggestion in enumerate(suggestions, 1):
+                    console.print(f"\n[bold]{i}. {suggestion.title}[/bold]")
+                    console.print(suggestion.prompt)
 
         return _run()
 

--- a/src/notebooklm/cli/grouped.py
+++ b/src/notebooklm/cli/grouped.py
@@ -51,7 +51,7 @@ class SectionedGroup(click.Group):
     Instead of a flat alphabetical list, commands are grouped by function:
     - Session: login, use, status, clear, doctor, auth, completion
     - Notebooks: list, create, delete, rename, summary, metadata
-    - Chat: ask, configure, history
+    - Chat: ask, suggest-prompts, configure, history
     - Command Groups: source, artifact, note, label, share, research, profile,
       agent, skill, language, mcp (show subcommands)
     - Artifact Actions: generate, download (show types)
@@ -63,7 +63,7 @@ class SectionedGroup(click.Group):
         [
             ("Session", ["login", "use", "status", "clear", "doctor", "auth", "completion"]),
             ("Notebooks", ["list", "create", "delete", "rename", "summary", "metadata"]),
-            ("Chat", ["ask", "configure", "history"]),
+            ("Chat", ["ask", "suggest-prompts", "configure", "history"]),
         ]
     )
 

--- a/tests/_baselines/cli_contract.py
+++ b/tests/_baselines/cli_contract.py
@@ -55,7 +55,7 @@ CLICK_GROUPS = (
 TOP_LEVEL_SURFACES = {
     "session": ("login", "auth", "use", "status", "clear"),
     "notebook": ("list", "create", "delete", "rename", "metadata", "summary"),
-    "chat": ("ask", "configure", "history"),
+    "chat": ("ask", "suggest-prompts", "configure", "history"),
 }
 
 EXTRA_TOP_LEVEL_COMMANDS = ("completion", "doctor")

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -7800,6 +7800,7 @@
         "skill",
         "source",
         "status",
+        "suggest-prompts",
         "summary",
         "use"
       ],
@@ -10384,6 +10385,104 @@
       ],
       "short_help": "Show current context (active notebook and..."
     },
+    "suggest-prompts": {
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 4,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Suggestion surface to target (1-9, default 4). 4=default chat questions, 5=critique, 6=audio/debate, 8=quiz, 9=flashcards. Out-of-range values exit 1 with a validation error.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mode",
+          "opts": [
+            "--mode"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Free-text steer for the kind of prompts to suggest.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "query",
+          "opts": [
+            "--query"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs (can be repeated). Defaults to all sources.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get AI-suggested prompts for a notebook."
+    },
     "summary": {
       "class": "Command",
       "params": [
@@ -10529,6 +10628,7 @@
     "skill",
     "source",
     "status",
+    "suggest-prompts",
     "summary",
     "use"
   ],
@@ -10536,6 +10636,7 @@
   "top_level_surfaces": {
     "chat": [
       "ask",
+      "suggest-prompts",
       "configure",
       "history"
     ],

--- a/tests/unit/cli/test_suggest_prompts.py
+++ b/tests/unit/cli/test_suggest_prompts.py
@@ -1,0 +1,169 @@
+"""Tests for the ``notebooklm suggest-prompts`` CLI command.
+
+Mirrors the sibling chat-command tests (``test_chat.py``): drives the command
+through the same ``inject_client`` seam used by the top-level ``ask`` command,
+patching ``client.notebooks.suggest_prompts`` rather than constructing a real
+client. Covers the default mode, an explicit ``--mode``, ``--json`` envelope
+shape, and an out-of-range ``--mode`` (the method's ``ValidationError`` must
+surface as a clean exit-1 / VALIDATION_ERROR envelope, not a traceback).
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import notebooklm.auth as auth_module
+from notebooklm.cli import helpers as helpers_module
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import PromptSuggestion
+
+from .conftest import create_mock_client, inject_client
+
+SUGGESTIONS = [
+    PromptSuggestion(title="Professional Briefing", prompt="Give me a briefing on the sources."),
+    PromptSuggestion(title="Key Risks", prompt="What are the key risks raised?"),
+    PromptSuggestion(title="Counterarguments", prompt="What are the strongest counterarguments?"),
+]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    with patch.object(helpers_module, "load_auth_from_storage") as mock:
+        mock.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        yield mock
+
+
+def _invoke(runner, mock_client, argv):
+    with patch.object(
+        auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = ("csrf", "session")
+        return runner.invoke(cli, argv, obj=inject_client(mock_client))
+
+
+def test_default_mode_lists_suggestions(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=SUGGESTIONS)
+
+    result = _invoke(runner, mock_client, ["suggest-prompts", "-n", "nb_123"])
+
+    assert result.exit_code == 0, result.output
+    # Default mode is 4 and source_ids defaults to None (all sources).
+    mock_client.notebooks.suggest_prompts.assert_awaited_once()
+    call = mock_client.notebooks.suggest_prompts.call_args
+    assert call.kwargs["mode"] == 4
+    assert call.kwargs["source_ids"] is None
+    assert call.kwargs["query"] is None
+    # Text output is a numbered list of title + prompt.
+    assert "Professional Briefing" in result.output
+    assert "Give me a briefing on the sources." in result.output
+    assert "1." in result.output
+
+
+def test_explicit_mode_and_query_forwarded(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=SUGGESTIONS)
+
+    result = _invoke(
+        runner,
+        mock_client,
+        ["suggest-prompts", "-n", "nb_123", "--mode", "8", "--query", "exam topics"],
+    )
+
+    assert result.exit_code == 0, result.output
+    call = mock_client.notebooks.suggest_prompts.call_args
+    assert call.kwargs["mode"] == 8
+    assert call.kwargs["query"] == "exam topics"
+
+
+def test_source_ids_forwarded(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=SUGGESTIONS)
+
+    result = _invoke(
+        runner,
+        mock_client,
+        ["suggest-prompts", "-n", "nb_123", "-s", "src_001", "-s", "src_002"],
+    )
+
+    assert result.exit_code == 0, result.output
+    call = mock_client.notebooks.suggest_prompts.call_args
+    assert call.kwargs["source_ids"] == ["src_001", "src_002"]
+
+
+def test_json_envelope_shape(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=SUGGESTIONS)
+
+    result = _invoke(runner, mock_client, ["suggest-prompts", "-n", "nb_123", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["notebook_id"] == "nb_123"
+    assert payload["count"] == 3
+    assert payload["suggestions"][0] == {
+        "title": "Professional Briefing",
+        "prompt": "Give me a briefing on the sources.",
+    }
+
+
+def test_empty_suggestions_text(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=[])
+
+    result = _invoke(runner, mock_client, ["suggest-prompts", "-n", "nb_123"])
+
+    assert result.exit_code == 0, result.output
+    assert "No prompt suggestions" in result.output
+
+
+def test_bad_mode_exits_one(runner, mock_auth):
+    mock_client = create_mock_client()
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=[])
+
+    result = _invoke(
+        runner,
+        mock_client,
+        ["suggest-prompts", "-n", "nb_123", "--mode", "99", "--json"],
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert "1..9" in payload["message"]
+
+
+def test_bad_mode_validated_before_source_resolution(runner, mock_auth):
+    # The mode check fires BEFORE notebook/source resolution, so an out-of-range
+    # mode with an unresolvable partial ``-s`` id still surfaces the mode error
+    # (not a "no source found" error) and never incurs a ``sources.list`` RPC.
+    mock_client = create_mock_client()
+    mock_client.sources.list = AsyncMock(return_value=[])
+    mock_client.notebooks.suggest_prompts = AsyncMock(return_value=[])
+
+    result = _invoke(
+        runner,
+        mock_client,
+        ["suggest-prompts", "-n", "nb_123", "-s", "does-not-exist", "--mode", "99", "--json"],
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert "1..9" in payload["message"]
+    mock_client.sources.list.assert_not_awaited()
+    mock_client.notebooks.suggest_prompts.assert_not_awaited()

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -217,6 +217,10 @@ def _fail_chat_ask(client: MagicMock) -> None:
     client.chat.ask = AsyncMock(side_effect=RuntimeError("network unreachable"))
 
 
+def _fail_suggest_prompts(client: MagicMock) -> None:
+    client.notebooks.suggest_prompts = AsyncMock(side_effect=RuntimeError("network unreachable"))
+
+
 def _fail_artifact_list(client: MagicMock) -> None:
     client.artifacts.list = AsyncMock(side_effect=RuntimeError("auth: 401 Unauthorized"))
 
@@ -589,6 +593,11 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
     ("share_status_failure", ["share", "status", "-n", "abc", "--json"], _fail_share_status),
     ("notebook_list_failure", ["list", "--json"], _fail_notebook_list),
     ("chat_ask_failure", ["ask", "hi", "-n", "abc", "--json"], _fail_chat_ask),
+    (
+        "suggest_prompts_failure",
+        ["suggest-prompts", "-n", "abc", "--json"],
+        _fail_suggest_prompts,
+    ),
     # notebook create: with_client + RuntimeError -> UNEXPECTED_ERROR envelope.
     (
         "notebook_create_failure",

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -41,6 +41,7 @@ from notebooklm.types import (
     Label,
     Note,
     Notebook,
+    PromptSuggestion,
     ResearchSource,
     ResearchStart,
     ResearchStatus,
@@ -295,6 +296,15 @@ def _customize_chat_ask(client: MagicMock) -> None:
             references=[],
             raw_response="",
         )
+    )
+
+
+def _customize_suggest_prompts(client: MagicMock) -> None:
+    client.notebooks.suggest_prompts = AsyncMock(
+        return_value=[
+            PromptSuggestion(title="Briefing", prompt="Give me a briefing."),
+            PromptSuggestion(title="Risks", prompt="What are the key risks?"),
+        ]
     )
 
 
@@ -609,6 +619,11 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
         "history_cmd",
         ["history", "-n", "abc123def456ghi789jkl", "--json"],
         None,
+    ),
+    (
+        "suggest_prompts_cmd",
+        ["suggest-prompts", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_suggest_prompts,
     ),
     # doctor / profile / notebook-create coverage (meta-audit G9 + I7 + I9):
     # `doctor` and `profile list` read NOTEBOOKLM_HOME directly and don't


### PR DESCRIPTION
Re-lands the `notebooklm suggest-prompts` CLI command + SKILL.md entry that was lost in a stacked-merge mishap.

## What happened
- #1616 (the CLI for `client.notebooks.suggest_prompts`) was based on `feat/chat-suggest-prompts` (#1615's branch).
- #1615 squash-merged to `main` while its tip was the API relocation only (`acf1d278`).
- #1616 then merged into the now-orphaned `feat/chat-suggest-prompts`, so its commit (`df5ed4fd`) never reached `main`. #1616 shows "MERGED" but only into the dead branch.

## This PR
Cherry-picks `df5ed4fd` onto `main`. The API method (`client.notebooks.suggest_prompts`) it depends on is already in `main` (via #1615), so it applies cleanly. One conflict — `SKILL.md`, where #1614's `research cancel` rows now coexist with the suggest-prompts rows — resolved by keeping both.

Adds the top-level `notebooklm suggest-prompts` command (`-n/--notebook`, `--mode`, `--query`, `-s/--source`, `--json`), CLI tests, guardrail/baseline updates, `docs/cli-reference.md`, and the `SKILL.md` entries.

Verified locally against `main` (which now has both #1614 and #1615): ruff, mypy, api-compat clean; full unit + guardrail suite **9575 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `suggest-prompts` command to the CLI, enabling generation of suggested prompts for notebooks with configurable mode, query filtering, and source selection; supports JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->