### PR TITLE
fix(mcp): generate artifacts with all sources when source_ids omitted

### DIFF
--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -201,8 +201,18 @@ async def _passthrough_sources(
     *,
     json_output: bool = False,
 ) -> Any:
-    """Return ``source_ids`` unchanged (MCP supplies full source ids)."""
-    return source_ids
+    """Return the supplied (already-full) source ids, or ``None`` when none were
+    given so the backend uses *every* source.
+
+    MCP supplies full source ids, so no partial-id resolution is needed. But an
+    EMPTY collection must map to ``None`` (not ``[]``): the generate core treats
+    ``None`` as "all sources" (mirroring the CLI's ``resolve_source_ids``, which
+    returns ``None`` for no input), whereas an empty list means "zero sources" —
+    which the backend refuses for source-needing kinds (quiz/audio/flashcards),
+    returning a null id surfaced as ``… generation is unavailable``. The tool
+    passes ``tuple(source_ids or ())``, so omitting ``source_ids`` arrives here
+    as ``()`` and must become ``None``."""
+    return source_ids or None
 
 
 async def _passthrough_download_notebook(notebook_id: str) -> str:

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -92,13 +92,32 @@ def _normalize_source_ids(value: Any) -> Any:
     return None if value is None else sorted(value)
 
 
-def _mcp_generate_call(artifact_type: str, method: str, extra: dict[str, Any]) -> Any:
-    """Drive the MCP ``artifact_generate`` tool; return the captured generate-method call."""
+def _normalized_call(call: Any) -> tuple[tuple, dict]:
+    """A captured generate-* call as ``(args, kwargs)`` for cross-adapter comparison.
+
+    Only ``source_ids`` is normalized (its container type differs: tuple vs list);
+    EVERY other positional/keyword arg is compared verbatim, so a divergence in any
+    default (language, audio_format, quantity, …) — not just source_ids — is caught.
+    """
+    kwargs = dict(call.kwargs)
+    kwargs["source_ids"] = _normalize_source_ids(kwargs.get("source_ids"))
+    return tuple(call.args), kwargs
+
+
+def _drive_mcp(tool: str, args: dict[str, Any], setup: Any = None, *, suppress: bool = True) -> Any:
+    """Drive an MCP ``tool`` against a fresh mocked client; return that client.
+
+    ``setup(client)`` wires the downstream method(s) the tool reaches. ``suppress``
+    swallows the call's exception so the sentinel-recorder e2e tests can capture a
+    downstream call and abort; the generate tests pass ``suppress=False`` to run the
+    full happy path (incl. return-serialization).
+    """
     client = MagicMock()
     for ns in _NAMESPACES:
         setattr(client, ns, MagicMock())
     client.artifacts._list_for_download = None
-    setattr(client.artifacts, method, AsyncMock(return_value=_FakeStatus()))
+    if setup is not None:
+        setup(client)
 
     @contextlib.asynccontextmanager
     async def factory() -> Any:
@@ -106,25 +125,28 @@ def _mcp_generate_call(artifact_type: str, method: str, extra: dict[str, Any]) -
 
     async def run() -> None:
         async with Client(create_server(client_factory=factory)) as c:
-            await c.call_tool(
-                "artifact_generate",
-                {"notebook": NB, "artifact_type": artifact_type, **extra},
-            )
+            if suppress:
+                with contextlib.suppress(Exception):
+                    await c.call_tool(tool, args)
+            else:
+                await c.call_tool(tool, args)
 
     asyncio.run(run())
-    return getattr(client.artifacts, method).await_args
+    return client
 
 
-def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
-    """Drive the CLI ``generate <cmd>``; return the captured generate-method call."""
-    from click.testing import CliRunner
+def _drive_cli(argv: list[str], setup: Any = None, *, check_exit: bool = False) -> Any:
+    """Drive the CLI with ``argv`` against a fresh mocked client; return that client.
 
+    ``setup(client)`` wires the downstream method(s) the command reaches.
+    ``check_exit`` asserts a clean exit (the generate tests); the sentinel-recorder
+    e2e tests leave it off because the sentinel aborts the command post-capture and
+    they assert on the captured call instead.
+    """
     client = create_mock_client()
-    setattr(
-        client.artifacts,
-        method,
-        AsyncMock(return_value={"task_id": "task-1", "status": "processing"}),
-    )
+    client.artifacts._list_for_download = None
+    if setup is not None:
+        setup(client)
     with (
         patch.object(helpers_module, "load_auth_from_storage", return_value={"SAPISID": "x"}),
         patch.object(
@@ -132,10 +154,34 @@ def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
         ) as mock_fetch,
     ):
         mock_fetch.return_value = ("csrf", "session")
-        result = CliRunner().invoke(
-            cli, ["generate", cmd, "-n", NB, *extra_args], obj=inject_client(client)
-        )
-    assert result.exit_code == 0, result.output
+        result = CliRunner().invoke(cli, argv, obj=inject_client(client))
+    if check_exit:
+        assert result.exit_code == 0, result.output
+    return client
+
+
+def _mcp_generate_call(artifact_type: str, method: str, extra: dict[str, Any]) -> Any:
+    """Drive the MCP ``artifact_generate`` tool; return the captured generate-method call."""
+    client = _drive_mcp(
+        "artifact_generate",
+        {"notebook": NB, "artifact_type": artifact_type, **extra},
+        setup=lambda c: setattr(c.artifacts, method, AsyncMock(return_value=_FakeStatus())),
+        suppress=False,
+    )
+    return getattr(client.artifacts, method).await_args
+
+
+def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
+    """Drive the CLI ``generate <cmd>``; return the captured generate-method call."""
+    client = _drive_cli(
+        ["generate", cmd, "-n", NB, *extra_args],
+        setup=lambda c: setattr(
+            c.artifacts,
+            method,
+            AsyncMock(return_value={"task_id": "task-1", "status": "processing"}),
+        ),
+        check_exit=True,
+    )
     return getattr(client.artifacts, method).call_args
 
 
@@ -153,8 +199,10 @@ def test_omitted_source_ids_parity(cmd: str, artifact_type: str, method: str) ->
     cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
     assert cli_src is None, f"CLI {cmd} omitted-sources should resolve to None, got {cli_src!r}"
     assert mcp_src is None, f"MCP {cmd} omitted-sources should resolve to None, got {mcp_src!r}"
-    # Notebook id is the first positional arg on both adapters.
-    assert mcp_call.args[0] == cli_call.args[0] == NB
+    # Full parity: notebook id (positional) AND every downstream kwarg agree, so a
+    # divergence in any default — not just source_ids — fails here.
+    assert _normalized_call(mcp_call) == _normalized_call(cli_call)
+    assert mcp_call.args[0] == NB
 
 
 def test_explicit_source_ids_parity() -> None:
@@ -165,6 +213,8 @@ def test_explicit_source_ids_parity() -> None:
     mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
     cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
     assert mcp_src == cli_src == sorted([SRC_A, SRC_B])
+    # And full parity on the rest of the call too.
+    assert _normalized_call(mcp_call) == _normalized_call(cli_call)
 
 
 # ---------------------------------------------------------------------------
@@ -222,43 +272,6 @@ def _recorder() -> tuple[list[tuple[tuple, dict]], Any]:
         raise _Captured
 
     return calls, fn
-
-
-def _drive_mcp(tool: str, args: dict[str, Any], setup: Any = None) -> None:
-    client = MagicMock()
-    for ns in _NAMESPACES:
-        setattr(client, ns, MagicMock())
-    client.artifacts._list_for_download = None
-    if setup is not None:
-        setup(client)
-
-    @contextlib.asynccontextmanager
-    async def factory() -> Any:
-        yield client
-
-    async def run() -> None:
-        async with Client(create_server(client_factory=factory)) as c:
-            with contextlib.suppress(Exception):
-                await c.call_tool(tool, args)
-
-    asyncio.run(run())
-
-
-def _drive_cli(argv: list[str], setup: Any = None) -> None:
-    client = create_mock_client()
-    client.artifacts._list_for_download = None
-    if setup is not None:
-        setup(client)
-    with (
-        patch.object(helpers_module, "load_auth_from_storage", return_value={"SAPISID": "x"}),
-        patch.object(
-            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-        ) as mock_fetch,
-    ):
-        mock_fetch.return_value = ("csrf", "session")
-        # Exit code is non-zero (the sentinel aborts post-capture) — we assert on the
-        # captured call, not the result, so don't check exit_code here.
-        CliRunner().invoke(cli, argv, obj=inject_client(client))
 
 
 def test_source_add_url_parity() -> None:

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -1,0 +1,197 @@
+"""CLI ↔ MCP adapter parity for artifact generation.
+
+Both the CLI ``generate`` command and the MCP ``artifact_generate`` tool are thin
+adapters over the *same* ``_app/generate`` core, but each plugs in its own
+notebook/source resolvers. When those resolvers disagree, the two surfaces drift
+apart even though every per-adapter unit test passes — which is exactly how #1652
+shipped: the CLI resolved an omitted ``source_ids`` to ``None`` ("all sources")
+while the MCP passthrough sent an empty list ("zero sources"), and the backend
+refused the latter (``<kind> generation is unavailable``).
+
+These tests drive both adapters against a mocked client for the same logical
+inputs and assert the downstream ``client.artifacts.generate_*`` call is
+equivalent. A mock can't enforce the backend contract, but it *can* pin that the
+two adapters agree — which is the property that broke.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp import Client  # noqa: E402 - after importorskip guard
+
+import notebooklm.auth as auth_module  # noqa: E402
+from notebooklm.cli import helpers as helpers_module  # noqa: E402
+from notebooklm.cli.resolve import resolve_notebook_id, resolve_source_ids  # noqa: E402
+from notebooklm.mcp._resolve import resolve_notebook  # noqa: E402
+from notebooklm.mcp.server import create_server  # noqa: E402
+from notebooklm.mcp.tools.artifacts import _passthrough_sources  # noqa: E402
+from notebooklm.notebooklm_cli import cli  # noqa: E402
+from notebooklm.types import GenerationState  # noqa: E402
+
+from .conftest import create_mock_client, inject_client  # noqa: E402
+
+# UUID-shaped ids so BOTH adapters treat them as already-full (the MCP
+# resolve_notebook skips the name lookup; the CLI resolve_source_ids skips the
+# fuzzy client.sources.list match) — matching how MCP supplies full ids.
+NB = "33333333-3333-3333-3333-333333333333"
+SRC_A = "11111111-1111-1111-1111-111111111111"
+SRC_B = "22222222-2222-2222-2222-222222222222"
+
+#: (cli subcommand, MCP artifact_type, client method) for source-needing kinds.
+_KINDS = [
+    ("quiz", "quiz", "generate_quiz"),
+    ("audio", "audio", "generate_audio"),
+    ("flashcards", "flashcards", "generate_flashcards"),
+]
+
+_NAMESPACES = (
+    "notebooks",
+    "sources",
+    "chat",
+    "artifacts",
+    "research",
+    "notes",
+    "sharing",
+    "labels",
+    "settings",
+    "mind_maps",
+)
+
+
+@dataclass
+class _FakeStatus:
+    """Minimal generate() return the MCP serializer accepts."""
+
+    task_id: str = "task-1"
+    status: GenerationState = GenerationState.COMPLETED
+    url: str | None = None
+    error: str | None = None
+    error_code: str | None = None
+    metadata: dict[str, Any] | None = field(default=None)
+
+    @property
+    def is_complete(self) -> bool:
+        return True
+
+
+def _normalize_source_ids(value: Any) -> Any:
+    """Compare source_ids by content, not container type (tuple vs list)."""
+    return None if value is None else sorted(value)
+
+
+def _mcp_generate_call(artifact_type: str, method: str, extra: dict[str, Any]) -> Any:
+    """Drive the MCP ``artifact_generate`` tool; return the captured generate-method call."""
+    client = MagicMock()
+    for ns in _NAMESPACES:
+        setattr(client, ns, MagicMock())
+    client.artifacts._list_for_download = None
+    setattr(client.artifacts, method, AsyncMock(return_value=_FakeStatus()))
+
+    @contextlib.asynccontextmanager
+    async def factory() -> Any:
+        yield client
+
+    async def run() -> None:
+        async with Client(create_server(client_factory=factory)) as c:
+            await c.call_tool(
+                "artifact_generate",
+                {"notebook": NB, "artifact_type": artifact_type, **extra},
+            )
+
+    asyncio.run(run())
+    return getattr(client.artifacts, method).await_args
+
+
+def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
+    """Drive the CLI ``generate <cmd>``; return the captured generate-method call."""
+    from click.testing import CliRunner
+
+    client = create_mock_client()
+    setattr(
+        client.artifacts,
+        method,
+        AsyncMock(return_value={"task_id": "task-1", "status": "processing"}),
+    )
+    with (
+        patch.object(helpers_module, "load_auth_from_storage", return_value={"SAPISID": "x"}),
+        patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch,
+    ):
+        mock_fetch.return_value = ("csrf", "session")
+        result = CliRunner().invoke(
+            cli, ["generate", cmd, "-n", NB, *extra_args], obj=inject_client(client)
+        )
+    assert result.exit_code == 0, result.output
+    return getattr(client.artifacts, method).call_args
+
+
+@pytest.mark.parametrize("cmd,artifact_type,method", _KINDS, ids=[k[0] for k in _KINDS])
+def test_omitted_source_ids_parity(cmd: str, artifact_type: str, method: str) -> None:
+    """Omitting sources: BOTH adapters must pass ``source_ids=None`` (= all sources).
+
+    The #1652 regression: MCP sent an empty tuple (= zero sources, refused) while the
+    CLI sent ``None``. This asserts they agree — and that the agreed value is ``None``.
+    """
+    mcp_call = _mcp_generate_call(artifact_type, method, {})
+    cli_call = _cli_generate_call(cmd, method, [])
+
+    mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
+    cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
+    assert cli_src is None, f"CLI {cmd} omitted-sources should resolve to None, got {cli_src!r}"
+    assert mcp_src is None, f"MCP {cmd} omitted-sources should resolve to None, got {mcp_src!r}"
+    # Notebook id is the first positional arg on both adapters.
+    assert mcp_call.args[0] == cli_call.args[0] == NB
+
+
+def test_explicit_source_ids_parity() -> None:
+    """With explicit (full) ids, both adapters pass the SAME ids downstream."""
+    mcp_call = _mcp_generate_call("quiz", "generate_quiz", {"source_ids": [SRC_A, SRC_B]})
+    cli_call = _cli_generate_call("quiz", "generate_quiz", ["-s", SRC_A, "-s", SRC_B])
+
+    mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
+    cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
+    assert mcp_src == cli_src == sorted([SRC_A, SRC_B])
+
+
+# ---------------------------------------------------------------------------
+# Resolver parity — every CLI/MCP operation funnels notebook/source references
+# through these shared resolvers, so pinning their agreement covers the
+# divergence surface for ALL operations, not just generate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_ids", [(), (SRC_A, SRC_B)], ids=["omitted", "full-ids"])
+def test_source_resolver_parity(source_ids: tuple[str, ...]) -> None:
+    """CLI ``resolve_source_ids`` and MCP ``_passthrough_sources`` must agree.
+
+    Omitted ⇒ ``None`` ("all sources"), NOT an empty list ("zero sources"); full ids
+    pass through identically. Neither path may hit ``client.sources.list``. This is
+    the exact contract whose violation caused #1652.
+    """
+    client = MagicMock()
+    cli_out = asyncio.run(resolve_source_ids(client, NB, source_ids))
+    mcp_out = asyncio.run(_passthrough_sources(client, NB, source_ids))
+    assert _normalize_source_ids(cli_out) == _normalize_source_ids(mcp_out)
+    if not source_ids:
+        assert cli_out is None and mcp_out is None
+    client.sources.list.assert_not_called()
+
+
+def test_notebook_resolver_parity_full_uuid() -> None:
+    """CLI ``resolve_notebook_id`` and MCP ``resolve_notebook`` agree on a full UUID
+    (fast-path: return it unchanged, no listing) — the shared entry every op uses."""
+    client = MagicMock()
+    cli_out = asyncio.run(resolve_notebook_id(client, NB))
+    mcp_out = asyncio.run(resolve_notebook(client, NB))
+    assert cli_out == mcp_out == NB
+    client.notebooks.list.assert_not_called()

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,16 +27,19 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+from click.testing import CliRunner  # noqa: E402
 from fastmcp import Client  # noqa: E402 - after importorskip guard
 
 import notebooklm.auth as auth_module  # noqa: E402
+from notebooklm._app import source_add as source_add_module  # noqa: E402
+from notebooklm._types.artifacts import ArtifactStatus, ArtifactTypeCode  # noqa: E402
 from notebooklm.cli import helpers as helpers_module  # noqa: E402
 from notebooklm.cli.resolve import resolve_notebook_id, resolve_source_ids  # noqa: E402
 from notebooklm.mcp._resolve import resolve_notebook  # noqa: E402
 from notebooklm.mcp.server import create_server  # noqa: E402
 from notebooklm.mcp.tools.artifacts import _passthrough_sources  # noqa: E402
 from notebooklm.notebooklm_cli import cli  # noqa: E402
-from notebooklm.types import GenerationState  # noqa: E402
+from notebooklm.types import Artifact, GenerationState  # noqa: E402
 
 from .conftest import create_mock_client, inject_client  # noqa: E402
 
@@ -195,3 +199,140 @@ def test_notebook_resolver_parity_full_uuid() -> None:
     mcp_out = asyncio.run(resolve_notebook(client, NB))
     assert cli_out == mcp_out == NB
     client.notebooks.list.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end per-operation parity for the heavier shared-core ops
+# (source_add, research, download). Each drives BOTH adapters and captures the
+# shared downstream call via a recorder that raises a sentinel — so neither
+# adapter's return-serialization runs (which is what made these brittle). We
+# compare the captured call, not the (discarded) result.
+# ---------------------------------------------------------------------------
+
+
+class _Captured(Exception):
+    """Raised by the recorder to short-circuit each adapter after the captured call."""
+
+
+def _recorder() -> tuple[list[tuple[tuple, dict]], Any]:
+    calls: list[tuple[tuple, dict]] = []
+
+    async def fn(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        raise _Captured
+
+    return calls, fn
+
+
+def _drive_mcp(tool: str, args: dict[str, Any], setup: Any = None) -> None:
+    client = MagicMock()
+    for ns in _NAMESPACES:
+        setattr(client, ns, MagicMock())
+    client.artifacts._list_for_download = None
+    if setup is not None:
+        setup(client)
+
+    @contextlib.asynccontextmanager
+    async def factory() -> Any:
+        yield client
+
+    async def run() -> None:
+        async with Client(create_server(client_factory=factory)) as c:
+            with contextlib.suppress(Exception):
+                await c.call_tool(tool, args)
+
+    asyncio.run(run())
+
+
+def _drive_cli(argv: list[str], setup: Any = None) -> None:
+    client = create_mock_client()
+    client.artifacts._list_for_download = None
+    if setup is not None:
+        setup(client)
+    with (
+        patch.object(helpers_module, "load_auth_from_storage", return_value={"SAPISID": "x"}),
+        patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch,
+    ):
+        mock_fetch.return_value = ("csrf", "session")
+        # Exit code is non-zero (the sentinel aborts post-capture) — we assert on the
+        # captured call, not the result, so don't check exit_code here.
+        CliRunner().invoke(cli, argv, obj=inject_client(client))
+
+
+def test_source_add_url_parity() -> None:
+    """source_add(url): both adapters build the SAME SourceAddPlan + notebook id.
+
+    Both run through ``_app.source_add.execute_source_add`` → module-level
+    ``add_source(sources, notebook_id=…, plan=…)``; patching that one symbol
+    captures both adapters' calls.
+    """
+    calls, fn = _recorder()
+    with patch.object(source_add_module, "add_source", fn):
+        _drive_mcp(
+            "source_add", {"notebook": NB, "source_type": "url", "url": "https://example.com/a"}
+        )
+        _drive_cli(["source", "add", "https://example.com/a", "-n", NB])
+    assert len(calls) == 2, f"expected MCP+CLI calls, got {calls!r}"
+    mcp_kwargs, cli_kwargs = calls[0][1], calls[1][1]
+    assert mcp_kwargs["notebook_id"] == cli_kwargs["notebook_id"] == NB
+    assert mcp_kwargs["plan"] == cli_kwargs["plan"]
+
+
+def test_research_start_parity() -> None:
+    """research: MCP ``research_start`` and CLI ``source add-research`` both call
+    ``client.research.start(nb_id, query, source, mode)`` with the same args/defaults."""
+    calls_m, fn_m = _recorder()
+    _drive_mcp(
+        "research_start",
+        {"notebook": NB, "query": "AI agents"},
+        setup=lambda c: setattr(c.research, "start", fn_m),
+    )
+    calls_c, fn_c = _recorder()
+    _drive_cli(
+        ["source", "add-research", "AI agents", "-n", NB, "--no-wait"],
+        setup=lambda c: setattr(c.research, "start", fn_c),
+    )
+    assert calls_m and calls_c, f"mcp={calls_m!r} cli={calls_c!r}"
+    assert calls_m[0] == calls_c[0]  # (nb_id, query, source="web", mode="fast")
+
+
+_AUDIO_ARTIFACT = Artifact(
+    id="art1",
+    title="Podcast",
+    _artifact_type=ArtifactTypeCode.AUDIO.value,
+    status=int(ArtifactStatus.COMPLETED),
+    created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+)
+
+
+def test_download_audio_parity(tmp_path: Any) -> None:
+    """download: MCP ``artifact_download`` and CLI ``download audio`` resolve the same
+    artifact and call ``client.artifacts.download_audio`` identically (via the shared
+    ``execute_download``)."""
+    out = str(tmp_path / "out.mp3")
+
+    def setup(client: Any) -> None:
+        client.artifacts._list_for_download = None
+        client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT])
+
+    calls_m, fn_m = _recorder()
+
+    def setup_m(c: Any) -> None:
+        setup(c)
+        c.artifacts.download_audio = fn_m
+
+    calls_c, fn_c = _recorder()
+
+    def setup_c(c: Any) -> None:
+        setup(c)
+        c.artifacts.download_audio = fn_c
+
+    _drive_mcp(
+        "artifact_download", {"notebook": NB, "artifact_type": "audio", "path": out}, setup=setup_m
+    )
+    # OUTPUT_PATH is a positional arg on the CLI leaf (not -o).
+    _drive_cli(["download", "audio", out, "-n", NB], setup=setup_c)
+    assert calls_m and calls_c, f"mcp={calls_m!r} cli={calls_c!r}"
+    assert calls_m[0] == calls_c[0]

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -104,13 +104,36 @@ def _normalized_call(call: Any) -> tuple[tuple, dict]:
     return tuple(call.args), kwargs
 
 
-def _drive_mcp(tool: str, args: dict[str, Any], setup: Any = None, *, suppress: bool = True) -> Any:
-    """Drive an MCP ``tool`` against a fresh mocked client; return that client.
+class _Captured(Exception):
+    """Raised by the recorder to short-circuit each adapter after the captured call.
 
-    ``setup(client)`` wires the downstream method(s) the tool reaches. ``suppress``
-    swallows the call's exception so the sentinel-recorder e2e tests can capture a
-    downstream call and abort; the generate tests pass ``suppress=False`` to run the
-    full happy path (incl. return-serialization).
+    NOTE: the MCP layer's ``mcp_errors`` wraps every exception into a ``ToolError``,
+    so this type does NOT survive the MCP boundary — which is why the drivers can't
+    simply ``suppress(_Captured)``. Instead the capture helpers below tolerate the
+    abort ONLY when a call was actually recorded, and otherwise re-raise the real
+    adapter error, so an unrelated pre-capture failure is never silently hidden.
+    """
+
+
+def _recorder() -> tuple[list[tuple[tuple, dict]], Any]:
+    """Return (calls, fn): an async fn that records each call then raises the sentinel."""
+    calls: list[tuple[tuple, dict]] = []
+
+    async def fn(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        raise _Captured
+
+    return calls, fn
+
+
+def _drive_mcp(
+    tool: str, args: dict[str, Any], setup: Any = None
+) -> tuple[Any, BaseException | None]:
+    """Drive an MCP ``tool`` against a fresh mocked client.
+
+    Returns ``(client, exc)`` where ``exc`` is the exception the call raised (or
+    ``None``). Callers classify it — the generate path expects ``None``; the e2e
+    capture path tolerates it only once a downstream call was recorded.
     """
     client = MagicMock()
     for ns in _NAMESPACES:
@@ -123,25 +146,25 @@ def _drive_mcp(tool: str, args: dict[str, Any], setup: Any = None, *, suppress: 
     async def factory() -> Any:
         yield client
 
+    captured: dict[str, BaseException] = {}
+
     async def run() -> None:
         async with Client(create_server(client_factory=factory)) as c:
-            if suppress:
-                with contextlib.suppress(Exception):
-                    await c.call_tool(tool, args)
-            else:
+            try:
                 await c.call_tool(tool, args)
+            except Exception as exc:  # noqa: BLE001 - caller classifies (see _mcp_capture)
+                captured["exc"] = exc
 
     asyncio.run(run())
-    return client
+    return client, captured.get("exc")
 
 
-def _drive_cli(argv: list[str], setup: Any = None, *, check_exit: bool = False) -> Any:
-    """Drive the CLI with ``argv`` against a fresh mocked client; return that client.
+def _drive_cli(argv: list[str], setup: Any = None) -> tuple[Any, Any]:
+    """Drive the CLI with ``argv`` against a fresh mocked client.
 
-    ``setup(client)`` wires the downstream method(s) the command reaches.
-    ``check_exit`` asserts a clean exit (the generate tests); the sentinel-recorder
-    e2e tests leave it off because the sentinel aborts the command post-capture and
-    they assert on the captured call instead.
+    Returns ``(client, result)``; ``result.exception`` / ``result.exit_code`` carry
+    any failure for the caller to classify (CliRunner captures exceptions, so a
+    sentinel abort surfaces as a non-zero exit rather than propagating).
     """
     client = create_mock_client()
     client.artifacts._list_for_download = None
@@ -155,33 +178,69 @@ def _drive_cli(argv: list[str], setup: Any = None, *, check_exit: bool = False) 
     ):
         mock_fetch.return_value = ("csrf", "session")
         result = CliRunner().invoke(cli, argv, obj=inject_client(client))
-    if check_exit:
-        assert result.exit_code == 0, result.output
-    return client
+    return client, result
+
+
+def _mcp_capture(
+    tool: str, args: dict[str, Any], namespace: str, method: str, setup: Any = None
+) -> Any:
+    """Drive an MCP tool, returning the single recorded ``namespace.method`` call.
+
+    If the tool never reached it, re-raise the REAL adapter error (chained) instead
+    of a bare empty-list assert — so a pre-capture failure is diagnosable.
+    """
+    calls, fn = _recorder()
+
+    def _setup(c: Any) -> None:
+        if setup is not None:
+            setup(c)
+        setattr(getattr(c, namespace), method, fn)
+
+    _, exc = _drive_mcp(tool, args, setup=_setup)
+    if not calls:
+        raise AssertionError(f"MCP {tool} never reached {namespace}.{method}") from exc
+    return calls[0]
+
+
+def _cli_capture(argv: list[str], namespace: str, method: str, setup: Any = None) -> Any:
+    """CLI counterpart of :func:`_mcp_capture`."""
+    calls, fn = _recorder()
+
+    def _setup(c: Any) -> None:
+        if setup is not None:
+            setup(c)
+        setattr(getattr(c, namespace), method, fn)
+
+    _, result = _drive_cli(argv, setup=_setup)
+    if not calls:
+        raise AssertionError(
+            f"CLI {argv} never reached {namespace}.{method}: {result.output}"
+        ) from result.exception
+    return calls[0]
 
 
 def _mcp_generate_call(artifact_type: str, method: str, extra: dict[str, Any]) -> Any:
     """Drive the MCP ``artifact_generate`` tool; return the captured generate-method call."""
-    client = _drive_mcp(
+    client, exc = _drive_mcp(
         "artifact_generate",
         {"notebook": NB, "artifact_type": artifact_type, **extra},
         setup=lambda c: setattr(c.artifacts, method, AsyncMock(return_value=_FakeStatus())),
-        suppress=False,
     )
+    assert exc is None, f"MCP generate {artifact_type} unexpectedly raised: {exc!r}"
     return getattr(client.artifacts, method).await_args
 
 
 def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
     """Drive the CLI ``generate <cmd>``; return the captured generate-method call."""
-    client = _drive_cli(
+    client, result = _drive_cli(
         ["generate", cmd, "-n", NB, *extra_args],
         setup=lambda c: setattr(
             c.artifacts,
             method,
             AsyncMock(return_value={"task_id": "task-1", "status": "processing"}),
         ),
-        check_exit=True,
     )
+    assert result.exit_code == 0, result.output
     return getattr(client.artifacts, method).call_args
 
 
@@ -205,10 +264,11 @@ def test_omitted_source_ids_parity(cmd: str, artifact_type: str, method: str) ->
     assert mcp_call.args[0] == NB
 
 
-def test_explicit_source_ids_parity() -> None:
-    """With explicit (full) ids, both adapters pass the SAME ids downstream."""
-    mcp_call = _mcp_generate_call("quiz", "generate_quiz", {"source_ids": [SRC_A, SRC_B]})
-    cli_call = _cli_generate_call("quiz", "generate_quiz", ["-s", SRC_A, "-s", SRC_B])
+@pytest.mark.parametrize("cmd,artifact_type,method", _KINDS, ids=[k[0] for k in _KINDS])
+def test_explicit_source_ids_parity(cmd: str, artifact_type: str, method: str) -> None:
+    """With explicit (full) ids, both adapters pass the SAME ids downstream (all kinds)."""
+    mcp_call = _mcp_generate_call(artifact_type, method, {"source_ids": [SRC_A, SRC_B]})
+    cli_call = _cli_generate_call(cmd, method, ["-s", SRC_A, "-s", SRC_B])
 
     mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
     cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
@@ -260,20 +320,6 @@ def test_notebook_resolver_parity_full_uuid() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _Captured(Exception):
-    """Raised by the recorder to short-circuit each adapter after the captured call."""
-
-
-def _recorder() -> tuple[list[tuple[tuple, dict]], Any]:
-    calls: list[tuple[tuple, dict]] = []
-
-    async def fn(*args: Any, **kwargs: Any) -> Any:
-        calls.append((args, kwargs))
-        raise _Captured
-
-    return calls, fn
-
-
 def test_source_add_url_parity() -> None:
     """source_add(url): both adapters build the SAME SourceAddPlan + notebook id.
 
@@ -283,11 +329,14 @@ def test_source_add_url_parity() -> None:
     """
     calls, fn = _recorder()
     with patch.object(source_add_module, "add_source", fn):
-        _drive_mcp(
+        _, mcp_exc = _drive_mcp(
             "source_add", {"notebook": NB, "source_type": "url", "url": "https://example.com/a"}
         )
-        _drive_cli(["source", "add", "https://example.com/a", "-n", NB])
-    assert len(calls) == 2, f"expected MCP+CLI calls, got {calls!r}"
+        _, cli_result = _drive_cli(["source", "add", "https://example.com/a", "-n", NB])
+    assert len(calls) == 2, (
+        f"both adapters must reach add_source; got {len(calls)} "
+        f"(mcp_exc={mcp_exc!r}, cli_exit={cli_result.exit_code}, cli_out={cli_result.output!r})"
+    )
     mcp_kwargs, cli_kwargs = calls[0][1], calls[1][1]
     assert mcp_kwargs["notebook_id"] == cli_kwargs["notebook_id"] == NB
     assert mcp_kwargs["plan"] == cli_kwargs["plan"]
@@ -296,19 +345,13 @@ def test_source_add_url_parity() -> None:
 def test_research_start_parity() -> None:
     """research: MCP ``research_start`` and CLI ``source add-research`` both call
     ``client.research.start(nb_id, query, source, mode)`` with the same args/defaults."""
-    calls_m, fn_m = _recorder()
-    _drive_mcp(
-        "research_start",
-        {"notebook": NB, "query": "AI agents"},
-        setup=lambda c: setattr(c.research, "start", fn_m),
+    mcp = _mcp_capture(
+        "research_start", {"notebook": NB, "query": "AI agents"}, "research", "start"
     )
-    calls_c, fn_c = _recorder()
-    _drive_cli(
-        ["source", "add-research", "AI agents", "-n", NB, "--no-wait"],
-        setup=lambda c: setattr(c.research, "start", fn_c),
+    cli = _cli_capture(
+        ["source", "add-research", "AI agents", "-n", NB, "--no-wait"], "research", "start"
     )
-    assert calls_m and calls_c, f"mcp={calls_m!r} cli={calls_c!r}"
-    assert calls_m[0] == calls_c[0]  # (nb_id, query, source="web", mode="fast")
+    assert mcp == cli  # (nb_id, query, source="web", mode="fast")
 
 
 _AUDIO_ARTIFACT = Artifact(
@@ -330,22 +373,15 @@ def test_download_audio_parity(tmp_path: Any) -> None:
         client.artifacts._list_for_download = None
         client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT])
 
-    calls_m, fn_m = _recorder()
-
-    def setup_m(c: Any) -> None:
-        setup(c)
-        c.artifacts.download_audio = fn_m
-
-    calls_c, fn_c = _recorder()
-
-    def setup_c(c: Any) -> None:
-        setup(c)
-        c.artifacts.download_audio = fn_c
-
-    _drive_mcp(
-        "artifact_download", {"notebook": NB, "artifact_type": "audio", "path": out}, setup=setup_m
+    mcp = _mcp_capture(
+        "artifact_download",
+        {"notebook": NB, "artifact_type": "audio", "path": out},
+        "artifacts",
+        "download_audio",
+        setup=setup,
     )
     # OUTPUT_PATH is a positional arg on the CLI leaf (not -o).
-    _drive_cli(["download", "audio", out, "-n", NB], setup=setup_c)
-    assert calls_m and calls_c, f"mcp={calls_m!r} cli={calls_c!r}"
-    assert calls_m[0] == calls_c[0]
+    cli = _cli_capture(
+        ["download", "audio", out, "-n", NB], "artifacts", "download_audio", setup=setup
+    )
+    assert mcp == cli

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -50,11 +50,27 @@ NB = "33333333-3333-3333-3333-333333333333"
 SRC_A = "11111111-1111-1111-1111-111111111111"
 SRC_B = "22222222-2222-2222-2222-222222222222"
 
-#: (cli subcommand, MCP artifact_type, client method) for source-needing kinds.
+#: (cli subcommand, MCP artifact_type, client method, mcp_extra, cli_extra) for every
+#: source-using generate kind. ``mcp_extra``/``cli_extra`` carry a kind's REQUIRED
+#: non-source input (data-table needs a description); they are NOT source_ids — the
+#: tests add sources themselves. ``mind-map`` is intentionally omitted: it renders
+#: synchronously via a different client path (tracked in #1653).
 _KINDS = [
-    ("quiz", "quiz", "generate_quiz"),
-    ("audio", "audio", "generate_audio"),
-    ("flashcards", "flashcards", "generate_flashcards"),
+    ("quiz", "quiz", "generate_quiz", {}, []),
+    ("audio", "audio", "generate_audio", {}, []),
+    ("flashcards", "flashcards", "generate_flashcards", {}, []),
+    ("video", "video", "generate_video", {}, []),
+    ("cinematic-video", "cinematic-video", "generate_cinematic_video", {}, []),
+    ("slide-deck", "slide-deck", "generate_slide_deck", {}, []),
+    ("infographic", "infographic", "generate_infographic", {}, []),
+    ("report", "report", "generate_report", {}, []),
+    (
+        "data-table",
+        "data-table",
+        "generate_data_table",
+        {"instructions": "Compare key concepts"},
+        ["Compare key concepts"],
+    ),
 ]
 
 _NAMESPACES = (
@@ -244,15 +260,20 @@ def _cli_generate_call(cmd: str, method: str, extra_args: list[str]) -> Any:
     return getattr(client.artifacts, method).call_args
 
 
-@pytest.mark.parametrize("cmd,artifact_type,method", _KINDS, ids=[k[0] for k in _KINDS])
-def test_omitted_source_ids_parity(cmd: str, artifact_type: str, method: str) -> None:
+@pytest.mark.parametrize(
+    "cmd,artifact_type,method,mcp_extra,cli_extra", _KINDS, ids=[k[0] for k in _KINDS]
+)
+def test_omitted_source_ids_parity(
+    cmd: str, artifact_type: str, method: str, mcp_extra: dict, cli_extra: list[str]
+) -> None:
     """Omitting sources: BOTH adapters must pass ``source_ids=None`` (= all sources).
 
     The #1652 regression: MCP sent an empty tuple (= zero sources, refused) while the
-    CLI sent ``None``. This asserts they agree — and that the agreed value is ``None``.
+    CLI sent ``None``. This asserts they agree — and that the agreed value is ``None`` —
+    across EVERY source-using generate kind (audio/video/slide-deck/report/…).
     """
-    mcp_call = _mcp_generate_call(artifact_type, method, {})
-    cli_call = _cli_generate_call(cmd, method, [])
+    mcp_call = _mcp_generate_call(artifact_type, method, mcp_extra)
+    cli_call = _cli_generate_call(cmd, method, cli_extra)
 
     mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
     cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
@@ -264,16 +285,80 @@ def test_omitted_source_ids_parity(cmd: str, artifact_type: str, method: str) ->
     assert mcp_call.args[0] == NB
 
 
-@pytest.mark.parametrize("cmd,artifact_type,method", _KINDS, ids=[k[0] for k in _KINDS])
-def test_explicit_source_ids_parity(cmd: str, artifact_type: str, method: str) -> None:
+@pytest.mark.parametrize(
+    "cmd,artifact_type,method,mcp_extra,cli_extra", _KINDS, ids=[k[0] for k in _KINDS]
+)
+def test_explicit_source_ids_parity(
+    cmd: str, artifact_type: str, method: str, mcp_extra: dict, cli_extra: list[str]
+) -> None:
     """With explicit (full) ids, both adapters pass the SAME ids downstream (all kinds)."""
-    mcp_call = _mcp_generate_call(artifact_type, method, {"source_ids": [SRC_A, SRC_B]})
-    cli_call = _cli_generate_call(cmd, method, ["-s", SRC_A, "-s", SRC_B])
+    mcp_call = _mcp_generate_call(
+        artifact_type, method, {**mcp_extra, "source_ids": [SRC_A, SRC_B]}
+    )
+    cli_call = _cli_generate_call(cmd, method, [*cli_extra, "-s", SRC_A, "-s", SRC_B])
 
     mcp_src = _normalize_source_ids(mcp_call.kwargs.get("source_ids"))
     cli_src = _normalize_source_ids(cli_call.kwargs.get("source_ids"))
     assert mcp_src == cli_src == sorted([SRC_A, SRC_B])
     # And full parity on the rest of the call too.
+    assert _normalized_call(mcp_call) == _normalized_call(cli_call)
+
+
+#: Per-type OPTIONS the MCP exposes as agent-settable, with a NON-DEFAULT value and the
+#: equivalent CLI flag(s). This guards that each kind's parameters/styles map to the SAME
+#: downstream call across adapters — not just source_ids.
+#:
+#: NOTE on scope: the MCP ``artifact_generate`` deliberately exposes only this curated
+#: subset (audio format/length, quiz/flashcards quantity/difficulty, report format). For
+#: video / cinematic-video / slide-deck / infographic / mind-map the MCP uses FIXED
+#: internal defaults (not agent-settable), so there is no explicit value that could
+#: diverge — their default-value parity is covered by ``test_omitted_source_ids_parity``.
+_OPTION_CASES = [
+    (
+        "audio",
+        "audio",
+        "generate_audio",
+        {"audio_format": "critique", "audio_length": "long"},
+        ["--format", "critique", "--length", "long"],
+    ),
+    (
+        "quiz",
+        "quiz",
+        "generate_quiz",
+        {"quantity": "more", "difficulty": "hard"},
+        ["--quantity", "more", "--difficulty", "hard"],
+    ),
+    (
+        "flashcards",
+        "flashcards",
+        "generate_flashcards",
+        {"quantity": "fewer", "difficulty": "easy"},
+        ["--quantity", "fewer", "--difficulty", "easy"],
+    ),
+    (
+        "report",
+        "report",
+        "generate_report",
+        {"report_format": "study-guide"},
+        ["--format", "study-guide"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd,artifact_type,method,mcp_opts,cli_opts", _OPTION_CASES, ids=[c[0] for c in _OPTION_CASES]
+)
+def test_explicit_option_parity(
+    cmd: str, artifact_type: str, method: str, mcp_opts: dict, cli_opts: list[str]
+) -> None:
+    """Each kind's agent-settable OPTIONS/STYLES map to the SAME downstream call.
+
+    A NON-DEFAULT value for every MCP-exposed option must produce an identical
+    ``generate_*`` call from the CLI's equivalent flags — catching any per-type
+    parameter-mapping divergence (the user's concern), not just source_ids.
+    """
+    mcp_call = _mcp_generate_call(artifact_type, method, mcp_opts)
+    cli_call = _cli_generate_call(cmd, method, cli_opts)
     assert _normalized_call(mcp_call) == _normalized_call(cli_call)
 
 

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -155,6 +155,17 @@ async def test_artifact_generate_passes_source_ids(mcp_call, mock_client) -> Non
     assert kwargs["source_ids"] == ("src-1", "src-2")
 
 
+async def test_artifact_generate_omitting_source_ids_uses_all(mcp_call, mock_client) -> None:
+    """Omitting ``source_ids`` must pass ``source_ids=None`` (=> all sources), NOT an
+    empty tuple. An empty list reaches the backend as 'zero sources', which it refuses
+    for source-needing kinds (quiz/audio/flashcards), returning a null id surfaced as
+    '… generation is unavailable'."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call("artifact_generate", {"notebook": NB_ID, "artifact_type": "audio"})
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] is None
+
+
 async def test_artifact_generate_unknown_type_is_validation_error(mcp_call, mock_client) -> None:
     with pytest.raises(ToolError) as excinfo:
         await mcp_call("artifact_generate", {"notebook": NB_ID, "artifact_type": "bogus"})

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -166,6 +166,17 @@ async def test_artifact_generate_omitting_source_ids_uses_all(mcp_call, mock_cli
     assert kwargs["source_ids"] is None
 
 
+async def test_artifact_generate_empty_source_ids_uses_all(mcp_call, mock_client) -> None:
+    """An EXPLICIT empty list is the same contract as omitting: => None (all sources),
+    never [] (which the backend refuses). Pins the full empty-vs-None contract."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate", {"notebook": NB_ID, "artifact_type": "audio", "source_ids": []}
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] is None
+
+
 async def test_artifact_generate_unknown_type_is_validation_error(mcp_call, mock_client) -> None:
     with pytest.raises(ToolError) as excinfo:
         await mcp_call("artifact_generate", {"notebook": NB_ID, "artifact_type": "bogus"})


### PR DESCRIPTION
## Bug
`artifact_generate` (quiz/audio/flashcards/…) over the MCP server fails with **`<kind> generation is unavailable`** whenever `source_ids` is **omitted** — even though the docstring promises *"omit it to use every source."* The CLI works fine on the same notebook/account.

## Root cause
- The tool builds `source_ids = tuple(source_ids or ())` → **`()`** when omitted.
- `_passthrough_sources` returned that **unchanged**, so the backend received an **empty source list = "zero sources."**
- Google refuses a source-needing artifact with no sources: **HTTP 200 + null artifact id**, which the client maps to `ArtifactFeatureUnavailableError` → "… generation is unavailable."
- The CLI works because its `resolve_source_ids` returns **`None`** for no input, and the backend treats `None` as **"all sources."**

## Fix
`_passthrough_sources` now returns `source_ids or None` — an empty collection maps to `None` (= every source), matching the CLI and the documented behavior. Non-empty ids pass through unchanged. One line + a docstring.

## Verification
- **Live (bearer against the deployed server):** MCP quiz **without** `source_ids` → "unavailable"; **with** explicit ids → real `task_id`. Same notebook generates fine via the CLI.
- **Unit:** new `test_artifact_generate_omitting_source_ids_uses_all` asserts the call passes `source_ids=None`; full `test_artifacts.py` green (22 passed).

## Why CI didn't catch it
The MCP tests mock `client.artifacts.generate_*` and never asserted the **omitted-sources** case resolved to `None` (only the explicit-ids case). The mock returns success regardless of `source_ids`, so the empty-vs-None distinction — which only matters against the real backend — was invisible. This PR adds that assertion; see the PR discussion for the broader gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected artifact generation so omitted `source_ids` are treated as “all sources” by passing `source_ids=None`.
  * Preserved “empty selection” semantics when `source_ids: []` is provided, ensuring it’s not conflated with the omitted case.

* **Tests**
  * Added unit contract tests covering both omitted and explicit empty `source_ids`.
  * Expanded CLI↔MCP parity tests to confirm consistent source/notebook resolution and matching downstream generation, download, and research call arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->