### PR TITLE
feat(mcp): artifact_download can target a specific artifact_id (#1668)

### DIFF
--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -155,7 +155,7 @@ from the browser/sandbox and seeds the temp file's basename+extension.
 The signed token **encodes the operation parameters**, so the handlers hold no
 server-side state:
 
-- download token payload: `{op:"dl", nb, atype, fmt?, exp}`
+- download token payload: `{op:"dl", nb, atype, fmt?, aid?, exp}`
 - upload token payload:   `{op:"ul", nb, title?, mime?, exp}`
 
 Carrying `title`/`mime` in the upload token preserves the current

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -237,6 +237,9 @@ task = artifact_generate(notebook="Quantum Computing", artifact_type="audio")
 artifact_status(notebook="Quantum Computing", task_id="<task_id from above>")   # poll until complete
 artifact_download(notebook="Quantum Computing", artifact_type="audio", path="podcast.mp3")
 
+# Target a specific/older artifact instead of the latest-by-type (full ID or unique prefix):
+artifact_download(notebook="Quantum Computing", artifact_type="audio", path="old_podcast.mp3", artifact_id="aaaaaaaa-aaaa")
+
 # Per-kind styling options are agent-settable, e.g. a custom-styled video:
 artifact_generate(notebook="Quantum Computing", artifact_type="video",
                   style="custom", style_prompt="hand-drawn diagrams")
@@ -272,7 +275,7 @@ a single in-flight task.
 | **Sources** | `source_list(notebook)` (each source has string `kind`/`status_label`) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` |
 | **Chat** | `chat_ask(notebook, question, conversation_id?, references?)` (`references`: lite\|full; never returns the raw debug blob) · `chat_configure(notebook, goal?, response_length?)` |
 | **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
-| **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?)` |
+| **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` |
 | **Server** | `server_info` — version + local auth health |
 

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -48,7 +48,7 @@ from .._app import source_add as add_core
 from ..exceptions import ValidationError
 from ._context import get_client_from_app
 from ._filelink import FileLinkError, FileTransferConfig
-from .tools.artifacts import _DOWNLOAD_SPECS
+from .tools.artifacts import _DOWNLOAD_SPECS, _resolve_artifact_id
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -182,14 +182,29 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         except RuntimeError:
             return PlainTextResponse("Server is not ready.", status_code=500)
 
+        # ``aid`` rides inside the HMAC-signed token, so a non-string value should be
+        # unreachable in practice — but the route treats the token as its source of
+        # truth, and a non-string ``aid`` would make ``_resolve_artifact_id`` raise a
+        # raw ``AttributeError`` (not ``ValidationError``) → a 500. Guard the shape so
+        # a malformed token fails as a clean 400 like any other bad ``aid``.
+        aid = payload.get("aid")
+        if aid is not None and not isinstance(aid, str):
+            return PlainTextResponse(
+                "This download link is invalid.",
+                status_code=400,
+                headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+            )
+
         temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
         temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
         try:
             args: dict[str, object] = {
                 "notebook_id": payload.get("nb"),
                 "output_path": temp_path,
-                "latest": True,
+                "latest": aid is None,
             }
+            if aid is not None:
+                args["artifact_id"] = aid
             fmt = payload.get("fmt")
             if fmt is not None:
                 args[spec.format_param_name] = fmt
@@ -198,9 +213,19 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 plan,
                 client,
                 notebook_resolver=_passthrough_notebook,
-                # download selects by ``latest``, so the artifact resolver is never
-                # invoked — supply the required identity stub inline.
-                artifact_resolver=lambda _artifacts, artifact_id: artifact_id,
+                artifact_resolver=_resolve_artifact_id,
+            )
+        except ValidationError as exc:
+            # A bad ``aid`` in the token — a no-match id (full UUID or prefix) or an
+            # ambiguous prefix (AmbiguousIdError) — surfaces here from
+            # ``_resolve_artifact_id``. Map it to a clean 400 instead of letting it
+            # bubble up as a Starlette 500. (The 409 below stays for the latest-by-type
+            # path when no completed artifact of that type exists yet.)
+            _cleanup(temp_dir)
+            return PlainTextResponse(
+                str(exc),
+                status_code=400,
+                headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
         except BaseException:
             _cleanup(temp_dir)

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -218,9 +218,12 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         except ValidationError as exc:
             # A bad ``aid`` in the token — a no-match id (full UUID or prefix) or an
             # ambiguous prefix (AmbiguousIdError) — surfaces here from
-            # ``_resolve_artifact_id``. Map it to a clean 400 instead of letting it
-            # bubble up as a Starlette 500. (The 409 below stays for the latest-by-type
-            # path when no completed artifact of that type exists yet.)
+            # ``_resolve_artifact_id``. The catch also covers ``build_download_plan``'s
+            # ``DownloadPlanValidationError`` (a ValidationError subclass), which a
+            # broker-minted token won't trigger but is correctly a 400 too. Map it to a
+            # clean 400 instead of letting it bubble up as a Starlette 500. (The 409
+            # below stays for the latest-by-type path when no completed artifact of that
+            # type exists yet.)
             _cleanup(temp_dir)
             return PlainTextResponse(
                 str(exc),

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -296,6 +296,9 @@ def _resolve_artifact_id(artifacts: list[Any], artifact_id: str) -> str:
         id_of=lambda a: a["id"],
         title_of=lambda a: a.get("title"),
     ).id
+    # The full-UUID fast-path returns the caller's casing verbatim; for a prefix
+    # match ``resolved`` is already the list's canonical id. A single
+    # case-insensitive scan normalizes both and confirms membership.
     resolved_lower = resolved.lower()
     for artifact in artifacts:
         if str(artifact["id"]).lower() == resolved_lower:

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -38,6 +38,7 @@ from ..._app import artifacts as artifact_core
 from ..._app import download as download_core
 from ..._app import generate as generate_core
 from ..._app.language import is_supported_language
+from ..._app.resolve import resolve_ref
 from ..._app.serialize import to_jsonable
 from ...exceptions import ValidationError
 from ...types import ArtifactType
@@ -273,9 +274,35 @@ async def _passthrough_download_notebook(notebook_id: str) -> str:
     return notebook_id
 
 
-def _no_partial_artifact(_artifacts: list[Any], artifact_id: str) -> str:
-    """Artifact-id resolver for the download core (MCP passes a full id through)."""
-    return artifact_id
+def _resolve_artifact_id(artifacts: list[Any], artifact_id: str) -> str:
+    """Resolve a full / partial / UUID artifact id against the type-filtered list.
+
+    Wraps the transport-neutral :func:`resolve_ref` (full-UUID fast-path, exact
+    match, unique prefix; ambiguous / no-match prefixes raise ``ValidationError`` /
+    ``AmbiguousIdError``). The fast-path returns a canonical UUID **verbatim**
+    without scanning ``artifacts``, so we match it case-insensitively against the
+    pre-fetched list and return the list's own id. This:
+
+    * fixes uppercase full UUIDs — ``select_artifact`` compares ids
+      case-sensitively, so returning the token's casing would spuriously miss; and
+    * makes a not-found full UUID raise the SAME hard error as a not-found /
+      ambiguous prefix (→ ``ToolError`` on stdio, 400 on the remote route) instead
+      of falling through to the download core's soft ``ERROR`` outcome — matching
+      how ``_resolve.py`` resolves notebooks / sources (every miss is ``NOT_FOUND``).
+    """
+    resolved = resolve_ref(
+        artifact_id,
+        artifacts,
+        id_of=lambda a: a["id"],
+        title_of=lambda a: a.get("title"),
+    ).id
+    resolved_lower = resolved.lower()
+    for artifact in artifacts:
+        if str(artifact["id"]).lower() == resolved_lower:
+            return str(artifact["id"])
+    # Mirror ``select_artifact``'s "Artifact <id> not found" wording so the message
+    # is uniform whether the miss is caught here or by the core.
+    raise ValidationError(f"Artifact {artifact_id} not found")
 
 
 def _is_http_transport() -> bool:
@@ -298,6 +325,7 @@ def _broker_download(
     notebook_id: str,
     artifact_type: str,
     output_format: str | None,
+    artifact_id: str | None = None,
 ) -> ToolResult:
     """Mint a signed download URL + a clickable ``resource_link`` for a remote
     ``artifact_download``.
@@ -310,16 +338,26 @@ def _broker_download(
         "nb": notebook_id,
         "atype": artifact_type,
     }  # op stamped by download_url
+    if artifact_id is not None:
+        payload["aid"] = artifact_id
     if output_format is not None:
         payload["fmt"] = output_format
     url = cfg.download_url(payload)
-    structured = {
+    structured: dict[str, Any] = {
         "status": "download_ready",
         "notebook_id": notebook_id,
         "artifact_type": artifact_type,
         "url": url,
         "expires_at": int(time.time()) + DOWNLOAD_TTL,
     }
+    if artifact_id is not None:
+        # Echo the targeted id the link was brokered for, so the agent's response
+        # records what it asked for (the token carries it, but the structured
+        # payload should be self-describing).
+        structured["artifact_id"] = artifact_id
+        desc = f"Download {artifact_type} artifact {artifact_id} (link expires)."
+    else:
+        desc = f"Download the latest {artifact_type} artifact (link expires)."
     link = ResourceLink(
         type="resource_link",
         name=f"{artifact_type} download",
@@ -327,7 +365,7 @@ def _broker_download(
         # passing the raw str (keeps mypy happy across pydantic-stub versions:
         # a bare str needed a [arg-type] ignore that CI's stubs flagged unused).
         uri=AnyUrl(url),
-        description=f"Download the latest {artifact_type} artifact (link expires).",
+        description=desc,
     )
     return ToolResult(content=[link], structured_content=structured)
 
@@ -542,20 +580,28 @@ def register(mcp: Any) -> None:
             "flashcards",
         ],
         path: str | None = None,
-        output_format: str | None = None,
+        output_format: Literal["pdf", "pptx", "json", "markdown", "html"] | None = None,
+        artifact_id: str | None = None,
     ) -> Any:
         """Download a generated artifact. Accepts a notebook name or ID.
 
         ``artifact_type`` is one of audio|video|slide-deck|infographic|report|
-        mind-map|data-table|quiz|flashcards (the latest artifact of that type is
-        selected). ``output_format`` overrides the default file format where
-        supported: slide-deck → pdf|pptx; quiz/flashcards → json|markdown|html.
+        mind-map|data-table|quiz|flashcards. ``output_format`` overrides the
+        default file format where supported: slide-deck → pdf|pptx; quiz/flashcards
+        → json|markdown|html.
+
+        ``artifact_id`` (optional; full or unique-prefix) targets a specific
+        artifact and overrides latest-by-type. If omitted, the latest artifact
+        of ``artifact_type`` is selected.
 
         Over **stdio** the artifact is written to ``path`` (the output file on the
         server host; required). Over the **remote (http) connector** the server's
         filesystem is unreachable, so the tool instead returns a clickable
         ``resource_link`` plus ``{"status": "download_ready", "url": …}`` — a
-        short-lived signed URL; ``path`` is ignored.
+        short-lived signed URL; ``path`` is ignored. On the remote connector the
+        broker cannot list artifacts, so an ``artifact_id`` is validated lazily when
+        the link is opened (an unknown/ambiguous id then yields a 400), unlike
+        ``output_format``, which is validated up front at the tool call.
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -585,7 +631,7 @@ def register(mcp: Any) -> None:
             if cfg is not None:
                 # Remote connector: broker a signed download URL (the server path is
                 # unreachable). `path` is accepted but ignored.
-                return _broker_download(cfg, nb_id, artifact_type, output_format)
+                return _broker_download(cfg, nb_id, artifact_type, output_format, artifact_id)
             # No file-transfer config. On the remote (http) connector the server
             # filesystem is unreachable REGARDLESS of `path`, so fail clearly here —
             # mirroring source_add type=file — BEFORE any server-side download (else a
@@ -601,8 +647,10 @@ def register(mcp: Any) -> None:
             args: dict[str, Any] = {
                 "notebook_id": nb_id,
                 "output_path": path,
-                "latest": True,
+                "latest": artifact_id is None,
             }
+            if artifact_id is not None:
+                args["artifact_id"] = artifact_id
             if output_format is not None:
                 args[spec.format_param_name] = output_format
             plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
@@ -610,7 +658,7 @@ def register(mcp: Any) -> None:
                 plan,
                 client,
                 notebook_resolver=_passthrough_download_notebook,
-                artifact_resolver=_no_partial_artifact,
+                artifact_resolver=_resolve_artifact_id,
             )
             return to_jsonable(result)
 

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -536,13 +536,27 @@ async def test_artifact_download_unknown_type_is_validation_error(mcp_call, mock
 async def test_artifact_download_bad_format_for_supported_type_is_validation(
     mcp_call, mock_client, tmp_path
 ) -> None:
-    """A bad ``format`` for a type that DOES support format projects VALIDATION."""
+    """A bad ``format`` for a type that DOES support format projects a Literal schema boundary error."""
     out = str(tmp_path / "quiz.json")
     mock_client.artifacts.list = AsyncMock(return_value=[_QUIZ_ARTIFACT])
     with pytest.raises(ToolError) as excinfo:
         await mcp_call(
             "artifact_download",
             {"notebook": NB_ID, "artifact_type": "quiz", "path": out, "output_format": "bogus"},
+        )
+    assert "validation error" in str(excinfo.value)
+
+
+async def test_artifact_download_bad_format_cross_validation_is_validation(
+    mcp_call, mock_client, tmp_path
+) -> None:
+    """An in-union format value that is invalid for the specific type raises a runtime VALIDATION error."""
+    out = str(tmp_path / "quiz.json")
+    mock_client.artifacts.list = AsyncMock(return_value=[_QUIZ_ARTIFACT])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_download",
+            {"notebook": NB_ID, "artifact_type": "quiz", "path": out, "output_format": "pdf"},
         )
     assert "VALIDATION" in str(excinfo.value)
 
@@ -570,6 +584,156 @@ async def test_artifact_download_no_artifacts(mcp_call, mock_client, tmp_path) -
         "artifact_download", {"notebook": NB_ID, "artifact_type": "audio", "path": out}
     )
     assert result.structured_content["outcome"] == "no_artifacts"
+
+
+_AUDIO_ARTIFACT_1 = Artifact(
+    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    title="Podcast 1",
+    _artifact_type=ArtifactTypeCode.AUDIO.value,
+    status=int(ArtifactStatus.COMPLETED),
+    created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+)
+_AUDIO_ARTIFACT_2 = Artifact(
+    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    title="Podcast 2",
+    _artifact_type=ArtifactTypeCode.AUDIO.value,
+    status=int(ArtifactStatus.COMPLETED),
+    created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+)
+
+
+async def test_artifact_download_by_full_id(mcp_call, mock_client, tmp_path) -> None:
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT_1, _AUDIO_ARTIFACT_2])
+    mock_client.artifacts.download_audio = AsyncMock(return_value=out)
+    result = await mcp_call(
+        "artifact_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "audio",
+            "path": out,
+            "artifact_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+    )
+    assert result.structured_content["outcome"] == "single_downloaded"
+    assert result.structured_content["artifact"]["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    mock_client.artifacts.download_audio.assert_awaited_once_with(
+        NB_ID, out, artifact_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    )
+
+
+async def test_artifact_download_by_unique_prefix(mcp_call, mock_client, tmp_path) -> None:
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT_1, _AUDIO_ARTIFACT_2])
+    mock_client.artifacts.download_audio = AsyncMock(return_value=out)
+    result = await mcp_call(
+        "artifact_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "audio",
+            "path": out,
+            "artifact_id": "bbbbbbbb-bbbb",
+        },
+    )
+    assert result.structured_content["outcome"] == "single_downloaded"
+    assert result.structured_content["artifact"]["id"] == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    mock_client.artifacts.download_audio.assert_awaited_once_with(
+        NB_ID, out, artifact_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    )
+
+
+async def test_artifact_download_by_id_not_found(mcp_call, mock_client, tmp_path) -> None:
+    # A not-found ``artifact_id`` (a full UUID absent from the list) is a hard miss,
+    # uniform with a not-found / ambiguous prefix — ``_resolve_artifact_id`` raises
+    # before the download core's soft ERROR path, mirroring how a bad notebook id
+    # surfaces (ToolError / NOT_FOUND).
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT_1, _AUDIO_ARTIFACT_2])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_download",
+            {
+                "notebook": NB_ID,
+                "artifact_type": "audio",
+                "path": out,
+                "artifact_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            },
+        )
+    assert "not found" in str(excinfo.value)
+    mock_client.artifacts.download_audio.assert_not_called()
+
+
+async def test_artifact_download_by_uppercase_full_id(mcp_call, mock_client, tmp_path) -> None:
+    # An uppercase full UUID must still resolve: resolve_ref fast-paths it verbatim,
+    # so _resolve_artifact_id case-insensitively matches it back to the list's
+    # canonical (lowercase) id that select_artifact compares against.
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT_1, _AUDIO_ARTIFACT_2])
+    mock_client.artifacts.download_audio = AsyncMock(return_value=out)
+    result = await mcp_call(
+        "artifact_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "audio",
+            "path": out,
+            "artifact_id": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+        },
+    )
+    assert result.structured_content["outcome"] == "single_downloaded"
+    assert result.structured_content["artifact"]["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    mock_client.artifacts.download_audio.assert_awaited_once_with(
+        NB_ID, out, artifact_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    )
+
+
+async def test_artifact_download_by_id_ambiguous_prefix(mcp_call, mock_client, tmp_path) -> None:
+    out = str(tmp_path / "out.mp3")
+    art_same_1 = Artifact(
+        id="cccccccc-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        title="Podcast A",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    art_same_2 = Artifact(
+        id="cccccccc-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        title="Podcast B",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[art_same_1, art_same_2])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_download",
+            {
+                "notebook": NB_ID,
+                "artifact_type": "audio",
+                "path": out,
+                "artifact_id": "cccccccc",
+            },
+        )
+    assert "Ambiguous ID" in str(excinfo.value)
+    mock_client.artifacts.download_audio.assert_not_called()
+
+
+async def test_artifact_download_latest_preserved(mcp_call, mock_client, tmp_path) -> None:
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT_1, _AUDIO_ARTIFACT_2])
+    mock_client.artifacts.download_audio = AsyncMock(return_value=out)
+    result = await mcp_call(
+        "artifact_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "audio",
+            "path": out,
+        },
+    )
+    assert result.structured_content["outcome"] == "single_downloaded"
+    assert result.structured_content["artifact"]["id"] == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    mock_client.artifacts.download_audio.assert_awaited_once_with(
+        NB_ID, out, artifact_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -189,7 +189,7 @@ async def test_artifact_download_config_rejects_invalid_format_value(mock_client
             "artifact_download",
             {"notebook": NB_ID, "artifact_type": "slide-deck", "output_format": "docx"},
         )
-    assert "VALIDATION" in str(excinfo.value)
+    assert "validation error" in str(excinfo.value)
 
 
 async def test_artifact_download_http_without_config_is_not_configured_error(
@@ -239,3 +239,27 @@ async def test_artifact_download_stdio_missing_path_is_clear_error(mock_client) 
 # The stdio path-download happy path (file_transfer absent) is already covered by
 # ``test_artifacts.py::test_artifact_download_audio`` (its server has no file
 # transfer), so it is not duplicated here.
+
+
+async def test_artifact_download_remote_tool_encodes_aid(mock_client, config) -> None:
+    # under http transport (with config), artifact_download returns download_ready
+    # and the minted token contains aid.
+    result = await _call(
+        mock_client,
+        config,
+        "artifact_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "audio",
+            "artifact_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    # The structured payload echoes the targeted id (self-describing), not only the
+    # token.
+    assert sc["artifact_id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    url = sc["url"]
+    token = url.split("/")[-1]
+    payload = config.signer.verify(token, op="dl")
+    assert payload["aid"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -14,6 +14,7 @@ import contextlib
 import os
 import tempfile
 from collections.abc import AsyncIterator, Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -23,6 +24,10 @@ import pytest
 pytest.importorskip("fastmcp")
 starlette_testclient = pytest.importorskip("starlette.testclient")
 
+from notebooklm._types.artifacts import (  # noqa: E402 - after importorskip guard
+    ArtifactStatus,
+    ArtifactTypeCode,
+)
 from notebooklm.mcp import _fileroutes  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._auth import build_auth_provider  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._filelink import (  # noqa: E402 - after importorskip guard
@@ -30,6 +35,7 @@ from notebooklm.mcp._filelink import (  # noqa: E402 - after importorskip guard
     FileTransferConfig,
 )
 from notebooklm.mcp.server import create_server  # noqa: E402 - after importorskip guard
+from notebooklm.types import Artifact  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -113,6 +119,127 @@ def test_download_route_forwards_fmt_from_token(monkeypatch, mock_client, config
         resp = client.get(_path(url))
     assert resp.status_code == 200
     assert captured["format_choice"] == "markdown"
+
+
+def test_download_route_forwards_aid_from_token(monkeypatch, mock_client, config) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake(plan, client, *, notebook_resolver, artifact_resolver, progress=None):
+        captured["artifact_id"] = plan.artifact_id
+        captured["latest"] = plan.latest
+        # Exercise the resolver to prove it's called
+        artifact_resolver([{"id": "a1", "title": "My Podcast"}], "a1")
+        await notebook_resolver(plan.notebook_id)
+        Path(plan.output_path).write_bytes(b"AUDIO")
+        return _fileroutes.download_core.DownloadResult(
+            outcome=_fileroutes.download_core.DownloadOutcome.SINGLE_DOWNLOADED,
+            artifact={"id": "a1", "title": "My Podcast", "selection_reason": "by id"},
+            output_path=plan.output_path,
+        )
+
+    monkeypatch.setattr(_fileroutes.download_core, "execute_download", fake)
+    app = _build(mock_client, config)
+    url = config.download_url({"nb": NB, "atype": "audio", "aid": "a1"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 200
+    assert captured["artifact_id"] == "a1"
+    assert captured["latest"] is False
+
+
+def test_download_route_latest_unchanged(monkeypatch, mock_client, config) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake(plan, client, *, notebook_resolver, artifact_resolver, progress=None):
+        captured["artifact_id"] = plan.artifact_id
+        captured["latest"] = plan.latest
+        await notebook_resolver(plan.notebook_id)
+        Path(plan.output_path).write_bytes(b"AUDIO")
+        return _fileroutes.download_core.DownloadResult(
+            outcome=_fileroutes.download_core.DownloadOutcome.SINGLE_DOWNLOADED,
+            artifact={"id": "a1", "title": "My Podcast", "selection_reason": "latest"},
+            output_path=plan.output_path,
+        )
+
+    monkeypatch.setattr(_fileroutes.download_core, "execute_download", fake)
+    app = _build(mock_client, config)
+    url = config.download_url({"nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 200
+    assert captured["artifact_id"] is None
+    assert captured["latest"] is True
+
+
+def test_download_route_ambiguous_aid_is_400_not_500(mock_client, config) -> None:
+    # An ambiguous ``aid`` prefix in the token must surface as a clean 400 (the real
+    # ``_resolve_artifact_id`` raises AmbiguousIdError → ValidationError), NOT bubble
+    # up as a Starlette 500. Runs the REAL execute_download (no monkeypatch) so the
+    # resolver actually fires against the mocked artifact list.
+    art_1 = Artifact(
+        id="cccccccc-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        title="Podcast A",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    art_2 = Artifact(
+        id="cccccccc-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        title="Podcast B",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[art_1, art_2])
+    app = _build(mock_client, config)
+    url = config.download_url({"nb": NB, "atype": "audio", "aid": "cccccccc"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 400
+    assert "Ambiguous ID" in resp.text
+
+
+def _one_audio() -> Artifact:
+    return Artifact(
+        id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        title="Podcast A",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_download_route_full_uuid_miss_is_400(mock_client, config) -> None:
+    # A not-found full UUID ``aid`` resolves hard (uniform with a missing prefix) →
+    # 400 with the real "not found" message, not the generic 409 not-ready text.
+    mock_client.artifacts.list = AsyncMock(return_value=[_one_audio()])
+    app = _build(mock_client, config)
+    url = config.download_url(
+        {"nb": NB, "atype": "audio", "aid": "dddddddd-dddd-dddd-dddd-dddddddddddd"}
+    )
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 400
+    assert "not found" in resp.text
+
+
+def test_download_route_no_match_prefix_is_400(mock_client, config) -> None:
+    mock_client.artifacts.list = AsyncMock(return_value=[_one_audio()])
+    app = _build(mock_client, config)
+    url = config.download_url({"nb": NB, "atype": "audio", "aid": "ffff"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 400
+
+
+def test_download_route_non_string_aid_is_400_not_500(mock_client, config) -> None:
+    # A signed token whose ``aid`` is not a string must fail as a clean 400, not a
+    # 500 from ``_resolve_artifact_id`` calling ``.strip()`` on a non-str.
+    app = _build(mock_client, config)
+    url = config.download_url({"nb": NB, "atype": "audio", "aid": 123})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 400
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -136,3 +136,20 @@ async def test_read_only_and_destructive_are_disjoint() -> None:
     assert not (READ_ONLY_TOOLS & DESTRUCTIVE_TOOLS)
     assert READ_ONLY_TOOLS <= EXPECTED_TOOLS
     assert DESTRUCTIVE_TOOLS <= EXPECTED_TOOLS
+
+
+async def test_artifact_download_advertises_artifact_id_and_format_enum(tools_by_name) -> None:
+    """``artifact_download`` advertises the ``artifact_id`` param and an enumerated
+    ``output_format`` so an agent's tool schema can target a specific artifact and
+    pick a valid format (issue #1668)."""
+    import json
+
+    tool = tools_by_name["artifact_download"]
+    properties = tool.inputSchema.get("properties", {})
+    assert "artifact_id" in properties, "artifact_download must expose 'artifact_id'"
+    assert "output_format" in properties, "artifact_download must expose 'output_format'"
+    # output_format is a Literal union → the schema (possibly under anyOf for the
+    # optional ``| None``) must enumerate every supported format value.
+    fmt_schema = json.dumps(properties["output_format"])
+    for value in ("pdf", "pptx", "json", "markdown", "html"):
+        assert value in fmt_schema, f"output_format schema missing {value!r}: {fmt_schema}"


### PR DESCRIPTION
## What & why

Closes #1668. `artifact_download` only ever selected the **latest** artifact of a given type, so an agent that listed artifacts and wanted a specific (or older) one couldn't target it. This adds an optional `artifact_id` parameter (full UUID or unique prefix); latest-by-type is preserved when it's omitted.

The transport-neutral download core (`_app/download.py`) already supported id-targeting via an injected `artifact_resolver` — this wires the MCP adapter to it (the CLI already exposes `-a/--artifact`).

## Changes

- **`_resolve_artifact_id`** replaces the no-op `_no_partial_artifact` stub. It wraps the transport-neutral `_app/resolve.py::resolve_ref` (full-UUID fast-path, exact, unique-prefix, ambiguous/no-match) and is shared by **both** the stdio path and the remote `/files/dl` signed-URL route.
- **Uniform, hard "not found".** The fast-path returns a full UUID verbatim without a membership check, so the resolver now matches it **case-insensitively** against the pre-fetched list and returns the list's canonical id. This (a) fixes uppercase full UUIDs (`select_artifact` compares case-sensitively) and (b) makes a not-found full UUID raise the same hard error as a not-found/ambiguous prefix (→ `ToolError` on stdio, `400` on the remote route) instead of the core's soft `ERROR` outcome — matching how `_resolve.py` resolves notebooks/sources.
- **Remote path.** `artifact_id` rides the signed token as `aid`; `download_route` resolves it (ambiguous/no-match → `400`, not a Starlette `500`). A non-string `aid` in a malformed token is guarded to a clean `400`. The `download_ready` payload echoes `artifact_id`.
- **`output_format` → `Literal["pdf","pptx","json","markdown","html"]`** (the union of all supported formats). Per-type cross-validation still runs at runtime (e.g. `pdf` for `quiz` is rejected); out-of-union values now fail at the schema boundary.
- **Docs:** `mcp-guide.md` (tool table + example), ADR-0024 (token payload gains `aid?`).

## Tests

stdio: download by full id / unique prefix / **uppercase** full id; not-found and ambiguous → `ToolError`; latest-by-type preserved. remote: token encodes + echoes `aid`; route forwards `aid` (`latest=False`) and leaves the default path unchanged; ambiguous / full-UUID-miss / no-match-prefix / non-string `aid` all → `400` (not `500`). Plus a manifest guard that the tool schema advertises `artifact_id` and the `output_format` enum.

## Verification

- `uv run pytest` — full suite green (11106 passed, 78 skipped, 1 xfailed)
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `uv run ruff check . && uv run ruff format --check .` — clean

Reviewed pre-PR with momus (3 models) on the plan and polish (code-simplifier + Claude + Codex) on the diff; the not-found-surface split, the uppercase-UUID bug, and the non-string-`aid` 500 were all caught and fixed in this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to download a specific artifact by full ID or unique prefix (instead of always using the latest).
  * The `artifact_download` tool now exposes an `artifact_id` option and constrains `output_format` to supported values.
* **Bug Fixes**
  * Invalid or ambiguous artifact identifiers now fail fast with clean, user-friendly errors (HTTP 400) rather than unexpected server errors.
  * Download tokens now carry an optional artifact ID when provided.
* **Documentation**
  * Updated the MCP guide and artifacts tool reference to reflect `artifact_id`.
* **Tests**
  * Expanded unit coverage for artifact selection, format validation, and token/route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->