### PR TITLE
feat(mcp): expose per-type generate styles/options on artifact_generate (#1654)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -236,12 +236,20 @@ conversation unless you pass a `conversation_id`.
 task = artifact_generate(notebook="Quantum Computing", artifact_type="audio")
 artifact_status(notebook="Quantum Computing", task_id="<task_id from above>")   # poll until complete
 artifact_download(notebook="Quantum Computing", artifact_type="audio", path="podcast.mp3")
+
+# Per-kind styling options are agent-settable, e.g. a custom-styled video:
+artifact_generate(notebook="Quantum Computing", artifact_type="video",
+                  style="custom", style_prompt="hand-drawn diagrams")
 ```
 
 `artifact_type` is one of `audio`, `video`, `cinematic-video`, `slide-deck`, `quiz`, `flashcards`,
-`infographic`, `data-table`, `mind-map`, `report`. Agent-settable options are `audio_format` /
-`audio_length` (audio), `quantity` / `difficulty` (quiz, flashcards), and `report_format` (report);
-the other kinds use fixed defaults.
+`infographic`, `data-table`, `mind-map`, `report`. Each kind's styling options are agent-settable
+(matching the CLI flags): `audio_format` / `audio_length` (audio); `video_format` / `style` /
+`style_prompt` (video); `deck_format` / `deck_length` (slide-deck); `quantity` / `difficulty`
+(quiz, flashcards); `orientation` / `detail` / `style` (infographic); `map_kind` (mind-map);
+and `report_format` (report). `cinematic-video` and `data-table` take no per-kind options. An
+option is valid only for its own kind — passing one to a different `artifact_type` is a
+validation error, not a silent no-op.
 
 ### Run deep research and import the findings
 

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -84,18 +84,81 @@ _KIND_DEFAULTS: dict[str, dict[str, Any]] = {
     "report": {"report_format": "briefing-doc"},
 }
 
-#: Accepted values for the agent-facing per-kind options. Validated up front so a
-#: bad choice surfaces as a clean ``VALIDATION`` error rather than a raw
-#: ``KeyError`` from a generate-core display-name lookup that runs before its own
-#: choice validation (the CLI never hits this because Click validates the
-#: ``Choice`` first; the neutral core's per-kind validation is incomplete for
-#: ``report_format``). The agent may still pass any of these by keyword.
-_OPTION_CHOICES: dict[str, tuple[str, ...]] = {
-    "report_format": ("briefing-doc", "study-guide", "blog-post", "custom"),
-    "audio_format": ("deep-dive", "brief", "critique", "debate"),
-    "audio_length": ("short", "default", "long"),
-    "quantity": ("fewer", "standard", "more"),
-    "difficulty": ("easy", "medium", "hard"),
+#: Per-kind agent-settable options → their accepted choices. ``None`` choices mean
+#: free text (only ``style_prompt``). This single table drives all three things the
+#: agent-facing override path needs:
+#:
+#: * **Choice validation** up front, so a bad value surfaces as a clean ``VALIDATION``
+#:   error rather than a raw ``KeyError`` from a generate-core display-name lookup that
+#:   runs before its own choice validation (the CLI never hits this — Click validates
+#:   the ``Choice`` first).
+#: * **The ``style`` collision** — ``video`` and ``infographic`` both take a ``style``
+#:   kwarg but with DIFFERENT choice sets (overlapping only on ``auto``/``anime``/
+#:   ``kawaii``); keying choices by ``artifact_type`` keeps them apart.
+#: * **Wrong-kind rejection** — an option valid for some other kind (e.g. ``orientation``
+#:   passed to ``quiz``) is rejected here, because the neutral core silently *ignores*
+#:   irrelevant extras (``build_generation_plan`` "picks the relevant subset"), which
+#:   would otherwise be a confusing silent no-op for an agent.
+#:
+#: The literal choice tuples are DUPLICATED from the neutral core's private ``_*_MAP``
+#: maps (MCP must not import them — the CLI/MCP boundary rule); a guardrail test pins
+#: these tuples equal to the core maps so they can't silently drift. ``map_kind`` has no
+#: core map (the core reads it raw and any non-``interactive`` value routes note-backed),
+#: so it is validated here ONLY.
+_KIND_OPTIONS: dict[str, dict[str, tuple[str, ...] | None]] = {
+    "audio": {
+        "audio_format": ("deep-dive", "brief", "critique", "debate"),
+        "audio_length": ("short", "default", "long"),
+    },
+    "video": {
+        "video_format": ("explainer", "brief", "cinematic"),
+        "style": (
+            "auto",
+            "custom",
+            "classic",
+            "whiteboard",
+            "kawaii",
+            "anime",
+            "watercolor",
+            "retro-print",
+            "heritage",
+            "paper-craft",
+        ),
+        "style_prompt": None,
+    },
+    "cinematic-video": {},
+    "slide-deck": {
+        "deck_format": ("detailed", "presenter"),
+        "deck_length": ("default", "short"),
+    },
+    "quiz": {
+        "quantity": ("fewer", "standard", "more"),
+        "difficulty": ("easy", "medium", "hard"),
+    },
+    "flashcards": {
+        "quantity": ("fewer", "standard", "more"),
+        "difficulty": ("easy", "medium", "hard"),
+    },
+    "infographic": {
+        "orientation": ("landscape", "portrait", "square"),
+        "detail": ("concise", "standard", "detailed"),
+        "style": (
+            "auto",
+            "sketch-note",
+            "professional",
+            "bento-grid",
+            "editorial",
+            "instructional",
+            "bricks",
+            "clay",
+            "anime",
+            "kawaii",
+            "scientific",
+        ),
+    },
+    "data-table": {},
+    "mind-map": {"map_kind": ("interactive", "note-backed")},
+    "report": {"report_format": ("briefing-doc", "study-guide", "blog-post", "custom")},
 }
 
 #: Download type registry, rebuilt from the neutral ``_app.download`` types so this
@@ -310,6 +373,14 @@ def register(mcp: Any) -> None:
         audio_length: str | None = None,
         quantity: str | None = None,
         difficulty: str | None = None,
+        video_format: str | None = None,
+        style: str | None = None,
+        style_prompt: str | None = None,
+        deck_format: str | None = None,
+        deck_length: str | None = None,
+        orientation: str | None = None,
+        detail: str | None = None,
+        map_kind: str | None = None,
     ) -> dict[str, Any]:
         """Start generating a studio artifact. Accepts a notebook name or ID.
 
@@ -321,29 +392,33 @@ def register(mcp: Any) -> None:
 
         * ``audio``        — podcast-style overview (``audio_format``:
           deep-dive|brief|critique|debate, ``audio_length``: short|default|long).
-        * ``video`` / ``cinematic-video`` — video overview.
-        * ``slide-deck``   — slide deck.
+        * ``video``        — video overview (``video_format``:
+          explainer|brief|cinematic, ``style``: auto|custom|classic|whiteboard|
+          kawaii|anime|watercolor|retro-print|heritage|paper-craft, ``style_prompt``:
+          free-text custom-style prompt — requires ``style=custom``).
+        * ``cinematic-video`` — AI-generated documentary video (no per-kind options).
+        * ``slide-deck``   — slide deck (``deck_format``: detailed|presenter,
+          ``deck_length``: default|short).
         * ``quiz`` / ``flashcards`` — study aids (``quantity``:
           fewer|standard|more, ``difficulty``: easy|medium|hard).
-        * ``infographic``  — single-image infographic.
-        * ``data-table``   — extracted data table.
-        * ``mind-map``     — interactive mind map.
+        * ``infographic``  — single-image infographic (``orientation``:
+          landscape|portrait|square, ``detail``: concise|standard|detailed,
+          ``style``: auto|sketch-note|professional|bento-grid|editorial|
+          instructional|bricks|clay|anime|kawaii|scientific).
+        * ``data-table``   — extracted data table (no per-kind options).
+        * ``mind-map``     — mind map (``map_kind``: interactive|note-backed).
         * ``report``       — text report (``report_format``:
           briefing-doc|study-guide|blog-post|custom).
 
-        Only the options listed above are agent-controllable: ``audio``
-        (``audio_format``/``audio_length``), ``quiz``/``flashcards``
-        (``quantity``/``difficulty``), and ``report`` (``report_format``). The
-        other kinds — ``video``, ``cinematic-video``, ``slide-deck``,
-        ``infographic``, ``data-table``, and ``mind-map`` — use FIXED internal
-        defaults for their per-kind options (video format/style, deck
-        format/length, infographic orientation/detail, mind-map kind) and do NOT
-        expose them as settable parameters.
+        Each per-kind option is valid ONLY for the kind(s) listed above; passing one
+        to a different ``artifact_type`` (e.g. ``orientation`` to ``quiz``) is a
+        validation error rather than a silent no-op. Options default to the standard
+        choice when omitted. Note ``style`` is shared by ``video`` and ``infographic``
+        but accepts each kind's own set of values.
 
         ``source_ids`` (optional) scopes generation to specific sources; omit it
         to use every source. ``instructions`` is free-text guidance for kinds
-        that accept it. Each agent-controllable option defaults to the standard
-        choice when omitted.
+        that accept it (including ``mind-map``).
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -364,28 +439,51 @@ def register(mcp: Any) -> None:
                 {
                     "notebook_id": nb_id,
                     "description": instructions or "",
+                    # ``mind-map`` reads ``raw_args["instructions"]`` (every other kind
+                    # reads ``description``); set it so mind-map instructions actually
+                    # reach the client — the extra key is ignored by the other builders.
+                    "instructions": instructions or None,
                     "source_ids": tuple(source_ids or ()),
                     "language": language,
                     "wait": False,
                     "json_output": True,
                 }
             )
-            # Apply caller-supplied per-kind overrides over the defaults,
-            # validating each against its choice set first.
+            # Apply caller-supplied per-kind overrides over the defaults. Each option is
+            # validated against the choice set for THIS ``artifact_type`` (see
+            # ``_KIND_OPTIONS``): an option not accepted by this kind is rejected (the
+            # core would otherwise silently ignore it), and a bad value surfaces a clean
+            # VALIDATION error. ``style_prompt`` (choices ``None``) is free text — the
+            # core enforces the ``style=custom`` ⇔ ``style_prompt`` combination rules.
+            allowed = _KIND_OPTIONS[artifact_type]
             for key, value in (
                 ("report_format", report_format),
                 ("audio_format", audio_format),
                 ("audio_length", audio_length),
                 ("quantity", quantity),
                 ("difficulty", difficulty),
+                ("video_format", video_format),
+                ("style", style),
+                ("style_prompt", style_prompt),
+                ("deck_format", deck_format),
+                ("deck_length", deck_length),
+                ("orientation", orientation),
+                ("detail", detail),
+                ("map_kind", map_kind),
             ):
-                if value is not None:
-                    choices = _OPTION_CHOICES[key]
-                    if value not in choices:
-                        raise ValidationError(
-                            f"Invalid {key} {value!r}; expected one of {list(choices)}"
-                        )
-                    raw_args[key] = value
+                if value is None:
+                    continue
+                if key not in allowed:
+                    raise ValidationError(
+                        f"option {key!r} is not valid for artifact_type {artifact_type!r}; "
+                        f"this kind accepts {sorted(allowed)}"
+                    )
+                choices = allowed[key]
+                if choices is not None and value not in choices:
+                    raise ValidationError(
+                        f"Invalid {key} {value!r}; expected one of {list(choices)}"
+                    )
+                raw_args[key] = value
 
             plan = generate_core.build_generation_plan(artifact_type, raw_args)
             result = await generate_core.execute_generation(

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -474,9 +474,14 @@ def register(mcp: Any) -> None:
                 if value is None:
                     continue
                 if key not in allowed:
+                    accepts = (
+                        f"this kind accepts {sorted(allowed)}"
+                        if allowed
+                        else "this kind accepts no per-kind options"
+                    )
                     raise ValidationError(
                         f"option {key!r} is not valid for artifact_type {artifact_type!r}; "
-                        f"this kind accepts {sorted(allowed)}"
+                        f"{accepts}"
                     )
                 choices = allowed[key]
                 if choices is not None and value not in choices:

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -433,29 +433,17 @@ def register(mcp: Any) -> None:
             # forwarded raw to the backend. Fail with a clean VALIDATION instead.
             if language is not None and not is_supported_language(language):
                 raise ValidationError(f"Unsupported language {language!r}")
-            nb_id = await resolve_notebook(client, notebook)
-            raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[artifact_type])
-            raw_args.update(
-                {
-                    "notebook_id": nb_id,
-                    "description": instructions or "",
-                    # ``mind-map`` reads ``raw_args["instructions"]`` (every other kind
-                    # reads ``description``); set it so mind-map instructions actually
-                    # reach the client — the extra key is ignored by the other builders.
-                    "instructions": instructions or None,
-                    "source_ids": tuple(source_ids or ()),
-                    "language": language,
-                    "wait": False,
-                    "json_output": True,
-                }
-            )
-            # Apply caller-supplied per-kind overrides over the defaults. Each option is
-            # validated against the choice set for THIS ``artifact_type`` (see
-            # ``_KIND_OPTIONS``): an option not accepted by this kind is rejected (the
-            # core would otherwise silently ignore it), and a bad value surfaces a clean
-            # VALIDATION error. ``style_prompt`` (choices ``None``) is free text — the
-            # core enforces the ``style=custom`` ⇔ ``style_prompt`` combination rules.
+
+            # Validate caller-supplied per-kind overrides FIRST — before resolving the
+            # notebook — so a wrong-kind or invalid option fails fast without a wasted
+            # notebook-resolution round-trip. Each option is validated against the choice
+            # set for THIS ``artifact_type`` (see ``_KIND_OPTIONS``): an option not accepted
+            # by this kind is rejected (the core would otherwise silently ignore it), and a
+            # bad value surfaces a clean VALIDATION error. ``style_prompt`` (choices
+            # ``None``) is free text — the core enforces the ``style=custom`` ⇔
+            # ``style_prompt`` combination rules.
             allowed = _KIND_OPTIONS[artifact_type]
+            overrides: dict[str, Any] = {}
             for key, value in (
                 ("report_format", report_format),
                 ("audio_format", audio_format),
@@ -488,7 +476,25 @@ def register(mcp: Any) -> None:
                     raise ValidationError(
                         f"Invalid {key} {value!r}; expected one of {list(choices)}"
                     )
-                raw_args[key] = value
+                overrides[key] = value
+
+            nb_id = await resolve_notebook(client, notebook)
+            raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[artifact_type])
+            raw_args.update(
+                {
+                    "notebook_id": nb_id,
+                    "description": instructions or "",
+                    # ``mind-map`` reads ``raw_args["instructions"]`` (every other kind
+                    # reads ``description``); set it so mind-map instructions actually
+                    # reach the client — the extra key is ignored by the other builders.
+                    "instructions": instructions or None,
+                    "source_ids": tuple(source_ids or ()),
+                    "language": language,
+                    "wait": False,
+                    "json_output": True,
+                }
+            )
+            raw_args.update(overrides)
 
             plan = generate_core.build_generation_plan(artifact_type, raw_args)
             result = await generate_core.execute_generation(

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -412,6 +412,35 @@ def test_explicit_option_parity(
     assert _normalized_call(mcp_call) == _normalized_call(cli_call)
 
 
+def test_mind_map_instructions_parity() -> None:
+    """CLI ``generate mind-map`` and MCP ``artifact_generate`` deliver the SAME
+    ``instructions`` to ``client.mind_maps.generate`` (interactive default).
+
+    Mind-map is excluded from the matrices above (its interactive path goes through
+    ``mind_maps.generate``, not ``artifacts.generate_*``), so this pins the cross-adapter
+    contract for the #1654 instructions fix directly: MCP previously stored the value as
+    ``description`` only and dropped it for mind-map.
+    """
+    note = "focus on the timeline"
+
+    mcp_client, mcp_exc = _drive_mcp(
+        "artifact_generate",
+        {"notebook": NB, "artifact_type": "mind-map", "instructions": note},
+        setup=lambda c: setattr(c.mind_maps, "generate", AsyncMock(return_value={"id": "mm1"})),
+    )
+    assert mcp_exc is None, f"MCP mind-map unexpectedly raised: {mcp_exc!r}"
+
+    cli_client, cli_result = _drive_cli(
+        ["generate", "mind-map", "-n", NB, "--instructions", note],
+        setup=lambda c: setattr(c.mind_maps, "generate", AsyncMock(return_value={"id": "mm1"})),
+    )
+    assert cli_result.exit_code == 0, cli_result.output
+
+    mcp_instr = mcp_client.mind_maps.generate.await_args.kwargs["instructions"]
+    cli_instr = cli_client.mind_maps.generate.await_args.kwargs["instructions"]
+    assert mcp_instr == cli_instr == note
+
+
 # ---------------------------------------------------------------------------
 # Resolver parity — every CLI/MCP operation funnels notebook/source references
 # through these shared resolvers, so pinning their agreement covers the

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -308,13 +308,21 @@ def test_explicit_source_ids_parity(
 #: equivalent CLI flag(s). This guards that each kind's parameters/styles map to the SAME
 #: downstream call across adapters — not just source_ids.
 #:
-#: NOTE on scope: the MCP ``artifact_generate`` deliberately exposes only this curated
-#: subset (audio format/length, quiz/flashcards quantity/difficulty, report format). For
-#: video / cinematic-video / slide-deck / infographic / mind-map the MCP uses FIXED
-#: internal defaults (not agent-settable), so there is no explicit value that could
-#: diverge — their default-value parity is covered by ``test_omitted_source_ids_parity``.
+#: Each row is ``(test_id, cmd, artifact_type, method, mcp_opts, cli_opts)``; the explicit
+#: ``test_id`` keeps the two ``video`` rows distinct.
+#:
+#: NOTE on scope (#1654): video / slide-deck / infographic per-kind options ARE now
+#: agent-settable via MCP and are covered here. ``infographic`` deliberately uses
+#: ``style="professional"`` — a value present ONLY in the infographic style set, NOT the
+#: video one (the two sets overlap on ``auto``/``anime``/``kawaii``) — so the case fails if
+#: MCP validated/forwarded against the wrong (video) set. ``cinematic-video`` and
+#: ``data-table`` expose no per-kind options. ``mind-map`` renders via a different client
+#: path (``mind_maps.generate`` / ``generate_mind_map``, see #1653) so it is NOT in this
+#: matrix; its ``map_kind`` + ``instructions`` parity is covered in
+#: ``tests/unit/mcp/test_artifacts.py``.
 _OPTION_CASES = [
     (
+        "audio",
         "audio",
         "audio",
         "generate_audio",
@@ -324,11 +332,13 @@ _OPTION_CASES = [
     (
         "quiz",
         "quiz",
+        "quiz",
         "generate_quiz",
         {"quantity": "more", "difficulty": "hard"},
         ["--quantity", "more", "--difficulty", "hard"],
     ),
     (
+        "flashcards",
         "flashcards",
         "flashcards",
         "generate_flashcards",
@@ -338,18 +348,58 @@ _OPTION_CASES = [
     (
         "report",
         "report",
+        "report",
         "generate_report",
         {"report_format": "study-guide"},
         ["--format", "study-guide"],
+    ),
+    (
+        "video",
+        "video",
+        "video",
+        "generate_video",
+        {"video_format": "brief", "style": "classic"},
+        ["--format", "brief", "--style", "classic"],
+    ),
+    (
+        "video-custom-style",
+        "video",
+        "video",
+        "generate_video",
+        {"style": "custom", "style_prompt": "hand-drawn"},
+        ["--style", "custom", "--style-prompt", "hand-drawn"],
+    ),
+    (
+        "slide-deck",
+        "slide-deck",
+        "slide-deck",
+        "generate_slide_deck",
+        {"deck_format": "presenter", "deck_length": "short"},
+        ["--format", "presenter", "--length", "short"],
+    ),
+    (
+        "infographic",
+        "infographic",
+        "infographic",
+        "generate_infographic",
+        {"orientation": "portrait", "detail": "detailed", "style": "professional"},
+        ["--orientation", "portrait", "--detail", "detailed", "--style", "professional"],
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "cmd,artifact_type,method,mcp_opts,cli_opts", _OPTION_CASES, ids=[c[0] for c in _OPTION_CASES]
+    "test_id,cmd,artifact_type,method,mcp_opts,cli_opts",
+    _OPTION_CASES,
+    ids=[c[0] for c in _OPTION_CASES],
 )
 def test_explicit_option_parity(
-    cmd: str, artifact_type: str, method: str, mcp_opts: dict, cli_opts: list[str]
+    test_id: str,
+    cmd: str,
+    artifact_type: str,
+    method: str,
+    mcp_opts: dict,
+    cli_opts: list[str],
 ) -> None:
     """Each kind's agent-settable OPTIONS/STYLES map to the SAME downstream call.
 

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -217,6 +217,211 @@ async def test_artifact_generate_valid_language_passes(mcp_call, mock_client) ->
 
 
 # ---------------------------------------------------------------------------
+# artifact_generate — per-kind options (#1654)
+# ---------------------------------------------------------------------------
+
+
+async def test_artifact_generate_video_options(mcp_call, mock_client) -> None:
+    """video format/style/style_prompt reach generate_video (custom style path)."""
+    mock_client.artifacts.generate_video = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "video",
+            "style": "custom",
+            "style_prompt": "hand-drawn diagrams",
+        },
+    )
+    kwargs = mock_client.artifacts.generate_video.await_args.kwargs
+    assert kwargs["video_style"].name == "CUSTOM"
+    assert kwargs["style_prompt"] == "hand-drawn diagrams"
+
+
+async def test_artifact_generate_slide_deck_options(mcp_call, mock_client) -> None:
+    mock_client.artifacts.generate_slide_deck = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "slide-deck",
+            "deck_format": "presenter",
+            "deck_length": "short",
+        },
+    )
+    kwargs = mock_client.artifacts.generate_slide_deck.await_args.kwargs
+    assert kwargs["slide_format"].name == "PRESENTER_SLIDES"
+    assert kwargs["slide_length"].name == "SHORT"
+
+
+async def test_artifact_generate_infographic_options(mcp_call, mock_client) -> None:
+    mock_client.artifacts.generate_infographic = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "infographic",
+            "orientation": "portrait",
+            "detail": "detailed",
+            "style": "professional",
+        },
+    )
+    kwargs = mock_client.artifacts.generate_infographic.await_args.kwargs
+    assert kwargs["orientation"].name == "PORTRAIT"
+    assert kwargs["detail_level"].name == "DETAILED"
+    assert kwargs["style"].name == "PROFESSIONAL"
+
+
+async def test_artifact_generate_mind_map_interactive_default(mcp_call, mock_client) -> None:
+    """Omitted ``map_kind`` defaults to interactive → routes to ``mind_maps.generate``."""
+    mock_client.mind_maps.generate = AsyncMock(return_value={"id": "mm1"})
+    await mcp_call("artifact_generate", {"notebook": NB_ID, "artifact_type": "mind-map"})
+    mock_client.mind_maps.generate.assert_awaited_once()
+    mock_client.artifacts.generate_mind_map.assert_not_called()
+
+
+async def test_artifact_generate_mind_map_note_backed_routes(mcp_call, mock_client) -> None:
+    """``map_kind=note-backed`` routes to ``artifacts.generate_mind_map`` instead."""
+    mock_client.artifacts.generate_mind_map = AsyncMock(return_value={"id": "mm1"})
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "mind-map", "map_kind": "note-backed"},
+    )
+    mock_client.artifacts.generate_mind_map.assert_awaited_once()
+    mock_client.mind_maps.generate.assert_not_called()
+
+
+async def test_artifact_generate_mind_map_forwards_instructions(mcp_call, mock_client) -> None:
+    """``instructions`` reaches the mind-map client call (the dropped-instructions fix).
+
+    MCP stores the tool ``instructions`` arg as ``raw_args["description"]``, but the
+    mind-map plan reads ``raw_args["instructions"]`` — so MCP also sets that key. Without
+    the fix, mind-map instructions were silently discarded.
+    """
+    mock_client.mind_maps.generate = AsyncMock(return_value={"id": "mm1"})
+    await mcp_call(
+        "artifact_generate",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "mind-map",
+            "instructions": "focus on the timeline",
+        },
+    )
+    kwargs = mock_client.mind_maps.generate.await_args.kwargs
+    assert kwargs["instructions"] == "focus on the timeline"
+
+
+@pytest.mark.parametrize(
+    "artifact_type,opts",
+    [
+        ("video", {"style": "professional"}),  # infographic-only value, invalid for video
+        ("infographic", {"style": "classic"}),  # video-only value, invalid for infographic
+        ("mind-map", {"map_kind": "bogus"}),  # core wouldn't catch — MCP must
+        ("slide-deck", {"deck_format": "nonsense"}),
+    ],
+    ids=["video-bad-style", "infographic-bad-style", "bad-map-kind", "bad-deck-format"],
+)
+async def test_artifact_generate_bad_option_value_is_validation_error(
+    mcp_call, mock_client, artifact_type: str, opts: dict
+) -> None:
+    """A value outside the kind's choice set projects as VALIDATION.
+
+    The per-type ``style`` cases prove the video/infographic style sets are enforced
+    separately (the two overlap only on auto/anime/kawaii).
+    """
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": artifact_type, **opts},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "artifact_type,opts",
+    [
+        ("quiz", {"orientation": "portrait"}),  # infographic option on quiz
+        ("video", {"deck_format": "presenter"}),  # slide-deck option on video
+        ("audio", {"video_format": "brief"}),  # video option on audio
+        ("video", {"map_kind": "interactive"}),  # mind-map option on video
+        ("cinematic-video", {"style": "classic"}),  # cinematic-video exposes NO options
+    ],
+    ids=[
+        "orientation-on-quiz",
+        "deck-on-video",
+        "video-on-audio",
+        "mapkind-on-video",
+        "style-on-cinematic",
+    ],
+)
+async def test_artifact_generate_wrong_kind_option_is_validation_error(
+    mcp_call, mock_client, artifact_type: str, opts: dict
+) -> None:
+    """An option valid for some OTHER kind is rejected, not silently ignored.
+
+    The neutral core ignores irrelevant extras, so this rejection lives in the MCP tool;
+    without it an agent's mis-targeted option would silently no-op.
+    """
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": artifact_type, **opts},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+async def test_artifact_generate_style_prompt_requires_custom(mcp_call, mock_client) -> None:
+    """``style_prompt`` without ``style=custom`` is rejected (core cross-field rule)."""
+    mock_client.artifacts.generate_video = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": "video", "style_prompt": "hand-drawn"},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+def test_kind_options_match_core_maps() -> None:
+    """The MCP per-kind choice tuples are DUPLICATED from the core's private maps (the
+    CLI/MCP boundary forbids importing them at runtime). Pin them equal so they can't
+    silently drift — the parity tests only exercise valid values and would miss a
+    *subset* drift (MCP wrongly rejecting a value the core accepts)."""
+    from notebooklm._app import generate_plans as gp
+    from notebooklm.mcp.tools.artifacts import _KIND_OPTIONS
+
+    assert _KIND_OPTIONS["audio"]["audio_format"] == tuple(gp._AUDIO_FORMAT_MAP)
+    assert _KIND_OPTIONS["audio"]["audio_length"] == tuple(gp._AUDIO_LENGTH_MAP)
+    assert _KIND_OPTIONS["video"]["video_format"] == tuple(gp._VIDEO_FORMAT_MAP)
+    assert _KIND_OPTIONS["video"]["style"] == tuple(gp._VIDEO_STYLE_MAP)
+    assert _KIND_OPTIONS["slide-deck"]["deck_format"] == tuple(gp._SLIDE_FORMAT_MAP)
+    assert _KIND_OPTIONS["slide-deck"]["deck_length"] == tuple(gp._SLIDE_LENGTH_MAP)
+    assert _KIND_OPTIONS["quiz"]["quantity"] == tuple(gp._QUIZ_QUANTITY_MAP)
+    assert _KIND_OPTIONS["quiz"]["difficulty"] == tuple(gp._QUIZ_DIFFICULTY_MAP)
+    assert _KIND_OPTIONS["infographic"]["orientation"] == tuple(gp._INFOGRAPHIC_ORIENTATION_MAP)
+    assert _KIND_OPTIONS["infographic"]["detail"] == tuple(gp._INFOGRAPHIC_DETAIL_MAP)
+    assert _KIND_OPTIONS["infographic"]["style"] == tuple(gp._INFOGRAPHIC_STYLE_MAP)
+    assert _KIND_OPTIONS["report"]["report_format"] == tuple(gp._REPORT_FORMAT_MAP)
+
+
+async def test_artifact_generate_exposes_new_option_params(mcp_list_tools) -> None:
+    """The agent-facing tool schema exposes every new per-kind option parameter."""
+    tools = await mcp_list_tools()
+    schema = next(t for t in tools if t.name == "artifact_generate").inputSchema
+    properties = schema.get("properties", {})
+    for param in (
+        "video_format",
+        "style",
+        "style_prompt",
+        "deck_format",
+        "deck_length",
+        "orientation",
+        "detail",
+        "map_kind",
+    ):
+        assert param in properties, f"artifact_generate must expose {param!r}"
+
+
+# ---------------------------------------------------------------------------
 # artifact_status (stateless poll)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -370,6 +370,18 @@ async def test_artifact_generate_wrong_kind_option_is_validation_error(
     assert "VALIDATION" in str(excinfo.value)
 
 
+async def test_artifact_generate_wrong_kind_message_for_optionless_kind(
+    mcp_call, mock_client
+) -> None:
+    """A kind with no per-kind options reports that clearly (not ``accepts []``)."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": "cinematic-video", "style": "classic"},
+        )
+    assert "no per-kind options" in str(excinfo.value)
+
+
 async def test_artifact_generate_style_prompt_requires_custom(mcp_call, mock_client) -> None:
     """``style_prompt`` without ``style=custom`` is rejected (core cross-field rule)."""
     mock_client.artifacts.generate_video = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
@@ -397,6 +409,10 @@ def test_kind_options_match_core_maps() -> None:
     assert _KIND_OPTIONS["slide-deck"]["deck_length"] == tuple(gp._SLIDE_LENGTH_MAP)
     assert _KIND_OPTIONS["quiz"]["quantity"] == tuple(gp._QUIZ_QUANTITY_MAP)
     assert _KIND_OPTIONS["quiz"]["difficulty"] == tuple(gp._QUIZ_DIFFICULTY_MAP)
+    # flashcards reuses the same core maps today; pin independently so a future
+    # flashcards-specific map can't drift the MCP set unnoticed.
+    assert _KIND_OPTIONS["flashcards"]["quantity"] == tuple(gp._QUIZ_QUANTITY_MAP)
+    assert _KIND_OPTIONS["flashcards"]["difficulty"] == tuple(gp._QUIZ_DIFFICULTY_MAP)
     assert _KIND_OPTIONS["infographic"]["orientation"] == tuple(gp._INFOGRAPHIC_ORIENTATION_MAP)
     assert _KIND_OPTIONS["infographic"]["detail"] == tuple(gp._INFOGRAPHIC_DETAIL_MAP)
     assert _KIND_OPTIONS["infographic"]["style"] == tuple(gp._INFOGRAPHIC_STYLE_MAP)

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -222,18 +222,20 @@ async def test_artifact_generate_valid_language_passes(mcp_call, mock_client) ->
 
 
 async def test_artifact_generate_video_options(mcp_call, mock_client) -> None:
-    """video format/style/style_prompt reach generate_video (custom style path)."""
+    """video format/style/style_prompt all reach generate_video (custom style path)."""
     mock_client.artifacts.generate_video = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
     await mcp_call(
         "artifact_generate",
         {
             "notebook": NB_ID,
             "artifact_type": "video",
+            "video_format": "brief",
             "style": "custom",
             "style_prompt": "hand-drawn diagrams",
         },
     )
     kwargs = mock_client.artifacts.generate_video.await_args.kwargs
+    assert kwargs["video_format"].name == "BRIEF"
     assert kwargs["video_style"].name == "CUSTOM"
     assert kwargs["style_prompt"] == "hand-drawn diagrams"
 


### PR DESCRIPTION
## Summary
Closes #1654. The MCP `artifact_generate` tool exposed only a curated option subset (audio format/length, quiz/flashcards quantity/difficulty, report format) and pinned the rest to fixed `_KIND_DEFAULTS`. An agent on claude.ai / Claude Code therefore couldn't pick a video style, slide-deck format, infographic orientation, or mind-map kind that the CLI already supports. This widens the surface (additive — omitted kwargs keep today's defaults).

### New agent-settable kwargs (mirroring the CLI flags)
| Kind | Options |
|---|---|
| `video` | `video_format`, `style`, `style_prompt` |
| `slide-deck` | `deck_format`, `deck_length` |
| `infographic` | `orientation`, `detail`, `style` |
| `mind-map` | `map_kind` |

`cinematic-video` / `data-table` expose no per-kind options.

### How
- Replaced the flat `_OPTION_CHOICES` + 5-key override loop with a single per-kind `_KIND_OPTIONS` table. One structure drives: choice validation, the video↔infographic `style` collision (same kwarg name, different sets — overlapping only on `auto`/`anime`/`kawaii`), and **wrong-kind rejection**.
- Wrong-kind options (e.g. `orientation` on `quiz`) now raise a clean VALIDATION error instead of silently no-op'ing (the neutral core ignores irrelevant extras). This hardening applies uniformly, including to the previously-curated options.
- **Fixed a pre-existing parity bug:** mind-map `instructions` were silently dropped (MCP stored them as `description`, but the mind-map plan reads `raw_args["instructions"]`). They now reach both the interactive (`mind_maps.generate`) and note-backed (`generate_mind_map`) client paths.
- The duplicated choice tuples are pinned equal to the core's private maps by a drift guardrail (the CLI/MCP boundary forbids importing them at runtime).

### Tests
- Extended CLI↔MCP `_OPTION_CASES` parity with per-type-discriminating values (infographic uses the infographic-only `professional` style, so the case fails if MCP validated against the video set).
- Per-option happy paths; per-type bad-style, wrong-kind, bad `map_kind`, and `style_prompt`-without-`custom` VALIDATION cases; mind-map `instructions` parity.
- Drift guardrail (`_KIND_OPTIONS` tuples == core maps) — catches *subset* drift the parity tests can't see.
- Schema assertion that the new params are exposed on the tool.

### Verification
- `uv run pytest` — 11069 passed, 78 skipped, 1 xfailed, 0 failures
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run ruff check . && uv run ruff format --check .` — clean

### Process
Plan was reviewed with momus across Claude + Codex + agy; iteration 1 (2 REJECT) surfaced the dropped mind-map instructions, the infographic test-value collision (`anime` is in both style maps), and the wrong-kind silent no-op; iteration 2 converged (all three OKAY, zero required fixes).

Follow-up to #1652 / #1653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded artifact generation with broader kind-specific options for video, slide decks, infographics, and mind maps (including map kind and per-kind styling controls).

* **Bug Fixes**
  * Now validates kind-scoped options correctly: wrong-artifact options are rejected with clear validation errors (no more silent ignores).
  * Mind map `instructions` are forwarded reliably, and `style_prompt` is accepted only when appropriate styling is selected.

* **Documentation**
  * Updated the MCP workflow guide with explicit per-kind styling examples and clarified which options apply to each artifact type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->