### PR TITLE
feat(auth): surface account/PSIDTS/master-token identity in auth check (#1640)

### DIFF
--- a/src/notebooklm/_app/auth_check.py
+++ b/src/notebooklm/_app/auth_check.py
@@ -32,10 +32,26 @@ import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+#: Cookie that carries the rotating session-freshness binding. Most likely to be
+#: missing/stale, so ``auth check`` surfaces it as a first-class field.
+_PSIDTS_COOKIE = "__Secure-1PSIDTS"
+
+#: Missing-PSIDTS guidance for a master-token profile, where a missing
+#: ``__Secure-1PSIDTS`` at rest is normal (it is minted on the first
+#: authenticated call, and at bootstrap since #1638) — the browser-extraction /
+#: App-Bound Encryption hint is wrong here.
+_MASTER_TOKEN_PSIDTS_HINT = (
+    f"A master_token.json is present, so a missing {_PSIDTS_COOKIE} at rest is "
+    "normal for this profile — it is minted on the first authenticated call (and "
+    "at bootstrap since #1638). Run 'notebooklm auth check --test' to mint and "
+    "verify, or re-run 'notebooklm login --master-token'."
+)
 
 
 @dataclass(frozen=True)
@@ -137,6 +153,83 @@ def _read_storage_state(
         return None, f"Storage unreadable: {exc}"
 
 
+def _psidts_status(storage_state: dict[str, Any]) -> dict[str, Any]:
+    """First-class ``__Secure-1PSIDTS`` presence + expiry, read from raw cookies.
+
+    Read straight off ``storage_state`` (not the domain-filtered extracted set)
+    so the field is available even when ``extract_cookies_from_storage`` raises
+    on a missing-PSIDTS profile. ``expires`` is the Playwright epoch-seconds
+    field; ``-1`` (session cookie) / missing maps to ``None``.
+    """
+    for cookie in storage_state.get("cookies", []):
+        if cookie.get("name") != _PSIDTS_COOKIE:
+            continue
+        expires_at: str | None = None
+        expires = cookie.get("expires")
+        if isinstance(expires, (int, float)) and expires > 0:
+            try:
+                expires_at = datetime.fromtimestamp(expires, tz=timezone.utc).isoformat()
+            except (OverflowError, ValueError, OSError):
+                # A corrupt/out-of-range epoch must not abort the whole check
+                # (auth check has no error envelope, and a broken session — the
+                # case it diagnoses — is the most likely to carry garbage here).
+                expires_at = None
+        return {"present": True, "expires_at": expires_at}
+    return {"present": False, "expires_at": None}
+
+
+def _account_info(plan: AuthCheckPlan, storage_state: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the persisted account ``{email, authuser}`` for this profile.
+
+    For env-var auth the in-band record lives in the parsed inline JSON; for a
+    file profile, the on-disk reader also consults the legacy sibling record.
+    """
+    from ..auth import (
+        get_account_email_for_storage,
+        get_authuser_for_storage,
+        read_account_metadata_from_storage_state,
+    )
+
+    if plan.has_env_auth:
+        meta = read_account_metadata_from_storage_state(storage_state)
+        email = meta.get("email") if isinstance(meta.get("email"), str) else None
+        raw_authuser = meta.get("authuser")
+        # Clamp to match the file path's get_authuser_for_storage (negatives → 0).
+        authuser = raw_authuser if isinstance(raw_authuser, int) and raw_authuser >= 0 else 0
+        return {"email": email or None, "authuser": authuser}
+    return {
+        "email": get_account_email_for_storage(plan.storage_path),
+        "authuser": get_authuser_for_storage(plan.storage_path),
+    }
+
+
+def _master_token_status(plan: AuthCheckPlan) -> dict[str, Any]:
+    """Note a sibling ``master_token.json`` (headless master-token profile).
+
+    The record lives beside ``storage_state.json`` (login --master-token writes
+    both into the profile dir), so resolve it relative to the actual storage path
+    — this also honors a ``--storage`` override. Env-var auth carries no profile
+    directory, so master-token is N/A there.
+    """
+    if plan.has_env_auth:
+        return {"present": False, "path": None, "account": None}
+
+    from ..auth import read_master_token
+
+    path = plan.storage_path.with_name("master_token.json")
+    if not path.exists():
+        return {"present": False, "path": str(path), "account": None}
+    account: str | None = None
+    try:
+        record = read_master_token(path)
+    except Exception as exc:  # malformed/unreadable — still report presence
+        logger.debug("master_token.json present but unreadable: %s", exc)
+        record = None
+    if record:
+        account = record.get("email")
+    return {"present": True, "path": str(path), "account": account}
+
+
 async def run_auth_check(
     plan: AuthCheckPlan,
     *,
@@ -151,6 +244,11 @@ async def run_auth_check(
 
     ``read_env_auth_json`` is injected (the CLI's consolidated accessor) so the
     neutral core reads the inline-auth payload without touching ``os.environ``.
+
+    The live ``--test`` ``notebook_count`` signal is *not* computed here: it needs
+    an opened ``NotebookLMClient``, which the transport-neutral core intentionally
+    does not construct. The CLI command layer adds it into ``details`` after this
+    returns (only when ``token_fetch`` passed and the probe is non-passive).
     """
     from ..auth import extract_cookies_from_storage
 
@@ -180,6 +278,15 @@ async def run_auth_check(
         return AuthCheckResult(plan=plan, checks=checks, details=details)
     checks["json_valid"] = True
 
+    # Identity + location facts (the same source of truth both renderers read,
+    # so the Rich table and --json envelope can never disagree — issue #1640).
+    details["account"] = _account_info(plan, storage_state)
+    details["profile"] = plan.profile
+    master_token = _master_token_status(plan)
+    psidts = _psidts_status(storage_state)
+    details["master_token"] = master_token
+    details["psidts"] = psidts
+
     # Check 3: cookies present + SID lookup.
     try:
         cookies = extract_cookies_from_storage(storage_state)
@@ -196,7 +303,16 @@ async def run_auth_check(
         details["cookies_by_domain"] = cookies_by_domain
         details["cookie_domains"] = sorted(cookies_by_domain.keys())
     except ValueError as exc:
-        details["error"] = str(exc)
+        # The default missing-cookie hint blames browser-cookie extraction
+        # (App-Bound Encryption). For a master-token profile a missing PSIDTS is
+        # normal and self-heals — but only when PSIDTS is the *sole* missing
+        # required cookie (SID present). If SID is also missing the session is
+        # not recoverable, so keep the generic hint.
+        sid_present = any(c.get("name") == "SID" for c in storage_state.get("cookies", []))
+        if sid_present and not psidts["present"] and master_token["present"]:
+            details["error"] = _MASTER_TOKEN_PSIDTS_HINT
+        else:
+            details["error"] = str(exc)
         return AuthCheckResult(plan=plan, checks=checks, details=details)
 
     # Check 4: optional token-fetch round-trip. ``passive`` selects the

--- a/src/notebooklm/_app/auth_check.py
+++ b/src/notebooklm/_app/auth_check.py
@@ -49,8 +49,8 @@ _PSIDTS_COOKIE = "__Secure-1PSIDTS"
 _MASTER_TOKEN_PSIDTS_HINT = (
     f"A master_token.json is present, so a missing {_PSIDTS_COOKIE} at rest is "
     "normal for this profile — it is minted on the first authenticated call (and "
-    "at bootstrap since #1638). Run 'notebooklm auth check --test' to mint and "
-    "verify, or re-run 'notebooklm login --master-token'."
+    "at bootstrap). Run 'notebooklm auth check --test' to mint and verify, or "
+    "re-run 'notebooklm login --master-token'."
 )
 
 
@@ -166,7 +166,9 @@ def _psidts_status(storage_state: dict[str, Any]) -> dict[str, Any]:
             continue
         expires_at: str | None = None
         expires = cookie.get("expires")
-        if isinstance(expires, (int, float)) and expires > 0:
+        # ``bool`` is an ``int`` subclass — a stray ``expires: true`` must not be
+        # read as epoch 1.
+        if isinstance(expires, (int, float)) and not isinstance(expires, bool) and expires > 0:
             try:
                 expires_at = datetime.fromtimestamp(expires, tz=timezone.utc).isoformat()
             except (OverflowError, ValueError, OSError):
@@ -192,10 +194,12 @@ def _account_info(plan: AuthCheckPlan, storage_state: dict[str, Any]) -> dict[st
 
     if plan.has_env_auth:
         meta = read_account_metadata_from_storage_state(storage_state)
-        email = meta.get("email") if isinstance(meta.get("email"), str) else None
+        raw_email = meta.get("email")
+        email = raw_email.strip() if isinstance(raw_email, str) else ""
         raw_authuser = meta.get("authuser")
-        # Clamp to match the file path's get_authuser_for_storage (negatives → 0).
-        authuser = raw_authuser if isinstance(raw_authuser, int) and raw_authuser >= 0 else 0
+        # Match the file path's get_authuser_for_storage: a real int only (``bool``
+        # is an ``int`` subclass, so exclude it), negatives clamped to 0.
+        authuser = raw_authuser if type(raw_authuser) is int and raw_authuser >= 0 else 0
         return {"email": email or None, "authuser": authuser}
     return {
         "email": get_account_email_for_storage(plan.storage_path),

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -159,6 +159,7 @@ __all__ = [
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "persist_minted_jar",
     "read_account_metadata",
+    "read_account_metadata_from_storage_state",
     "read_master_token",
     "REQUIRED_COOKIE_DOMAINS",
     "validate_with_recovery",
@@ -210,6 +211,7 @@ _account_context_path = _auth_account._account_context_path
 extract_email_from_html = _auth_account.extract_email_from_html
 _probe_authuser = _auth_account._probe_authuser
 read_account_metadata = _auth_account.read_account_metadata
+read_account_metadata_from_storage_state = _auth_account.read_account_metadata_from_storage_state
 get_authuser_for_storage = _auth_account.get_authuser_for_storage
 get_account_email_for_storage = _auth_account.get_account_email_for_storage
 format_authuser_value = _auth_account.format_authuser_value

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -249,18 +249,25 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
         table.add_row("Storage", "", details.get("storage_path", ""))
 
         master = details.get("master_token") or {}
+        mt_path = master.get("path")
         if master.get("present"):
             mt_account = master.get("account")
-            mt_text = master.get("path", "")
+            mt_text = mt_path or ""
             if mt_account:
                 mt_text = f"{mt_text} (account: {mt_account})"
             table.add_row("Master token", "[green]✓ present[/green]", mt_text)
         else:
-            table.add_row("Master token", "", "[dim]not present[/dim]")
+            # Name where we looked (matches the --json master_token.path), so the
+            # diagnostic is actionable even when the file is absent.
+            absent = f"[dim]not present ({mt_path})[/dim]" if mt_path else "[dim]not present[/dim]"
+            table.add_row("Master token", "", absent)
 
         psidts = details.get("psidts") or {}
         expires_at = psidts.get("expires_at")
-        psidts_detail = f"expires {expires_at}" if expires_at else "session cookie (no expiry)"
+        # ``expires_at`` is None for a genuine session cookie AND for a corrupt /
+        # unreadable epoch — "no expiry recorded" is accurate for both and avoids
+        # mislabeling an unparseable cookie as session-scoped.
+        psidts_detail = f"expires {expires_at}" if expires_at else "no expiry recorded"
         table.add_row(
             # Literal duplicated rather than imported — cli/ must not import
             # notebooklm._* privates (CLI-boundary gate).

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -203,13 +203,24 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
     details = result.details
 
     if plan.json_output:
-        json_output_response(
-            {
-                "status": "ok" if all_passed else "error",
-                "checks": checks,
-                "details": details,
-            }
-        )
+        # Promote the identity/location facts to top-level keys for CI gates
+        # (the same values the Rich table shows — sourced from one ``details``
+        # so the two surfaces can't disagree, issue #1640). ``notebook_count`` is
+        # only meaningful with --test, so it is emitted only then (null if the
+        # probe could not run).
+        payload = {
+            "status": "ok" if all_passed else "error",
+            "account": details.get("account"),
+            "profile": details.get("profile"),
+            "storage_path": details.get("storage_path"),
+            "master_token": details.get("master_token"),
+            "psidts": details.get("psidts"),
+            "checks": checks,
+            "details": details,
+        }
+        if plan.test_fetch:
+            payload["notebook_count"] = details.get("notebook_count")
+        json_output_response(payload)
         if not all_passed:
             exit_with_code(1)
         return
@@ -224,6 +235,39 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
         if val is None:
             return "[dim]⊘ skipped[/dim]"
         return "[green]✓ pass[/green]" if val else "[red]✗ fail[/red]"
+
+    # Identity + location rows (mirror the --json top-level fields). Present only
+    # once the storage JSON parsed; ``account`` is the sentinel for that.
+    if "account" in details:
+        account = details["account"] or {}
+        email = account.get("email")
+        account_text = (
+            f"{email} (authuser {account.get('authuser', 0)})" if email else "[dim]unknown[/dim]"
+        )
+        table.add_row("Account", "", account_text)
+        table.add_row("Profile", "", details.get("profile") or "[dim]default[/dim]")
+        table.add_row("Storage", "", details.get("storage_path", ""))
+
+        master = details.get("master_token") or {}
+        if master.get("present"):
+            mt_account = master.get("account")
+            mt_text = master.get("path", "")
+            if mt_account:
+                mt_text = f"{mt_text} (account: {mt_account})"
+            table.add_row("Master token", "[green]✓ present[/green]", mt_text)
+        else:
+            table.add_row("Master token", "", "[dim]not present[/dim]")
+
+        psidts = details.get("psidts") or {}
+        expires_at = psidts.get("expires_at")
+        psidts_detail = f"expires {expires_at}" if expires_at else "session cookie (no expiry)"
+        table.add_row(
+            # Literal duplicated rather than imported — cli/ must not import
+            # notebooklm._* privates (CLI-boundary gate).
+            "__Secure-1PSIDTS",
+            status_icon(bool(psidts.get("present"))),
+            psidts_detail if psidts.get("present") else "",
+        )
 
     table.add_row(
         "Storage exists",
@@ -246,6 +290,13 @@ def _render_auth_check_result(result: AuthCheckResult) -> None:
         status_icon(checks["token_fetch"]),
         "use --test to check" if checks["token_fetch"] is None else "",
     )
+    if plan.test_fetch:
+        count = details.get("notebook_count")
+        table.add_row(
+            "Notebooks",
+            "",
+            str(count) if count is not None else "[dim]n/a[/dim]",
+        )
 
     console.print(table)
 

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -291,7 +291,7 @@ def resolve_client_factory(
     return NotebookLMClient
 
 
-def auth_check_notebook_count(ctx) -> int | None:
+def auth_check_notebook_count(ctx: click.Context) -> int | None:
     """Best-effort live notebook count for ``auth check --test``; ``None`` on any
     failure.
 

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -291,6 +291,34 @@ def resolve_client_factory(
     return NotebookLMClient
 
 
+def auth_check_notebook_count(ctx) -> int | None:
+    """Best-effort live notebook count for ``auth check --test``; ``None`` on any
+    failure.
+
+    Both :func:`get_auth_tokens` and the client open run their own ``run_async``
+    (the CLI's single-top-level-loop invariant), so this MUST be called from sync
+    code -- never from inside ``run_async(run_auth_check(...))``, which would nest
+    event loops. The count never affects the exit code: ``token_fetch`` is the
+    authoritative validity check, so any failure here just leaves ``None``.
+    """
+    helpers = _helpers_facade()
+    try:
+        auth = get_auth_tokens(ctx)
+    except Exception as exc:  # auth resolution failed -- skip the optional count
+        logger.debug("auth check notebook-count: auth resolution failed: %s", exc)
+        return None
+
+    async def _count() -> int:
+        async with resolve_client_factory(ctx)(auth) as client:
+            return len(await client.notebooks.list())
+
+    try:
+        return helpers.run_async(_count())
+    except Exception as exc:
+        logger.debug("auth check notebook-count probe failed: %s", exc)
+        return None
+
+
 def run_client_workflow(
     ctx: click.Context,
     *,

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -43,7 +43,12 @@ from ._session_render import (
     _render_status,
     _use_notebook_table,
 )
-from .auth_runtime import handle_auth_error, resolve_client_factory, run_client_workflow
+from .auth_runtime import (
+    auth_check_notebook_count,
+    handle_auth_error,
+    resolve_client_factory,
+    run_client_workflow,
+)
 from .context import clear_context, set_current_notebook
 from .error_handler import _output_error, exit_with_code, handle_errors
 from .playwright_login_io import (
@@ -830,6 +835,19 @@ def register_session_commands(cli):
             ctx, test_fetch=test_fetch, json_output=json_output, passive=passive
         )
         result = run_async(run_auth_check(plan))
+
+        # Live notebook count: a "the API really accepts this session" signal
+        # beyond the homepage token round-trip. Computed here (not in the neutral
+        # core, which never opens a client) and only when the token fetch already
+        # passed. Skipped for --passive: opening a client may rotate/persist
+        # cookies, which the read-only contract (issue #1569) forbids.
+        if test_fetch and not passive and result.checks["token_fetch"] is True:
+            # cli-rpc-unenveloped: the notebook count is a best-effort liveness
+            # probe whose failures degrade to null, so this RPC must NOT route
+            # through the error envelope (a failed count must not fail the auth
+            # check or hijack its exit code).
+            result.details["notebook_count"] = auth_check_notebook_count(ctx)
+
         _render_auth_check_result(result)
 
     @auth_group.command("refresh")

--- a/tests/_guardrails/test_public_surface.py
+++ b/tests/_guardrails/test_public_surface.py
@@ -75,6 +75,7 @@ EXPECTED_AUTH_ALL: list[str] = [
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "persist_minted_jar",
     "read_account_metadata",
+    "read_account_metadata_from_storage_state",
     "read_master_token",
     "REQUIRED_COOKIE_DOMAINS",
     "validate_with_recovery",

--- a/tests/unit/app/test_app_auth_check.py
+++ b/tests/unit/app/test_app_auth_check.py
@@ -418,6 +418,18 @@ async def test_env_auth_reads_account_from_inline_json(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_env_auth_account_normalizes_whitespace_and_rejects_bool(tmp_path: Path) -> None:
+    """Env-auth account mirrors the file path: whitespace-only email → None, and a
+    bool authuser (``bool`` is an ``int`` subclass) falls back to 0."""
+    plan = _plan(storage_path=tmp_path / "ignored.json", has_env_auth=True)
+    state = _valid_storage_state()
+    state["notebooklm"] = {"account": {"email": "   ", "authuser": True}}
+    result = await run_auth_check(plan, read_env_auth_json=lambda: json.dumps(state))
+
+    assert result.details["account"] == {"email": None, "authuser": 0}
+
+
+@pytest.mark.asyncio
 async def test_missing_sid_and_psidts_keeps_generic_hint(tmp_path: Path) -> None:
     """When BOTH SID and PSIDTS are missing the session is unrecoverable, so the
     master-token hint must NOT fire even with a sibling master_token.json."""

--- a/tests/unit/app/test_app_auth_check.py
+++ b/tests/unit/app/test_app_auth_check.py
@@ -273,6 +273,170 @@ async def test_token_fetch_not_run_when_test_fetch_false(tmp_path: Path) -> None
 
 
 # ---------------------------------------------------------------------------
+# Identity + location facts (issue #1640)
+# ---------------------------------------------------------------------------
+
+
+def _storage_with_account(
+    *cookie_names: str, email: str | None = None, authuser: int = 0
+) -> dict[str, Any]:
+    """A valid storage_state carrying the in-band account namespace."""
+    state = _valid_storage_state(*cookie_names)
+    if email is not None:
+        state["notebooklm"] = {"account": {"email": email, "authuser": authuser}}
+    return state
+
+
+@pytest.mark.asyncio
+async def test_identity_fields_populated_from_storage(tmp_path: Path) -> None:
+    storage = tmp_path / "storage_state.json"
+    storage.write_text(
+        json.dumps(_storage_with_account("APISID", "SAPISID", email="you@gmail.com", authuser=2)),
+        encoding="utf-8",
+    )
+    plan = _plan(storage_path=storage, profile="github")
+
+    result = await run_auth_check(plan, read_env_auth_json=_never_read_env)
+
+    assert result.details["account"] == {"email": "you@gmail.com", "authuser": 2}
+    assert result.details["profile"] == "github"
+    assert result.details["storage_path"] == str(storage)
+    assert result.details["psidts"]["present"] is True
+    # No sibling master_token.json → reported absent with the path it looked for.
+    assert result.details["master_token"]["present"] is False
+    assert result.details["master_token"]["path"] == str(storage.with_name("master_token.json"))
+
+
+@pytest.mark.asyncio
+async def test_psidts_expiry_surfaced(tmp_path: Path) -> None:
+    storage = tmp_path / "storage_state.json"
+    storage.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "v", "domain": ".google.com", "path": "/"},
+                    {
+                        "name": "__Secure-1PSIDTS",
+                        "value": "v",
+                        "domain": ".google.com",
+                        "path": "/",
+                        "expires": 1_800_000_000,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = await run_auth_check(_plan(storage_path=storage), read_env_auth_json=_never_read_env)
+
+    psidts = result.details["psidts"]
+    assert psidts["present"] is True
+    # Epoch 1_800_000_000 → 2027-01-15T08:00:00+00:00 (UTC ISO).
+    assert psidts["expires_at"].startswith("2027-01-15T08:00:00")
+
+
+@pytest.mark.asyncio
+async def test_psidts_out_of_range_expiry_degrades_to_none(tmp_path: Path) -> None:
+    """A corrupt/out-of-range ``expires`` must not abort the check (auth check
+    has no error envelope); the field degrades to present + expires_at=None."""
+    storage = tmp_path / "storage_state.json"
+    storage.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "v", "domain": ".google.com", "path": "/"},
+                    {
+                        "name": "__Secure-1PSIDTS",
+                        "value": "v",
+                        "domain": ".google.com",
+                        "path": "/",
+                        "expires": 1e20,  # OverflowError from datetime.fromtimestamp
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = await run_auth_check(_plan(storage_path=storage), read_env_auth_json=_never_read_env)
+
+    assert result.details["psidts"] == {"present": True, "expires_at": None}
+
+
+@pytest.mark.asyncio
+async def test_master_token_present_and_account_read(tmp_path: Path) -> None:
+    storage = tmp_path / "storage_state.json"
+    storage.write_text(json.dumps(_valid_storage_state("APISID", "SAPISID")), encoding="utf-8")
+    auth_module.write_master_token(
+        storage.with_name("master_token.json"),
+        email="owner@gmail.com",
+        master_token="aas_et/secret",
+        android_id="0123456789abcdef",
+    )
+    result = await run_auth_check(_plan(storage_path=storage), read_env_auth_json=_never_read_env)
+
+    mt = result.details["master_token"]
+    assert mt["present"] is True
+    assert mt["account"] == "owner@gmail.com"
+    assert mt["path"] == str(storage.with_name("master_token.json"))
+
+
+@pytest.mark.asyncio
+async def test_missing_psidts_with_master_token_uses_corrected_hint(tmp_path: Path) -> None:
+    """A master-token profile missing PSIDTS at rest gets master-token guidance,
+    not the (wrong) browser-extraction / App-Bound Encryption hint."""
+    storage = tmp_path / "storage_state.json"
+    # SID + secondary binding present, but no __Secure-1PSIDTS (the recoverable,
+    # self-healing case for a master-token profile).
+    storage.write_text(json.dumps(_storage_state("SID", "APISID", "SAPISID")), encoding="utf-8")
+    auth_module.write_master_token(
+        storage.with_name("master_token.json"),
+        email="owner@gmail.com",
+        master_token="aas_et/secret",
+        android_id="0123456789abcdef",
+    )
+    result = await run_auth_check(_plan(storage_path=storage), read_env_auth_json=_never_read_env)
+
+    assert result.checks["cookies_present"] is False
+    assert "master_token.json is present" in result.details["error"]
+    assert "App-Bound Encryption" not in result.details["error"]
+    assert result.details["master_token"]["present"] is True
+
+
+@pytest.mark.asyncio
+async def test_env_auth_reads_account_from_inline_json(tmp_path: Path) -> None:
+    plan = _plan(
+        storage_path=tmp_path / "ignored.json",
+        has_env_auth=True,
+        profile="work",
+    )
+    inline = json.dumps(_storage_with_account(email="ci@gmail.com", authuser=1))
+    result = await run_auth_check(plan, read_env_auth_json=lambda: inline)
+
+    assert result.details["account"] == {"email": "ci@gmail.com", "authuser": 1}
+    # Env-auth has no profile directory → master-token is N/A.
+    assert result.details["master_token"] == {"present": False, "path": None, "account": None}
+
+
+@pytest.mark.asyncio
+async def test_missing_sid_and_psidts_keeps_generic_hint(tmp_path: Path) -> None:
+    """When BOTH SID and PSIDTS are missing the session is unrecoverable, so the
+    master-token hint must NOT fire even with a sibling master_token.json."""
+    storage = tmp_path / "storage_state.json"
+    # Neither SID nor __Secure-1PSIDTS — only the secondary binding pair.
+    storage.write_text(json.dumps(_storage_state("APISID", "SAPISID")), encoding="utf-8")
+    auth_module.write_master_token(
+        storage.with_name("master_token.json"),
+        email="owner@gmail.com",
+        master_token="aas_et/secret",
+        android_id="0123456789abcdef",
+    )
+    result = await run_auth_check(_plan(storage_path=storage), read_env_auth_json=_never_read_env)
+
+    assert result.checks["cookies_present"] is False
+    assert "master_token.json is present" not in result.details["error"]
+
+
+# ---------------------------------------------------------------------------
 # all_passed rollup
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -515,6 +515,47 @@ class TestAuthCheckCommand:
         output = json.loads(result.output)
         assert output["notebook_count"] == 3
 
+    def test_auth_check_never_leaks_secret_values(self, runner, tmp_path):
+        """auth check must surface identity (names, domains, paths, email) but
+        NEVER a secret value — no cookie values, no master_token value — in either
+        the Rich table or --json. Security invariant for issue #1640."""
+        storage = tmp_path / "storage_state.json"
+        secrets = {
+            "SID": "SID_SECRET_VALUE_abc123",
+            "__Secure-1PSIDTS": "PSIDTS_SECRET_VALUE_xyz789",
+            "APISID": "APISID_SECRET_VALUE",
+            "SAPISID": "SAPISID_SECRET_VALUE",
+        }
+        storage.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {"name": n, "value": v, "domain": ".google.com", "path": "/"}
+                        for n, v in secrets.items()
+                    ],
+                    "notebooklm": {"account": {"email": "you@gmail.com", "authuser": 0}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        master_secret = "aas_et/MASTER_TOKEN_SECRET_DO_NOT_LEAK"
+        auth_module.write_master_token(
+            storage.with_name("master_token.json"),
+            email="you@gmail.com",
+            master_token=master_secret,
+            android_id="0123456789abcdef",
+        )
+        forbidden = [master_secret, *secrets.values()]
+
+        for args in (
+            ["--storage", str(storage), "auth", "check"],
+            ["--storage", str(storage), "auth", "check", "--json"],
+        ):
+            result = runner.invoke(cli, args)
+            assert result.exit_code == 0, result.output
+            leaked = [s for s in forbidden if s in result.output]
+            assert not leaked, f"auth check leaked secret value(s) {leaked} via {args}"
+
     def test_auth_check_master_token_psidts_hint(self, runner, mock_storage_path):
         """Missing PSIDTS on a master-token profile shows the corrected guidance,
         not the browser-extraction / App-Bound Encryption hint."""

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -423,6 +423,126 @@ class TestAuthCheckCommand:
         with patch_session_login_dual("get_storage_path", return_value=storage_file):
             yield storage_file
 
+    def _write_valid_storage(self, path):
+        """A storage_state that passes every local check, with in-band account."""
+        path.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {"name": n, "value": f"{n}-v", "domain": ".google.com", "path": "/"}
+                        for n in ("SID", "__Secure-1PSIDTS", "APISID", "SAPISID")
+                    ],
+                    "notebooklm": {"account": {"email": "you@gmail.com", "authuser": 0}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_auth_check_identity_fields_parity_rich_vs_json(self, runner, mock_storage_path):
+        """Every identity/location fact is shown in BOTH the table and --json,
+        sourced from one result so the two surfaces never disagree (issue #1640)."""
+        self._write_valid_storage(mock_storage_path)
+        auth_module.write_master_token(
+            mock_storage_path.with_name("master_token.json"),
+            email="you@gmail.com",
+            master_token="aas_et/secret",
+            android_id="0123456789abcdef",
+        )
+        master_path = str(mock_storage_path.with_name("master_token.json"))
+
+        json_result = runner.invoke(cli, ["auth", "check", "--json"])
+        assert json_result.exit_code == 0, json_result.output
+        payload = json.loads(json_result.output)
+
+        # JSON exposes the identity facts at top level.
+        assert payload["account"]["email"] == "you@gmail.com"
+        assert payload["storage_path"] == str(mock_storage_path)
+        assert payload["master_token"]["path"] == master_path
+        assert payload["master_token"]["present"] is True
+        assert payload["psidts"]["present"] is True
+
+        rich_result = runner.invoke(cli, ["auth", "check"])
+        assert rich_result.exit_code == 0, rich_result.output
+        text = rich_result.output
+
+        # Parity: each identity fact in the JSON also appears in the table. Paths
+        # can wrap in the Rich table, so compare on the filename, not the full
+        # path string.
+        assert payload["account"]["email"] in text
+        assert "master_token.json" in text
+        assert "__Secure-1PSIDTS" in text
+        assert "Account" in text and "Master token" in text
+
+    def test_auth_check_test_json_includes_live_notebook_count(self, runner, tmp_path):
+        """notebook_count flows through the REAL command wiring on --test --json.
+
+        Regression for the nested-event-loop bug: the count probe must run from
+        sync context (after run_auth_check's loop closes), not inside it, or
+        run_async would raise and the count would silently be null. Uses an
+        explicit --storage path so both the core check and the probe's auth
+        loader resolve the same file.
+        """
+        storage = tmp_path / "storage_state.json"
+        self._write_valid_storage(storage)
+
+        class _FakeNotebooks:
+            async def list(self):
+                return [object(), object(), object()]  # 3 notebooks
+
+        class _FakeClient:
+            notebooks = _FakeNotebooks()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        def factory(auth=None, **kwargs):
+            return _FakeClient()
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf_token", "session_id")
+            result = runner.invoke(
+                cli,
+                ["--storage", str(storage), "auth", "check", "--test", "--json"],
+                obj={"client_factory": factory},
+            )
+
+        assert result.exit_code == 0, result.output
+        output = json.loads(result.output)
+        assert output["notebook_count"] == 3
+
+    def test_auth_check_master_token_psidts_hint(self, runner, mock_storage_path):
+        """Missing PSIDTS on a master-token profile shows the corrected guidance,
+        not the browser-extraction / App-Bound Encryption hint."""
+        # SID + secondary binding but no __Secure-1PSIDTS.
+        mock_storage_path.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {"name": n, "value": f"{n}-v", "domain": ".google.com", "path": "/"}
+                        for n in ("SID", "APISID", "SAPISID")
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        auth_module.write_master_token(
+            mock_storage_path.with_name("master_token.json"),
+            email="you@gmail.com",
+            master_token="aas_et/secret",
+            android_id="0123456789abcdef",
+        )
+
+        result = runner.invoke(cli, ["auth", "check", "--json"])
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert "master_token.json is present" in payload["details"]["error"]
+        assert "App-Bound Encryption" not in payload["details"]["error"]
+
     def test_auth_check_storage_not_found(self, runner, mock_storage_path):
         """Test auth check when storage file doesn't exist."""
         # Ensure file doesn't exist


### PR DESCRIPTION
## Summary

Closes #1640. `auth check` / `auth check --json` is the canonical machine-readable gate for headless/CI auth, but it omitted the identity a gate needs. This enriches the transport-neutral core (`_app/auth_check.py`) so **both** the Rich table and `--json` render the same facts from one `result.details` (they can't disagree):

- **account** `{email, authuser}` — from the persisted in-band record; env-auth reads the inline `NOTEBOOKLM_AUTH_JSON` (authuser clamped to `>=0`).
- **profile** name + explicit **`storage_state.json`** path and the sibling **`master_token.json`** path/account (the secret token value is never exposed — only `present`/`path`/`account`).
- first-class **`__Secure-1PSIDTS`** `{present, expires_at}` — the expiry parse is guarded against out-of-range epochs so a corrupt `storage_state` reports `expires_at: null` instead of aborting the whole check.
- **`notebook_count`** on `--test` — a live "the API really accepts this session" signal. Computed in the **command layer** (the neutral core never opens a client), best-effort (degrades to `null`), and **non-passive only** so the read-only probe contract (#1569) holds.
- **missing-PSIDTS guidance** now branches: for a master-token profile a missing PSIDTS at rest is normal/self-healing (minted on first call / at bootstrap, #1638) — shown only when SID is present; otherwise the generic hint stays.

`read_account_metadata_from_storage_state` is re-exported on the `notebooklm.auth` facade (deliberate surface change, freeze guardrail updated) so the `_app` env-auth path can read it without importing a private.

## Test plan
- [x] `tests/unit/app/test_app_auth_check.py` — identity fields, PSIDTS expiry + out-of-range degradation, master-token present/account, master-token hint (and correct gating when SID **and** PSIDTS are both missing), env-auth account.
- [x] `tests/unit/cli/test_auth_subcommands.py` — rich↔json **parity** test, master-token-hint CLI test, and a **real-wiring** `--test --json` `notebook_count` test (regression for a nested-event-loop bug where the probe was always null).
- [x] `tests/_guardrails/test_public_surface.py` — facade freeze updated.
- [x] mypy clean, ruff clean, full suite green (one unrelated pre-existing failure: `test_integration_allow_no_vcr_taxonomy_policy_is_current`, curl_cffi allowlist drift, not in this diff).

## Notes
- The notebook-count probe lives in `cli/auth_runtime.auth_check_notebook_count` (keeps `session_cmd.py` under the ADR-0008 module-size budget) and carries a `cli-rpc-unenveloped` waiver: a failed count must not hijack the command's exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `auth check` now shows richer identity/session diagnostics (account/profile, storage path, master-token presence, and `__Secure-1PSIDTS` with expiry status) in both text and `--json` output.
  * When `--test` is enabled (and not `--passive`), `auth check` adds a live, best-effort notebook count to both text and `--json`.

* **Bug Fixes**
  * Corrected guidance when `__Secure-1PSIDTS` is missing but a master token profile exists, and degraded gracefully for invalid `__Secure-1PSIDTS` expiry values.

* **Tests**
  * Added parity and regression tests covering output consistency, notebook-count wiring, and that sensitive values are never printed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->