### PR TITLE
fix: backport .md upload + access-gate redirect fixes to 0.7.x (#1628, #1630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Maintenance backports on the 0.7.x line (cherry-picked from `main` ahead of
+the v0.8.0 breaking release).
+
+### Fixed
+
+- **Markdown (`.md`) uploads no longer fail on Python 3.10** (backport of
+  #1628; fixes #1627). `mimetypes.guess_type` returns `None` for `.md` on
+  Python 3.10 and on hosts without a populated `/etc/mime.types`, so the upload
+  fell back to `application/octet-stream`; NotebookLM could not infer a parser
+  and processing failed server-side (status=ERROR), surfacing as
+  "Error uploading source" / `SourceProcessingError`. `.md`/`.markdown` are now
+  pinned to `text/markdown` before the opaque fallback.
+- **Clearer error when NotebookLM redirects to its region / anti-abuse access
+  gate** (backport of #1630). A redirect to `notebooklm.google` is now
+  classified and surfaced with an actionable message instead of an opaque
+  failure.
+
 ## [0.7.2] - 2026-06-18
 
 Maintenance patch on the 0.7.x line. Backports fixes from `main`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,6 +120,18 @@ await client.refresh_auth()
 ```
 Or re-run `notebooklm login` if session cookies are also expired. If the failure persists across re-login, the page structure has likely changed — file an issue and include the `Preview:` snippet from the error.
 
+#### "NotebookLM redirected this request to its region / anti-abuse access gate"
+
+**Cause:** The request to `notebooklm.google.com` was redirected to **`notebooklm.google/?location=unsupported`** — Google's region / anti-abuse risk-control gate (the marketing/landing page, which has no CSRF token). This is **not** a library bug, expired login, or page-structure change, and **re-running `notebooklm login` will not fix it** (the cookies are fine). It is driven by the *access environment*, not just the account's country, and fires even for accounts in supported regions when Google sees:
+
+- a **VPN / proxy / datacenter / shared IP** (especially previously-abused ones),
+- an **IP ↔ timezone ↔ browser-language mismatch**, or
+- a **non-browser / automated access pattern** (a raw HTTP client without a real browser fingerprint).
+
+**Confirm:** open `https://notebooklm.google.com` in a normal browser, signed in to the same account, on the same network. If it also redirects to `notebooklm.google/?location=unsupported`, the gate is environmental.
+
+**Solution:** access from a **residential connection in a supported region**, keep your system **timezone/language consistent** with the IP's country, and avoid shared/datacenter VPN exit IPs. (See issue [#1630](https://github.com/teng-lin/notebooklm-py/issues/1630).)
+
 #### Browser opens but login fails
 
 **Cause:** Google detecting automation and blocking login.

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 import re
 from urllib.parse import urlparse
 
-from .._url_utils import contains_google_auth_redirect, is_google_auth_redirect
+from .._url_utils import (
+    contains_google_auth_redirect,
+    is_google_auth_redirect,
+    is_notebooklm_unavailable_redirect,
+    notebooklm_unavailable_location,
+)
 from ..exceptions import AuthExtractionError
 
 
@@ -178,6 +183,26 @@ def _safe_url(url: str) -> str:
     return f"{parsed.scheme}://{netloc}{path}"
 
 
+def _unavailable_redirect_message(final_url: str) -> str:
+    """Build the access-gate message for a redirect to ``notebooklm.google``.
+
+    The redirect is Google's region / anti-abuse gate (commonly
+    ``?location=unsupported``), not expired auth or a page-structure change. We
+    surface the ``location`` parameter explicitly because :func:`_safe_url` drops
+    the query — and that parameter is the actual diagnostic.
+    """
+    location = notebooklm_unavailable_location(final_url)
+    where = _safe_url(final_url)
+    target = f"{where} (location={location})" if location else where
+    return (
+        f"NotebookLM redirected this request to its region / anti-abuse access gate: "
+        f"{target}. This is not a library bug or an expired login. Likely a VPN/proxy "
+        "or datacenter IP, or an IP/timezone/language mismatch. Verify by opening "
+        "https://notebooklm.google.com in a normal browser on the same network; if it "
+        "redirects there too, use a residential connection in a supported region."
+    )
+
+
 def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     """
     Extract CSRF token (SNlM0e) from NotebookLM page HTML.
@@ -206,8 +231,14 @@ def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     token = extract_wiz_field(html, "SNlM0e", strict=False)
     if token is not None:
         return token
-    # Drift path: differentiate "auth expired" from "shape changed" because
-    # the remediation differs (re-login vs file a bug).
+    # Drift path: differentiate "access gate" / "auth expired" / "shape changed"
+    # because the remediation differs (fix environment / re-login / file a bug).
+    # The *final URL* is the authoritative landing signal, so it is checked
+    # before the weaker ``contains_google_auth_redirect(html)`` body scan — the
+    # ``notebooklm.google`` gate page itself carries an ``accounts.google.com``
+    # sign-in link, which would otherwise mis-route it to "auth expired" (#1630).
+    if is_notebooklm_unavailable_redirect(final_url):
+        raise ValueError(_unavailable_redirect_message(final_url))
     if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
         raise ValueError(
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
@@ -241,6 +272,10 @@ def extract_session_id_from_html(html: str, final_url: str = "") -> str:
     sid = extract_wiz_field(html, "FdrFJe", strict=False)
     if sid is not None:
         return sid
+    # Final-URL landing host is authoritative; check it before the body scan
+    # (the gate page carries an accounts.google.com link). See extract_csrf.
+    if is_notebooklm_unavailable_redirect(final_url):
+        raise ValueError(_unavailable_redirect_message(final_url))
     if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
         raise ValueError(
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -261,6 +261,16 @@ _MEDIA_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 _STRICT_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = ()
 _HTML_UPLOAD_SUFFIXES = frozenset({".html", ".htm", ".xhtml", ".xht"})
 _HTML_UPLOAD_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
+# ``mimetypes.guess_type`` returns ``None`` for some text suffixes on Python 3.10
+# and on hosts without a populated ``/etc/mime.types`` (notably ``.md``). Without
+# an override the upload falls back to ``application/octet-stream`` (see
+# ``_resolve_upload_content_type``), NotebookLM cannot infer how to parse the
+# file, and processing fails with status=ERROR. Pin the types we know NotebookLM
+# accepts so upload works regardless of the host's MIME table.
+_EXTENSION_CONTENT_TYPES: dict[str, str] = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+}
 
 
 # Single-loop-per-client invariant per ADR-0004; not safe for multi-loop fan-out.
@@ -448,7 +458,11 @@ def _resolve_upload_content_type(file_path: Path, mime_type: str | None) -> str:
         return content_type
 
     guessed, _encoding = mimetypes.guess_type(file_path.name)
-    return guessed or "application/octet-stream"
+    if guessed:
+        return guessed
+    # Fall back to the pinned overrides before the opaque octet-stream default
+    # (see ``_EXTENSION_CONTENT_TYPES`` for why; #1627).
+    return _EXTENSION_CONTENT_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
 
 
 def _normalize_content_type(content_type: str) -> str:

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -5,7 +5,16 @@ flagged by CodeQL (py/incomplete-url-substring-sanitization).
 """
 
 import re
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
+
+# The NotebookLM marketing/landing host (note: no ``.com``). A request to the
+# app host ``notebooklm.google.com`` is redirected here — typically
+# ``notebooklm.google/?location=unsupported`` — when Google's region /
+# anti-abuse risk-control declines the request's *environment* (VPN/proxy or
+# datacenter IP, IP/timezone/language mismatch, non-browser access pattern).
+# This is distinct from the ``accounts.google.com`` login redirect (expired or
+# invalid auth) and from a genuine page-structure change.
+_NOTEBOOKLM_MARKETING_HOST = "notebooklm.google"
 
 
 def is_youtube_url(url: str) -> bool:
@@ -64,3 +73,57 @@ def contains_google_auth_redirect(text: str) -> bool:
     url_pattern = r'https?://[^\s"\'<>]+'
     urls = re.findall(url_pattern, text)
     return any(is_google_auth_redirect(url) for url in urls)
+
+
+def is_notebooklm_unavailable_redirect(url: str) -> bool:
+    """Check if a URL is the NotebookLM marketing/landing host (an access gate).
+
+    A request to the app (``notebooklm.google.com``) redirected to the bare
+    ``notebooklm.google`` host means Google's region / anti-abuse risk-control
+    declined the request's environment — *not* expired auth (that goes to
+    ``accounts.google.com``) and *not* a page-structure change. The bare host is
+    distinguished from the app host purely by the absent ``.com`` suffix, so an
+    exact / subdomain match on ``notebooklm.google`` never matches
+    ``notebooklm.google.com``.
+
+    Args:
+        url: URL to check (typically ``response.url`` after redirects).
+
+    Returns:
+        True if the URL is the ``notebooklm.google`` landing host.
+    """
+    try:
+        hostname = (urlparse(url).hostname or "").lower()
+        return hostname == _NOTEBOOKLM_MARKETING_HOST or hostname.endswith(
+            "." + _NOTEBOOKLM_MARKETING_HOST
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def notebooklm_unavailable_location(url: str) -> str | None:
+    """Return the ``location`` query value from a NotebookLM access-gate URL.
+
+    Surfaces the diagnostic Google attaches to the marketing redirect (e.g.
+    ``"unsupported"`` from ``notebooklm.google/?location=unsupported``) so the
+    cause is visible even though the URL scrubber drops the rest of the query.
+    Returns ``None`` when absent or unparseable.
+
+    Args:
+        url: URL to inspect (typically ``response.url`` after redirects).
+    """
+    try:
+        values = parse_qs(urlparse(url).query).get("location")
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if not values:
+        return None
+    # Sequence unpacking (not ``values[0]``) — the parse-qs list isn't an RPC row,
+    # but the positional-indexing guardrail can't tell; the guard above keeps the
+    # unpack safe.
+    first, *_ = values
+    # The value lands in a user-facing error string, so keep only a bounded,
+    # sane diagnostic token (e.g. ``unsupported``) — never echo arbitrary,
+    # newline-bearing, or URL-shaped query content.
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "", first)[:64]
+    return sanitized or None

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -73,7 +73,11 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # it is irreducible without splitting these modules, which is out of scope for
     # the bug fix. New ceilings are the measured post-fix LOC.
     "_artifacts.py": 1478,
-    "_source/upload.py": 1236,
+    # +14 LOC backporting the .md content-type pin (#1628): the override map
+    # plus its rationale comment and the fallback branch in
+    # ``_resolve_upload_content_type``. Irreducible without splitting the module,
+    # which is out of scope for a maintenance backport.
+    "_source/upload.py": 1250,
     "cli/session_cmd.py": 1080,
     "_sources.py": 1023,
     "cli/services/playwright_login.py": 988,

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -717,3 +717,71 @@ class TestExtractSessionIdRedirect:
 
         with pytest.raises(ValueError, match="Authentication expired"):
             extract_session_id_from_html(html)
+
+
+class TestUnavailableRedirectClassification:
+    """A redirect to notebooklm.google is the region/anti-abuse gate, not a drift (#1630)."""
+
+    _MARKETING_HTML = "<html><body>NotebookLM marketing splash — no WIZ_global_data.</body></html>"
+
+    def test_csrf_classifies_location_unsupported_redirect(self):
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._MARKETING_HTML, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "location=unsupported" in msg  # the diagnostic is surfaced, not swallowed
+        assert "page structure" not in msg  # NOT the misleading file-a-bug message
+
+    def test_session_id_classifies_redirect(self):
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(self._MARKETING_HTML, "https://notebooklm.google")
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "page structure" not in msg
+
+    def test_app_host_drift_still_says_page_structure(self):
+        # A token-less response from the real APP host (not the gate) keeps the
+        # original "page structure" message — the gate branch must not capture it.
+        with pytest.raises(ValueError, match="page structure"):
+            extract_csrf_from_html(self._MARKETING_HTML, "https://notebooklm.google.com/")
+
+    # The real notebooklm.google gate page carries an accounts.google.com sign-in
+    # link; the authoritative final-URL gate check must win over the body scan,
+    # otherwise it mis-routes to "Authentication expired" (the codex finding).
+    _GATE_HTML_WITH_SIGNIN = (
+        '<html><body>NotebookLM <a href="https://accounts.google.com/ServiceLogin">'
+        "Sign in</a></body></html>"
+    )
+
+    def test_csrf_gate_wins_over_accounts_link_in_body(self):
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "Authentication expired" not in msg
+
+    def test_session_id_gate_wins_over_accounts_link_in_body(self):
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        msg = str(exc.value)
+        assert "region / anti-abuse access gate" in msg
+        assert "Authentication expired" not in msg
+
+    def test_gate_message_does_not_trigger_auto_refresh(self):
+        # An environmental gate must NOT match the auth-error signals that drive
+        # NOTEBOOKLM_REFRESH_CMD — re-auth can't fix it, so refreshing is futile.
+        # Pin it so a careless reword of the message can't silently re-enable it.
+        from notebooklm._auth.refresh import _AUTH_ERROR_SIGNALS
+
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._GATE_HTML_WITH_SIGNIN, "https://notebooklm.google/?location=unsupported"
+            )
+        lowered = str(exc.value).lower()
+        assert not any(signal in lowered for signal in _AUTH_ERROR_SIGNALS)

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -149,6 +149,57 @@ def test_resolve_upload_content_type_blank_mime_raises() -> None:
         _resolve_upload_content_type(Path("a.bin"), "   ")
 
 
+def test_resolve_upload_content_type_md_uses_markdown_when_mimetypes_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``.md`` resolves to ``text/markdown`` even when ``mimetypes`` misses.
+
+    Python 3.10 and hosts without a system MIME table return ``None`` for
+    ``.md``; the pinned override prevents a fall back to
+    ``application/octet-stream``, which NotebookLM cannot infer a parser for
+    (processing then fails server-side with status=ERROR).
+    """
+    import mimetypes
+    from pathlib import Path
+
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("notes.md"), None) == "text/markdown"
+    assert _resolve_upload_content_type(Path("NOTES.MARKDOWN"), None) == "text/markdown"
+
+
+def test_resolve_upload_content_type_unknown_suffix_falls_back_to_octet_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A suffix with no MIME guess and no override still falls back to octet-stream."""
+    import mimetypes
+    from pathlib import Path
+
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("blob.unknownext"), None) == "application/octet-stream"
+
+
+def test_resolve_upload_content_type_override_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pinned override sits last in precedence: explicit mime > guess > override.
+
+    The override only fills the gap when ``mimetypes`` misses (#1627); it must not
+    shadow an explicit mime_type or a successful guess, and it keys on the final
+    suffix only (so ``notes.md.txt`` is not mistaken for markdown).
+    """
+    import mimetypes
+    from pathlib import Path
+
+    # Explicit mime_type wins over the pinned ``.md`` override.
+    assert _resolve_upload_content_type(Path("notes.md"), "text/plain") == "text/plain"
+    # A successful guess wins over the override (sentinel proves the guess path ran).
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: ("application/x-sentinel", None))
+    assert _resolve_upload_content_type(Path("notes.md"), None) == "application/x-sentinel"
+    # On a miss, the override keys on the actual suffix: ``.md.txt`` -> ``.txt`` -> octet-stream.
+    monkeypatch.setattr(mimetypes, "guess_type", lambda _name: (None, None))
+    assert _resolve_upload_content_type(Path("notes.md.txt"), None) == "application/octet-stream"
+
+
 def test_extract_register_file_source_id_ambiguous_field_candidates() -> None:
     """Two distinct context-matched SOURCE_IDs are ambiguous -> None (line 271).
 

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -9,7 +9,9 @@ import pytest
 from notebooklm._url_utils import (
     contains_google_auth_redirect,
     is_google_auth_redirect,
+    is_notebooklm_unavailable_redirect,
     is_youtube_url,
+    notebooklm_unavailable_location,
 )
 
 
@@ -181,3 +183,78 @@ class TestUrlParsingExceptionPaths:
         # swallowed.
         text = f"redirecting to {self.MALFORMED_IPV6} signin"
         assert contains_google_auth_redirect(text) is False
+
+    def test_is_notebooklm_unavailable_redirect_swallows_parse_error(self):
+        assert is_notebooklm_unavailable_redirect(self.MALFORMED_IPV6) is False
+
+    def test_notebooklm_unavailable_location_swallows_parse_error(self):
+        assert notebooklm_unavailable_location(self.MALFORMED_IPV6) is None
+
+
+class TestIsNotebookLMUnavailableRedirect:
+    """Tests for is_notebooklm_unavailable_redirect() — the region/anti-abuse gate (#1630)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notebooklm.google",
+            "https://notebooklm.google/",
+            "https://notebooklm.google/?location=unsupported",
+            "https://www.notebooklm.google/?location=unsupported",
+            "http://notebooklm.google",
+        ],
+    )
+    def test_marketing_host_is_gate(self, url: str):
+        assert is_notebooklm_unavailable_redirect(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # The APP host (with .com) is NOT the gate — the whole point.
+            "https://notebooklm.google.com",
+            "https://notebooklm.google.com/",
+            "https://notebooklm.google.com/notebook/abc",
+            "https://accounts.google.com/ServiceLogin",
+            # Spoofed lookalikes must not match.
+            "https://notebooklm.google.evil.com/",
+            "https://evil.com/notebooklm.google",
+            "https://fakenotebooklm.google/",
+            "",
+        ],
+    )
+    def test_non_gate_urls(self, url: str):
+        assert is_notebooklm_unavailable_redirect(url) is False
+
+
+class TestNotebookLMUnavailableLocation:
+    """Tests for notebooklm_unavailable_location() — surfaces the ?location= diagnostic."""
+
+    def test_extracts_location(self):
+        assert (
+            notebooklm_unavailable_location("https://notebooklm.google/?location=unsupported")
+            == "unsupported"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notebooklm.google/",
+            "https://notebooklm.google",
+            "https://notebooklm.google/?foo=bar",
+        ],
+    )
+    def test_no_location_returns_none(self, url: str):
+        assert notebooklm_unavailable_location(url) is None
+
+    def test_sanitizes_injected_value(self):
+        # The value lands in a user-facing error string: control chars / spaces /
+        # URL-shaped content are stripped, and the result is length-bounded.
+        assert (
+            notebooklm_unavailable_location(
+                "https://notebooklm.google/?location=un%0Asupported%20hi"
+            )
+            == "unsupportedhi"
+        )
+        assert notebooklm_unavailable_location("https://notebooklm.google/?location=%0A%20") is None
+        long = notebooklm_unavailable_location("https://notebooklm.google/?location=" + "a" * 200)
+        assert long is not None and len(long) == 64


### PR DESCRIPTION
## Summary

Two runtime bug-fix backports from `main` to the **0.7.x maintenance line**, both merged after v0.7.2 and absent from `release/v0.7.x`:

- **#1628** — `fix(sources): pin .md content-type for uploads on Python 3.10` (fixes #1627)
- **#1630** — `fix(auth): classify notebooklm.google access-gate redirect`

## Why these

0.7.x supports Python `>=3.10`, so #1628 affects real users: on 3.10 (or any host without `/etc/mime.types`) `mimetypes.guess_type(".md")` returns `None`, the upload falls back to `application/octet-stream`, and NotebookLM fails processing server-side (`status=ERROR`) — surfacing as "Error uploading source" / `SourceProcessingError`. #1630 turns an opaque auth redirect failure into an actionable message.

## Backport notes

- **#1628 was applied manually**, not cherry-picked: on `main` the resolver moved to `_source/_upload_decode.py`, but on 0.7.x it still lives in `_source/upload.py`. The change (the `_EXTENSION_CONTENT_TYPES` override + fallback) and its three unit tests are otherwise identical to the original.
- **#1630 cherry-picked cleanly** (`-x`, auto-merge on docs/test files).

## Verification

```
ruff check + format --check  → clean
mypy src/notebooklm/_source/upload.py → Success
pytest test_source_upload_coverage.py test_auth_extraction.py → 92 passed
```

CHANGELOG `[Unreleased]` updated with both entries.

Out of scope (considered, deferred): #1636 (chat error-quality, not a crash), #1607 (dev-only vcrpy bump), #1629 (hardens a feature not on 0.7.x), #1582 (read-path forward-compat hardening, no active break).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

