### PR TITLE
feat(mcp): tolerate source_ids as JSON-string/comma/scalar (coerce_list) (#1680)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1180,6 +1180,7 @@ src/notebooklm/
 │   ├── _errors.py               # Structured tool-error projection (CATEGORY_TABLE/ERROR_CODES/mcp_errors/to_tool_error/tool_error_payload) over _app.errors.classify
 │   ├── _resolve.py              # resolve_notebook/resolve_source/resolve_note — name + partial-id resolution over _app.resolve plus exact-title matching
 │   ├── _confirm.py              # needs_confirmation() both-mode envelope + READ_ONLY/DESTRUCTIVE ToolAnnotations
+│   ├── _coerce.py               # coerce_list(value) — tolerant list-param normalizer (real list/tuple, JSON-array string, comma string, scalar → list[str]; None stays None for the "all sources" contract); used by artifact_generate/chat_ask source_ids
 │   └── tools/                   # Per-domain tool modules; each exposes register(mcp) wired by server.register_all
 │       ├── __init__.py          # Tools package marker (no click/rich/cli)
 │       ├── _passthrough.py      # Shared pass-through resolvers (passthrough_notebook_id/passthrough_child_id) for the CLI-shaped _app executors

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -270,7 +270,7 @@ a single in-flight task.
 |--------|-------|
 | **Notebooks** | `notebook_list` · `notebook_create(title)` · `notebook_describe(notebook)` · `notebook_rename(notebook, new_title)` · `notebook_delete(notebook, confirm)` |
 | **Sources** | `source_list(notebook)` (each source has string `kind`/`status_label`) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` |
-| **Chat** | `chat_ask(notebook, question, conversation_id?, references?)` (`references`: lite\|full; never returns the raw debug blob) · `chat_configure(notebook, goal?, response_length?)` |
+| **Chat** | `chat_ask(notebook, question, conversation_id?, references?, source_ids?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all) · `chat_configure(notebook, goal?, response_length?)` |
 | **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` |

--- a/src/notebooklm/mcp/_coerce.py
+++ b/src/notebooklm/mcp/_coerce.py
@@ -1,0 +1,67 @@
+"""Tolerant coercion of list-shaped MCP tool params.
+
+Real MCP clients and some LLM tool-callers send a "list of strings" param in
+several shapes: a real list/tuple, a JSON-array string ``'["a","b"]'``, a
+comma-separated string ``"a,b"``, or a bare scalar. Tools that type such a param
+as ``list[str]`` and trust the schema reject the non-list shapes at the Pydantic
+boundary. :func:`coerce_list` normalizes all of them to a ``list[str]`` so a tool
+can accept the param typed ``list[str] | str | None`` and pre-parse it.
+
+``None`` is preserved as ``None`` (callers treat ``None`` as "unset" — for
+``source_ids`` that means "all sources", which is DISTINCT from an explicit empty
+list meaning "zero sources"; see the source-ids contract in ``tools/artifacts.py``
+and #1652). An empty/whitespace-only string yields ``[]``.
+
+This module imports NO ``click`` / ``rich`` / ``cli`` — only stdlib ``json``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["coerce_list"]
+
+
+def coerce_list(value: Any) -> list[str] | None:
+    """Normalize a list-shaped value into a ``list[str]`` (or ``None``).
+
+    Accepts a real ``list``/``tuple``, a JSON-array string, a comma-separated
+    string, or a bare scalar:
+
+    * ``None`` -> ``None`` (preserves the "unset"/"all" contract — NOT ``[]``).
+    * ``list`` / ``tuple`` -> each element stringified.
+    * a JSON-array string (``'["a","b"]'``) -> the parsed list, stringified. If
+      the string starts with ``[`` but is not valid JSON or not a JSON list,
+      matched outer brackets are stripped (handling the bracketed-but-unquoted
+      ``"[a, b]"`` some clients emit) and it falls back to comma-splitting.
+    * any other string -> split on commas, stripping whitespace and dropping
+      empty segments (so ``""`` / ``"   "`` -> ``[]``, ``"a"`` -> ``["a"]``).
+    * a bare non-string scalar (e.g. ``5``) -> ``["5"]`` (defensive: a non-string
+      scalar is rejected by Pydantic before reaching a tool typed
+      ``list[str] | str | None``, so this branch only matters for direct calls).
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+            # Not valid JSON (or not a JSON list) — e.g. the bracketed-but-unquoted
+            # "[a, b]" some clients/LLMs emit. Strip matched outer brackets so the
+            # comma-split below yields clean items ("a"/"b"), not "[a"/"b]". An
+            # unbalanced "[a,b" (no closing bracket) is left as-is.
+            if text.endswith("]"):
+                text = text.removeprefix("[").removesuffix("]")
+        return [part.strip() for part in text.split(",") if part.strip()]
+    # bare non-string scalar (int, etc.)
+    return [str(value)]

--- a/src/notebooklm/mcp/_coerce.py
+++ b/src/notebooklm/mcp/_coerce.py
@@ -32,9 +32,10 @@ def coerce_list(value: Any) -> list[str] | None:
     * ``None`` -> ``None`` (preserves the "unset"/"all" contract — NOT ``[]``).
     * ``list`` / ``tuple`` -> each element stringified.
     * a JSON-array string (``'["a","b"]'``) -> the parsed list, stringified. If
-      the string starts with ``[`` but is not valid JSON or not a JSON list,
-      matched outer brackets are stripped (handling the bracketed-but-unquoted
-      ``"[a, b]"`` some clients emit) and it falls back to comma-splitting.
+      the string starts with ``[`` but is not valid JSON or not a JSON list, the
+      leading ``[`` (and a trailing ``]`` if present) is stripped — handling the
+      bracketed-but-unquoted ``"[a, b]"`` / unbalanced ``"[a,b"`` some clients
+      emit — and it falls back to comma-splitting.
     * any other string -> split on commas, stripping whitespace and dropping
       empty segments (so ``""`` / ``"   "`` -> ``[]``, ``"a"`` -> ``["a"]``).
     * a bare non-string scalar (e.g. ``5``) -> ``["5"]`` (defensive: a non-string
@@ -57,11 +58,12 @@ def coerce_list(value: Any) -> list[str] | None:
             if isinstance(parsed, list):
                 return [str(item) for item in parsed]
             # Not valid JSON (or not a JSON list) — e.g. the bracketed-but-unquoted
-            # "[a, b]" some clients/LLMs emit. Strip matched outer brackets so the
-            # comma-split below yields clean items ("a"/"b"), not "[a"/"b]". An
-            # unbalanced "[a,b" (no closing bracket) is left as-is.
-            if text.endswith("]"):
-                text = text.removeprefix("[").removesuffix("]")
+            # "[a, b]" some clients/LLMs emit. A leading "[" is never a valid source
+            # ref, so strip it (and a matching trailing "]") before the comma-split
+            # below — yielding clean items ("a"/"b") instead of "[a"/"b]". This also
+            # covers the unbalanced "[a,b" case so a stray "[" can't leak into a
+            # resolved id and surface as a confusing "not found".
+            text = text.removeprefix("[").removesuffix("]")
         return [part.strip() for part in text.split(",") if part.strip()]
     # bare non-string scalar (int, etc.)
     return [str(value)]

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -41,6 +41,7 @@ from ..._app.language import is_supported_language
 from ..._app.serialize import to_jsonable
 from ...exceptions import ValidationError
 from ...types import ArtifactType
+from .._coerce import coerce_list
 from .._confirm import READ_ONLY
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors
@@ -360,7 +361,7 @@ def register(mcp: Any) -> None:
             "mind-map",
             "report",
         ],
-        source_ids: list[str] | None = None,
+        source_ids: list[str] | str | None = None,
         instructions: str = "",
         language: str | None = None,
         report_format: str | None = None,
@@ -412,11 +413,19 @@ def register(mcp: Any) -> None:
         but accepts each kind's own set of values.
 
         ``source_ids`` (optional) scopes generation to specific sources; omit it
-        to use every source. ``instructions`` is free-text guidance for kinds
-        that accept it (including ``mind-map``).
+        to use every source. It accepts a real list, a JSON-array string, or a
+        comma-separated string (the comma form cannot carry a source title that
+        itself contains a comma — use a JSON array or a real list for those).
+        ``instructions`` is free-text guidance for kinds that accept it
+        (including ``mind-map``).
         """
         client = get_client(ctx)
         with mcp_errors():
+            # Tolerate ``source_ids`` sent as a JSON-array string / comma string /
+            # scalar (some MCP clients + LLM tool-callers do); normalize to a
+            # ``list[str]`` up front. ``None`` stays ``None`` (=> all sources, the
+            # #1652 contract); ``""``/``[]`` collapse to all sources downstream.
+            source_ids = coerce_list(source_ids)
             # ``artifact_type`` is a Literal — FastMCP/Pydantic rejects an unknown
             # kind at the schema boundary, so no runtime membership check is needed.
             # Validate ``language`` up front: the neutral generate core's default

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -22,15 +22,17 @@ Both bodies wrap in :func:`mcp_errors`. This module imports NO ``click`` /
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal
 
 from fastmcp import Context
 
 from ..._app import chat as core
 from ..._app.serialize import to_jsonable
+from .._coerce import coerce_list
 from .._context import get_client
 from .._errors import mcp_errors
-from .._resolve import resolve_notebook
+from .._resolve import resolve_notebook, resolve_source
 
 #: Reference fields kept in the default ("lite") ``chat_ask`` projection. The full
 #: ``ChatReference`` also carries chunk-level char offsets / ``chunk_id`` /
@@ -49,11 +51,18 @@ def register(mcp: Any) -> None:
         question: str,
         conversation_id: str | None = None,
         references: Literal["lite", "full"] = "lite",
+        source_ids: list[str] | str | None = None,
     ) -> dict[str, Any]:
         """Ask a notebook's sources a question. Accepts a notebook name or ID.
 
         Pass ``conversation_id`` to continue a specific conversation; omit it to
         continue the notebook's most-recent conversation (or start a new one).
+
+        ``source_ids`` (optional) scopes the question to specific sources by
+        id/prefix/title; omit it to query every source. It accepts a real list, a
+        JSON-array string, or a comma-separated string (the comma form cannot
+        carry a source title that itself contains a comma — use a JSON array or a
+        real list for those).
 
         Returns the ``answer`` plus citation ``references``. The internal
         ``raw_response`` debugging blob is never included. ``references`` controls
@@ -63,7 +72,22 @@ def register(mcp: Any) -> None:
         client = get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
-            result = await client.chat.ask(nb_id, question, conversation_id=conversation_id)
+            # Tolerate ``source_ids`` sent as a JSON-array string / comma string /
+            # scalar, then resolve each ref (id/prefix/title) the same way every
+            # other source-accepting tool does. Omitted/empty stays None (=> all
+            # sources, mirroring ``client.chat.ask``'s None contract).
+            refs = coerce_list(source_ids)
+            resolved_source_ids = (
+                list(await asyncio.gather(*(resolve_source(client, nb_id, ref) for ref in refs)))
+                if refs
+                else None
+            )
+            result = await client.chat.ask(
+                nb_id,
+                question,
+                source_ids=resolved_source_ids,
+                conversation_id=conversation_id,
+            )
             payload = to_jsonable(result)
             # Drop the debug-only raw wire-protocol blob (it just burns agent context).
             payload.pop("raw_response", None)

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -201,6 +201,67 @@ async def test_artifact_generate_empty_source_ids_uses_all(mcp_call, mock_client
     assert kwargs["source_ids"] is None
 
 
+# Full-UUID source ids take resolve_source's fast path (no listing needed), so the
+# string-shape coercion tests below need no ``sources.list`` mock.
+_SRC_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_SRC_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+async def test_artifact_generate_source_ids_json_string(mcp_call, mock_client) -> None:
+    """``source_ids`` sent as a JSON-array string is tolerated (coerce_list)."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": f'["{_SRC_A}","{_SRC_B}"]'},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] == (_SRC_A, _SRC_B)
+
+
+async def test_artifact_generate_source_ids_comma_string(mcp_call, mock_client) -> None:
+    """``source_ids`` sent as a comma-separated string is tolerated (coerce_list)."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": f"{_SRC_A},{_SRC_B}"},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] == (_SRC_A, _SRC_B)
+
+
+async def test_artifact_generate_source_ids_scalar_string(mcp_call, mock_client) -> None:
+    """``source_ids`` sent as a bare scalar string is tolerated (coerce_list)."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": _SRC_A},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] == (_SRC_A,)
+
+
+async def test_artifact_generate_source_ids_empty_string_uses_all(mcp_call, mock_client) -> None:
+    """An empty string coerces to [] => collapses to None (all sources)."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": ""},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] is None
+
+
+async def test_artifact_generate_source_ids_whitespace_uses_all(mcp_call, mock_client) -> None:
+    """A whitespace-only string coerces to [] => collapses to None (all sources)."""
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": "   "},
+    )
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] is None
+
+
 async def test_artifact_generate_unknown_type_is_validation_error(mcp_call, mock_client) -> None:
     """An unknown artifact_type is rejected at the Literal schema boundary."""
     with pytest.raises(ToolError) as excinfo:

--- a/tests/unit/mcp/test_chat.py
+++ b/tests/unit/mcp/test_chat.py
@@ -60,7 +60,9 @@ async def test_chat_ask(mcp_call, mock_client) -> None:
     result = await mcp_call("chat_ask", {"notebook": NB_ID, "question": "what?"})
     assert result.structured_content["answer"] == "42"
     assert result.structured_content["conversation_id"] == CONV_ID
-    mock_client.chat.ask.assert_awaited_once_with(NB_ID, "what?", conversation_id=None)
+    mock_client.chat.ask.assert_awaited_once_with(
+        NB_ID, "what?", source_ids=None, conversation_id=None
+    )
 
 
 async def test_chat_ask_passes_conversation_id(mcp_call, mock_client) -> None:
@@ -71,7 +73,9 @@ async def test_chat_ask_passes_conversation_id(mcp_call, mock_client) -> None:
         "chat_ask",
         {"notebook": NB_ID, "question": "follow up", "conversation_id": CONV_ID},
     )
-    mock_client.chat.ask.assert_awaited_once_with(NB_ID, "follow up", conversation_id=CONV_ID)
+    mock_client.chat.ask.assert_awaited_once_with(
+        NB_ID, "follow up", source_ids=None, conversation_id=CONV_ID
+    )
 
 
 async def test_chat_ask_resolves_notebook_by_name(mcp_call, mock_client) -> None:
@@ -82,7 +86,81 @@ async def test_chat_ask_resolves_notebook_by_name(mcp_call, mock_client) -> None
         return_value=FakeAskResult(answer="hi", conversation_id=CONV_ID)
     )
     await mcp_call("chat_ask", {"notebook": "My Notebook", "question": "q"})
-    mock_client.chat.ask.assert_awaited_once_with(NB_ID, "q", conversation_id=None)
+    mock_client.chat.ask.assert_awaited_once_with(NB_ID, "q", source_ids=None, conversation_id=None)
+
+
+# Full-UUID source ids take resolve_source's fast path (no listing needed).
+_SRC_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_SRC_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+async def test_chat_ask_omitting_source_ids_uses_all(mcp_call, mock_client) -> None:
+    """Omitting ``source_ids`` => None (=> all sources, client.chat.ask's contract)."""
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call("chat_ask", {"notebook": NB_ID, "question": "what?"})
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] is None
+
+
+async def test_chat_ask_source_ids_list(mcp_call, mock_client) -> None:
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call(
+        "chat_ask",
+        {"notebook": NB_ID, "question": "what?", "source_ids": [_SRC_A, _SRC_B]},
+    )
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [_SRC_A, _SRC_B]
+
+
+async def test_chat_ask_source_ids_json_string(mcp_call, mock_client) -> None:
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call(
+        "chat_ask",
+        {"notebook": NB_ID, "question": "what?", "source_ids": f'["{_SRC_A}"]'},
+    )
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [_SRC_A]
+
+
+async def test_chat_ask_source_ids_comma_string(mcp_call, mock_client) -> None:
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call(
+        "chat_ask",
+        {"notebook": NB_ID, "question": "what?", "source_ids": f"{_SRC_A},{_SRC_B}"},
+    )
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [_SRC_A, _SRC_B]
+
+
+async def test_chat_ask_source_ids_scalar_string(mcp_call, mock_client) -> None:
+    """A bare scalar-string source_ids resolves/passes a single id (coerce_list)."""
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call("chat_ask", {"notebook": NB_ID, "question": "what?", "source_ids": _SRC_A})
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [_SRC_A]
+
+
+async def test_chat_ask_empty_source_ids_uses_all(mcp_call, mock_client) -> None:
+    """An explicit empty list => None (all sources), never [] (zero sources)."""
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call("chat_ask", {"notebook": NB_ID, "question": "what?", "source_ids": []})
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] is None
+
+
+async def test_chat_ask_whitespace_source_ids_uses_all(mcp_call, mock_client) -> None:
+    """A whitespace-only string coerces to [] => collapses to None (all sources)."""
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call("chat_ask", {"notebook": NB_ID, "question": "what?", "source_ids": "   "})
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] is None
 
 
 async def test_chat_configure_goal_and_length(mcp_call, mock_client) -> None:

--- a/tests/unit/mcp/test_coerce.py
+++ b/tests/unit/mcp/test_coerce.py
@@ -85,6 +85,7 @@ def test_bracketed_unquoted_single() -> None:
     assert coerce_list("[a]") == ["a"]
 
 
-def test_unbalanced_open_bracket_falls_back_to_comma_split() -> None:
-    """An unbalanced "[a,b" (no closing bracket) is NOT stripped — comma-split as-is."""
-    assert coerce_list("[a,b") == ["[a", "b"]
+def test_unbalanced_open_bracket_strips_leading_bracket() -> None:
+    """An unbalanced "[a,b" (no closing bracket) still has its stray leading "["
+    stripped so it can't leak into a resolved id."""
+    assert coerce_list("[a,b") == ["a", "b"]

--- a/tests/unit/mcp/test_coerce.py
+++ b/tests/unit/mcp/test_coerce.py
@@ -1,0 +1,90 @@
+"""Unit tests for the MCP ``coerce_list`` list-param normalizer.
+
+Covers every input shape an MCP client / LLM tool-caller might send a list param
+as: a real list/tuple, a JSON-array string, a comma-separated string, a bare
+scalar, empty, and ``None`` (the contract-critical "stays None" case).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip cleanly when the `mcp` extra (fastmcp) is absent: importing
+# ``notebooklm.mcp._coerce`` loads ``notebooklm.mcp.__init__`` -> fastmcp.
+pytest.importorskip("fastmcp")
+
+from notebooklm.mcp._coerce import coerce_list  # noqa: E402 - after importorskip guard
+
+
+def test_none_stays_none() -> None:
+    """The contract-critical case: None must NOT become [] (None => "all sources")."""
+    assert coerce_list(None) is None
+
+
+def test_real_list_is_stringified() -> None:
+    assert coerce_list(["a", "b"]) == ["a", "b"]
+
+
+def test_real_tuple_is_stringified() -> None:
+    assert coerce_list(("a", "b")) == ["a", "b"]
+
+
+def test_list_elements_are_stringified() -> None:
+    assert coerce_list([1, 2]) == ["1", "2"]
+
+
+def test_json_array_string() -> None:
+    assert coerce_list('["a","b"]') == ["a", "b"]
+
+
+def test_json_array_string_single() -> None:
+    assert coerce_list('["a"]') == ["a"]
+
+
+def test_json_empty_array_string() -> None:
+    assert coerce_list("[]") == []
+
+
+def test_json_array_non_string_elements_stringified() -> None:
+    assert coerce_list("[1, 2]") == ["1", "2"]
+
+
+def test_comma_string() -> None:
+    assert coerce_list("a,b") == ["a", "b"]
+
+
+def test_comma_string_strips_and_drops_empties() -> None:
+    assert coerce_list("a, b ,") == ["a", "b"]
+
+
+def test_scalar_string() -> None:
+    assert coerce_list("a") == ["a"]
+
+
+def test_empty_string_is_empty_list() -> None:
+    assert coerce_list("") == []
+
+
+def test_whitespace_string_is_empty_list() -> None:
+    assert coerce_list("   ") == []
+
+
+def test_non_string_scalar_is_stringified() -> None:
+    """Defensive direct-call behavior (a non-string scalar is rejected by Pydantic
+    before reaching a tool typed ``list[str] | str | None``)."""
+    assert coerce_list(5) == ["5"]
+
+
+def test_bracketed_unquoted_string_strips_brackets() -> None:
+    """A bracketed-but-unquoted "[a, b]" (not valid JSON) has its matched outer
+    brackets stripped before comma-split, yielding clean items."""
+    assert coerce_list("[a, b]") == ["a", "b"]
+
+
+def test_bracketed_unquoted_single() -> None:
+    assert coerce_list("[a]") == ["a"]
+
+
+def test_unbalanced_open_bracket_falls_back_to_comma_split() -> None:
+    """An unbalanced "[a,b" (no closing bracket) is NOT stripped — comma-split as-is."""
+    assert coerce_list("[a,b") == ["[a", "b"]


### PR DESCRIPTION
## Summary
Closes #1680. Real MCP clients and some LLM tool-callers send list params as a real list, a JSON-array string (`'["a","b"]'`), a comma string (`"a,b"`), or a bare scalar. Tools typing the param as `list[str]` reject the non-list shapes at the Pydantic boundary.

- New shared helper `src/notebooklm/mcp/_coerce.py` — `coerce_list(value)` normalizes all shapes to `list[str]`. Imports only stdlib `json` (MCP-boundary clean).
- Applied as a tolerant pre-parse to `source_ids` in `artifact_generate` (params widened to `list[str] | str | None`).
- `chat_ask` newly exposes `source_ids` (the underlying `client.chat.ask` already accepted it), resolved by id/prefix/title like every sibling source-accepting tool.
- Bracketed-but-unquoted `"[a, b]"` is tolerated (matched outer brackets stripped, then comma-split).

## Contract (the #1652 None=all vs []=none risk)
`coerce_list(None)` stays `None` (NOT `[]`) → "all sources". An empty/whitespace string and an explicit empty list collapse to `None` (all sources) downstream in BOTH tools. `client.chat.ask` treats `source_ids=None` as all sources (`_chat/api.py:302`). Pinned by dedicated tests on both tools.

## Test plan
- [x] `tests/unit/mcp/test_coerce.py` — every input shape (list / tuple / JSON-array string / comma / scalar / empty / whitespace / None / non-string scalar / bracketed-unquoted / unbalanced).
- [x] `test_artifacts.py` + `test_chat.py` — end-to-end through the in-memory FastMCP client for list / JSON-string / comma / scalar / empty / whitespace, plus the None=all and []=all contract cases.
- [x] Full suite: 11121 passed, 78 skipped, 1 xfailed (`mcp` extra synced so MCP tests ran).
- [x] `mypy` clean (289 files); `ruff check` + `ruff format --check` clean.
- [x] `scripts/audit_public_api_compat.py` exit 0 (change is additive; no new breaks).

## Deferred polish findings
- A perf nit raised by one reviewer: when multiple **non-UUID** source refs are passed, the `asyncio.gather` over `resolve_source` issues N concurrent identical `sources.list` calls. This is the pre-existing pattern already in `artifact_generate` (faithfully mirrored in `chat_ask` for consistency); the proper fix is a shared batch-resolve helper applied to both tools. Tracked as a follow-up rather than diverging the two tools here. Common case (full-UUID refs) takes the no-list fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `chat_ask` now supports scoping questions to specific sources via an optional `source_ids` input (list, JSON-array string, or comma-separated string).
  * `artifact_generate` now accepts `source_ids` in the same flexible formats.
* **Bug Fixes**
  * Omitted, empty, or whitespace-only `source_ids` now consistently fall back to querying all sources.
  * Improved normalization across varied input shapes for more reliable source scoping.
* **Documentation**
  * Updated MCP guide tool reference for `chat_ask` to document `source_ids`.
  * Refreshed architecture documentation with the new list-normalization module entry.
* **Tests**
  * Added unit coverage for `source_ids` coercion and tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->