### PR TITLE
test(server): cover GET /notes/{id} in notes auth matrix (#1620 follow-up)

### DIFF
--- a/tests/server/test_notes.py
+++ b/tests/server/test_notes.py
@@ -92,6 +92,7 @@ def test_unauthorized_on_each_verb(raw_client: TestClient) -> None:
     h = {"Host": "127.0.0.1"}
     base = "/v1/notebooks/nb-1/notes"
     assert raw_client.get(base, headers=h).status_code == 401
+    assert raw_client.get(f"{base}/n-1", headers=h).status_code == 401
     assert raw_client.post(base, json={"title": "x"}, headers=h).status_code == 401
     assert (
         raw_client.put(f"{base}/n-1", json={"title": "x", "content": "y"}, headers=h).status_code


### PR DESCRIPTION
## Summary
Closes a one-assertion coverage gap claude[bot] flagged during its review of #1620: `test_unauthorized_on_each_verb` asserted 401 for list-GET / POST / PUT / DELETE but omitted the single-note `GET /v1/notebooks/{id}/notes/{note_id}` — despite the test's "each verb" name.

All five notes routes sit under the auth-gated `/v1` group (`dependencies=[Depends(require_auth)]`), so the read returns 401 before any lookup; `n-1` is an arbitrary id.

## Test plan
- [x] `uv run pytest tests/server/test_notes.py` → 11 passed
- [x] ruff clean
- [x] Polished — code-simplifier (no-op), claude + codex review (both clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended authorization verification tests for the notes API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->