### PR TITLE
feat(server): expose sharing endpoints

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1273,7 +1273,8 @@ src/notebooklm/
         ├── notebooks.py         # /v1/notebooks list/get/create/delete
         ├── sources.py           # /v1/notebooks/{id}/sources list/get/add(url·text·file)/delete + poll-the-resource status
         ├── chat.py              # POST /v1/notebooks/{id}/chat — blocking ask (no SSE)
-        └── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download (registry-projected poll; server-generated temp download path)
+        ├── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download (registry-projected poll; server-generated temp download path)
+        └── share.py             # /v1/notebooks/{id}/share status/public/users/view-level over _app.sharing
 ```
 
 ## ADR cross-references

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -352,9 +352,10 @@ curl -H "Authorization: Bearer $TOKEN" -d '{"url":"https://example.com"}' \
      -H 'Content-Type: application/json' $BASE/v1/notebooks/<id>/sources/url
 curl -H "Authorization: Bearer $TOKEN" -d '{"question":"Summarize"}' \
      -H 'Content-Type: application/json' $BASE/v1/notebooks/<id>/chat # blocking answer
+curl -H "Authorization: Bearer $TOKEN" $BASE/v1/notebooks/<id>/share # sharing status
 ```
 
-Endpoints: `/v1/notebooks` (list/get/create/delete); `/v1/notebooks/{id}/sources` (list/get/add via `url`·`text`·`file`/delete); `/v1/notebooks/{id}/chat` (blocking ask, no streaming); `/v1/notebooks/{id}/artifacts` (list / generate / poll / download). Long-running work (source ingest, artifact generation) is **poll-the-resource**: the create call returns immediately and the matching `GET` reports `pending` until the resource is ready (`200`), `404` for an id the server never created, `409`/`410` for a failed/removed artifact.
+Endpoints: `/v1/notebooks` (list/get/create/delete); `/v1/notebooks/{id}/sources` (list/get/add via `url`·`text`·`file`/delete); `/v1/notebooks/{id}/chat` (blocking ask, no streaming); `/v1/notebooks/{id}/artifacts` (list / generate / poll / download); `/v1/notebooks/{id}/share` (status / public link / users / view level). Long-running work (source ingest, artifact generation) is **poll-the-resource**: the create call returns immediately and the matching `GET` reports `pending` until the resource is ready (`200`), `404` for an id the server never created, `409`/`410` for a failed/removed artifact.
 
 **Artifacts & uploads:**
 

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -35,7 +35,7 @@ from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
 from ._pending import PendingRegistry
-from .routes import artifacts, chat, notebooks, sources
+from .routes import artifacts, chat, notebooks, share, sources
 from .routes.sources import MAX_UPLOAD_BYTES
 
 __all__ = ["SERVER_NAME", "create_app"]
@@ -132,6 +132,7 @@ def create_app(*, client_factory: ClientFactory | None = None) -> FastAPI:
     v1.include_router(sources.router)
     v1.include_router(chat.router)
     v1.include_router(artifacts.router)
+    v1.include_router(share.router)
     app.include_router(v1)
 
     return app

--- a/src/notebooklm/server/routes/__init__.py
+++ b/src/notebooklm/server/routes/__init__.py
@@ -8,6 +8,6 @@ NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from . import artifacts, chat, notebooks, sources
+from . import artifacts, chat, notebooks, share, sources
 
-__all__ = ["artifacts", "chat", "notebooks", "sources"]
+__all__ = ["artifacts", "chat", "notebooks", "share", "sources"]

--- a/src/notebooklm/server/routes/share.py
+++ b/src/notebooklm/server/routes/share.py
@@ -1,0 +1,143 @@
+"""Sharing routes — notebook share status, public link, and user access."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel
+
+from ..._app import sharing as core
+from ..._app.serialize import to_jsonable
+from ...client import NotebookLMClient
+from ...types import SharePermission
+from ...types import ShareViewLevel as ShareViewLevelEnum
+from .._context import get_client
+from ._passthrough import passthrough_notebook_id
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/notebooks/{notebook_id}/share", tags=["share"])
+
+ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
+
+
+class SharePublic(BaseModel):
+    """Request body for toggling public link sharing."""
+
+    enable: bool
+
+
+class ShareUserAdd(BaseModel):
+    """Request body for sharing a notebook with a user."""
+
+    email: str
+    permission: Literal["viewer", "editor"] = "viewer"
+    notify: bool = True
+    welcome_message: str = ""
+
+
+class ShareUserUpdate(BaseModel):
+    """Request body for changing a user's permission."""
+
+    permission: Literal["viewer", "editor"]
+
+
+class ShareViewLevelUpdate(BaseModel):
+    """Request body for changing public viewer access level."""
+
+    level: Literal["full", "chat"]
+
+
+_PERMISSIONS = {
+    "viewer": SharePermission.VIEWER,
+    "editor": SharePermission.EDITOR,
+}
+
+_VIEW_LEVELS = {
+    "full": ShareViewLevelEnum.FULL_NOTEBOOK,
+    "chat": ShareViewLevelEnum.CHAT_ONLY,
+}
+
+
+@router.get("")
+async def get_share_status(notebook_id: str, client: ClientDep) -> dict[str, Any]:
+    """Return notebook sharing status."""
+    status = await core.execute_share_status(
+        client,
+        notebook_id,
+        resolve_notebook_id=passthrough_notebook_id,
+    )
+    return to_jsonable(status)
+
+
+@router.post("/public")
+async def set_public(notebook_id: str, body: SharePublic, client: ClientDep) -> dict[str, Any]:
+    """Enable or disable public link sharing."""
+    status = await core.execute_share_set_public(
+        client,
+        notebook_id,
+        body.enable,
+        resolve_notebook_id=passthrough_notebook_id,
+    )
+    return to_jsonable(status)
+
+
+@router.post("/users", status_code=201)
+async def add_user(notebook_id: str, body: ShareUserAdd, client: ClientDep) -> dict[str, Any]:
+    """Share a notebook with a user."""
+    permission = _PERMISSIONS[body.permission]
+    resolved_id = await core.execute_share_add_user(
+        client,
+        notebook_id,
+        body.email,
+        permission=permission,
+        notify=body.notify,
+        welcome_message=body.welcome_message,
+        resolve_notebook_id=passthrough_notebook_id,
+    )
+    return {
+        "notebook_id": resolved_id,
+        "email": body.email,
+        "permission": body.permission,
+        "notify": body.notify,
+    }
+
+
+@router.patch("/users/{email}")
+async def update_user(
+    notebook_id: str, email: str, body: ShareUserUpdate, client: ClientDep
+) -> dict[str, Any]:
+    """Update a shared user's permission.
+
+    NotebookLM creates the membership if the email is not already shared.
+    """
+    resolved_id = await core.execute_share_update_user(
+        client,
+        notebook_id,
+        email,
+        _PERMISSIONS[body.permission],
+        resolve_notebook_id=passthrough_notebook_id,
+    )
+    return {"notebook_id": resolved_id, "email": email, "permission": body.permission}
+
+
+@router.delete("/users/{email}", status_code=204)
+async def remove_user(notebook_id: str, email: str, client: ClientDep) -> Response:
+    """Remove a user's notebook access."""
+    await core.execute_share_remove_user(client, notebook_id, email)
+    return Response(status_code=204)
+
+
+@router.post("/view-level")
+async def set_view_level(
+    notebook_id: str, body: ShareViewLevelUpdate, client: ClientDep
+) -> dict[str, Any]:
+    """Set what public viewers can access."""
+    _resolved_id, status = await core.execute_share_set_view_level(
+        client,
+        notebook_id,
+        _VIEW_LEVELS[body.level],
+        resolve_notebook_id=passthrough_notebook_id,
+    )
+    return to_jsonable(status)

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -213,11 +213,13 @@ class FakeSharing:
     async def update_user(
         self, notebook_id: str, email: str, permission: SharePermission
     ) -> ShareStatus:
-        self._s.shared_users.setdefault(notebook_id, {})[email] = SharedUser(
-            email=email,
+        return await self.add_user(
+            notebook_id,
+            email,
             permission=permission,
+            notify=False,
+            welcome_message="",
         )
-        return self._s.share_status(notebook_id)
 
     async def remove_user(self, notebook_id: str, email: str) -> ShareStatus:
         self._s.shared_users.get(notebook_id, {}).pop(email, None)

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -1,9 +1,10 @@
 """In-memory fake :class:`NotebookLMClient` for the REST server tests.
 
 Mirrors the public client namespaces the REST routes touch
-(``notebooks`` / ``sources`` / ``chat`` / ``artifacts``) with simple in-memory
-state — no auth, no network. Tests inject it via ``create_app(client_factory=…)``
-and drive the app through a FastAPI ``TestClient``.
+(``notebooks`` / ``sources`` / ``chat`` / ``artifacts`` / ``sharing``) with
+simple in-memory state — no auth, no network. Tests inject it via
+``create_app(client_factory=…)`` and drive the app through a FastAPI
+``TestClient``.
 
 State is scriptable per test: pre-seed notebooks/sources/artifacts, override the
 poll/get behavior (e.g. return ``None`` for the not-yet-listable window), and
@@ -18,9 +19,10 @@ from typing import Any
 from notebooklm._types.artifacts import Artifact, GenerationState, GenerationStatus
 from notebooklm._types.chat import AskResult
 from notebooklm._types.notebooks import Notebook
+from notebooklm._types.sharing import SharedUser, ShareStatus
 from notebooklm._types.sources import Source
 from notebooklm.exceptions import NotebookNotFoundError
-from notebooklm.rpc.types import SourceStatus
+from notebooklm.rpc.types import ShareAccess, SharePermission, ShareViewLevel, SourceStatus
 
 #: download-spec kind -> internal artifact type-code.
 _KIND_CODE = {
@@ -177,6 +179,51 @@ class FakeArtifacts:
         return self._s.download_return_path or output_path
 
 
+class FakeSharing:
+    def __init__(self, state: FakeClient) -> None:
+        self._s = state
+
+    async def get_status(self, notebook_id: str) -> ShareStatus:
+        return self._s.share_status(notebook_id)
+
+    async def set_public(self, notebook_id: str, enable: bool) -> ShareStatus:
+        self._s.public_shares[notebook_id] = enable
+        return self._s.share_status(notebook_id)
+
+    async def set_view_level(self, notebook_id: str, level: ShareViewLevel) -> ShareStatus:
+        self._s.share_view_levels[notebook_id] = level
+        return self._s.share_status(notebook_id)
+
+    async def add_user(
+        self,
+        notebook_id: str,
+        email: str,
+        *,
+        permission: SharePermission,
+        notify: bool,
+        welcome_message: str,
+    ) -> ShareStatus:
+        self._s.shared_users.setdefault(notebook_id, {})[email] = SharedUser(
+            email=email,
+            permission=permission,
+        )
+        self._s.last_share_notify = notify
+        return self._s.share_status(notebook_id)
+
+    async def update_user(
+        self, notebook_id: str, email: str, permission: SharePermission
+    ) -> ShareStatus:
+        self._s.shared_users.setdefault(notebook_id, {})[email] = SharedUser(
+            email=email,
+            permission=permission,
+        )
+        return self._s.share_status(notebook_id)
+
+    async def remove_user(self, notebook_id: str, email: str) -> ShareStatus:
+        self._s.shared_users.get(notebook_id, {}).pop(email, None)
+        return self._s.share_status(notebook_id)
+
+
 class FakeClient:
     """Scriptable in-memory client mirroring the namespaces the routes use."""
 
@@ -185,12 +232,16 @@ class FakeClient:
         self.sources_store: dict[str, dict[str, Source]] = {}
         self.artifacts_store: dict[str, dict[str, Artifact]] = {}
         self.poll_states: dict[tuple[str, str], GenerationState] = {}
+        self.public_shares: dict[str, bool] = {}
+        self.share_view_levels: dict[str, ShareViewLevel] = {}
+        self.shared_users: dict[str, dict[str, SharedUser]] = {}
 
         self.new_source_status: SourceStatus = SourceStatus.PROCESSING
         self.hide_new_sources: bool = False
         self.download_bytes: bytes = b"FAKE-ARTIFACT-BYTES"
         self.download_return_path: str | None = None
         self.chat_error: Exception | None = None
+        self.last_share_notify: bool | None = None
 
         self.next_task = 1
         self.next_source = 1
@@ -201,3 +252,17 @@ class FakeClient:
         self.sources = FakeSources(self)
         self.chat = FakeChat(self)
         self.artifacts = FakeArtifacts(self)
+        self.sharing = FakeSharing(self)
+
+    def share_status(self, notebook_id: str) -> ShareStatus:
+        is_public = self.public_shares.get(notebook_id, False)
+        return ShareStatus(
+            notebook_id=notebook_id,
+            is_public=is_public,
+            access=ShareAccess.ANYONE_WITH_LINK if is_public else ShareAccess.RESTRICTED,
+            view_level=self.share_view_levels.get(notebook_id, ShareViewLevel.FULL_NOTEBOOK),
+            shared_users=list(self.shared_users.get(notebook_id, {}).values()),
+            share_url=f"https://notebooklm.google.com/notebook/{notebook_id}"
+            if is_public
+            else None,
+        )

--- a/tests/server/test_share.py
+++ b/tests/server/test_share.py
@@ -1,0 +1,104 @@
+"""Sharing routes under /v1/notebooks/{id}/share."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from notebooklm._types.sharing import SharedUser
+from notebooklm.rpc.types import SharePermission
+
+from .fakes import FakeClient
+
+
+def test_share_status_returns_current_state(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.public_shares["nb-1"] = True
+    fake_client.shared_users["nb-1"] = {
+        "reader@example.com": SharedUser(
+            email="reader@example.com",
+            permission=SharePermission.VIEWER,
+        )
+    }
+
+    resp = authed_client.get("/v1/notebooks/nb-1/share")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["notebook_id"] == "nb-1"
+    assert body["is_public"] is True
+    assert body["share_url"].endswith("/nb-1")
+    assert body["shared_users"][0]["email"] == "reader@example.com"
+
+
+def test_set_public_toggles_link(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/share/public", json={"enable": True})
+
+    assert resp.status_code == 200
+    assert resp.json()["is_public"] is True
+    assert resp.json()["access"] == 1
+
+    resp = authed_client.post("/v1/notebooks/nb-1/share/public", json={"enable": False})
+
+    assert resp.status_code == 200
+    assert resp.json()["is_public"] is False
+    assert resp.json()["share_url"] is None
+
+
+def test_add_update_and_remove_user(authed_client: TestClient, fake_client: FakeClient) -> None:
+    add = authed_client.post(
+        "/v1/notebooks/nb-1/share/users",
+        json={"email": "reader@example.com", "permission": "viewer", "notify": False},
+    )
+    assert add.status_code == 201
+    assert add.json() == {
+        "notebook_id": "nb-1",
+        "email": "reader@example.com",
+        "permission": "viewer",
+        "notify": False,
+    }
+    assert fake_client.shared_users["nb-1"]["reader@example.com"].permission == (
+        SharePermission.VIEWER
+    )
+    assert fake_client.last_share_notify is False
+
+    update = authed_client.patch(
+        "/v1/notebooks/nb-1/share/users/reader@example.com",
+        json={"permission": "editor"},
+    )
+    assert update.status_code == 200
+    assert update.json()["permission"] == "editor"
+    assert fake_client.shared_users["nb-1"]["reader@example.com"].permission == (
+        SharePermission.EDITOR
+    )
+
+    remove = authed_client.delete("/v1/notebooks/nb-1/share/users/reader@example.com")
+    assert remove.status_code == 204
+    assert "reader@example.com" not in fake_client.shared_users["nb-1"]
+
+
+def test_set_view_level(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/share/view-level", json={"level": "chat"})
+
+    assert resp.status_code == 200
+    assert resp.json()["view_level"] == 1
+
+
+def test_share_rejects_bad_permission(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/share/users",
+        json={"email": "reader@example.com", "permission": "owner"},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_share_routes_require_auth(raw_client: TestClient) -> None:
+    h = {"Host": "127.0.0.1"}
+    assert raw_client.get("/v1/notebooks/nb-1/share", headers=h).status_code == 401
+    assert (
+        raw_client.post(
+            "/v1/notebooks/nb-1/share/public", json={"enable": True}, headers=h
+        ).status_code
+        == 401
+    )

--- a/tests/server/test_share.py
+++ b/tests/server/test_share.py
@@ -62,6 +62,7 @@ def test_add_update_and_remove_user(authed_client: TestClient, fake_client: Fake
     )
     assert fake_client.last_share_notify is False
 
+    fake_client.last_share_notify = True
     update = authed_client.patch(
         "/v1/notebooks/nb-1/share/users/reader@example.com",
         json={"permission": "editor"},
@@ -71,6 +72,7 @@ def test_add_update_and_remove_user(authed_client: TestClient, fake_client: Fake
     assert fake_client.shared_users["nb-1"]["reader@example.com"].permission == (
         SharePermission.EDITOR
     )
+    assert fake_client.last_share_notify is False
 
     remove = authed_client.delete("/v1/notebooks/nb-1/share/users/reader@example.com")
     assert remove.status_code == 204


### PR DESCRIPTION
## Summary
- add REST `/v1/notebooks/{id}/share` routes for status, public links, users, and view-level updates
- wire the share router into the FastAPI app and fake server client
- document the new REST share surface and architecture map entry

## Task
Fixes #1618

## Test plan
- [x] `uv run pytest tests/server/test_share.py`
- [x] `uv run pytest tests/server`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Keep add/update REST responses as lean acknowledgement payloads instead of adding an extra status fetch.
- Do not add server-only email syntax validation; existing CLI/client surfaces pass email through to NotebookLM.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added notebook sharing endpoints under `/v1/notebooks/{id}/share`, including enable/disable public links.
  * Share notebooks with individual users with viewer/editor permissions, and manage user access (add/update/remove).
  * Set the public viewer access level for shared notebooks.

* **Documentation**
  * Updated architecture and installation docs with the new notebook sharing REST endpoint and example requests.

* **Tests**
  * Added automated coverage for sharing status, public toggles, user lifecycle, view-level updates, validation, and authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->