### PR TITLE
feat(mcp): remote HTTP transport — bearer auth + Docker/Cloudflare deploy (Phase A)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build-context excludes for deploy/Dockerfile (context = repo root).
+# Keeps the context small and never bakes secrets/venvs/caches into the image.
+.git
+.venv
+.venv*/
+.worktrees/
+**/__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+.sisyphus/
+node_modules/
+# never copy deploy secrets into the build
+deploy/profile/
+deploy/.env

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,9 @@
+# Copy to .env (which is gitignored) and fill in. NEVER commit real values.
+
+# Bearer token clients must present to use the MCP endpoint. Generate a strong
+# random value, e.g.:  python -c "import secrets; print(secrets.token_urlsafe(32))"
+NOTEBOOKLM_MCP_TOKEN=
+
+# Cloudflare Tunnel token (Zero Trust dashboard → Networks → Tunnels → your
+# tunnel → install/connector token).
+CF_TUNNEL_TOKEN=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -11,3 +11,14 @@ CF_TUNNEL_TOKEN=
 # Optional: pin the cloudflared image to a release from
 # github.com/cloudflare/cloudflared/releases (defaults to `latest`).
 # CLOUDFLARED_VERSION=2025.1.0
+
+# Which host profile dir to mount — the Google account the server drives.
+# Defaults to your local "default" profile. Point at a dedicated/throwaway
+# profile here (recommended — master_token.json is a full-account credential).
+# NOTEBOOKLM_PROFILE_DIR=/home/you/.notebooklm/profiles/throwaway
+
+# The container runs as this uid:gid so the mounted profile needs NO chown (your
+# own CLI keeps owning the files). `make` fills these from `id` automatically;
+# set them only for raw `docker compose` (use your own: id -u / id -g).
+# NOTEBOOKLM_UID=1000
+# NOTEBOOKLM_GID=1000

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,3 +7,7 @@ NOTEBOOKLM_MCP_TOKEN=
 # Cloudflare Tunnel token (Zero Trust dashboard → Networks → Tunnels → your
 # tunnel → install/connector token).
 CF_TUNNEL_TOKEN=
+
+# Optional: pin the cloudflared image to a release from
+# github.com/cloudflare/cloudflared/releases (defaults to `latest`).
+# CLOUDFLARED_VERSION=2025.1.0

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,3 @@
+# Never commit deployment secrets.
+.env
+profile/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,35 @@
+# Remote notebooklm-mcp server — single-tenant, bearer-gated, streamable-HTTP.
+#
+# The image is stateless: the profile (incl. master_token.json) is mounted at
+# runtime, never baked in. Run behind a Cloudflare Tunnel (or any TLS reverse
+# proxy) — see deploy/README.md.
+FROM python:3.12-slim
+
+# Default to the published package. Override at build time to pin a version or
+# install from a local wheel:
+#   docker build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==X.Y.Z" .
+ARG NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]"
+
+RUN pip install --no-cache-dir "${NOTEBOOKLM_SPEC}"
+
+# Run as a non-root user; the mounted profile dir must be writable by this uid
+# (keepalive/recovery rotates cookies into storage_state.json).
+RUN useradd --create-home --uid 10001 app
+USER app
+
+ENV NOTEBOOKLM_MCP_HOST=0.0.0.0 \
+    NOTEBOOKLM_MCP_PORT=8000 \
+    NOTEBOOKLM_PROFILE=server
+
+EXPOSE 8000
+
+# Liveness: stdlib-only TCP connect to the bound port. No curl/wget/nc needed,
+# and it never touches the auth-gated /mcp route. The port is hardcoded to 8000
+# (the image default below) — exec-form HEALTHCHECK can't read env vars, so if
+# you override NOTEBOOKLM_MCP_PORT, update this port to match.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ["python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',8000))==0 else 1)"]
+
+# --host 0.0.0.0 is non-loopback, so NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1 AND a
+# NOTEBOOKLM_MCP_TOKEN are MANDATORY (the entrypoint refuses to start otherwise).
+CMD ["notebooklm-mcp", "--transport", "http"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -23,12 +23,14 @@ ENV NOTEBOOKLM_MCP_HOST=0.0.0.0 \
 
 EXPOSE 9420
 
-# Liveness: stdlib-only TCP connect to the bound port. No curl/wget/nc needed,
-# and it never touches the auth-gated /mcp route. The port is hardcoded to 9420
-# (the image default above) — exec-form HEALTHCHECK can't read env vars, so if
-# you override NOTEBOOKLM_MCP_PORT, update this port to match.
+# Liveness: stdlib-only TCP connect to the listener over loopback. No curl/wget/nc
+# needed, and it never touches the auth-gated /mcp route. The python process reads
+# NOTEBOOKLM_MCP_PORT from its own env at runtime (a program sees its environment
+# even in exec-form — only shell `$VAR` substitution doesn't), so overriding the
+# port keeps the healthcheck in sync. Host is always loopback: the server binds
+# 0.0.0.0, which you connect to via 127.0.0.1 from inside the container.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD ["python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',9420))==0 else 1)"]
+    CMD ["python", "-c", "import os,socket,sys; p=int(os.environ.get('NOTEBOOKLM_MCP_PORT','9420')); s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',p))==0 else 1)"]
 
 # --host 0.0.0.0 is non-loopback, so NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1 AND a
 # NOTEBOOKLM_MCP_TOKEN are MANDATORY (the entrypoint refuses to start otherwise).

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,17 +18,17 @@ RUN useradd --create-home --uid 10001 app
 USER app
 
 ENV NOTEBOOKLM_MCP_HOST=0.0.0.0 \
-    NOTEBOOKLM_MCP_PORT=8000 \
+    NOTEBOOKLM_MCP_PORT=9420 \
     NOTEBOOKLM_PROFILE=server
 
-EXPOSE 8000
+EXPOSE 9420
 
 # Liveness: stdlib-only TCP connect to the bound port. No curl/wget/nc needed,
-# and it never touches the auth-gated /mcp route. The port is hardcoded to 8000
-# (the image default below) — exec-form HEALTHCHECK can't read env vars, so if
+# and it never touches the auth-gated /mcp route. The port is hardcoded to 9420
+# (the image default above) — exec-form HEALTHCHECK can't read env vars, so if
 # you override NOTEBOOKLM_MCP_PORT, update this port to match.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD ["python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',8000))==0 else 1)"]
+    CMD ["python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',9420))==0 else 1)"]
 
 # --host 0.0.0.0 is non-loopback, so NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1 AND a
 # NOTEBOOKLM_MCP_TOKEN are MANDATORY (the entrypoint refuses to start otherwise).

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,14 +3,27 @@
 # The image is stateless: the profile (incl. master_token.json) is mounted at
 # runtime, never baked in. Run behind a Cloudflare Tunnel (or any TLS reverse
 # proxy) — see deploy/README.md.
+#
+# Two install modes (the compose build context is the repo root):
+#   * DEV / from-source (DEFAULT): installs THIS checkout, so `docker compose up`
+#     deploys exactly the code in this repo. Leave NOTEBOOKLM_SPEC empty.
+#   * PRODUCTION / from PyPI: build with a release spec, e.g.
+#       docker compose build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==0.8.0"
+#     (or set it under build.args in docker-compose.yml).
 FROM python:3.12-slim
 
-# Default to the published package. Override at build time to pin a version or
-# install from a local wheel:
-#   docker build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==X.Y.Z" .
-ARG NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]"
+ARG NOTEBOOKLM_SPEC=""
 
-RUN pip install --no-cache-dir "${NOTEBOOKLM_SPEC}"
+# Copy the repo source (build context = repo root; see .dockerignore for excludes).
+COPY . /src
+
+# Empty NOTEBOOKLM_SPEC → install the copied source (dev). Non-empty → install
+# that spec from PyPI (production) and ignore the copied source.
+RUN if [ -n "$NOTEBOOKLM_SPEC" ]; then \
+        pip install --no-cache-dir "$NOTEBOOKLM_SPEC"; \
+    else \
+        pip install --no-cache-dir "/src[mcp,headless]"; \
+    fi
 
 # Run as a non-root user; the mounted profile dir must be writable by this uid
 # (keepalive/recovery rotates cookies into storage_state.json).

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,0 +1,35 @@
+# Convenience wrapper for the remote notebooklm-mcp deploy.
+#   make dev    — build + install THIS repo checkout (default)
+#   make prod   — build + install a published PyPI release (VERSION=x.y.z)
+#   make logs / restart / down / config
+# Override the compose command with COMPOSE=... if needed.
+
+COMPOSE ?= docker compose
+VERSION ?= 0.8.0
+
+.PHONY: help dev prod up restart logs down config
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-9s\033[0m %s\n", $$1, $$2}'
+
+dev: ## Build from source (this checkout) and start
+	$(COMPOSE) up -d --build
+
+prod: ## Build from a published release and start (e.g. make prod VERSION=0.8.0)
+	$(COMPOSE) build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==$(VERSION)"
+	$(COMPOSE) up -d
+
+up: dev ## Alias for `dev`
+
+restart: ## Rebuild + recreate after a source/config change
+	$(COMPOSE) up -d --build
+
+logs: ## Tail the server logs
+	$(COMPOSE) logs -f notebooklm-mcp
+
+down: ## Stop and remove the stack
+	$(COMPOSE) down
+
+config: ## Validate the merged compose config
+	$(COMPOSE) config

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -7,6 +7,13 @@
 COMPOSE ?= docker compose
 VERSION ?= 0.8.0
 
+# Run the container as YOUR uid/gid so the mounted profile needs no chown, and
+# default the mounted profile to your local "default" profile. All overridable
+# (env or `make dev NOTEBOOKLM_PROFILE_DIR=...`); exported so compose sees them.
+export NOTEBOOKLM_UID ?= $(shell id -u)
+export NOTEBOOKLM_GID ?= $(shell id -g)
+export NOTEBOOKLM_PROFILE_DIR ?= $(HOME)/.notebooklm/profiles/default
+
 .PHONY: help dev prod up restart logs down config
 
 help: ## Show this help

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,20 +47,26 @@ In the Cloudflare **Zero Trust** dashboard → **Networks → Tunnels**:
    record and serves TLS with its own cert.
 
 ## 4. Run
+
+The `Makefile` wraps the two build modes — one command each:
+
 ```bash
-cd deploy && docker compose up -d
-docker compose logs -f notebooklm-mcp   # should report it bound 0.0.0.0:9420
+cd deploy
+make dev                    # build + install THIS checkout (source) and start
+make prod VERSION=0.8.0     # build + install a published PyPI release and start
+make logs                   # tail the server log (expect: bound 0.0.0.0:9420)
+make restart                # rebuild + recreate after a source/config change
+make down                   # stop and remove
 ```
 
-**Build modes** — the image installs `notebooklm-py` two ways (the build context
-is the repo root):
-- **From source (default):** `docker compose up` builds and installs *this
-  checkout*, so you deploy the exact code in the repo (right for dev / an
-  unreleased branch). After changing source, rebuild with `docker compose up -d
-  --build`.
-- **From a published release:** uncomment `build.args.NOTEBOOKLM_SPEC` in
-  `docker-compose.yml` (e.g. `notebooklm-py[mcp,headless]==0.8.0`) or build with
-  `docker compose build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==0.8.0"`.
+Equivalent raw compose (the image installs `notebooklm-py` two ways; build
+context is the repo root):
+- **From source (default):** `docker compose up -d --build` installs *this
+  checkout* — you deploy the exact code in the repo (right for dev / an
+  unreleased branch).
+- **From a published release:** `docker compose build --build-arg
+  NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==0.8.0"` then `docker compose up -d`
+  (or uncomment `build.args.NOTEBOOKLM_SPEC` in `docker-compose.yml`).
 
 ## 5. Connect from Claude Code
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,7 +5,7 @@ behind a Cloudflare Tunnel: no public IP, no open ports, no TLS certificate to
 manage. Single-tenant, self-hosted.
 
 > ⚠️ **Use a dedicated / throwaway Google account.** The mounted
-> `master_token.json` is a durable, full-account credential. Treat `./profile`
+> `master_token.json` is a durable, full-account credential. Treat the mounted profile dir
 > and `.env` as secrets (both are gitignored).
 
 ## Prerequisites
@@ -17,20 +17,22 @@ manage. Single-tenant, self-hosted.
 pip install "notebooklm-py[browser,headless]"
 notebooklm login --master-token --account you@example.com
 ```
-This writes `master_token.json` (+ a minted `storage_state.json`) into the
-profile dir. Copy that profile dir here:
-```bash
-mkdir -p deploy/profile
-cp -r ~/.notebooklm/profiles/<profile>/. deploy/profile/
-chmod 600 deploy/profile/master_token.json
-# The container runs as uid 10001 (non-root). It must be able to READ
-# master_token.json AND WRITE storage_state.json (+ its .lock) for cookie
-# rotation, so give that uid ownership of the bind-mounted dir:
-sudo chown -R 10001:10001 deploy/profile
-```
-The profile dir is mounted **read-write** — the server re-mints/rotates cookies
-into `storage_state.json` here, so it must be writable by uid 10001 (a read-only
-mount, or a dir the container uid can't write, makes the session die ~1 h in).
+This writes `master_token.json` (+ a minted `storage_state.json`) into
+`~/.notebooklm/profiles/<profile>/`. **You don't copy or chown anything** — the
+container mounts that dir directly and runs as *your* uid:gid, so the files stay
+owned by you (your `notebooklm` CLI keeps working) and are readable/writable with
+no permission dance.
+
+- **Default:** mounts `~/.notebooklm/profiles/default`.
+- **Other profile:** set `NOTEBOOKLM_PROFILE_DIR` in `.env` (e.g. a
+  dedicated/throwaway profile — recommended, since `master_token.json` is a
+  full-account credential).
+
+The dir is mounted **read-write** because the server re-mints/rotates cookies into
+`storage_state.json` (+ its `.lock`) — a read-only mount makes the session die
+~1 h in. Running as your uid is what makes that write work without a chown.
+(`make` fills your uid/gid from `id` automatically; for raw `docker compose`, set
+`NOTEBOOKLM_UID`/`NOTEBOOKLM_GID` in `.env`.)
 
 ## 2. Configure secrets
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,13 +43,13 @@ cp deploy/.env.example deploy/.env
 In the Cloudflare **Zero Trust** dashboard → **Networks → Tunnels**:
 1. Create a tunnel; copy its **token** into `CF_TUNNEL_TOKEN` in `.env`.
 2. Add a **Public Hostname** (e.g. `notebooklm-mcp.yourdomain.com`) →
-   **Service** `http://notebooklm-mcp:8000`. Cloudflare auto-creates the DNS
+   **Service** `http://notebooklm-mcp:9420`. Cloudflare auto-creates the DNS
    record and serves TLS with its own cert.
 
 ## 4. Run
 ```bash
 cd deploy && docker compose up -d
-docker compose logs -f notebooklm-mcp   # should report it bound 0.0.0.0:8000
+docker compose logs -f notebooklm-mcp   # should report it bound 0.0.0.0:9420
 ```
 
 ## 5. Connect from Claude Code

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,82 @@
+# Remote `notebooklm-mcp` — Docker + Cloudflare Tunnel
+
+Run the MCP server as a **remote connector** (Claude Code / Claude.ai / Cursor)
+behind a Cloudflare Tunnel: no public IP, no open ports, no TLS certificate to
+manage. Single-tenant, self-hosted.
+
+> ⚠️ **Use a dedicated / throwaway Google account.** The mounted
+> `master_token.json` is a durable, full-account credential. Treat `./profile`
+> and `.env` as secrets (both are gitignored).
+
+## Prerequisites
+- Docker + Docker Compose.
+- A domain on Cloudflare (free plan is fine) for the Tunnel hostname.
+
+## 1. Bootstrap the master token (once, on a machine with a browser)
+```bash
+pip install "notebooklm-py[browser,headless]"
+notebooklm login --master-token --account you@example.com
+```
+This writes `master_token.json` (+ a minted `storage_state.json`) into the
+profile dir. Copy that profile dir here:
+```bash
+mkdir -p deploy/profile
+cp -r ~/.notebooklm/profiles/<profile>/. deploy/profile/
+chmod 600 deploy/profile/master_token.json
+# The container runs as uid 10001 (non-root). It must be able to READ
+# master_token.json AND WRITE storage_state.json (+ its .lock) for cookie
+# rotation, so give that uid ownership of the bind-mounted dir:
+sudo chown -R 10001:10001 deploy/profile
+```
+The profile dir is mounted **read-write** — the server re-mints/rotates cookies
+into `storage_state.json` here, so it must be writable by uid 10001 (a read-only
+mount, or a dir the container uid can't write, makes the session die ~1 h in).
+
+## 2. Configure secrets
+```bash
+cp deploy/.env.example deploy/.env
+# NOTEBOOKLM_MCP_TOKEN: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# CF_TUNNEL_TOKEN: from the Cloudflare dashboard (next step)
+```
+
+## 3. Create the Cloudflare Tunnel
+In the Cloudflare **Zero Trust** dashboard → **Networks → Tunnels**:
+1. Create a tunnel; copy its **token** into `CF_TUNNEL_TOKEN` in `.env`.
+2. Add a **Public Hostname** (e.g. `notebooklm-mcp.yourdomain.com`) →
+   **Service** `http://notebooklm-mcp:8000`. Cloudflare auto-creates the DNS
+   record and serves TLS with its own cert.
+
+## 4. Run
+```bash
+cd deploy && docker compose up -d
+docker compose logs -f notebooklm-mcp   # should report it bound 0.0.0.0:8000
+```
+
+## 5. Connect from Claude Code
+```bash
+claude mcp add --transport http notebooklm \
+  https://notebooklm-mcp.yourdomain.com/mcp \
+  --header "Authorization: Bearer $NOTEBOOKLM_MCP_TOKEN"
+```
+(For Claude.ai / Desktop custom connectors, add the same URL under
+**Settings → Connectors**. The static bearer works for Claude Code today; a
+polished one-click OAuth flow is a future enhancement.)
+
+## Notes & security
+- **Two auth layers.** The `NOTEBOOKLM_MCP_TOKEN` bearer gates *who can use the
+  endpoint*; the master token authenticates *the server to Google*. The master
+  token **never** traverses the tunnel — only MCP tool calls/results do. The
+  bearer **does** terminate at Cloudflare (Cloudflare can see it in transit, like
+  any reverse-proxied request), so rotate it freely.
+- **Fail-closed.** The server refuses to start on a non-loopback bind without
+  `NOTEBOOKLM_MCP_TOKEN` set.
+- **One container per account.** Do not scale replicas off one master token —
+  concurrent re-mints invalidate each other's session.
+- **Rotate the bearer**: change `NOTEBOOKLM_MCP_TOKEN` in `.env`,
+  `docker compose up -d`, and update the `claude mcp add` header.
+- **Files**: the connector moves text/references only. Add device files via
+  Google Drive (`source_add` with a Drive id) or the NotebookLM app; consume
+  generated podcasts/videos/slides in the NotebookLM app (same account).
+- **Optional hardening**: instead of a single `rw` bind-mount, mount
+  `master_token.json` as a separate read-only Docker secret and use a writable
+  named volume for `storage_state.json` + `.storage_state.json.lock`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,6 +52,16 @@ cd deploy && docker compose up -d
 docker compose logs -f notebooklm-mcp   # should report it bound 0.0.0.0:9420
 ```
 
+**Build modes** — the image installs `notebooklm-py` two ways (the build context
+is the repo root):
+- **From source (default):** `docker compose up` builds and installs *this
+  checkout*, so you deploy the exact code in the repo (right for dev / an
+  unreleased branch). After changing source, rebuild with `docker compose up -d
+  --build`.
+- **From a published release:** uncomment `build.args.NOTEBOOKLM_SPEC` in
+  `docker-compose.yml` (e.g. `notebooklm-py[mcp,headless]==0.8.0`) or build with
+  `docker compose build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==0.8.0"`.
+
 ## 5. Connect from Claude Code
 ```bash
 claude mcp add --transport http notebooklm \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,7 +1,8 @@
 # Remote notebooklm-mcp behind a Cloudflare Tunnel.
 #
 #   cp .env.example .env   # then set NOTEBOOKLM_MCP_TOKEN + CF_TUNNEL_TOKEN
-#   # put your bootstrapped profile (incl. master_token.json) in ./profile/
+#   # by default it mounts ~/.notebooklm/profiles/default (override via
+#   # NOTEBOOKLM_PROFILE_DIR); runs as your uid so no chown is needed
 #   docker compose up -d
 #
 # No host ports are published — the ONLY way in is through Cloudflare, which
@@ -17,17 +18,31 @@ services:
       #   NOTEBOOKLM_SPEC: "notebooklm-py[mcp,headless]==0.8.0"
     # image: ghcr.io/...   # or pull a prebuilt image instead of building
     restart: unless-stopped
+    # Run as YOUR uid:gid so the mounted profile's files (owned by you on the
+    # host) are readable AND writable with NO chown — and your own `notebooklm`
+    # CLI keeps owning them. Defaults to 1000:1000; `make` fills these from
+    # `id -u`/`id -g` automatically, or set them in .env.
+    user: "${NOTEBOOKLM_UID:-1000}:${NOTEBOOKLM_GID:-1000}"
     environment:
       # Bearer token clients must present (Authorization: Bearer ...). Env-only.
       NOTEBOOKLM_MCP_TOKEN: ${NOTEBOOKLM_MCP_TOKEN:?set NOTEBOOKLM_MCP_TOKEN in .env}
       # Binds 0.0.0.0 (for the cloudflared sidecar) → makes the token MANDATORY.
       NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND: "1"
+      # Point the app at the mounted profile, independent of the (arbitrary) uid's
+      # home. The host dir is always mounted as the profile literally named
+      # "server"; NOTEBOOKLM_HOME/profiles/server is where the app reads+writes.
+      NOTEBOOKLM_HOME: /data
+      NOTEBOOKLM_PROFILE: server
+      # HOME points at the writable mount too, so an arbitrary uid with no
+      # /etc/passwd entry never trips a `~` / getpwuid lookup.
+      HOME: /data/profiles/server
     volumes:
       # READ-WRITE: keepalive/recovery rotates cookies into storage_state.json
-      # (+ its .lock) here. A read-only mount kills the session ~1h in.
-      # Treat ./profile as a secret — master_token.json is a full-account
-      # credential (keep it mode 0600 inside).
-      - ./profile:/home/app/.notebooklm/profiles/server:rw
+      # (+ its .lock). A read-only mount kills the session ~1h in.
+      # Defaults to your local "default" profile; override with NOTEBOOKLM_PROFILE_DIR
+      # in .env to point at a different profile dir (e.g. a dedicated/throwaway one).
+      # Treat the dir as a secret — master_token.json is a full-account credential.
+      - "${NOTEBOOKLM_PROFILE_DIR:-${HOME}/.notebooklm/profiles/default}:/data/profiles/server:rw"
     # No `ports:` — not reachable except via the tunnel.
 
   cloudflared:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,8 +8,14 @@
 # terminates TLS with its own cert (no CA cert for you to manage). See README.md.
 services:
   notebooklm-mcp:
-    build: .
-    # image: ghcr.io/...   # or pull a prebuilt image instead of `build: .`
+    build:
+      # Context is the repo root so the image can install THIS checkout (dev).
+      context: ..
+      dockerfile: deploy/Dockerfile
+      # For a published release instead of this checkout, uncomment:
+      # args:
+      #   NOTEBOOKLM_SPEC: "notebooklm-py[mcp,headless]==0.8.0"
+    # image: ghcr.io/...   # or pull a prebuilt image instead of building
     restart: unless-stopped
     environment:
       # Bearer token clients must present (Authorization: Bearer ...). Env-only.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,12 +25,19 @@ services:
     # No `ports:` — not reachable except via the tunnel.
 
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    # Pinnable for reproducibility: set CLOUDFLARED_VERSION in .env to a release
+    # from github.com/cloudflare/cloudflared/releases. Defaults to `latest` (the
+    # tunnel connector is backward-compatible and is what Cloudflare recommends
+    # running), so the template works without choosing a tag.
+    image: cloudflare/cloudflared:${CLOUDFLARED_VERSION:-latest}
     restart: unless-stopped
     command: tunnel run
     environment:
       # From the Cloudflare Zero Trust dashboard (Networks → Tunnels). Configure
-      # the tunnel's Public Hostname to point at http://notebooklm-mcp:8000.
+      # the tunnel's Public Hostname to point at http://notebooklm-mcp:9420.
       TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:?set CF_TUNNEL_TOKEN in .env}
     depends_on:
-      - notebooklm-mcp
+      # Wait until the MCP server passes its HEALTHCHECK (port listening), not
+      # merely until its container starts, before bringing the tunnel up.
+      notebooklm-mcp:
+        condition: service_healthy

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,36 @@
+# Remote notebooklm-mcp behind a Cloudflare Tunnel.
+#
+#   cp .env.example .env   # then set NOTEBOOKLM_MCP_TOKEN + CF_TUNNEL_TOKEN
+#   # put your bootstrapped profile (incl. master_token.json) in ./profile/
+#   docker compose up -d
+#
+# No host ports are published — the ONLY way in is through Cloudflare, which
+# terminates TLS with its own cert (no CA cert for you to manage). See README.md.
+services:
+  notebooklm-mcp:
+    build: .
+    # image: ghcr.io/...   # or pull a prebuilt image instead of `build: .`
+    restart: unless-stopped
+    environment:
+      # Bearer token clients must present (Authorization: Bearer ...). Env-only.
+      NOTEBOOKLM_MCP_TOKEN: ${NOTEBOOKLM_MCP_TOKEN:?set NOTEBOOKLM_MCP_TOKEN in .env}
+      # Binds 0.0.0.0 (for the cloudflared sidecar) → makes the token MANDATORY.
+      NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND: "1"
+    volumes:
+      # READ-WRITE: keepalive/recovery rotates cookies into storage_state.json
+      # (+ its .lock) here. A read-only mount kills the session ~1h in.
+      # Treat ./profile as a secret — master_token.json is a full-account
+      # credential (keep it mode 0600 inside).
+      - ./profile:/home/app/.notebooklm/profiles/server:rw
+    # No `ports:` — not reachable except via the tunnel.
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel run
+    environment:
+      # From the Cloudflare Zero Trust dashboard (Networks → Tunnels). Configure
+      # the tunnel's Public Hostname to point at http://notebooklm-mcp:8000.
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:?set CF_TUNNEL_TOKEN in .env}
+    depends_on:
+      - notebooklm-mcp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1169,8 +1169,9 @@ src/notebooklm/
 ├── notebooklm_cli.py            # Entry-point assembler — imports + registers cli/ groups
 ├── mcp/                         # MCP server (opt-in `mcp` extra) — transport-neutral adapter over _app/, sibling to cli/
 │   ├── __init__.py              # Re-exports create_server / SERVER_NAME / SERVER_INSTRUCTIONS
-│   ├── __main__.py              # `notebooklm-mcp` entrypoint: argparse (--profile/--transport/--host/--port/--log-level), stderr logging, loopback HTTP bind guard
-│   ├── server.py                # create_server(profile, client_factory): FastMCP server; lifespan binds one NotebookLMClient; register_all tool-registration seam
+│   ├── __main__.py              # `notebooklm-mcp` entrypoint: argparse (--profile/--transport/--host/--port/--log-level), stderr logging, loopback HTTP bind guard + fail-closed token guard (non-loopback bind requires NOTEBOOKLM_MCP_TOKEN); builds the auth provider and passes it to create_server on the http path
+│   ├── server.py                # create_server(profile, client_factory, auth): FastMCP server; lifespan binds one NotebookLMClient; register_all tool-registration seam; auth passed explicitly (never reads the token env)
+│   ├── _auth.py                 # Remote-transport bearer auth: McpBearerAuthProvider(TokenVerifier) with constant-time hmac.compare_digest over NOTEBOOKLM_MCP_TOKEN (env-only, never logged/repr'd); build_auth_provider/get_configured_token — mirrors server/_auth.py, NOT fastmcp StaticTokenVerifier
 │   ├── _context.py              # AppState dataclass + get_client(ctx) — the lifespan-bound client
 │   ├── _errors.py               # Structured tool-error projection (CATEGORY_TABLE/ERROR_CODES/mcp_errors/to_tool_error/tool_error_payload) over _app.errors.classify
 │   ├── _resolve.py              # resolve_notebook/resolve_source/resolve_note — name + partial-id resolution over _app.resolve plus exact-title matching

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -87,10 +87,44 @@ notebooklm-mcp --transport http --port 9000
 | `--port` | `8000` | http only |
 | `--log-level` | `INFO` | logs go to **stderr**; stdout stays pure JSON-RPC |
 
+There is no `--token` flag — the HTTP bearer token is **env-only**
+(`NOTEBOOKLM_MCP_TOKEN`) so it cannot leak via `ps aux`.
+
 `stdio` is right for Claude Desktop/Code, Cursor, and Windsurf (they launch the server as a
 subprocess). Use `http` for a local web client or to share one running server across clients on
-the same machine. The HTTP transport is single-user and loopback-only by design; binding to a
-non-loopback address requires the explicit `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` override.
+the same machine. The HTTP transport is loopback-only by default; binding to a non-loopback
+address requires **both** the explicit `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` override **and** a
+`NOTEBOOKLM_MCP_TOKEN` — the server fails closed (refuses to start) on a network bind without a
+token, since it fronts a full Google account.
+
+## Remote deployment (Docker + Cloudflare Tunnel)
+
+Because master-token auth keeps the session alive unattended (no browser), the HTTP transport can
+run as a **remote connector** reachable from Claude Code, Claude.ai, and mobile. The
+[`deploy/`](../deploy/) directory ships a turn-key setup — a Dockerfile + Compose stack with a
+`cloudflared` sidecar — so you get HTTPS with **no public IP, no open ports, and no TLS
+certificate to manage** (Cloudflare terminates TLS at its edge).
+
+```bash
+# 1. bootstrap once (machine with a browser):
+notebooklm login --master-token --account you@example.com
+cp -r ~/.notebooklm/profiles/<profile>/. deploy/profile/   # mounted read-write
+# 2. secrets:
+cp deploy/.env.example deploy/.env                          # set MCP token + tunnel token
+# 3. create a Cloudflare Tunnel → public hostname → http://notebooklm-mcp:8000
+# 4. run:
+cd deploy && docker compose up -d
+# 5. connect:
+claude mcp add --transport http notebooklm https://<host>/mcp \
+  --header "Authorization: Bearer $NOTEBOOKLM_MCP_TOKEN"
+```
+
+Full step-by-step (incl. the security model and the read-write profile requirement) is in
+[`deploy/README.md`](../deploy/README.md). Use a **dedicated/throwaway Google account** — the
+mounted `master_token.json` is a durable full-account credential. The connector moves
+text/references only; add device files via Google Drive (`source_add` with a Drive id) or the
+NotebookLM app, and consume generated podcasts/videos in the NotebookLM app (same account).
+`OAuth` connectors and multi-tenant hosting are out of scope for this single-tenant setup.
 
 ## Core concepts
 

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -75,7 +75,7 @@ The console script is `notebooklm-mcp`:
 ```bash
 notebooklm-mcp                         # stdio transport (default — for desktop hosts)
 notebooklm-mcp --profile work          # bind a specific auth profile
-notebooklm-mcp --transport http        # loopback streamable-HTTP on 127.0.0.1:8000
+notebooklm-mcp --transport http        # loopback streamable-HTTP on 127.0.0.1:9420
 notebooklm-mcp --transport http --port 9000
 ```
 
@@ -84,7 +84,7 @@ notebooklm-mcp --transport http --port 9000
 | `--profile` | active profile | which stored auth profile the process binds |
 | `--transport` | `stdio` | `stdio` (subprocess hosts) or `http` (loopback) |
 | `--host` | `127.0.0.1` | http only; non-loopback is **refused** unless `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` |
-| `--port` | `8000` | http only |
+| `--port` | `9420` | http only |
 | `--log-level` | `INFO` | logs go to **stderr**; stdout stays pure JSON-RPC |
 
 There is no `--token` flag — the HTTP bearer token is **env-only**
@@ -111,7 +111,7 @@ notebooklm login --master-token --account you@example.com
 cp -r ~/.notebooklm/profiles/<profile>/. deploy/profile/   # mounted read-write
 # 2. secrets:
 cp deploy/.env.example deploy/.env                          # set MCP token + tunnel token
-# 3. create a Cloudflare Tunnel → public hostname → http://notebooklm-mcp:8000
+# 3. create a Cloudflare Tunnel → public hostname → http://notebooklm-mcp:9420
 # 4. run:
 cd deploy && docker compose up -d
 # 5. connect:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ impersonate = ["curl_cffi>=0.11,<1"]
 # pure-Python (no native wheels), so it is safe in `all`. >=1.1.0 for
 # exchange_token; no <2 cap so the 2.0.0 ServiceDisabled fix installs.
 headless = ["gpsoauth>=1.1.0"]
-mcp = ["fastmcp>=2.14,<4"]
+# >=3.0: the remote-transport bearer auth (FastMCP(auth=...) + TokenVerifier)
+# landed in fastmcp 3.0; 2.x lacks it and would ImportError in mcp/_auth.py.
+mcp = ["fastmcp>=3.0,<4"]
 # Optional single-tenant REST server (the third _app adapter, after cli/ and
 # mcp/). EXPERIMENTAL: the /v1 surface may change in a minor release; it is
 # excluded from the public-API compatibility gate. python-multipart is REQUIRED

--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -143,8 +143,8 @@ def _build_parser() -> argparse.ArgumentParser:
         # NOTEBOOKLM_MCP_PORT must not crash the parser before CLI args are read
         # (which would make --port unable to override it). Kept as a string and
         # converted after parse with a clear error (see ``_resolve_port``).
-        default=os.environ.get("NOTEBOOKLM_MCP_PORT", "8000"),
-        help="HTTP bind port (http transport only; default: 8000).",
+        default=os.environ.get("NOTEBOOKLM_MCP_PORT", "9420"),
+        help="HTTP bind port (http transport only; default: 9420).",
     )
     parser.add_argument(
         "--log-level",
@@ -188,15 +188,19 @@ def main(argv: list[str] | None = None) -> None:
         )
 
     if args.transport == "http":
+        # Normalize the host once and use it for the guards AND the bind — the
+        # loopback check tolerates surrounding whitespace, so an env value like
+        # " 127.0.0.1 " must not pass the guards and then fail at bind time.
+        host = args.host.strip()
         allow_external = os.environ.get(ALLOW_EXTERNAL_BIND_ENV) == "1"
-        _check_http_bind_allowed(args.host, allow_external=allow_external)
+        _check_http_bind_allowed(host, allow_external=allow_external)
         # Resolve the token once, BEFORE building the server: the same value
         # gates startup (fail closed on a network bind) and, when present,
         # becomes the per-request bearer verifier.
         token = get_configured_token()
-        _check_http_token_required(args.host, token)
+        _check_http_token_required(host, token)
         server = create_server(profile=args.profile, auth=build_auth_provider(token))
-        server.run(transport="http", host=args.host, port=_resolve_port(args.port))
+        server.run(transport="http", host=host, port=_resolve_port(args.port))
     else:
         # show_banner=False keeps FastMCP's startup banner out of the host's logs
         # (and off stdout — stdio requires uncontaminated JSON-RPC).

--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -4,9 +4,13 @@ Two transports are supported:
 
 * **stdio** (default): the client speaks JSON-RPC over stdin/stdout. stdout must
   carry *pristine* JSON-RPC, so all logging is pinned to **stderr**.
-* **http** (loopback): a local streamable-HTTP server. A bind guard refuses any
-  non-loopback ``--host`` unless ``NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1`` is set,
-  so an MCP server is never accidentally exposed to the network.
+* **http**: a streamable-HTTP server. A bind guard refuses any non-loopback
+  ``--host`` unless ``NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1`` is set, so an MCP
+  server is never accidentally exposed to the network. A second, fail-closed
+  guard refuses to start on a non-loopback bind unless ``NOTEBOOKLM_MCP_TOKEN``
+  is set — a network-reachable server fronting a full Google account must require
+  a bearer token. The token is **env-only** (never a CLI flag, so it cannot leak
+  via ``ps aux``) and is verified by :mod:`._auth`.
 
 The auth profile is bound once at startup via ``--profile`` /
 ``NOTEBOOKLM_PROFILE``. This module imports NO ``click`` / ``rich`` / ``cli``.
@@ -20,6 +24,7 @@ import logging
 import os
 import sys
 
+from ._auth import MCP_TOKEN_ENV, build_auth_provider, get_configured_token
 from .server import create_server
 
 __all__ = ["main"]
@@ -49,14 +54,18 @@ def _configure_logging(level: str) -> None:
 
 
 def _is_loopback(host: str) -> bool:
-    """Return whether ``host`` resolves to a loopback interface."""
-    if host in _LOOPBACK_HOSTNAMES:
+    """Return whether ``host`` resolves to a loopback interface.
+
+    Hostnames are case-insensitive, so ``LOCALHOST`` is normalized before the
+    check; an IP literal (``127.0.0.1`` / ``::1``) is parsed. Anything else
+    (a public DNS name, ``0.0.0.0``, ``::``) is NOT loopback — fail closed.
+    """
+    normalized = host.strip().lower()
+    if normalized in _LOOPBACK_HOSTNAMES:
         return True
     try:
-        return ipaddress.ip_address(host).is_loopback
+        return ipaddress.ip_address(normalized).is_loopback
     except ValueError:
-        # A non-numeric, non-"localhost" hostname (e.g. a public DNS name) is NOT
-        # treated as loopback — fail closed.
         return False
 
 
@@ -85,6 +94,26 @@ def _check_http_bind_allowed(host: str, *, allow_external: bool) -> None:
         f"This would expose the server to the network. Set "
         f"{ALLOW_EXTERNAL_BIND_ENV}=1 to override (only behind a trusted proxy)."
     )
+
+
+def _check_http_token_required(host: str, token: str | None) -> None:
+    """Refuse a non-loopback HTTP bind without a bearer token (fail closed).
+
+    Keyed off the effective non-loopback bind — NOT the ``ALLOW_EXTERNAL_BIND``
+    flag — so a loopback dev run never needs a token, while any network-reachable
+    bind (which fronts a full Google account) must carry one. Mirrors the REST
+    server's ``_check_token_configured`` startup guard.
+
+    Raises:
+        SystemExit: ``host`` is non-loopback and ``token`` is ``None``.
+    """
+    if not _is_loopback(host) and token is None:
+        raise SystemExit(
+            f"Refusing to bind the MCP HTTP transport to non-loopback host "
+            f"'{host}' without {MCP_TOKEN_ENV} set. A network-reachable "
+            f"MCP server fronts a full Google account and must require a "
+            f"bearer token. Set {MCP_TOKEN_ENV} to a strong random value."
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -132,12 +161,15 @@ def _resolve_port(raw: str) -> int:
     parser build before ``--port`` can override it.
     """
     try:
-        return int(raw)
+        port = int(raw)
     except (TypeError, ValueError):
         raise SystemExit(
             f"Invalid port {raw!r}: must be an integer "
             f"(check the --port argument and NOTEBOOKLM_MCP_PORT)."
         ) from None
+    if not 1 <= port <= 65535:
+        raise SystemExit(f"Invalid port {port}: must be in 1..65535.")
+    return port
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -155,15 +187,20 @@ def main(argv: list[str] | None = None) -> None:
             f"NOTEBOOKLM_MCP_TRANSPORT)."
         )
 
-    server = create_server(profile=args.profile)
-
     if args.transport == "http":
         allow_external = os.environ.get(ALLOW_EXTERNAL_BIND_ENV) == "1"
         _check_http_bind_allowed(args.host, allow_external=allow_external)
+        # Resolve the token once, BEFORE building the server: the same value
+        # gates startup (fail closed on a network bind) and, when present,
+        # becomes the per-request bearer verifier.
+        token = get_configured_token()
+        _check_http_token_required(args.host, token)
+        server = create_server(profile=args.profile, auth=build_auth_provider(token))
         server.run(transport="http", host=args.host, port=_resolve_port(args.port))
     else:
         # show_banner=False keeps FastMCP's startup banner out of the host's logs
         # (and off stdout — stdio requires uncontaminated JSON-RPC).
+        server = create_server(profile=args.profile)
         server.run(transport="stdio", show_banner=False)
 
 

--- a/src/notebooklm/mcp/_auth.py
+++ b/src/notebooklm/mcp/_auth.py
@@ -1,0 +1,104 @@
+"""Bearer-token auth for the remote (HTTP) MCP transport.
+
+The stdio transport is local and unauthenticated (FastMCP skips auth for stdio).
+The HTTP transport, once bound to a non-loopback interface, fronts a full-account
+Google session and MUST require a bearer token — the fail-closed startup check
+lives in :mod:`.__main__`, and this module supplies the verifier FastMCP runs on
+every request.
+
+Design — mirror the REST server's `server/_auth.py` posture, NOT
+``fastmcp``'s ``StaticTokenVerifier``:
+
+* ``StaticTokenVerifier``'s own source warns "Never use this in production —
+  tokens are stored in plain text"; it pulls in ``authlib``/JOSE for what is a
+  single string comparison; and its token dict requires a ``client_id`` key with
+  no default (``{token: {}}`` raises ``KeyError`` on the first request).
+* A ~20-line :class:`~fastmcp.server.auth.auth.TokenVerifier` subclass doing a
+  constant-time :func:`hmac.compare_digest` is the right tool: no extra
+  dependency, a clean 401, and the token held in a private attribute that never
+  reaches a log or ``repr`` (honoring the #1517/#1518 redaction discipline — the
+  REST server protects ``NOTEBOOKLM_SERVER_TOKEN`` the same way).
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+__all__ = [
+    "MCP_TOKEN_ENV",
+    "McpBearerAuthProvider",
+    "build_auth_provider",
+    "get_configured_token",
+]
+
+#: Env var carrying the bearer token the HTTP transport validates every request
+#: against. Env-only (never a CLI flag) so the value cannot leak via ``ps aux``.
+MCP_TOKEN_ENV = "NOTEBOOKLM_MCP_TOKEN"
+
+#: Synthetic client id stamped on a validated token. Single-tenant: there is one
+#: token and one logical client, so this is a constant, not a lookup.
+_CLIENT_ID = "notebooklm-mcp"
+
+
+def get_configured_token() -> str | None:
+    """Return the configured MCP bearer token, or ``None`` when unset/empty.
+
+    Read live from the environment. An empty / whitespace-only value is treated
+    as *unset* (fail closed) — same semantics as the REST server's token.
+    """
+    token = os.environ.get(MCP_TOKEN_ENV)
+    if token is None:
+        return None
+    token = token.strip()
+    return token or None
+
+
+class McpBearerAuthProvider(TokenVerifier):
+    """Gate the HTTP transport on a single bearer token (constant-time compare).
+
+    FastMCP runs :meth:`verify_token` for every request via its
+    ``RequireAuthMiddleware``; a ``None`` return is a 401. The token lives in a
+    name-mangled private attribute and is deliberately kept out of ``repr`` so it
+    cannot leak into a log line or an exception render.
+    """
+
+    def __init__(self, token: str) -> None:
+        super().__init__()
+        # Name-mangled (``_McpBearerAuthProvider__token``) so a default repr /
+        # vars() dump does not surface it; __repr__ is overridden too.
+        self.__token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        # Compare BYTES, not str: Starlette latin-1-decodes the Authorization
+        # header, so a non-ASCII bearer reaches here as a str that
+        # hmac.compare_digest(str, str) would reject with TypeError (→ an
+        # unhandled 500 + traceback instead of a clean 401). Encoding both sides
+        # keeps the constant-time compare and returns None (401) for any
+        # non-matching/malformed token.
+        if hmac.compare_digest(
+            token.encode("utf-8", "surrogatepass"), self.__token.encode("utf-8")
+        ):
+            # Do NOT echo the live token back into the AccessToken: FastMCP stores
+            # it on the request scope (scope["user"]) and AccessToken's pydantic
+            # repr would expose it in any scope/log dump. We never read the field,
+            # so stamp an opaque constant instead (the last cleartext copy gone).
+            return AccessToken(token=_CLIENT_ID, client_id=_CLIENT_ID, scopes=[])
+        return None
+
+    def __repr__(self) -> str:  # never leak the token
+        return f"{type(self).__name__}(token=<redacted>)"
+
+
+def build_auth_provider(token: str | None) -> McpBearerAuthProvider | None:
+    """Return a provider for a non-empty ``token``, else ``None`` (no auth).
+
+    The caller (``__main__`` on the http path) resolves the token and, when the
+    bind is network-reachable, refuses to start without one; this helper only
+    maps token→provider so ``create_server`` stays env-free.
+    """
+    return McpBearerAuthProvider(token) if token else None

--- a/src/notebooklm/mcp/_auth.py
+++ b/src/notebooklm/mcp/_auth.py
@@ -13,17 +13,19 @@ Design — mirror the REST server's `server/_auth.py` posture, NOT
   tokens are stored in plain text"; it pulls in ``authlib``/JOSE for what is a
   single string comparison; and its token dict requires a ``client_id`` key with
   no default (``{token: {}}`` raises ``KeyError`` on the first request).
-* A ~20-line :class:`~fastmcp.server.auth.auth.TokenVerifier` subclass doing a
-  constant-time :func:`hmac.compare_digest` is the right tool: no extra
-  dependency, a clean 401, and the token held in a private attribute that never
-  reaches a log or ``repr`` (honoring the #1517/#1518 redaction discipline — the
-  REST server protects ``NOTEBOOKLM_SERVER_TOKEN`` the same way).
+* A ~25-line :class:`~fastmcp.server.auth.auth.TokenVerifier` subclass doing a
+  constant-time :func:`hmac.compare_digest` on **SHA-256 digests** is the right
+  tool: no extra dependency, a clean 401, and only a non-reversible digest of the
+  token is retained (never the cleartext, so a ``vars()``/scope dump can't leak
+  it) — honoring the #1517/#1518 redaction discipline, the way the REST server
+  protects ``NOTEBOOKLM_SERVER_TOKEN``.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import os
 
@@ -62,35 +64,39 @@ class McpBearerAuthProvider(TokenVerifier):
     """Gate the HTTP transport on a single bearer token (constant-time compare).
 
     FastMCP runs :meth:`verify_token` for every request via its
-    ``RequireAuthMiddleware``; a ``None`` return is a 401. The token lives in a
-    name-mangled private attribute and is deliberately kept out of ``repr`` so it
-    cannot leak into a log line or an exception render.
+    ``RequireAuthMiddleware``; a ``None`` return is a 401. The instance holds only
+    the **SHA-256 digest** of the configured token, never the cleartext — so
+    ``vars(provider)`` / a scope dump cannot surface it — and verification hashes
+    the presented token and compares digests in constant time.
     """
 
     def __init__(self, token: str) -> None:
         super().__init__()
-        # Name-mangled (``_McpBearerAuthProvider__token``) so a default repr /
-        # vars() dump does not surface it; __repr__ is overridden too.
-        self.__token = token
+        # Store only a digest of the configured token (its raw UTF-8 bytes hashed).
+        # The digest is non-reversible and cannot be replayed as a token (verify
+        # hashes the *presented* value), so no cleartext copy is retained anywhere.
+        self.__digest = hashlib.sha256(token.encode("utf-8")).digest()
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        # Compare BYTES, not str: Starlette latin-1-decodes the Authorization
-        # header, so a non-ASCII bearer reaches here as a str that
-        # hmac.compare_digest(str, str) would reject with TypeError (→ an
-        # unhandled 500 + traceback instead of a clean 401). Encoding both sides
-        # keeps the constant-time compare and returns None (401) for any
-        # non-matching/malformed token.
-        if hmac.compare_digest(
-            token.encode("utf-8", "surrogatepass"), self.__token.encode("utf-8")
-        ):
-            # Do NOT echo the live token back into the AccessToken: FastMCP stores
-            # it on the request scope (scope["user"]) and AccessToken's pydantic
-            # repr would expose it in any scope/log dump. We never read the field,
-            # so stamp an opaque constant instead (the last cleartext copy gone).
+        # Starlette latin-1-decodes the Authorization header, so ``token`` here is
+        # the latin-1 view of the raw request bytes. ``.encode("latin-1")`` round-
+        # trips that back to the EXACT bytes the client sent, which we hash and
+        # compare against the configured token's UTF-8-byte digest — so an ASCII
+        # token and a UTF-8-encoded non-ASCII token both verify correctly. A header
+        # string outside latin-1 (cannot come from Starlette) simply fails to match.
+        try:
+            presented = token.encode("latin-1")
+        except UnicodeEncodeError:
+            return None
+        if hmac.compare_digest(hashlib.sha256(presented).digest(), self.__digest):
+            # Do NOT echo the live token into the AccessToken: FastMCP stores it on
+            # the request scope (scope["user"]) and AccessToken's pydantic repr
+            # would expose it in any scope/log dump. We never read the field, so
+            # stamp an opaque constant instead.
             return AccessToken(token=_CLIENT_ID, client_id=_CLIENT_ID, scopes=[])
         return None
 
-    def __repr__(self) -> str:  # never leak the token
+    def __repr__(self) -> str:  # never surface auth material
         return f"{type(self).__name__}(token=<redacted>)"
 
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -22,6 +22,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import cast
 
 from fastmcp import FastMCP
+from fastmcp.server.auth import AuthProvider
 
 from ..client import NotebookLMClient
 from ._context import AppState
@@ -65,6 +66,7 @@ def create_server(
     *,
     profile: str | None = None,
     client_factory: ClientFactory | None = None,
+    auth: AuthProvider | None = None,
 ) -> FastMCP:
     """Build the FastMCP server.
 
@@ -74,6 +76,11 @@ def create_server(
         client_factory: Test seam — a zero-arg callable returning an async context
             manager that yields a client. Defaults to
             ``NotebookLMClient.from_storage(profile=...)``.
+        auth: Optional FastMCP auth provider gating the HTTP transport. Passed
+            **explicitly** by the caller — this function never reads
+            ``NOTEBOOKLM_MCP_TOKEN`` itself, so stdio runs and the unit suite
+            never silently attach auth (the token check + provider build live in
+            :mod:`.__main__`, only on the network-bound http path).
 
     Returns:
         A configured :class:`~fastmcp.FastMCP` server whose lifespan binds one
@@ -95,6 +102,6 @@ def create_server(
         async with factory() as client:
             yield AppState(client=client)
 
-    mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS, lifespan=lifespan)
+    mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS, lifespan=lifespan, auth=auth)
     register_all(mcp)
     return mcp

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -68,13 +68,95 @@ def test_defaults_wire_stdio_transport(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``--transport http`` with the default host binds the loopback port."""
+    """``--transport http`` on loopback binds the port and needs NO token (auth=None)."""
     fake_server = MagicMock()
-    monkeypatch.setattr(
-        entry, "create_server", lambda *, profile=None, client_factory=None: fake_server
-    )
+    captured: dict[str, object] = {}
+
+    def fake_create_server(*, profile=None, client_factory=None, auth=None):
+        captured["auth"] = auth
+        return fake_server
+
+    monkeypatch.setattr(entry, "create_server", fake_create_server)
     monkeypatch.delenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
 
     entry.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8123"])
 
     fake_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=8123)
+    # Loopback + no token → unauthenticated (today's local-dev behavior preserved).
+    assert captured["auth"] is None
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("localhost", True),
+        ("LOCALHOST", True),  # hostnames are case-insensitive
+        (" localhost ", True),  # surrounding whitespace tolerated
+        ("0.0.0.0", False),  # all-interfaces is NOT loopback → token required
+        ("::", False),
+        ("example.com", False),  # public DNS name → fail closed
+        ("192.168.1.5", False),  # LAN address → not loopback
+    ],
+)
+def test_is_loopback_classification(host: str, expected: bool) -> None:
+    assert entry._is_loopback(host) is expected
+
+
+def test_http_loopback_with_token_attaches_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loopback + a token set → auth IS attached (the safe, more-restrictive
+    interaction): setting the token opts even a loopback bind into the gate."""
+    fake_server = MagicMock()
+    captured: dict[str, object] = {}
+
+    def fake_create_server(*, profile=None, client_factory=None, auth=None):
+        captured["auth"] = auth
+        return fake_server
+
+    monkeypatch.setattr(entry, "create_server", fake_create_server)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_TOKEN", "loopback-token")
+
+    entry.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8124"])
+
+    from notebooklm.mcp._auth import McpBearerAuthProvider
+
+    assert isinstance(captured["auth"], McpBearerAuthProvider)
+
+
+def test_http_non_loopback_without_token_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail closed: a network-reachable bind without a token must not start —
+    even with the external-bind override set, the server is built nowhere."""
+    built = MagicMock(side_effect=AssertionError("create_server must not be reached"))
+    monkeypatch.setattr(entry, "create_server", built)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
+
+    assert "NOTEBOOKLM_MCP_TOKEN" in str(excinfo.value)
+    built.assert_not_called()
+
+
+def test_http_non_loopback_with_token_attaches_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A network bind WITH a token builds the server with a bearer auth provider."""
+    from notebooklm.mcp._auth import McpBearerAuthProvider
+
+    fake_server = MagicMock()
+    captured: dict[str, object] = {}
+
+    def fake_create_server(*, profile=None, client_factory=None, auth=None):
+        captured["auth"] = auth
+        return fake_server
+
+    monkeypatch.setattr(entry, "create_server", fake_create_server)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.setenv("NOTEBOOKLM_MCP_TOKEN", "s3cret-token")
+
+    entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
+
+    fake_server.run.assert_called_once_with(transport="http", host="0.0.0.0", port=8000)
+    assert isinstance(captured["auth"], McpBearerAuthProvider)

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -87,6 +87,21 @@ def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch)
     assert captured["auth"] is None
 
 
+def test_http_default_port_is_9420(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default HTTP port is 9420 (no --port / NOTEBOOKLM_MCP_PORT)."""
+    fake_server = MagicMock()
+    monkeypatch.setattr(
+        entry, "create_server", lambda *, profile=None, client_factory=None, auth=None: fake_server
+    )
+    monkeypatch.delenv("NOTEBOOKLM_MCP_PORT", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+
+    entry.main(["--transport", "http"])
+
+    fake_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=9420)
+
+
 def test_bogus_transport_env_default_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
     """An invalid env-derived transport default must SystemExit, not silently run
     stdio (argparse ``choices`` validates an explicit flag but not the env default)."""

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -87,6 +87,18 @@ def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch)
     assert captured["auth"] is None
 
 
+def test_bogus_transport_env_default_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An invalid env-derived transport default must SystemExit, not silently run
+    stdio (argparse ``choices`` validates an explicit flag but not the env default)."""
+    monkeypatch.setenv("NOTEBOOKLM_MCP_TRANSPORT", "websocket")
+    monkeypatch.setattr(entry, "create_server", MagicMock())
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main([])
+
+    assert "Invalid transport" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     ("host", "expected"),
     [

--- a/tests/unit/mcp/test_remote_auth.py
+++ b/tests/unit/mcp/test_remote_auth.py
@@ -9,7 +9,7 @@ without an explicit ``auth=``).
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -162,3 +162,63 @@ def test_http_app_accepts_correct_bearer() -> None:
         r = client.post("/mcp", json=init, headers=headers)
     assert r.status_code != 401  # passed the bearer gate
     assert r.status_code == 200  # initialize handshake handled
+
+
+@pytest.mark.asyncio
+async def test_authenticated_tool_call_over_http_transport() -> None:
+    """Full integration: a real MCP ``Client`` drives the real FastMCP HTTP
+    transport + auth middleware + protocol handshake + tool dispatch, end to end.
+
+    With the correct bearer the client completes the handshake and a
+    ``notebook_list`` tool call (dispatched through ``_app`` to a stubbed
+    NotebookLMClient) returns its structured result; a wrong bearer is rejected
+    with 401. Runs entirely in-process over an httpx ASGI transport — no port, no
+    network, no extra deps (the existing ``mcp_vcr`` suite covers the in-memory
+    transport; this is the one path that also exercises HTTP + the bearer gate).
+    """
+    pytest.importorskip("starlette")
+    import httpx
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    from notebooklm.mcp.server import create_server
+
+    stub = MagicMock()
+    stub.notebooks.list = AsyncMock(return_value=[])  # canned: empty list serializes cleanly
+
+    @asynccontextmanager
+    async def factory():
+        yield stub
+
+    server = create_server(
+        client_factory=lambda: factory(), auth=build_auth_provider("right-token")
+    )
+    app = server.http_app()
+
+    def httpx_factory(**kwargs):
+        # fastmcp passes its own transport/headers; drive the app in-process via ASGI.
+        kwargs.pop("transport", None)
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://mcp.test", **kwargs
+        )
+
+    def make_transport(token: str) -> StreamableHttpTransport:
+        return StreamableHttpTransport(
+            "http://mcp.test/mcp",
+            headers={"Authorization": f"Bearer {token}"},
+            httpx_client_factory=httpx_factory,
+        )
+
+    # Running the app lifespan binds the (stubbed) client for the request lifetime.
+    async with app.router.lifespan_context(app):
+        async with Client(make_transport("right-token")) as mcp:
+            tools = await mcp.list_tools()
+            assert any(t.name == "notebook_list" for t in tools)
+            result = await mcp.call_tool("notebook_list", {})
+            assert result.structured_content == {"notebooks": []}
+            stub.notebooks.list.assert_awaited()  # dispatch really reached the client
+
+        # Wrong bearer → rejected by the auth middleware (never reaches a tool).
+        with pytest.raises(httpx.HTTPStatusError):
+            async with Client(make_transport("wrong-token")) as mcp:
+                await mcp.list_tools()

--- a/tests/unit/mcp/test_remote_auth.py
+++ b/tests/unit/mcp/test_remote_auth.py
@@ -1,0 +1,152 @@
+"""Tests for ``notebooklm.mcp._auth`` — the remote-transport bearer gate.
+
+Covers the custom :class:`McpBearerAuthProvider` (constant-time verify, redacted
+repr), the env accessor (strip + empty→None), ``build_auth_provider`` mapping,
+and the contract that ``create_server`` stays **env-free** (no auth attached
+without an explicit ``auth=``).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from notebooklm.mcp._auth import (  # noqa: E402 - after importorskip guard
+    MCP_TOKEN_ENV,
+    McpBearerAuthProvider,
+    build_auth_provider,
+    get_configured_token,
+)
+
+
+@pytest.mark.asyncio
+async def test_verify_token_accepts_exact_match_only() -> None:
+    provider = McpBearerAuthProvider("correct-horse")
+    ok = await provider.verify_token("correct-horse")
+    assert ok is not None
+    assert ok.client_id == "notebooklm-mcp"
+    assert ok.scopes == []
+    # The validated AccessToken must NOT echo the live bearer (it is stored on the
+    # request scope; its pydantic repr would otherwise leak the token).
+    assert ok.token != "correct-horse"
+    assert await provider.verify_token("wrong") is None
+    assert await provider.verify_token("") is None
+    # Non-ASCII bearer → clean reject (no TypeError → no 500).
+    assert await provider.verify_token("nøt-ascii-Ω") is None
+
+
+def test_repr_never_leaks_the_token() -> None:
+    # repr is the realistic leak path (an f-string / logger.info(provider)); the
+    # value must live in __dict__ to be compared, so we defend repr, not storage.
+    provider = McpBearerAuthProvider("super-secret-value")
+    assert "super-secret-value" not in repr(provider)
+    assert "redacted" in repr(provider)
+    # Mangled attribute name keeps it off `provider.token` / casual access.
+    assert not hasattr(provider, "token")
+
+
+def test_get_configured_token_strips_and_treats_empty_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOKEN_ENV, "  tok-123  ")
+    assert get_configured_token() == "tok-123"
+    monkeypatch.setenv(MCP_TOKEN_ENV, "   ")
+    assert get_configured_token() is None
+    monkeypatch.delenv(MCP_TOKEN_ENV, raising=False)
+    assert get_configured_token() is None
+
+
+def test_build_auth_provider_maps_token_to_provider() -> None:
+    assert build_auth_provider(None) is None
+    assert build_auth_provider("") is None
+    provider = build_auth_provider("a-token")
+    assert isinstance(provider, McpBearerAuthProvider)
+
+
+def test_create_server_is_env_free(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``create_server`` must NOT read ``NOTEBOOKLM_MCP_TOKEN`` — auth is attached
+    only when the caller passes it (so stdio + this suite never gate)."""
+    from notebooklm.mcp.server import create_server
+
+    @asynccontextmanager
+    async def fake_factory():
+        yield MagicMock()
+
+    monkeypatch.setenv(MCP_TOKEN_ENV, "present-but-ignored")
+    server = create_server(profile="x", client_factory=lambda: fake_factory())
+    assert server.auth is None
+
+    provider = build_auth_provider("explicit")
+    server_with_auth = create_server(
+        profile="x", client_factory=lambda: fake_factory(), auth=provider
+    )
+    assert server_with_auth.auth is provider
+
+
+def test_http_app_rejects_request_without_bearer() -> None:
+    """End-to-end through FastMCP's real auth middleware: a request to /mcp with
+    no/invalid bearer is rejected (401) before reaching any tool/client."""
+    starlette_testclient = pytest.importorskip("starlette.testclient")
+    from notebooklm.mcp.server import create_server
+
+    @asynccontextmanager
+    async def fake_factory():
+        yield MagicMock()
+
+    server = create_server(
+        profile="x", client_factory=lambda: fake_factory(), auth=build_auth_provider("right-token")
+    )
+    app = server.http_app()
+    client = starlette_testclient.TestClient(app)
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    accept = {"Accept": "application/json, text/event-stream"}
+
+    # No token → rejected at the auth layer (never reaches the transport/client).
+    assert client.post("/mcp", json=body, headers=accept).status_code == 401
+    # Wrong token → also rejected.
+    assert (
+        client.post(
+            "/mcp", json=body, headers={**accept, "Authorization": "Bearer nope"}
+        ).status_code
+        == 401
+    )
+
+
+def test_http_app_accepts_correct_bearer() -> None:
+    """Positive path: the CORRECT token is NOT rejected — it passes the auth gate
+    and the MCP initialize handshake succeeds (guards against a blanket-reject
+    regression that the 401-only tests would miss)."""
+    starlette_testclient = pytest.importorskip("starlette.testclient")
+    from notebooklm.mcp.server import create_server
+
+    @asynccontextmanager
+    async def fake_factory():
+        yield MagicMock()
+
+    server = create_server(
+        profile="x", client_factory=lambda: fake_factory(), auth=build_auth_provider("right-token")
+    )
+    app = server.http_app()
+    init = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1"},
+        },
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer right-token",
+    }
+    # `with` runs the lifespan so the streamable-HTTP session manager initializes.
+    with starlette_testclient.TestClient(app) as client:
+        r = client.post("/mcp", json=init, headers=headers)
+    assert r.status_code != 401  # passed the bearer gate
+    assert r.status_code == 200  # initialize handshake handled

--- a/tests/unit/mcp/test_remote_auth.py
+++ b/tests/unit/mcp/test_remote_auth.py
@@ -218,7 +218,8 @@ async def test_authenticated_tool_call_over_http_transport() -> None:
             assert result.structured_content == {"notebooks": []}
             stub.notebooks.list.assert_awaited()  # dispatch really reached the client
 
-        # Wrong bearer → rejected by the auth middleware (never reaches a tool).
-        with pytest.raises(httpx.HTTPStatusError):
+        # Wrong bearer → rejected by the auth middleware with 401 (never a tool).
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
             async with Client(make_transport("wrong-token")) as mcp:
                 await mcp.list_tools()
+        assert excinfo.value.response.status_code == 401

--- a/tests/unit/mcp/test_remote_auth.py
+++ b/tests/unit/mcp/test_remote_auth.py
@@ -35,8 +35,20 @@ async def test_verify_token_accepts_exact_match_only() -> None:
     assert ok.token != "correct-horse"
     assert await provider.verify_token("wrong") is None
     assert await provider.verify_token("") is None
-    # Non-ASCII bearer → clean reject (no TypeError → no 500).
-    assert await provider.verify_token("nøt-ascii-Ω") is None
+
+
+@pytest.mark.asyncio
+async def test_verify_token_matches_utf8_token_through_latin1_header() -> None:
+    """A non-ASCII token sent UTF-8-encoded verifies correctly: Starlette latin-1-
+    decodes the header, and verify_token round-trips it back to the request bytes.
+    (Guards the encoding-mismatch bug gemini-code-assist flagged.)"""
+    provider = McpBearerAuthProvider("café-Ω-token")  # configured (clean str)
+    # What Starlette hands verify_token: the latin-1 view of the UTF-8 header bytes.
+    as_received = "café-Ω-token".encode().decode("latin-1")
+    assert await provider.verify_token(as_received) is not None
+    # The raw (non-round-tripped) string must NOT match — and must not raise even
+    # though it contains a non-latin-1 char.
+    assert await provider.verify_token("café-Ω-token") is None
 
 
 def test_repr_never_leaks_the_token() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1342,7 +1342,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "curl-cffi", marker = "extra == 'impersonate'", specifier = ">=0.11,<1" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115,<1" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.14,<4" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
     { name = "filelock", specifier = ">=3.13,<4" },
     { name = "gpsoauth", marker = "extra == 'headless'", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.29" },


### PR DESCRIPTION
## Summary

Makes `notebooklm-mcp` deployable as a **remote MCP connector** (Claude Code / Claude.ai / Cursor), single-tenant, gated by a bearer token, with a turn-key **Docker + Cloudflare Tunnel** deploy (no public IP, no open ports, no CA cert to manage).

Master-token headless auth (#1638/#1639) keeps the upstream Google session alive unattended — the prerequisite a long-running remote server needed. The HTTP transport + bind guard already existed; this adds the **client→server auth layer** and packaging. **Two auth layers, never conflated:** the `NOTEBOOKLM_MCP_TOKEN` bearer gates *who may use the endpoint*; the master token authenticates *the server to Google* (never traverses the tunnel, never in MCP output).

## What's in it
- **`mcp/_auth.py`** — `McpBearerAuthProvider(TokenVerifier)`: constant-time **byte**-compare of an **env-only** token (no `--token` flag → no `ps aux` leak), name-mangled token + redacted `__repr__`, and the validated `AccessToken` stamps an opaque client id (never the live token — it's stored on the request scope). Mirrors `server/_auth.py`; deliberately **not** fastmcp's `StaticTokenVerifier`.
- **`mcp/__main__.py`** — fail-closed: a non-loopback http bind **without** a token refuses to start (checked **before** `create_server`, keyed off the effective bind).
- **`mcp/server.py`** — `create_server(auth=…)` is **env-free** (stdio + the unit suite never gate).
- **`deploy/`** — Dockerfile (non-root, stdlib TCP healthcheck), compose with a `cloudflared` sidecar + a **read-write** profile mount (a `ro` mount kills cookie rotation/recovery ~1h in), `.env.example`, `.gitignore`, README.
- Docs + `fastmcp>=3.0` pin (the auth API is 3.0+).

## Process
- **Plan converged through oracle+momus review across codex/claude/agy** (2 rounds): resolved the `StaticTokenVerifier`-is-wrong, read-only-mount-kills-session, fastmcp-pin, and healthcheck blockers before any code.
- **Polished** (code-simplifier + triple review codex/claude/agy): fixed an `AccessToken` token-leak, a non-ASCII-bearer→500 bug (now clean 401), and the Docker uid/profile-ownership gotcha.

## Test plan
- [x] Custom provider gates the **real** FastMCP HTTP middleware end-to-end: no/wrong token → 401, correct → MCP session (`test_remote_auth.py`).
- [x] **Live run** against a real profile: listed notebooks through the remote transport (26 tools, `notebook_list` OK).
- [x] Fail-closed matrix: non-loopback + no token ⇒ refuse to start; loopback/`0.0.0.0`/`::`/IPv6 classification.
- [x] mypy + ruff clean; 1248 unit/guardrail tests pass.

## Out of scope (single-tenant)
OAuth/DCR connectors, multi-tenant hosting, and file upload/download brokers — files are delegated to Google Drive / the NotebookLM app / local stdio (the connector moves text + references only, never bytes through the model).

## Follow-up
`server/_auth.py:121` has the same latent non-ASCII `hmac.compare_digest(str,str)` pattern (loopback+Host-gated, lower risk) — tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Turn-key remote MCP deployment via Docker + Cloudflare Tunnel with a non-root container, health checks, and no host port publishing.
  * HTTP remote access protected by an environment-driven bearer token (no `--token` flag).
* **Documentation**
  * Added a full deployment guide and expanded MCP run/security notes, including the default HTTP port update to `9420`.
* **Bug Fixes**
  * Fail-closed behavior for non-loopback HTTP binds unless external binding is explicitly enabled and the required token is set.
* **Tests**
  * Added CLI and HTTP-level unit coverage for bind validation and bearer auth behavior.
* **Chores**
  * Provided an env example and added deployment secret safeguards.
* **Dependencies**
  * Updated FastMCP version range for MCP feature support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->