### PR TITLE
test(curl_cffi): skip-if-missing instead of importorskip so allow_no_vcr stays collected

### DIFF
--- a/tests/integration/test_curl_cffi_cassette_conformance.py
+++ b/tests/integration/test_curl_cffi_cassette_conformance.py
@@ -23,6 +23,7 @@ curl_cffi bypasses VCR (libcurl, not httpx) so this is local-server-backed
 from __future__ import annotations
 
 import gzip
+import importlib.util
 import json
 import threading
 from contextlib import contextmanager
@@ -33,12 +34,21 @@ import httpx
 import pytest
 import yaml
 
-pytest.importorskip("curl_cffi", reason="requires the optional [impersonate] extra")
+from notebooklm._curl_cffi_transport import CurlCffiAsyncClient
+from notebooklm._streaming_post import stream_post_with_size_cap
 
-from notebooklm._curl_cffi_transport import CurlCffiAsyncClient  # noqa: E402
-from notebooklm._streaming_post import stream_post_with_size_cap  # noqa: E402
-
-pytestmark = pytest.mark.allow_no_vcr
+# Keep this module COLLECTED even when the optional extra is absent (the imports
+# above don't need curl_cffi at import time) so its ``allow_no_vcr`` marker stays
+# visible to the test-taxonomy inventory. A module-level ``importorskip`` would
+# drop the file from collection, making its allowlist entry look stale. The
+# ``skipif`` instead skips at runtime when curl_cffi isn't installed.
+pytestmark = [
+    pytest.mark.allow_no_vcr,
+    pytest.mark.skipif(
+        importlib.util.find_spec("curl_cffi") is None,
+        reason="requires the optional [impersonate] extra",
+    ),
+]
 
 _CASSETTE_DIR = Path(__file__).resolve().parent.parent / "cassettes"
 

--- a/tests/integration/test_curl_cffi_transport_integration.py
+++ b/tests/integration/test_curl_cffi_transport_integration.py
@@ -12,19 +12,29 @@ httpx), so this tier is local-server-backed, not cassette-backed — hence
 
 from __future__ import annotations
 
+import importlib.util
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import httpx
 import pytest
 
-pytest.importorskip("curl_cffi", reason="requires the optional [impersonate] extra")
+from notebooklm._curl_cffi_transport import CurlCffiAsyncClient
+from notebooklm._runtime.init import _resolve_async_client_factory
+from notebooklm._streaming_post import stream_post_with_size_cap
 
-from notebooklm._curl_cffi_transport import CurlCffiAsyncClient  # noqa: E402
-from notebooklm._runtime.init import _resolve_async_client_factory  # noqa: E402
-from notebooklm._streaming_post import stream_post_with_size_cap  # noqa: E402
-
-pytestmark = pytest.mark.allow_no_vcr
+# Keep this module COLLECTED even when the optional extra is absent (the imports
+# above don't need curl_cffi at import time) so its ``allow_no_vcr`` marker stays
+# visible to the test-taxonomy inventory. A module-level ``importorskip`` would
+# drop the file from collection, making its allowlist entry look stale. The
+# ``skipif`` instead skips at runtime when curl_cffi isn't installed.
+pytestmark = [
+    pytest.mark.allow_no_vcr,
+    pytest.mark.skipif(
+        importlib.util.find_spec("curl_cffi") is None,
+        reason="requires the optional [impersonate] extra",
+    ),
+]
 
 
 class _Handler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## What

The two curl_cffi integration suites used a module-level `pytest.importorskip("curl_cffi")`, which **drops the whole module from collection** when the optional `[impersonate]` extra is absent. That makes their entries in `integration_allow_no_vcr_files.txt` look *stale* to the test-taxonomy inventory (a file is "stale" if allowlisted but not currently collected with the `allow_no_vcr` marker), failing `test_integration_allow_no_vcr_taxonomy_policy_is_current` in any environment without curl_cffi installed.

## Why

The adapter import (`notebooklm._curl_cffi_transport`) does **not** need curl_cffi at import time (the real import is lazy), so collection succeeds without the extra. There's no reason to drop the module from collection — only to skip the tests at runtime.

## How

Replace the module-level `importorskip` with a `skipif` pytestmark: the module stays **collected** (its `allow_no_vcr` marker visible to the inventory) and the tests **skip at runtime** when curl_cffi is missing. The notebooklm imports become proper top-level imports (no more `# noqa: E402`).

## Verification
Without curl_cffi installed: the 11 tests **collect and skip** (previously: silently dropped), `scripts/test_taxonomy_inventory.py --check` exits 0, and `test_integration_allow_no_vcr_allowlist` passes. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of an optional dependency so related tests are skipped at runtime instead of being dropped from collection.

* **Tests**
  * Kept integration test coverage visible in test runs even when the optional browser/client package is not installed.
  * Preserved test markers so the test suite reports remain more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->