### PR TITLE
test(mcp): comprehensive live-API e2e for the MCP server + CLI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,8 +129,10 @@ jobs:
       shell: bash
       run: |
         # --extra impersonate so the ubuntu curl_cffi smoke step below can run.
+        # --extra mcp so the MCP/CLI live e2e suite (tests/e2e/test_mcp*.py,
+        # test_cli_live.py) actually RUNS instead of importorskip-ping fastmcp.
         attempt=1; max=3
-        until uv sync --frozen --extra browser --extra dev --extra markdown --extra impersonate; do
+        until uv sync --frozen --extra browser --extra dev --extra markdown --extra impersonate --extra mcp; do
           if [ "$attempt" -ge "$max" ]; then
             echo "::error::uv sync failed after $max attempts" >&2
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live-API e2e coverage for the MCP server and the CLI binary.** The nightly
+  E2E job now installs `--extra mcp`, so the MCP/CLI layers run against the real
+  NotebookLM API once per release instead of being silently `importorskip`-ped.
+  New suites: per-domain MCP tool round-trips plus a 26-tool→test matrix
+  (`tests/e2e/test_mcp.py`); the HTTP transport, bearer gate, `.well-known`
+  discovery, and signed-URL upload/download routes driven in-process over
+  `httpx.ASGITransport` (`tests/e2e/test_mcp_http.py`); live-only contract
+  checks — the `source_ids` omitted-`==`-`[]`-`==`-all collapse (#1652),
+  not-found resolution, destructive confirm-gating, and the MCP error shape
+  (`tests/e2e/test_mcp_contracts.py`); and a CLI-binary `--json` smoke including
+  stdout-purity on a live failure (`tests/e2e/test_cli_live.py`). A standalone
+  `scripts/mcp_live_smoke.py` runs the upload+download round-trip against a
+  deployed server (PASS/FAIL) to bootstrap the new per-release manual
+  "MCP connector smoke" checklist in `docs/releasing.md`.
 - **Remote MCP file upload & download** (ADR-0024). Over the remote (HTTP)
   connector — where the claude.ai browser can't carry the MCP credential and the
   JSON-RPC channel can't carry bytes — `source_add type=file` and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -273,7 +273,8 @@ upload/download pages). Verify that by hand, once per release (~10 min):
 - [ ] **Download** the generated artifact via the signed link.
 
 Bootstrap / sanity helper for the upload+download halves (drives a RUNNING
-server's file routes, prints PASS/FAIL):
+server's file routes, prints PASS/FAIL). Requires the `mcp` extra (e.g.
+`uv sync --extra mcp`):
 
 ```bash
 python scripts/mcp_live_smoke.py \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -252,6 +252,36 @@ no break against the baseline) is a CI failure, not silent cruft.
   2. Commit and push
   3. Re-run RPC health check
 
+### MCP connector smoke (manual, per release)
+
+The nightly E2E run now installs `--extra mcp` and exercises the MCP/CLI layers
+against the live API (`tests/e2e/test_mcp*.py`, `test_cli_live.py`) — so the
+on-demand Nightly run above already covers Layer A (tools ⇄ live API) and Layer B
+(HTTP transport + signed-URL routes, in-process). What it **cannot** cover is
+claude.ai actually driving the remote connector (OAuth login + the browser
+upload/download pages). Verify that by hand, once per release (~10 min):
+
+- [ ] `cd deploy && make dev` (or point at your deployed tunnel) and connect the
+      connector in claude.ai.
+- [ ] **OAuth login page** renders and the password gate accepts your password.
+- [ ] List notebooks through the connector.
+- [ ] Add a URL source.
+- [ ] Ask a question and get a grounded answer.
+- [ ] Generate **one** artifact (e.g. a report).
+- [ ] **Upload** a local file via the signed link (open it in a browser, pick a
+      file, confirm the source lands).
+- [ ] **Download** the generated artifact via the signed link.
+
+Bootstrap / sanity helper for the upload+download halves (drives a RUNNING
+server's file routes, prints PASS/FAIL):
+
+```bash
+python scripts/mcp_live_smoke.py \
+    --base-url https://your-tunnel.example.com \
+    --bearer "$NOTEBOOKLM_MCP_TOKEN" \
+    --notebook <notebook-id>
+```
+
 ---
 
 ## Package Verification

--- a/scripts/mcp_live_smoke.py
+++ b/scripts/mcp_live_smoke.py
@@ -90,8 +90,12 @@ async def _run(args: argparse.Namespace) -> bool:
     from fastmcp import Client
     from fastmcp.client.transports import StreamableHttpTransport
 
+    if not args.bearer:
+        _fail("no bearer token: pass --bearer or set $NOTEBOOKLM_MCP_TOKEN")
+        return False
+
     base_url = args.base_url.rstrip("/")
-    headers = {"Authorization": f"Bearer {args.bearer}"} if args.bearer else {}
+    headers = {"Authorization": f"Bearer {args.bearer}"}
     transport = StreamableHttpTransport(f"{base_url}/mcp", headers=headers)
 
     passed = True
@@ -148,7 +152,9 @@ async def _run(args: argparse.Namespace) -> bool:
         art_listing = await mcp.call_tool("artifact_list", {"notebook": dl_notebook})
         artifacts = (art_listing.structured_content or {}).get("artifacts", [])
         if args.artifact_type:
-            dl_type = args.artifact_type
+            # Tolerate underscored values copied from artifact metadata
+            # (slide_deck/mind_map/…); the download tool expects hyphens.
+            dl_type = args.artifact_type.replace("_", "-")
         else:
             candidate = next(
                 (

--- a/scripts/mcp_live_smoke.py
+++ b/scripts/mcp_live_smoke.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Standalone release sanity tool: drive a RUNNING remote MCP server's file
+side-channel end to end and print PASS/FAIL.
+
+This productionizes the upload+download round-trip the Layer-B e2e tests run
+in-process, but against a real deployed server (the claude.ai connector backend)
+— it is the bootstrap for the manual "MCP connector smoke" release checklist in
+``docs/releasing.md``. Point it at the server's public base URL + bearer token;
+it mints a signed upload URL through ``source_add(file)``, POSTs a small file to
+it, confirms the source landed, then (optionally) mints a download URL for an
+existing artifact and streams it back.
+
+Usage::
+
+    python scripts/mcp_live_smoke.py \
+        --base-url https://your-tunnel.example.com \
+        --bearer "$NOTEBOOKLM_MCP_TOKEN" \
+        --notebook <notebook-id-or-name> \
+        [--download-notebook <id>] [--artifact-type report]
+
+Requires the ``mcp`` extra (``fastmcp`` + ``httpx``). Exits 0 on PASS, 1 on FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from urllib.parse import urlsplit
+
+#: Artifact ``_artifact_type`` values whose download is wired through
+#: ``artifact_download`` (serialized form, underscored; the tool key is hyphenated).
+_DOWNLOADABLE = {
+    "audio",
+    "video",
+    "slide_deck",
+    "infographic",
+    "report",
+    "mind_map",
+    "data_table",
+    "quiz",
+    "flashcards",
+}
+
+
+def _ok(msg: str) -> None:
+    print(f"  PASS  {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  FAIL  {msg}")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Live PASS/FAIL smoke for a running remote MCP server's file routes.",
+    )
+    parser.add_argument("--base-url", required=True, help="Public base URL of the MCP server.")
+    parser.add_argument(
+        "--bearer",
+        default=os.environ.get("NOTEBOOKLM_MCP_TOKEN"),
+        help="Bearer token (defaults to $NOTEBOOKLM_MCP_TOKEN).",
+    )
+    parser.add_argument(
+        "--notebook",
+        required=True,
+        help="Notebook id or name to upload the smoke source into.",
+    )
+    parser.add_argument(
+        "--download-notebook",
+        default=None,
+        help="Notebook to download an existing artifact from (default: --notebook).",
+    )
+    parser.add_argument(
+        "--artifact-type",
+        default=None,
+        help="Force a download artifact_type (default: auto-pick an existing one).",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Only run the upload round-trip.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> bool:
+    import httpx
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    base_url = args.base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {args.bearer}"} if args.bearer else {}
+    transport = StreamableHttpTransport(f"{base_url}/mcp", headers=headers)
+
+    passed = True
+    async with Client(transport) as mcp, httpx.AsyncClient(timeout=120.0) as http:
+        # --- upload round-trip -------------------------------------------------
+        print("Upload round-trip:")
+        body = b"notebooklm MCP live smoke upload.\n"
+        result = await mcp.call_tool(
+            "source_add",
+            {
+                "notebook": args.notebook,
+                "source_type": "file",
+                "title": "MCP live smoke",
+                "mime_type": "text/plain",
+            },
+        )
+        structured = result.structured_content or {}
+        if structured.get("status") != "upload_required" or not structured.get("url"):
+            _fail(f"source_add(file) did not return an upload URL: {structured}")
+            return False
+        _ok("minted signed upload URL")
+
+        up = await http.post(
+            structured["url"]
+            + ("&" if urlsplit(structured["url"]).query else "?")
+            + "filename=mcp-smoke.txt",
+            content=body,
+            headers={"Accept": "application/json", "Content-Type": "text/plain"},
+        )
+        if up.status_code != 200:
+            _fail(f"upload POST returned {up.status_code}: {up.text}")
+            return False
+        source_id = up.json().get("source_id")
+        if not source_id:
+            _fail(f"upload response missing source_id: {up.text}")
+            return False
+        _ok(f"uploaded source {source_id}")
+
+        listing = await mcp.call_tool("source_list", {"notebook": args.notebook})
+        ids = [s["id"] for s in (listing.structured_content or {}).get("sources", [])]
+        if source_id in ids:
+            _ok("source confirmed live in source_list")
+        else:
+            _fail("uploaded source not found in source_list")
+            passed = False
+
+        # --- download round-trip ----------------------------------------------
+        if args.skip_download:
+            print("Download round-trip: skipped (--skip-download)")
+            return passed
+
+        print("Download round-trip:")
+        dl_notebook = args.download_notebook or args.notebook
+        art_listing = await mcp.call_tool("artifact_list", {"notebook": dl_notebook})
+        artifacts = (art_listing.structured_content or {}).get("artifacts", [])
+        if args.artifact_type:
+            dl_type = args.artifact_type
+        else:
+            candidate = next(
+                (
+                    a
+                    for a in artifacts
+                    if a.get("_artifact_type") in _DOWNLOADABLE
+                    and a.get("status") in (None, "ready", "completed")
+                ),
+                None,
+            )
+            if candidate is None:
+                _fail("no existing downloadable artifact (pass --artifact-type or generate one)")
+                return False
+            dl_type = candidate["_artifact_type"].replace("_", "-")
+
+        dl_result = await mcp.call_tool(
+            "artifact_download", {"notebook": dl_notebook, "artifact_type": dl_type}
+        )
+        dl_structured = dl_result.structured_content or {}
+        if dl_structured.get("status") != "download_ready" or not dl_structured.get("url"):
+            _fail(f"artifact_download did not return a download URL: {dl_structured}")
+            return False
+        _ok(f"minted signed download URL for {dl_type}")
+
+        resp = await http.get(dl_structured["url"])
+        if resp.status_code != 200 or not resp.content:
+            _fail(f"download GET returned {resp.status_code} ({len(resp.content)} bytes)")
+            return False
+        _ok(f"downloaded {len(resp.content)} bytes")
+
+    return passed
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        passed = asyncio.run(_run(args))
+    except Exception as exc:  # noqa: BLE001 - top-level smoke wants one clean line
+        print(f"  FAIL  unexpected error: {exc}")
+        passed = False
+    print()
+    print("RESULT: PASS" if passed else "RESULT: FAIL")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/_mcp_live_helpers.py
+++ b/tests/e2e/_mcp_live_helpers.py
@@ -85,4 +85,11 @@ async def call_tool(
     """Call one MCP tool over the in-memory transport and return its structured content."""
     async with mcp_client(real_client) as client:
         result = await client.call_tool(name, args or {})
+    # Every tool in this suite returns a structured dict on success. Assert it here
+    # so a caller subscripting the result fails LOUDLY (with the tool name) instead
+    # of with an opaque ``NoneType`` subscript error — and so the assertion can't
+    # be silently masked into a passing test by a ``(x or {})`` fallback.
+    assert result.structured_content is not None, (
+        f"MCP tool {name!r} returned no structured content"
+    )
     return result.structured_content

--- a/tests/e2e/_mcp_live_helpers.py
+++ b/tests/e2e/_mcp_live_helpers.py
@@ -1,0 +1,88 @@
+"""Shared helpers for the live MCP e2e suites.
+
+A ``_``-prefixed (non-``test_``) module so the per-suite modules
+(``test_mcp.py``, ``test_mcp_http.py``, ``test_mcp_contracts.py``) can share the
+in-memory FastMCP driver + the downloadable-artifact mapping WITHOUT importing
+one ``test_*`` module from another (forbidden by
+``tests/_guardrails/test_no_cross_test_imports.py``).
+
+Imported only by modules that have already ``pytest.importorskip("fastmcp")``,
+so the ``fastmcp`` import here is safe (it never loads on a no-``mcp`` install).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastmcp import Client
+
+from notebooklm import NotebookLMClient
+from notebooklm.mcp.server import create_server
+
+#: Serialized ``Artifact._artifact_type`` values (underscored) whose download is
+#: wired through ``artifact_download``. The download tool's spec keys are
+#: hyphenated, so callers translate ``_`` → ``-`` (see :func:`download_type`).
+DOWNLOADABLE_ARTIFACT_TYPES = {
+    "audio",
+    "video",
+    "slide_deck",
+    "infographic",
+    "report",
+    "mind_map",
+    "data_table",
+    "quiz",
+    "flashcards",
+}
+
+
+def download_type(serialized_artifact_type: str) -> str:
+    """Map a serialized ``_artifact_type`` (``slide_deck``) to a download key (``slide-deck``)."""
+    return serialized_artifact_type.replace("_", "-")
+
+
+def pick_downloadable_artifact(artifacts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the first ready, downloadable artifact in ``artifacts`` (or ``None``).
+
+    "Ready" tolerates a missing ``status`` (some serializations omit it) as well
+    as the terminal ``ready``/``completed`` states; "downloadable" is membership
+    in :data:`DOWNLOADABLE_ARTIFACT_TYPES`. Lets a test reuse whatever artifact a
+    notebook already has and skip cleanly when none qualifies.
+    """
+    return next(
+        (
+            a
+            for a in artifacts
+            if a.get("_artifact_type") in DOWNLOADABLE_ARTIFACT_TYPES
+            and a.get("status") in (None, "ready", "completed")
+        ),
+        None,
+    )
+
+
+@contextlib.asynccontextmanager
+async def mcp_client(real_client: NotebookLMClient) -> AsyncIterator[Client]:
+    """Yield an in-memory FastMCP ``Client`` bound to ``real_client``.
+
+    Wraps the already-open E2E ``client`` fixture in a no-op async-context-manager
+    factory so the server lifespan re-yields the same client (the fixture owns the
+    open/close lifecycle; the factory must NOT close it).
+    """
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[NotebookLMClient]:
+        yield real_client
+
+    server = create_server(client_factory=factory)
+    async with Client(server) as client:
+        yield client
+
+
+async def call_tool(
+    real_client: NotebookLMClient, name: str, args: dict[str, Any] | None = None
+) -> Any:
+    """Call one MCP tool over the in-memory transport and return its structured content."""
+    async with mcp_client(real_client) as client:
+        result = await client.call_tool(name, args or {})
+    return result.structured_content

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,14 +1,21 @@
 """E2E test fixtures and configuration."""
 
+import contextlib
 import hashlib
 import logging
 import os
+import subprocess
 import sys
 import warnings
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 import pytest
+
+if TYPE_CHECKING:
+    from notebooklm.client import NotebookLMClient
 
 # Load .env file if python-dotenv is available
 try:
@@ -899,3 +906,150 @@ async def multi_source_notebook_id(client):
             warnings.warn(
                 f"Failed to delete multi-source notebook {notebook_id}: {e}", stacklevel=2
             )
+
+
+# =============================================================================
+# Layer B — in-process MCP HTTP transport (ASGI, no socket)
+# =============================================================================
+# These helpers build the FastMCP http app bound to the LIVE e2e client (via the
+# ``client_factory`` seam) and drive it entirely in-process over
+# ``httpx.ASGITransport`` — the proven pattern from
+# ``tests/unit/mcp/test_remote_auth.py``. No port, no subprocess. fastmcp is
+# imported LAZILY inside these helpers so the shared e2e conftest still loads
+# cleanly when the ``mcp`` extra is absent (non-MCP e2e suites must not break).
+
+#: Bearer token the Layer-B tests authenticate the in-process http transport
+#: with. Arbitrary (the server compares against whatever ``build_auth`` was given).
+MCP_TEST_BEARER = "e2e-test-bearer-token"
+
+#: Base URL the in-process ASGI app answers on. Requests are routed by
+#: ``httpx.ASGITransport`` straight to the app object, so the host is cosmetic.
+_ASGI_BASE_URL = "http://app"
+
+
+class InProcessMcp:
+    """Handle to an in-process MCP http app for the Layer-B e2e tests.
+
+    Exposes both transports the tests need within one app lifespan:
+
+    * :meth:`mcp_client` — a ``fastmcp.Client`` over ``StreamableHttpTransport``
+      that drives MCP tool calls through the bearer-gated ``/mcp`` route.
+    * :meth:`raw_client` — a plain ``httpx.AsyncClient`` for the raw custom
+      routes (``/files/*``, ``/.well-known/*``, and the unauth ``/mcp`` probe).
+    """
+
+    def __init__(self, app: Any, token: str) -> None:
+        self.app = app
+        self.token = token
+
+    def mcp_client(self, token: str | None = None) -> Any:
+        """Return a (not-yet-entered) ``fastmcp.Client`` bearer-authed to the app."""
+        import httpx
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        bearer = self.token if token is None else token
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            # fastmcp passes its own transport; drive the app in-process via ASGI.
+            kwargs.pop("transport", None)
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=self.app), base_url=_ASGI_BASE_URL, **kwargs
+            )
+
+        return Client(
+            StreamableHttpTransport(
+                f"{_ASGI_BASE_URL}/mcp",
+                headers={"Authorization": f"Bearer {bearer}"},
+                httpx_client_factory=httpx_factory,
+            )
+        )
+
+    def raw_client(self) -> Any:
+        """Return a (not-yet-entered) plain ``httpx.AsyncClient`` over the ASGI app."""
+        import httpx
+
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=self.app), base_url=_ASGI_BASE_URL
+        )
+
+
+def asgi_path(url: str) -> str:
+    """Strip a minted signed URL down to the path the in-process ASGI client hits.
+
+    Minted ``/files/*`` URLs carry the configured public origin
+    (``https://127.0.0.1``); the in-process httpx client routes by path, so only
+    the path segment matters. Preserves any query string (none today, but cheap).
+    """
+    parts = urlsplit(url)
+    return parts.path + (f"?{parts.query}" if parts.query else "")
+
+
+@contextlib.asynccontextmanager
+async def inprocess_mcp_server(
+    real_client: "NotebookLMClient",
+    *,
+    token: str | None = MCP_TEST_BEARER,
+    oauth: Any = None,
+    file_transfer: Any = None,
+) -> AsyncIterator[InProcessMcp]:
+    """Build the MCP http app bound to ``real_client`` and enter its lifespan.
+
+    Mirrors ``tests/unit/mcp/test_remote_auth.py`` exactly, but the
+    ``client_factory`` yields the already-open LIVE e2e client (the fixture owns
+    its lifecycle, so the factory must NOT close it). Entering
+    ``app.router.lifespan_context`` is REQUIRED — the ``/files/*`` handlers read
+    the lifespan-bound client off ``app.state`` and 500 without it.
+    """
+    from notebooklm.mcp._auth import build_auth
+    from notebooklm.mcp.server import create_server
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator["NotebookLMClient"]:
+        yield real_client
+
+    server = create_server(
+        client_factory=factory,
+        auth=build_auth(token, oauth),
+        file_transfer=file_transfer,
+    )
+    app = server.http_app()
+    async with app.router.lifespan_context(app):
+        yield InProcessMcp(app, token or MCP_TEST_BEARER)
+
+
+# =============================================================================
+# CLI subprocess helper (deliverable 4)
+# =============================================================================
+
+
+def run_cli(
+    *args: str,
+    notebook: str | None = None,
+    extra_env: dict[str, str] | None = None,
+    timeout: float = 180.0,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the CLI as ``sys.executable -m notebooklm.notebooklm_cli``.
+
+    Runs the real installed CLI in a child process so the binary entry point,
+    argument parsing, and ``--json`` stdout/stderr split are exercised end to
+    end. The child inherits the parent environment (so ``NOTEBOOKLM_AUTH_JSON`` /
+    storage materialized for the e2e client carries over) — never ``--profile``,
+    which would make the CLI ignore an inline ``NOTEBOOKLM_AUTH_JSON`` secret.
+
+    Pass the target notebook via ``notebook=`` (exported as
+    ``NOTEBOOKLM_NOTEBOOK``) or an explicit ``-n <id>`` in ``args`` — NEVER
+    ``notebooklm use`` (that mutates shared profile state).
+    """
+    env = os.environ.copy()
+    if notebook is not None:
+        env["NOTEBOOKLM_NOTEBOOK"] = notebook
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "notebooklm.notebooklm_cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )

--- a/tests/e2e/test_cli_live.py
+++ b/tests/e2e/test_cli_live.py
@@ -1,0 +1,118 @@
+"""Live e2e smoke for the CLI **binary**, invoked as a child process via
+``sys.executable -m notebooklm.notebooklm_cli`` (not a raw ``notebooklm`` binary —
+CI PATH fragility). The notebook is passed by ``-n <id>`` / ``NOTEBOOKLM_NOTEBOOK``,
+never ``notebooklm use`` (which mutates shared profile state).
+
+These exercise the parts only a real subprocess can: argument parsing, the
+console-script wiring, and the ``--json`` stdout/stderr split — including the
+contract that on a LIVE failure ``--json`` still emits a single valid JSON object
+on **stdout** (logs go to stderr).
+
+Requires auth and the ``mcp`` extra (``importorskip`` — keeps this module skipping
+in lock-step with the rest of the MCP/CLI-live suite when the extra is absent);
+auto-marked ``e2e`` by ``conftest.pytest_itemcollected``.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+# Skip in lock-step with the rest of the MCP/CLI-live suite when the extra is absent.
+pytest.importorskip("fastmcp")
+
+from .conftest import requires_auth, run_cli  # noqa: E402 - after importorskip guard
+
+pytestmark = pytest.mark.e2e
+
+
+@requires_auth
+class TestCliLive:
+    """The CLI binary against the live account."""
+
+    @pytest.mark.readonly
+    def test_list_json(self):
+        """``list --json`` returns a JSON array/object of notebooks on stdout."""
+        proc = run_cli("list", "--json")
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        # ``list --json`` emits the notebooks payload; accept either a bare list
+        # or an enveloped object so the test is robust to the exact shape.
+        notebooks = payload if isinstance(payload, list) else payload.get("notebooks", payload)
+        assert isinstance(notebooks, list)
+
+    @pytest.mark.readonly
+    def test_status_json_shape(self):
+        """``status --json`` is a LOCAL-context/JSON-shape smoke (no live API).
+
+        It reads on-disk context, not the live API — included only to prove the
+        binary + ``--json`` envelope work end to end.
+        """
+        proc = run_cli("status", "--json")
+        assert proc.returncode == 0, proc.stderr
+        assert isinstance(json.loads(proc.stdout), dict)
+
+    @pytest.mark.readonly
+    def test_ask_json(self, read_only_notebook_id):
+        """``ask -n <read_only> --json`` returns a structured answer on stdout."""
+        proc = run_cli(
+            "ask",
+            "What is this notebook about?",
+            "-n",
+            read_only_notebook_id,
+            "--json",
+        )
+        if proc.returncode != 0 and "rate" in (proc.stdout + proc.stderr).lower():
+            pytest.skip(f"chat rate-limited: {proc.stdout or proc.stderr}")
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert isinstance(payload, dict)
+
+    def test_source_add_then_list_json(self, temp_notebook):
+        """``source add <url> -n <temp> --json`` then ``source list`` confirms it."""
+        nb = temp_notebook.id
+        add = run_cli("source", "add", "https://example.com", "-n", nb, "--json")
+        assert add.returncode == 0, add.stderr
+        assert isinstance(json.loads(add.stdout), dict)
+
+        listing = run_cli("source", "list", "-n", nb, "--json")
+        assert listing.returncode == 0, listing.stderr
+        payload = json.loads(listing.stdout)
+        sources = payload if isinstance(payload, list) else payload.get("sources", [])
+        assert isinstance(sources, list)
+        assert sources, "expected at least the seeded + added sources"
+
+    @pytest.mark.readonly
+    def test_json_stdout_purity_on_failure(self):
+        """A LIVE failure under ``--json`` still emits VALID JSON on stdout.
+
+        Drives ``ask`` against a bogus notebook id: the command fails (non-zero
+        exit), but the ``--json`` contract requires a single parseable JSON error
+        object on **stdout**, with human/log output confined to stderr.
+        """
+        bogus = f"nonexistent-{uuid4().hex}"
+        proc = run_cli("ask", "hello", "-n", bogus, "--json")
+        assert proc.returncode != 0
+        # stdout must be exactly one valid JSON object (the error envelope).
+        error = json.loads(proc.stdout)
+        assert isinstance(error, dict)
+        assert error.get("error") or error.get("code") or error.get("message")
+
+    @pytest.mark.variants
+    def test_generate_through_cli_wiring(self, generation_notebook_id):
+        """One generate-through-CLI wiring smoke (returns an id; no poll-to-done)."""
+        proc = run_cli(
+            "generate",
+            "report",
+            "a short briefing",
+            "-n",
+            generation_notebook_id,
+            "--json",
+        )
+        if proc.returncode != 0 and "rate" in (proc.stdout + proc.stderr).lower():
+            pytest.skip(f"generation rate-limited: {proc.stdout or proc.stderr}")
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert isinstance(payload, dict)

--- a/tests/e2e/test_cli_live.py
+++ b/tests/e2e/test_cli_live.py
@@ -28,6 +28,13 @@ from .conftest import requires_auth, run_cli  # noqa: E402 - after importorskip 
 pytestmark = pytest.mark.e2e
 
 
+def _is_rate_limited(proc) -> bool:
+    """True only on the real limiter signal (HTTP 429 / "rate limit") — NOT any
+    message that merely contains "rate", which could mask an unrelated failure."""
+    blob = f"{proc.stdout}\n{proc.stderr}".lower()
+    return "rate limit" in blob or "429" in blob
+
+
 @requires_auth
 class TestCliLive:
     """The CLI binary against the live account."""
@@ -64,25 +71,34 @@ class TestCliLive:
             read_only_notebook_id,
             "--json",
         )
-        if proc.returncode != 0 and "rate" in (proc.stdout + proc.stderr).lower():
+        if proc.returncode != 0 and _is_rate_limited(proc):
             pytest.skip(f"chat rate-limited: {proc.stdout or proc.stderr}")
         assert proc.returncode == 0, proc.stderr
         payload = json.loads(proc.stdout)
         assert isinstance(payload, dict)
 
     def test_source_add_then_list_json(self, temp_notebook):
-        """``source add <url> -n <temp> --json`` then ``source list`` confirms it."""
+        """``source add <url> -n <temp> --json`` then ``source list`` confirms it.
+
+        Asserts the SPECIFIC added source id shows up in the live listing —
+        ``temp_notebook`` already seeds one source, so a bare ``assert sources``
+        would pass even if the add path no-op'd.
+        """
         nb = temp_notebook.id
         add = run_cli("source", "add", "https://example.com", "-n", nb, "--json")
         assert add.returncode == 0, add.stderr
-        assert isinstance(json.loads(add.stdout), dict)
+        added = json.loads(add.stdout)
+        assert isinstance(added, dict)
+        added_id = added.get("id") or added.get("source_id") or added.get("source", {}).get("id")
+        assert added_id, f"source add returned no id: {added}"
 
         listing = run_cli("source", "list", "-n", nb, "--json")
         assert listing.returncode == 0, listing.stderr
         payload = json.loads(listing.stdout)
         sources = payload if isinstance(payload, list) else payload.get("sources", [])
-        assert isinstance(sources, list)
-        assert sources, "expected at least the seeded + added sources"
+        assert any(s.get("id") == added_id for s in sources), (
+            f"added source {added_id!r} not found in the live listing"
+        )
 
     @pytest.mark.readonly
     def test_json_stdout_purity_on_failure(self):
@@ -111,7 +127,7 @@ class TestCliLive:
             generation_notebook_id,
             "--json",
         )
-        if proc.returncode != 0 and "rate" in (proc.stdout + proc.stderr).lower():
+        if proc.returncode != 0 and _is_rate_limited(proc):
             pytest.skip(f"generation rate-limited: {proc.stdout or proc.stderr}")
         assert proc.returncode == 0, proc.stderr
         payload = json.loads(proc.stdout)

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -24,9 +24,7 @@ These require auth (``requires_auth``) and the ``mcp`` extra
 
 from __future__ import annotations
 
-import contextlib
-from collections.abc import AsyncIterator
-from typing import Any
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -34,41 +32,25 @@ import pytest
 # Require the `mcp` extra; skip the whole module cleanly when fastmcp is absent.
 pytest.importorskip("fastmcp")
 
-from fastmcp import Client  # noqa: E402 - after importorskip guard
-
-from notebooklm import NotebookLMClient  # noqa: E402 - after importorskip guard
-from notebooklm.mcp.server import create_server  # noqa: E402 - after importorskip guard
-
+# Shared in-memory MCP driver lives in a ``_``-prefixed helper module so the
+# sibling live-MCP test modules can reuse it without importing one ``test_*``
+# module from another (forbidden by test_no_cross_test_imports). Re-exported
+# under the historical ``_call`` / ``_mcp_client`` names this module already used.
+from ._mcp_live_helpers import (  # noqa: E402 - after importorskip guard
+    call_tool as _call,
+)
+from ._mcp_live_helpers import (  # noqa: E402 - after importorskip guard
+    download_type as _download_type,
+)
+from ._mcp_live_helpers import (  # noqa: E402 - after importorskip guard
+    mcp_client as _mcp_client,
+)
+from ._mcp_live_helpers import (  # noqa: E402 - after importorskip guard
+    pick_downloadable_artifact as _pick_downloadable_artifact,
+)
 from .conftest import requires_auth  # noqa: E402 - after importorskip guard
 
 pytestmark = pytest.mark.e2e
-
-
-@contextlib.asynccontextmanager
-async def _mcp_client(real_client: NotebookLMClient) -> AsyncIterator[Client]:
-    """Yield an in-memory FastMCP ``Client`` bound to ``real_client``.
-
-    Wraps the already-open E2E ``client`` fixture in a no-op async-context-manager
-    factory so the server lifespan re-yields the same client (the fixture owns the
-    open/close lifecycle; the factory must NOT close it).
-    """
-
-    @contextlib.asynccontextmanager
-    async def factory() -> AsyncIterator[NotebookLMClient]:
-        yield real_client
-
-    server = create_server(client_factory=factory)
-    async with Client(server) as mcp_client:
-        yield mcp_client
-
-
-async def _call(
-    real_client: NotebookLMClient, name: str, args: dict[str, Any] | None = None
-) -> Any:
-    """Call one MCP tool and return its structured content."""
-    async with _mcp_client(real_client) as mcp_client:
-        result = await mcp_client.call_tool(name, args or {})
-    return result.structured_content
 
 
 @requires_auth
@@ -204,3 +186,328 @@ class TestMcpNameResolution:
         # Case-insensitive match also resolves to the same id.
         described_upper = await _call(client, "notebook_describe", {"notebook": title.upper()})
         assert described_upper["notebook_id"] == nb_id
+
+
+# Tool → owning-test matrix. Every one of the 26 registered tools must map to a
+# test (or a documented owner) so a newly-added tool fails ``test_tool_matrix``
+# until it gains live coverage. ``test_tool_matrix`` asserts this set equals the
+# live manifest.
+TOOL_COVERAGE: dict[str, str] = {
+    # notebooks / meta
+    "notebook_list": "TestMcpReadOnly.test_notebook_list",
+    "notebook_create": "TestMcpLifecycle.test_create_describe_rename_delete",
+    "notebook_describe": "TestMcpLifecycle / TestMcpNameResolution",
+    "notebook_rename": "TestMcpLifecycle.test_create_describe_rename_delete",
+    "notebook_delete": "TestMcpLifecycle.test_create_describe_rename_delete",
+    "server_info": "TestMcpReadOnly.test_server_info",
+    # sources
+    "source_add": "TestMcpSources.test_source_roundtrip / test_source_add_text",
+    "source_list": "TestMcpSources.test_source_roundtrip",
+    "source_get_content": "TestMcpSources.test_source_roundtrip",
+    "source_rename": "TestMcpSources.test_source_roundtrip",
+    "source_delete": "TestMcpSources.test_source_roundtrip",
+    "source_wait": "TestMcpSources.test_source_roundtrip",
+    # chat
+    "chat_ask": "TestMcpChat.test_configure_then_ask",
+    "chat_configure": "TestMcpChat.test_configure_then_ask",
+    # notes
+    "note_create": "TestMcpNotes.test_note_crud",
+    "note_list": "TestMcpNotes.test_note_crud",
+    "note_update": "TestMcpNotes.test_note_crud",
+    "note_delete": "TestMcpNotes.test_note_crud",
+    # artifacts
+    "artifact_list": "TestMcpArtifacts.test_artifact_list",
+    "artifact_generate": "TestMcpArtifacts.test_generate_report_wiring (variants)",
+    "artifact_status": "TestMcpArtifacts.test_generate_report_wiring (variants)",
+    "artifact_download": "TestMcpArtifacts.test_download_existing_artifact",
+    # research
+    "research_start": "TestMcpResearch.test_start_status_cancel (variants)",
+    "research_status": "TestMcpResearch.test_status_readonly",
+    "research_cancel": "TestMcpResearch.test_start_status_cancel (variants)",
+    "research_import": "tests/e2e research suite (CLI import roundtrip)",
+}
+
+
+@requires_auth
+class TestMcpToolMatrix:
+    """Every registered tool is accounted for by a live test (the 26-tool matrix)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_tool_matrix(self, client):
+        """The owning-test matrix must cover EXACTLY the live tool manifest.
+
+        Guards against a new tool shipping without live MCP coverage: a tool
+        added to the server but missing from ``TOOL_COVERAGE`` fails here.
+        """
+        async with _mcp_client(client) as mcp_client:
+            tools = await mcp_client.list_tools()
+        live = {tool.name for tool in tools}
+        documented = set(TOOL_COVERAGE)
+        assert documented == live, (
+            f"tool/test matrix drift — only in manifest: {sorted(live - documented)}; "
+            f"only in matrix: {sorted(documented - live)}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_every_readonly_tool_is_callable(self, client, read_only_notebook_id):
+        """Each read-only tool dispatches live and returns a structured dict.
+
+        Covers the read-only surface that is callable with only a notebook (or
+        nothing) plus ``source_get_content`` (a real source id is resolved from
+        ``source_list``). ``artifact_status`` needs a live ``task_id`` and is
+        instead covered by ``TestMcpArtifacts`` (the generation wiring smoke).
+        """
+        nb = read_only_notebook_id
+
+        # No-arg reads.
+        assert isinstance(await _call(client, "notebook_list"), dict)
+        assert isinstance(await _call(client, "server_info"), dict)
+
+        # Notebook-scoped reads.
+        for name in ("notebook_describe", "source_list", "artifact_list", "note_list"):
+            structured = await _call(client, name, {"notebook": nb})
+            assert isinstance(structured, dict), f"{name} returned {type(structured)}"
+
+        # research_status with no in-flight task classifies cleanly (no_research / etc.).
+        research = await _call(client, "research_status", {"notebook": nb})
+        assert "status" in research
+
+        # source_get_content needs a real source id — resolve one from the listing.
+        listing = await _call(client, "source_list", {"notebook": nb})
+        sources = listing.get("sources") or []
+        if sources:
+            src_id = sources[0]["id"]
+            content = await _call(client, "source_get_content", {"notebook": nb, "source": src_id})
+            assert content["source"]["id"] == src_id
+
+
+@requires_auth
+class TestMcpSources:
+    """Source domain: add / wait / list / get / rename / delete through MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_source_roundtrip(self, client, temp_notebook):
+        """A URL source round-trips: add → (wait) → list → get → rename → delete."""
+        nb = temp_notebook.id
+
+        added = await _call(
+            client,
+            "source_add",
+            {"notebook": nb, "source_type": "url", "url": "https://example.com"},
+        )
+        assert isinstance(added, dict)
+        src_id = (added.get("source") or {}).get("id")
+        assert src_id, f"source_add did not return a source id: {added}"
+
+        # Wait for processing (best-effort: the roundtrip's value is the wiring,
+        # not example.com's fetch outcome — just assert it dispatched cleanly).
+        waited = await _call(
+            client, "source_wait", {"notebook": nb, "source": src_id, "timeout": 120.0}
+        )
+        assert waited.get("notebook_id") == nb
+        assert "status" in waited
+
+        listing = await _call(client, "source_list", {"notebook": nb})
+        ids = [s["id"] for s in listing["sources"]]
+        assert src_id in ids
+
+        content = await _call(client, "source_get_content", {"notebook": nb, "source": src_id})
+        assert content["source"]["id"] == src_id
+
+        renamed = await _call(
+            client,
+            "source_rename",
+            {"notebook": nb, "source": src_id, "new_title": "Renamed Source"},
+        )
+        assert isinstance(renamed, dict)
+
+        # Confirm-gating: preview without confirm, then confirm=True deletes.
+        preview = await _call(client, "source_delete", {"notebook": nb, "source": src_id})
+        assert preview["status"] == "needs_confirmation"
+        deleted = await _call(
+            client, "source_delete", {"notebook": nb, "source": src_id, "confirm": True}
+        )
+        assert deleted["status"] == "deleted"
+        assert deleted["source_id"] == src_id
+
+    @pytest.mark.asyncio
+    async def test_source_add_text(self, client, temp_notebook):
+        """A text source adds through MCP and appears in the listing."""
+        nb = temp_notebook.id
+        added = await _call(
+            client,
+            "source_add",
+            {
+                "notebook": nb,
+                "source_type": "text",
+                "text": "Live MCP text source body for the e2e suite.",
+                "title": "MCP Text Source",
+            },
+        )
+        src_id = (added.get("source") or {}).get("id")
+        assert src_id, f"text source_add did not return an id: {added}"
+        listing = await _call(client, "source_list", {"notebook": nb})
+        assert src_id in [s["id"] for s in listing["sources"]]
+
+
+@requires_auth
+class TestMcpChat:
+    """Chat domain: configure then ask against the read-only notebook."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_configure_then_ask(self, client, read_only_notebook_id):
+        """``chat_configure`` then ``chat_ask`` returns a non-empty answer."""
+        nb = read_only_notebook_id
+
+        configured = await _call(
+            client, "chat_configure", {"notebook": nb, "response_length": "shorter"}
+        )
+        assert isinstance(configured, dict)
+
+        answer = await _call(
+            client, "chat_ask", {"notebook": nb, "question": "What is this notebook about?"}
+        )
+        assert answer.get("answer"), f"chat_ask returned no answer: {answer}"
+        # citations land under ``references`` (the ChatAnswer wire field).
+        assert isinstance(answer.get("references", []), list)
+
+
+@requires_auth
+class TestMcpNotes:
+    """Note domain: create / list / update / delete through MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_note_crud(self, client, temp_notebook):
+        nb = temp_notebook.id
+
+        created = await _call(
+            client,
+            "note_create",
+            {"notebook": nb, "title": "E2E MCP Note", "content": "Initial body."},
+        )
+        note_id = created["note_id"]
+        assert note_id
+        # note_create returns a `created: True` bool (NOT a `status` key like
+        # note_update/note_delete — the tool return shapes are asymmetric).
+        assert created["created"] is True
+
+        listing = await _call(client, "note_list", {"notebook": nb})
+        assert note_id in [n["id"] for n in listing["notes"]]
+
+        updated = await _call(
+            client, "note_update", {"notebook": nb, "note": note_id, "content": "Updated body."}
+        )
+        assert updated["status"] == "updated"
+        assert updated["note_id"] == note_id
+
+        preview = await _call(client, "note_delete", {"notebook": nb, "note": note_id})
+        assert preview["status"] == "needs_confirmation"
+        deleted = await _call(
+            client, "note_delete", {"notebook": nb, "note": note_id, "confirm": True}
+        )
+        assert deleted["status"] == "deleted"
+        assert deleted["note_id"] == note_id
+
+
+@requires_auth
+class TestMcpArtifacts:
+    """Artifact domain: list (read) + a download of an existing artifact, plus a
+    generation **wiring smoke** (marked ``variants`` — heavy, no poll-to-done)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_artifact_list(self, client, generation_notebook_id):
+        """``artifact_list`` returns the notebook's artifacts as a list."""
+        structured = await _call(client, "artifact_list", {"notebook": generation_notebook_id})
+        assert isinstance(structured["artifacts"], list)
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_download_existing_artifact(self, client, generation_notebook_id, tmp_path):
+        """Download an EXISTING artifact (no fresh generation) to a local path.
+
+        Reuses whatever downloadable artifact the notebook already has (generation
+        e2e populates them nightly). Skips cleanly when none is present so this
+        never depends on cross-file test ordering.
+        """
+        listing = await _call(client, "artifact_list", {"notebook": generation_notebook_id})
+        candidate = _pick_downloadable_artifact(listing["artifacts"])
+        if candidate is None:
+            pytest.skip("no existing downloadable artifact on the generation notebook")
+
+        dl_type = _download_type(candidate["_artifact_type"])
+        out_path = tmp_path / f"artifact-{dl_type}"
+        result = await _call(
+            client,
+            "artifact_download",
+            {
+                "notebook": generation_notebook_id,
+                "artifact_type": dl_type,
+                "path": str(out_path),
+            },
+        )
+        assert isinstance(result, dict)
+        # The stdio download core writes the file and reports its path; assert
+        # bytes landed on disk.
+        written = Path(result.get("output_path") or out_path)
+        assert written.exists(), f"download produced no file: {result}"
+        assert written.stat().st_size > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.variants
+    async def test_generate_report_wiring(self, client, generation_notebook_id):
+        """Wiring smoke: ``artifact_generate`` threads through and returns a
+        ``task_id``; one ``artifact_status`` poll dispatches. Does NOT poll to
+        completion (the RPC health of generation is proven by ``test_generation``)."""
+        generated = await _call(
+            client,
+            "artifact_generate",
+            {"notebook": generation_notebook_id, "artifact_type": "report"},
+        )
+        task_id = generated.get("task_id")
+        assert task_id, f"artifact_generate returned no task_id: {generated}"
+
+        status = await _call(
+            client,
+            "artifact_status",
+            {"notebook": generation_notebook_id, "task_id": task_id},
+        )
+        assert status["notebook_id"] == generation_notebook_id
+        assert "status" in status
+
+
+@requires_auth
+class TestMcpResearch:
+    """Research domain: a read-only status smoke (nightly) + a start/cancel wiring
+    smoke (``variants`` — spawns a backend job)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_status_readonly(self, client, read_only_notebook_id):
+        """``research_status`` classifies a notebook with no in-flight research."""
+        structured = await _call(client, "research_status", {"notebook": read_only_notebook_id})
+        assert "status" in structured
+        assert structured["notebook_id"] == read_only_notebook_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.variants
+    async def test_start_status_cancel(self, client, temp_notebook):
+        """Wiring smoke: start a fast web research run, poll status once, cancel."""
+        nb = temp_notebook.id
+        started = await _call(
+            client,
+            "research_start",
+            {"notebook": nb, "query": "history of machine learning", "mode": "fast"},
+        )
+        assert started["notebook_id"] == nb
+
+        status = await _call(client, "research_status", {"notebook": nb})
+        assert "status" in status
+
+        run_id = status.get("task_id") or started.get("task_id")
+        if run_id:
+            cancelled = await _call(client, "research_cancel", {"notebook": nb, "run_id": run_id})
+            assert cancelled["cancelled"] is True

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -507,7 +507,10 @@ class TestMcpResearch:
         status = await _call(client, "research_status", {"notebook": nb})
         assert "status" in status
 
-        run_id = status.get("task_id") or started.get("task_id")
-        if run_id:
-            cancelled = await _call(client, "research_cancel", {"notebook": nb, "run_id": run_id})
-            assert cancelled["cancelled"] is True
+        # research_cancel MUST actually run — TOOL_COVERAGE claims it here, so a
+        # missing run id is a real failure (not a silent skip that would let the
+        # coverage matrix report a false positive).
+        run_id = started.get("task_id") or status.get("task_id")
+        assert run_id, f"research_start/status yielded no run id to cancel: {started} / {status}"
+        cancelled = await _call(client, "research_cancel", {"notebook": nb, "run_id": run_id})
+        assert cancelled["cancelled"] is True

--- a/tests/e2e/test_mcp_contracts.py
+++ b/tests/e2e/test_mcp_contracts.py
@@ -18,6 +18,7 @@ Requires auth and the ``mcp`` extra (``importorskip``); auto-marked ``e2e`` by
 
 from __future__ import annotations
 
+import asyncio
 from uuid import uuid4
 
 import pytest
@@ -55,6 +56,13 @@ class TestSourceIdsContract:
             {"notebook": generation_notebook_id, "artifact_type": "report"},
         )
         assert omitted.get("task_id"), f"omitted source_ids did not generate: {omitted}"
+
+        # Brief pause so the second submit isn't racing the first on the same
+        # notebook — if the backend serializes generation it can reject a
+        # back-to-back submit with FAILED_PRECONDITION (not a RateLimitError, so
+        # the skip wrapper wouldn't catch it). The contract under test is source-id
+        # resolution, not concurrent submits.
+        await asyncio.sleep(3)
 
         empty = await _call(
             client,

--- a/tests/e2e/test_mcp_contracts.py
+++ b/tests/e2e/test_mcp_contracts.py
@@ -1,0 +1,142 @@
+"""Live-only contract tests for the MCP tools — the behaviours that mocked unit
+tests structurally cannot prove, against the real NotebookLM API.
+
+The headline case is the ``source_ids`` collapse (#1652): the ``artifact_generate``
+tool deliberately maps BOTH an omitted ``source_ids`` AND an explicit
+``source_ids=[]`` to ``None`` ("all sources"), shielding callers from the raw
+backend behaviour where ``[]`` means "zero sources" (which the backend refuses).
+A mock only proves the resolver *received* ``None``; only a LIVE call proves the
+backend actually ACCEPTS the collapsed all-sources request and starts generating.
+
+Also covers not-found resolution, destructive confirm-gating (the entity must
+survive a no-confirm call), and the MCP error projection shape. All ``e2e``
+(light) so they run nightly.
+
+Requires auth and the ``mcp`` extra (``importorskip``); auto-marked ``e2e`` by
+``conftest.pytest_itemcollected``.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+# Require the `mcp` extra; skip the whole module cleanly when fastmcp is absent.
+pytest.importorskip("fastmcp")
+
+from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
+
+from ._mcp_live_helpers import call_tool as _call  # noqa: E402 - after importorskip guard
+from .conftest import requires_auth  # noqa: E402 - after importorskip guard
+
+pytestmark = pytest.mark.e2e
+
+
+@requires_auth
+class TestSourceIdsContract:
+    """#1652: omitted ``source_ids`` == ``[]`` == all sources, identically."""
+
+    @pytest.mark.asyncio
+    async def test_omitted_and_empty_source_ids_both_generate_from_all(
+        self, client, generation_notebook_id
+    ):
+        """Both omitting ``source_ids`` and passing ``[]`` start generation and
+        return a ``task_id`` — the tool collapses ``[]`` → ``None`` (all sources),
+        never forwarding the backend-refused empty selection.
+
+        This is the highest-value live catch: a regression that stopped
+        collapsing ``[]`` would surface here (the ``[]`` call would fail with the
+        backend's "… generation is unavailable") while passing every mock.
+        """
+        omitted = await _call(
+            client,
+            "artifact_generate",
+            {"notebook": generation_notebook_id, "artifact_type": "report"},
+        )
+        assert omitted.get("task_id"), f"omitted source_ids did not generate: {omitted}"
+
+        empty = await _call(
+            client,
+            "artifact_generate",
+            {
+                "notebook": generation_notebook_id,
+                "artifact_type": "report",
+                "source_ids": [],
+            },
+        )
+        assert empty.get("task_id"), f"empty source_ids did not generate: {empty}"
+
+
+@requires_auth
+class TestNotFoundResolution:
+    """A bogus id surfaces a clean not-found error, never a silent null success."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_describe_bogus_notebook_errors(self, client):
+        bogus = f"nonexistent-{uuid4().hex}"
+        with pytest.raises(ToolError) as excinfo:
+            await _call(client, "notebook_describe", {"notebook": bogus})
+        # The MCP error projection carries a structured CODE in the message.
+        assert "NOT_FOUND" in str(excinfo.value) or "not found" in str(excinfo.value).lower()
+
+
+@requires_auth
+class TestConfirmGating:
+    """Destructive tools without ``confirm`` preview-only; the entity survives."""
+
+    @pytest.mark.asyncio
+    async def test_note_delete_without_confirm_does_not_delete(self, client, temp_notebook):
+        nb = temp_notebook.id
+        created = await _call(
+            client,
+            "note_create",
+            {"notebook": nb, "title": "Confirm-Gate Note", "content": "Body."},
+        )
+        note_id = created["note_id"]
+
+        # No confirm → preview only.
+        preview = await _call(client, "note_delete", {"notebook": nb, "note": note_id})
+        assert preview["status"] == "needs_confirmation"
+
+        # The note must still exist (the no-confirm call did NOT delete).
+        listing = await _call(client, "note_list", {"notebook": nb})
+        assert note_id in [n["id"] for n in listing["notes"]]
+
+        # Clean up with an explicit confirm.
+        deleted = await _call(
+            client, "note_delete", {"notebook": nb, "note": note_id, "confirm": True}
+        )
+        assert deleted["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_notebook_delete_without_confirm_does_not_delete(
+        self, client, created_notebooks, cleanup_notebooks
+    ):
+        created = await _call(client, "notebook_create", {"title": f"Confirm-{uuid4().hex[:8]}"})
+        nb_id = created["notebook_id"]
+        created_notebooks.append(nb_id)
+
+        preview = await _call(client, "notebook_delete", {"notebook": nb_id})
+        assert preview["status"] == "needs_confirmation"
+
+        # Still resolvable → not deleted.
+        described = await _call(client, "notebook_describe", {"notebook": nb_id})
+        assert described["notebook_id"] == nb_id
+
+
+@requires_auth
+class TestErrorProjection:
+    """An invalid call surfaces as the MCP error shape, not a raw traceback."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_invalid_artifact_type_is_validation_error(self, client, read_only_notebook_id):
+        with pytest.raises(ToolError) as excinfo:
+            await _call(
+                client,
+                "artifact_generate",
+                {"notebook": read_only_notebook_id, "artifact_type": "not-a-real-type"},
+            )
+        assert "VALIDATION" in str(excinfo.value)

--- a/tests/e2e/test_mcp_http.py
+++ b/tests/e2e/test_mcp_http.py
@@ -1,0 +1,208 @@
+"""Layer-B e2e: the MCP **HTTP transport + bearer gate + signed-URL file routes**
+against the real NotebookLM API, driven entirely in-process over
+``httpx.ASGITransport`` (no socket, no subprocess).
+
+Follows the proven repo pattern at ``tests/unit/mcp/test_remote_auth.py`` — the
+only difference is that the ``client_factory`` yields the LIVE e2e ``client``
+fixture instead of a stub, so tool calls hit real Google while still exercising:
+
+* the bearer auth gate on ``/mcp`` (unauth → 401, bearer → tools),
+* the ``.well-known`` discovery metadata,
+* the ``/files/ul`` + ``/files/dl`` signed-URL routes (the claude.ai connector's
+  out-of-band upload/download channel), including the
+  custom-route-bypasses-bearer tripwire (``/files/ul/<bad>`` → **403**, not 401).
+
+Requires auth and the ``mcp`` extra (``importorskip``); auto-marked ``e2e`` by
+``conftest.pytest_itemcollected``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Require the `mcp` extra; skip the whole module cleanly when fastmcp is absent.
+pytest.importorskip("fastmcp")
+
+from notebooklm.mcp._filelink import (  # noqa: E402 - after importorskip guard
+    FileLinkSigner,
+    FileTransferConfig,
+)
+
+from ._mcp_live_helpers import (  # noqa: E402 - after importorskip guard
+    download_type,
+    pick_downloadable_artifact,
+)
+from .conftest import (  # noqa: E402 - after importorskip guard
+    asgi_path,
+    inprocess_mcp_server,
+    requires_auth,
+)
+
+pytestmark = pytest.mark.e2e
+
+# A bare-https origin satisfies ``FileTransferConfig`` without going through
+# ``__main__._build_file_transfer`` (which would re-validate); the in-process
+# ASGI client routes by path, so the host never has to be reachable.
+_PUBLIC_BASE_URL = "https://127.0.0.1"
+
+
+def _file_transfer() -> FileTransferConfig:
+    return FileTransferConfig(FileLinkSigner(os.urandom(32)), _PUBLIC_BASE_URL)
+
+
+@requires_auth
+class TestMcpHttpAuthGate:
+    """The bearer gate on the in-process HTTP transport."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_unauthenticated_mcp_is_rejected(self, client):
+        """A ``/mcp`` request with no bearer is rejected (401) before any tool."""
+        async with inprocess_mcp_server(client) as im, im.raw_client() as raw:
+            resp = await raw.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_bearer_lists_tools_live(self, client):
+        """With the correct bearer, the MCP client lists tools over the HTTP transport."""
+        async with inprocess_mcp_server(client) as im, im.mcp_client() as mcp:
+            tools = await mcp.list_tools()
+        assert any(t.name == "notebook_list" for t in tools)
+
+
+@requires_auth
+class TestMcpHttpWellKnown:
+    """OAuth discovery metadata is auth-type-specific."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_bearer_only_serves_no_oauth_metadata(self, client):
+        """Bearer-only auth mounts NO OAuth discovery routes (empirically verified
+        against fastmcp 3.2.0: a plain ``TokenVerifier`` serves neither the
+        protected-resource nor the authorization-server metadata). Bearer clients
+        (Claude Code/Desktop) carry the token directly and never run OAuth
+        discovery; only the self-hosted OAuth provider (the claude.ai path, tested
+        below) mounts ``.well-known`` metadata."""
+        async with inprocess_mcp_server(client) as im, im.raw_client() as raw:
+            for path in (
+                "/.well-known/oauth-protected-resource",
+                "/.well-known/oauth-authorization-server",
+            ):
+                resp = await raw.get(path)
+                assert resp.status_code == 404, f"{path} unexpectedly served: {resp.status_code}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_authorization_server_metadata_with_oauth_provider(self, client):
+        """An OAuth provider mounts the *authorization-server* metadata route.
+
+        Bearer-only auth has NO authorization-server route, so this uses a real
+        self-hosted OAuth provider (the claude.ai login path).
+        """
+        from notebooklm.mcp._oauth import OAuthConfig, build_oauth_provider
+
+        oauth = build_oauth_provider(
+            OAuthConfig(password="a-strong-random-password-1234567890", base_url=_PUBLIC_BASE_URL)
+        )
+        async with inprocess_mcp_server(client, oauth=oauth) as im, im.raw_client() as raw:
+            resp = await raw.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        assert resp.json().get("registration_endpoint")
+
+
+@requires_auth
+class TestMcpHttpFileRoutes:
+    """Signed-URL upload/download routes against the live API."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_bad_upload_token_is_403_not_401(self, client):
+        """``/files/ul/<bad>`` → 403 (custom routes are NOT behind the bearer gate).
+
+        Pins the security-critical fact that the signed token — not the MCP
+        bearer — is the sole auth for the file routes: an unauthenticated browser
+        opening a bad link gets a 403 from the signer, never a 401.
+        """
+        async with (
+            inprocess_mcp_server(client, file_transfer=_file_transfer()) as im,
+            im.raw_client() as raw,
+        ):
+            resp = await raw.get("/files/ul/not-a-valid-token")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_upload_roundtrip(self, client, temp_notebook):
+        """source_add(file) mints an upload URL; a raw POST adds the source live."""
+        nb = temp_notebook.id
+        body = b"Live MCP upload roundtrip content for the e2e suite.\n"
+        async with inprocess_mcp_server(client, file_transfer=_file_transfer()) as im:
+            # Mint the signed upload URL through the MCP tool over HTTP.
+            async with im.mcp_client() as mcp:
+                result = await mcp.call_tool(
+                    "source_add",
+                    {
+                        "notebook": nb,
+                        "source_type": "file",
+                        "title": "MCP HTTP Upload",
+                        "mime_type": "text/plain",
+                    },
+                )
+            structured = result.structured_content
+            assert structured["status"] == "upload_required"
+            upload_path = asgi_path(structured["url"])
+
+            # Upload the raw bytes (the browser fetch passes the filename via query).
+            async with im.raw_client() as raw:
+                up = await raw.post(
+                    f"{upload_path}?filename=mcp-upload.txt",
+                    content=body,
+                    headers={"Accept": "application/json", "Content-Type": "text/plain"},
+                )
+            assert up.status_code == 200, up.text
+            payload = up.json()
+            assert payload["status"] == "added"
+            source_id = payload["source_id"]
+            assert source_id
+
+            # Confirm the source landed, live, through the MCP listing.
+            async with im.mcp_client() as mcp:
+                listing = await mcp.call_tool("source_list", {"notebook": nb})
+            ids = [s["id"] for s in listing.structured_content["sources"]]
+            assert source_id in ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.readonly
+    async def test_download_roundtrip(self, client, generation_notebook_id):
+        """artifact_download mints a download URL; a raw GET streams the bytes.
+
+        Reuses an EXISTING artifact on the generation notebook (no fresh
+        generation); skips cleanly when none is present.
+        """
+        async with inprocess_mcp_server(client, file_transfer=_file_transfer()) as im:
+            async with im.mcp_client() as mcp:
+                listing = await mcp.call_tool("artifact_list", {"notebook": generation_notebook_id})
+                candidate = pick_downloadable_artifact(listing.structured_content["artifacts"])
+                if candidate is None:
+                    pytest.skip("no existing downloadable artifact on the generation notebook")
+
+                dl_type = download_type(candidate["_artifact_type"])
+                result = await mcp.call_tool(
+                    "artifact_download",
+                    {"notebook": generation_notebook_id, "artifact_type": dl_type},
+                )
+            structured = result.structured_content
+            assert structured["status"] == "download_ready"
+            download_path = asgi_path(structured["url"])
+
+            async with im.raw_client() as raw:
+                resp = await raw.get(download_path)
+            assert resp.status_code == 200, resp.text
+            assert len(resp.content) > 0
+            assert "content-disposition" in {k.lower() for k in resp.headers}

--- a/tests/e2e/test_mcp_http.py
+++ b/tests/e2e/test_mcp_http.py
@@ -96,7 +96,10 @@ class TestMcpHttpWellKnown:
                 "/.well-known/oauth-authorization-server",
             ):
                 resp = await raw.get(path)
-                assert resp.status_code == 404, f"{path} unexpectedly served: {resp.status_code}"
+                assert resp.status_code == 404, (
+                    f"{path} unexpectedly served (fastmcp metadata behavior changed?): "
+                    f"{resp.status_code}"
+                )
 
     @pytest.mark.asyncio
     @pytest.mark.readonly
@@ -174,7 +177,9 @@ class TestMcpHttpFileRoutes:
             # Confirm the source landed, live, through the MCP listing.
             async with im.mcp_client() as mcp:
                 listing = await mcp.call_tool("source_list", {"notebook": nb})
-            ids = [s["id"] for s in listing.structured_content["sources"]]
+            sc = listing.structured_content
+            assert sc is not None, "source_list returned no structured content"
+            ids = [s["id"] for s in sc["sources"]]
             assert source_id in ids
 
     @pytest.mark.asyncio
@@ -188,7 +193,9 @@ class TestMcpHttpFileRoutes:
         async with inprocess_mcp_server(client, file_transfer=_file_transfer()) as im:
             async with im.mcp_client() as mcp:
                 listing = await mcp.call_tool("artifact_list", {"notebook": generation_notebook_id})
-                candidate = pick_downloadable_artifact(listing.structured_content["artifacts"])
+                sc = listing.structured_content
+                assert sc is not None, "artifact_list returned no structured content"
+                candidate = pick_downloadable_artifact(sc["artifacts"])
                 if candidate is None:
                     pytest.skip("no existing downloadable artifact on the generation notebook")
 


### PR DESCRIPTION
## What & why

The MCP server had **no working live coverage** — `tests/e2e/test_mcp.py` was collected-then-**skipped** every night because the nightly install never had `--extra mcp`. This adds comprehensive live-API coverage across three layers plus the CLI binary, and a manual checklist for the one layer CI can't reach.

| Layer | What it exercises | How |
|---|---|---|
| **A. MCP ⇄ live API** | all 26 tools' logic vs real Google | in-memory `fastmcp.Client` + real client via `client_factory` |
| **B. HTTP transport + auth + signed-URL routes** | bearer gate, `.well-known`, `/files/ul`+`/dl` | **in-process** `httpx.ASGITransport` (no socket/subprocess), per `test_remote_auth.py` |
| **C. claude.ai driving the connector** | OAuth login, browser upload | **manual** `docs/releasing.md` checklist + `scripts/mcp_live_smoke.py` |

## Highlights
- **`test_mcp_contracts.py`** catches what mocked unit tests structurally can't: the #1652 **`source_ids` omitted == `[]` == all-sources** contract, not-found resolution, destructive confirm-gating.
- **`test_mcp_http.py`** (Layer B) pins the security-critical `/files/ul/<bad>` → **403 not 401** (custom routes bypass the bearer; the signed token is the sole auth), the upload roundtrip, and auth-type-specific `.well-known` (bearer-only serves none; an OAuth provider serves the AS metadata).
- **`test_cli_live.py`** exercises the real binary (`python -m`, `-n`/env, never `use`) incl. the `--json` stdout-purity-on-failure contract.
- **Quota-aware:** heavy generation/research are **wiring smokes** (return a `task_id`, no poll) marked `variants`; the download test **reuses an existing artifact** — so nightly doesn't re-burn the RPCs `test_generation.py` already covers. `--extra mcp` added to nightly (the hard prerequisite).

## Process & verification
- Plan converged across **two 3-model review rounds** (Claude/Codex/agy) — they caught the Layer-B lifespan requirement and an inverted `source_ids` assertion before any code.
- **Live-verified end-to-end against the real NotebookLM API** (~32 tests across all tiers: contract 5, Layer-B 6, Layer-A 13, CLI 5, variants wiring 3). The live runs additionally caught **two wrong test assumptions** static checks missed — bearer-only `.well-known` is `404` (no OAuth discovery), and `note_create` returns `created: True` not a `status` key — both fixed.
- `mypy` + `ruff` clean; unit suite `8986 passed`; `tests/e2e` collects 205 (34 new); the no-cross-test-imports guardrail green (shared driver lives in `_mcp_live_helpers.py`).

No `src/` behavior changes — this is test + CI + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded nightly live MCP server and CLI E2E coverage to run the full live NotebookLM API suite (including signed upload/download smoke).
  * Added a standalone live smoke command to verify end-to-end upload/download PASS/FAIL against a running server.
  * Added new live MCP HTTP and contract test coverage (auth, discovery metadata, confirmation gating, and validation/error shapes).
* **Bug Fixes**
  * Improved JSON stdout purity checks for CLI failure paths and strengthened destructive-action confirmation behavior assertions.
* **Documentation**
  * Updated release manual smoke checklist with concrete end-to-end verification steps and the new helper command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->