### PR TITLE
feat(mcp): source_get_content returns full indexed text + metadata

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -269,7 +269,7 @@ a single in-flight task.
 | Domain | Tools |
 |--------|-------|
 | **Notebooks** | `notebook_list` · `notebook_create(title)` · `notebook_describe(notebook)` · `notebook_rename(notebook, new_title)` · `notebook_delete(notebook, confirm)` |
-| **Sources** | `source_list(notebook)` · `source_get_content(notebook, source)` · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` |
+| **Sources** | `source_list(notebook)` · `source_get_content(notebook, source, output_format?)` (metadata **+ full indexed text**; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` |
 | **Chat** | `chat_ask(notebook, question, conversation_id?)` · `chat_configure(notebook, goal?, response_length?)` |
 | **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?)` |

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any
+from typing import Any, Literal, cast
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
@@ -59,10 +59,29 @@ def register(mcp: Any) -> None:
             return {"notebook_id": nb_id, "sources": to_jsonable(sources)}
 
     @mcp.tool(annotations=READ_ONLY)
-    async def source_get_content(ctx: Context, notebook: str, source: str) -> dict[str, Any]:
-        """Fetch a source's details. Accepts a notebook/source name or ID."""
+    async def source_get_content(
+        ctx: Context, notebook: str, source: str, output_format: str = "text"
+    ) -> dict[str, Any]:
+        """Fetch a source's metadata AND its full indexed text content.
+
+        Accepts a notebook/source name or ID. Returns the source ``metadata``
+        (id/title/url/kind/status) plus the extracted ``content`` and its
+        ``char_count``.
+
+        ``output_format`` selects how the text is rendered: ``text`` (default) is
+        flattened plaintext; ``markdown`` preserves headings/tables/links/emphasis
+        (requires the server's ``markdownify`` extra — otherwise a clean error).
+
+        ``content`` is ``null`` (and ``char_count`` 0) when the source has no
+        extractable text yet — e.g. it is still processing — so this tool returns
+        the metadata even before the body is available.
+        """
         client = get_client(ctx)
         with mcp_errors():
+            if output_format not in ("text", "markdown"):
+                raise ValidationError(
+                    f"Invalid output_format {output_format!r}; expected 'text' or 'markdown'"
+                )
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
             result = await content_core.execute_source_get(
@@ -74,7 +93,33 @@ def register(mcp: Any) -> None:
             # ``{"source": null}`` as a success.
             if result.source is None:
                 raise SourceNotFoundError(src_id)
-            return to_jsonable(result)
+
+            # Fetch the full indexed text. The metadata fetch already confirmed the
+            # source exists, so a NOT_FOUND from the fulltext RPC means the body is
+            # not retrievable yet (e.g. still processing) — degrade to content=None
+            # rather than failing the whole call, so the metadata still comes back.
+            content: str | None = None
+            char_count = 0
+            try:
+                fulltext = await content_core.execute_source_fulltext(
+                    client,
+                    content_core.SourceFulltextPlan(
+                        notebook_id=nb_id,
+                        source_id=src_id,
+                        output_format=cast(Literal["text", "markdown"], output_format),
+                    ),
+                )
+                content = fulltext.fulltext.content or None
+                char_count = fulltext.fulltext.char_count
+            except SourceNotFoundError:
+                content = None
+                char_count = 0
+
+            payload = to_jsonable(result)
+            payload["content"] = content
+            payload["char_count"] = char_count
+            payload["output_format"] = output_format
+            return payload
 
     @mcp.tool
     async def source_rename(

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -114,6 +114,11 @@ def register(mcp: Any) -> None:
                     # extra, which the server may not have installed. Surface a
                     # deterministic CONFIG error (with the install hint) rather than
                     # the bug-class UNEXPECTED a bare ImportError would project as.
+                    # Restrict the remap to the markdown path: an ImportError on the
+                    # text path (or a future regression) is genuinely unexpected and
+                    # must keep propagating as such, not be mislabeled CONFIG.
+                    if output_format != "markdown":
+                        raise
                     raise ConfigurationError(str(exc)) from exc
                 content = fulltext.fulltext.content or None
                 char_count = fulltext.fulltext.char_count

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -28,7 +28,7 @@ from ..._app import source_content as content_core
 from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
 from ..._app.serialize import to_jsonable
-from ...exceptions import SourceNotFoundError, ValidationError
+from ...exceptions import ConfigurationError, SourceNotFoundError, ValidationError
 from ...urls import is_youtube_url
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -102,12 +102,19 @@ def register(mcp: Any) -> None:
             content: str | None = None
             char_count = 0
             if result.source.is_ready:
-                fulltext = await content_core.execute_source_fulltext(
-                    client,
-                    content_core.SourceFulltextPlan(
-                        notebook_id=nb_id, source_id=src_id, output_format=output_format
-                    ),
-                )
+                try:
+                    fulltext = await content_core.execute_source_fulltext(
+                        client,
+                        content_core.SourceFulltextPlan(
+                            notebook_id=nb_id, source_id=src_id, output_format=output_format
+                        ),
+                    )
+                except ImportError as exc:
+                    # ``output_format='markdown'`` needs the optional ``markdownify``
+                    # extra, which the server may not have installed. Surface a
+                    # deterministic CONFIG error (with the install hint) rather than
+                    # the bug-class UNEXPECTED a bare ImportError would project as.
+                    raise ConfigurationError(str(exc)) from exc
                 content = fulltext.fulltext.content or None
                 char_count = fulltext.fulltext.char_count
 

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
@@ -60,7 +60,10 @@ def register(mcp: Any) -> None:
 
     @mcp.tool(annotations=READ_ONLY)
     async def source_get_content(
-        ctx: Context, notebook: str, source: str, output_format: str = "text"
+        ctx: Context,
+        notebook: str,
+        source: str,
+        output_format: Literal["text", "markdown"] = "text",
     ) -> dict[str, Any]:
         """Fetch a source's metadata AND its full indexed text content.
 
@@ -72,16 +75,12 @@ def register(mcp: Any) -> None:
         flattened plaintext; ``markdown`` preserves headings/tables/links/emphasis
         (requires the server's ``markdownify`` extra — otherwise a clean error).
 
-        ``content`` is ``null`` (and ``char_count`` 0) when the source has no
-        extractable text yet — e.g. it is still processing — so this tool returns
-        the metadata even before the body is available.
+        ``content`` is ``null`` (and ``char_count`` 0) when the source is not yet
+        ready (still processing / errored) or has no extractable text, so this tool
+        returns the metadata even before the body is available.
         """
         client = get_client(ctx)
         with mcp_errors():
-            if output_format not in ("text", "markdown"):
-                raise ValidationError(
-                    f"Invalid output_format {output_format!r}; expected 'text' or 'markdown'"
-                )
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
             result = await content_core.execute_source_get(
@@ -94,26 +93,23 @@ def register(mcp: Any) -> None:
             if result.source is None:
                 raise SourceNotFoundError(src_id)
 
-            # Fetch the full indexed text. The metadata fetch already confirmed the
-            # source exists, so a NOT_FOUND from the fulltext RPC means the body is
-            # not retrievable yet (e.g. still processing) — degrade to content=None
-            # rather than failing the whole call, so the metadata still comes back.
+            # Only fetch the body once the source is READY. A not-ready source
+            # (still processing / errored) has no retrievable text yet, so return
+            # its metadata with content=None instead of fetching. Gating on status
+            # (rather than catching the fulltext fetch's SourceNotFoundError) keeps
+            # a genuine "source is gone" — e.g. deleted between these two calls —
+            # propagating as NOT_FOUND instead of masquerading as "no content".
             content: str | None = None
             char_count = 0
-            try:
+            if result.source.is_ready:
                 fulltext = await content_core.execute_source_fulltext(
                     client,
                     content_core.SourceFulltextPlan(
-                        notebook_id=nb_id,
-                        source_id=src_id,
-                        output_format=cast(Literal["text", "markdown"], output_format),
+                        notebook_id=nb_id, source_id=src_id, output_format=output_format
                     ),
                 )
                 content = fulltext.fulltext.content or None
                 char_count = fulltext.fulltext.char_count
-            except SourceNotFoundError:
-                content = None
-                char_count = 0
 
             payload = to_jsonable(result)
             payload["content"] = content

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -14,9 +14,9 @@ Tools covered and the cassette each replays:
   ``sources_add_file.yaml`` (``ADD_SOURCE_FILE`` → ``o4cbdc`` + upload POSTs);
   ``drive`` over ``sources_add_drive.yaml`` (``ADD_SOURCE`` → ``izAoDd``).
 * ``source_rename`` over ``sources_rename.yaml`` (``UPDATE_SOURCE`` → ``b7Wfje``).
-* ``source_get_content`` over ``sources_get_fulltext.yaml`` — only the leading
-  ``GET_NOTEBOOK`` (``rLM1Ne``) is consumed (``execute_source_get`` filters the
-  source list); the trailing ``hizoJc`` interaction is left unplayed.
+* ``source_get_content`` over ``sources_get_fulltext.yaml`` — consumes BOTH the
+  leading ``GET_NOTEBOOK`` (``rLM1Ne``, metadata via ``execute_source_get``) and
+  the trailing ``hizoJc`` (``GET_SOURCE``, full text via ``execute_source_fulltext``).
 * ``source_wait`` (single + all) over ``sources_list.yaml`` — the poller probes
   source status via the same ``GET_NOTEBOOK`` list, and every recorded source is
   already ``READY`` so it resolves on the first poll.
@@ -349,14 +349,14 @@ async def test_mcp_source_rename_over_vcr() -> None:
 @pytest.mark.asyncio
 @notebooklm_vcr.use_cassette("sources_get_fulltext.yaml")
 async def test_mcp_source_get_content_over_vcr() -> None:
-    """``source_get_content`` returns the resolved source through the real client.
+    """``source_get_content`` returns the resolved source metadata AND its full text.
 
-    ``execute_source_get`` calls ``client.sources.get_or_none``, which filters the
-    notebook's ``GET_NOTEBOOK`` (``rLM1Ne``) source list — so only the cassette's
-    leading ``rLM1Ne`` interaction is consumed (the trailing ``hizoJc`` fulltext
-    interaction is left unplayed). The full-UUID source ref skips the resolver's
-    own list preflight, and the id must exist in the recorded list for the lookup
-    to return a (non-``None``) source rather than NOT_FOUND.
+    ``execute_source_get`` calls ``client.sources.get_or_none`` (filters the
+    notebook's ``GET_NOTEBOOK`` / ``rLM1Ne`` source list), then
+    ``execute_source_fulltext`` issues ``GET_SOURCE`` (``hizoJc``) — so both
+    cassette interactions are consumed. The full-UUID source ref skips the
+    resolver's own list preflight, and the id must exist in the recorded list for
+    the lookup to return a (non-``None``) source rather than NOT_FOUND.
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -369,8 +369,15 @@ async def test_mcp_source_get_content_over_vcr() -> None:
 
     structured = result.structured_content
     assert isinstance(structured, dict)
-    # ``execute_source_get`` projects to {"notebook_id", "source_id", "source"}.
-    assert set(structured) == {"notebook_id", "source_id", "source"}
+    # Now projects metadata PLUS the full-text fields.
+    assert set(structured) == {
+        "notebook_id",
+        "source_id",
+        "source",
+        "content",
+        "char_count",
+        "output_format",
+    }
     assert structured["notebook_id"] == GET_CONTENT_NOTEBOOK_ID
     assert structured["source_id"] == SOURCES_LIST_SOURCE_ID
     source = structured["source"]
@@ -379,6 +386,10 @@ async def test_mcp_source_get_content_over_vcr() -> None:
     assert source["title"] == SOURCES_LIST_SOURCE_TITLE
     assert source["url"] == "https://github.com/shareAI-lab/learn-claude-code"
     assert source["status"] == 2  # SourceStatus.READY
+    # Full text came back from the recorded GET_SOURCE interaction.
+    assert structured["output_format"] == "text"
+    assert isinstance(structured["content"], str) and structured["content"]
+    assert structured["char_count"] == len(structured["content"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -73,7 +73,7 @@ RENAME_ECHOED_SOURCE_ID = "b1b9efdd-b2af-4974-ad97-16025c05f1d7"
 RENAME_ECHOED_TITLE = "VCR Test Renamed Source"
 
 # ``sources_get_fulltext.yaml`` GET_NOTEBOOK was recorded against this notebook;
-# ``source_get_content`` consumes only that leading ``rLM1Ne`` interaction.
+# ``source_get_content`` consumes its ``rLM1Ne`` (metadata) + ``hizoJc`` (full text).
 GET_CONTENT_NOTEBOOK_ID = "167481cd-23a3-4331-9a45-c8948900bf91"
 
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -29,6 +29,22 @@ class FakeSource:
     id: str
     title: str | None = None
 
+    @property
+    def is_ready(self) -> bool:  # mirrors Source.is_ready; not a field → not serialized
+        return True
+
+
+@dataclass
+class FakeNotReadySource:
+    """A source that exists but is still processing (``is_ready`` False)."""
+
+    id: str
+    title: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return False
+
 
 @dataclass
 class FakeFulltext:
@@ -106,25 +122,51 @@ async def test_source_get_content_markdown_format(mcp_call, mock_client) -> None
     )
 
 
-async def test_source_get_content_invalid_format_is_validation_error(mcp_call, mock_client) -> None:
+async def test_source_get_content_invalid_format_rejected(mcp_call, mock_client) -> None:
+    """An out-of-enum ``output_format`` is rejected at the schema boundary.
+
+    Typing the param as ``Literal["text", "markdown"]`` makes FastMCP/Pydantic emit
+    a JSON-schema enum and reject anything else before the tool body runs — agents
+    see the allowed values in the tool schema.
+    """
     with pytest.raises(ToolError) as excinfo:
         await mcp_call(
             "source_get_content",
             {"notebook": NB_ID, "source": SRC_ID, "output_format": "pdf"},
         )
-    assert "VALIDATION" in str(excinfo.value)
+    msg = str(excinfo.value).lower()
+    assert "text" in msg and "markdown" in msg
 
 
-async def test_source_get_content_unavailable_body_returns_null_content(
+async def test_source_get_content_not_ready_returns_null_without_fetch(
     mcp_call, mock_client
 ) -> None:
-    """A still-processing source (fulltext NOT_FOUND) returns metadata + content=null."""
-    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
-    mock_client.sources.get_fulltext = AsyncMock(side_effect=SourceNotFoundError(SRC_ID))
+    """A still-processing source returns metadata + content=null and does NOT fetch
+    the body (gating on status avoids both a wasted RPC and masking a genuine
+    not-found)."""
+    mock_client.sources.get_or_none = AsyncMock(
+        return_value=FakeNotReadySource(id=SRC_ID, title="Doc")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(return_value=FakeFulltext(content="x"))
     result = await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
     assert result.structured_content["source"] == {"id": SRC_ID, "title": "Doc"}
     assert result.structured_content["content"] is None
     assert result.structured_content["char_count"] == 0
+    assert result.structured_content["output_format"] == "text"
+    mock_client.sources.get_fulltext.assert_not_called()
+
+
+async def test_source_get_content_ready_but_gone_propagates_not_found(
+    mcp_call, mock_client
+) -> None:
+    """A READY source whose fulltext fetch raises NOT_FOUND (e.g. deleted between the
+    metadata and body calls) propagates as NOT_FOUND — it is NOT masked as
+    content=null."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(side_effect=SourceNotFoundError(SRC_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
+    assert "NOT_FOUND" in str(excinfo.value) or "not found" in str(excinfo.value).lower()
 
 
 async def test_source_get_content_empty_body_normalized_to_null(mcp_call, mock_client) -> None:

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -138,6 +138,28 @@ async def test_source_get_content_invalid_format_rejected(mcp_call, mock_client)
     assert "text" in msg and "markdown" in msg
 
 
+async def test_source_get_content_markdown_missing_extra_is_config_error(
+    mcp_call, mock_client
+) -> None:
+    """``output_format='markdown'`` without the ``markdownify`` extra surfaces a CONFIG
+    error (with the install hint), not a bug-class UNEXPECTED."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        side_effect=ImportError(
+            "The 'markdown' format requires the 'markdownify' package. "
+            "Install it with: pip install 'notebooklm-py[markdown]'"
+        )
+    )
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_get_content",
+            {"notebook": NB_ID, "source": SRC_ID, "output_format": "markdown"},
+        )
+    msg = str(excinfo.value)
+    assert "CONFIG" in msg
+    assert "markdownify" in msg  # the actionable install hint survives
+
+
 async def test_source_get_content_not_ready_returns_null_without_fetch(
     mcp_call, mock_client
 ) -> None:

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -30,6 +30,16 @@ class FakeSource:
     title: str | None = None
 
 
+@dataclass
+class FakeFulltext:
+    """Stand-in for ``SourceFulltext`` (what ``client.sources.get_fulltext`` returns)."""
+
+    content: str = ""
+    char_count: int = 0
+    source_id: str = ""
+    title: str = ""
+
+
 NB_ID = "11111111-1111-1111-1111-111111111111"
 SRC_ID = "33333333-3333-3333-3333-333333333333"
 SRC2_ID = "44444444-4444-4444-4444-444444444444"
@@ -61,20 +71,79 @@ async def test_source_list_resolves_notebook_by_name(mcp_call, mock_client) -> N
 
 
 async def test_source_get_content(mcp_call, mock_client) -> None:
+    """Returns the source metadata AND its full text content + char_count."""
     mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="hello world", char_count=11)
+    )
     result = await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
     assert result.structured_content == {
         "notebook_id": NB_ID,
         "source_id": SRC_ID,
         "source": {"id": SRC_ID, "title": "Doc"},
+        "content": "hello world",
+        "char_count": 11,
+        "output_format": "text",
     }
     mock_client.sources.get_or_none.assert_awaited_once_with(NB_ID, SRC_ID)
+    mock_client.sources.get_fulltext.assert_awaited_once_with(NB_ID, SRC_ID, output_format="text")
+
+
+async def test_source_get_content_markdown_format(mcp_call, mock_client) -> None:
+    """``output_format='markdown'`` is forwarded to the fulltext fetch."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="# Heading", char_count=9)
+    )
+    result = await mcp_call(
+        "source_get_content",
+        {"notebook": NB_ID, "source": SRC_ID, "output_format": "markdown"},
+    )
+    assert result.structured_content["content"] == "# Heading"
+    assert result.structured_content["output_format"] == "markdown"
+    mock_client.sources.get_fulltext.assert_awaited_once_with(
+        NB_ID, SRC_ID, output_format="markdown"
+    )
+
+
+async def test_source_get_content_invalid_format_is_validation_error(mcp_call, mock_client) -> None:
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_get_content",
+            {"notebook": NB_ID, "source": SRC_ID, "output_format": "pdf"},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+async def test_source_get_content_unavailable_body_returns_null_content(
+    mcp_call, mock_client
+) -> None:
+    """A still-processing source (fulltext NOT_FOUND) returns metadata + content=null."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(side_effect=SourceNotFoundError(SRC_ID))
+    result = await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
+    assert result.structured_content["source"] == {"id": SRC_ID, "title": "Doc"}
+    assert result.structured_content["content"] is None
+    assert result.structured_content["char_count"] == 0
+
+
+async def test_source_get_content_empty_body_normalized_to_null(mcp_call, mock_client) -> None:
+    """An empty extracted body (``""``) is surfaced as ``null``, not an empty string."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="", char_count=0)
+    )
+    result = await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
+    assert result.structured_content["content"] is None
 
 
 async def test_source_get_content_resolves_source_by_name(mcp_call, mock_client) -> None:
     """A non-id ``source`` ref resolves by exact title within the notebook."""
     mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID, title="Paper")])
     mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Paper"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="body", char_count=4)
+    )
     result = await mcp_call("source_get_content", {"notebook": NB_ID, "source": "Paper"})
     assert result.structured_content["source_id"] == SRC_ID
     mock_client.sources.get_or_none.assert_awaited_once_with(NB_ID, SRC_ID)

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -160,6 +160,16 @@ async def test_source_get_content_markdown_missing_extra_is_config_error(
     assert "markdownify" in msg  # the actionable install hint survives
 
 
+async def test_source_get_content_text_import_error_not_remapped(mcp_call, mock_client) -> None:
+    """An ImportError on the TEXT path is genuinely unexpected — it must NOT be
+    relabeled CONFIG (the remap is restricted to the markdown case)."""
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(side_effect=ImportError("unrelated boom"))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_get_content", {"notebook": NB_ID, "source": SRC_ID})
+    assert "CONFIG" not in str(excinfo.value)
+
+
 async def test_source_get_content_not_ready_returns_null_without_fetch(
     mcp_call, mock_client
 ) -> None:


### PR DESCRIPTION
## Summary
`source_get_content` was misleadingly named — it returned only source **metadata** (id/title/url/kind/status), no text. An MCP agent had **no way to read a source's actual content**, even though the client (`get_fulltext`) and CLI (`source fulltext`) both expose it.

Per discussion, rather than add a new tool (the MCP tool surface is intentionally lean, near its ~25-tool ceiling), and since `source_list` already covers per-source metadata, this **folds the full text into the existing `source_get_content`**.

### New response (additive — existing `source`/`source_id`/`notebook_id` keys unchanged)
- **`content`** — the extracted full text. `null` when the body isn't available yet (e.g. still processing); metadata still returns, so the call never fails on a not-ready source.
- **`char_count`**
- **`output_format`** — `text` (default, flattened plaintext) or `markdown` (headings/tables/links preserved; requires the server's `markdownify` extra, else a clean validation error).

### Design decisions (confirmed)
- **Format:** added `output_format` param (text default), mirroring the CLI's `source fulltext` and the existing `artifact_download` param naming.
- **Not-ready / empty body:** return metadata + `content: null` rather than erroring — safest for agents.

Reuses the transport-neutral `_app.source_content.execute_source_fulltext` core (no new RPC, no core change).

### Tests
- Unit: text + markdown happy paths, invalid-format → VALIDATION, not-ready (`get_fulltext` raises `SourceNotFoundError`) → `content: null`, empty body `""` → `null`.
- VCR: the existing `test_mcp_source_get_content_over_vcr` now consumes the previously-**unplayed** `GET_SOURCE` (`hizoJc`) interaction already recorded in `sources_get_fulltext.yaml`, asserting real `content`/`char_count`.
- Docs updated.

### Verification
- `uv run pytest tests/unit/mcp tests/integration/mcp_vcr/test_sources.py tests/_guardrails` — 1113 passed
- mypy + ruff clean

Follow-up to the #1654/#1653 MCP↔CLI parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `source_get_content` now returns extracted source content details (`content`, `char_count`, `output_format`) alongside existing metadata.
  * Added `output_format` selection (`text` or `markdown`).

* **Bug Fixes**
  * If a source isn’t ready, the tool returns consistent partial results (`content: null`, `char_count: 0`) without attempting fulltext retrieval.
  * Empty extracted content is normalized to `content: null`.
  * Invalid `output_format` values return a validation error; markdown formatting issues return a deterministic configuration error.

* **Documentation**
  * Updated MCP tool reference for `source_get_content` to include `output_format` and the expanded response.

* **Tests**
  * Updated and expanded integration/unit tests to validate the new response shape and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->