### PR TITLE
docs(generate): document source_ids None=all vs []=none contract (#1653)

### DIFF
--- a/src/notebooklm/_app/generate_plans.py
+++ b/src/notebooklm/_app/generate_plans.py
@@ -73,6 +73,15 @@ NotebookResolver = Callable[..., Awaitable[str]]
 
 #: Resolves a tuple of (possibly partial) source ids to full ids. The CLI
 #: adapter injects ``cli.resolve.resolve_source_ids``.
+#:
+#: Backend contract every resolver MUST honor: return ``None`` for "no sources
+#: given" (⇒ generate over ALL sources), NOT an empty list. ``[]``/``()`` means
+#: "zero sources", which the backend refuses for source-needing kinds
+#: (quiz/audio/flashcards): it replies HTTP 200 with a null artifact id, surfaced
+#: as ``ArtifactFeatureUnavailableError`` ("… generation is unavailable"). This was
+#: #1652 — the MCP pass-through resolver sent ``()`` where the CLI resolver sent
+#: ``None``, so the two adapters diverged. A new adapter's resolver must map the
+#: empty case to ``None``; ``tests/unit/cli/test_cli_mcp_parity.py`` pins it.
 SourceResolver = Callable[..., Awaitable[Any]]
 
 # Display name used in user-facing strings ("Audio ready", "rate limited", etc.).

--- a/src/notebooklm/server/routes/_passthrough.py
+++ b/src/notebooklm/server/routes/_passthrough.py
@@ -44,7 +44,8 @@ async def passthrough_source_ids(
     except for the empty case, which mirrors ``cli.resolve.resolve_source_ids``:
     no selection resolves to ``None``, not an empty tuple. The client treats
     ``None`` as "scope to all sources"; an empty sequence as "no sources", which
-    the API rejects for quiz/flashcards (``… generation is unavailable``). So a
+    the API rejects for source-needing kinds — quiz/audio/flashcards
+    (``… generation is unavailable``). So a
     bare ``POST .../artifacts`` (no ``source_ids``) generates over all sources,
     matching the CLI's no-``--source`` behavior.
     """


### PR DESCRIPTION
## Summary
Closes #1653. Closes the last remaining gap from the #1652 follow-up: the `source_ids` backend contract (`None` ⇒ all sources; `[]`/`()` ⇒ zero sources ⇒ backend refuses source-needing kinds with `ArtifactFeatureUnavailableError`) is documented in the MCP pass-through resolver and pinned by the CLI↔MCP parity test, but **not** in the neutral `_app/generate` core where a future adapter author injects their own `SourceResolver`.

This adds the contract to the `SourceResolver` type-alias doc so the next adapter doesn't re-trip #1652.

### Why #1653's other three gaps are already done
| Gap | Where |
|---|---|
| 1. CLI↔MCP parity test | `tests/unit/cli/test_cli_mcp_parity.py` |
| 2. Omitted/default + explicit-non-default per kind | `test_omitted_source_ids_parity` + `_OPTION_CASES`/`test_explicit_option_parity` (extended in #1654) |
| 3. Non-mocked (VCR) MCP generate path | `test_mcp_artifact_generate_report_over_vcr` / `…_quiz_over_vcr` |
| 4. Document the contract in `_app/generate` | **this PR** |

Doc-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-selection behavior so requests without explicit sources work consistently across supported interfaces.
  * Clarified and enforced the distinction between “no sources provided” (generate over all sources) and “zero/invalid sources” (rejected when a source is required).
  * Restored parity between different entry points to match resolver behavior.
* **Documentation**
  * Updated API documentation for passthrough source ID handling to better describe generation availability and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->