### PR TITLE
ci(security): set persist-credentials:false on checkout steps (#1471)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,6 +107,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ needs.resolve-branch.outputs.branch }}
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -81,6 +81,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ needs.resolve-branch.outputs.branch }}
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         # triggering ref for push/pull_request (input is empty there).
         ref: ${{ inputs.custom_branch || github.ref }}
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -148,6 +149,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.custom_branch || github.ref }}
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -210,6 +212,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.custom_branch || github.ref }}
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -274,6 +277,7 @@ jobs:
         # Honor the workflow_dispatch custom_branch input; falls back to the
         # triggering ref for push/pull_request (input is empty there).
         ref: ${{ inputs.custom_branch || github.ref }}
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6

--- a/.github/workflows/verify-artifacts.yml
+++ b/.github/workflows/verify-artifacts.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- Adds `persist-credentials: false` to all **13** `actions/checkout@v6` steps across the 10 workflow files.
- Closes the zizmor **`artipacked`** vector: by default `actions/checkout` writes the `GITHUB_TOKEN` into `.git/config`, where any subsequent step or compromised third-party action in the job can read and exfiltrate it. CodeRabbit flagged this on #1471 (🟠 Major) and it was never addressed.

## Why it's safe
- No workflow does `git push` / `git commit` / `git tag` / auto-commit, so nothing writes back using the persisted credential.
- `claude.yml` authenticates via its own `claude_code_oauth_token` and runs with `contents: read` — it doesn't rely on the checkout-persisted token.
- Token-using steps (`gh` calls, ref resolution during checkout itself) are unaffected: `persist-credentials: false` only stops the token from being *persisted to .git/config after* checkout; the token still works *during* checkout and via explicit `GH_TOKEN`/`secrets`.

## Scope
- Pure, behavior-preserving CI hardening. YAML validated for all 10 files; the `claude.yml` step correctly merges the new key into its existing `with:` (`fetch-depth: 1`).
- **Out of scope:** SHA-pinning of actions (zizmor `unpinned-uses`) — a separate, higher-churn concern.

## Test plan
- [x] All 10 workflow YAML files parse cleanly
- [x] 13/13 checkout steps covered; no duplicate `with:` keys
- [x] Polished (code-simplifier + claude+codex review + ultrathink — all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configurations in CI/CD workflows to improve credential handling across automated build, test, and publish pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->