### PR TITLE
Resolve artifact generate source refs

### DIFF
--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -6,9 +6,10 @@ Thin adapters over the transport-neutral artifact cores:
 * ``artifact_generate`` is a hybrid over the neutral ``generate`` core: it builds a
   :class:`~notebooklm._app.generate.GenerationPlan` via ``build_generation_plan``
   (which enum-maps + validates the per-kind options) and drives
-  ``execute_generation`` with **pass-through** notebook/source resolvers (MCP has
-  already resolved the notebook id and supplies full source ids). Each ``type``
-  routes to the matching ``client.artifacts.generate_*`` method.
+  ``execute_generation`` with a pass-through notebook resolver (MCP has already
+  resolved the notebook id) and an MCP source resolver that accepts full ids,
+  prefixes, and exact titles. Each ``type`` routes to the matching
+  ``client.artifacts.generate_*`` method.
 * ``artifact_status`` is the **stateless** poll path (``_app.artifacts.poll_artifact``
   → ``client.artifacts.poll_status``) so an agent can poll a ``task_id`` across
   separate tool calls without holding server state.
@@ -44,7 +45,7 @@ from .._confirm import READ_ONLY
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors
 from .._filelink import DOWNLOAD_TTL, FileTransferConfig
-from .._resolve import resolve_notebook
+from .._resolve import resolve_notebook, resolve_source
 from ._passthrough import passthrough_notebook_id
 
 if TYPE_CHECKING:
@@ -264,24 +265,28 @@ _DOWNLOAD_SPECS: dict[str, download_core.DownloadTypeSpec] = {
 
 
 async def _passthrough_sources(
-    _client: NotebookLMClient,
-    _notebook_id: str,
+    client: NotebookLMClient,
+    notebook_id: str,
     source_ids: Any,
     *,
     json_output: bool = False,
 ) -> Any:
-    """Return the supplied (already-full) source ids, or ``None`` when none were
-    given so the backend uses *every* source.
+    """Resolve source refs to full ids, or ``None`` when none were given.
 
-    MCP supplies full source ids, so no partial-id resolution is needed. But an
-    EMPTY collection must map to ``None`` (not ``[]``): the generate core treats
-    ``None`` as "all sources" (mirroring the CLI's ``resolve_source_ids``, which
-    returns ``None`` for no input), whereas an empty list means "zero sources" —
-    which the backend refuses for source-needing kinds (quiz/audio/flashcards),
-    returning a null id surfaced as ``… generation is unavailable``. The tool
-    passes ``tuple(source_ids or ())``, so omitting ``source_ids`` arrives here
-    as ``()`` and must become ``None``."""
-    return source_ids or None
+    The generate core treats ``None`` as "all sources" (mirroring the CLI's
+    ``resolve_source_ids``), whereas an empty list means "zero sources" and is
+    rejected by the backend for source-needing kinds. The tool passes
+    ``tuple(source_ids or ())``, so omitted ``source_ids`` and an explicit empty
+    list arrive here as ``()`` and must become ``None``.
+
+    Non-empty collections resolve each element through MCP's source resolver so
+    full UUIDs fast-path, unique prefixes expand, exact titles match, and empty
+    strings fail validation just like sibling source-accepting tools.
+    """
+    del json_output  # MCP source resolution is silent; keep the core callback signature.
+    if not source_ids:
+        return None
+    return [await resolve_source(client, notebook_id, source_id) for source_id in source_ids]
 
 
 async def _passthrough_download_notebook(notebook_id: str) -> str:

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -35,6 +35,8 @@ from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
 NB_ID = "11111111-1111-1111-1111-111111111111"
 TASK_ID = "task-abc-123"
+SRC_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+SRC_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 
 #: Real-``Artifact`` builders for the download core (it filters on
 #: ``isinstance(a, Artifact)`` + the int type code + ``is_completed``).
@@ -62,6 +64,12 @@ class FakeArtifact:
     kind: ArtifactType = ArtifactType.AUDIO
     is_completed: bool = True
     created_at: datetime = field(default_factory=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc))
+
+
+@dataclass
+class FakeSource:
+    id: str
+    title: str | None
 
 
 @dataclass
@@ -145,14 +153,51 @@ async def test_artifact_generate_report_routes_to_report(mcp_call, mock_client) 
     mock_client.artifacts.generate_report.assert_awaited_once()
 
 
-async def test_artifact_generate_passes_source_ids(mcp_call, mock_client) -> None:
+async def test_artifact_generate_resolves_source_id_prefix(mcp_call, mock_client) -> None:
     mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    mock_client.sources.list = AsyncMock(
+        return_value=[
+            FakeSource(id=SRC_A, title="Methods.pdf"),
+            FakeSource(id=SRC_B, title="Appendix.pdf"),
+        ]
+    )
     await mcp_call(
         "artifact_generate",
-        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": ["src-1", "src-2"]},
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": [SRC_A[:12]]},
     )
     kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
-    assert kwargs["source_ids"] == ("src-1", "src-2")
+    assert kwargs["source_ids"] == [SRC_A]
+    mock_client.sources.list.assert_awaited_once_with(NB_ID)
+
+
+async def test_artifact_generate_resolves_source_title(mcp_call, mock_client) -> None:
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    mock_client.sources.list = AsyncMock(
+        return_value=[
+            FakeSource(id=SRC_A, title="Methods.pdf"),
+            FakeSource(id=SRC_B, title="Appendix.pdf"),
+        ]
+    )
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": ["appendix.pdf"]},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] == [SRC_B]
+    mock_client.sources.list.assert_awaited_once_with(NB_ID)
+
+
+async def test_artifact_generate_empty_string_source_id_is_validation_error(
+    mcp_call, mock_client
+) -> None:
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": "audio", "source_ids": [""]},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.artifacts.generate_audio.assert_not_called()
 
 
 async def test_artifact_generate_omitting_source_ids_uses_all(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary

Fixes #1671.

`artifact_generate` now resolves each non-empty `source_ids` entry through the MCP source resolver before calling the generation core. This matches sibling MCP tools and CLI behavior: full UUIDs fast-path, source ID prefixes expand to full IDs, exact source titles resolve, and empty string elements fail validation instead of being forwarded raw to the backend.

The omitted/empty collection contract from #1652 is preserved: omitted `source_ids` and explicit `[]` still resolve to `None`, so generation uses all sources.

## Root Cause

`artifact_generate` used `_passthrough_sources`, which only converted an empty collection to `None` and otherwise forwarded values unchanged. Agents passing a prefix or title after `source_list` could get confusing backend rejections or mis-scoped generation.

## Validation

- `.venv/bin/pytest tests/unit/mcp/test_artifacts.py -q`
- `.venv/bin/pytest tests/unit/cli/test_cli_mcp_parity.py -q`
- `.venv/bin/ruff check src/notebooklm/mcp/tools/artifacts.py tests/unit/mcp/test_artifacts.py tests/unit/cli/test_cli_mcp_parity.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source selection for artifact generation so inputs can be matched by full ID, unique prefix, or exact title.
  * Empty source selections are now treated as invalid and return a validation error instead of being sent onward.
  * When no sources are provided, the system now correctly uses all available sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->