### PR TITLE
feat(mcp): optional WorkOS AuthKit OAuth for claude.ai (Phase B)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -2,7 +2,23 @@
 
 # Bearer token clients must present to use the MCP endpoint. Generate a strong
 # random value, e.g.:  python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Works with Claude Code / Desktop (which send an Authorization header).
 NOTEBOOKLM_MCP_TOKEN=
+
+# --- Optional: WorkOS AuthKit OAuth (only needed to connect from claude.ai, ----
+# whose connector UI is OAuth-only and has no bearer field). Leave ALL FOUR unset
+# to stay bearer-only (Claude Code/Desktop are unaffected). When set, they are
+# additive — the bearer keeps working AND claude.ai can connect via OAuth.
+# Setup: WorkOS dashboard → create AuthKit, ENABLE Dynamic Client Registration,
+# add a JWT template that injects `email` + `email_verified` into the ACCESS
+# token, register https://<your-host> as a redirect; copy the domain + client id.
+# All four are required together (partial config refuses to start).
+# NOTEBOOKLM_MCP_AUTHKIT_DOMAIN=https://your-project.authkit.app
+# NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID=client_xxxxxxxx
+# NOTEBOOKLM_MCP_AUTHKIT_BASE_URL=https://your-host.example.com
+# Comma-separated allowlist of emails admitted via OAuth (MANDATORY when OAuth is
+# on — only these identities reach the account). Case-insensitive.
+# NOTEBOOKLM_MCP_ALLOWED_EMAILS=you@example.com
 
 # Cloudflare Tunnel token (Zero Trust dashboard → Networks → Tunnels → your
 # tunnel → install/connector token).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,9 +76,37 @@ claude mcp add --transport http notebooklm \
   https://notebooklm-mcp.yourdomain.com/mcp \
   --header "Authorization: Bearer $NOTEBOOKLM_MCP_TOKEN"
 ```
-(For Claude.ai / Desktop custom connectors, add the same URL under
-**Settings → Connectors**. The static bearer works for Claude Code today; a
-polished one-click OAuth flow is a future enhancement.)
+Claude **Desktop** also accepts the bearer. Claude **.ai** (web/mobile) does
+not — its connector UI is OAuth-only — so use step 6 for it.
+
+## 6. (Optional) Connect from claude.ai — OAuth via WorkOS AuthKit
+claude.ai's custom-connector UI has no bearer field; it speaks OAuth. WorkOS
+AuthKit (free tier) provides that OAuth layer. **This is opt-in and additive** —
+leave it unconfigured to stay bearer-only (Claude Code/Desktop keep working).
+
+1. **WorkOS dashboard** (workos.com, free): create an **AuthKit** project.
+   - **Enable Dynamic Client Registration** (Applications → Configuration) — claude.ai needs it.
+   - Add a **JWT template** that injects `email` **and** `email_verified` into the
+     **access token** (not just the ID token) — the allowlist reads them from the
+     access-token JWT. *(If your decoded access token lacks `email`, the connector
+     correctly rejects every login; this template is the fix.)*
+   - Register `https://<your-host>` as an allowed redirect.
+   - Copy the **AuthKit domain** and **Client ID**.
+2. **`.env`** — set all four (see `.env.example`); leave them blank to stay bearer-only:
+   ```
+   NOTEBOOKLM_MCP_AUTHKIT_DOMAIN=https://your-project.authkit.app
+   NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID=client_xxxxxxxx
+   NOTEBOOKLM_MCP_AUTHKIT_BASE_URL=https://<your-host>
+   NOTEBOOKLM_MCP_ALLOWED_EMAILS=you@example.com
+   ```
+   `make dev` again. (Partial config refuses to start — all four are required together.)
+3. **claude.ai → Settings → Connectors → Add custom connector** → `https://<your-host>/mcp`.
+   The browser OAuth flow runs via WorkOS; only emails in the allowlist are admitted.
+   Claude Code keeps using the bearer (both work at once).
+
+> The `email` allowlist is the real backstop — without it, *any* WorkOS-authenticated
+> user could reach your account, so it is **mandatory** whenever OAuth is enabled.
+> (You may see an `authlib.jose` deprecation line from FastMCP on startup — harmless.)
 
 ## Notes & security
 - **Two auth layers.** The `NOTEBOOKLM_MCP_TOKEN` bearer gates *who can use the
@@ -86,8 +114,9 @@ polished one-click OAuth flow is a future enhancement.)
   token **never** traverses the tunnel — only MCP tool calls/results do. The
   bearer **does** terminate at Cloudflare (Cloudflare can see it in transit, like
   any reverse-proxied request), so rotate it freely.
-- **Fail-closed.** The server refuses to start on a non-loopback bind without
-  `NOTEBOOKLM_MCP_TOKEN` set.
+- **Fail-closed.** The server refuses to start on a non-loopback bind with no
+  auth at all (neither `NOTEBOOKLM_MCP_TOKEN` nor WorkOS OAuth), and refuses
+  partial/allowlist-less OAuth config.
 - **One container per account.** Do not scale replicas off one master token —
   concurrent re-mints invalidate each other's session.
 - **Rotate the bearer**: change `NOTEBOOKLM_MCP_TOKEN` in `.env`,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -91,12 +91,16 @@ vars unset to stay bearer-only (Claude Code / Desktop keep working unchanged).
 > access token**, your **AuthKit domain**, and your **project Client ID**.
 
 ### 6a. Create the AuthKit project
-1. Sign up at **dashboard.workos.com** and create an **Environment** (use the
-   *Staging* / test environment first). AuthKit is on by default for new projects;
-   if not, enable it under **Authentication**.
-2. Under **Authentication → Sign-in methods**, enable at least one method you'll log
-   in with (e.g. **Email + Password** or **Google OAuth**). This is how *you* prove
-   identity during the claude.ai login.
+1. Sign up at **dashboard.workos.com**. A **Staging** environment is created for you
+   automatically (do the whole setup there first, then repeat for Production). AuthKit
+   is on by default for new environments.
+2. **Email + Password sign-in is enabled by default**, so you can log in right away —
+   no method to turn on. To *add* a social option (Google / Microsoft / GitHub), use
+   the dashboard's **"Get started" onboarding** (it walks you through authentication
+   methods, the redirect URI, and your API keys) or the **Users** area. Exact menu
+   labels move around between WorkOS releases — follow the in-dashboard onboarding
+   rather than a fixed path. This is just how *you* prove identity at the claude.ai
+   login; the connector works with the default Email + Password.
 
 ### 6b. Enable Dynamic Client Registration (so claude.ai can self-register)
 claude.ai has no pre-shared client credentials with your server — it registers

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -108,6 +108,11 @@ leave it unconfigured to stay bearer-only (Claude Code/Desktop keep working).
 > user could reach your account, so it is **mandatory** whenever OAuth is enabled.
 > (You may see an `authlib.jose` deprecation line from FastMCP on startup — harmless.)
 
+> **The default compose still requires `NOTEBOOKLM_MCP_TOKEN`** — OAuth is layered on
+> top of the bearer (so Claude Code/Desktop keep working). For an **OAuth-only** deploy
+> with no bearer, drop the `:?` guard on `NOTEBOOKLM_MCP_TOKEN` in `docker-compose.yml`;
+> the server's own fail-closed check still requires bearer *or* OAuth on a network bind.
+
 ## Notes & security
 - **Two auth layers.** The `NOTEBOOKLM_MCP_TOKEN` bearer gates *who can use the
   endpoint*; the master token authenticates *the server to Google*. The master

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -80,33 +80,86 @@ Claude **Desktop** also accepts the bearer. Claude **.ai** (web/mobile) does
 not — its connector UI is OAuth-only — so use step 6 for it.
 
 ## 6. (Optional) Connect from claude.ai — OAuth via WorkOS AuthKit
-claude.ai's custom-connector UI has no bearer field; it speaks OAuth. WorkOS
-AuthKit (free tier) provides that OAuth layer. **This is opt-in and additive** —
-leave it unconfigured to stay bearer-only (Claude Code/Desktop keep working).
+claude.ai's custom-connector UI has no bearer-token field; it only speaks OAuth.
+WorkOS **AuthKit** (free tier) is the OAuth authorization server that gives claude.ai
+something to log in against, while our server stays a *resource server* that just
+validates the resulting token. **This is opt-in and additive** — leave all four env
+vars unset to stay bearer-only (Claude Code / Desktop keep working unchanged).
 
-1. **WorkOS dashboard** (workos.com, free): create an **AuthKit** project.
-   - **Enable Dynamic Client Registration** (Applications → Configuration) — claude.ai needs it.
-   - Add a **JWT template** that injects `email` **and** `email_verified` into the
-     **access token** (not just the ID token) — the allowlist reads them from the
-     access-token JWT. *(If your decoded access token lacks `email`, the connector
-     correctly rejects every login; this template is the fix.)*
-   - Register `https://<your-host>` as an allowed redirect.
-   - Copy the **AuthKit domain** and **Client ID**.
-2. **`.env`** — set all four (see `.env.example`); leave them blank to stay bearer-only:
-   ```
-   NOTEBOOKLM_MCP_AUTHKIT_DOMAIN=https://your-project.authkit.app
-   NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID=client_xxxxxxxx
-   NOTEBOOKLM_MCP_AUTHKIT_BASE_URL=https://<your-host>
-   NOTEBOOKLM_MCP_ALLOWED_EMAILS=you@example.com
-   ```
-   `make dev` again. (Partial config refuses to start — all four are required together.)
-3. **claude.ai → Settings → Connectors → Add custom connector** → `https://<your-host>/mcp`.
-   The browser OAuth flow runs via WorkOS; only emails in the allowlist are admitted.
-   Claude Code keeps using the bearer (both work at once).
+> Dashboard paths below are current as of mid-2026; WorkOS occasionally relabels
+> menus. The four things you must end up with: **DCR enabled**, **email in the
+> access token**, your **AuthKit domain**, and your **project Client ID**.
+
+### 6a. Create the AuthKit project
+1. Sign up at **dashboard.workos.com** and create an **Environment** (use the
+   *Staging* / test environment first). AuthKit is on by default for new projects;
+   if not, enable it under **Authentication**.
+2. Under **Authentication → Sign-in methods**, enable at least one method you'll log
+   in with (e.g. **Email + Password** or **Google OAuth**). This is how *you* prove
+   identity during the claude.ai login.
+
+### 6b. Enable Dynamic Client Registration (so claude.ai can self-register)
+claude.ai has no pre-shared client credentials with your server — it registers
+itself at connect time. Enable that:
+- **Dashboard → Applications → Connect → Configuration → enable “Dynamic Client
+  Registration” (DCR).**
+  *(WorkOS's newer “Client ID Metadata Document (CIMD)” also works for clients that
+  support it; enabling DCR covers claude.ai today. Enable both if offered.)*
+
+### 6c. Put `email` + `email_verified` in the ACCESS token (the load-bearing step)
+Our allowlist reads the `email` claim off the **access token** (the JWT claude.ai
+presents to our server) — and WorkOS does **not** put `email` there by default. Add
+a JWT Template:
+- **Dashboard → Authentication → Features → JWT Template**, and add:
+  ```json
+  {
+    "email": {{ user.email }},
+    "email_verified": {{ user.email_verified }}
+  }
+  ```
+  (Reserved claims `iss`/`sub`/`exp`/`iat`/`nbf`/`jti` can't be overridden.) Without
+  this, the connector correctly **rejects every login** — see the verify step (6f).
+
+### 6d. Do NOT configure Resource Indicators (audience must equal your Client ID)
+Our server (via FastMCP `AuthKitProvider`) validates the token's `aud` claim against
+your **project Client ID**. WorkOS's optional *Resource Indicators* feature would
+instead set `aud` to your MCP URL — which our server would then reject. So **leave
+Resource Indicators unset** (the default), so `aud` stays the project default that
+equals your Client ID. (If a future setup needs resource-bound audiences, that's a
+small code change — open an issue.)
+
+### 6e. Collect the values and start the server
+- **AuthKit domain:** **Authentication → AuthKit** (e.g. `https://your-project.authkit.app`).
+- **Client ID:** **Dashboard → API Keys** → the `client_01…` value (project-level —
+  NOT a per-client DCR id, NOT the secret API key).
+- Put them in `deploy/.env` (see `.env.example`); leave blank to stay bearer-only:
+  ```
+  NOTEBOOKLM_MCP_AUTHKIT_DOMAIN=https://your-project.authkit.app
+  NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID=client_01XXXXXXXXXXXXXXXXXXXXXXXX
+  NOTEBOOKLM_MCP_AUTHKIT_BASE_URL=https://<your-host>      # your public tunnel URL
+  NOTEBOOKLM_MCP_ALLOWED_EMAILS=you@example.com            # who OAuth admits
+  ```
+  Then `make dev` (or `make prod VERSION=…`). All four are required together —
+  partial config refuses to start.
+
+### 6f. Verify the token BEFORE adding the connector (saves debugging)
+The two failure modes (missing `email`, wrong `aud`) are invisible until a token is
+issued. Confirm with WorkOS's **Authentication → Users → (a user) → “Get access
+token”** (or any AuthKit login), copy the JWT, and paste it into **jwt.io**:
+- `aud` **equals your `NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID`** → audience OK.
+- `email` is present and `email_verified` is `true` → allowlist will admit it.
+If `aud` is a URL or some other value instead of the client id, you have Resource
+Indicators configured (undo 6d) or a WorkOS/FastMCP version skew — stop and open an
+issue rather than guessing.
+
+### 6g. Add the connector on claude.ai
+- **claude.ai → Settings → Connectors → Add custom connector** → URL
+  `https://<your-host>/mcp`. The browser OAuth flow runs via WorkOS; only emails in
+  your allowlist are admitted. Claude Code keeps using the bearer — both work at once.
 
 > The `email` allowlist is the real backstop — without it, *any* WorkOS-authenticated
-> user could reach your account, so it is **mandatory** whenever OAuth is enabled.
-> (You may see an `authlib.jose` deprecation line from FastMCP on startup — harmless.)
+> user could reach your account — so it is **mandatory** whenever OAuth is enabled.
+> (A harmless `authlib.jose` deprecation line from FastMCP may print on startup.)
 
 > **The default compose still requires `NOTEBOOKLM_MCP_TOKEN`** — OAuth is layered on
 > top of the bearer (so Claude Code/Desktop keep working). For an **OAuth-only** deploy

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       NOTEBOOKLM_MCP_TOKEN: ${NOTEBOOKLM_MCP_TOKEN:?set NOTEBOOKLM_MCP_TOKEN in .env}
       # Binds 0.0.0.0 (for the cloudflared sidecar) → makes the token MANDATORY.
       NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND: "1"
+      # Optional WorkOS AuthKit OAuth (for claude.ai). Unset → bearer-only; set all
+      # four together (partial config refuses to start). See .env.example.
+      NOTEBOOKLM_MCP_AUTHKIT_DOMAIN: ${NOTEBOOKLM_MCP_AUTHKIT_DOMAIN:-}
+      NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID: ${NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID:-}
+      NOTEBOOKLM_MCP_AUTHKIT_BASE_URL: ${NOTEBOOKLM_MCP_AUTHKIT_BASE_URL:-}
+      NOTEBOOKLM_MCP_ALLOWED_EMAILS: ${NOTEBOOKLM_MCP_ALLOWED_EMAILS:-}
       # Point the app at the mounted profile, independent of the (arbitrary) uid's
       # home. The host dir is always mounted as the profile literally named
       # "server"; NOTEBOOKLM_HOME/profiles/server is where the app reads+writes.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,6 +25,10 @@ services:
     user: "${NOTEBOOKLM_UID:-1000}:${NOTEBOOKLM_GID:-1000}"
     environment:
       # Bearer token clients must present (Authorization: Bearer ...). Env-only.
+      # REQUIRED for the Docker path even when WorkOS OAuth is also configured —
+      # OAuth is layered ON TOP of the bearer (Claude Code/Desktop use the bearer,
+      # claude.ai uses OAuth). For an OAuth-ONLY deploy with no bearer, drop this
+      # `:?` guard and rely on the server's own fail-closed auth check.
       NOTEBOOKLM_MCP_TOKEN: ${NOTEBOOKLM_MCP_TOKEN:?set NOTEBOOKLM_MCP_TOKEN in .env}
       # Binds 0.0.0.0 (for the cloudflared sidecar) → makes the token MANDATORY.
       NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND: "1"

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -119,12 +119,17 @@ claude mcp add --transport http notebooklm https://<host>/mcp \
   --header "Authorization: Bearer $NOTEBOOKLM_MCP_TOKEN"
 ```
 
+The static bearer above works for Claude Code and Desktop. **claude.ai (web/mobile)** has an
+OAuth-only connector UI, so it needs the optional **WorkOS AuthKit OAuth** layer — opt-in and
+additive (unset → bearer-only; when set, the bearer and OAuth work side by side, with an email
+allowlist gating who OAuth admits). Setup is step 6 of [`deploy/README.md`](../deploy/README.md).
+
 Full step-by-step (incl. the security model and the read-write profile requirement) is in
 [`deploy/README.md`](../deploy/README.md). Use a **dedicated/throwaway Google account** — the
 mounted `master_token.json` is a durable full-account credential. The connector moves
 text/references only; add device files via Google Drive (`source_add` with a Drive id) or the
 NotebookLM app, and consume generated podcasts/videos in the NotebookLM app (same account).
-`OAuth` connectors and multi-tenant hosting are out of scope for this single-tenant setup.
+Multi-tenant hosting remains out of scope for this single-tenant setup.
 
 ## Core concepts
 

--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -24,7 +24,14 @@ import logging
 import os
 import sys
 
-from ._auth import MCP_TOKEN_ENV, build_auth_provider, get_configured_token
+from ._auth import (
+    MCP_TOKEN_ENV,
+    AuthKitConfig,
+    build_auth,
+    build_authkit_provider,
+    get_authkit_config,
+    get_configured_token,
+)
 from .server import create_server
 
 __all__ = ["main"]
@@ -96,23 +103,25 @@ def _check_http_bind_allowed(host: str, *, allow_external: bool) -> None:
     )
 
 
-def _check_http_token_required(host: str, token: str | None) -> None:
-    """Refuse a non-loopback HTTP bind without a bearer token (fail closed).
+def _check_http_auth_required(host: str, token: str | None, authkit: AuthKitConfig | None) -> None:
+    """Refuse a non-loopback HTTP bind without SOME auth (fail closed).
 
     Keyed off the effective non-loopback bind — NOT the ``ALLOW_EXTERNAL_BIND``
-    flag — so a loopback dev run never needs a token, while any network-reachable
-    bind (which fronts a full Google account) must carry one. Mirrors the REST
-    server's ``_check_token_configured`` startup guard.
+    flag — so a loopback dev run never needs auth, while any network-reachable
+    bind (which fronts a full Google account) must carry either a bearer token
+    (Claude Code / Desktop) or WorkOS AuthKit OAuth (claude.ai). Mirrors the REST
+    server's startup guard.
 
     Raises:
-        SystemExit: ``host`` is non-loopback and ``token`` is ``None``.
+        SystemExit: ``host`` is non-loopback and neither a token nor OAuth is set.
     """
-    if not _is_loopback(host) and token is None:
+    if not _is_loopback(host) and token is None and authkit is None:
         raise SystemExit(
             f"Refusing to bind the MCP HTTP transport to non-loopback host "
-            f"'{host}' without {MCP_TOKEN_ENV} set. A network-reachable "
-            f"MCP server fronts a full Google account and must require a "
-            f"bearer token. Set {MCP_TOKEN_ENV} to a strong random value."
+            f"'{host}' without authentication. A network-reachable MCP server "
+            f"fronts a full Google account and must require auth: set "
+            f"{MCP_TOKEN_ENV} (a strong random bearer for Claude Code/Desktop) "
+            f"and/or the WorkOS AuthKit env vars (OAuth for claude.ai)."
         )
 
 
@@ -194,12 +203,15 @@ def main(argv: list[str] | None = None) -> None:
         host = args.host.strip()
         allow_external = os.environ.get(ALLOW_EXTERNAL_BIND_ENV) == "1"
         _check_http_bind_allowed(host, allow_external=allow_external)
-        # Resolve the token once, BEFORE building the server: the same value
-        # gates startup (fail closed on a network bind) and, when present,
-        # becomes the per-request bearer verifier.
+        # Resolve auth BEFORE building the server, on the http path only, so
+        # create_server stays env-free. The bearer (Claude Code/Desktop) and the
+        # optional WorkOS AuthKit OAuth (claude.ai) are both env-driven;
+        # get_authkit_config() raises on partial/no-allowlist config (fail closed).
         token = get_configured_token()
-        _check_http_token_required(host, token)
-        server = create_server(profile=args.profile, auth=build_auth_provider(token))
+        authkit_config = get_authkit_config()
+        _check_http_auth_required(host, token, authkit_config)
+        authkit = build_authkit_provider(authkit_config) if authkit_config else None
+        server = create_server(profile=args.profile, auth=build_auth(token, authkit))
         server.run(transport="http", host=host, port=_resolve_port(args.port))
     else:
         # show_banner=False keeps FastMCP's startup banner out of the host's logs

--- a/src/notebooklm/mcp/_auth.py
+++ b/src/notebooklm/mcp/_auth.py
@@ -27,20 +27,41 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
 import os
+from dataclasses import dataclass
 
-from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.auth import AccessToken, AuthProvider, TokenVerifier
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
+    "ALLOWED_EMAILS_ENV",
+    "AUTHKIT_BASE_URL_ENV",
+    "AUTHKIT_CLIENT_ID_ENV",
+    "AUTHKIT_DOMAIN_ENV",
     "MCP_TOKEN_ENV",
+    "AuthKitConfig",
     "McpBearerAuthProvider",
+    "build_auth",
     "build_auth_provider",
+    "build_authkit_provider",
+    "get_authkit_config",
     "get_configured_token",
 ]
 
 #: Env var carrying the bearer token the HTTP transport validates every request
 #: against. Env-only (never a CLI flag) so the value cannot leak via ``ps aux``.
 MCP_TOKEN_ENV = "NOTEBOOKLM_MCP_TOKEN"
+
+#: Optional WorkOS AuthKit OAuth (for claude.ai, whose connector UI is OAuth-only).
+#: All four are env-only. When none are set, the server stays bearer-only (Phase A)
+#: so Claude Code / Desktop are unaffected. When any are set, ALL of domain +
+#: base_url + client_id + allowed-emails are required (partial config fails closed).
+AUTHKIT_DOMAIN_ENV = "NOTEBOOKLM_MCP_AUTHKIT_DOMAIN"
+AUTHKIT_BASE_URL_ENV = "NOTEBOOKLM_MCP_AUTHKIT_BASE_URL"
+AUTHKIT_CLIENT_ID_ENV = "NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID"
+ALLOWED_EMAILS_ENV = "NOTEBOOKLM_MCP_ALLOWED_EMAILS"
 
 #: Synthetic client id stamped on a validated token. Single-tenant: there is one
 #: token and one logical client, so this is a constant, not a lookup.
@@ -108,3 +129,153 @@ def build_auth_provider(token: str | None) -> McpBearerAuthProvider | None:
     maps token→provider so ``create_server`` stays env-free.
     """
     return McpBearerAuthProvider(token) if token else None
+
+
+# ---------------------------------------------------------------------------
+# Optional WorkOS AuthKit OAuth (for claude.ai). Strictly additive: only active
+# when configured; otherwise the bearer path above is unchanged.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuthKitConfig:
+    """Resolved, validated WorkOS AuthKit config (all fields required when OAuth
+    is on). ``allowed_emails`` is the case-folded set the identity allowlist
+    admits."""
+
+    domain: str
+    base_url: str
+    client_id: str
+    allowed_emails: frozenset[str]
+
+
+def _split_emails(raw: str) -> frozenset[str]:
+    return frozenset(e.strip().casefold() for e in raw.split(",") if e.strip())
+
+
+def get_authkit_config() -> AuthKitConfig | None:
+    """Resolve the AuthKit config from env, or ``None`` when OAuth is off.
+
+    OFF when none of the AuthKit env vars are set. When ANY is set the user
+    intends OAuth, so ALL of domain + base_url + client_id + allowed-emails are
+    required and a missing one raises (fail closed):
+
+    * ``client_id`` missing → AuthKit's ``JWTVerifier`` would skip ``audience``
+      validation → cross-project token replay. Mandatory.
+    * allowed-emails missing → an OAuth endpoint to a full-account credential with
+      no allowlist is world-open. Mandatory.
+
+    Raises:
+        SystemExit: partial/invalid config (names the offending env var).
+    """
+    domain = (os.environ.get(AUTHKIT_DOMAIN_ENV) or "").strip()
+    base_url = (os.environ.get(AUTHKIT_BASE_URL_ENV) or "").strip()
+    client_id = (os.environ.get(AUTHKIT_CLIENT_ID_ENV) or "").strip()
+    allowed = _split_emails(os.environ.get(ALLOWED_EMAILS_ENV) or "")
+
+    if not (domain or base_url or client_id or allowed):
+        return None  # OAuth off — bearer-only (Phase A).
+
+    missing = [
+        name
+        for name, val in (
+            (AUTHKIT_DOMAIN_ENV, domain),
+            (AUTHKIT_BASE_URL_ENV, base_url),
+            (AUTHKIT_CLIENT_ID_ENV, client_id),
+            (ALLOWED_EMAILS_ENV, allowed),
+        )
+        if not val
+    ]
+    if missing:
+        raise SystemExit(
+            "WorkOS AuthKit OAuth is partially configured; set ALL of "
+            f"{', '.join(sorted(missing))} (or unset every AuthKit var to stay "
+            "bearer-only). client_id is mandatory (audience validation / replay "
+            "defense); allowed-emails is mandatory (the identity allowlist)."
+        )
+    return AuthKitConfig(
+        domain=domain, base_url=base_url, client_id=client_id, allowed_emails=allowed
+    )
+
+
+class _EmailAllowlistVerifier(TokenVerifier):
+    """Wrap an OAuth token verifier and admit only allowlisted, verified emails.
+
+    Delegates verification to ``inner`` (AuthKit's local ``JWTVerifier`` — never a
+    userinfo verifier, which would leak the bearer to WorkOS), then gates on the
+    token's ``email`` claim. A non-match returns ``None`` (→ 401; a ``TokenVerifier``
+    cannot signal 403, and 401 is the better choice — it does not reveal that
+    WorkOS auth succeeded). The bearer path is NOT wrapped (its ``AccessToken`` has
+    no email claim), so Claude Code is unaffected.
+    """
+
+    def __init__(self, inner: TokenVerifier, allowed_emails: frozenset[str]) -> None:
+        super().__init__()
+        self._inner = inner
+        self._allowed = allowed_emails
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        result = await self._inner.verify_token(token)
+        if result is None:
+            return None
+        claims = result.claims or {}
+        email = claims.get("email")
+        if not isinstance(email, str) or not email.strip():
+            # The WorkOS access-token JWT carried no email claim — almost always a
+            # missing JWT-template mapping. Reject loudly (never coerce to "").
+            logger.warning(
+                "OAuth token has no 'email' claim; rejecting. Configure the WorkOS "
+                "access-token JWT template to include email + email_verified (see "
+                "the remote-deployment docs)."
+            )
+            return None
+        if claims.get("email_verified") is not True:
+            logger.warning("OAuth token email is not verified; rejecting.")
+            return None
+        if email.strip().casefold() not in self._allowed:
+            logger.warning("OAuth email not in NOTEBOOKLM_MCP_ALLOWED_EMAILS; rejecting.")
+            return None
+        return result
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(inner={type(self._inner).__name__})"
+
+
+def build_authkit_provider(config: AuthKitConfig) -> AuthProvider:
+    """Build a WorkOS ``AuthKitProvider`` whose token verifier is wrapped in the
+    email allowlist.
+
+    Let AuthKit build its own default ``JWTVerifier`` (correct jwks_uri / issuer /
+    audience=client_id) and reassign ``token_verifier`` to the allowlist wrapper —
+    ``RemoteAuthProvider.verify_token`` resolves ``self.token_verifier`` at call
+    time, so this takes effect without duplicating the construction.
+    """
+    # Lazy import: AuthKitProvider pulls authlib/JWTVerifier (a deprecation warning
+    # on import); keep it off the stdio / bearer-only path.
+    from fastmcp.server.auth.providers.workos import AuthKitProvider
+
+    provider = AuthKitProvider(
+        authkit_domain=config.domain.rstrip("/"),  # avoid //oauth2/jwks (404)
+        base_url=config.base_url,
+        client_id=config.client_id,
+        required_scopes=["openid"],  # NOT "email": that gates the scope STRING, not the claim
+    )
+    provider.token_verifier = _EmailAllowlistVerifier(
+        provider.token_verifier, config.allowed_emails
+    )
+    return provider
+
+
+def build_auth(token: str | None, authkit: AuthProvider | None) -> AuthProvider | None:
+    """Compose the active auth provider for ``create_server(auth=...)``.
+
+    * bearer + authkit → ``MultiAuth`` (claude.ai uses OAuth, Claude Code the
+      bearer; the bearer is a verifier so a non-JWT bearer falls through locally).
+    * one of them → that one. * neither → ``None`` (loopback dev).
+    """
+    bearer = McpBearerAuthProvider(token) if token else None
+    if authkit and bearer:
+        from fastmcp.server.auth import MultiAuth
+
+        return MultiAuth(server=authkit, verifiers=[bearer])
+    return authkit or bearer

--- a/src/notebooklm/mcp/_auth.py
+++ b/src/notebooklm/mcp/_auth.py
@@ -271,9 +271,14 @@ def build_authkit_provider(config: AuthKitConfig) -> AuthProvider:
         authkit_domain=config.domain.rstrip("/"),  # avoid //oauth2/jwks (404)
         base_url=config.base_url,
         client_id=config.client_id,
-        required_scopes=["openid"],  # NOT "email": that gates the scope STRING, not the claim
-        # Advertise email in the protected-resource metadata so the client requests
-        # it — maximizes the chance the access-token JWT carries the email claim.
+        # Enforce NO OAuth scope: the email allowlist is the gate, so requiring a
+        # `scope` claim (e.g. "openid") would only add a fragile dependency — if the
+        # access-token JWT lacks it, every login silently rejects. Validation rests
+        # on signature + audience(=client_id) + the allowlist, not on scopes.
+        required_scopes=[],
+        # Still ADVERTISE the standard scopes in the protected-resource metadata so
+        # the client requests `email` — maximizing the chance WorkOS injects the
+        # email claim into the access token. Advisory (advertised, not required).
         scopes_supported=["openid", "profile", "email"],
     )
     provider.token_verifier = _EmailAllowlistVerifier(
@@ -289,7 +294,7 @@ def build_auth(token: str | None, authkit: AuthProvider | None) -> AuthProvider 
       bearer; the bearer is a verifier so a non-JWT bearer falls through locally).
     * one of them → that one. * neither → ``None`` (loopback dev).
     """
-    bearer = McpBearerAuthProvider(token) if token else None
+    bearer = build_auth_provider(token)  # reuse the token→provider mapper (no dup)
     if authkit and bearer:
         from fastmcp.server.auth import MultiAuth
 

--- a/src/notebooklm/mcp/_auth.py
+++ b/src/notebooklm/mcp/_auth.py
@@ -198,6 +198,19 @@ def get_authkit_config() -> AuthKitConfig | None:
     )
 
 
+def _claim_is_true(value: object) -> bool:
+    """True only for a JSON boolean ``true`` or the string ``"true"`` (case-insensitive).
+
+    WorkOS JWT templates can render ``{{ user.email_verified }}`` as either a real
+    boolean or the string ``"true"`` depending on dashboard config, so accept both.
+    The claim is **signed** by WorkOS (the client cannot forge its type), so this is
+    still fail-closed for genuinely-unverified identities — it widens the accepted
+    *type*, not the *gate*. Everything else (``False``, ``"false"``, ``1``, ``None``,
+    missing) is rejected.
+    """
+    return value is True or (isinstance(value, str) and value.strip().casefold() == "true")
+
+
 class _EmailAllowlistVerifier(TokenVerifier):
     """Wrap an OAuth token verifier and admit only allowlisted, verified emails.
 
@@ -229,7 +242,7 @@ class _EmailAllowlistVerifier(TokenVerifier):
                 "the remote-deployment docs)."
             )
             return None
-        if claims.get("email_verified") is not True:
+        if not _claim_is_true(claims.get("email_verified")):
             logger.warning("OAuth token email is not verified; rejecting.")
             return None
         if email.strip().casefold() not in self._allowed:
@@ -259,6 +272,9 @@ def build_authkit_provider(config: AuthKitConfig) -> AuthProvider:
         base_url=config.base_url,
         client_id=config.client_id,
         required_scopes=["openid"],  # NOT "email": that gates the scope STRING, not the claim
+        # Advertise email in the protected-resource metadata so the client requests
+        # it — maximizes the chance the access-token JWT carries the email claim.
+        scopes_supported=["openid", "profile", "email"],
     )
     provider.token_verifier = _EmailAllowlistVerifier(
         provider.token_verifier, config.allowed_emails

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -25,6 +25,21 @@ pytest.importorskip("fastmcp")
 from notebooklm.mcp import __main__ as entry  # noqa: E402 - after importorskip guard
 
 
+@pytest.fixture(autouse=True)
+def _clear_oauth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main()`` now reads the WorkOS AuthKit env on every HTTP run, so clear it by
+    default — an ambient developer/CI environment with ``NOTEBOOKLM_MCP_AUTHKIT_*``
+    set must not perturb these bearer-focused tests. The OAuth tests set the vars
+    explicitly (after this autouse cleanup runs)."""
+    for var in (
+        "NOTEBOOKLM_MCP_AUTHKIT_DOMAIN",
+        "NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID",
+        "NOTEBOOKLM_MCP_AUTHKIT_BASE_URL",
+        "NOTEBOOKLM_MCP_ALLOWED_EMAILS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
     """``main(["--help"])`` prints argparse help and exits 0."""
     with pytest.raises(SystemExit) as excinfo:

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -187,3 +187,78 @@ def test_http_non_loopback_with_token_attaches_auth(monkeypatch: pytest.MonkeyPa
 
     fake_server.run.assert_called_once_with(transport="http", host="0.0.0.0", port=8000)
     assert isinstance(captured["auth"], McpBearerAuthProvider)
+
+
+def _set_authkit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_MCP_AUTHKIT_DOMAIN", "https://x.authkit.app")
+    monkeypatch.setenv("NOTEBOOKLM_MCP_AUTHKIT_BASE_URL", "https://host")
+    monkeypatch.setenv("NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID", "client_abc")
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOWED_EMAILS", "you@example.com")
+
+
+def test_http_non_loopback_with_oauth_only_satisfies_the_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network bind with WorkOS OAuth configured (no bearer) starts and attaches
+    the AuthKit provider — OAuth alone satisfies the fail-closed auth requirement."""
+    from notebooklm.mcp._auth import McpBearerAuthProvider
+
+    fake_server = MagicMock()
+    captured: dict[str, object] = {}
+
+    def fake_create_server(*, profile=None, client_factory=None, auth=None):
+        captured["auth"] = auth
+        return fake_server
+
+    monkeypatch.setattr(entry, "create_server", fake_create_server)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+    _set_authkit_env(monkeypatch)
+
+    entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
+
+    fake_server.run.assert_called_once()
+    auth = captured["auth"]
+    assert auth is not None and not isinstance(auth, McpBearerAuthProvider)  # the AuthKit provider
+
+
+def test_http_non_loopback_with_oauth_and_bearer_composes_multiauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bearer + WorkOS OAuth → MultiAuth (claude.ai uses OAuth, Claude Code the bearer)."""
+    from fastmcp.server.auth import MultiAuth
+
+    fake_server = MagicMock()
+    captured: dict[str, object] = {}
+
+    def fake_create_server(*, profile=None, client_factory=None, auth=None):
+        captured["auth"] = auth
+        return fake_server
+
+    monkeypatch.setattr(entry, "create_server", fake_create_server)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.setenv("NOTEBOOKLM_MCP_TOKEN", "s3cret-token")
+    _set_authkit_env(monkeypatch)
+
+    entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
+
+    assert isinstance(captured["auth"], MultiAuth)
+
+
+def test_http_non_loopback_partial_oauth_config_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Partial WorkOS config (missing client_id / allowlist) fails closed at startup."""
+    built = MagicMock(side_effect=AssertionError("create_server must not be reached"))
+    monkeypatch.setattr(entry, "create_server", built)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_AUTHKIT_DOMAIN", "https://x.authkit.app")  # only one var
+    for k in (
+        "NOTEBOOKLM_MCP_AUTHKIT_BASE_URL",
+        "NOTEBOOKLM_MCP_AUTHKIT_CLIENT_ID",
+        "NOTEBOOKLM_MCP_ALLOWED_EMAILS",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    with pytest.raises(SystemExit):
+        entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
+    built.assert_not_called()

--- a/tests/unit/mcp/test_workos_oauth.py
+++ b/tests/unit/mcp/test_workos_oauth.py
@@ -183,6 +183,22 @@ def test_build_authkit_serves_oauth_discovery_routes() -> None:
     assert any(".well-known/oauth-protected-resource" in p for p in paths)
 
 
+def test_protected_resource_metadata_advertises_scopes() -> None:
+    """The wrapper's own scopes_supported is [] (it forwards no required_scopes);
+    the provider must advertise the explicit scopes so a strict client requests
+    `email` — else it could omit it and the access token lacks the email claim."""
+    from starlette.applications import Starlette
+    from starlette.testclient import TestClient
+
+    provider = build_authkit_provider(_cfg())
+    # No scope is ENFORCED (the email allowlist is the gate, not OAuth scopes).
+    assert provider.token_verifier._inner.required_scopes == []
+    app = Starlette(routes=provider.get_routes())
+    with TestClient(app) as client:
+        meta = client.get("/.well-known/oauth-protected-resource").json()
+    assert "email" in meta["scopes_supported"]
+
+
 def test_build_auth_matrix() -> None:
     authkit = build_authkit_provider(_cfg())
     # bearer + authkit → MultiAuth (claude.ai OAuth + Claude Code bearer)

--- a/tests/unit/mcp/test_workos_oauth.py
+++ b/tests/unit/mcp/test_workos_oauth.py
@@ -99,10 +99,15 @@ def _allow() -> frozenset[str]:
 
 
 @pytest.mark.asyncio
-async def test_allowlist_accepts_verified_listed_email(_allow: frozenset[str]) -> None:
-    inner = _StubVerifier({"email": "You@Example.com", "email_verified": True})
+@pytest.mark.parametrize("verified", [True, "true", "True", " TRUE "])
+async def test_allowlist_accepts_verified_listed_email(
+    _allow: frozenset[str], verified: object
+) -> None:
+    # email_verified may be a JSON boolean OR a string (WorkOS JWT templates render
+    # variables as strings); both forms are accepted. Email match is case-insensitive.
+    inner = _StubVerifier({"email": "You@Example.com", "email_verified": verified})
     v = _EmailAllowlistVerifier(inner, _allow)
-    assert await v.verify_token("tok") is not None  # case-insensitive match
+    assert await v.verify_token("tok") is not None
 
 
 @pytest.mark.asyncio
@@ -110,7 +115,10 @@ async def test_allowlist_accepts_verified_listed_email(_allow: frozenset[str]) -
     "claims",
     [
         {"email": "nope@x.com", "email_verified": True},  # not on allowlist
-        {"email": "you@example.com", "email_verified": False},  # unverified
+        {"email": "you@example.com", "email_verified": False},  # unverified (bool)
+        {"email": "you@example.com", "email_verified": "false"},  # unverified (string)
+        {"email": "you@example.com", "email_verified": 1},  # truthy non-bool → reject
+        {"email": "you@example.com"},  # missing email_verified
         {"email_verified": True},  # missing email claim (JWT template not set)
         {"email": "   ", "email_verified": True},  # blank email
     ],
@@ -150,6 +158,23 @@ def test_build_authkit_wraps_token_verifier_in_allowlist() -> None:
     # The default JWTVerifier was replaced by our allowlist wrapper (the wrap takes
     # effect because RemoteAuthProvider delegates to self.token_verifier at runtime).
     assert isinstance(provider.token_verifier, _EmailAllowlistVerifier)
+
+
+@pytest.mark.asyncio
+async def test_provider_verify_routes_through_allowlist_at_runtime() -> None:
+    """Option-B guard: ``provider.verify_token`` must actually delegate to the
+    allowlist wrapper at call time (not a verifier captured at construction). If a
+    future fastmcp cached the original verifier, the allowlist would be silently
+    bypassed while ``test_build_authkit_wraps_...`` still passed — this catches that.
+    Drive the provider end-to-end with a stubbed inner and confirm the gate fires.
+    """
+    provider = build_authkit_provider(_cfg())
+    wrapper = provider.token_verifier
+    assert isinstance(wrapper, _EmailAllowlistVerifier)
+    wrapper._inner = _StubVerifier({"email": "evil@x.com", "email_verified": True})
+    assert await provider.verify_token("x") is None  # not allowlisted → rejected via wrapper
+    wrapper._inner = _StubVerifier({"email": "you@example.com", "email_verified": True})
+    assert await provider.verify_token("x") is not None  # allowlisted → admitted
 
 
 def test_build_authkit_serves_oauth_discovery_routes() -> None:

--- a/tests/unit/mcp/test_workos_oauth.py
+++ b/tests/unit/mcp/test_workos_oauth.py
@@ -1,0 +1,171 @@
+"""Tests for the optional WorkOS AuthKit OAuth path (``notebooklm.mcp._auth``).
+
+Covers config resolution (off / partial-fail-closed / full), the email-allowlist
+verifier (accept + every reject path), the ``build_authkit_provider`` wrap, the
+``build_auth`` composition (bearer | authkit | MultiAuth | None), and that OAuth
+discovery routes are served when OAuth is on. No network: the AuthKit provider is
+built (JWKS is fetched lazily at verify time, not construction) and the allowlist
+verifier is driven with a stub inner verifier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp.server.auth import AccessToken, MultiAuth, TokenVerifier  # noqa: E402
+
+from notebooklm.mcp._auth import (  # noqa: E402
+    ALLOWED_EMAILS_ENV,
+    AUTHKIT_BASE_URL_ENV,
+    AUTHKIT_CLIENT_ID_ENV,
+    AUTHKIT_DOMAIN_ENV,
+    AuthKitConfig,
+    McpBearerAuthProvider,
+    _EmailAllowlistVerifier,
+    build_auth,
+    build_authkit_provider,
+    get_authkit_config,
+)
+
+_AUTHKIT_ENVS = (
+    AUTHKIT_DOMAIN_ENV,
+    AUTHKIT_BASE_URL_ENV,
+    AUTHKIT_CLIENT_ID_ENV,
+    ALLOWED_EMAILS_ENV,
+)
+
+
+@pytest.fixture
+def _clear_authkit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in _AUTHKIT_ENVS:
+        monkeypatch.delenv(k, raising=False)
+
+
+class _StubVerifier(TokenVerifier):
+    """Inner verifier stand-in: returns a token with the given claims for any
+    input, or None when ``claims is None``."""
+
+    def __init__(self, claims: dict | None) -> None:
+        super().__init__()
+        self._claims = claims
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if self._claims is None:
+            return None
+        return AccessToken(token="t", client_id="c", scopes=[], claims=self._claims)
+
+
+# ---------------------------------------------------------------------------
+# get_authkit_config
+# ---------------------------------------------------------------------------
+
+
+def test_config_off_when_unset(_clear_authkit_env: None) -> None:
+    assert get_authkit_config() is None
+
+
+@pytest.mark.parametrize("present", list(_AUTHKIT_ENVS))
+def test_partial_config_fails_closed(
+    _clear_authkit_env: None, monkeypatch: pytest.MonkeyPatch, present: str
+) -> None:
+    monkeypatch.setenv(present, "x@y.com" if present == ALLOWED_EMAILS_ENV else "val")
+    with pytest.raises(SystemExit):
+        get_authkit_config()
+
+
+def test_full_config_casefolds_emails(
+    _clear_authkit_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(AUTHKIT_DOMAIN_ENV, "https://x.authkit.app")
+    monkeypatch.setenv(AUTHKIT_BASE_URL_ENV, "https://host")
+    monkeypatch.setenv(AUTHKIT_CLIENT_ID_ENV, "client_abc")
+    monkeypatch.setenv(ALLOWED_EMAILS_ENV, " You@Example.com , other@x.com ")
+    cfg = get_authkit_config()
+    assert cfg is not None
+    assert cfg.client_id == "client_abc"
+    assert cfg.allowed_emails == frozenset({"you@example.com", "other@x.com"})
+
+
+# ---------------------------------------------------------------------------
+# _EmailAllowlistVerifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _allow() -> frozenset[str]:
+    return frozenset({"you@example.com"})
+
+
+@pytest.mark.asyncio
+async def test_allowlist_accepts_verified_listed_email(_allow: frozenset[str]) -> None:
+    inner = _StubVerifier({"email": "You@Example.com", "email_verified": True})
+    v = _EmailAllowlistVerifier(inner, _allow)
+    assert await v.verify_token("tok") is not None  # case-insensitive match
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {"email": "nope@x.com", "email_verified": True},  # not on allowlist
+        {"email": "you@example.com", "email_verified": False},  # unverified
+        {"email_verified": True},  # missing email claim (JWT template not set)
+        {"email": "   ", "email_verified": True},  # blank email
+    ],
+)
+async def test_allowlist_rejects(_allow: frozenset[str], claims: dict) -> None:
+    v = _EmailAllowlistVerifier(_StubVerifier(claims), _allow)
+    assert await v.verify_token("tok") is None
+
+
+@pytest.mark.asyncio
+async def test_allowlist_passes_through_inner_none(_allow: frozenset[str]) -> None:
+    v = _EmailAllowlistVerifier(_StubVerifier(None), _allow)
+    assert await v.verify_token("tok") is None
+
+
+def test_allowlist_repr_hides_nothing_sensitive(_allow: frozenset[str]) -> None:
+    v = _EmailAllowlistVerifier(_StubVerifier({}), _allow)
+    assert "you@example.com" not in repr(v)
+
+
+# ---------------------------------------------------------------------------
+# build_authkit_provider + build_auth composition
+# ---------------------------------------------------------------------------
+
+
+def _cfg() -> AuthKitConfig:
+    return AuthKitConfig(
+        domain="https://x.authkit.app/",  # trailing slash → must be stripped
+        base_url="https://host",
+        client_id="client_abc",
+        allowed_emails=frozenset({"you@example.com"}),
+    )
+
+
+def test_build_authkit_wraps_token_verifier_in_allowlist() -> None:
+    provider = build_authkit_provider(_cfg())
+    # The default JWTVerifier was replaced by our allowlist wrapper (the wrap takes
+    # effect because RemoteAuthProvider delegates to self.token_verifier at runtime).
+    assert isinstance(provider.token_verifier, _EmailAllowlistVerifier)
+
+
+def test_build_authkit_serves_oauth_discovery_routes() -> None:
+    provider = build_authkit_provider(_cfg())
+    paths = {getattr(r, "path", "") for r in provider.get_routes()}
+    assert any(".well-known/oauth-protected-resource" in p for p in paths)
+
+
+def test_build_auth_matrix() -> None:
+    authkit = build_authkit_provider(_cfg())
+    # bearer + authkit → MultiAuth (claude.ai OAuth + Claude Code bearer)
+    both = build_auth("tok", authkit)
+    assert isinstance(both, MultiAuth)
+    # oauth only
+    assert build_auth(None, authkit) is authkit
+    # bearer only
+    assert isinstance(build_auth("tok", None), McpBearerAuthProvider)
+    # neither
+    assert build_auth(None, None) is None


### PR DESCRIPTION
## What & why
claude.ai's custom-connector UI is **OAuth-only** (no bearer field), so the Phase A static-bearer server (#1645) can't be added there. This adds an **opt-in** WorkOS AuthKit OAuth layer via FastMCP's `AuthKitProvider`, composed with the existing bearer through `MultiAuth`.

**OAuth is strictly additive (per request):** with no WorkOS env set, the server is **byte-identical to Phase A** (bearer-only) — Claude Code / Desktop are unaffected. When configured, the bearer *and* OAuth work side by side (claude.ai uses OAuth; Claude Code uses the bearer).

## Design (source-verified vs fastmcp 3.2.0)
- **`MultiAuth(server=AuthKitProvider, verifiers=[bearer])`** — serves OAuth discovery (`.well-known/*`) for claude.ai **and** keeps accepting the static bearer.
- **Local `JWTVerifier`, never userinfo** — a Claude Code bearer fails JWT decode offline and falls through to the local bearer check, so **the bearer never reaches WorkOS** (no leak/latency regression).
- **Mandatory email allowlist** (`NOTEBOOKLM_MCP_ALLOWED_EMAILS`) — wraps AuthKit's token verifier; admits only allowlisted, **verified** emails (`email_verified` accepted as bool `true` or string `"true"` — WorkOS templates may render either; signed claim, so no bypass). A reject returns `None` → **401**.
- **Fail closed:** OAuth on requires all of domain + base_url + **client_id** (audience/replay defense) + allowlist; partial config or a non-loopback bind with neither bearer nor OAuth → refuse to start.

## Auth resolution
| `NOTEBOOKLM_MCP_TOKEN` | WorkOS config | provider |
|---|---|---|
| set | absent | bearer (Phase A) |
| set | present | `MultiAuth(authkit + bearer)` |
| unset | present | AuthKit OAuth |
| unset | absent | none (loopback dev) |

## Files
- `mcp/_auth.py` — `AuthKitConfig` / `get_authkit_config` (fail-closed), `_EmailAllowlistVerifier`, `build_authkit_provider` (Option-B wrap), `build_auth`. Bearer untouched.
- `mcp/__main__.py` — OAuth-aware fail-closed guard + auth composition (`create_server` stays env-free).
- `deploy/` — optional WorkOS env passthrough (unset → bearer-only); `docs/` — deploy README step 6 (AuthKit setup incl. the email JWT-template) + mcp-guide note.
- tests — config matrix, allowlist accept/reject paths, `email_verified` type handling, runtime-wrap delegation, OAuth discovery routes, OAuth-aware fail-closed entrypoint.

## Review
Plan converged through 2 rounds of oracle+momus review (codex/claude/agy); implementation polished (code-simplifier: no changes; agy: SHIP; ultrathink: 3 fixes applied). mypy + ruff clean; **1278 unit/guardrail tests pass**.

## Out of scope / follow-ups
Self-hosted AS, multi-tenant, other IdPs, file upload/download. **#1 live-verify before relying on it:** confirm WorkOS injects `email` + `email_verified` into the **access** token (not just the ID token) — the connector correctly rejects every login if absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional WorkOS AuthKit (OAuth) authentication for the MCP HTTP endpoint with an email allowlist, alongside existing bearer-token auth.
  * Deployment guides now support OAuth-only connector setups for **claude.ai**, with additive layering.
* **Bug Fixes**
  * Strengthened fail-closed startup for non-loopback access: the server now requires valid bearer auth or valid OAuth (rejects missing/partial auth, including allowlist-less OAuth and no-auth setups).
* **Documentation**
  * Updated environment examples, compose guidance, and the deployment README with clear OAuth-only vs layered setup instructions.
* **Tests**
  * Added unit tests for OAuth configuration resolution, claim/allowlist enforcement, and combined auth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->