### PR TITLE
feat(cli): add --json to the remaining local commands + enforce JSON coverage

### DIFF
--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -15,7 +15,7 @@ from rich.markup import render as render_markup
 from rich.table import Table
 
 from .error_handler import _output_error, exit_with_code
-from .rendering import console, json_output_response
+from .rendering import console, json_error_response, json_output_response
 from .services.auth_diagnostics import AuthCheckResult
 from .services.auth_source import AUTH_JSON_ENV_NAME
 from .services.login.outcomes import BrowserCookieOutcome
@@ -140,7 +140,7 @@ def _render_status(report: StatusReport, *, json_output: bool) -> None:
     console.print(table)
 
 
-def _render_logout_outcome(outcome: LogoutOutcome) -> None:
+def _render_logout_outcome(outcome: LogoutOutcome, *, json_output: bool = False) -> None:
     """Render a :class:`LogoutOutcome` and apply its exit policy.
 
     Owns the presentation + exit policy for the ``run_logout`` flow,
@@ -148,7 +148,28 @@ def _render_logout_outcome(outcome: LogoutOutcome) -> None:
     :class:`OSError` failures, prints the diagnostic and then exits 1; on
     success prints either the green "Logged out." line or the yellow
     "No active session found." no-op line and returns normally.
+
+    With ``json_output`` the same outcomes are emitted as a single JSON
+    document (success) or the ``{"error": true, ...}`` envelope (failure,
+    exit 1) so automation can consume the result.
     """
+    if json_output:
+        failure = outcome.failure
+        if failure is not None:
+            json_error_response(
+                f"logout_{failure.kind}_failed",
+                failure.error_message,
+                {"path": str(failure.path), "env_auth_remains": outcome.env_auth_remains},
+            )
+        json_output_response(
+            {
+                "status": "logged_out" if outcome.removed_any else "already_logged_out",
+                "removed": outcome.removed_any,
+                "env_auth_remains": outcome.env_auth_remains,
+            }
+        )
+        return
+
     if outcome.env_auth_remains:
         console.print(
             f"[yellow]Note: {AUTH_JSON_ENV_NAME} is set — env-based auth will "

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -155,19 +155,23 @@ def _render_logout_outcome(outcome: LogoutOutcome, *, json_output: bool = False)
     """
     if json_output:
         failure = outcome.failure
+        # ``json_error_response`` is NoReturn (exits 1); the explicit ``else``
+        # makes it structurally impossible to emit both the error envelope and
+        # the success payload — one JSON document per invocation, always.
         if failure is not None:
             json_error_response(
                 f"logout_{failure.kind}_failed",
                 failure.error_message,
                 {"path": str(failure.path), "env_auth_remains": outcome.env_auth_remains},
             )
-        json_output_response(
-            {
-                "status": "logged_out" if outcome.removed_any else "already_logged_out",
-                "removed": outcome.removed_any,
-                "env_auth_remains": outcome.env_auth_remains,
-            }
-        )
+        else:
+            json_output_response(
+                {
+                    "status": "logged_out" if outcome.removed_any else "already_logged_out",
+                    "removed": outcome.removed_any,
+                    "env_auth_remains": outcome.env_auth_remains,
+                }
+            )
         return
 
     if outcome.env_auth_remains:

--- a/src/notebooklm/cli/playwright_login_io.py
+++ b/src/notebooklm/cli/playwright_login_io.py
@@ -189,10 +189,13 @@ def _verify_token_fetch_after_refresh(
     except Exception as exc:  # noqa: BLE001 — surface any failure as a clean exit 1
         message = f"refresh completed but the post-refresh token fetch failed: {exc}"
         if json_output:
-            json_error_response("post_refresh_token_fetch_failed", message)
+            json_error_response("post_refresh_token_fetch_failed", message)  # NoReturn
+        # Non-json path only (the json branch above exits): human error on stderr.
         click.echo(f"Error: {message}", err=True)
         exit_with_code(1)
-    if not quiet:
+    # Suppress the human success line in --json mode too (not just --quiet), so the
+    # caller's single JSON document is the only thing on stdout.
+    if not quiet and not json_output:
         console.print("[green]ok[/green] verified: token fetch succeeds after refresh")
 
 

--- a/src/notebooklm/cli/playwright_login_io.py
+++ b/src/notebooklm/cli/playwright_login_io.py
@@ -31,8 +31,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
+import click
+
 from .error_handler import exit_with_code
-from .rendering import console
+from .rendering import console, json_error_response
 from .runtime import run_async
 from .services.login.io_seam import set_default_login_io_factory
 from .services.playwright_login import (
@@ -164,8 +166,39 @@ def repair_after_refresh(
     )
 
 
+def _verify_token_fetch_after_refresh(
+    storage_path: Path, profile: str | None, *, quiet: bool, json_output: bool = False
+) -> None:
+    """Confirm a token fetch actually succeeds after ``auth refresh``.
+
+    Runs the strictly read-only passive probe (no NOTEBOOKLM_REFRESH_CMD, no
+    cookie rotation, no write). A successful ``auth refresh`` — especially the
+    ``--browser-cookies`` rewrite — does not by itself prove the resulting
+    cookies authenticate; ``--verify`` makes that an explicit, fail-loud gate
+    so unattended schedulers can rely on the exit code (issue #1569).
+
+    With ``json_output`` a verify failure is emitted as the error envelope on
+    stdout (exit 1); otherwise the human ``Error: …`` line goes to stderr. The
+    ``fetch_tokens_passive`` import is deferred so the ``notebooklm.auth`` patch
+    seam used by the auth-subcommand tests stays effective.
+    """
+    from ..auth import fetch_tokens_passive
+
+    try:
+        run_async(fetch_tokens_passive(storage_path, profile))
+    except Exception as exc:  # noqa: BLE001 — surface any failure as a clean exit 1
+        message = f"refresh completed but the post-refresh token fetch failed: {exc}"
+        if json_output:
+            json_error_response("post_refresh_token_fetch_failed", message)
+        click.echo(f"Error: {message}", err=True)
+        exit_with_code(1)
+    if not quiet:
+        console.print("[green]ok[/green] verified: token fetch succeeds after refresh")
+
+
 __all__ = [
     "PlaywrightLoginIO",
+    "_verify_token_fetch_after_refresh",
     "make_login_io",
     "prepare_paths_or_exit",
     "repair_after_refresh",

--- a/src/notebooklm/cli/profile_cmd.py
+++ b/src/notebooklm/cli/profile_cmd.py
@@ -243,8 +243,9 @@ def switch_cmd(name, json_output):
         )
 
     config_path = get_config_path()
-    # Capture the previous value for the status message before mutating.
-    # The lock-protected mutator below is the source of truth for the write.
+    # Best-effort prior value for the human status line only. It is read outside
+    # the lock, so a concurrent ``profile switch`` could make it stale — which is
+    # why it is NOT exposed in the machine-readable ``--json`` contract.
     old_profile = _read_config(config_path).get("default_profile", "default")
 
     try:
@@ -255,7 +256,7 @@ def switch_cmd(name, json_output):
         ) from None
 
     if json_output:
-        json_output_response({"profile": name, "previous": old_profile, "status": "switched"})
+        json_output_response({"profile": name, "status": "switched"})
         return
     console.print(f"[green]Switched default profile: {old_profile} → {name}[/green]")
 
@@ -409,15 +410,21 @@ def rename_cmd(old_name, new_name, json_output):
         default_updated = was_updated()
 
     if json_output:
-        payload: dict[str, object] = {
-            "old_name": old_name,
-            "new_name": new_name,
-            "default_updated": default_updated,
-            "status": "renamed",
-        }
-        if config_error is not None:
-            payload["config_warning"] = config_error
-        json_output_response(payload)
+        # The directory move (the rename itself) has already succeeded; exit 0 +
+        # ``status: renamed`` reflects that, matching the text-mode contract. A
+        # failed default-pointer retarget is a recoverable secondary failure
+        # surfaced via ``config_warning`` (always present — null when clean — so
+        # automation can detect it with ``payload["config_warning"]`` without a
+        # KeyError).
+        json_output_response(
+            {
+                "old_name": old_name,
+                "new_name": new_name,
+                "default_updated": default_updated,
+                "status": "renamed",
+                "config_warning": config_error,
+            }
+        )
         return
 
     if config_error is not None:

--- a/src/notebooklm/cli/profile_cmd.py
+++ b/src/notebooklm/cli/profile_cmd.py
@@ -178,7 +178,8 @@ def _run_list_cmd(*, json_output: bool) -> None:
 
 @profile.command("create")
 @click.argument("name")
-def create_cmd(name):
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def create_cmd(name, json_output):
     """Create a new profile.
 
     Creates an empty profile directory. Use 'notebooklm -p NAME login' to authenticate.
@@ -210,13 +211,17 @@ def create_cmd(name):
         raise click.ClickException(  # cli-input-validation: profile create filesystem failure
             f"Failed to create profile '{name}': {e}"
         ) from None
+    if json_output:
+        json_output_response({"profile": name, "status": "created"})
+        return
     console.print(f"[green]Profile '{name}' created.[/green]")
     console.print(f"[dim]Run 'notebooklm -p {name} login' to authenticate.[/dim]")
 
 
 @profile.command("switch")
 @click.argument("name")
-def switch_cmd(name):
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def switch_cmd(name, json_output):
     """Set the default profile.
 
     \b
@@ -249,6 +254,9 @@ def switch_cmd(name):
             f"Failed to update config.json: {e}"
         ) from None
 
+    if json_output:
+        json_output_response({"profile": name, "previous": old_profile, "status": "switched"})
+        return
     console.print(f"[green]Switched default profile: {old_profile} → {name}[/green]")
 
 
@@ -272,7 +280,8 @@ def switch_cmd(name):
     hidden=True,
     help="[Deprecated] Alias for --yes/-y.",
 )
-def delete_cmd(name, yes, confirm):
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def delete_cmd(name, yes, confirm, json_output):
     """Delete a profile and its data.
 
     Removes the profile directory including auth cookies, context, and browser profile.
@@ -306,7 +315,9 @@ def delete_cmd(name, yes, confirm):
             f"Profile '{name}' not found."
         )
 
-    if not yes:
+    # ``--json`` implies non-interactive: skip the prompt (matching the
+    # confirming-mutation contract that ``run_confirmed_mutation`` enforces).
+    if not yes and not json_output:
         if not click.confirm(f"Delete profile '{name}' and all its data?"):
             console.print("[dim]Cancelled.[/dim]")
             return
@@ -321,13 +332,17 @@ def delete_cmd(name, yes, confirm):
         raise click.ClickException(  # cli-input-validation: profile delete filesystem failure
             f"Failed to delete profile '{name}': {e}"
         ) from None
+    if json_output:
+        json_output_response({"profile": name, "status": "deleted"})
+        return
     console.print(f"[green]Profile '{name}' deleted.[/green]")
 
 
 @profile.command("rename")
 @click.argument("old_name")
 @click.argument("new_name")
-def rename_cmd(old_name, new_name):
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def rename_cmd(old_name, new_name, json_output):
     """Rename a profile.
 
     \b
@@ -384,15 +399,33 @@ def rename_cmd(old_name, new_name):
         old_name=old_name, new_name=new_name
     )
 
+    config_error: str | None = None
+    default_updated = False
     try:
         _atomic_write_config(config_path, retarget_mutator)
     except OSError as e:
+        config_error = str(e)
+    else:
+        default_updated = was_updated()
+
+    if json_output:
+        payload: dict[str, object] = {
+            "old_name": old_name,
+            "new_name": new_name,
+            "default_updated": default_updated,
+            "status": "renamed",
+        }
+        if config_error is not None:
+            payload["config_warning"] = config_error
+        json_output_response(payload)
+        return
+
+    if config_error is not None:
         console.print(
-            f"[yellow]Warning: profile renamed but config.json update failed: {e}[/yellow]\n"
+            f"[yellow]Warning: profile renamed but config.json update failed: {config_error}[/yellow]\n"
             f"[yellow]Run 'notebooklm profile switch {new_name}' to fix.[/yellow]"
         )
-    else:
-        if was_updated():
-            console.print(f"[dim]Updated default profile in config: {old_name} → {new_name}[/dim]")
+    elif default_updated:
+        console.print(f"[dim]Updated default profile in config: {old_name} → {new_name}[/dim]")
 
     console.print(f"[green]Profile renamed: {old_name} → {new_name}[/green]")

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -574,9 +574,13 @@ def register_session_commands(cli):
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     def clear_cmd(json_output):
         """Clear current notebook context."""
-        clear_context()
+        cleared = clear_context()
         if json_output:
-            json_output_response({"status": "cleared"})
+            # Preserve the actual outcome so automation can tell a real clear
+            # from a no-op (the text path stays idempotent for humans).
+            json_output_response(
+                {"status": "cleared" if cleared else "already_clear", "cleared": cleared}
+            )
             return
         console.print("[green]Context cleared[/green]")
 

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -942,8 +942,8 @@ def register_session_commands(cli):
                     "default keepalive refresh with --json instead.",
                 )
 
-            # --json suppresses human status lines (like --quiet); verify failures
-            # exit 1 via stderr only.
+            # --json suppresses human status lines (like --quiet); a verify failure
+            # emits the error envelope on stdout in --json mode, else on stderr.
             quiet = quiet or json_output
 
             profile = ctx.obj.get("profile") if ctx.obj else None

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import functools
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 import httpx
@@ -52,12 +52,13 @@ from .auth_runtime import (
 from .context import clear_context, set_current_notebook
 from .error_handler import _output_error, exit_with_code, handle_errors
 from .playwright_login_io import (
+    _verify_token_fetch_after_refresh,
     prepare_paths_or_exit,
     repair_after_refresh,
     run_login,
     validate_flags_or_exit,
 )
-from .rendering import console, json_output_response
+from .rendering import console, json_error_response, json_output_response
 from .resolve import resolve_notebook_id
 from .runtime import run_async
 from .services.auth_diagnostics import (
@@ -101,36 +102,6 @@ async def fetch_tokens_with_domains(*args: Any, **kwargs: Any) -> Any:
     from ..auth import fetch_tokens_with_domains as auth_fetch_tokens_with_domains
 
     return await auth_fetch_tokens_with_domains(*args, **kwargs)
-
-
-async def fetch_tokens_passive(*args: Any, **kwargs: Any) -> Any:
-    """Patch-compatible forwarding wrapper for the read-only passive token fetch."""
-    from ..auth import fetch_tokens_passive as auth_fetch_tokens_passive
-
-    return await auth_fetch_tokens_passive(*args, **kwargs)
-
-
-def _verify_token_fetch_after_refresh(
-    storage_path: Path, profile: str | None, *, quiet: bool
-) -> None:
-    """Confirm a token fetch actually succeeds after ``auth refresh``.
-
-    Runs the strictly read-only passive probe (no NOTEBOOKLM_REFRESH_CMD, no
-    cookie rotation, no write). A successful ``auth refresh`` — especially the
-    ``--browser-cookies`` rewrite — does not by itself prove the resulting
-    cookies authenticate; ``--verify`` makes that an explicit, fail-loud gate
-    so unattended schedulers can rely on the exit code (issue #1569).
-    """
-    try:
-        run_async(fetch_tokens_passive(storage_path, profile))
-    except Exception as exc:  # noqa: BLE001 — surface any failure as a clean exit 1
-        click.echo(
-            f"Error: refresh completed but the post-refresh token fetch failed: {exc}",
-            err=True,
-        )
-        exit_with_code(1)
-    if not quiet:
-        console.print("[green]ok[/green] verified: token fetch succeeds after refresh")
 
 
 def _click_exception_from(exc: LoginConfigurationError) -> click.ClickException:
@@ -600,9 +571,13 @@ def register_session_commands(cli):
         _render_status(report, json_output=json_output)
 
     @cli.command("clear")
-    def clear_cmd():
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    def clear_cmd(json_output):
         """Clear current notebook context."""
         clear_context()
+        if json_output:
+            json_output_response({"status": "cleared"})
+            return
         console.print("[green]Context cleared[/green]")
 
     @cli.group("auth")
@@ -611,8 +586,9 @@ def register_session_commands(cli):
         pass
 
     @auth_group.command("logout")
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.pass_context
-    def auth_logout(ctx):
+    def auth_logout(ctx, json_output):
         """Log out by clearing saved authentication.
 
         Removes both the saved cookie file (storage_state.json) and the
@@ -626,7 +602,7 @@ def register_session_commands(cli):
           notebooklm --storage A.json auth logout      # Clear the override auth file
         """
         outcome = execute_logout(ctx)
-        _render_logout_outcome(outcome)
+        _render_logout_outcome(outcome, json_output=json_output)
 
     @auth_group.command("inspect")
     @click.option(
@@ -888,8 +864,9 @@ def register_session_commands(cli):
             "passive probe). Exit non-zero if the post-refresh cookies still fail."
         ),
     )
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.pass_context
-    def auth_refresh(ctx, browser_cookies, include_domains_raw, quiet, verify):
+    def auth_refresh(ctx, browser_cookies, include_domains_raw, quiet, verify, json_output):
         """Refresh stored cookies by exercising the auth path once or reading browser cookies.
 
         Default mode is a one-shot keepalive: opens a session, runs the
@@ -930,26 +907,44 @@ def register_session_commands(cli):
         See docs/troubleshooting.md ("Cookie freshness for long-running /
         unattended use") for launchd / systemd / cron recipes.
         """
-        with handle_errors():
+
+        def _fail(code: str, message: str) -> NoReturn:
+            # --json -> envelope on stdout (NoReturn); else human stderr. Both exit 1.
+            if json_output:
+                json_error_response(code, message)
+            click.echo(f"Error: {message}", err=True)
+            exit_with_code(1)
+
+        with handle_errors(json_output=json_output):
             if has_env_auth_json():
-                click.echo(
-                    f"Error: 'auth refresh' is incompatible with {AUTH_JSON_ENV_NAME}. "
+                _fail(
+                    "auth_json_env_conflict",
+                    f"'auth refresh' is incompatible with {AUTH_JSON_ENV_NAME}. "
                     "The keepalive needs a writable storage_state.json to persist "
                     "rotated cookies. Either unset the env var for this "
                     "process and use a profile-backed storage file, or arrange for "
                     "the env var to be refreshed externally.",
-                    err=True,
                 )
-                exit_with_code(1)
 
             include_domains = _parse_include_domains(include_domains_raw)
             if include_domains and browser_cookies is None:
-                click.echo(
-                    "Error: --include-domains only applies when --browser-cookies "
+                _fail(
+                    "include_domains_without_browser_cookies",
+                    "--include-domains only applies when --browser-cookies "
                     "is also set (the keepalive-only path does not re-extract cookies).",
-                    err=True,
                 )
-                exit_with_code(1)
+
+            # --json is keepalive-only (--browser-cookies prints to stdout) — refuse.
+            if json_output and browser_cookies is not None:
+                _fail(
+                    "json_unsupported_with_browser_cookies",
+                    "--json is not supported with --browser-cookies; use the "
+                    "default keepalive refresh with --json instead.",
+                )
+
+            # --json suppresses human status lines (like --quiet); verify failures
+            # exit 1 via stderr only.
+            quiet = quiet or json_output
 
             profile = ctx.obj.get("profile") if ctx.obj else None
             storage_path = get_storage_path(profile=profile)
@@ -976,7 +971,14 @@ def register_session_commands(cli):
                     console.print(f"[green]ok[/green] refreshed: {storage_path}")
 
             if verify:
-                _verify_token_fetch_after_refresh(storage_path, profile, quiet=quiet)
+                _verify_token_fetch_after_refresh(
+                    storage_path, profile, quiet=quiet, json_output=json_output
+                )
+
+            if json_output:
+                json_output_response(
+                    {"status": "ok", "storage_path": str(storage_path), "verified": verify}
+                )
 
 
 # Backward-compat constant kept at module scope for tests that import it

--- a/src/notebooklm/cli/skill_cmd.py
+++ b/src/notebooklm/cli/skill_cmd.py
@@ -35,7 +35,7 @@ from .._app.skill import (
 from ..io import replace_file_atomically
 from .agent_templates import get_agent_source_content
 from .error_handler import exit_with_code
-from .rendering import console
+from .rendering import console, json_output_response
 
 __all__ = [
     "SCOPES",
@@ -284,27 +284,46 @@ def install(scope: str, target_name: str, dry_run: bool, no_clobber: bool, force
     show_default=True,
     help="Inspect Claude Code, universal agent skill directories, or both.",
 )
-def status(scope: str, target_name: str):
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def status(scope: str, target_name: str, json_output: bool):
     """Check installed skill targets and version info."""
     cli_version = get_package_version()
     selected_targets = iter_targets(target_name)
-    any_installed = False
+    target_rows = []
+    for target in selected_targets:
+        skill_path = get_skill_path(target, scope)
+        skill_version = get_skill_version(skill_path)
+        installed = skill_path.exists()
+        target_rows.append(
+            {
+                "target": target,
+                "label": TARGETS[target].label,
+                "installed": installed,
+                "path": str(skill_path),
+                "skill_version": skill_version if installed else None,
+                "version_mismatch": bool(
+                    installed and skill_version and skill_version != cli_version
+                ),
+            }
+        )
+    any_installed = any(row["installed"] for row in target_rows)
+
+    if json_output:
+        json_output_response({"scope": scope, "cli_version": cli_version, "targets": target_rows})
+        return
 
     console.print(f"NotebookLM skill status ({scope} scope)")
     console.print(f"  CLI version: {cli_version}")
 
-    for target in selected_targets:
-        skill_path = get_skill_path(target, scope)
-        skill_version = get_skill_version(skill_path)
+    for row in target_rows:
         status_label = (
-            "[green]Installed[/green]" if skill_path.exists() else "[yellow]Not installed[/yellow]"
+            "[green]Installed[/green]" if row["installed"] else "[yellow]Not installed[/yellow]"
         )
-        console.print(f"  {TARGETS[target].label}: {status_label}")
-        console.print(f"    Path: {skill_path}")
-        if skill_path.exists():
-            any_installed = True
-            console.print(f"    Skill version: {skill_version or 'unknown'}")
-            if skill_version and skill_version != cli_version:
+        console.print(f"  {row['label']}: {status_label}")
+        console.print(f"    Path: {row['path']}")
+        if row["installed"]:
+            console.print(f"    Skill version: {row['skill_version'] or 'unknown'}")
+            if row["version_mismatch"]:
                 console.print(
                     "    [yellow]Version mismatch[/yellow] - run [cyan]notebooklm skill install[/cyan]"
                 )

--- a/tests/_guardrails/test_cli_json_output_coverage.py
+++ b/tests/_guardrails/test_cli_json_output_coverage.py
@@ -1,0 +1,77 @@
+"""Every CLI leaf command must support ``--json`` -- unless explicitly waived.
+
+Automation drives this CLI through ``--json`` (stable, machine-readable output
+on stdout; diagnostics to stderr). A new command that ships without ``--json``
+is a silent hole in that contract: scripts can't consume it and the gap is only
+noticed when someone tries. This ratchet walks the live Click tree and asserts
+the set of leaf commands lacking ``--json`` equals a frozen, classified
+allowlist -- so adding a new command forces a *conscious* choice (grow
+``--json`` or justify an entry here), and fixing a gap forces removing its
+entry.
+
+Exact-match (both directions):
+
+* A new leaf command without ``--json`` and not in the allowlist FAILS -- add
+  ``@json_option`` / ``@click.option("--json", ...)`` (the common case) or, if
+  the command genuinely emits no structured data, add it here with a one-line
+  reason.
+* An allowlisted command that GAINS ``--json`` FAILS as STALE -- remove it from
+  the allowlist (anti-rot; mirrors the stale-waiver checks in the sibling
+  ``test_cli_rpc_envelope`` / exit-path gates).
+
+Everything in the allowlist is EXEMPT by design: it emits no structured payload
+(interactive auth, a shell-completion script, or packaged prose/skill content
+that *is* the output). There is intentionally no "gap" tier -- the gaps were
+closed when this gate landed; a new command either grows ``--json`` or earns a
+justified exemption here.
+"""
+
+from __future__ import annotations
+
+import click
+
+from notebooklm.notebooklm_cli import cli
+
+#: Leaf commands (full space-joined path) that legitimately lack ``--json``.
+COMMANDS_WITHOUT_JSON: frozenset[str] = frozenset(
+    {
+        "login",  # interactive browser auth flow
+        "completion",  # emits a shell completion script, not data
+        "agent show",  # emits agent instruction prose (the text IS the payload)
+        "skill show",  # emits packaged skill content
+        "skill install",  # local file-install side-effect
+        "skill uninstall",  # local file-removal side-effect
+        "mcp install",  # wires the MCP server into an editor config
+    }
+)
+
+
+def _leaf_commands_without_json(cmd: click.Command, path: list[str]) -> set[str]:
+    if isinstance(cmd, click.Group):
+        found: set[str] = set()
+        # Deliberately includes ``hidden`` commands (iterating ``commands`` rather
+        # than ``list_commands``): hiding a command from ``--help`` does not exempt
+        # it from the JSON-output contract, so the gate stays broader than the
+        # ``--help``-scoped contract walk in test_cli_contract.py.
+        for name, sub in cmd.commands.items():
+            found |= _leaf_commands_without_json(sub, [*path, name])
+        return found
+    has_json = any("--json" in p.opts for p in cmd.params if isinstance(p, click.Option))
+    return set() if has_json else {" ".join(path)}
+
+
+def test_new_cli_commands_support_json_output() -> None:
+    actual = _leaf_commands_without_json(cli, [])
+
+    missing = actual - COMMANDS_WITHOUT_JSON
+    assert not missing, (
+        "These CLI commands lack `--json`. Add a `--json` option (the norm), or "
+        "if the command emits no structured data, add it to COMMANDS_WITHOUT_JSON "
+        f"in {__file__} with a reason: {sorted(missing)}"
+    )
+
+    stale = COMMANDS_WITHOUT_JSON - actual
+    assert not stale, (
+        "These commands now support `--json` (or were renamed/removed) -- drop "
+        f"them from COMMANDS_WITHOUT_JSON in {__file__}: {sorted(stale)}"
+    )

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -1354,7 +1354,26 @@
     },
     "auth logout": {
       "class": "Command",
-      "params": [],
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
       "short_help": "Log out by clearing saved authentication."
     },
     "auth refresh": {
@@ -1433,13 +1452,50 @@
           "type": {
             "name": "boolean"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Refresh stored cookies by exercising the..."
     },
     "clear": {
       "class": "Command",
-      "params": [],
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
       "short_help": "Clear current notebook context."
     },
     "completion": {
@@ -8138,6 +8194,24 @@
           "type": {
             "name": "text"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Create a new profile."
@@ -8184,6 +8258,24 @@
           "name": "confirm",
           "opts": [
             "--confirm"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
           ],
           "required": false,
           "secondary_opts": [],
@@ -8238,6 +8330,24 @@
           "type": {
             "name": "text"
           }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
         }
       ],
       "short_help": "Rename a profile."
@@ -8252,6 +8362,24 @@
           "required": true,
           "type": {
             "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
           }
         }
       ],
@@ -9187,6 +9315,24 @@
               "agents"
             ],
             "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
           }
         }
       ],

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1853,6 +1853,28 @@ class TestAuthRefreshCommand:
         assert "ok" in result.output.lower()
         mock_fetch.assert_awaited_once()
 
+    def test_auth_refresh_json_success(self, runner, mock_storage_path):
+        """--json emits a single structured keepalive result on stdout."""
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "ok"
+        assert payload["verified"] is False
+
+    def test_auth_refresh_json_with_browser_cookies_is_refused(self, runner, mock_storage_path):
+        """``--json`` + ``--browser-cookies`` returns the error envelope, never the
+        interactive login-IO output (which writes Rich text to stdout and would
+        corrupt the single-JSON-document contract)."""
+        result = runner.invoke(cli, ["auth", "refresh", "--browser-cookies", "chrome", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["error"] is True
+        assert payload["code"] == "json_unsupported_with_browser_cookies"
+
     def test_auth_refresh_quiet_suppresses_success_output(self, runner, mock_storage_path):
         """--quiet keeps stdout clean when refresh succeeds (cron-friendly)."""
         with patch.object(
@@ -1970,6 +1992,25 @@ class TestAuthRefreshCommand:
         assert result.exit_code == 1
         assert "post-refresh token fetch failed" in result.output.lower()
         assert "Traceback (most recent call last)" not in result.output
+
+    def test_auth_refresh_verify_failure_json_envelope(self, runner, mock_storage_path):
+        """``--verify`` failure under ``--json`` emits the error envelope on stdout
+        (exit 1), not a human stderr line — the json contract holds on this path."""
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            mock_passive.side_effect = ValueError("Authentication expired or invalid.")
+            result = runner.invoke(cli, ["auth", "refresh", "--verify", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["error"] is True
+        assert payload["code"] == "post_refresh_token_fetch_failed"
 
     def test_auth_refresh_verify_after_browser_cookies(self, runner, mock_storage_path):
         """``--verify`` also gates the ``--browser-cookies`` rewrite path."""

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1865,6 +1865,26 @@ class TestAuthRefreshCommand:
         assert payload["status"] == "ok"
         assert payload["verified"] is False
 
+    def test_auth_refresh_json_verify_success(self, runner, mock_storage_path):
+        """``--json --verify`` success emits a single document with verified=True —
+        the human '[green]ok[/green] verified' line must NOT leak onto stdout."""
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(
+                auth_module, "fetch_tokens_passive", new_callable=AsyncMock
+            ) as mock_passive,
+        ):
+            mock_fetch.return_value = ("csrf_ok", "session_ok")
+            mock_passive.return_value = ("csrf_ok", "session_ok")
+            result = runner.invoke(cli, ["auth", "refresh", "--verify", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)  # raises if a stray line preceded the JSON
+        assert payload["status"] == "ok"
+        assert payload["verified"] is True
+        assert "verified:" not in result.stdout  # no human line leaked
+
     def test_auth_refresh_json_with_browser_cookies_is_refused(self, runner, mock_storage_path):
         """``--json`` + ``--browser-cookies`` returns the error envelope, never the
         interactive login-IO output (which writes Rich text to stdout and would

--- a/tests/unit/cli/test_cli_contract.py
+++ b/tests/unit/cli/test_cli_contract.py
@@ -234,6 +234,10 @@ def test_json_stdout_routing_and_exit_codes_for_download_runtime(
 # (``agent show`` / ``skill install`` / ``profile``); the concrete commands
 # that actually carry ``--json`` today and bypass the error envelope are:
 JSON_CONTRACT_EXEMPTIONS: dict[str, str] = {
+    "auth logout": "Local auth-state mutation: clears on-disk creds, no auth required.",
+    "auth refresh": "Local keepalive: rotates/rewrites the on-disk cookie jar, not an auth-gated RPC.",
+    "clear": "Local context reset: clears the active-notebook file, no auth required.",
+    "skill status": "Local install introspection: reads on-disk skill targets, no auth required.",
     "auth check": "Diagnostic command: emits a status report payload and exits 0.",
     "doctor": "Diagnostic/repair command: emits a checks report payload, not the error envelope.",
     "language get": "Settings read: emits the resolved language, no auth required.",

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -199,6 +199,30 @@ class TestAuthLogoutCommand:
         assert payload["status"] == "already_logged_out"
         assert payload["removed"] is False
 
+    def test_auth_logout_json_failure_is_single_error_document(
+        self, runner: CliRunner, isolated_home: Path, monkeypatch
+    ) -> None:
+        """A per-step failure under ``--json`` emits exactly ONE error envelope
+        (exit 1) — never both the error and the success payload."""
+        from notebooklm.cli.services.session_context import LogoutFailure, LogoutOutcome
+
+        failure = LogoutOutcome(
+            removed_any=False,
+            env_auth_remains=False,
+            failure=LogoutFailure(
+                kind="storage",
+                path=isolated_home / "x" / "storage_state.json",
+                error_message="permission denied",
+                partial_storage_removed=False,
+            ),
+        )
+        monkeypatch.setattr("notebooklm.cli.session_cmd.execute_logout", lambda ctx: failure)
+        result = runner.invoke(cli, ["auth", "logout", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)  # raises if stdout isn't a single document
+        assert payload["error"] is True
+        assert payload["code"] == "logout_storage_failed"
+
     def test_auth_logout_also_clears_context(self, runner: CliRunner, isolated_home: Path) -> None:
         """``auth logout`` removes context.json so post-logout commands start fresh.
 

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -148,6 +148,13 @@ class TestClearCommand:
         assert result.exit_code == 0, result.output
         assert "Context cleared" in result.output
 
+    def test_clear_json(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``clear --json`` emits a single structured document on stdout."""
+        _seed_context(isolated_home, notebook_id="abc123", title="Demo", is_owner=True)
+        result = runner.invoke(cli, ["clear", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"status": "cleared"}
+
 
 # ---------------------------------------------------------------------------
 # auth logout
@@ -174,6 +181,23 @@ class TestAuthLogoutCommand:
 
         assert result.exit_code == 0, result.output
         assert "Already logged out" in result.output
+
+    def test_auth_logout_json(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``auth logout --json`` emits a structured logged-out document."""
+        _seed_storage_state(isolated_home)
+        result = runner.invoke(cli, ["auth", "logout", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "logged_out"
+        assert payload["removed"] is True
+
+    def test_auth_logout_json_no_session(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``auth logout --json`` with nothing to remove reports already-logged-out."""
+        result = runner.invoke(cli, ["auth", "logout", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "already_logged_out"
+        assert payload["removed"] is False
 
     def test_auth_logout_also_clears_context(self, runner: CliRunner, isolated_home: Path) -> None:
         """``auth logout`` removes context.json so post-logout commands start fresh.

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -199,27 +199,31 @@ class TestAuthLogoutCommand:
         assert payload["status"] == "already_logged_out"
         assert payload["removed"] is False
 
-    def test_auth_logout_json_failure_is_single_error_document(
-        self, runner: CliRunner, isolated_home: Path, monkeypatch
-    ) -> None:
+    def test_render_logout_outcome_json_failure_is_single_document(self) -> None:
         """A per-step failure under ``--json`` emits exactly ONE error envelope
-        (exit 1) — never both the error and the success payload."""
+        (exit 1) — never both the error and the success payload. Exercises the
+        render helper directly (no monkeypatch) since it owns the exit policy."""
+        import contextlib
+        import io
+
+        from notebooklm.cli._session_render import _render_logout_outcome
         from notebooklm.cli.services.session_context import LogoutFailure, LogoutOutcome
 
-        failure = LogoutOutcome(
+        outcome = LogoutOutcome(
             removed_any=False,
             env_auth_remains=False,
             failure=LogoutFailure(
                 kind="storage",
-                path=isolated_home / "x" / "storage_state.json",
+                path=Path("/tmp/x/storage_state.json"),
                 error_message="permission denied",
                 partial_storage_removed=False,
             ),
         )
-        monkeypatch.setattr("notebooklm.cli.session_cmd.execute_logout", lambda ctx: failure)
-        result = runner.invoke(cli, ["auth", "logout", "--json"])
-        assert result.exit_code == 1, result.output
-        payload = json.loads(result.stdout)  # raises if stdout isn't a single document
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), pytest.raises(SystemExit) as exc:
+            _render_logout_outcome(outcome, json_output=True)
+        assert exc.value.code == 1
+        payload = json.loads(buf.getvalue())  # raises if stdout isn't a single document
         assert payload["error"] is True
         assert payload["code"] == "logout_storage_failed"
 

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -149,11 +149,17 @@ class TestClearCommand:
         assert "Context cleared" in result.output
 
     def test_clear_json(self, runner: CliRunner, isolated_home: Path) -> None:
-        """``clear --json`` emits a single structured document on stdout."""
+        """``clear --json`` reports an actual clear (cleared=True)."""
         _seed_context(isolated_home, notebook_id="abc123", title="Demo", is_owner=True)
         result = runner.invoke(cli, ["clear", "--json"])
         assert result.exit_code == 0, result.output
-        assert json.loads(result.output) == {"status": "cleared"}
+        assert json.loads(result.output) == {"status": "cleared", "cleared": True}
+
+    def test_clear_json_noop(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``clear --json`` with nothing to clear reports cleared=False (no-op)."""
+        result = runner.invoke(cli, ["clear", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"status": "already_clear", "cleared": False}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -493,7 +493,7 @@ class TestProfileJsonOutput:
         )
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
-        assert payload == {"profile": "work", "previous": "default", "status": "switched"}
+        assert payload == {"profile": "work", "status": "switched"}
         assert read_config(tmp_path)["default_profile"] == "work"
 
     def test_delete_json_skips_confirm(self, runner, tmp_path):
@@ -518,6 +518,7 @@ class TestProfileJsonOutput:
             "new_name": "client",
             "default_updated": False,
             "status": "renamed",
+            "config_warning": None,
         }
         assert (tmp_path / "profiles" / "client").exists()
 

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -473,3 +473,71 @@ class TestProfileRenameCommand:
         assert result.exit_code == 0, result.output
         assert (tmp_path / "profiles" / "client").exists()
         assert read_config(tmp_path) == {}
+
+
+class TestProfileJsonOutput:
+    """``--json`` emits a single parseable document for every profile mutation."""
+
+    def test_create_json(self, runner, tmp_path):
+        result = runner.invoke(
+            cli, ["profile", "create", "work", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"profile": "work", "status": "created"}
+        assert (tmp_path / "profiles" / "work").exists()
+
+    def test_switch_json(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        result = runner.invoke(
+            cli, ["profile", "switch", "work", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload == {"profile": "work", "previous": "default", "status": "switched"}
+        assert read_config(tmp_path)["default_profile"] == "work"
+
+    def test_delete_json_skips_confirm(self, runner, tmp_path):
+        make_profile(tmp_path, "default")
+        make_profile(tmp_path, "work")
+        # No --yes: --json must imply non-interactive and delete without prompting.
+        result = runner.invoke(
+            cli, ["profile", "delete", "work", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"profile": "work", "status": "deleted"}
+        assert not (tmp_path / "profiles" / "work").exists()
+
+    def test_rename_json(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        result = runner.invoke(
+            cli, ["profile", "rename", "work", "client", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "old_name": "work",
+            "new_name": "client",
+            "default_updated": False,
+            "status": "renamed",
+        }
+        assert (tmp_path / "profiles" / "client").exists()
+
+    def test_create_duplicate_json_error_envelope(self, runner, tmp_path):
+        """A validation failure under ``--json`` still emits one JSON document on
+        stdout (the grouped-CLI ClickException -> envelope path), not human text."""
+        make_profile(tmp_path, "work")
+        result = runner.invoke(
+            cli, ["profile", "create", "work", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["error"] is True
+        assert payload["code"] == "VALIDATION_ERROR"
+
+    def test_switch_missing_json_error_envelope(self, runner, tmp_path):
+        result = runner.invoke(
+            cli, ["profile", "switch", "missing", "--json"], env=notebooklm_env(tmp_path)
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["error"] is True
+        assert payload["code"] == "VALIDATION_ERROR"

--- a/tests/unit/cli/test_skill.py
+++ b/tests/unit/cli/test_skill.py
@@ -1,6 +1,7 @@
 """Tests for skill CLI commands."""
 
 import importlib
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -519,6 +520,28 @@ class TestSkillStatus:
         assert result.exit_code == 0
         assert "version mismatch" not in result.output.lower()
         assert result.output.count("Installed") >= 2
+
+    def test_skill_status_json(self, runner, tmp_path):
+        """``skill status --json`` emits a single structured document."""
+        home = tmp_path / "home"
+        version = "1.2.3"
+        dest = home / ".agents" / "skills" / "notebooklm" / "SKILL.md"
+        dest.parent.mkdir(parents=True)
+        dest.write_text(f"<!-- notebooklm-py v{version} -->\n# Test")
+
+        with (
+            patch.object(skill_module.Path, "home", return_value=home),
+            patch.object(skill_module, "get_package_version", return_value=version),
+        ):
+            result = runner.invoke(cli, ["skill", "status", "--target", "agents", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["cli_version"] == version
+        agents = next(t for t in payload["targets"] if t["target"] == "agents")
+        assert agents["installed"] is True
+        assert agents["skill_version"] == version
+        assert agents["version_mismatch"] is False
 
 
 class TestSkillUninstall:

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -778,9 +778,31 @@ _INTROSPECTION_RATIONALE = (
     "success path; ``--json`` purity is checked indirectly by the format unit "
     "tests in tests/unit/cli/."
 )
+_PROFILE_RATIONALE = (
+    "Local filesystem profile mutation (no NotebookLMClient); the ``--json`` "
+    "success payloads AND the validation-error envelope (VALIDATION_ERROR, via "
+    "the grouped-CLI ClickException handler) are asserted directly in "
+    "tests/unit/cli/test_profile.py::TestProfileJsonOutput."
+)
+_SESSION_LOCAL_RATIONALE = (
+    "Local session-context / auth-state command (no NotebookLMClient); the "
+    "``--json`` success and error envelopes are asserted in "
+    "tests/unit/cli/test_cli_session_local.py + test_auth_subcommands.py "
+    "(incl. auth refresh --verify failure and the --browser-cookies refusal)."
+)
 
 
 JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
+    # session/profile/skill local commands — no NotebookLMClient; --json output
+    # is asserted in the dedicated cli unit tests named in each rationale.
+    ("clear",): _SESSION_LOCAL_RATIONALE,
+    ("auth", "logout"): _SESSION_LOCAL_RATIONALE,
+    ("auth", "refresh"): _SESSION_LOCAL_RATIONALE,
+    ("profile", "create"): _PROFILE_RATIONALE,
+    ("profile", "delete"): _PROFILE_RATIONALE,
+    ("profile", "rename"): _PROFILE_RATIONALE,
+    ("profile", "switch"): _PROFILE_RATIONALE,
+    ("skill", "status"): _INTROSPECTION_RATIONALE,
     # artifact group — get/poll/wait need a real or fully-stubbed generation
     # status payload that round-trips through the artifact formatter chain.
     ("artifact", "delete"): _MUTATION_RATIONALE_SUCCESS,
@@ -859,6 +881,16 @@ JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
 
 
 JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
+    # session/profile/skill local commands — error envelope asserted in the
+    # dedicated cli unit tests named in each rationale.
+    ("clear",): _SESSION_LOCAL_RATIONALE,
+    ("auth", "logout"): _SESSION_LOCAL_RATIONALE,
+    ("auth", "refresh"): _SESSION_LOCAL_RATIONALE,
+    ("profile", "create"): _PROFILE_RATIONALE,
+    ("profile", "delete"): _PROFILE_RATIONALE,
+    ("profile", "rename"): _PROFILE_RATIONALE,
+    ("profile", "switch"): _PROFILE_RATIONALE,
+    ("skill", "status"): _INTROSPECTION_RATIONALE,
     # artifact group — error envelope is covered for list + wait. Remaining
     # entries are mutations that surface @with_client's UNEXPECTED_ERROR
     # envelope on RPC failure; coverage can grow with the suite.


### PR DESCRIPTION
## What

Closes the JSON-output gaps surfaced by a Click-tree audit: **8 leaf commands** that emit structured results but lacked `--json`. Adds the flag (and a single machine-readable document on stdout) to:

`clear` · `auth logout` · `auth refresh` · `skill status` · `profile create` · `profile delete` · `profile rename` · `profile switch`

## Why

Automation drives this CLI through `--json`. A command without it is a silent hole in that contract — scripts can't consume it and the gap is only noticed when someone hits it. After this change, **only genuinely non-data commands** lack `--json` (login, completion, agent show, skill show, skill install/uninstall, mcp install).

## How

- Each command emits one JSON document on stdout via `json_output_response`; diagnostics stay on stderr.
- `--json` implies non-interactive: `profile delete --json` skips the confirm (matching the `run_confirmed_mutation` contract).
- `auth refresh --json` folds its keepalive status into one document (treats `--json` like `--quiet` for human lines). It is **keepalive-only**: combined with `--browser-cookies` (which routes through the interactive login-IO renderer that prints to stdout) it returns a structured error rather than corrupting stdout. `--verify` failures emit the error envelope too.
- New guardrail `tests/_guardrails/test_cli_json_output_coverage.py` walks the live Click tree and asserts every leaf command supports `--json` except a frozen, classified allowlist. A new command now either grows `--json` or earns a justified exemption (exact-match, both directions).

## Supporting
- Regenerated `cli_contract` baseline; JSON stdout-purity + error-inventory waivers (with rationale) for the new commands; `JSON_CONTRACT_EXEMPTIONS` for the local commands that exit 0 with a payload; dedicated `--json` success + error unit tests per command.
- Extracted `_verify_token_fetch_after_refresh` to `playwright_login_io.py` (its natural async-runner/render/exit-seam home) to keep `session_cmd.py` under the module-size budget.

## Verification
`uv run mypy src/notebooklm` clean · full guardrails + CLI + JSON suites green (3226 passed locally) · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded `--json` support across more CLI commands, including `clear`, `auth logout`, `auth refresh`, profile create/switch/delete/rename, and `skill status`, with structured JSON success responses.
  * `auth refresh --json` now produces JSON-only results for success and typed error envelopes, including verification outcomes and refusal when `--browser-cookies` is used.
* **Bug Fixes**
  * `profile delete --json` is now non-interactive (no confirmation prompt).
* **Tests**
  * Added a CLI JSON contract guardrail plus expanded unit tests/fixtures to validate JSON shapes and JSON stdout purity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->