### PR TITLE
fix(mcp): unify source_wait single-vs-all failure contract (#1669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP `source_wait` now returns one unified per-source aggregate** (#1669).
+  Both modes — waiting for a single `source` or for every source in the notebook
+  — return the same shape: `{notebook_id, ok, ready, timed_out, failed,
+  not_found}`. `ready` carries the sources that reached READY (with
+  `kind`/`status_label` labels); the three error buckets carry
+  `{source_id, error}` entries; `ok` is `true` iff all error buckets are empty.
+  Previously the single-source mode returned `{status: ready|not_found|failed|
+  timeout}` while the all-sources mode **threw on the first failure and discarded
+  every source that had already become ready** — the all-sources mode now reports
+  **partial progress** instead. (A `source` reference that does not resolve still
+  raises NOT_FOUND before the wait — an input error, distinct from a resolved
+  source the backend reports missing/failed/slow.)
 - **Regenerable test baselines (Phase 1; contributor-facing, no public API
   change).** Frozen public-surface snapshots that were hand-typed copies of
   values the code already derives — `_FROZEN_TYPES_ALL` and

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -16,9 +16,10 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
@@ -28,7 +29,13 @@ from ..._app import source_content as content_core
 from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
 from ..._app.serialize import to_jsonable
-from ...exceptions import ConfigurationError, SourceNotFoundError, ValidationError
+from ...exceptions import (
+    ConfigurationError,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceTimeoutError,
+    ValidationError,
+)
 from ...urls import is_youtube_url
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -37,6 +44,9 @@ from .._filelink import UPLOAD_TTL, FileTransferConfig
 from .._resolve import resolve_notebook, resolve_source
 from ._passthrough import passthrough_child_id
 from ._preview import title_for_id
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
 
 #: MCP source types. Superset of the neutral ``source_add`` core's types
 #: (which lacks ``drive``); ``drive`` is dispatched to the Drive path.
@@ -233,8 +243,22 @@ def register(mcp: Any) -> None:
         """Wait for sources to finish processing. Accepts a notebook name or ID.
 
         Waits for a single source when ``source`` (name or ID) is given, otherwise
-        for every source in the notebook. Returns the ready sources, or surfaces a
-        not-found / processing / timeout error.
+        for every source in the notebook. BOTH modes return the SAME structured
+        aggregate, so an agent never has to branch on the shape:
+
+            {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
+
+        ``ready`` holds the sources that reached READY (each with ``kind`` /
+        ``status_label`` labels); ``timed_out`` / ``failed`` / ``not_found`` hold
+        ``{"source_id", "error"}`` entries for the sources that did not. ``ok`` is
+        ``true`` iff all three error buckets are empty. The all-sources mode reports
+        **partial progress** — a slow or failed source no longer discards the ones
+        that did become ready.
+
+        A single-source ``source`` ref that does not resolve (e.g. an unknown title)
+        still raises NOT_FOUND before the wait — that is an input error, distinct
+        from a resolved source the backend reports missing/failed/slow (which lands
+        in a bucket).
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -254,17 +278,12 @@ def register(mcp: Any) -> None:
                         interval=interval,
                     ),
                 )
-                return _wait_outcome_payload(nb_id, outcome)
+                return _aggregate_wait_outcomes(nb_id, [outcome])
             sources = await client.sources.list(nb_id)
-            source_ids = [s.id for s in sources]
-            # ``wait_for_sources`` forwards **kwargs to ``wait_until_ready``,
-            # whose poll-interval kwarg is ``initial_interval`` — thread the
-            # advertised ``interval`` through so the all-sources branch honors it
-            # just like the single-source branch above.
-            ready = await client.sources.wait_for_sources(
-                nb_id, source_ids, timeout=timeout, initial_interval=interval
+            outcomes = await _wait_all_sources(
+                client, nb_id, [s.id for s in sources], timeout=timeout, interval=interval
             )
-            return {"notebook_id": nb_id, "ready": to_jsonable(ready)}
+            return _aggregate_wait_outcomes(nb_id, outcomes)
 
     @mcp.tool
     async def source_add(
@@ -457,16 +476,94 @@ def _select_content(
     raise ValidationError(f"Unknown source type {source_type!r}")  # pragma: no cover
 
 
-def _wait_outcome_payload(notebook_id: str, outcome: wait_core.SourceWaitOutcome) -> dict[str, Any]:
-    """Project a single-source :class:`SourceWaitOutcome` onto the wire shape."""
-    if isinstance(outcome, wait_core.SourceWaitReady):
-        return {
-            "notebook_id": notebook_id,
-            "status": "ready",
-            "source": to_jsonable(outcome.source),
-        }
-    if isinstance(outcome, wait_core.SourceWaitNotFound):
-        return {"notebook_id": notebook_id, "status": "not_found", "error": str(outcome.error)}
-    if isinstance(outcome, wait_core.SourceWaitProcessingError):
-        return {"notebook_id": notebook_id, "status": "failed", "error": str(outcome.error)}
-    return {"notebook_id": notebook_id, "status": "timeout", "error": str(outcome.error)}
+async def _wait_all_sources(
+    client: NotebookLMClient,
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    timeout: float,
+    interval: float,
+) -> list[wait_core.SourceWaitOutcome]:
+    """Wait for every source concurrently, returning one outcome per source.
+
+    Unlike ``client.sources.wait_for_sources`` (which re-raises the first failure
+    and discards the sources that already became ready), each per-source wait runs
+    through :func:`execute_source_wait`, which maps the three handled
+    ``SourceWait*`` failures to a typed outcome instead of raising — so a slow or
+    failed source never throws away its siblings' progress.
+
+    An UNEXPECTED exception (e.g. an auth/transport ``RPCError``, a bug) is NOT a
+    handled outcome: a bare ``asyncio.gather`` would re-raise it without cancelling
+    the still-running sibling pollers, leaking coroutines. Mirror the library's
+    ``wait_for_sources`` discipline (``_source/polling.py``): drive explicit tasks
+    and, on any such escape, cancel + drain the pending siblings before re-raising
+    (it then flows through ``mcp_errors()``).
+    """
+    tasks = [
+        asyncio.create_task(
+            wait_core.execute_source_wait(
+                client,
+                wait_core.SourceWaitPlan(
+                    notebook_id=notebook_id,
+                    source_id=sid,
+                    timeout=timeout,
+                    interval=interval,
+                ),
+            )
+        )
+        for sid in source_ids
+    ]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+def _wait_bucket_entry(
+    error: SourceNotFoundError | SourceProcessingError | SourceTimeoutError,
+) -> dict[str, str]:
+    """Project a handled wait failure onto its ``{source_id, error}`` bucket entry."""
+    return {"source_id": error.source_id, "error": str(error)}
+
+
+def _aggregate_wait_outcomes(
+    notebook_id: str, outcomes: list[wait_core.SourceWaitOutcome]
+) -> dict[str, Any]:
+    """Project per-source wait outcomes onto the unified aggregate wire shape.
+
+    Both ``source_wait`` modes (single source, all sources) share this contract:
+    ready sources are returned alongside the ones that timed out / failed / went
+    missing, so the all-sources mode reports partial progress instead of discarding
+    the sources that did become ready. ``ok`` is ``True`` iff nothing landed in an
+    error bucket.
+    """
+    ready: list[dict[str, Any]] = []
+    timed_out: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    not_found: list[dict[str, str]] = []
+    for outcome in outcomes:
+        if isinstance(outcome, wait_core.SourceWaitReady):
+            ready.append(_source_view(outcome.source))
+        elif isinstance(outcome, wait_core.SourceWaitTimeout):
+            timed_out.append(_wait_bucket_entry(outcome.error))
+        elif isinstance(outcome, wait_core.SourceWaitProcessingError):
+            failed.append(_wait_bucket_entry(outcome.error))
+        elif isinstance(outcome, wait_core.SourceWaitNotFound):
+            not_found.append(_wait_bucket_entry(outcome.error))
+        else:  # exhaustive over the closed SourceWaitOutcome union
+            # mypy narrows ``outcome`` to ``Never`` here; a future outcome variant
+            # would surface as a type error AND fail loudly at runtime rather than
+            # being silently dropped from every bucket.
+            raise AssertionError(f"unhandled SourceWaitOutcome: {outcome!r}")
+    return {
+        "notebook_id": notebook_id,
+        "ok": not (timed_out or failed or not_found),
+        "ready": ready,
+        "timed_out": timed_out,
+        "failed": failed,
+        "not_found": not_found,
+    }

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -307,7 +307,8 @@ class TestMcpSources:
             client, "source_wait", {"notebook": nb, "source": src_id, "timeout": 120.0}
         )
         assert waited.get("notebook_id") == nb
-        assert "status" in waited
+        # Unified aggregate contract: both modes carry an explicit ``ok`` signal.
+        assert "ok" in waited
 
         listing = await _call(client, "source_list", {"notebook": nb})
         ids = [s["id"] for s in listing["sources"]]

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -410,7 +410,8 @@ async def test_mcp_source_wait_single_over_vcr() -> None:
     ``execute_source_wait`` drives ``client.sources.wait_until_ready``, whose
     poller probes source status via the same ``GET_NOTEBOOK`` (``rLM1Ne``) list.
     The recorded source is already ``READY``, so it resolves on the first poll
-    and the tool returns the ``"ready"`` outcome wire shape.
+    and the tool returns the unified aggregate (``ok`` True, the source in
+    ``ready``, all error buckets empty).
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -425,14 +426,17 @@ async def test_mcp_source_wait_single_over_vcr() -> None:
 
     structured = result.structured_content
     assert isinstance(structured, dict)
-    # Single-source ready outcome: {"notebook_id", "status", "source"}.
-    assert set(structured) == {"notebook_id", "status", "source"}
+    # Unified aggregate shape, shared with the all-sources branch.
+    assert set(structured) == {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
     assert structured["notebook_id"] == SOURCES_LIST_NOTEBOOK_ID
-    assert structured["status"] == "ready"
-    source = structured["source"]
-    assert isinstance(source, dict)
+    assert structured["ok"] is True
+    assert structured["timed_out"] == structured["failed"] == structured["not_found"] == []
+    ready = structured["ready"]
+    assert len(ready) == 1
+    source = ready[0]
     assert source["id"] == SOURCES_LIST_SOURCE_ID
     assert source["status"] == 2  # SourceStatus.READY
+    assert source["status_label"] == "ready"
 
 
 @pytest.mark.asyncio
@@ -441,10 +445,11 @@ async def test_mcp_source_wait_all_over_vcr() -> None:
     """``source_wait`` (no ``source``) waits for every source in the notebook.
 
     The all-sources branch lists sources (``GET_NOTEBOOK`` → ``rLM1Ne``) then
-    waits on each id. Every recorded source is already ``READY``, so they all
-    resolve on the first poll and the tool returns the ``{"notebook_id",
-    "ready": [...]}`` wire shape. ``allow_playback_repeats`` lets the per-source
-    polls re-match the single recorded ``rLM1Ne`` interaction.
+    fans out a per-source wait on each id. Every recorded source is already
+    ``READY``, so they all resolve on the first poll and the tool returns the
+    unified aggregate (``ok`` True, the sources in ``ready``, error buckets
+    empty). ``allow_playback_repeats`` lets the per-source polls re-match the
+    single recorded ``rLM1Ne`` interaction.
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -458,8 +463,10 @@ async def test_mcp_source_wait_all_over_vcr() -> None:
 
     structured = result.structured_content
     assert isinstance(structured, dict)
-    assert set(structured) == {"notebook_id", "ready"}
+    assert set(structured) == {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
     assert structured["notebook_id"] == SOURCES_LIST_NOTEBOOK_ID
+    assert structured["ok"] is True
+    assert structured["timed_out"] == structured["failed"] == structured["not_found"] == []
     ready = structured["ready"]
     assert isinstance(ready, list)
     assert ready, "expected at least one ready source from the cassette"

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -9,6 +9,7 @@ preview-then-delete flow, and error projection.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,7 +21,12 @@ pytest.importorskip("fastmcp")
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
 from notebooklm._types.sources import SourceType  # noqa: E402 - after importorskip guard
-from notebooklm.exceptions import SourceNotFoundError  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    RPCError,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceTimeoutError,
+)
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
@@ -360,33 +366,40 @@ async def test_source_delete_with_confirm_deletes(mcp_call, mock_client) -> None
     mock_client.sources.delete.assert_awaited_once_with(NB_ID, SRC_ID)
 
 
-async def test_source_wait_all_sources(mcp_call, mock_client) -> None:
-    mock_client.sources.list = AsyncMock(
-        return_value=[FakeSource(id=SRC_ID), FakeSource(id=SRC2_ID)]
-    )
-    mock_client.sources.wait_for_sources = AsyncMock(
-        return_value=[FakeSource(id=SRC_ID, title="A"), FakeSource(id=SRC2_ID, title="B")]
-    )
-    result = await mcp_call("source_wait", {"notebook": NB_ID})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "ready": [{"id": SRC_ID, "title": "A"}, {"id": SRC2_ID, "title": "B"}],
-    }
-    mock_client.sources.wait_for_sources.assert_awaited_once_with(
-        NB_ID, [SRC_ID, SRC2_ID], timeout=120.0, initial_interval=1.0
-    )
+# ---------------------------------------------------------------------------
+# source_wait — both modes share ONE aggregate contract:
+#   {notebook_id, ok, ready, timed_out, failed, not_found}
+# ``ready`` carries _source_view rows; the three error buckets carry
+# {source_id, error}. ``ok`` is True iff all three error buckets are empty.
+# ---------------------------------------------------------------------------
+
+_AGGREGATE_KEYS = {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
 
 
-async def test_source_wait_all_sources_forwards_interval(mcp_call, mock_client) -> None:
-    """The all-sources branch honors the advertised ``interval`` (was dropped)."""
-    mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID)])
-    mock_client.sources.wait_for_sources = AsyncMock(
-        return_value=[FakeSource(id=SRC_ID, title="A")]
-    )
-    await mcp_call("source_wait", {"notebook": NB_ID, "timeout": 30.0, "interval": 3.0})
-    mock_client.sources.wait_for_sources.assert_awaited_once_with(
-        NB_ID, [SRC_ID], timeout=30.0, initial_interval=3.0
-    )
+def _assert_aggregate_shape(structured: dict[str, Any]) -> None:
+    """Pin the six-key aggregate so the shape isn't re-asserted per test."""
+    assert set(structured) == _AGGREGATE_KEYS
+    assert isinstance(structured["ok"], bool)
+    for key in ("ready", "timed_out", "failed", "not_found"):
+        assert isinstance(structured[key], list)
+
+
+def _dispatch_wait_until_ready(by_id: dict[str, Any]) -> Any:
+    """Build a ``wait_until_ready`` side_effect dispatching on the source id.
+
+    The tool calls ``wait_until_ready(notebook_id, source_id, timeout=…,
+    initial_interval=…)`` (per source), so ``source_id`` is the 2nd positional
+    arg. ``by_id`` maps a source id to either a ``FakeSource`` (returned ready) or
+    an ``Exception`` instance (raised) — letting one fan-out mix ready/failed/etc.
+    """
+
+    def _side_effect(_notebook_id: str, source_id: str, **_kwargs: Any) -> Any:
+        outcome = by_id[source_id]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    return AsyncMock(side_effect=_side_effect)
 
 
 async def test_source_wait_single_source_ready(mcp_call, mock_client) -> None:
@@ -394,17 +407,169 @@ async def test_source_wait_single_source_ready(mcp_call, mock_client) -> None:
         return_value=FakeSource(id=SRC_ID, title="Ready")
     )
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "status": "ready",
-        "source": {"id": SRC_ID, "title": "Ready"},
-    }
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert sc["ready"] == [
+        {"id": SRC_ID, "title": "Ready", "kind": "web_page", "status_label": "ready"}
+    ]
+    assert sc["timed_out"] == sc["failed"] == sc["not_found"] == []
 
 
 async def test_source_wait_single_source_not_found(mcp_call, mock_client) -> None:
+    """A resolved full-UUID source the backend can't find → ``not_found`` bucket."""
     mock_client.sources.wait_until_ready = AsyncMock(side_effect=SourceNotFoundError(SRC_ID))
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
-    assert result.structured_content["status"] == "not_found"
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is False
+    assert sc["ready"] == []
+    assert sc["not_found"] == [{"source_id": SRC_ID, "error": f"Source not found: {SRC_ID}"}]
+
+
+async def test_source_wait_single_source_timeout(mcp_call, mock_client) -> None:
+    mock_client.sources.wait_until_ready = AsyncMock(
+        side_effect=SourceTimeoutError(SRC_ID, 5.0, last_status=1)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is False
+    assert sc["timed_out"] and sc["timed_out"][0]["source_id"] == SRC_ID
+    assert sc["failed"] == sc["not_found"] == []
+
+
+async def test_source_wait_single_source_failed(mcp_call, mock_client) -> None:
+    mock_client.sources.wait_until_ready = AsyncMock(
+        side_effect=SourceProcessingError(SRC_ID, status=3)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is False
+    assert sc["failed"] and sc["failed"][0]["source_id"] == SRC_ID
+    assert sc["timed_out"] == sc["not_found"] == []
+
+
+async def test_source_wait_single_source_name_miss_raises(mcp_call, mock_client) -> None:
+    """An UNRESOLVABLE non-UUID ``source`` ref is an input error → ToolError NOT_FOUND,
+    NOT a ``not_found`` bucket entry (the resolver raises before the wait loop)."""
+    mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID, title="Other")])
+    mock_client.sources.wait_until_ready = AsyncMock()
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_wait", {"notebook": NB_ID, "source": "No Such Title"})
+    assert "NOT_FOUND" in str(excinfo.value)
+    mock_client.sources.wait_until_ready.assert_not_called()
+
+
+async def test_source_wait_all_sources_all_ready(mcp_call, mock_client) -> None:
+    mock_client.sources.list = AsyncMock(
+        return_value=[FakeSource(id=SRC_ID), FakeSource(id=SRC2_ID)]
+    )
+    mock_client.sources.wait_for_sources = AsyncMock()
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {SRC_ID: FakeSource(id=SRC_ID, title="A"), SRC2_ID: FakeSource(id=SRC2_ID, title="B")}
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert {row["id"] for row in sc["ready"]} == {SRC_ID, SRC2_ID}
+    assert sc["timed_out"] == sc["failed"] == sc["not_found"] == []
+    # The aggregate fans out per-source wait_until_ready, NOT the throw-on-first
+    # wait_for_sources helper (which would discard partial progress).
+    mock_client.sources.wait_for_sources.assert_not_called()
+
+
+async def test_source_wait_all_sources_partial_progress(mcp_call, mock_client) -> None:
+    """One call mixing ready + timeout + failed + not_found keeps the ready ones
+    (partial progress) and sets ok=False — the core of #1669."""
+    ready_id, timeout_id, failed_id, missing_id = (
+        "10000000-0000-0000-0000-000000000001",
+        "20000000-0000-0000-0000-000000000002",
+        "30000000-0000-0000-0000-000000000003",
+        "40000000-0000-0000-0000-000000000004",
+    )
+    mock_client.sources.list = AsyncMock(
+        return_value=[FakeSource(id=i) for i in (ready_id, timeout_id, failed_id, missing_id)]
+    )
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            ready_id: FakeSource(id=ready_id, title="OK"),
+            timeout_id: SourceTimeoutError(timeout_id, 5.0),
+            failed_id: SourceProcessingError(failed_id, status=3),
+            missing_id: SourceNotFoundError(missing_id),
+        }
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is False
+    assert [row["id"] for row in sc["ready"]] == [ready_id]
+    assert [e["source_id"] for e in sc["timed_out"]] == [timeout_id]
+    assert [e["source_id"] for e in sc["failed"]] == [failed_id]
+    assert [e["source_id"] for e in sc["not_found"]] == [missing_id]
+
+
+async def test_source_wait_all_sources_empty_notebook(mcp_call, mock_client) -> None:
+    """A notebook with no sources → all buckets empty, ok=True."""
+    mock_client.sources.list = AsyncMock(return_value=[])
+    result = await mcp_call("source_wait", {"notebook": NB_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc == {
+        "notebook_id": NB_ID,
+        "ok": True,
+        "ready": [],
+        "timed_out": [],
+        "failed": [],
+        "not_found": [],
+    }
+
+
+async def test_source_wait_all_sources_forwards_interval(mcp_call, mock_client) -> None:
+    """The all-sources branch honors the advertised ``timeout``/``interval`` per source."""
+    mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID)])
+    mock_client.sources.wait_until_ready = AsyncMock(return_value=FakeSource(id=SRC_ID, title="A"))
+    await mcp_call("source_wait", {"notebook": NB_ID, "timeout": 30.0, "interval": 3.0})
+    mock_client.sources.wait_until_ready.assert_awaited_once_with(
+        NB_ID, SRC_ID, timeout=30.0, initial_interval=3.0
+    )
+
+
+async def test_source_wait_all_sources_cancels_siblings_on_unexpected_error(
+    mcp_call, mock_client
+) -> None:
+    """An UNEXPECTED per-source exception (not one of the 3 handled wait failures)
+    propagates as ToolError AND cancels/drains the still-running sibling pollers —
+    no leaked coroutine. Mirrors the library-level wait_for_sources leak guard."""
+    slow_id, raiser_id = (
+        "50000000-0000-0000-0000-000000000005",
+        "60000000-0000-0000-0000-000000000006",
+    )
+    sibling_cancelled = asyncio.Event()
+
+    async def _wait(_nb: str, source_id: str, **_kwargs: Any) -> Any:
+        if source_id == raiser_id:
+            await asyncio.sleep(0)  # let the slow sibling start first
+            raise RPCError("unexpected boom")
+        try:
+            await asyncio.sleep(30)  # the slow sibling — should be cancelled
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        return FakeSource(id=slow_id)  # pragma: no cover - never reached
+
+    mock_client.sources.list = AsyncMock(
+        return_value=[FakeSource(id=slow_id), FakeSource(id=raiser_id)]
+    )
+    mock_client.sources.wait_until_ready = _wait
+    mock_client.sources.wait_for_sources = AsyncMock()
+
+    with pytest.raises(ToolError):
+        await mcp_call("source_wait", {"notebook": NB_ID})
+    assert sibling_cancelled.is_set(), "slow sibling poller was not cancelled/drained"
+    mock_client.sources.wait_for_sources.assert_not_called()
 
 
 async def test_source_add_text(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary

Resolves the remaining scope of #1669: unify the MCP `source_wait` tool's single-vs-all-sources failure contract. (PR #1686 already shipped the `READ_ONLY` annotation and the `timeout>=0`/`interval>0` bounds — not re-touched here.)

- Both modes now return ONE structured per-source aggregate: `{notebook_id, ok, ready, timed_out, failed, not_found}`. `ready` carries the sources that reached READY (with `kind`/`status_label` labels); the three error buckets carry `{source_id, error}` entries; `ok` is `true` iff all error buckets are empty.
- Previously the single-source mode returned `{status: ready|not_found|failed|timeout}` (a success dict) while the all-sources mode **threw on the first failure and discarded every source that had already become ready**. The all-sources mode now reports **partial progress** by fanning out `execute_source_wait` per source (each maps the three handled wait failures to a typed outcome instead of raising).
- An UNEXPECTED exception (e.g. a transport/auth `RPCError`, a bug) in the fan-out cancels + drains the still-running sibling pollers before re-raising — mirroring the library's `wait_for_sources` leak guard — then projects through `mcp_errors()`. `CancelledError` is never swallowed.
- A `source` ref that does not resolve still raises NOT_FOUND before the wait (input error), distinct from a resolved source the backend reports missing/failed/slow (which lands in a bucket).

## Task

GitHub issue #1669 (reduced scope — unified failure contract + tests). Plan + momus convergence (codex/claude/agy) in `.sisyphus/plans/1669-source-wait-contract.md`.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Full `uv run pytest` (with `mcp` extra so MCP unit + VCR tests actually run) — 11097 passed, 78 skipped, 1 xfailed
- [x] `scripts/audit_public_api_compat.py` — exit 0 (no allowlist entry needed; MCP tool return shapes are not in the audited public surface)
- New/updated tests in `tests/unit/mcp/test_sources.py` (both modes × ready/timeout/failed/not_found, partial progress, empty notebook, interval forwarding, resolver name-miss, cancel-drain leak guard), `tests/integration/mcp_vcr/test_sources.py`, `tests/e2e/test_mcp.py`.

## Deferred polish findings

None. Polish (code-simplifier + triple review claude/codex/agy + ultrathink) produced 0 critical/important; 2 suggestions (exhaustive outcome match via `Never`-narrowed guard, precise `client` type under `TYPE_CHECKING`) were applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `source_wait` now returns a unified response shape for both single-source and all-sources requests.
  * The response includes `ok`, `ready`, `timed_out`, `failed`, and `not_found`, making partial progress visible instead of failing fast.
  * Ready sources are preserved even when some sources time out or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->