### PR TITLE
fix(deploy): stop Makefile from shadowing NOTEBOOKLM_PROFILE_DIR in .env

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -13,12 +13,15 @@ VERSION ?= 0.8.0
 # Profile-aware compose invocation — selects exactly one tunnel sidecar.
 DC = $(COMPOSE) --profile $(TUNNEL)
 
-# Run the container as YOUR uid/gid so the mounted profile needs no chown, and
-# default the mounted profile to your local "default" profile. All overridable
-# (env or `make dev NOTEBOOKLM_PROFILE_DIR=...`); exported so compose sees them.
+# Run the container as YOUR uid/gid so the mounted profile needs no chown.
 export NOTEBOOKLM_UID ?= $(shell id -u)
 export NOTEBOOKLM_GID ?= $(shell id -g)
-export NOTEBOOKLM_PROFILE_DIR ?= $(HOME)/.notebooklm/profiles/default
+# NOTE: do NOT set/export NOTEBOOKLM_PROFILE_DIR here. make does not read .env, so a
+# `?=` default would resolve to "default" and `export` would push it into compose's
+# env, where it OUTRANKS the .env value (shell env > .env) — silently ignoring the
+# user's `.env` setting. Compose reads NOTEBOOKLM_PROFILE_DIR from .env directly and
+# defaults to ~/.notebooklm/profiles/default on its own; a shell/CLI override such as
+# `NOTEBOOKLM_PROFILE_DIR=… make dev` is still auto-exported by make to the recipe.
 
 .PHONY: help dev prod up restart logs down config _require-tunnel-token
 


### PR DESCRIPTION
## Problem
`make dev` ignored `NOTEBOOKLM_PROFILE_DIR` set in `deploy/.env` and **always mounted the `default` profile** — so a dedicated/throwaway profile configured in `.env` was silently never used.

## Root cause
**make does not read `.env`.** The Makefile had:
```make
export NOTEBOOKLM_PROFILE_DIR ?= $(HOME)/.notebooklm/profiles/default
```
With the var only present in `.env`, make's `?=` resolved to the **default** and `export` pushed it into the `docker compose` child environment. Compose precedence is **shell env > `.env` file**, so the exported default **outranked** the user's `.env` value. The documented "set it in `.env`" path only worked with raw `docker compose`, never via `make`.

## Fix
Don't set/export `NOTEBOOKLM_PROFILE_DIR` in the Makefile at all:
- Compose already reads it from `.env` and defaults to `~/.notebooklm/profiles/default` via its own `:-` fallback (`docker-compose.yml`).
- make still **auto-exports** a shell/CLI override, so `NOTEBOOKLM_PROFILE_DIR=… make dev` and `make dev NOTEBOOKLM_PROFILE_DIR=…` keep working.
- `NOTEBOOKLM_UID`/`GID` are computed defaults the user doesn't set in `.env`, so they stay exported (no shadowing concern).

## Verification (`make config`, inspecting the mounted source)
| Case | Result |
|---|---|
| `.env` sets `NOTEBOOKLM_PROFILE_DIR=/tmp/FROM_ENV_FILE` | `source: /tmp/FROM_ENV_FILE` ✅ (was: default) |
| unset | `source: …/profiles/default` ✅ |
| `make config NOTEBOOKLM_PROFILE_DIR=/tmp/FROM_CLI` | `source: /tmp/FROM_CLI` ✅ |

Follow-up to #1647. Deploy-only; no Python changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment setup for local development and deployment.
  * Profile location settings now follow the standard environment file or an explicit override, reducing unexpected configuration conflicts.
  * User and group settings remain supported for container runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->