### PR TITLE
fix(chat): surface oversized-question rejection instead of generic parse error

### DIFF
--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -338,10 +338,12 @@ def _extract_chunk_with_parseable(
             #
             # Don't flip ``parseable`` here: a null inner_json is not a
             # successfully decoded envelope. Both raise paths below are
-            # ``NoReturn`` for a recognized rejection, so flow only reaches the
-            # next iteration when item[5] was absent/empty.
+            # ``NoReturn``, and any present payload (``is not None`` — even an
+            # empty ``[]``, which ``_raise_chat_rejection`` reports without a
+            # status) is treated as a rejection, so flow only reaches the next
+            # iteration when item[5] was absent or a non-list.
             error_payload = frame.error_payload
-            if error_payload:
+            if error_payload is not None:
                 raise_if_rate_limited(error_payload)
                 _raise_chat_rejection(error_payload)
             continue
@@ -430,8 +432,9 @@ def _raise_chat_rejection(error_payload: list) -> NoReturn:
     centralises the ``error_payload[0]`` position (issue #1491).
     """
     status = ErrorPayloadRow(error_payload).status_code
+    detail = f" (status {status!r})" if status is not None else ""
     raise ChatError(
-        f"Chat request was rejected by the server (status {status!r}). "
+        f"Chat request was rejected by the server{detail}. "
         "This usually means the request was malformed or too large — e.g. an "
         "over-long question (there is a ~5.5k-character ceiling); shorten it "
         "and try again."

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -324,14 +324,26 @@ def _extract_chunk_with_parseable(
 
         inner_json = frame.inner_json
         if not isinstance(inner_json, str):
-            # item[2] is null — check item[5] for a server-side error payload.
-            # Don't flip ``parseable`` here: a null inner_json without a
-            # recognized error payload is not a successfully decoded
-            # envelope. The error-payload path raises, so flow only
-            # reaches the next iteration when item[5] was absent/unusable.
+            # item[2] is null — this ``wrb.fr`` carries no answer JSON. In real
+            # traffic that only happens when the server rejected the request and
+            # put a status/error payload at item[5] instead (a successful
+            # answer/heartbeat frame always has a *string* at item[2]; no live
+            # capture has ever shown a null-item[2] ``wrb.fr`` on success).
+            # Surface it rather than silently skipping, which collapsed every
+            # rejection into the generic "no parseable chunks" failure
+            # (issue #1472). The error code is NOT the ``["e", ...]`` /
+            # ``["di", ...]`` / ``["af.httprm", ...]`` frames elsewhere in the
+            # response — those are batchexecute stream bookkeeping and their
+            # trailing number is a running byte count, not a code.
+            #
+            # Don't flip ``parseable`` here: a null inner_json is not a
+            # successfully decoded envelope. Both raise paths below are
+            # ``NoReturn`` for a recognized rejection, so flow only reaches the
+            # next iteration when item[5] was absent/empty.
             error_payload = frame.error_payload
-            if error_payload is not None:
+            if error_payload:
                 raise_if_rate_limited(error_payload)
+                _raise_chat_rejection(error_payload)
             continue
 
         try:
@@ -402,6 +414,28 @@ def _extract_chunk_with_parseable(
         # "API drift" / ``ChatResponseParseError``.
 
     return None, False, refs, None, parseable
+
+
+def _raise_chat_rejection(error_payload: list) -> NoReturn:
+    """Surface a ``wrb.fr`` request-rejection (status at item[5]) as a ``ChatError``.
+
+    A streamed-chat ``wrb.fr`` frame with a null inner JSON (no answer) but a
+    non-empty payload at item[5] is a server rejection — e.g. an over-long
+    question yields ``["wrb.fr", None, None, None, None, [3]]`` (issue #1472),
+    where ``[3]`` is a grpc-style status (``3`` == ``INVALID_ARGUMENT``). The
+    caller has already run :func:`raise_if_rate_limited` for the richer
+    ``UserDisplayableError`` shape, so this is the catch-all for the bare-status
+    rejection that previously collapsed into the generic "no parseable chunks"
+    error. The status is echoed so callers see the real failure. ``ErrorPayloadRow``
+    centralises the ``error_payload[0]`` position (issue #1491).
+    """
+    status = ErrorPayloadRow(error_payload).status_code
+    raise ChatError(
+        f"Chat request was rejected by the server (status {status!r}). "
+        "This usually means the request was malformed or too large — e.g. an "
+        "over-long question (there is a ~5.5k-character ceiling); shorten it "
+        "and try again."
+    )
 
 
 def _raise_chat_error_frame(item: list) -> NoReturn:

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -435,9 +435,9 @@ def _raise_chat_rejection(error_payload: list) -> NoReturn:
     detail = f" (status {status!r})" if status is not None else ""
     raise ChatError(
         f"Chat request was rejected by the server{detail}. "
-        "This usually means the request was malformed or too large — e.g. an "
-        "over-long question (there is a ~5.5k-character ceiling); shorten it "
-        "and try again."
+        "This usually means the request was malformed or too large — most often "
+        "an over-long question past the server-side size limit; shorten it and "
+        "try again."
     )
 
 

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -449,14 +449,26 @@ class StreamFrameRow:
 class ErrorPayloadRow:
     """Typed view of a streamed-chat error payload (``item[5]``).
 
-    Structure: ``[8, None, [["type.googleapis.com/.../UserDisplayableError", …]]]``.
-    Centralises the ``error_payload[2]`` and inner ``entry[0]`` reads so
-    ``raise_if_rate_limited`` stops open-coding them (issue #1491).
+    Structure: ``[8, None, [["type.googleapis.com/.../UserDisplayableError", …]]]``
+    for the rich rate-limit shape, or a bare ``[3]`` status for a request-level
+    rejection (issue #1472). Centralises the ``error_payload[0]`` status, the
+    ``error_payload[2]`` entries, and the inner ``entry[0]`` reads so
+    ``raise_if_rate_limited`` / ``_raise_chat_rejection`` stop open-coding them
+    (issue #1491).
     """
 
     _raw: list[Any] = field(repr=False)
 
+    _STATUS_POS: ClassVar[int] = 0
     _ENTRIES_POS: ClassVar[int] = 2
+
+    @property
+    def status_code(self) -> Any:
+        """Leading status/code at ``error_payload[0]`` (e.g. ``3`` for a bare
+        ``[3]`` rejection, ``8`` for the rate-limit shape) — ``None`` if absent."""
+        if not self._raw:
+            return None
+        return self._raw[self._STATUS_POS]
 
     @property
     def entries(self) -> list[Any]:

--- a/tests/cassettes/chat_ask_oversized_rejection.yaml
+++ b/tests/cassettes/chat_ask_oversized_rejection.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2264832f19-cce2-4d59-a69e-4763c5ca57ea%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782537130637&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '296'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=rLM1Ne&source-path=%2Fnotebook%2F64832f19-cce2-4d59-a69e-4763c5ca57ea&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        400
+
+        [["wrb.fr","rLM1Ne","[[\"T#1472 scratch oversized rejection\",null,\"64832f19-cce2-4d59-a69e-4763c5ca57ea\",\"\",null,[1,false,true,null,null,[1782537131,665112000],1,false,[1782537131,443988000],null,null,null,false,true,1,false,null,true,1,null,null,null,false],null,null,null,[true,true,true],[6,500,300,500000,2]]]",null,null,null,"generic"],["di",169],["af.httprm",169,"-8485418463010796162",8]]
+
+        23
+
+        [["e",4,null,null,438]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '438'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Sat, 27 Jun 2026 05:12:11 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:11 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5Bnull%2C%22%5B%5B%5D%2C%5C%22Summarize%20the%20following%20requirement%20in%20detail%3A%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%5C%22%2Cnull%2C%5B2%2Cnull%2C%5B1%5D%2C%5B1%5D%5D%2Cnull%2Cnull%2Cnull%2C%5C%2264832f19-cce2-4d59-a69e-4763c5ca57ea%5C%22%2C1%5D%22%5D&at=SCRUBBED_CSRF%3A1782537130637&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '12567'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed?bl=boq_labs-tailwind-frontend_20260301.03_p0&hl=en&_reqid=200000&rt=c&f.sid=SCRUBBED
+  response:
+    body:
+      string: ')]}''
+
+
+        36
+
+        [["wrb.fr",null,null,null,null,[3]]]
+
+        55
+
+        [["di",156],["af.httprm",156,"-8343793854737661657",8]]
+
+        23
+
+        [["e",4,null,null,132]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '132'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Sat, 27 Jun 2026 05:12:12 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 27-Jun-2027 05:12:12 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_chat_oversized_rejection_vcr.py
+++ b/tests/integration/test_chat_oversized_rejection_vcr.py
@@ -1,0 +1,150 @@
+"""Oversized-question rejection streaming-chat VCR cassette.
+
+Regression guard for discussion #1472. The streaming-chat endpoint rejects an
+over-long question (above a ~5.5k-character ceiling) with a ``wrb.fr`` frame
+that carries **no answer JSON** (null ``item[2]``) and a bare grpc-style status
+at ``item[5]`` — e.g.::
+
+    [["wrb.fr", null, null, null, null, [3]]]   # 3 == INVALID_ARGUMENT
+    [["di", 198], ["af.httprm", 197, "...", 6]]
+    [["e", 4, null, null, 132]]                  # stream bookkeeping, NOT the error
+
+The pre-fix parser only surfaced ``"er"`` frames and the
+``UserDisplayableError`` payload shape, so this bare-status rejection collapsed
+into the generic ``ChatResponseParseError`` ("No parseable chunks ..."), masking
+the real cause. The ``["e", ...]`` trailer is a batchexecute stream terminator
+whose trailing number is a running byte count, not an error code — so the fix
+must NOT key off it. ``_chat/wire.py`` now raises a :class:`ChatError`
+("rejected by the server (status 3) ...") instead.
+
+This cassette captures one real rejection so the surfacing stays covered in
+integration (not just the synthetic unit test in
+``tests/unit/test_streaming_chat_wire.py``).
+
+Recording
+---------
+::
+
+    NOTEBOOKLM_VCR_RECORD=1 uv run pytest \\
+        tests/integration/test_chat_oversized_rejection_vcr.py -v -s
+
+A fresh scratch notebook is created/deleted OUTSIDE the cassette context (its
+now-deleted UUID is read back from the cassette on replay). No sources are
+needed — the size rejection fires before retrieval. The ``ask`` call is expected
+to raise ``ChatError`` during recording; the HTTP interaction is still captured
+because VCR records at the transport layer, before the parser runs.
+
+Replay
+------
+Opts into the ``freq`` body matcher (the ``GenerateFreeFormStreamed`` POST has no
+``rpcids`` to match on); ``freq`` disambiguates by param count + ``notebook_id``
+at slot 7. The recorded notebook id is read out of the cassette and passed back
+into ``ask`` so the replayed request matches the recording.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+
+import pytest
+import yaml
+
+from notebooklm import NotebookLMClient
+from notebooklm.exceptions import ChatError
+from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+CASSETTE_NAME = "chat_ask_oversized_rejection.yaml"
+CASSETTE_PATH = Path(__file__).parent.parent / "cassettes" / CASSETTE_NAME
+
+_MATCH_ON = ["method", "scheme", "host", "port", "path", "freq"]
+
+
+def _oversized_question() -> str:
+    """A deterministic, PII-free question past the ~5.5k-char ceiling.
+
+    Built from a fixed word list cycled by index (no RNG, so it is identical
+    across Python versions and between record and replay). The server limit is
+    token-based, not character-based, so this targets ~10k chars — comfortably
+    past the live trigger point (empirically ~8k for this vocabulary) while
+    keeping the recorded cassette small.
+    """
+    words = (  # noqa: SIM905 — readable prose source, not a hand-maintained list
+        "agent loop context window subagent skill orchestration retrieval citation "
+        "notebook source artifact podcast transcript embedding token prompt latency "
+        "concurrency idempotency schema decoder encoder envelope batchexecute rpc"
+    ).split()
+    out = ["Summarize the following requirement in detail:"]
+    i = 0
+    while sum(len(w) + 1 for w in out) < 10000:
+        out.append(words[i % len(words)])
+        i += 1
+    return " ".join(out)
+
+
+def _recorded_notebook_id() -> str:
+    """Read the scratch ``notebook_id`` (slot 7) out of the recorded cassette."""
+    assert CASSETTE_PATH.exists(), (
+        f"cassette missing: {CASSETTE_PATH}. "
+        "Re-record with NOTEBOOKLM_VCR_RECORD=1 — see module docstring."
+    )
+    with CASSETTE_PATH.open(encoding="utf-8") as fh:
+        cassette = yaml.safe_load(fh)
+
+    chat = [
+        i
+        for i in cassette.get("interactions", [])
+        if "GenerateFreeFormStreamed" in i.get("request", {}).get("uri", "")
+    ]
+    assert len(chat) == 1, (
+        f"expected exactly one GenerateFreeFormStreamed interaction in {CASSETTE_NAME}, "
+        f"found {len(chat)}"
+    )
+    body = chat[0]["request"]["body"]
+    if isinstance(body, bytes):
+        body = body.decode("utf-8")
+    params: list[Any] = json.loads(json.loads(parse_qs(body)["f.req"][0])[1])
+    assert len(params) > 7, f"cassette params too short ({len(params)}); re-record."
+    notebook_id = params[7]
+    assert isinstance(notebook_id, str), f"slot 7 (notebook_id) not a string: {notebook_id!r}"
+    return notebook_id
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_oversized_question_raises_chat_error_not_parse_error() -> None:
+    """An over-long question surfaces a ``ChatError`` rejection, not a parse error.
+
+    The assertion is the regression: pre-fix this raised
+    ``ChatResponseParseError`` ("No parseable chunks ..."). The message must name
+    the server status so the real failure (request too large) reaches the caller.
+    """
+    auth = await get_vcr_auth()
+    question = _oversized_question()
+    async with NotebookLMClient(auth) as client:
+        if _vcr_record_mode:
+            notebook = await client.notebooks.create("T#1472 scratch oversized rejection")
+            notebook_id = notebook.id
+            try:
+                with (
+                    notebooklm_vcr.use_cassette(CASSETTE_NAME, match_on=_MATCH_ON),
+                    pytest.raises(ChatError),
+                ):
+                    await client.chat.ask(notebook_id, question)
+            finally:
+                try:
+                    await client.notebooks.delete(notebook_id)
+                except Exception:  # noqa: BLE001 — best-effort scratch cleanup
+                    pass
+        else:
+            notebook_id = _recorded_notebook_id()
+            with (
+                notebooklm_vcr.use_cassette(CASSETTE_NAME, match_on=_MATCH_ON),
+                pytest.raises(ChatError, match=r"rejected by the server \(status"),
+            ):
+                await client.chat.ask(notebook_id, question)

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -324,9 +324,12 @@ class TestErrorPayloadRow:
 
     @pytest.mark.parametrize(
         ("payload", "expected"),
-        [([3], 3), ([8, None, []], 8), ([], None)],
+        [([3], 3), ([8, None, []], 8), ([], None), ([None], None)],
     )
     def test_status_code_reads_leading_slot(self, payload: list, expected: object) -> None:
+        # ``[None]`` (leading slot present but null) yields ``None`` — the
+        # rejection message then omits the status detail rather than printing
+        # ``(status None)``.
         assert ErrorPayloadRow(payload).status_code == expected
 
     @pytest.mark.parametrize("entry", [[], [123], "x", None])

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -84,7 +84,7 @@ class TestFramePositionContract:
         ) == (0, 2, 2, 5)
 
     def test_error_payload_positions_pinned(self) -> None:
-        assert ErrorPayloadRow._ENTRIES_POS == 2
+        assert (ErrorPayloadRow._STATUS_POS, ErrorPayloadRow._ENTRIES_POS) == (0, 2)
 
     def test_text_leaf_positions_pinned(self) -> None:
         assert TextLeafRow._TEXT_POS == 2
@@ -321,6 +321,13 @@ class TestErrorPayloadRow:
     @pytest.mark.parametrize("payload", [[8, None], [8, None, "x"], []])
     def test_absent_or_non_list_entries_degrade(self, payload: list) -> None:
         assert ErrorPayloadRow(payload).entries == []
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [([3], 3), ([8, None, []], 8), ([], None)],
+    )
+    def test_status_code_reads_leading_slot(self, payload: list, expected: object) -> None:
+        assert ErrorPayloadRow(payload).status_code == expected
 
     @pytest.mark.parametrize("entry", [[], [123], "x", None])
     def test_non_string_entry_type_is_none(self, entry: object) -> None:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -714,6 +714,46 @@ def test_error_frame_without_code_still_surfaces_chat_error() -> None:
         parse_streaming_chat_response(_length_prefixed(error_frame))
 
 
+def test_oversized_request_rejection_surfaces_status_not_parse_error() -> None:
+    """A null-inner ``wrb.fr`` with an item[5] status payload is a rejection.
+
+    The server rejects an over-long question with a ``wrb.fr`` frame carrying no
+    answer JSON (null item[2]) and a bare grpc-style status at item[5]
+    (``[3]`` == ``INVALID_ARGUMENT``), followed by ``di`` / ``af.httprm`` / ``e``
+    stream-bookkeeping frames. The parser used to skip the status frame and
+    raise the generic "No parseable chunks" error, masking the real cause
+    (discussion #1472). It now raises a :class:`ChatError` echoing the status.
+
+    The body below is byte-for-byte the real captured rejection from #1472 — the
+    ``["e", 4, None, None, 132]`` trailer is deliberately included to pin that it
+    is NOT treated as the error (its trailing ``132`` is a response byte count,
+    not an error code).
+    """
+    wire = _length_prefixed(
+        json.dumps([["wrb.fr", None, None, None, None, [3]]]),
+        json.dumps([["di", 198], ["af.httprm", 197, "-1460015816955467607", 6]]),
+        json.dumps([["e", 4, None, None, 132]]),
+    )
+
+    with pytest.raises(ChatError, match=r"rejected by the server \(status 3\)"):
+        parse_streaming_chat_response(wire)
+
+
+def test_e_terminator_frame_does_not_break_successful_answer() -> None:
+    """A trailing ``"e"`` stream terminator must not turn a good answer into an error.
+
+    Successful streamed responses end with an ``["e", n, None, None, bytes]``
+    bookkeeping frame (the trailing number is a running byte count). Regression
+    guard for discussion #1472: the ``"e"`` tag must stay inert so a valid
+    answer parses normally instead of raising.
+    """
+    body = _length_prefixed(_chunk("Real answer."), json.dumps([["e", 15, None, None, 41687]]))
+
+    result = parse_streaming_chat_response(body)
+
+    assert result.answer == "Real answer."
+
+
 def test_chat_wire_static_import_guard() -> None:
     forbidden = {
         "notebooklm",

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -739,6 +739,19 @@ def test_oversized_request_rejection_surfaces_status_not_parse_error() -> None:
         parse_streaming_chat_response(wire)
 
 
+def test_null_inner_frame_with_empty_payload_still_raises_without_status() -> None:
+    """A null-inner ``wrb.fr`` with an empty ``[]`` payload is not swallowed.
+
+    Guards the ``is not None`` (not truthy) check: a present-but-empty item[5]
+    has no status to report, but the frame still carries no answer, so it must
+    raise a rejection rather than collapse into "No parseable chunks".
+    """
+    wire = _length_prefixed(json.dumps([["wrb.fr", None, None, None, None, []]]))
+
+    with pytest.raises(ChatError, match=r"rejected by the server\."):
+        parse_streaming_chat_response(wire)
+
+
 def test_e_terminator_frame_does_not_break_successful_answer() -> None:
     """A trailing ``"e"`` stream terminator must not turn a good answer into an error.
 

--- a/tests/unit/test_vcr_scrubbing.py
+++ b/tests/unit/test_vcr_scrubbing.py
@@ -230,3 +230,32 @@ def test_scrub_response_helper_scrubs_set_cookie_token(
     joined = "".join(set_cookie) if isinstance(set_cookie, list) else set_cookie
     assert "g.a000" not in joined, f"Set-Cookie token leaked:\n{joined}"
     assert "LSID=SCRUBBED" in joined
+
+
+def test_scrub_response_scrubs_lowercase_set_cookie_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``scrub_response`` scrubs a lowercase ``set-cookie`` header (HTTP/2).
+
+    Google serves HTTP/2, whose header names are lowercase, so a fresh recording
+    carries ``set-cookie`` (not the title-case ``Set-Cookie`` older cassettes
+    have). A case-sensitive lookup would leave the live session token unscrubbed
+    — this pins the case-insensitive match.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_VCR_RECORD_ERRORS", raising=False)
+    vcr_config_path = Path(__file__).resolve().parent.parent / "vcr_config.py"
+    spec = importlib.util.spec_from_file_location("tests_vcr_config_scrub_ci", vcr_config_path)
+    assert spec is not None and spec.loader is not None
+    vcr_config = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(vcr_config)
+
+    response: dict[str, Any] = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"set-cookie": [f"SIDCC={_G_A000}; expires=Sun, 27-Jun-2027; path=/; Secure"]},
+        "body": {"string": b"[]"},
+    }
+    out = vcr_config.scrub_response(response)
+    set_cookie = out["headers"]["set-cookie"]
+    joined = "".join(set_cookie) if isinstance(set_cookie, list) else set_cookie
+    assert "g.a000" not in joined, f"lowercase set-cookie token leaked:\n{joined}"
+    assert "SIDCC=SCRUBBED" in joined

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -217,6 +217,24 @@ def _substitute_synthetic_error(response: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
+def _ci_header_key(headers: dict[str, Any], name: str) -> str | None:
+    """Return the actual key in ``headers`` matching ``name`` case-insensitively.
+
+    Google serves HTTP/2, whose header names are lowercase (``set-cookie``),
+    while older cassettes were recorded with title-case (``Set-Cookie``). A
+    case-sensitive ``name in headers`` check misses the lowercase form and
+    silently leaves live ``Set-Cookie`` session tokens unscrubbed — the
+    ``test_cassette_shapes`` guard would catch the leak, but the scrubber must
+    prevent it, not merely rely on detection. Returns the first matching key or
+    ``None``.
+    """
+    lowered = name.lower()
+    for key in headers:
+        if key.lower() == lowered:
+            return key
+    return None
+
+
 def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     """Scrub sensitive data from recorded HTTP response.
 
@@ -270,12 +288,13 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     # cookie pair's value while preserving the cookie attributes (Path / Domain
     # / Expires / Secure / HttpOnly / ...). Both passes are idempotent.
     headers = response.get("headers", {})
-    if "Set-Cookie" in headers:
-        cookies = headers["Set-Cookie"]
+    cookie_key = _ci_header_key(headers, "Set-Cookie")
+    if cookie_key is not None:
+        cookies = headers[cookie_key]
         if isinstance(cookies, list):
-            headers["Set-Cookie"] = [scrub_set_cookie(scrub_string(c)) for c in cookies]
+            headers[cookie_key] = [scrub_set_cookie(scrub_string(c)) for c in cookies]
         elif isinstance(cookies, str):
-            headers["Set-Cookie"] = scrub_set_cookie(scrub_string(cookies))
+            headers[cookie_key] = scrub_set_cookie(scrub_string(cookies))
 
     # Scrub resumable-upload session tokens echoed in response headers. The
     # ``X-Goog-Upload-(Control-)URL`` values embed ``upload_id=<token>`` (handled
@@ -284,14 +303,16 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     # a fresh recording leaks per-upload tokens past ``scrub_response`` (the guard
     # catches them, but the scrubber should prevent them — not just detect).
     for _name in ("X-Goog-Upload-URL", "X-Goog-Upload-Control-URL"):
-        if _name in headers:
-            _vals = headers[_name]
-            headers[_name] = (
+        _key = _ci_header_key(headers, _name)
+        if _key is not None:
+            _vals = headers[_key]
+            headers[_key] = (
                 [scrub_string(v) for v in _vals] if isinstance(_vals, list) else scrub_string(_vals)
             )
-    if "X-GUploader-UploadID" in headers:
-        _vals = headers["X-GUploader-UploadID"]
-        headers["X-GUploader-UploadID"] = (
+    _uploader_key = _ci_header_key(headers, "X-GUploader-UploadID")
+    if _uploader_key is not None:
+        _vals = headers[_uploader_key]
+        headers[_uploader_key] = (
             ["SCRUBBED_UPLOAD_ID" for _ in _vals]
             if isinstance(_vals, list)
             else "SCRUBBED_UPLOAD_ID"

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -217,22 +217,20 @@ def _substitute_synthetic_error(response: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
-def _ci_header_key(headers: dict[str, Any], name: str) -> str | None:
-    """Return the actual key in ``headers`` matching ``name`` case-insensitively.
+def _ci_header_keys(headers: dict[str, Any], name: str) -> list[str]:
+    """Return ALL keys in ``headers`` matching ``name`` case-insensitively.
 
     Google serves HTTP/2, whose header names are lowercase (``set-cookie``),
     while older cassettes were recorded with title-case (``Set-Cookie``). A
     case-sensitive ``name in headers`` check misses the lowercase form and
     silently leaves live ``Set-Cookie`` session tokens unscrubbed — the
     ``test_cassette_shapes`` guard would catch the leak, but the scrubber must
-    prevent it, not merely rely on detection. Returns the first matching key or
-    ``None``.
+    prevent it, not merely rely on detection. Returns *every* matching key (not
+    just the first) so a dict carrying both ``Set-Cookie`` and ``set-cookie``
+    gets every token-bearing entry scrubbed, not one.
     """
     lowered = name.lower()
-    for key in headers:
-        if key.lower() == lowered:
-            return key
-    return None
+    return [key for key in headers if key.lower() == lowered]
 
 
 def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
@@ -288,8 +286,7 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     # cookie pair's value while preserving the cookie attributes (Path / Domain
     # / Expires / Secure / HttpOnly / ...). Both passes are idempotent.
     headers = response.get("headers", {})
-    cookie_key = _ci_header_key(headers, "Set-Cookie")
-    if cookie_key is not None:
+    for cookie_key in _ci_header_keys(headers, "Set-Cookie"):
         cookies = headers[cookie_key]
         if isinstance(cookies, list):
             headers[cookie_key] = [scrub_set_cookie(scrub_string(c)) for c in cookies]
@@ -303,14 +300,12 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     # a fresh recording leaks per-upload tokens past ``scrub_response`` (the guard
     # catches them, but the scrubber should prevent them — not just detect).
     for _name in ("X-Goog-Upload-URL", "X-Goog-Upload-Control-URL"):
-        _key = _ci_header_key(headers, _name)
-        if _key is not None:
+        for _key in _ci_header_keys(headers, _name):
             _vals = headers[_key]
             headers[_key] = (
                 [scrub_string(v) for v in _vals] if isinstance(_vals, list) else scrub_string(_vals)
             )
-    _uploader_key = _ci_header_key(headers, "X-GUploader-UploadID")
-    if _uploader_key is not None:
+    for _uploader_key in _ci_header_keys(headers, "X-GUploader-UploadID"):
         _vals = headers[_uploader_key]
         headers[_uploader_key] = (
             ["SCRUBBED_UPLOAD_ID" for _ in _vals]


### PR DESCRIPTION
## What

Fixes #1634 (re #1472): an over-long chat question was rejected by the server but the client surfaced the generic `ChatResponseParseError` — *"No parseable chunks in streaming chat response"* — hiding the real cause.

## Root cause

The rejection lives in the **`wrb.fr` frame itself**, not a separate error frame:

```
[["wrb.fr", null, null, null, null, [3]]]   ← null inner JSON, [3] = grpc status at item[5]
[["di",198],["af.httprm",197,"…",6]]
[["e",4,null,null,132]]                      ← stream terminator, NOT the error
```

A successful/heartbeat frame always has a **string** at `item[2]`; no cassette in the corpus has a null-`item[2]` `wrb.fr` on success. The parser entered that branch but only checked `item[5]` for the richer `UserDisplayableError` (rate-limit) shape, so the bare `[3]` status (`3` == `INVALID_ARGUMENT`) was swallowed.

### Why not the discussion's suggested fix

Discussion #1472 proposed `if tag == "e": raise`. That is **wrong** — `"e"` is the batchexecute **stream terminator** present in *every* successful response (e.g. `[["e",4,null,null,438]]`); its trailing number is a running **byte count**, not an error code. The two live failures showed `132`/`133` despite inputs of 5,489 vs 72,487 chars — those are the ~132-byte sizes of the tiny error responses. Raising on `"e"` throws *after* a valid answer streamed (it breaks 7 chat integration tests). A regression test pins the terminator as inert.

## Fix

- `_chat/wire.py`: in the null-inner `wrb.fr` branch, after the existing rate-limit check, raise a `ChatError` (*"rejected by the server (status 3) … request too large; shorten it"*) via a new `ErrorPayloadRow.status_code` adapter property (keeps the #1491 positional-read convention — no raw subscripts).
- **Scrubber security fix (found while recording the cassette):** `scrub_response` matched response headers case-sensitively (`"Set-Cookie"`), but Google serves **HTTP/2 lowercase** headers (`set-cookie`), so live `SIDCC`/`__Secure-*PSIDCC` tokens landed **unscrubbed**. A `_ci_header_key` case-insensitive match now covers `Set-Cookie` and the `X-Goog-Upload-*` / `X-GUploader-UploadID` scrubs.

## Tests

- Unit: rejection surfaces the status; `"e"` terminator stays inert; `ErrorPayloadRow.status_code`; lowercase-`set-cookie` scrub.
- Integration: a record/replay VCR cassette (`chat_ask_oversized_rejection.yaml`) pinning the live rejection path.

## Verification

- Live-verified: oversized question → clear `ChatError`; short question → still answers (no false positive).
- `mypy` + `ruff` clean; full unit/integration/guardrails green (the 2 `test_auth_headless_reauth` failures are environmental — missing `--extra browser` in the dev venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming chat now consistently rejects server-side streamed errors with clear `ChatError` messages, including server status details when available, instead of generic parsing failures.
  * Oversized chat requests now surface status-aware server rejection behavior rather than “no parseable chunks.”
  * Response scrubbing now redacts token-bearing headers correctly even when HTTP/2 header keys arrive in lowercase (e.g., `set-cookie`).
* **Tests**
  * Added integration coverage for oversized chat rejections using a new VCR cassette.
  * Expanded unit tests for streamed rejection-frame edge cases and terminator-frame handling.
  * Added a unit test for lowercase `set-cookie` scrubbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->