### PR TITLE
feat(server): notes CRUD routes for /v1/notebooks/{id}/notes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1272,6 +1272,7 @@ src/notebooklm/
         ├── _passthrough.py      # Pass-through resolvers handed to the _app cores (REST works in full ids)
         ├── notebooks.py         # /v1/notebooks list/get/create/delete
         ├── sources.py           # /v1/notebooks/{id}/sources list/get/add(url·text·file)/delete + poll-the-resource status
+        ├── notes.py             # /v1/notebooks/{id}/notes list/get/create/update(PUT)/delete — thin adapter over client.notes
         ├── chat.py              # POST /v1/notebooks/{id}/chat — blocking ask (no SSE)
         ├── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download (registry-projected poll; server-generated temp download path)
         └── share.py             # /v1/notebooks/{id}/share status/public/users/view-level over _app.sharing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -355,7 +355,7 @@ curl -H "Authorization: Bearer $TOKEN" -d '{"question":"Summarize"}' \
 curl -H "Authorization: Bearer $TOKEN" $BASE/v1/notebooks/<id>/share # sharing status
 ```
 
-Endpoints: `/v1/notebooks` (list/get/create/delete); `/v1/notebooks/{id}/sources` (list/get/add via `url`·`text`·`file`/delete); `/v1/notebooks/{id}/chat` (blocking ask, no streaming); `/v1/notebooks/{id}/artifacts` (list / generate / poll / download); `/v1/notebooks/{id}/share` (status / public link / users / view level). Long-running work (source ingest, artifact generation) is **poll-the-resource**: the create call returns immediately and the matching `GET` reports `pending` until the resource is ready (`200`), `404` for an id the server never created, `409`/`410` for a failed/removed artifact.
+Endpoints: `/v1/notebooks` (list/get/create/delete); `/v1/notebooks/{id}/sources` (list/get/add via `url`·`text`·`file`/delete); `/v1/notebooks/{id}/notes` (list/get/create/update via `PUT`/delete); `/v1/notebooks/{id}/chat` (blocking ask, no streaming); `/v1/notebooks/{id}/artifacts` (list / generate / poll / download); `/v1/notebooks/{id}/share` (status / public link / users / view level). Long-running work (source ingest, artifact generation) is **poll-the-resource**: the create call returns immediately and the matching `GET` reports `pending` until the resource is ready (`200`), `404` for an id the server never created, `409`/`410` for a failed/removed artifact.
 
 **Artifacts & uploads:**
 

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -35,7 +35,7 @@ from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
 from ._pending import PendingRegistry
-from .routes import artifacts, chat, notebooks, share, sources
+from .routes import artifacts, chat, notebooks, notes, share, sources
 from .routes.sources import MAX_UPLOAD_BYTES
 
 __all__ = ["SERVER_NAME", "create_app"]
@@ -130,6 +130,7 @@ def create_app(*, client_factory: ClientFactory | None = None) -> FastAPI:
     v1 = APIRouter(prefix="/v1", dependencies=[Depends(require_auth)])
     v1.include_router(notebooks.router)
     v1.include_router(sources.router)
+    v1.include_router(notes.router)
     v1.include_router(chat.router)
     v1.include_router(artifacts.router)
     v1.include_router(share.router)

--- a/src/notebooklm/server/routes/__init__.py
+++ b/src/notebooklm/server/routes/__init__.py
@@ -8,6 +8,6 @@ NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from . import artifacts, chat, notebooks, share, sources
+from . import artifacts, chat, notebooks, notes, share, sources
 
-__all__ = ["artifacts", "chat", "notebooks", "share", "sources"]
+__all__ = ["artifacts", "chat", "notebooks", "notes", "share", "sources"]

--- a/src/notebooklm/server/routes/notes.py
+++ b/src/notebooklm/server/routes/notes.py
@@ -1,0 +1,86 @@
+"""Note routes — ``/v1/notebooks/{id}/notes`` list / get / create / update / delete.
+
+Thin adapters over the public ``client.notes`` namespace (the facade already
+owns the raise-on-miss, idempotent-delete, and update-preflight contracts), in
+the same shape as :mod:`.notebooks`. Responses go straight through
+:func:`notebooklm._app.serialize.to_jsonable`.
+
+A missing note surfaces as ``NoteNotFoundError`` from the facade, which the
+server's exception handler projects onto a 404 ``not_found`` envelope — so these
+handlers never hand-raise for the not-found case. ``delete`` is idempotent (never
+404s on an absent id). Mind maps are out of scope here; list them via
+``/v1/notebooks/{id}/artifacts``.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel
+
+from ..._app.serialize import to_jsonable
+from ...client import NotebookLMClient
+from .._context import get_client
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/notebooks/{notebook_id}/notes", tags=["notes"])
+
+ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
+
+
+class NoteCreate(BaseModel):
+    """Request body for creating a note (both fields default, matching the facade)."""
+
+    title: str = "New Note"
+    content: str = ""
+
+
+class NoteUpdate(BaseModel):
+    """Request body for a full-replacement note update (PUT)."""
+
+    title: str
+    content: str
+
+
+@router.get("")
+async def list_notes(notebook_id: str, client: ClientDep) -> dict[str, Any]:
+    """List a notebook's text notes (excludes mind maps and deleted notes)."""
+    notes = await client.notes.list(notebook_id)
+    return {"notebook_id": notebook_id, "notes": to_jsonable(notes)}
+
+
+@router.get("/{note_id}")
+async def get_note(notebook_id: str, note_id: str, client: ClientDep) -> dict[str, Any]:
+    """Fetch one note (raises ``NoteNotFoundError`` → 404 on a miss)."""
+    note = await client.notes.get(notebook_id, note_id)
+    return to_jsonable(note)
+
+
+@router.post("", status_code=201)
+async def create_note(notebook_id: str, body: NoteCreate, client: ClientDep) -> dict[str, Any]:
+    """Create a note with the given title and content."""
+    note = await client.notes.create(notebook_id, body.title, body.content)
+    return to_jsonable(note)
+
+
+@router.put("/{note_id}")
+async def update_note(
+    notebook_id: str, note_id: str, body: NoteUpdate, client: ClientDep
+) -> dict[str, Any]:
+    """Replace a note's title and content (raises ``NoteNotFoundError`` → 404 on a miss)."""
+    await client.notes.update(notebook_id, note_id, content=body.content, title=body.title)
+    # Re-fetch so the response carries the canonical note shape (same as GET);
+    # the update preflight already 404s a missing note, so it exists here.
+    note = await client.notes.get(notebook_id, note_id)
+    return to_jsonable(note)
+
+
+@router.delete("/{note_id}", status_code=204)
+async def delete_note(notebook_id: str, note_id: str, client: ClientDep) -> Response:
+    """Delete a note (idempotent-on-missing — never 404 for an absent id)."""
+    await client.notes.delete(notebook_id, note_id)
+    return Response(status_code=204)

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -151,7 +151,11 @@ class FakeNotes:
         if existing is None:
             raise NoteNotFoundError(note_id)
         self._s.notes_store[notebook_id][note_id] = Note(
-            id=note_id, notebook_id=notebook_id, title=title, content=content
+            id=note_id,
+            notebook_id=notebook_id,
+            title=title,
+            content=content,
+            created_at=existing.created_at,
         )
 
     async def delete(self, notebook_id: str, note_id: str) -> None:

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -19,9 +19,10 @@ from typing import Any
 from notebooklm._types.artifacts import Artifact, GenerationState, GenerationStatus
 from notebooklm._types.chat import AskResult
 from notebooklm._types.notebooks import Notebook
+from notebooklm._types.notes import Note
 from notebooklm._types.sharing import SharedUser, ShareStatus
 from notebooklm._types.sources import Source
-from notebooklm.exceptions import NotebookNotFoundError
+from notebooklm.exceptions import NotebookNotFoundError, NoteNotFoundError
 from notebooklm.rpc.types import ShareAccess, SharePermission, ShareViewLevel, SourceStatus
 
 #: download-spec kind -> internal artifact type-code.
@@ -114,6 +115,48 @@ class FakeSources:
         if not self._s.hide_new_sources:
             bucket[src.id] = src
         return src
+
+
+class FakeNotes:
+    def __init__(self, state: FakeClient) -> None:
+        self._s = state
+
+    async def list(self, notebook_id: str) -> list[Note]:
+        return list(self._s.notes_store.get(notebook_id, {}).values())
+
+    async def get_or_none(self, notebook_id: str, note_id: str) -> Note | None:
+        return self._s.notes_store.get(notebook_id, {}).get(note_id)
+
+    async def get(self, notebook_id: str, note_id: str) -> Note:
+        note = await self.get_or_none(notebook_id, note_id)
+        if note is None:
+            raise NoteNotFoundError(note_id)
+        return note
+
+    async def create(self, notebook_id: str, title: str, content: str) -> Note:
+        bucket = self._s.notes_store.setdefault(notebook_id, {})
+        note = Note(
+            id=f"note-{self._s.next_note}",
+            notebook_id=notebook_id,
+            title=title,
+            content=content,
+        )
+        self._s.next_note += 1
+        bucket[note.id] = note
+        return note
+
+    async def update(self, notebook_id: str, note_id: str, content: str, title: str) -> None:
+        # Mirror the facade: a missing note fails loud (drives the 404 path).
+        existing = await self.get_or_none(notebook_id, note_id)
+        if existing is None:
+            raise NoteNotFoundError(note_id)
+        self._s.notes_store[notebook_id][note_id] = Note(
+            id=note_id, notebook_id=notebook_id, title=title, content=content
+        )
+
+    async def delete(self, notebook_id: str, note_id: str) -> None:
+        # Idempotent-on-missing (the public delete contract).
+        self._s.notes_store.get(notebook_id, {}).pop(note_id, None)
 
 
 class FakeChat:
@@ -232,6 +275,7 @@ class FakeClient:
     def __init__(self) -> None:
         self.notebooks_store: dict[str, Notebook] = {}
         self.sources_store: dict[str, dict[str, Source]] = {}
+        self.notes_store: dict[str, dict[str, Note]] = {}
         self.artifacts_store: dict[str, dict[str, Artifact]] = {}
         self.poll_states: dict[tuple[str, str], GenerationState] = {}
         self.public_shares: dict[str, bool] = {}
@@ -247,11 +291,13 @@ class FakeClient:
 
         self.next_task = 1
         self.next_source = 1
+        self.next_note = 1
         self.uploaded_paths: list[str] = []
         self.last_ask: dict[str, Any] | None = None
 
         self.notebooks = FakeNotebooks(self)
         self.sources = FakeSources(self)
+        self.notes = FakeNotes(self)
         self.chat = FakeChat(self)
         self.artifacts = FakeArtifacts(self)
         self.sharing = FakeSharing(self)

--- a/tests/server/test_notes.py
+++ b/tests/server/test_notes.py
@@ -1,0 +1,100 @@
+"""/v1/notebooks/{id}/notes list / get / create / update / delete."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from notebooklm._types.notes import Note
+
+from .fakes import FakeClient
+
+
+def _seed(fake_client: FakeClient, note: Note) -> None:
+    fake_client.notes_store.setdefault(note.notebook_id, {})[note.id] = note
+
+
+def test_list_returns_notes(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed(fake_client, Note(id="n-1", notebook_id="nb-1", title="First", content="hi"))
+    resp = authed_client.get("/v1/notebooks/nb-1/notes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["notebook_id"] == "nb-1"
+    assert [n["title"] for n in body["notes"]] == ["First"]
+
+
+def test_create_returns_201_with_new_note(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/notes", json={"title": "T", "content": "C"})
+    assert resp.status_code == 201
+    assert resp.json()["title"] == "T"
+    assert resp.json()["content"] == "C"
+
+
+def test_create_defaults(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/notes", json={})
+    assert resp.status_code == 201
+    assert resp.json()["title"] == "New Note"
+
+
+def test_get_existing_note(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed(fake_client, Note(id="n-9", notebook_id="nb-1", title="Nine", content="x"))
+    resp = authed_client.get("/v1/notebooks/nb-1/notes/n-9")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "n-9"
+
+
+def test_get_missing_note_is_404(authed_client: TestClient) -> None:
+    resp = authed_client.get("/v1/notebooks/nb-1/notes/nope")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["category"] == "not_found"
+
+
+def test_update_replaces_and_returns_note(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    _seed(fake_client, Note(id="n-2", notebook_id="nb-1", title="Old", content="old"))
+    resp = authed_client.put(
+        "/v1/notebooks/nb-1/notes/n-2", json={"title": "New", "content": "new"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "New"
+    assert resp.json()["content"] == "new"
+    # The id is carried only by the re-fetched Note (the request body has none),
+    # so asserting it makes the handler's post-update re-fetch load-bearing.
+    assert resp.json()["id"] == "n-2"
+
+
+def test_update_missing_note_is_404(authed_client: TestClient) -> None:
+    resp = authed_client.put("/v1/notebooks/nb-1/notes/nope", json={"title": "x", "content": "y"})
+    assert resp.status_code == 404
+
+
+def test_update_requires_both_fields(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # PUT is a full replacement: NoteUpdate makes both fields required (no
+    # defaults, unlike NoteCreate), so a partial body is a 422.
+    _seed(fake_client, Note(id="n-4", notebook_id="nb-1", title="Old", content="old"))
+    resp = authed_client.put("/v1/notebooks/nb-1/notes/n-4", json={"title": "x"})
+    assert resp.status_code == 422
+
+
+def test_delete_existing_is_204(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed(fake_client, Note(id="n-3", notebook_id="nb-1", title="Three", content="x"))
+    resp = authed_client.delete("/v1/notebooks/nb-1/notes/n-3")
+    assert resp.status_code == 204
+    assert "n-3" not in fake_client.notes_store["nb-1"]
+
+
+def test_delete_missing_is_idempotent_204(authed_client: TestClient) -> None:
+    resp = authed_client.delete("/v1/notebooks/nb-1/notes/never-existed")
+    assert resp.status_code == 204
+
+
+def test_unauthorized_on_each_verb(raw_client: TestClient) -> None:
+    h = {"Host": "127.0.0.1"}
+    base = "/v1/notebooks/nb-1/notes"
+    assert raw_client.get(base, headers=h).status_code == 401
+    assert raw_client.post(base, json={"title": "x"}, headers=h).status_code == 401
+    assert (
+        raw_client.put(f"{base}/n-1", json={"title": "x", "content": "y"}, headers=h).status_code
+        == 401
+    )
+    assert raw_client.delete(f"{base}/n-1", headers=h).status_code == 401


### PR DESCRIPTION
## Summary
- Adds REST `/v1/notebooks/{id}/notes` routes: `GET` (list), `GET /{id}`, `POST` (create, 201), `PUT /{id}` (full-replacement update), `DELETE /{id}` (204, idempotent).
- Thin adapter over the public async `client.notes.*` facade, mirroring the existing `routes/notebooks.py` / `routes/sources.py` patterns. `NoteNotFoundError` → 404 `not_found` via the shared exception handler; `delete` is idempotent-on-missing. Router mounted under the auth-gated `/v1` group.
- Adds `FakeNotes` to the server test fakes and a `test_notes.py` (11 cases: CRUD, 404s, idempotent delete, full-replacement 422, per-verb 401). Updates the docs endpoint listing.

## Design notes
- Calls the `client.notes.*` namespace directly rather than the `_app/notes.py` executors — those inject CLI partial-id resolvers the REST adapter (full ids) doesn't need; this matches how `sources.py` does list/get/delete.
- `PUT` re-fetches via `get` to return the canonical note body (the facade `update` returns `None`); the update preflight already 404s a missing note.
- Mind maps are out of scope here — list them via `/v1/notebooks/{id}/artifacts`.

## Test plan
- [x] `uv run pytest tests/server -q` → 147 passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → clean
- [x] `uv run ruff check . && ruff format --check` → clean

## Deferred polish findings
- **Parent-notebook existence preflight (→404):** not added — sibling `sources` routes also defer parent-existence to the facade; making notes diverge (and adding a round-trip per call) would be a cross-cutting change to all nested routes, out of scope here.
- **Real-client VCR integration leg:** `test_integration_real_client.py` deliberately samples a route subset and replays only existing cassettes (recording needs live auth); the adapter is covered by `FakeNotes` + the unit status-5→404 composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authenticated REST API endpoints for notebook notes at `/v1/notebooks/{id}/notes`: list, create, retrieve, replace (via `PUT`), and delete.
  * Create supports default values when the request body is empty; `PUT` performs full replacement.
* **Documentation**
  * Updated REST API documentation and the server route architecture map to include the new notes endpoints.
* **Tests**
  * Added CRUD + authorization tests, including 404 for missing notes and idempotent 204 responses for delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->