### PR TITLE
fix(chat): surface oversized-request errors instead of "No parseable chunks"

### DIFF
--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -329,9 +329,20 @@ def _extract_chunk_with_parseable(
             # recognized error payload is not a successfully decoded
             # envelope. The error-payload path raises, so flow only
             # reaches the next iteration when item[5] was absent/unusable.
+            #
+            # A successful streamed answer ALWAYS carries a string ``inner_json``
+            # (the answer JSON), so a null-inner ``wrb.fr`` only ever arrives on
+            # the server-side error channel. The first slot of ``item[5]`` is a
+            # gRPC-style status code: ``8`` (RESOURCE_EXHAUSTED) is the rate
+            # limit handled above; ``3`` (INVALID_ARGUMENT) is what an oversized
+            # request returns (``["wrb.fr", null, ..., [3]]``). Before this
+            # guard, every non-rate-limit status silently fell through to "no
+            # parseable chunks", masking real errors like the request-size
+            # ceiling — surface it instead (issue #1634).
             error_payload = frame.error_payload
             if error_payload is not None:
                 raise_if_rate_limited(error_payload)
+                _raise_chat_status_error_frame(error_payload)
             continue
 
         try:
@@ -428,6 +439,37 @@ def _raise_chat_error_frame(item: list) -> NoReturn:
         f"Chat request failed: the server returned an error frame{detail}. "
         "This usually means the request was rejected or the conversation "
         "could not be served; try again."
+    )
+
+
+def _raise_chat_status_error_frame(error_payload: list) -> NoReturn:
+    """Surface a non-rate-limit ``wrb.fr`` error payload as a ``ChatError``.
+
+    A streamed answer always carries a string ``inner_json``; a null-inner
+    ``wrb.fr`` frame is the server-side error channel, where ``error_payload``
+    (``item[5]``) leads with a gRPC-style status code. ``8``
+    (RESOURCE_EXHAUSTED) is the rate limit handled by
+    :func:`raise_if_rate_limited` before this call; the load-bearing case here
+    is ``3`` (INVALID_ARGUMENT), which an oversized request returns
+    (``["wrb.fr", null, ..., [3]]``). Such errors previously collapsed into the
+    generic ``ChatResponseParseError`` ("No parseable chunks …"), masking the
+    real cause (issue #1634). The status code is echoed; code ``3`` adds the
+    request-size hint since that is its common trigger.
+    """
+    code = ErrorPayloadRow(error_payload).status_code
+    if code == 3:
+        raise ChatError(
+            "Chat request failed: the server rejected it (status code 3, "
+            "INVALID_ARGUMENT). This usually means the request was too large — "
+            "the question, or the accumulated conversation history, exceeded the "
+            "server's size limit; shorten the question or start a new "
+            "conversation and try again."
+        )
+    detail = f" (status code {code!r})" if code is not None else ""
+    raise ChatError(
+        f"Chat request failed: the server returned an error{detail} with no "
+        "answer payload. The request was rejected or could not be served; "
+        "try again."
     )
 
 

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -450,13 +450,29 @@ class ErrorPayloadRow:
     """Typed view of a streamed-chat error payload (``item[5]``).
 
     Structure: ``[8, None, [["type.googleapis.com/.../UserDisplayableError", …]]]``.
-    Centralises the ``error_payload[2]`` and inner ``entry[0]`` reads so
-    ``raise_if_rate_limited`` stops open-coding them (issue #1491).
+    The leading slot is a gRPC-style status code (``8`` = RESOURCE_EXHAUSTED for
+    the rate limit, ``3`` = INVALID_ARGUMENT for an oversized request whose
+    payload is the bare ``[3]``). Centralises the ``error_payload[0]`` status,
+    ``error_payload[2]`` entries, and inner ``entry[0]`` reads so the chat error
+    handlers stop open-coding them (issues #1491, #1634).
     """
 
     _raw: list[Any] = field(repr=False)
 
+    _STATUS_CODE_POS: ClassVar[int] = 0
     _ENTRIES_POS: ClassVar[int] = 2
+
+    @property
+    def status_code(self) -> Any:
+        """Leading gRPC-style status code at ``error_payload[0]`` — ``None`` if absent.
+
+        A short or non-list payload yields ``None`` (no usable code); the slot
+        is read with a length guard, not ``safe_index`` — an error payload is
+        itself the failure signal, so a missing code is not schema drift.
+        """
+        if not isinstance(self._raw, list) or len(self._raw) <= self._STATUS_CODE_POS:
+            return None
+        return self._raw[self._STATUS_CODE_POS]
 
     @property
     def entries(self) -> list[Any]:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -84,7 +84,7 @@ class TestFramePositionContract:
         ) == (0, 2, 2, 5)
 
     def test_error_payload_positions_pinned(self) -> None:
-        assert ErrorPayloadRow._ENTRIES_POS == 2
+        assert (ErrorPayloadRow._STATUS_CODE_POS, ErrorPayloadRow._ENTRIES_POS) == (0, 2)
 
     def test_text_leaf_positions_pinned(self) -> None:
         assert TextLeafRow._TEXT_POS == 2
@@ -325,6 +325,16 @@ class TestErrorPayloadRow:
     @pytest.mark.parametrize("entry", [[], [123], "x", None])
     def test_non_string_entry_type_is_none(self, entry: object) -> None:
         assert ErrorPayloadRow.entry_type(entry) is None
+
+    def test_status_code_reads_leading_slot(self) -> None:
+        # Rate-limit payload leads with 8 (RESOURCE_EXHAUSTED); the bare
+        # oversized-request payload is [3] (INVALID_ARGUMENT) — see issue #1634.
+        assert ErrorPayloadRow([8, None, [["x"]]]).status_code == 8
+        assert ErrorPayloadRow([3]).status_code == 3
+
+    @pytest.mark.parametrize("payload", [[], "x"])
+    def test_status_code_absent_or_non_list_is_none(self, payload: object) -> None:
+        assert ErrorPayloadRow(payload).status_code is None
 
 
 class TestTextLeafRow:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -714,6 +714,60 @@ def test_error_frame_without_code_still_surfaces_chat_error() -> None:
         parse_streaming_chat_response(_length_prefixed(error_frame))
 
 
+def test_oversize_request_status_frame_surfaces_chat_error() -> None:
+    """An oversized request must surface the size-limit error, not a parse error.
+
+    When the question (or accumulated history) exceeds the server's size limit,
+    the chat endpoint returns a null-inner ``wrb.fr`` frame carrying the bare
+    status payload ``[3]`` (gRPC INVALID_ARGUMENT) and no answer chunk. The
+    trailing ``["e", n, null, null, N]`` frame is a batchexecute byte-count
+    trailer (``N`` = response bytes), NOT an error code — it appears on every
+    streamed response. The parser previously recognised neither the ``[3]``
+    status nor surfaced anything, so the response collapsed into the generic
+    ``ChatResponseParseError`` ("No parseable chunks …"), masking the real
+    cause (issue #1634).
+    """
+    # The exact wire frame sequence captured in issue #1634 (the "e" frame's
+    # 132 is the byte count of this small error response, not a code).
+    response = _length_prefixed(
+        json.dumps([["wrb.fr", None, None, None, None, [3]]]),
+        json.dumps([["di", 198], ["af.httprm", 197, "-1460015816955467607", 6]]),
+        json.dumps([["e", 4, None, None, 132]]),
+    )
+
+    with pytest.raises(ChatError, match=r"status code 3.*too large") as raised:
+        parse_streaming_chat_response(response)
+
+    assert "INVALID_ARGUMENT" in str(raised.value)
+
+
+def test_benign_byte_count_e_frame_does_not_raise() -> None:
+    """A streamed answer ending in the ``"e"`` byte-count trailer parses cleanly.
+
+    Guards the #1634 fix against the naive "treat every ``e`` frame as an error"
+    approach: the trailer ``["e", 24, null, null, 441040]`` rides on every
+    successful response and must never be mistaken for an error.
+    """
+    answer = _chunk("The answer.", conversation_id="conv")
+    byte_count_trailer = json.dumps([["e", 24, None, None, 441040]])
+    response = _length_prefixed(answer, byte_count_trailer)
+
+    result = parse_streaming_chat_response(response)
+    assert result.answer == "The answer."
+
+
+def test_non_rate_limit_error_payload_surfaces_generic_chat_error() -> None:
+    """A null-inner ``wrb.fr`` with an unrecognized status code still raises.
+
+    Any non-rate-limit error payload on the null-inner channel surfaces a
+    ``ChatError`` echoing the status code rather than collapsing into the
+    generic parse error (issue #1634)."""
+    error_frame = json.dumps([["wrb.fr", None, None, None, None, [7]]])
+
+    with pytest.raises(ChatError, match=r"status code 7"):
+        parse_streaming_chat_response(_length_prefixed(error_frame))
+
+
 def test_chat_wire_static_import_guard() -> None:
     forbidden = {
         "notebooklm",


### PR DESCRIPTION
## Summary

An oversized chat request (a very long question, or a large accumulated conversation history) returns a null-inner `wrb.fr` frame carrying the bare status payload `[3]` (gRPC `INVALID_ARGUMENT`) and no answer chunk. The streamed-chat parser only special-cased the rate-limit payload (status `8`, `RESOURCE_EXHAUSTED` via `UserDisplayableError`), so the `[3]` status silently fell through to zero parseable chunks and raised the generic:

```
ChatResponseParseError: No parseable chunks in streaming chat response (6 lines scanned)...
```

…instead of surfacing the real cause. This now raises a clear `ChatError`.

## Related Issue

Closes #1634

## Changes

- `_chat/wire.py`: in the null-inner-`wrb.fr` branch (the server-side error channel), after the existing rate-limit check, surface any remaining error payload as a `ChatError` echoing its leading gRPC-style status code via a new `_raise_chat_status_error_frame` helper. Status `3` adds a "request too large" hint since that is its common trigger.
- `_row_adapters/chat.py`: add `ErrorPayloadRow.status_code` (the `error_payload[0]` slot) and pin it in the position contract.
- Tests: the exact #1634 wire capture now raises `ChatError` (status 3); a regression test asserts a normal answer ending in the byte-count trailer still parses; an unrecognized status code surfaces a generic `ChatError`.

## Root cause

A successful streamed answer **always** carries a string `inner_json` (verified across all chat cassettes), so a null-inner `wrb.fr` frame only ever arrives on the error channel, where `item[5]` leads with a gRPC-style status code. Only `8` was handled; every other code (including `3`) degraded to the misleading parse error.

## Note on the issue's hypothesis

The issue pinned the error on the trailing `["e", n, null, null, N]` frame and proposed treating `tag in ("er", "e")` as an error. Investigation showed that frame is a **batchexecute byte-count trailer** (`N` = cumulative response bytes, present on *every* streamed response — e.g. `["e",24,null,null,441040]` ends a successful 440 KB answer). The `132`/`133` in the report were simply the byte size of the small error body, **not** an error code. Keying off the `"e"` tag would have raised on every chat call (it broke 8 chat integration tests in a local trial); the real, stable signal is the `wrb.fr` `[3]` status payload. A regression test guards against the byte-count-trailer false positive.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest ... --cov-fail-under=90` → 10424 passed, 92% coverage)
- [x] Linting and formatting pass (`uv run ruff check .` / `ruff format --check .`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] No architectural shape change; no ADR needed.

## Notes

The fix handles the error channel generically (any non-rate-limit status code surfaces a `ChatError` instead of collapsing into a parse error), so future server-side status codes on this channel are no longer masked. The position-sensitive `item[5][0]` read is centralised in `ErrorPayloadRow` per the repo's row-adapter convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFpW8w1gMQVXN9kHS5MTLD)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed chat error handling so rejected or malformed server responses now surface clearer error messages instead of a generic parse failure.
  * Oversized requests now report a more specific invalid-argument message.
  * Non-rate-limit server status codes are now shown in the error details.
  * Preserved correct parsing for valid streamed responses, including benign trailer frames.
* **Tests**
  * Added coverage for oversized requests, unknown server error codes, and valid trailer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->