### PR TITLE
Add auth import-cookies command

### DIFF
--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -14,12 +14,8 @@ auth diagnostics, and auth-source precedence. Command-side wrappers in
 exit, and async-runner seams for the Playwright and browser-cookie login
 services.
 
-Body-used names that *moved* into those services are re-imported here as
-the command layer's own bindings. A handful are also bound on the
-``notebooklm.cli.session_cmd`` namespace by tests that pre-date ADR-0008's
-services-side patching convention (e.g. ``_sync_server_language_to_config``,
-``_login_browser_cookies_single``); those names stay because they are
-referenced from this module's body.
+Body-used names that moved into services are re-imported here as command-layer
+bindings and legacy patch seams.
 """
 
 from __future__ import annotations
@@ -27,23 +23,19 @@ from __future__ import annotations
 import functools
 import json
 import logging
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 import httpx
 
-from .._auth.browser_capture import filter_storage_state_cookies_by_domain_policy
-from .._auth.cookie_policy import MINIMUM_REQUIRED_COOKIES
+from .. import auth
 from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
 from ..exceptions import AuthError, NotebookNotFoundError
 from ..io import atomic_write_json
 from ..paths import get_storage_path
 
-# Render helpers live in a sibling module to keep this file small; they are
-# imported back so ``register_session_commands`` calls them through this
-# module's own namespace (see ADR-0008).
+# Render helpers stay in a sibling module; command registration calls them here.
 from ._session_render import (
     _render_auth_check_result,
     _render_auth_inspect,
@@ -71,12 +63,6 @@ from .services.auth_diagnostics import (
 from .services.auth_source import AUTH_JSON_ENV_NAME, auth_source_from_ctx, has_env_auth_json
 
 # Direct imports replace the D1-PR-3-retired forwarding wrappers; see ADR-0008.
-# These names are all called from this module's body. Several also serve as
-# ``notebooklm.cli.session_cmd.*`` monkeypatch surfaces for tests that pre-date
-# ADR-0008's services-side patching convention (e.g.
-# ``_sync_server_language_to_config``, ``_login_browser_cookies_single``,
-# ``_refresh_from_browser_cookies``, ``_enumerate_browser_accounts``); those
-# patches keep working because the body-used name stays bound here.
 from .services.login import (
     _enumerate_browser_accounts,
     _login_all_accounts_from_browser,
@@ -84,9 +70,7 @@ from .services.login import (
     _refresh_from_browser_cookies,
     _sync_server_language_to_config,
 )
-from .services.login import (
-    cookie_domains as _cookie_domains,
-)
+from .services.login import cookie_domains as _cookie_domains
 from .services.login.exceptions import LoginConfigurationError
 from .services.login.outcomes import BrowserCookieOutcome, NetworkFailure
 from .services.playwright_login import (
@@ -94,6 +78,7 @@ from .services.playwright_login import (
 )
 from .services.playwright_login import (
     PlaywrightLoginPlan,
+    filter_storage_state_cookies_by_domain_policy,
 )
 from .services.session_context import (
     UseNotebookResult,
@@ -176,7 +161,7 @@ def _read_auth_json_input(path: str) -> Any:
     """Read a cookie JSON payload from a file path or stdin (``-``)."""
     try:
         if path == "-":
-            return json.loads(sys.stdin.read())
+            return json.loads(click.get_text_stream("stdin").read())
         return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
     except UnicodeDecodeError as exc:
         raise click.ClickException(  # cli-input-validation: import-cookies text decode failure
@@ -257,7 +242,7 @@ def _import_cookie_json(
 
     empty_required = sorted(
         name
-        for name in MINIMUM_REQUIRED_COOKIES
+        for name in auth.MINIMUM_REQUIRED_COOKIES
         if not isinstance(extracted_cookies.get(name), str) or not extracted_cookies[name]
     )
     if empty_required:
@@ -793,7 +778,7 @@ def register_session_commands(cli):
         with handle_errors():
             auth_source = auth_source_from_ctx(ctx)
             if auth_source.has_env_auth:
-                raise click.ClickException(
+                raise click.ClickException(  # cli-input-validation: import-cookies env-auth conflict
                     f"'auth import-cookies' is incompatible with {AUTH_JSON_ENV_NAME}. "
                     "Unset the env var first so the imported cookies can be used "
                     "from storage_state.json."

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
-import os
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -175,10 +175,12 @@ def _read_auth_json_input(path: str) -> Any:
     """Read a cookie JSON payload from a file path or stdin (``-``)."""
     try:
         if path == "-":
-            import sys
-
             return json.loads(sys.stdin.read())
         return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        raise click.ClickException(  # cli-input-validation: import-cookies text decode failure
+            f"Could not decode {path!r} as UTF-8: {exc}"
+        ) from None
     except json.JSONDecodeError as exc:
         raise click.ClickException(  # cli-input-validation: import-cookies JSON parse failure
             f"Invalid JSON: {exc}"
@@ -192,9 +194,12 @@ def _read_auth_json_input(path: str) -> Any:
 def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
     """Normalize supported cookie JSON shapes to Playwright storage_state."""
     if isinstance(payload, dict) and isinstance(payload.get("cookies"), list):
+        # Import only cookies: a storage_state's ``origins`` (localStorage /
+        # sessionStorage) bypass the cookie-domain allowlist, so drop them rather
+        # than persist unrelated site data. Matches the bare-list branch below.
         return {
-            **payload,
             "cookies": [_normalize_imported_cookie(cookie) for cookie in payload["cookies"]],
+            "origins": [],
         }
     if isinstance(payload, list):
         return {
@@ -216,7 +221,7 @@ def _normalize_imported_cookie(cookie: Any) -> Any:
     if "expires" not in normalized:
         # EditThisCookie / Cookie-Editor style exports usually call this field
         # ``expirationDate``. Playwright storage_state uses ``expires``.
-        normalized["expires"] = normalized.get("expirationDate", -1)
+        normalized["expires"] = normalized.pop("expirationDate", -1)
     normalized.setdefault("path", "/")
     normalized.setdefault("httpOnly", False)
     normalized.setdefault("secure", False)
@@ -249,9 +254,7 @@ def _import_cookie_json(
             f"{exc}\n\n{hint}"
         ) from None
 
-    storage_path.parent.mkdir(parents=True, exist_ok=True)
-    if os.name != "nt":
-        os.chmod(storage_path.parent, 0o700)
+    storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     atomic_write_json(storage_path, filtered_state)
     return filtered_state
 
@@ -779,13 +782,11 @@ def register_session_commands(cli):
         with handle_errors():
             auth_source = auth_source_from_ctx(ctx)
             if auth_source.has_env_auth:
-                click.echo(
-                    f"Error: 'auth import-cookies' is incompatible with {AUTH_JSON_ENV_NAME}. "
+                raise click.ClickException(
+                    f"'auth import-cookies' is incompatible with {AUTH_JSON_ENV_NAME}. "
                     "Unset the env var first so the imported cookies can be used "
-                    "from storage_state.json.",
-                    err=True,
+                    "from storage_state.json."
                 )
-                exit_with_code(1)
 
             include_domains = _parse_include_domains(include_domains_raw)
             storage_path = auth_source.storage_path_for_diagnostics()

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -35,6 +35,7 @@ import click
 import httpx
 
 from .._auth.browser_capture import filter_storage_state_cookies_by_domain_policy
+from .._auth.cookie_policy import MINIMUM_REQUIRED_COOKIES
 from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
 from ..exceptions import AuthError, NotebookNotFoundError
 from ..io import atomic_write_json
@@ -247,12 +248,22 @@ def _import_cookie_json(
     try:
         # This validates required cookies and catches malformed cookie shapes
         # using the same loader later runtime calls use.
-        extract_cookies_from_storage(filtered_state)
+        extracted_cookies = extract_cookies_from_storage(filtered_state)
     except ValueError as exc:
         hint = missing_cookies_hint(cookie_names)
         raise click.ClickException(  # cli-input-validation: import-cookies required-cookie validation
             f"{exc}\n\n{hint}"
         ) from None
+
+    empty_required = sorted(
+        name
+        for name in MINIMUM_REQUIRED_COOKIES
+        if not isinstance(extracted_cookies.get(name), str) or not extracted_cookies[name]
+    )
+    if empty_required:
+        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie value validation
+            "Required cookies must have non-empty string values: " + ", ".join(empty_required)
+        )
 
     storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     atomic_write_json(storage_path, filtered_state)

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -28,17 +28,16 @@ import functools
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 import httpx
 
-from .._atomic_io import atomic_write_json
 from .._auth.browser_capture import filter_storage_state_cookies_by_domain_policy
 from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
 from ..exceptions import AuthError, NotebookNotFoundError
+from ..io import atomic_write_json
 from ..paths import get_storage_path
 
 # Render helpers live in a sibling module to keep this file small; they are
@@ -176,12 +175,18 @@ def _read_auth_json_input(path: str) -> Any:
     """Read a cookie JSON payload from a file path or stdin (``-``)."""
     try:
         if path == "-":
+            import sys
+
             return json.loads(sys.stdin.read())
         return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise click.ClickException(f"Invalid JSON: {exc}") from None
+        raise click.ClickException(  # cli-input-validation: import-cookies JSON parse failure
+            f"Invalid JSON: {exc}"
+        ) from None
     except OSError as exc:
-        raise click.ClickException(f"Could not read {path!r}: {exc}") from None
+        raise click.ClickException(  # cli-input-validation: import-cookies JSON read failure
+            f"Could not read {path!r}: {exc}"
+        ) from None
 
 
 def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
@@ -196,7 +201,7 @@ def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
             "cookies": [_normalize_imported_cookie(cookie) for cookie in payload],
             "origins": [],
         }
-    raise click.ClickException(
+    raise click.ClickException(  # cli-input-validation: import-cookies JSON shape validation
         "Cookie JSON must be either a Playwright storage_state object "
         "with a 'cookies' list or a bare list of cookie objects."
     )
@@ -240,7 +245,9 @@ def _import_cookie_json(
         extract_cookies_from_storage(filtered_state)
     except ValueError as exc:
         hint = missing_cookies_hint(cookie_names)
-        raise click.ClickException(f"{exc}\n\n{hint}") from None
+        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie validation
+            f"{exc}\n\n{hint}"
+        ) from None
 
     storage_path.parent.mkdir(parents=True, exist_ok=True)
     if os.name != "nt":

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,7 +68,7 @@ from .services.auth_diagnostics import (
     plan_from_click_context,
     run_auth_check,
 )
-from .services.auth_source import AUTH_JSON_ENV_NAME, has_env_auth_json
+from .services.auth_source import AUTH_JSON_ENV_NAME, auth_source_from_ctx, has_env_auth_json
 
 # Direct imports replace the D1-PR-3-retired forwarding wrappers; see ADR-0008.
 # These names are all called from this module's body. Several also serve as
@@ -191,7 +192,10 @@ def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
             "cookies": [_normalize_imported_cookie(cookie) for cookie in payload["cookies"]],
         }
     if isinstance(payload, list):
-        return {"cookies": [_normalize_imported_cookie(cookie) for cookie in payload], "origins": []}
+        return {
+            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload],
+            "origins": [],
+        }
     raise click.ClickException(
         "Cookie JSON must be either a Playwright storage_state object "
         "with a 'cookies' list or a bare list of cookie objects."
@@ -239,9 +243,9 @@ def _import_cookie_json(
         raise click.ClickException(f"{exc}\n\n{hint}") from None
 
     storage_path.parent.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        os.chmod(storage_path.parent, 0o700)
     atomic_write_json(storage_path, filtered_state)
-    if sys.platform != "win32":
-        storage_path.parent.chmod(0o700)
     return filtered_state
 
 
@@ -746,7 +750,9 @@ def register_session_commands(cli):
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.option("--quiet", "quiet", is_flag=True, help="Suppress success output")
     @click.pass_context
-    def auth_import_cookies(ctx, json_path, include_domains_raw, include_optional, json_output, quiet):
+    def auth_import_cookies(
+        ctx, json_path, include_domains_raw, include_optional, json_output, quiet
+    ):
         """Import authentication cookies from JSON and save them persistently.
 
         Accepts either a Playwright ``storage_state`` object (``{"cookies": [...]}``)
@@ -764,7 +770,8 @@ def register_session_commands(cli):
           cat cookies.json | notebooklm auth import-cookies -
         """
         with handle_errors():
-            if has_env_auth_json():
+            auth_source = auth_source_from_ctx(ctx)
+            if auth_source.has_env_auth:
                 click.echo(
                     f"Error: 'auth import-cookies' is incompatible with {AUTH_JSON_ENV_NAME}. "
                     "Unset the env var first so the imported cookies can be used "
@@ -774,12 +781,7 @@ def register_session_commands(cli):
                 exit_with_code(1)
 
             include_domains = _parse_include_domains(include_domains_raw)
-            profile = ctx.obj.get("profile") if ctx.obj else None
-            storage_path = (
-                ctx.obj.get("storage_path")
-                if ctx.obj and ctx.obj.get("storage_path") is not None
-                else get_storage_path(profile=profile)
-            )
+            storage_path = auth_source.storage_path_for_diagnostics()
 
             imported = _import_cookie_json(
                 payload=_read_auth_json_input(json_path),

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -25,13 +25,18 @@ referenced from this module's body.
 from __future__ import annotations
 
 import functools
+import json
 import logging
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 import httpx
 
+from .._atomic_io import atomic_write_json
+from .._auth.browser_capture import filter_storage_state_cookies_by_domain_policy
+from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
 from ..exceptions import AuthError, NotebookNotFoundError
 from ..paths import get_storage_path
 
@@ -164,6 +169,80 @@ def _is_valid_account_metadata(metadata: dict[str, Any]) -> bool:
     if raw_email is None:
         return True
     return isinstance(raw_email, str) and bool(raw_email.strip())
+
+
+def _read_auth_json_input(path: str) -> Any:
+    """Read a cookie JSON payload from a file path or stdin (``-``)."""
+    try:
+        if path == "-":
+            return json.loads(sys.stdin.read())
+        return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"Invalid JSON: {exc}") from None
+    except OSError as exc:
+        raise click.ClickException(f"Could not read {path!r}: {exc}") from None
+
+
+def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
+    """Normalize supported cookie JSON shapes to Playwright storage_state."""
+    if isinstance(payload, dict) and isinstance(payload.get("cookies"), list):
+        return {
+            **payload,
+            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload["cookies"]],
+        }
+    if isinstance(payload, list):
+        return {"cookies": [_normalize_imported_cookie(cookie) for cookie in payload], "origins": []}
+    raise click.ClickException(
+        "Cookie JSON must be either a Playwright storage_state object "
+        "with a 'cookies' list or a bare list of cookie objects."
+    )
+
+
+def _normalize_imported_cookie(cookie: Any) -> Any:
+    """Translate common browser-export cookie fields toward storage_state."""
+    if not isinstance(cookie, dict):
+        return cookie
+
+    normalized = dict(cookie)
+    if "expires" not in normalized:
+        # EditThisCookie / Cookie-Editor style exports usually call this field
+        # ``expirationDate``. Playwright storage_state uses ``expires``.
+        normalized["expires"] = normalized.get("expirationDate", -1)
+    normalized.setdefault("path", "/")
+    normalized.setdefault("httpOnly", False)
+    normalized.setdefault("secure", False)
+    normalized.setdefault("sameSite", "None")
+    return normalized
+
+
+def _import_cookie_json(
+    *,
+    payload: Any,
+    storage_path: Path,
+    include_domains: set[str],
+    include_optional: bool,
+) -> dict[str, Any]:
+    """Validate, filter, and persist cookie JSON to ``storage_state.json``."""
+    storage_state = _coerce_cookie_json_to_storage_state(payload)
+    filtered_state = filter_storage_state_cookies_by_domain_policy(
+        storage_state,
+        include_optional=include_optional,
+        include_domains=include_domains,
+    )
+    cookie_names = cookie_names_from_storage(filtered_state)
+    try:
+        # This validates required cookies and catches malformed cookie shapes
+        # using the same loader later runtime calls use.
+        extract_cookies_from_storage(filtered_state)
+    except ValueError as exc:
+        hint = missing_cookies_hint(cookie_names)
+        raise click.ClickException(f"{exc}\n\n{hint}") from None
+
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(storage_path, filtered_state)
+    if sys.platform != "win32":
+        storage_path.parent.chmod(0o700)
+    return filtered_state
 
 
 # Legacy thin alias kept for the small set of session-cmd-internal helpers
@@ -643,6 +722,85 @@ def register_session_commands(cli):
             _render_auth_inspect_error(enum_result, json_output=json_output)
         _, accounts = enum_result
         _render_auth_inspect(browser_name, list(accounts), json_output=json_output, verbose=verbose)
+
+    @auth_group.command("import-cookies")
+    @click.argument("json_path", type=click.Path(exists=False))
+    @click.option(
+        "--include-domains",
+        "include_domains_raw",
+        multiple=True,
+        default=(),
+        help=(
+            "Opt in to persisting sibling-product cookies. Same syntax as "
+            "'notebooklm login --include-domains': youtube, docs, myaccount, "
+            "mail, all. By default, only required Google auth/Drive/NotebookLM "
+            "cookie domains are kept."
+        ),
+    )
+    @click.option(
+        "--include-optional",
+        is_flag=True,
+        default=False,
+        help="Persist all optional sibling-product cookie domains.",
+    )
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    @click.option("--quiet", "quiet", is_flag=True, help="Suppress success output")
+    @click.pass_context
+    def auth_import_cookies(ctx, json_path, include_domains_raw, include_optional, json_output, quiet):
+        """Import authentication cookies from JSON and save them persistently.
+
+        Accepts either a Playwright ``storage_state`` object (``{"cookies": [...]}``)
+        or a bare JSON list of cookie objects, including JSON exported from many
+        browser-cookie tools. Use ``-`` to read JSON from stdin.
+
+        The imported cookies are filtered through the same domain allowlist used
+        by browser login, validated locally for NotebookLM-required cookies, and
+        written atomically to the active profile's ``storage_state.json`` (or the
+        root ``--storage`` override) with private file permissions.
+
+        Examples:
+          notebooklm auth import-cookies cookies.json
+          notebooklm -p work auth import-cookies playwright-storage-state.json
+          cat cookies.json | notebooklm auth import-cookies -
+        """
+        with handle_errors():
+            if has_env_auth_json():
+                click.echo(
+                    f"Error: 'auth import-cookies' is incompatible with {AUTH_JSON_ENV_NAME}. "
+                    "Unset the env var first so the imported cookies can be used "
+                    "from storage_state.json.",
+                    err=True,
+                )
+                exit_with_code(1)
+
+            include_domains = _parse_include_domains(include_domains_raw)
+            profile = ctx.obj.get("profile") if ctx.obj else None
+            storage_path = (
+                ctx.obj.get("storage_path")
+                if ctx.obj and ctx.obj.get("storage_path") is not None
+                else get_storage_path(profile=profile)
+            )
+
+            imported = _import_cookie_json(
+                payload=_read_auth_json_input(json_path),
+                storage_path=storage_path,
+                include_domains=include_domains,
+                include_optional=include_optional,
+            )
+
+            if json_output:
+                json_output_response(
+                    {
+                        "success": True,
+                        "storage_path": str(storage_path),
+                        "cookie_count": len(imported.get("cookies", [])),
+                    }
+                )
+            elif not quiet:
+                console.print(
+                    f"[green]ok[/green] imported {len(imported.get('cookies', []))} "
+                    f"cookies to: {storage_path}"
+                )
 
     @auth_group.command("check")
     @click.option(

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -1110,6 +1110,7 @@
       "class": "Group",
       "commands": [
         "check",
+        "import-cookies",
         "inspect",
         "logout",
         "refresh"
@@ -1176,6 +1177,101 @@
         }
       ],
       "short_help": "Check authentication status and diagnose..."
+    },
+    "auth import-cookies": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "json_path",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Opt in to persisting sibling-product cookies. Same syntax as 'notebooklm login --include-domains': youtube, docs, myaccount, mail, all. By default, only required Google auth/Drive/NotebookLM cookie domains are kept.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Persist all optional sibling-product cookie domains.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "include_optional",
+          "opts": [
+            "--include-optional"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Suppress success output",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "quiet",
+          "opts": [
+            "--quiet"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Import authentication cookies from JSON..."
     },
     "auth inspect": {
       "class": "Command",

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -224,6 +224,24 @@ class TestAuthImportCookiesCommand:
         assert stat.S_IMODE(auth_dir.stat().st_mode) == 0o700
         assert stat.S_IMODE(storage_path.stat().st_mode) == 0o600
 
+    def test_import_cookies_rejects_empty_required_cookie_values(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        cookies = _valid_cookie_export()
+        for cookie in cookies:
+            if cookie["name"] == "SID":
+                cookie["value"] = ""
+        input_path.write_text(json.dumps(cookies), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "Required cookies must have non-empty string values" in result.output
+        assert "SID" in result.output
+        assert not storage_path.exists()
+
     def test_import_cookies_rejects_missing_required_cookies_without_leaking_values(
         self, runner, tmp_path
     ):

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -25,6 +25,102 @@ from ._session_helpers import (
 )
 
 
+def _valid_cookie_export(extra_cookies=None):
+    cookies = [
+        {"name": "SID", "value": "fixture-sid", "domain": ".google.com", "path": "/"},
+        {
+            "name": "__Secure-1PSIDTS",
+            "value": "fixture-psidts",
+            "domain": ".google.com",
+            "path": "/",
+        },
+        {"name": "APISID", "value": "fixture-apisid", "domain": ".google.com", "path": "/"},
+        {"name": "SAPISID", "value": "fixture-sapisid", "domain": ".google.com", "path": "/"},
+    ]
+    if extra_cookies:
+        cookies.extend(extra_cookies)
+    return cookies
+
+
+class TestAuthImportCookiesCommand:
+    """Tests for the 'auth import-cookies' command."""
+
+    def test_import_cookies_accepts_bare_cookie_list_and_storage_override(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(
+            json.dumps(
+                _valid_cookie_export(
+                    [
+                        {
+                            "name": "UNRELATED",
+                            "value": "should-not-persist",
+                            "domain": ".example.com",
+                            "path": "/",
+                        }
+                    ]
+                )
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "imported" in result.output
+        stored = json.loads(storage_path.read_text(encoding="utf-8"))
+        stored_names = {cookie["name"] for cookie in stored["cookies"]}
+        assert {"SID", "__Secure-1PSIDTS", "APISID", "SAPISID"} <= stored_names
+        assert "UNRELATED" not in stored_names
+
+    def test_import_cookies_accepts_playwright_storage_state_from_stdin(self, runner, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+        payload = {"cookies": _valid_cookie_export(), "origins": []}
+
+        result = runner.invoke(
+            cli,
+            ["--storage", str(storage_path), "auth", "import-cookies", "-", "--json"],
+            input=json.dumps(payload),
+        )
+
+        assert result.exit_code == 0, result.output
+        output = json.loads(result.output)
+        assert output["success"] is True
+        assert output["cookie_count"] == 4
+        assert json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
+
+    def test_import_cookies_rejects_missing_required_cookies_without_leaking_values(
+        self, runner, tmp_path
+    ):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        secret_value = "super-secret-cookie-value"
+        input_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "APISID",
+                        "value": secret_value,
+                        "domain": ".google.com",
+                        "path": "/",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "Missing required cookies" in result.output
+        assert secret_value not in result.output
+        assert not storage_path.exists()
+
+
 class TestAuthCheckCommand:
     """Tests for the 'auth check' command."""
 

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -7,6 +7,7 @@ helpers live in ``_session_helpers.py``; the proxy-block-aware
 """
 
 import json
+import stat
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -90,6 +91,138 @@ class TestAuthImportCookiesCommand:
         assert output["success"] is True
         assert output["cookie_count"] == 4
         assert json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
+
+    def test_import_cookies_drops_origins_from_playwright_storage_state(self, runner, tmp_path):
+        input_path = tmp_path / "playwright-storage-state.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(
+            json.dumps(
+                {
+                    "cookies": _valid_cookie_export(),
+                    "origins": [
+                        {
+                            "origin": "https://evil.example.com",
+                            "localStorage": [{"name": "token", "value": "do-not-persist"}],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        stored = json.loads(storage_path.read_text(encoding="utf-8"))
+        assert stored["cookies"]
+        assert stored["origins"] == []
+
+    def test_import_cookies_rejects_env_auth_json_interlock(self, runner, tmp_path, monkeypatch):
+        input_path = tmp_path / "cookies.json"
+        input_path.write_text(json.dumps(_valid_cookie_export()), encoding="utf-8")
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps({"cookies": []}))
+
+        result = runner.invoke(cli, ["auth", "import-cookies", str(input_path)])
+
+        assert result.exit_code != 0
+        assert "auth import-cookies" in result.output
+        assert "NOTEBOOKLM_AUTH_JSON" in result.output
+
+    def test_import_cookies_rejects_malformed_json(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text("{not valid json", encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid JSON" in result.output
+        assert not storage_path.exists()
+
+    def test_import_cookies_rejects_unsupported_json_shape(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(json.dumps({"not_cookies": []}), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "Cookie JSON must be either" in result.output
+        assert not storage_path.exists()
+
+    def test_import_cookies_include_domains_opts_into_sibling_product_cookies(
+        self, runner, tmp_path
+    ):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(
+            json.dumps(
+                _valid_cookie_export(
+                    [
+                        {
+                            "name": "DOCS_PREF",
+                            "value": "docs-cookie",
+                            "domain": "docs.google.com",
+                            "path": "/",
+                        }
+                    ]
+                )
+            ),
+            encoding="utf-8",
+        )
+
+        result_default = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result_default.exit_code == 0, result_default.output
+        default_names = {
+            cookie["name"]
+            for cookie in json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
+        }
+        assert "DOCS_PREF" not in default_names
+
+        result_optin = runner.invoke(
+            cli,
+            [
+                "--storage",
+                str(storage_path),
+                "auth",
+                "import-cookies",
+                str(input_path),
+                "--include-domains",
+                "docs",
+            ],
+        )
+
+        assert result_optin.exit_code == 0, result_optin.output
+        optin_names = {
+            cookie["name"]
+            for cookie in json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
+        }
+        assert "DOCS_PREF" in optin_names
+
+    def test_import_cookies_sets_private_file_and_directory_permissions(self, runner, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("POSIX permission bits are not stable on Windows")
+        input_path = tmp_path / "cookies.json"
+        auth_dir = tmp_path / "profile"
+        storage_path = auth_dir / "storage_state.json"
+        input_path.write_text(json.dumps(_valid_cookie_export()), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert stat.S_IMODE(auth_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(storage_path.stat().st_mode) == 0o600
 
     def test_import_cookies_rejects_missing_required_cookies_without_leaking_values(
         self, runner, tmp_path

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -793,6 +793,7 @@ JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
     ("artifact", "wait"): _MUTATION_RATIONALE_SUCCESS,
     # auth-flow commands (covered by dedicated test files).
     ("auth", "check"): _AUTH_RATIONALE,
+    ("auth", "import-cookies"): _AUTH_RATIONALE,
     ("auth", "inspect"): _AUTH_RATIONALE,
     ("configure",): _AUTH_RATIONALE,
     # top-level notebook `delete` mutation — success path is covered by
@@ -871,6 +872,7 @@ JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
     ("artifact", "suggestions"): _MUTATION_RATIONALE_ERROR,
     # auth-flow error paths (covered by dedicated test files).
     ("auth", "check"): _AUTH_RATIONALE,
+    ("auth", "import-cookies"): _AUTH_RATIONALE,
     ("auth", "inspect"): _AUTH_RATIONALE,
     ("configure",): _AUTH_RATIONALE,
     # top-level notebook `delete` mutation — error path is covered by


### PR DESCRIPTION
## AI-generated draft — not human-reviewed

This is a **draft PR prepared by an AI assistant on behalf of Bernardo Chrispim Baron**. It has **not yet been reviewed by Bernardo or another human maintainer**. Please treat it as an initial proposal that needs careful human review before merge.

## Summary

Adds a persistent cookie JSON import command:

```bash
notebooklm auth import-cookies cookies.json
cat cookies.json | notebooklm auth import-cookies -
```

The command accepts either:

- a Playwright `storage_state` object with a `cookies` list, or
- a bare JSON list of cookie objects exported by common browser-cookie tools.

Imported cookies are normalized, filtered through the existing auth-domain policy, validated locally for NotebookLM-required cookies, and written atomically to the active profile's `storage_state.json` or the root `--storage` override.

## Motivation

`NOTEBOOKLM_AUTH_JSON` already supports inline auth JSON, but it is environment-variable based and not persistent. This PR adds a file-backed import path for users who can obtain cookies as JSON but find the browser/Playwright login flow difficult.

## Safety / privacy considerations

- Cookie values are not printed in success output.
- Validation failures should not echo cookie values.
- Writes use existing atomic JSON writing with private file permissions.
- Imported cookies are filtered by the same domain allowlist used by browser login, rather than persisting arbitrary domains.

## Tests run

```bash
uv run --extra dev --exclude-newer-package ruff=2026-06-20T00:00:00Z pytest tests/unit/cli/test_auth_subcommands.py::TestAuthImportCookiesCommand -q
uv run --extra dev --exclude-newer-package ruff=2026-06-20T00:00:00Z pytest tests/unit/cli/test_auth_subcommands.py -q
uv run --extra dev --exclude-newer-package ruff=2026-06-20T00:00:00Z ruff check src/notebooklm/cli/session_cmd.py tests/unit/cli/test_auth_subcommands.py
```

Results:

- `3 passed` for the new tests
- `68 passed` for the full auth subcommand test file
- `ruff check` passed

Note: the `--exclude-newer-package ruff=...` override was needed locally because the project pins `ruff==0.15.18` while the configured global exclude-newer cutoff predates that release.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `auth import-cookies` command to import cookie JSON from a file or stdin, validate required cookies, and persist a domain-filtered auth storage state. Supports including sibling/product domains, optional domain persistence, `--json` output, and `--quiet` mode.
* **Bug Fixes**
  * Accepts Playwright-style storage input (including dropping `origins`), normalizes cookie fields, enforces non-empty required cookie values, blocks conflicting env-based auth usage, and avoids writing storage on invalid inputs.
* **Tests**
  * Expanded unit coverage for filtering, stdin import, error handling, POSIX permissions, and updated stdout-purity waivers for the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->