### PR TITLE
fix(auth): harden auth import-cookies (review follow-up to #1626)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1189,6 +1189,7 @@ src/notebooklm/
 ├── cli/                         # CLI implementation
     ├── __init__.py              # Re-exports click groups under historical names from *_cmd modules
     ├── _chromium_profiles.py    # Multi-user-data-profile cookie extraction for Chromium browsers
+    ├── _cookie_import.py        # `auth import-cookies` helpers: parse/normalize/validate cookie JSON + backup-then-atomic-write storage_state
     ├── _download_specs.py       # Registry data for `download <type>` leaf commands
     ├── _encoding.py             # Encoding-safe CLI output helpers
     ├── _firefox_containers.py   # Container-aware Firefox cookie extraction

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -61,6 +61,7 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `auth check --test` | Validate with network test | `notebooklm auth check --test` |
 | `auth check --json` | Output as JSON | `notebooklm auth check --json` |
 | `auth inspect` | List Google accounts visible to a browser cookie store (read-only) | `notebooklm auth inspect --browser chrome` |
+| `auth import-cookies` | Import auth cookies from a JSON file (or stdin) into the active profile | `notebooklm auth import-cookies cookies.json` |
 | `auth logout` | Clear saved cookies and cached browser profile | `notebooklm auth logout` |
 | `auth refresh` | One-shot SIDTS rotation poke (for OS schedulers) | `notebooklm auth refresh` |
 | `auth refresh --quiet` | Refresh; suppress success output | `notebooklm auth refresh --quiet` |
@@ -446,6 +447,40 @@ notebooklm login --fresh
 - Without `--account` or `--all-accounts`, imports the selected browser/profile's default Google account into the target profile.
 - For Chromium-family browsers, unscoped `chrome`, `brave`, `edge`, etc. fan out across populated user profiles when account selection is needed. Use `chrome::<profile-name-or-directory>` to read exactly one profile; directory names such as `Default` and `Profile 1` are stable across UI renames.
 - Use `notebooklm auth inspect --browser <browser>` to see available account emails before a targeted import; pass `-v` to show the Chromium profile directory each account came from.
+
+### Authentication: `auth import-cookies`
+
+Import authentication cookies from a JSON file (or stdin) and persist them to the active profile's `storage_state.json` — a file-backed, persistent alternative to the env-var-based `NOTEBOOKLM_AUTH_JSON` for users who can obtain cookies as JSON but find the browser/Playwright login flow difficult.
+
+> **⚠️ These are full-account credentials.** A JSON cookie export grants the same access as being logged in. Only import a file you exported yourself, keep it private, and delete it after import. Be especially cautious with third-party browser cookie-export extensions.
+
+```bash
+notebooklm auth import-cookies JSON_PATH [OPTIONS]
+```
+
+Accepts either a Playwright `storage_state` object (`{"cookies": [...]}`) or a bare JSON list of cookie objects (the shape most browser cookie-export tools produce). Use `-` to read JSON from stdin. Common export fields are normalized (e.g. `expirationDate` → `expires`), `__Secure-`/`__Host-` cookies are forced `Secure`, and any `storage_state` `origins` (localStorage/sessionStorage) are dropped.
+
+Imported cookies are filtered through the **same domain allowlist** used by browser login, validated locally for the NotebookLM-required cookies (and a usable secondary binding — `OSID`, or `APISID`+`SAPISID`), and written atomically with private (`0o600`) permissions. Invalid input never overwrites an existing session, and an existing `storage_state.json` is first copied to `storage_state.json.bak` so a stale import can be rolled back.
+
+Incompatible with `NOTEBOOKLM_AUTH_JSON`: unset that env var first, otherwise the env auth takes precedence and the imported file would be ignored.
+
+**Options:**
+- `--include-domains LABEL[,LABEL...]` - Opt in to persisting sibling-product cookies (default: required Google auth/Drive/NotebookLM domains only). Same labels as `login`: `youtube`, `docs`, `myaccount`, `mail`, `all`.
+- `--include-optional` - Persist all optional sibling-product cookie domains.
+- `--json` - Emit a JSON result (`storage_path`, `cookie_count`, `backup_path`).
+- `--quiet` - Suppress success output.
+
+**Examples:**
+```bash
+# Import a bare cookie list exported by a browser tool
+notebooklm auth import-cookies cookies.json
+
+# Import a Playwright storage_state into a named profile
+notebooklm -p work auth import-cookies playwright-storage-state.json
+
+# Pipe JSON from stdin
+cat cookies.json | notebooklm auth import-cookies -
+```
 
 ### Session: `use`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -460,12 +460,12 @@ notebooklm auth import-cookies JSON_PATH [OPTIONS]
 
 Accepts either a Playwright `storage_state` object (`{"cookies": [...]}`) or a bare JSON list of cookie objects (the shape most browser cookie-export tools produce). Use `-` to read JSON from stdin. Common export fields are normalized (e.g. `expirationDate` → `expires`), `__Secure-`/`__Host-` cookies are forced `Secure`, and any `storage_state` `origins` (localStorage/sessionStorage) are dropped.
 
-Imported cookies are filtered through the **same domain allowlist** used by browser login, validated locally for the NotebookLM-required cookies (and a usable secondary binding — `OSID`, or `APISID`+`SAPISID`), and written atomically with private (`0o600`) permissions. Invalid input never overwrites an existing session, and an existing `storage_state.json` is first copied to `storage_state.json.bak` so a stale import can be rolled back.
+Imported cookies are filtered through the **same domain allowlist** used by browser login, validated locally for the NotebookLM-required cookies (and a usable secondary binding — `OSID`, or `APISID`+`SAPISID`), and written atomically with private (`0o600`) permissions. Invalid input never overwrites an existing session, and an existing `storage_state.json` is first copied to `storage_state.json.bak` so a stale import can be rolled back (one step — each run overwrites the previous `.bak`).
 
-Incompatible with `NOTEBOOKLM_AUTH_JSON`: unset that env var first, otherwise the env auth takes precedence and the imported file would be ignored.
+Incompatible with `NOTEBOOKLM_AUTH_JSON`: unset that env var first, or the command exits with an error (it does not silently fall back to the env auth).
 
 **Options:**
-- `--include-domains LABEL[,LABEL...]` - Opt in to persisting sibling-product cookies (default: required Google auth/Drive/NotebookLM domains only). Same labels as `login`: `youtube`, `docs`, `myaccount`, `mail`, `all`.
+- `--include-domains LABEL` (repeatable) - Opt in to persisting sibling-product cookies (default: required Google auth/Drive/NotebookLM domains only). Pass labels comma-separated or repeat the flag (e.g. `--include-domains youtube,docs` or `--include-domains youtube --include-domains docs`). Same labels as `login`: `youtube`, `docs`, `myaccount`, `mail`, `all`.
 - `--include-optional` - Persist all optional sibling-product cookie domains.
 - `--json` - Emit a JSON result (`storage_path`, `cookie_count`, `backup_path`).
 - `--quiet` - Suppress success output.

--- a/src/notebooklm/cli/_cookie_import.py
+++ b/src/notebooklm/cli/_cookie_import.py
@@ -1,0 +1,200 @@
+"""Cookie-JSON import helpers for ``notebooklm auth import-cookies``.
+
+Split out of :mod:`notebooklm.cli.session_cmd` to keep that module under the
+ADR-0008 module-size budget (and to keep stdlib names like ``shutil`` off its
+retired patch surface). ``register_session_commands`` imports
+:func:`_import_cookie_json` / :func:`_read_auth_json_input` back.
+
+These are presentation-adjacent CLI helpers (they raise ``click.ClickException``
+directly), so they live beside the command rather than in ``cli/services/``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import click
+
+from .. import auth
+from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
+from ..io import atomic_write_json
+from .services.playwright_login import filter_storage_state_cookies_by_domain_policy
+
+__all__ = ["_import_cookie_json", "_read_auth_json_input"]
+
+
+def _read_auth_json_input(path: str) -> Any:
+    """Read a cookie JSON payload from a file path or stdin (``-``)."""
+    try:
+        if path == "-":
+            return json.loads(click.get_text_stream("stdin").read())
+        return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        raise click.ClickException(  # cli-input-validation: import-cookies text decode failure
+            f"Could not decode {path!r} as UTF-8: {exc}"
+        ) from None
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(  # cli-input-validation: import-cookies JSON parse failure
+            f"Invalid JSON: {exc}"
+        ) from None
+    except OSError as exc:
+        raise click.ClickException(  # cli-input-validation: import-cookies JSON read failure
+            f"Could not read {path!r}: {exc}"
+        ) from None
+
+
+def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
+    """Normalize supported cookie JSON shapes to Playwright storage_state."""
+    if isinstance(payload, dict) and isinstance(payload.get("cookies"), list):
+        # Import only cookies: a storage_state's ``origins`` (localStorage /
+        # sessionStorage) bypass the cookie-domain allowlist, so drop them rather
+        # than persist unrelated site data. Matches the bare-list branch below.
+        return {
+            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload["cookies"]],
+            "origins": [],
+        }
+    if isinstance(payload, list):
+        return {
+            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload],
+            "origins": [],
+        }
+    raise click.ClickException(  # cli-input-validation: import-cookies JSON shape validation
+        "Cookie JSON must be either a Playwright storage_state object "
+        "with a 'cookies' list or a bare list of cookie objects."
+    )
+
+
+def _normalize_imported_cookie(cookie: Any) -> Any:
+    """Translate common browser-export cookie fields toward storage_state."""
+    if not isinstance(cookie, dict):
+        return cookie
+
+    normalized = dict(cookie)
+    if "expires" not in normalized:
+        # EditThisCookie / Cookie-Editor style exports usually call this field
+        # ``expirationDate``. Playwright storage_state uses ``expires``.
+        normalized["expires"] = normalized.pop("expirationDate", -1)
+    normalized.setdefault("path", "/")
+    normalized.setdefault("httpOnly", False)
+    name = normalized.get("name")
+    if isinstance(name, str) and name.startswith(("__Secure-", "__Host-")):
+        # ``__Secure-``/``__Host-`` prefixed cookies are invalid unless ``Secure``
+        # (Chromium rejects them on a storage_state re-injection), so force the
+        # flag rather than persist an insecure variant when a bare-list export
+        # omitted it. Many Google auth cookies (e.g. ``__Secure-1PSIDTS``) use
+        # this prefix.
+        normalized["secure"] = True
+    else:
+        normalized.setdefault("secure", False)
+    normalized.setdefault("sameSite", "None")
+    return normalized
+
+
+def _nonempty_cookie_names(filtered_state: dict[str, Any]) -> set[str]:
+    """Names of ``filtered_state`` cookies that carry a non-empty string value.
+
+    Reads the raw cookie list rather than the flattened
+    ``extract_cookies_from_storage`` dict, so a non-empty cookie is never masked
+    by an empty same-name duplicate — matching the runtime jar, which skips empty
+    rows when building httpx cookies.
+    """
+    return {
+        cookie["name"]
+        for cookie in filtered_state.get("cookies", [])
+        if isinstance(cookie, dict)
+        and isinstance(cookie.get("name"), str)
+        and isinstance(cookie.get("value"), str)
+        and cookie["value"]
+    }
+
+
+def _has_usable_secondary_binding(filtered_state: dict[str, Any]) -> bool:
+    """Whether ``filtered_state`` carries a non-empty secondary auth binding.
+
+    Mirrors the name-level check in ``_auth.cookie_policy`` (``OSID``, or both
+    ``APISID`` and ``SAPISID``) but at the **value** level — that check counts a
+    present-but-empty cookie as satisfying the binding, which import-cookies must
+    not accept as a usable login.
+    """
+    nonempty = _nonempty_cookie_names(filtered_state)
+    return "OSID" in nonempty or {"APISID", "SAPISID"} <= nonempty
+
+
+def _backup_existing_storage(storage_path: Path) -> Path | None:
+    """Copy an existing ``storage_state.json`` to a ``.bak`` sibling before overwrite.
+
+    ``import-cookies`` replaces the target outright, so a stale-but-valid import
+    would otherwise silently destroy a working session with no undo. Copying the
+    prior file to ``<name>.bak`` (``copy2`` preserves its ``0o600`` mode) leaves a
+    one-step recovery path. Returns the backup path, or ``None`` when there was
+    nothing to back up.
+    """
+    if not storage_path.exists():
+        return None
+    backup_path = storage_path.with_name(storage_path.name + ".bak")
+    shutil.copy2(storage_path, backup_path)
+    # ``copy2`` preserves the SOURCE mode; force private perms so a backup of a
+    # (legacy/world-readable) storage_state never leaks credentials at rest.
+    backup_path.chmod(0o600)
+    return backup_path
+
+
+def _import_cookie_json(
+    *,
+    payload: Any,
+    storage_path: Path,
+    include_domains: set[str],
+    include_optional: bool,
+) -> tuple[dict[str, Any], Path | None]:
+    """Validate, filter, and persist cookie JSON to ``storage_state.json``.
+
+    Returns the persisted ``storage_state`` and the path of any ``.bak`` backup
+    taken of a pre-existing target (``None`` when none was needed).
+    """
+    storage_state = _coerce_cookie_json_to_storage_state(payload)
+    filtered_state = filter_storage_state_cookies_by_domain_policy(
+        storage_state,
+        include_optional=include_optional,
+        include_domains=include_domains,
+    )
+    cookie_names = cookie_names_from_storage(filtered_state)
+    try:
+        # This validates required cookies and catches malformed cookie shapes
+        # using the same loader later runtime calls use.
+        extracted_cookies = extract_cookies_from_storage(filtered_state)
+    except ValueError as exc:
+        hint = missing_cookies_hint(cookie_names)
+        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie validation
+            f"{exc}\n\n{hint}"
+        ) from None
+
+    empty_required = sorted(
+        name
+        for name in auth.MINIMUM_REQUIRED_COOKIES
+        if not isinstance(extracted_cookies.get(name), str) or not extracted_cookies[name]
+    )
+    if empty_required:
+        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie value validation
+            "Required cookies must have non-empty string values: " + ", ".join(empty_required)
+        )
+
+    # The name-level secondary-binding check counts a present-but-empty cookie as
+    # satisfying the binding, so a set whose ``APISID``/``SAPISID`` (or ``OSID``)
+    # are present-but-empty can pass required-cookie validation yet be unusable.
+    # Reject that specific false-"ok". Like the login flow (which only warns), we
+    # stay silent when no secondary-binding cookie is present at all.
+    secondary_present = {"OSID", "APISID", "SAPISID"} & set(cookie_names)
+    if secondary_present and not _has_usable_secondary_binding(filtered_state):
+        raise click.ClickException(  # cli-input-validation: import-cookies secondary-binding validation
+            "Secondary-binding cookies are present but have empty values "
+            "(need a non-empty OSID, or non-empty APISID and SAPISID): "
+            + ", ".join(sorted(secondary_present))
+        )
+
+    storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    backup_path = _backup_existing_storage(storage_path)
+    atomic_write_json(storage_path, filtered_state)
+    return filtered_state, backup_path

--- a/src/notebooklm/cli/_cookie_import.py
+++ b/src/notebooklm/cli/_cookie_import.py
@@ -67,10 +67,14 @@ def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
     )
 
 
-def _normalize_imported_cookie(cookie: Any) -> Any:
+def _normalize_imported_cookie(cookie: Any) -> dict[str, Any]:
     """Translate common browser-export cookie fields toward storage_state."""
     if not isinstance(cookie, dict):
-        return cookie
+        # Reject non-object entries at the boundary rather than pass them through
+        # to the downstream extractor (which assumes dict-like rows).
+        raise click.ClickException(  # cli-input-validation: import-cookies non-object cookie entry
+            "Each cookie must be a JSON object; the cookie list contains a non-object entry."
+        )
 
     normalized = dict(cookie)
     if "expires" not in normalized:

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -21,7 +21,6 @@ bindings and legacy patch seams.
 from __future__ import annotations
 
 import functools
-import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -29,11 +28,11 @@ from typing import TYPE_CHECKING, Any
 import click
 import httpx
 
-from .. import auth
-from ..auth import cookie_names_from_storage, extract_cookies_from_storage, missing_cookies_hint
 from ..exceptions import AuthError, NotebookNotFoundError
-from ..io import atomic_write_json
 from ..paths import get_storage_path
+
+# Cookie-JSON import helpers (split out to keep this module under the size budget).
+from ._cookie_import import _import_cookie_json, _read_auth_json_input
 
 # Render helpers stay in a sibling module; command registration calls them here.
 from ._session_render import (
@@ -78,7 +77,6 @@ from .services.playwright_login import (
 )
 from .services.playwright_login import (
     PlaywrightLoginPlan,
-    filter_storage_state_cookies_by_domain_policy,
 )
 from .services.session_context import (
     UseNotebookResult,
@@ -155,104 +153,6 @@ def _is_valid_account_metadata(metadata: dict[str, Any]) -> bool:
     if raw_email is None:
         return True
     return isinstance(raw_email, str) and bool(raw_email.strip())
-
-
-def _read_auth_json_input(path: str) -> Any:
-    """Read a cookie JSON payload from a file path or stdin (``-``)."""
-    try:
-        if path == "-":
-            return json.loads(click.get_text_stream("stdin").read())
-        return json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
-    except UnicodeDecodeError as exc:
-        raise click.ClickException(  # cli-input-validation: import-cookies text decode failure
-            f"Could not decode {path!r} as UTF-8: {exc}"
-        ) from None
-    except json.JSONDecodeError as exc:
-        raise click.ClickException(  # cli-input-validation: import-cookies JSON parse failure
-            f"Invalid JSON: {exc}"
-        ) from None
-    except OSError as exc:
-        raise click.ClickException(  # cli-input-validation: import-cookies JSON read failure
-            f"Could not read {path!r}: {exc}"
-        ) from None
-
-
-def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
-    """Normalize supported cookie JSON shapes to Playwright storage_state."""
-    if isinstance(payload, dict) and isinstance(payload.get("cookies"), list):
-        # Import only cookies: a storage_state's ``origins`` (localStorage /
-        # sessionStorage) bypass the cookie-domain allowlist, so drop them rather
-        # than persist unrelated site data. Matches the bare-list branch below.
-        return {
-            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload["cookies"]],
-            "origins": [],
-        }
-    if isinstance(payload, list):
-        return {
-            "cookies": [_normalize_imported_cookie(cookie) for cookie in payload],
-            "origins": [],
-        }
-    raise click.ClickException(  # cli-input-validation: import-cookies JSON shape validation
-        "Cookie JSON must be either a Playwright storage_state object "
-        "with a 'cookies' list or a bare list of cookie objects."
-    )
-
-
-def _normalize_imported_cookie(cookie: Any) -> Any:
-    """Translate common browser-export cookie fields toward storage_state."""
-    if not isinstance(cookie, dict):
-        return cookie
-
-    normalized = dict(cookie)
-    if "expires" not in normalized:
-        # EditThisCookie / Cookie-Editor style exports usually call this field
-        # ``expirationDate``. Playwright storage_state uses ``expires``.
-        normalized["expires"] = normalized.pop("expirationDate", -1)
-    normalized.setdefault("path", "/")
-    normalized.setdefault("httpOnly", False)
-    normalized.setdefault("secure", False)
-    normalized.setdefault("sameSite", "None")
-    return normalized
-
-
-def _import_cookie_json(
-    *,
-    payload: Any,
-    storage_path: Path,
-    include_domains: set[str],
-    include_optional: bool,
-) -> dict[str, Any]:
-    """Validate, filter, and persist cookie JSON to ``storage_state.json``."""
-    storage_state = _coerce_cookie_json_to_storage_state(payload)
-    filtered_state = filter_storage_state_cookies_by_domain_policy(
-        storage_state,
-        include_optional=include_optional,
-        include_domains=include_domains,
-    )
-    cookie_names = cookie_names_from_storage(filtered_state)
-    try:
-        # This validates required cookies and catches malformed cookie shapes
-        # using the same loader later runtime calls use.
-        extracted_cookies = extract_cookies_from_storage(filtered_state)
-    except ValueError as exc:
-        hint = missing_cookies_hint(cookie_names)
-        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie validation
-            f"{exc}\n\n{hint}"
-        ) from None
-
-    empty_required = sorted(
-        name
-        for name in auth.MINIMUM_REQUIRED_COOKIES
-        if not isinstance(extracted_cookies.get(name), str) or not extracted_cookies[name]
-    )
-    if empty_required:
-        raise click.ClickException(  # cli-input-validation: import-cookies required-cookie value validation
-            "Required cookies must have non-empty string values: " + ", ".join(empty_required)
-        )
-
-    storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    atomic_write_json(storage_path, filtered_state)
-    return filtered_state
 
 
 # Legacy thin alias kept for the small set of session-cmd-internal helpers
@@ -775,7 +675,7 @@ def register_session_commands(cli):
           notebooklm -p work auth import-cookies playwright-storage-state.json
           cat cookies.json | notebooklm auth import-cookies -
         """
-        with handle_errors():
+        with handle_errors(json_output=json_output):
             auth_source = auth_source_from_ctx(ctx)
             if auth_source.has_env_auth:
                 raise click.ClickException(  # cli-input-validation: import-cookies env-auth conflict
@@ -787,7 +687,7 @@ def register_session_commands(cli):
             include_domains = _parse_include_domains(include_domains_raw)
             storage_path = auth_source.storage_path_for_diagnostics()
 
-            imported = _import_cookie_json(
+            imported, backup_path = _import_cookie_json(
                 payload=_read_auth_json_input(json_path),
                 storage_path=storage_path,
                 include_domains=include_domains,
@@ -800,6 +700,7 @@ def register_session_commands(cli):
                         "success": True,
                         "storage_path": str(storage_path),
                         "cookie_count": len(imported.get("cookies", [])),
+                        "backup_path": str(backup_path) if backup_path else None,
                     }
                 )
             elif not quiet:
@@ -807,6 +708,8 @@ def register_session_commands(cli):
                     f"[green]ok[/green] imported {len(imported.get('cookies', []))} "
                     f"cookies to: {storage_path}"
                 )
+                if backup_path:
+                    console.print(f"[dim]previous session backed up to: {backup_path}[/dim]")
 
     @auth_group.command("check")
     @click.option(

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -288,6 +288,9 @@ class TestAuthImportCookiesCommand:
         assert json.loads(backup_path.read_text(encoding="utf-8"))["cookies"] == []
         assert json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
         assert "backed up to" in result.output
+        if sys.platform != "win32":
+            # The .bak holds credentials too — it must be private (0o600).
+            assert stat.S_IMODE(backup_path.stat().st_mode) == 0o600
 
     def test_import_cookies_no_backup_when_target_absent(self, runner, tmp_path):
         input_path = tmp_path / "cookies.json"
@@ -378,6 +381,36 @@ class TestAuthImportCookiesCommand:
 
         assert result.exit_code == 0, result.output
         assert storage_path.exists()
+
+    def test_import_cookies_rejects_non_object_cookie_entry(self, runner, tmp_path):
+        # A bare list containing a non-object element must fail cleanly at the
+        # normalization boundary, not crash in the downstream extractor.
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(json.dumps([*_valid_cookie_export(), "not-an-object"]), "utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "must be a JSON object" in result.output
+        assert not storage_path.exists()
+
+    def test_import_cookies_json_error_output_is_json(self, runner, tmp_path):
+        # The handle_errors(json_output=...) fix: a failure under --json must
+        # render the JSON error envelope, not plain text.
+        input_path = tmp_path / "bad.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text("not valid json", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            ["--storage", str(storage_path), "auth", "import-cookies", str(input_path), "--json"],
+        )
+
+        assert result.exit_code != 0
+        assert json.loads(result.output)["error"] is True  # parses as JSON
 
 
 class TestAuthCheckCommand:

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -271,6 +271,114 @@ class TestAuthImportCookiesCommand:
         assert secret_value not in result.output
         assert not storage_path.exists()
 
+    def test_import_cookies_backs_up_existing_storage_state(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text(json.dumps({"cookies": [], "origins": []}), encoding="utf-8")
+        input_path.write_text(json.dumps(_valid_cookie_export()), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        backup_path = storage_path.with_name(storage_path.name + ".bak")
+        assert backup_path.exists(), "previous storage_state should be backed up"
+        # The backup holds the PRIOR contents; the live file holds the import.
+        assert json.loads(backup_path.read_text(encoding="utf-8"))["cookies"] == []
+        assert json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
+        assert "backed up to" in result.output
+
+    def test_import_cookies_no_backup_when_target_absent(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_text(json.dumps(_valid_cookie_export()), encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            ["--storage", str(storage_path), "auth", "import-cookies", str(input_path), "--json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["backup_path"] is None
+        assert not storage_path.with_name(storage_path.name + ".bak").exists()
+
+    def test_import_cookies_forces_secure_on_secure_prefixed_cookie(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        # __Secure-1PSIDTS arrives with secure omitted (bare-list export style).
+        cookies = [c for c in _valid_cookie_export() if c["name"] != "__Secure-1PSIDTS"]
+        cookies.append(
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "fixture-psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "secure": False,
+            }
+        )
+        input_path.write_text(json.dumps(cookies), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        stored = json.loads(storage_path.read_text(encoding="utf-8"))
+        secure_cookie = next(c for c in stored["cookies"] if c["name"] == "__Secure-1PSIDTS")
+        assert secure_cookie["secure"] is True
+
+    def test_import_cookies_rejects_present_but_empty_secondary_binding(self, runner, tmp_path):
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        # SID + __Secure-1PSIDTS present and non-empty, but the secondary binding
+        # (APISID/SAPISID) is present-with-empty values and there is no OSID:
+        # the name-level check would pass, so the value-level guard must catch it.
+        cookies = [
+            {"name": "SID", "value": "fixture-sid", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "fixture-psidts",
+                "domain": ".google.com",
+                "path": "/",
+            },
+            {"name": "APISID", "value": "", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "", "domain": ".google.com", "path": "/"},
+        ]
+        input_path.write_text(json.dumps(cookies), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "present but have empty values" in result.output
+        assert "OSID" in result.output
+        assert not storage_path.exists()
+
+    def test_import_cookies_allows_missing_secondary_binding(self, runner, tmp_path):
+        # No secondary-binding cookie present at all: like the login flow (which
+        # only warns), import-cookies must NOT hard-reject this — it persists.
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        cookies = [
+            {"name": "SID", "value": "fixture-sid", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "fixture-psidts",
+                "domain": ".google.com",
+                "path": "/",
+            },
+        ]
+        input_path.write_text(json.dumps(cookies), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert storage_path.exists()
+
 
 class TestAuthCheckCommand:
     """Tests for the 'auth check' command."""


### PR DESCRIPTION
## Summary
Follow-up addressing the review findings on #1626 (which merged as an AI-drafted PR explicitly needing human review). No new capability — pure hardening of the `notebooklm auth import-cookies` command.

## Changes
- **Backup before overwrite (Important).** An existing `storage_state.json` is copied to a `0o600` `.bak` before the atomic write, so a stale-but-valid import can't silently destroy a working session. Surfaced in `--json` (`backup_path`) and human output. *No interactive `--force` — it would break the documented `cat cookies.json | … import-cookies -` stdin pipe.*
- **Force `secure` on prefixed cookies.** `__Secure-`/`__Host-` cookies are invalid unless `Secure`; a bare-list export that omits the flag would otherwise persist an insecure variant (and Chromium rejects it on a storage_state re-injection).
- **Reject present-but-empty secondary binding.** A name-only check counts a present-but-empty `APISID`/`SAPISID` (with no `OSID`) as satisfying the binding, so an unusable set could be saved as a false "ok". This rejects that specific case while staying silent when no secondary-binding cookie is present at all — consistent with the login flow, which only warns. The non-empty check reads the raw cookie list so a non-empty regional duplicate isn't masked by an empty base-domain one (matches the httpx jar).
- **`--json` error rendering.** `handle_errors` now receives `json_output`.
- **Docs.** Documents the command in `docs/cli-reference.md` (with a credential-sensitivity warning) and the repo tree.

## Refactor
The import helpers moved from `session_cmd.py` into a new sibling `cli/_cookie_import.py` (mirroring `cli/_session_render.py`) to keep `session_cmd.py` under the ADR-0008 1000-line budget (now 898) and off its retired patch surface.

## Review provenance
Findings came from an adversarial review of #1626 (claude + codex). This PR was itself polished (code-simplifier + claude + codex): codex caught the too-strict-on-missing-binding, the flatten-masking, and the backup-perms issues — all fixed here and pinned by tests.

## Out of scope
Cookie-value control-char sanitization (a store-wide concern, not specific to import) and an unbounded `stdin.read()` cap — noted in the #1626 review, deferrable.

## Test plan
- [x] `pytest tests/unit/cli/test_auth_subcommands.py` (80 passed; 6 new import-cookies cases: backup-present, no-backup-absent, secure-prefix forcing, present-but-empty reject, missing-binding-allowed)
- [x] full guardrail + CLI suites, freshness gate, ruff, mypy — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `auth import-cookies` to import authentication cookies from a file or stdin.
  * Stores the imported session in the active profile and reports any prior session backup.

* **Bug Fixes**
  * Improved safety when replacing `storage_state.json` by creating a protected backup before overwriting.
  * Strengthened cookie validation/normalization (including secure cookie handling and stricter secondary-binding checks).

* **Documentation**
  * Expanded the CLI reference with command details, input formats, options, safeguards, and examples.

* **Tests**
  * Added unit coverage for backup behavior, output shape, validation failures, and JSON error envelopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->