### PR TITLE
ci(test): parallelize matrix pytest with -n auto --dist loadgroup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,14 +293,13 @@ jobs:
       run: uv run python tests/scripts/check_cassettes_clean.py --secrets-only --recursive tests/fixtures
 
     - name: Run tests with coverage
-      # ``-n auto --dist loadgroup`` parallelizes the ~11k-test suite across all
-      # runner cores (pytest-xdist is already a dev dep). ``loadgroup`` honors
-      # ``@pytest.mark.xdist_group`` — the documented per-test isolation escape hatch
-      # (tests/integration/concurrency/conftest.py) — while unmarked tests distribute
-      # like ``load``; the suite is parallel-safe via per-test ``NOTEBOOKLM_HOME`` tmp
-      # isolation. pytest-cov combines per-worker coverage automatically, so the
-      # coverage.json + per-file floors below are unaffected (verified: identical total
-      # and floor verdict vs single-threaded). Local 4-core: 303s -> 95s (3.2x).
+      # ``-n auto --dist loadgroup`` parallelizes the ~11k-test suite across the
+      # runner's cores (pytest-xdist is already a dev dep). ``loadgroup`` honors
+      # ``@pytest.mark.xdist_group`` — the isolation escape hatch for tests touching
+      # process-global state (tests/integration/concurrency/conftest.py); unmarked
+      # tests distribute like ``load``. The suite is parallel-safe via per-test
+      # ``NOTEBOOKLM_HOME`` tmp isolation, and pytest-cov merges per-worker coverage
+      # automatically, so the coverage.json + per-file floors below are unaffected.
       #
       # Emit coverage.json so the per-file floor check below can read it without
       # re-running the suite. ``term-missing`` is kept so build logs still show the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,10 +293,19 @@ jobs:
       run: uv run python tests/scripts/check_cassettes_clean.py --secrets-only --recursive tests/fixtures
 
     - name: Run tests with coverage
-      # Emit coverage.json so the per-file floor check below can read it
-      # without re-running the suite. ``term-missing`` is kept so build logs
-      # still show the missing-lines summary.
-      run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
+      # ``-n auto --dist loadgroup`` parallelizes the ~11k-test suite across all
+      # runner cores (pytest-xdist is already a dev dep). ``loadgroup`` honors
+      # ``@pytest.mark.xdist_group`` — the documented per-test isolation escape hatch
+      # (tests/integration/concurrency/conftest.py) — while unmarked tests distribute
+      # like ``load``; the suite is parallel-safe via per-test ``NOTEBOOKLM_HOME`` tmp
+      # isolation. pytest-cov combines per-worker coverage automatically, so the
+      # coverage.json + per-file floors below are unaffected (verified: identical total
+      # and floor verdict vs single-threaded). Local 4-core: 303s -> 95s (3.2x).
+      #
+      # Emit coverage.json so the per-file floor check below can read it without
+      # re-running the suite. ``term-missing`` is kept so build logs still show the
+      # missing-lines summary.
+      run: uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
 
     - name: Assert per-file coverage floors
       # Linux-only because ``coverage.json`` on Windows records backslash


### PR DESCRIPTION
## What
Parallelize the `test` matrix's pytest run (the only ~13-min leg) by adding `-n auto --dist loadgroup`. Single-line change to `.github/workflows/test.yml`.

## Why
The 15-leg matrix ran ~11,155 tests **single-threaded**. Baseline matrix-leg durations on `main`:
- ubuntu/macos: **~7-10 min**
- windows: **~11-17 min**

`pytest-xdist` is **already a dev dependency** and the suite is already parallel-safe (per-test `NOTEBOOKLM_HOME` tmp isolation; the #1482 `pythonpath` xdist fix).

## Local evidence (4-core)
| | single | `-n auto --dist loadgroup` |
|---|---|---|
| pytest time | 303s | **95s (3.2×)** |
| coverage | 96% (22763/761) | **identical** |
| per-file-floor script verdict | exit 0, 5 floors met | **identical** |
| stability | — | **5× repeated runs, zero intermittency** |

The 90% gate passes under xdist (95.82%); `pytest-cov` combines per-worker coverage automatically (no `[tool.coverage.run]` change needed — verified by running the actual CI floor script on both single + parallel `coverage.json`).

## Design notes
- **`loadgroup` (not `loadscope`)**: honors `@pytest.mark.xdist_group` — the per-test isolation escape hatch documented in `tests/integration/concurrency/conftest.py`; `loadscope` would silently ignore it. Unmarked tests distribute like `load` (suite is stable under that).
- **Scope:** only the matrix coverage run changes. `quality` (collect-only), `publish`/`testpypi`/`verify-package` smoke, and **nightly e2e** (live API, `--reruns`) stay **serial** — e2e must never get `-n` (rate-limit/ordering hazards).
- The 2 tests that fail in a `browser`-extra-less sandbox are env-only and pass on CI (which installs `--extra browser`).

## Review
Plan reviewed by **momus (claude + codex), 2 rounds to convergence** (both OKAY) — see commit rationale. Excluded agy per project policy.

## ⚠️ Do not merge yet — pending CI verification
The goal requires confirming the speedup **on GitHub CI** (local ≠ CI; Windows uses process-`spawn`, runner cores vary). Watching this PR's matrix legs vs the baseline above; if Windows regresses, follow-up makes `-n` OS-conditional. **No auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI “Run tests with coverage” step to execute tests in parallel for faster runs.
  * Kept the existing coverage reporting outputs and the same minimum coverage threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->