### PR TITLE
fix(auth): classify notebooklm.google access-gate redirect (#1630)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,6 +121,18 @@ await client.refresh_auth()
 ```
 Or re-run `notebooklm login` if session cookies are also expired. If the failure persists across re-login, the page structure has likely changed — file an issue and include the `Preview:` snippet from the error.
 
+#### "NotebookLM redirected this request to its region / anti-abuse access gate"
+
+**Cause:** The request to `notebooklm.google.com` was redirected to **`notebooklm.google/?location=unsupported`** — Google's region / anti-abuse risk-control gate (the marketing/landing page, which has no CSRF token). This is **not** a library bug, expired login, or page-structure change, and **re-running `notebooklm login` will not fix it** (the cookies are fine). It is driven by the *access environment*, not just the account's country, and fires even for accounts in supported regions when Google sees:
+
+- a **VPN / proxy / datacenter / shared IP** (especially previously-abused ones),
+- an **IP ↔ timezone ↔ browser-language mismatch**, or
+- a **non-browser / automated access pattern** (a raw HTTP client without a real browser fingerprint).
+
+**Confirm:** open `https://notebooklm.google.com` in a normal browser, signed in to the same account, on the same network. If it also redirects to `notebooklm.google/?location=unsupported`, the gate is environmental.
+
+**Solution:** access from a **residential connection in a supported region**, keep your system **timezone/language consistent** with the IP's country, and avoid shared/datacenter VPN exit IPs. (See issue [#1630](https://github.com/teng-lin/notebooklm-py/issues/1630).)
+
 #### Browser opens but login fails
 
 **Cause:** Google detecting automation and blocking login.

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 import re
 from urllib.parse import urlparse
 
-from .._url_utils import contains_google_auth_redirect, is_google_auth_redirect
+from .._url_utils import (
+    contains_google_auth_redirect,
+    is_google_auth_redirect,
+    is_notebooklm_unavailable_redirect,
+    notebooklm_unavailable_location,
+)
 from ..exceptions import AuthExtractionError
 
 
@@ -178,6 +183,26 @@ def _safe_url(url: str) -> str:
     return f"{parsed.scheme}://{netloc}{path}"
 
 
+def _unavailable_redirect_message(final_url: str) -> str:
+    """Build the access-gate message for a redirect to ``notebooklm.google``.
+
+    The redirect is Google's region / anti-abuse gate (commonly
+    ``?location=unsupported``), not expired auth or a page-structure change. We
+    surface the ``location`` parameter explicitly because :func:`_safe_url` drops
+    the query — and that parameter is the actual diagnostic.
+    """
+    location = notebooklm_unavailable_location(final_url)
+    where = _safe_url(final_url)
+    target = f"{where} (location={location})" if location else where
+    return (
+        f"NotebookLM redirected this request to its region / anti-abuse access gate: "
+        f"{target}. This is not a library bug or an expired login. Likely a VPN/proxy "
+        "or datacenter IP, or an IP/timezone/language mismatch. Verify by opening "
+        "https://notebooklm.google.com in a normal browser on the same network; if it "
+        "redirects there too, use a residential connection in a supported region."
+    )
+
+
 def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     """
     Extract CSRF token (SNlM0e) from NotebookLM page HTML.
@@ -206,8 +231,14 @@ def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     token = extract_wiz_field(html, "SNlM0e", strict=False)
     if token is not None:
         return token
-    # Drift path: differentiate "auth expired" from "shape changed" because
-    # the remediation differs (re-login vs file a bug).
+    # Drift path: differentiate "access gate" / "auth expired" / "shape changed"
+    # because the remediation differs (fix environment / re-login / file a bug).
+    # The *final URL* is the authoritative landing signal, so it is checked
+    # before the weaker ``contains_google_auth_redirect(html)`` body scan — the
+    # ``notebooklm.google`` gate page itself carries an ``accounts.google.com``
+    # sign-in link, which would otherwise mis-route it to "auth expired" (#1630).
+    if is_notebooklm_unavailable_redirect(final_url):
+        raise ValueError(_unavailable_redirect_message(final_url))
     if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
         raise ValueError(
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
@@ -241,6 +272,10 @@ def extract_session_id_from_html(html: str, final_url: str = "") -> str:
     sid = extract_wiz_field(html, "FdrFJe", strict=False)
     if sid is not None:
         return sid
+    # Final-URL landing host is authoritative; check it before the body scan
+    # (the gate page carries an accounts.google.com link). See extract_csrf.
+    if is_notebooklm_unavailable_redirect(final_url):
+        raise ValueError(_unavailable_redirect_message(final_url))
     if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
         raise ValueError(
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -116,12 +116,14 @@ def notebooklm_unavailable_location(url: str) -> str | None:
         values = parse_qs(urlparse(url).query).get("location")
     except (AttributeError, TypeError, ValueError):
         return None
-    # ``next(iter(...))`` rather than ``values[0]`` — the parse-qs list is not an
-    # RPC row, but the positional-indexing guardrail can't tell, and the first
-    # value is all we want anyway.
-    raw = next(iter(values or ()), "")
+    if not values:
+        return None
+    # Sequence unpacking (not ``values[0]``) — the parse-qs list isn't an RPC row,
+    # but the positional-indexing guardrail can't tell; the guard above keeps the
+    # unpack safe.
+    first, *_ = values
     # The value lands in a user-facing error string, so keep only a bounded,
     # sane diagnostic token (e.g. ``unsupported``) — never echo arbitrary,
     # newline-bearing, or URL-shaped query content.
-    sanitized = re.sub(r"[^A-Za-z0-9_-]", "", raw)[:64]
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "", first)[:64]
     return sanitized or None

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -5,7 +5,16 @@ flagged by CodeQL (py/incomplete-url-substring-sanitization).
 """
 
 import re
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
+
+# The NotebookLM marketing/landing host (note: no ``.com``). A request to the
+# app host ``notebooklm.google.com`` is redirected here — typically
+# ``notebooklm.google/?location=unsupported`` — when Google's region /
+# anti-abuse risk-control declines the request's *environment* (VPN/proxy or
+# datacenter IP, IP/timezone/language mismatch, non-browser access pattern).
+# This is distinct from the ``accounts.google.com`` login redirect (expired or
+# invalid auth) and from a genuine page-structure change.
+_NOTEBOOKLM_MARKETING_HOST = "notebooklm.google"
 
 
 def is_youtube_url(url: str) -> bool:
@@ -64,3 +73,55 @@ def contains_google_auth_redirect(text: str) -> bool:
     url_pattern = r'https?://[^\s"\'<>]+'
     urls = re.findall(url_pattern, text)
     return any(is_google_auth_redirect(url) for url in urls)
+
+
+def is_notebooklm_unavailable_redirect(url: str) -> bool:
+    """Check if a URL is the NotebookLM marketing/landing host (an access gate).
+
+    A request to the app (``notebooklm.google.com``) redirected to the bare
+    ``notebooklm.google`` host means Google's region / anti-abuse risk-control
+    declined the request's environment — *not* expired auth (that goes to
+    ``accounts.google.com``) and *not* a page-structure change. The bare host is
+    distinguished from the app host purely by the absent ``.com`` suffix, so an
+    exact / subdomain match on ``notebooklm.google`` never matches
+    ``notebooklm.google.com``.
+
+    Args:
+        url: URL to check (typically ``response.url`` after redirects).
+
+    Returns:
+        True if the URL is the ``notebooklm.google`` landing host.
+    """
+    try:
+        hostname = (urlparse(url).hostname or "").lower()
+        return hostname == _NOTEBOOKLM_MARKETING_HOST or hostname.endswith(
+            "." + _NOTEBOOKLM_MARKETING_HOST
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def notebooklm_unavailable_location(url: str) -> str | None:
+    """Return the ``location`` query value from a NotebookLM access-gate URL.
+
+    Surfaces the diagnostic Google attaches to the marketing redirect (e.g.
+    ``"unsupported"`` from ``notebooklm.google/?location=unsupported``) so the
+    cause is visible even though the URL scrubber drops the rest of the query.
+    Returns ``None`` when absent or unparseable.
+
+    Args:
+        url: URL to inspect (typically ``response.url`` after redirects).
+    """
+    try:
+        values = parse_qs(urlparse(url).query).get("location")
+    except (AttributeError, TypeError, ValueError):
+        return None
+    # ``next(iter(...))`` rather than ``values[0]`` — the parse-qs list is not an
+    # RPC row, but the positional-indexing guardrail can't tell, and the first
+    # value is all we want anyway.
+    raw = next(iter(values or ()), "")
+    # The value lands in a user-facing error string, so keep only a bounded,
+    # sane diagnostic token (e.g. ``unsupported``) — never echo arbitrary,
+    # newline-bearing, or URL-shaped query content.
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "", raw)[:64]
+    return sanitized or None

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -718,3 +718,71 @@ class TestExtractSessionIdRedirect:
 
         with pytest.raises(ValueError, match="Authentication expired"):
             extract_session_id_from_html(html)
+
+
+class TestUnavailableRedirectClassification:
+    """A redirect to notebooklm.google is the region/anti-abuse gate, not a drift (#1630)."""
+
+    _MARKETING_HTML = "<html><body>NotebookLM marketing splash — no WIZ_global_data.</body></html>"
+
+    def test_csrf_classifies_location_unsupported_redirect(self):
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._MARKETING_HTML, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "location=unsupported" in msg  # the diagnostic is surfaced, not swallowed
+        assert "page structure" not in msg  # NOT the misleading file-a-bug message
+
+    def test_session_id_classifies_redirect(self):
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(self._MARKETING_HTML, "https://notebooklm.google")
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "page structure" not in msg
+
+    def test_app_host_drift_still_says_page_structure(self):
+        # A token-less response from the real APP host (not the gate) keeps the
+        # original "page structure" message — the gate branch must not capture it.
+        with pytest.raises(ValueError, match="page structure"):
+            extract_csrf_from_html(self._MARKETING_HTML, "https://notebooklm.google.com/")
+
+    # The real notebooklm.google gate page carries an accounts.google.com sign-in
+    # link; the authoritative final-URL gate check must win over the body scan,
+    # otherwise it mis-routes to "Authentication expired" (the codex finding).
+    _GATE_HTML_WITH_SIGNIN = (
+        '<html><body>NotebookLM <a href="https://accounts.google.com/ServiceLogin">'
+        "Sign in</a></body></html>"
+    )
+
+    def test_csrf_gate_wins_over_accounts_link_in_body(self):
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "Authentication expired" not in msg
+
+    def test_session_id_gate_wins_over_accounts_link_in_body(self):
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "Authentication expired" not in msg
+
+    def test_gate_message_does_not_trigger_auto_refresh(self):
+        # An environmental gate must NOT match the auth-error signals that drive
+        # NOTEBOOKLM_REFRESH_CMD — re-auth can't fix it, so refreshing is futile.
+        # Pin it so a careless reword of the message can't silently re-enable it.
+        from notebooklm._auth.refresh import _AUTH_ERROR_SIGNALS
+
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        lowered = str(exc.value).lower()
+        assert not any(signal in lowered for signal in _AUTH_ERROR_SIGNALS)

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -9,7 +9,9 @@ import pytest
 from notebooklm._url_utils import (
     contains_google_auth_redirect,
     is_google_auth_redirect,
+    is_notebooklm_unavailable_redirect,
     is_youtube_url,
+    notebooklm_unavailable_location,
 )
 
 
@@ -181,3 +183,59 @@ class TestUrlParsingExceptionPaths:
         # swallowed.
         text = f"redirecting to {self.MALFORMED_IPV6} signin"
         assert contains_google_auth_redirect(text) is False
+
+
+class TestIsNotebookLMUnavailableRedirect:
+    """Tests for is_notebooklm_unavailable_redirect() — the region/anti-abuse gate (#1630)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notebooklm.google",
+            "https://notebooklm.google/",
+            "https://notebooklm.google/?location=unsupported",
+            "https://www.notebooklm.google/?location=unsupported",
+            "http://notebooklm.google",
+        ],
+    )
+    def test_marketing_host_is_gate(self, url: str):
+        assert is_notebooklm_unavailable_redirect(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # The APP host (with .com) is NOT the gate — the whole point.
+            "https://notebooklm.google.com",
+            "https://notebooklm.google.com/",
+            "https://notebooklm.google.com/notebook/abc",
+            "https://accounts.google.com/ServiceLogin",
+            # Spoofed lookalikes must not match.
+            "https://notebooklm.google.evil.com/",
+            "https://evil.com/notebooklm.google",
+            "https://fakenotebooklm.google/",
+            "",
+        ],
+    )
+    def test_non_gate_urls(self, url: str):
+        assert is_notebooklm_unavailable_redirect(url) is False
+
+
+class TestNotebookLMUnavailableLocation:
+    """Tests for notebooklm_unavailable_location() — surfaces the ?location= diagnostic."""
+
+    def test_extracts_location(self):
+        assert (
+            notebooklm_unavailable_location("https://notebooklm.google/?location=unsupported")
+            == "unsupported"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notebooklm.google/",
+            "https://notebooklm.google",
+            "https://notebooklm.google/?foo=bar",
+        ],
+    )
+    def test_no_location_returns_none(self, url: str):
+        assert notebooklm_unavailable_location(url) is None

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -184,6 +184,12 @@ class TestUrlParsingExceptionPaths:
         text = f"redirecting to {self.MALFORMED_IPV6} signin"
         assert contains_google_auth_redirect(text) is False
 
+    def test_is_notebooklm_unavailable_redirect_swallows_parse_error(self):
+        assert is_notebooklm_unavailable_redirect(self.MALFORMED_IPV6) is False
+
+    def test_notebooklm_unavailable_location_swallows_parse_error(self):
+        assert notebooklm_unavailable_location(self.MALFORMED_IPV6) is None
+
 
 class TestIsNotebookLMUnavailableRedirect:
     """Tests for is_notebooklm_unavailable_redirect() — the region/anti-abuse gate (#1630)."""
@@ -239,3 +245,16 @@ class TestNotebookLMUnavailableLocation:
     )
     def test_no_location_returns_none(self, url: str):
         assert notebooklm_unavailable_location(url) is None
+
+    def test_sanitizes_injected_value(self):
+        # The value lands in a user-facing error string: control chars / spaces /
+        # URL-shaped content are stripped, and the result is length-bounded.
+        assert (
+            notebooklm_unavailable_location(
+                "https://notebooklm.google/?location=un%0Asupported%20hi"
+            )
+            == "unsupportedhi"
+        )
+        assert notebooklm_unavailable_location("https://notebooklm.google/?location=%0A%20") is None
+        long = notebooklm_unavailable_location("https://notebooklm.google/?location=" + "a" * 200)
+        assert long is not None and len(long) == 64


### PR DESCRIPTION
## Summary
Fixes #1630. A request to `notebooklm.google.com` that Google's **region / anti-abuse risk-control** declines is redirected to **`notebooklm.google/?location=unsupported`** (the marketing host — no CSRF token). The extractor only recognized `accounts.google.com` redirects, so it mislabeled this as *"page structure has changed"* (sending users to file a bug), and the URL scrubber swallowed the `?location=unsupported` diagnostic.

**This is not a regional-availability block.** The `location=unsupported` gate is *environmental* — VPN/proxy/datacenter IPs, IP↔timezone↔language mismatch, or non-browser access patterns — and fires even for accounts in supported regions. Re-running `notebooklm login` does **not** fix it (the cookies are fine). Confirmed via research + the prior identical report #890 (same `Final URL: https://notebooklm.google` after a *successful* `login --fresh`).

## Changes
- **`_url_utils.py`** — `is_notebooklm_unavailable_redirect()` (exact/subdomain match on `notebooklm.google`; provably never matches the app host `notebooklm.google.com`) + `notebooklm_unavailable_location()` (extracts and **sanitizes** the `?location=` token).
- **`_auth/extraction.py`** — classify the gate redirect in both `extract_csrf_from_html` / `extract_session_id_from_html` with an accurate message that names the cause and surfaces `location=unsupported`. Two subtle correctness points (both pinned by tests):
  - The final-URL gate check runs **before** the `contains_google_auth_redirect(html)` body scan, because the gate page itself carries an `accounts.google.com` sign-in link (would otherwise mis-route to "Authentication expired").
  - The message deliberately avoids `_AUTH_ERROR_SIGNALS`, so an *environmental* gate does **not** trigger a futile `NOTEBOOKLM_REFRESH_CMD` refresh subprocess.
- **`docs/troubleshooting.md`** — new section: the gate, how to confirm (open the app host in a normal browser on the same network), and the residential-IP / supported-region remediation.

## Behavior preserved
Still a `ValueError` (caller/retry contract unchanged). The app host and spoofed lookalikes never match the new classifier; a genuine token-less response from `notebooklm.google.com` still yields the original "page structure" message.

## Test plan
- [x] `pytest tests/unit/test_url_utils.py tests/unit/test_auth_extraction.py` → 125 passed (classifier, sanitizer, both extractors, app-host/lookalike negatives, body-link ordering for both extractors, the refresh-signal invariant)
- [x] full guardrails (1037), ruff, mypy, freshness — all green

A diagnosis comment with the user-facing remediation is already posted on #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when NotebookLM redirects to an unsupported region/access gate, including a clearer “region / anti-abuse access gate” message.
  * Ensures the redirect state takes precedence over expired-login and page-structure error detection.
  * Added safer, sanitized handling of redirect details so user-facing messages stay concise without leaking unnecessary URL data.

* **Documentation**
  * Updated troubleshooting guide with a new section for this redirect message, including an “environmental confirm” checklist and recommended network/locale settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->