### PR TITLE
feat(mcp): advertise agent-direct upload in source_add file response

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -184,10 +184,14 @@ def register(mcp: Any) -> None:
         * ``file``    — over **stdio**, requires ``path`` (a local file path on the
           server host). Over the **remote (http) connector** the server's
           filesystem is unreachable, so instead the tool returns
-          ``{"status": "upload_required", "url": …}``: open the short-lived signed
-          URL in a browser and upload the file, then confirm with ``source_wait`` /
-          ``source_list``. ``title`` / ``mime_type`` (carried in the signed URL) and
-          the supplied ``path`` (its basename seeds the default title) are honored.
+          ``{"status": "upload_required", "url": …, "agent_upload": {…}}``. A human
+          opens the short-lived signed URL in a browser and uploads the file; an
+          **agent that already holds the bytes** skips the browser and POSTs them as
+          the raw request body to the same URL (see the ``agent_upload`` recipe in
+          the response — with ``Accept: application/json`` it returns
+          ``{"status": "added", "source_id": …}``). Then confirm with ``source_wait``
+          / ``source_list``. ``title`` / ``mime_type`` (carried in the signed URL)
+          and the supplied ``path`` (its basename seeds the default title) are honored.
         * ``drive``   — requires ``document_id`` (Google Drive file id); ``title``
           and ``mime_type`` (one of google-doc|google-slides|google-sheets|pdf,
           default google-doc) optional.
@@ -290,11 +294,29 @@ def _broker_upload(
         payload["title"] = default_title
     if mime_type:
         payload["mime"] = mime_type
+    url = cfg.upload_url(payload)
     return {
         "status": "upload_required",
         "notebook_id": notebook_id,
-        "url": cfg.upload_url(payload),
+        "url": url,
         "expires_at": int(time.time()) + UPLOAD_TTL,
+        # A human opens ``url`` in a browser and picks a file. An AGENT that already
+        # holds the bytes does NOT need the browser: stream the file as the raw body
+        # of a POST to the same URL and it adds the source directly (the server never
+        # reads the agent's filesystem — the bytes flow to it). With
+        # ``Accept: application/json`` the route returns ``{"status":"added",
+        # "source_id":…}`` instead of an HTML page.
+        "agent_upload": {
+            "method": "POST",
+            "url": f"{url}?filename=<basename>",
+            "headers": {"Accept": "application/json", "Content-Type": "<mime-type>"},
+            "body": "the raw file bytes (not multipart/form-data)",
+            "returns": '{"status": "added", "source_id": …}',
+            "example": (
+                'curl -X POST -H "Accept: application/json" --data-binary @report.pdf '
+                f'"{url}?filename=report.pdf"'
+            ),
+        },
     }
 
 

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -300,18 +300,16 @@ def _broker_upload(
         "notebook_id": notebook_id,
         "url": url,
         "expires_at": int(time.time()) + UPLOAD_TTL,
-        # A human opens ``url`` in a browser and picks a file. An AGENT that already
-        # holds the bytes does NOT need the browser: stream the file as the raw body
-        # of a POST to the same URL and it adds the source directly (the server never
-        # reads the agent's filesystem — the bytes flow to it). With
-        # ``Accept: application/json`` the route returns ``{"status":"added",
-        # "source_id":…}`` instead of an HTML page.
+        # An agent holding the bytes skips the browser: POST them as the raw body here.
         "agent_upload": {
             "method": "POST",
             "url": f"{url}?filename=<basename>",
-            "headers": {"Accept": "application/json", "Content-Type": "<mime-type>"},
+            "headers": {
+                "Accept": "application/json",
+                "Content-Type": "<mime-type> (fallback only; ignored when mime_type was passed)",
+            },
             "body": "the raw file bytes (not multipart/form-data)",
-            "returns": '{"status": "added", "source_id": …}',
+            "returns": '{"status": "added", "source_id": ...}',
             "example": (
                 'curl -X POST -H "Accept: application/json" --data-binary @report.pdf '
                 f'"{url}?filename=report.pdf"'

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -93,6 +93,7 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     agent = sc["agent_upload"]
     assert agent["method"] == "POST"
     assert agent["headers"]["Accept"] == "application/json"
+    assert agent["url"].startswith(sc["url"])
     assert sc["url"] in agent["example"]
 
 

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -88,6 +88,12 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     payload = config.signer.verify(token, op="ul")
     assert payload["title"] == "My Doc"
     assert payload["mime"] == "application/pdf"
+    # The response self-documents the agent-direct path so an agent doesn't fall
+    # back to the human "open in a browser" flow it can't perform.
+    agent = sc["agent_upload"]
+    assert agent["method"] == "POST"
+    assert agent["headers"]["Accept"] == "application/json"
+    assert sc["url"] in agent["example"]
 
 
 async def test_source_add_file_default_title_from_path_basename(mock_client, config) -> None:


### PR DESCRIPTION
## Summary
Over the remote (http) MCP connector, `source_add type=file` returns `upload_required` with a signed `/files/ul` URL and prose telling the caller to **open it in a browser and upload the file**. An agent reading that tries to do the human thing — open a browser it doesn't have.

But the `/files/ul` route already accepts a **raw `curl`/`PUT` body** and returns clean JSON when asked (ADR-0024) — the route docstring literally calls out *"an agent uploading a file it holds gets clean JSON; a human browser gets the HTML page."* The capability existed; the tool response just never told the agent.

This makes the response **self-documenting for agents** — no new route, no new capability, purely additive metadata.

## Change
- `_broker_upload` adds an `agent_upload` block to the `upload_required` payload:
  ```json
  "agent_upload": {
    "method": "POST",
    "url": ".../files/ul/<token>?filename=<basename>",
    "headers": {"Accept": "application/json", "Content-Type": "<mime-type>"},
    "body": "the raw file bytes (not multipart/form-data)",
    "returns": "{\"status\": \"added\", \"source_id\": …}",
    "example": "curl -X POST -H \"Accept: application/json\" --data-binary @report.pdf \"...?filename=report.pdf\""
  }
  ```
- `source_add` docstring `file` bullet now describes the agent path alongside the browser one.

## Verification
- Live: minted a URL via the tool, then `curl -X POST -H "Accept: application/json" --data-binary @/tmp/agent_upload_demo.md "<url>?filename=agent_upload_demo.md"` → `HTTP 200` `{"status":"added","source_id":"5333c65f-…"}`; the source then appeared in `source_list` (`_type_code: 8`, ready). **No browser involved.**
- `uv run pytest tests/unit/mcp/` — 322 passed (extended the `upload_required` happy-path test to assert the `agent_upload` affordance).
- `uv run mypy src/notebooklm/mcp/tools/sources.py` — clean; `ruff check`/`format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the remote-source file upload flow, including signed upload URL behavior, preserved metadata (e.g., title and mime type), and filename handling.
  * Expanded the tool’s returned upload instructions with clearer request/response details.

* **Bug Fixes**
  * Improved the upload-required response to provide more complete upload metadata, including method, headers, and an example payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->