### PR TITLE
feat(mcp): type artifact_generate option params as Literal (#1666)

### DIFF
--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -364,19 +364,53 @@ def register(mcp: Any) -> None:
         source_ids: list[str] | str | None = None,
         instructions: str = "",
         language: str | None = None,
-        report_format: str | None = None,
-        audio_format: str | None = None,
-        audio_length: str | None = None,
-        quantity: str | None = None,
-        difficulty: str | None = None,
-        video_format: str | None = None,
-        style: str | None = None,
+        # Finite-choice per-kind options are typed as ``Literal`` so FastMCP/Pydantic
+        # emits a JSON-schema ``enum`` (agents discover valid values from the schema,
+        # not by trial-and-error) and rejects out-of-enum values at the boundary. The
+        # members are DUPLICATED from the neutral core's private ``_*_MAP`` maps via
+        # ``_KIND_OPTIONS`` (the CLI/MCP boundary forbids importing them); a guardrail
+        # test pins each ``enum`` equal to ``_KIND_OPTIONS`` (itself pinned to the core
+        # maps) so they can't drift. ``style_prompt``/``language`` stay free text.
+        report_format: Literal["briefing-doc", "study-guide", "blog-post", "custom"] | None = None,
+        audio_format: Literal["deep-dive", "brief", "critique", "debate"] | None = None,
+        audio_length: Literal["short", "default", "long"] | None = None,
+        quantity: Literal["fewer", "standard", "more"] | None = None,
+        difficulty: Literal["easy", "medium", "hard"] | None = None,
+        video_format: Literal["explainer", "brief", "cinematic"] | None = None,
+        # ``style`` is shared by ``video`` and ``infographic`` with DIFFERENT value
+        # sets (overlap only auto/anime/kawaii). One param carries one Literal, so this
+        # is the UNION of both kinds' values; the runtime ``_KIND_OPTIONS`` loop narrows
+        # it per-kind (a video-only value on infographic, or vice versa, is rejected
+        # there with a clean VALIDATION error).
+        style: Literal[
+            # full video set (auto/kawaii/anime also valid for infographic)
+            "auto",
+            "custom",
+            "classic",
+            "whiteboard",
+            "kawaii",
+            "anime",
+            "watercolor",
+            "retro-print",
+            "heritage",
+            "paper-craft",
+            # infographic styles not already listed above
+            "sketch-note",
+            "professional",
+            "bento-grid",
+            "editorial",
+            "instructional",
+            "bricks",
+            "clay",
+            "scientific",
+        ]
+        | None = None,
         style_prompt: str | None = None,
-        deck_format: str | None = None,
-        deck_length: str | None = None,
-        orientation: str | None = None,
-        detail: str | None = None,
-        map_kind: str | None = None,
+        deck_format: Literal["detailed", "presenter"] | None = None,
+        deck_length: Literal["default", "short"] | None = None,
+        orientation: Literal["landscape", "portrait", "square"] | None = None,
+        detail: Literal["concise", "standard", "detailed"] | None = None,
+        map_kind: Literal["interactive", "note-backed"] | None = None,
     ) -> dict[str, Any]:
         """Start generating a studio artifact. Accepts a notebook name or ID.
 

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -29,12 +29,33 @@ from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     ArtifactNotFoundError,
     NotebookNotFoundError,
 )
+from notebooklm.mcp.tools.artifacts import _KIND_OPTIONS  # noqa: E402
 from notebooklm.types import Artifact, ArtifactType, GenerationState  # noqa: E402
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
 NB_ID = "11111111-1111-1111-1111-111111111111"
 TASK_ID = "task-abc-123"
+
+
+def _schema_enum(prop: dict[str, Any]) -> set[str] | None:
+    """The JSON-schema ``enum`` for a tool param, or ``None`` if it has none.
+
+    Handles BOTH shapes FastMCP/Pydantic emits: a required ``Literal`` renders a
+    flat ``{"enum": [...]}``; an optional ``Literal[...] | None`` renders
+    ``{"anyOf": [{"enum": [...], "type": "string"}, {"type": "null"}]}``. A
+    free-text ``str``/``str | None`` param has no ``enum`` branch → ``None``.
+    """
+    if "enum" in prop:
+        return set(prop["enum"])
+    # ``anyOf`` is Pydantic v2's shape for ``T | None`` today; also scan ``oneOf``
+    # so the helper survives a future schema-generation switch to the JSON-Schema
+    # mutually-exclusive form rather than silently returning ``None``.
+    for branch in prop.get("anyOf", []) + prop.get("oneOf", []):
+        if "enum" in branch:
+            return set(branch["enum"])
+    return None
+
 
 #: Real-``Artifact`` builders for the download core (it filters on
 #: ``isinstance(a, Artifact)`` + the int type code + ``is_completed``).
@@ -269,16 +290,6 @@ async def test_artifact_generate_unknown_type_is_validation_error(mcp_call, mock
     assert "audio" in str(excinfo.value) and "report" in str(excinfo.value)
 
 
-async def test_artifact_generate_bad_enum_is_validation_error(mcp_call, mock_client) -> None:
-    """A bad per-kind option (e.g. report_format) projects as VALIDATION."""
-    with pytest.raises(ToolError) as excinfo:
-        await mcp_call(
-            "artifact_generate",
-            {"notebook": NB_ID, "artifact_type": "report", "report_format": "nonsense"},
-        )
-    assert "VALIDATION" in str(excinfo.value)
-
-
 async def test_artifact_generate_bad_language_is_validation_error(mcp_call, mock_client) -> None:
     """An unsupported ``language`` projects as VALIDATION up front (not forwarded raw)."""
     mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
@@ -404,25 +415,76 @@ async def test_artifact_generate_mind_map_forwards_instructions(mcp_call, mock_c
     [
         ("video", {"style": "professional"}),  # infographic-only value, invalid for video
         ("infographic", {"style": "classic"}),  # video-only value, invalid for infographic
-        ("mind-map", {"map_kind": "bogus"}),  # core wouldn't catch — MCP must
-        ("slide-deck", {"deck_format": "nonsense"}),
     ],
-    ids=["video-bad-style", "infographic-bad-style", "bad-map-kind", "bad-deck-format"],
+    ids=["video-bad-style", "infographic-bad-style"],
 )
-async def test_artifact_generate_bad_option_value_is_validation_error(
+async def test_artifact_generate_cross_kind_style_is_validation_error(
     mcp_call, mock_client, artifact_type: str, opts: dict
 ) -> None:
-    """A value outside the kind's choice set projects as VALIDATION.
+    """A ``style`` value that IS in the global union Literal but invalid for THIS kind
+    projects as VALIDATION via the runtime ``_KIND_OPTIONS`` loop.
 
-    The per-type ``style`` cases prove the video/infographic style sets are enforced
-    separately (the two overlap only on auto/anime/kawaii).
+    ``style`` is a single union Literal (video ∪ infographic), so these values pass
+    the schema boundary and must be narrowed per-kind at runtime — proving the
+    video/infographic style sets stay enforced separately (they overlap only on
+    auto/anime/kawaii).
     """
     with pytest.raises(ToolError) as excinfo:
         await mcp_call(
             "artifact_generate",
             {"notebook": NB_ID, "artifact_type": artifact_type, **opts},
         )
-    assert "VALIDATION" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    # ...and NOT a boundary rejection: these values are in the global union Literal,
+    # so they pass Pydantic and are caught by the runtime per-kind narrowing.
+    assert "literal_error" not in msg
+
+
+@pytest.mark.parametrize(
+    "artifact_type,opts,accepted",
+    [
+        (
+            "report",
+            {"report_format": "nonsense"},
+            ("briefing-doc", "study-guide", "blog-post", "custom"),
+        ),
+        ("mind-map", {"map_kind": "bogus"}, ("interactive", "note-backed")),
+        ("slide-deck", {"deck_format": "nonsense"}, ("detailed", "presenter")),
+        # A value outside the GLOBAL union ``style`` Literal rejects at the boundary
+        # too (distinct from the cross-kind cases above, which ARE in the union).
+        (
+            "video",
+            {"style": "nonsense"},
+            tuple(
+                set(_KIND_OPTIONS["video"]["style"]) | set(_KIND_OPTIONS["infographic"]["style"])
+            ),
+        ),
+    ],
+    ids=["bad-report-format", "bad-map-kind", "bad-deck-format", "out-of-union-style"],
+)
+async def test_artifact_generate_bad_option_value_is_schema_boundary_error(
+    mcp_call, mock_client, artifact_type: str, opts: dict, accepted: tuple[str, ...]
+) -> None:
+    """An out-of-enum value for a ``Literal`` option rejects at the schema boundary
+    (pydantic ``literal_error``), surfacing the accepted members — NOT the runtime
+    ``"VALIDATION"`` projection (which only fires for values that pass the boundary,
+    i.e. the cross-kind ``style`` cases above).
+
+    This is the point of the Literal typing: bad values reject earlier (no
+    ``"VALIDATION"`` substring — same as the unknown-``artifact_type`` case), with
+    the schema enum surfaced to the agent. The ``"VALIDATION" not in`` +
+    ``literal_error in`` assertions are what actually distinguish a boundary
+    rejection from the runtime path (both list the accepted members)."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_generate",
+            {"notebook": NB_ID, "artifact_type": artifact_type, **opts},
+        )
+    msg = str(excinfo.value)
+    assert all(member in msg for member in accepted)
+    assert "VALIDATION" not in msg
+    assert "literal_error" in msg
 
 
 @pytest.mark.parametrize(
@@ -523,6 +585,59 @@ async def test_artifact_generate_exposes_new_option_params(mcp_list_tools) -> No
         "map_kind",
     ):
         assert param in properties, f"artifact_generate must expose {param!r}"
+
+
+async def test_artifact_generate_option_params_expose_enums(mcp_list_tools) -> None:
+    """Each finite-choice option param is typed ``Literal`` → the tool schema exposes a
+    JSON-schema ``enum`` matching ``_KIND_OPTIONS`` (acceptance criterion for #1666).
+
+    The expected enum is read from ``_KIND_OPTIONS`` (pinned equal to the neutral core
+    maps by ``test_kind_options_match_core_maps``), so a core-map change not mirrored
+    into BOTH ``_KIND_OPTIONS`` and the signature ``Literal`` fails here. ``style`` is a
+    single union Literal, so its enum is the union across video+infographic; ``quantity``
+    /``difficulty`` are shared by quiz+flashcards (identical today — assert the union so
+    a future flashcards-specific set is still covered)."""
+    tools = await mcp_list_tools()
+    schema = next(t for t in tools if t.name == "artifact_generate").inputSchema
+    props = schema.get("properties", {})
+
+    # Single-kind option params: enum == that kind's choice set.
+    single_kind = {
+        "report_format": "report",
+        "audio_format": "audio",
+        "audio_length": "audio",
+        "video_format": "video",
+        "deck_format": "slide-deck",
+        "deck_length": "slide-deck",
+        "orientation": "infographic",
+        "detail": "infographic",
+        "map_kind": "mind-map",
+    }
+    for param, kind in single_kind.items():
+        assert _schema_enum(props[param]) == set(_KIND_OPTIONS[kind][param]), param
+
+    # quantity/difficulty: shared by quiz+flashcards (union).
+    for param in ("quantity", "difficulty"):
+        expected = set(_KIND_OPTIONS["quiz"][param]) | set(_KIND_OPTIONS["flashcards"][param])
+        assert _schema_enum(props[param]) == expected, param
+
+    # style: single union Literal across video + infographic.
+    expected_style = set(_KIND_OPTIONS["video"]["style"]) | set(
+        _KIND_OPTIONS["infographic"]["style"]
+    )
+    assert _schema_enum(props["style"]) == expected_style
+
+
+async def test_artifact_generate_free_text_params_have_no_enum(mcp_list_tools) -> None:
+    """``style_prompt`` and ``language`` stay free text — NOT converted to ``Literal``.
+
+    Uses the same nested-aware ``_schema_enum`` helper so an accidental conversion that
+    hid an ``enum`` inside an ``anyOf`` branch would still be caught."""
+    tools = await mcp_list_tools()
+    schema = next(t for t in tools if t.name == "artifact_generate").inputSchema
+    props = schema.get("properties", {})
+    assert _schema_enum(props["style_prompt"]) is None
+    assert _schema_enum(props["language"]) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -51,7 +51,7 @@ def _schema_enum(prop: dict[str, Any]) -> set[str] | None:
     # ``anyOf`` is Pydantic v2's shape for ``T | None`` today; also scan ``oneOf``
     # so the helper survives a future schema-generation switch to the JSON-Schema
     # mutually-exclusive form rather than silently returning ``None``.
-    for branch in prop.get("anyOf", []) + prop.get("oneOf", []):
+    for branch in (prop.get("anyOf") or []) + (prop.get("oneOf") or []):
         if "enum" in branch:
             return set(branch["enum"])
     return None
@@ -457,7 +457,12 @@ async def test_artifact_generate_cross_kind_style_is_validation_error(
             "video",
             {"style": "nonsense"},
             tuple(
-                set(_KIND_OPTIONS["video"]["style"]) | set(_KIND_OPTIONS["infographic"]["style"])
+                # sorted() so the parametrize id / member order is deterministic
+                # across runs (set iteration order varies with hash randomization).
+                sorted(
+                    set(_KIND_OPTIONS["video"]["style"])
+                    | set(_KIND_OPTIONS["infographic"]["style"])
+                )
             ),
         ),
     ],


### PR DESCRIPTION
## Summary
Closes the remaining piece of **#1666**: the per-kind **OPTION** params on the MCP `artifact_generate` tool are now typed as `Literal[...]` (the primary discriminators shipped in #1686; `artifact_download` is handled by #1668).

- Converts `report_format`, `audio_format`, `audio_length`, `quantity`, `difficulty`, `video_format`, `deck_format`, `deck_length`, `orientation`, `detail`, `map_kind`, and `style` from bare `str | None` to `Literal[...] | None`, so FastMCP/Pydantic emits JSON-schema `enum`s and rejects out-of-enum values at the boundary. Agents discover valid values from the schema instead of by trial-and-error.
- **`style` collision:** `video` and `infographic` both take `style` with different value sets (overlap only auto/anime/kawaii). A single param carries one Literal, so `style` is the **union** of both kinds' values; the existing `_KIND_OPTIONS` runtime loop is kept as defense-in-depth and narrows the union per-kind (and still rejects wrong-kind params, which a flat Literal can't express).
- `style_prompt` and `language` intentionally stay free text.

## Behavior
- **No change for valid inputs** — omitted options still default via `_KIND_DEFAULTS`; valid values pass exactly as before.
- For **invalid** inputs this is not purely additive: an out-of-enum value for a Literal param now rejects at the Pydantic schema boundary (a `literal_error` listing the accepted members) **before** the tool body, instead of via the runtime `VALIDATION` projection. A value that is a valid global Literal member but wrong for the kind (cross-kind `style`, wrong-kind params) still rejects via the runtime loop → `VALIDATION`.

## Drift safety
The signature Literals duplicate the choice values (Literals must be static; the CLI/MCP boundary forbids importing the core `_*_MAP` maps). A new `test_artifact_generate_option_params_expose_enums` pins each schema `enum` to `_KIND_OPTIONS`, which is itself pinned to the core maps by the existing `test_kind_options_match_core_maps` — so the three-place chain (core map → `_KIND_OPTIONS` → signature Literal) fails CI if a value isn't mirrored everywhere.

## Test plan
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run pytest` — 11094 passed, 78 skipped, 1 xfailed
- New tests: enum-exposure (positive), free-text `style_prompt`/`language` (negative, nested-`anyOf`-aware), boundary-rejection (single-kind + out-of-union-style; asserts `literal_error` and NOT `VALIDATION`), cross-kind `style` runtime `VALIDATION` (asserts `VALIDATION` and NOT `literal_error`).

## Polish
code-simplifier + triple review (claude/codex/agy) + ultrathink. Consensus finding fixed: boundary tests now assert `"VALIDATION" not in` + `"literal_error" in` to truly distinguish boundary from runtime rejection (both list the accepted members). No deferred findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for artifact creation options so invalid choices are rejected reliably at the tool boundary.
  * Strengthened consistency of shared option handling across artifact types, including clearer error behavior for cross-kind styles.
* **Tests**
  * Expanded coverage to verify runtime validation errors versus schema-bound enum failures.
  * Added assertions that selectable-choice fields expose their allowed values, while free-text fields remain unrestricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->