### PR TITLE
fix(sources): pin .md content-type for uploads on Python 3.10

### DIFF
--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -307,10 +307,8 @@ def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
     guessed, _encoding = mimetypes.guess_type(file_path.name)
     if guessed:
         return guessed
-    # ``mimetypes`` has no entry for some text suffixes (e.g. ``.md``) on
-    # Python 3.10 / hosts without a system MIME table — fall back to the
-    # pinned mapping before the opaque ``application/octet-stream`` default,
-    # which NotebookLM cannot infer a parser for (processing fails, #1627).
+    # Fall back to the pinned overrides before the opaque octet-stream default
+    # (see ``_EXTENSION_CONTENT_TYPES`` for why; #1627).
     return _EXTENSION_CONTENT_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
 
 

--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -40,6 +40,16 @@ _MEDIA_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 _STRICT_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = ()
 _HTML_UPLOAD_SUFFIXES = frozenset({".html", ".htm", ".xhtml", ".xht"})
 _HTML_UPLOAD_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
+# ``mimetypes.guess_type`` returns ``None`` for some text suffixes on Python 3.10
+# and on hosts without a populated ``/etc/mime.types`` (notably ``.md``). Without
+# an override the upload falls back to ``application/octet-stream`` (see
+# ``_resolve_upload_content_type``), NotebookLM cannot infer how to parse the
+# file, and processing fails with status=ERROR. Pin the types we know NotebookLM
+# accepts so upload works regardless of the host's MIME table.
+_EXTENSION_CONTENT_TYPES: dict[str, str] = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+}
 
 
 def _normalize_upload_path(path: str) -> str:
@@ -295,7 +305,13 @@ def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
         return content_type
 
     guessed, _encoding = mimetypes.guess_type(file_path.name)
-    return guessed or "application/octet-stream"
+    if guessed:
+        return guessed
+    # ``mimetypes`` has no entry for some text suffixes (e.g. ``.md``) on
+    # Python 3.10 / hosts without a system MIME table — fall back to the
+    # pinned mapping before the opaque ``application/octet-stream`` default,
+    # which NotebookLM cannot infer a parser for (processing fails, #1627).
+    return _EXTENSION_CONTENT_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
 
 
 def _normalize_content_type(content_type: str) -> str:

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -148,6 +148,35 @@ def test_resolve_upload_content_type_blank_mime_raises() -> None:
         _resolve_upload_content_type(Path("a.bin"), "   ")
 
 
+def test_resolve_upload_content_type_md_uses_markdown_when_mimetypes_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``.md`` resolves to ``text/markdown`` even when ``mimetypes`` misses.
+
+    Python 3.10 and hosts without a system MIME table return ``None`` for
+    ``.md``; the pinned override prevents a fall back to
+    ``application/octet-stream``, which NotebookLM cannot infer a parser for
+    (processing then fails server-side with status=ERROR).
+    """
+    import mimetypes
+    from pathlib import Path
+
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("notes.md"), None) == "text/markdown"
+    assert _resolve_upload_content_type(Path("NOTES.MARKDOWN"), None) == "text/markdown"
+
+
+def test_resolve_upload_content_type_unknown_suffix_falls_back_to_octet_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A suffix with no MIME guess and no override still falls back to octet-stream."""
+    import mimetypes
+    from pathlib import Path
+
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("blob.unknownext"), None) == "application/octet-stream"
+
+
 def test_extract_register_file_source_id_ambiguous_field_candidates() -> None:
     """Two distinct context-matched SOURCE_IDs are ambiguous -> None .
     Each inner dict carries a matching ``SOURCE_NAME`` so both SOURCE_IDs are

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -177,6 +177,28 @@ def test_resolve_upload_content_type_unknown_suffix_falls_back_to_octet_stream(
     assert _resolve_upload_content_type(Path("blob.unknownext"), None) == "application/octet-stream"
 
 
+def test_resolve_upload_content_type_override_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pinned override sits last in precedence: explicit mime > guess > override.
+
+    The override only fills the gap when ``mimetypes`` misses (#1627); it must not
+    shadow an explicit mime_type or a successful guess, and it keys on the final
+    suffix only (so ``notes.md.txt`` is not mistaken for markdown).
+    """
+    import mimetypes
+    from pathlib import Path
+
+    # Explicit mime_type wins over the pinned ``.md`` override.
+    assert _resolve_upload_content_type(Path("notes.md"), "text/plain") == "text/plain"
+    # A successful guess wins over the override (sentinel proves the guess path ran).
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: ("application/x-sentinel", None))
+    assert _resolve_upload_content_type(Path("notes.md"), None) == "application/x-sentinel"
+    # On a miss, the override keys on the actual suffix: ``.md.txt`` -> ``.txt`` -> octet-stream.
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("notes.md.txt"), None) == "application/octet-stream"
+
+
 def test_extract_register_file_source_id_ambiguous_field_candidates() -> None:
     """Two distinct context-matched SOURCE_IDs are ambiguous -> None .
     Each inner dict carries a matching ``SOURCE_NAME`` so both SOURCE_IDs are


### PR DESCRIPTION
-

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload content-type resolution so `.md`/`.markdown` files reliably resolve to `text/markdown`, even when system MIME guessing is incomplete.
  * Kept safe fallback behavior for unknown extensions (`application/octet-stream`), and ensured precedence when an explicit MIME type is provided.

* **Tests**
  * Added unit coverage for Markdown detection when MIME guessing fails (including uppercase suffixes).
  * Added unit coverage for unknown-extension fallback and for correct precedence between explicit MIME and guessing/overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->