### PR TITLE
feat(mcp): batch source_add via urls=[...] with per-item result list (#1673)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -230,6 +230,25 @@ internal/loopback hosts by default; pass `allow_internal=true` only for
 deliberate local NotebookLM tests. `chat_ask` continues the most-recent
 conversation unless you pass a `conversation_id`.
 
+To ingest many URLs at once, pass `urls` (batch mode) instead of `source_type`
+— one call instead of one round-trip each. The response is an explicit per-item
+list so a partial failure is never hidden behind a single success flag:
+
+```text
+source_add(notebook="Quantum Computing", urls=[
+    "https://arxiv.org/abs/2401.00001",
+    "https://www.youtube.com/watch?v=...",
+])
+# → {"notebook_id": ..., "added": 2, "failed": 0,
+#    "results": [{"input": "https://arxiv.org/abs/2401.00001", "status": "added", "source_id": ..., "title": ...},
+#                {"input": "https://www.youtube.com/watch?v=...", "status": "added", "source_id": ..., "title": ...}]}
+```
+
+Batch mode is URL-only (a non-URL entry is reported as a per-item `VALIDATION`
+error, never added as text); `source_type`/`url`/`text`/`title`/`path`/
+`document_id`/`mime_type` are not valid with `urls`, but `allow_internal`
+applies to every entry.
+
 ### Generate and download a studio artifact
 
 ```text
@@ -272,7 +291,7 @@ a single in-flight task.
 | Domain | Tools |
 |--------|-------|
 | **Notebooks** | `notebook_list` · `notebook_create(title)` · `notebook_describe(notebook)` · `notebook_rename(notebook, new_title)` · `notebook_delete(notebook, confirm)` |
-| **Sources** | `source_list(notebook, status?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` (echoes `kind`/`status_label`; flags a failed import inline with a `warning`) |
+| **Sources** | `source_list(notebook, status?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` (single; echoes `kind`/`status_label`, flags a failed import inline with a `warning`) / `source_add(notebook, urls=[...], allow_internal?)` (batch → per-item `results`) |
 | **Chat** | `chat_ask(notebook, question, conversation_id?, references?, source_ids?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all) · `chat_configure(notebook, goal?, response_length?)` |
 | **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` |

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -8,8 +8,10 @@ the typed result to the wire with :func:`to_jsonable`.
 ``source_add`` is a hybrid over two cores: ``url``/``text``/``file``/``youtube``
 flow through ``_app.source_add`` (``build_source_add_plan`` + ``execute_source_add``);
 ``drive`` flows through ``_app.source_mutations.execute_source_add_drive`` (the
-neutral ``source_add`` core has no Drive path). ``source_wait`` waits for one
-source when ``source`` is given, else every source in the notebook.
+neutral ``source_add`` core has no Drive path). It also has a batch mode
+(``urls=[...]``) that adds many http(s) URLs sequentially and returns an explicit
+per-item result list. ``source_wait`` waits for one source when ``source`` is
+given, else every source in the notebook.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -40,7 +42,7 @@ from ...types import source_status_to_str
 from ...urls import is_youtube_url
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
-from .._errors import mcp_errors
+from .._errors import mcp_errors, tool_error_payload
 from .._filelink import UPLOAD_TTL, FileTransferConfig
 from .._resolve import resolve_notebook, resolve_source
 from ._passthrough import passthrough_child_id
@@ -48,6 +50,7 @@ from ._preview import title_for_id
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
+    from ...types import Source
 
 #: MCP source types. Superset of the neutral ``source_add`` core's types
 #: (which lacks ``drive``); ``drive`` is dispatched to the Drive path.
@@ -338,7 +341,7 @@ def register(mcp: Any) -> None:
     async def source_add(
         ctx: Context,
         notebook: str,
-        source_type: Literal["url", "text", "file", "drive", "youtube"],
+        source_type: Literal["url", "text", "file", "drive", "youtube"] | None = None,
         url: str | None = None,
         text: str | None = None,
         title: str | None = None,
@@ -346,10 +349,14 @@ def register(mcp: Any) -> None:
         document_id: str | None = None,
         mime_type: str | None = None,
         allow_internal: bool = False,
+        urls: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Add a source to a notebook. Accepts a notebook name or ID.
+        """Add a source to a notebook (single or batch). Accepts a notebook name or ID.
 
-        ``source_type`` selects the input and which named argument is required:
+        Call in exactly ONE of two modes:
+
+        **Single mode** — pass ``source_type``; it selects the input and which named
+        argument is required:
 
         * ``url``     — requires ``url``.
         * ``youtube`` — requires ``url`` (a YouTube link).
@@ -369,8 +376,8 @@ def register(mcp: Any) -> None:
           and ``mime_type`` (one of google-doc|google-slides|google-sheets|pdf,
           default google-doc) optional.
 
-        The other named inputs are mutually exclusive — supply only the one your
-        ``source_type`` requires.
+        The single-mode named inputs are mutually exclusive — supply only the one
+        your ``source_type`` requires.
 
         The added source is echoed back under ``source`` with string ``kind`` /
         ``status_label`` labels. Imports are processed ASYNCHRONOUSLY, so the echo
@@ -379,21 +386,74 @@ def register(mcp: Any) -> None:
         ``source_list(status="error")``. When the add response ALREADY reflects a
         failed import, ``source_add`` flags it inline (``status_label="error"`` plus
         a top-level ``warning``) instead of looking like a clean add.
+
+        **Batch mode** — pass ``urls`` (a list of **http/https URLs**, YouTube links
+        included) to add many in one call instead of one round-trip each. Each entry
+        is validated and added independently; the response is an explicit per-item
+        list so partial failure is never hidden::
+
+            {"notebook_id": …, "added": <int>, "failed": <int>,
+             "results": [{"input": "<url>", "status": "added", "source_id": …,
+                          "title": …, "status_label": …, "warning"?: …},
+                         {"input": "<url>", "status": "error",
+                          "error": {"code": …, "message": …, "retriable": …, "hint"?: …}}]}
+
+        ``results`` is positional (``results[i]`` is for ``urls[i]``); ``status`` is
+        ``"added"`` or ``"error"`` (the ADD outcome). An ``"added"`` item also carries
+        the source's ``status_label`` (the async-import status) and, when the add
+        response already reflects a failed import, an inline ``warning`` — same
+        failure-signaling as single mode. A failed item NEVER aborts the rest of the
+        batch and an ``error`` item's ``error`` carries the same structured contract a
+        single-mode failure raises. Batch is URL-only: a non-URL entry (plain text,
+        a local path, ``file://``/``ftp://``) is reported as a per-item ``VALIDATION``
+        error — it is never silently added as text or read off the filesystem.
+        ``allow_internal`` applies to every entry; the other single-mode named inputs
+        (``source_type``/``url``/``text``/``title``/``path``/``document_id``/
+        ``mime_type``) are not valid with ``urls``.
         """
         client = get_client(ctx)
         with mcp_errors():
-            # ``source_type`` is a Literal — FastMCP/Pydantic rejects an unknown value
-            # at the schema boundary, so no runtime membership check is needed.
-            if (
+            # Mode selection (fail-closed) BEFORE any notebook I/O, so a malformed
+            # call never reaches notebooks.list. Exactly one of source_type / urls.
+            if urls is not None and source_type is not None:
+                raise ValidationError(
+                    "provide either 'source_type' (single add) or 'urls' (batch), not both"
+                )
+            if urls is None and source_type is None:
+                raise ValidationError("provide 'source_type' (single add) or 'urls' (batch)")
+            if urls is not None:
+                _reject_batch_scalars(
+                    url=url,
+                    text=text,
+                    title=title,
+                    path=path,
+                    document_id=document_id,
+                    mime_type=mime_type,
+                )
+                if not urls:
+                    raise ValidationError("urls must contain at least one URL")
+            elif (
                 mime_type is not None
                 and source_type == "drive"
                 and mime_type not in _DRIVE_MIME_CHOICES
             ):
+                # Single-mode drive mime validation (kept pre-resolve, as before).
                 raise ValidationError(
                     f"Invalid mime_type {mime_type!r} for drive; "
                     f"expected one of {list(_DRIVE_MIME_CHOICES)}"
                 )
+
             nb_id = await resolve_notebook(client, notebook)
+
+            if urls is not None:
+                return await _add_url_batch(client, nb_id, urls, allow_internal=allow_internal)
+
+            # Single-add mode: the mode checks above guarantee source_type is set.
+            # A hard raise (not assert — stripped under ``python -O``) both narrows
+            # the type for the single-mode dispatch and fails loudly if the
+            # invariant is ever broken by a future edit.
+            if source_type is None:  # pragma: no cover - unreachable given the mode guards
+                raise ValidationError("internal error: source_type unexpectedly None")
 
             if source_type == "file":
                 cfg = get_file_transfer(ctx)
@@ -424,21 +484,16 @@ def register(mcp: Any) -> None:
                 return _add_result_payload(drive_result.source, to_jsonable(drive_result))
 
             content = _select_content(source_type, url=url, text=text, path=path)
-            plan = add_core.build_source_add_plan(
-                content=content,
+            src = await _add_one(
+                client,
+                nb_id,
+                content,
                 source_type=source_type,
                 title=title,
                 mime_type=mime_type,
-                follow_symlinks=False,
-                validate_path=add_core.validate_upload_path,
-                looks_path_shaped=add_core.looks_like_path,
                 allow_internal=allow_internal,
             )
-            add_result = await add_core.execute_source_add(
-                client,
-                add_core.SourceAddExecutionPlan(notebook_id=nb_id, plan=plan),
-            )
-            return _add_result_payload(add_result.source, to_jsonable(add_result))
+            return _add_result_payload(src, to_jsonable(add_core.SourceAddResult(source=src)))
 
 
 def _is_http_transport() -> bool:
@@ -503,6 +558,144 @@ def _broker_upload(
                 f'"{url}?filename=report.pdf"'
             ),
         },
+    }
+
+
+async def _add_one(
+    client: NotebookLMClient,
+    notebook_id: str,
+    content: str,
+    *,
+    source_type: add_core.SourceAddType,
+    title: str | None,
+    mime_type: str | None,
+    allow_internal: bool,
+) -> Source:
+    """Build the source-add plan + execute it, returning the created ``Source``.
+
+    The single seam shared by single-mode and batch-mode ``source_add`` (and the
+    point #1679 layers add-time failure-signaling onto). Callers do their own
+    presence / host validation BEFORE reaching here — single mode via
+    :func:`_select_content` (which keeps the YouTube-host guard), batch mode via
+    the explicit ``source_type="url"`` that forces :func:`add_core.validate_url`.
+    """
+    plan = add_core.build_source_add_plan(
+        content=content,
+        source_type=source_type,
+        title=title,
+        mime_type=mime_type,
+        follow_symlinks=False,
+        validate_path=add_core.validate_upload_path,
+        looks_path_shaped=add_core.looks_like_path,
+        allow_internal=allow_internal,
+    )
+    result = await add_core.execute_source_add(
+        client,
+        add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan),
+    )
+    return result.source
+
+
+def _reject_batch_scalars(
+    *,
+    url: str | None,
+    text: str | None,
+    title: str | None,
+    path: str | None,
+    document_id: str | None,
+    mime_type: str | None,
+) -> None:
+    """Reject single-add scalars supplied alongside the batch ``urls`` param.
+
+    Batch mode derives each title from the server, so the single-add scalars
+    belong to single mode only. ``allow_internal`` is intentionally NOT rejected
+    — it legitimately applies to every URL in the batch.
+    """
+    offenders = [
+        name
+        for name, value in (
+            ("url", url),
+            ("text", text),
+            ("title", title),
+            ("path", path),
+            ("document_id", document_id),
+            ("mime_type", mime_type),
+        )
+        if value is not None
+    ]
+    if offenders:
+        raise ValidationError(
+            "these arguments are not valid with 'urls' (batch mode): " + ", ".join(offenders)
+        )
+
+
+async def _add_url_batch(
+    client: NotebookLMClient,
+    notebook_id: str,
+    urls: list[str],
+    *,
+    allow_internal: bool,
+) -> dict[str, Any]:
+    """Add many http(s) URLs in one call, returning an explicit per-item result list.
+
+    The saving over N single ``source_add`` calls is the per-call MCP/agent
+    round-trip overhead: the URL adds themselves run **sequentially** here, on
+    purpose — concurrent bulk writes invite backend rate-limiting (CLAUDE.md
+    pitfall #4), and a ``RATE_LIMITED`` failure is then isolated per item and
+    surfaced ``retriable=true`` rather than aborting the batch.
+
+    Each entry is added with ``source_type="url"`` so :func:`add_core.validate_url`
+    enforces the http/https scheme allowlist + SSRF guard per item; a non-URL entry
+    (plain text, a local path, ``file://``/``ftp://``) is reported as a per-item
+    ``VALIDATION`` error and is NEVER silently added as text or read off the local
+    filesystem. A per-item failure is isolated (recorded + skipped), never raised,
+    so partial — or total — failure is always visible per item rather than
+    collapsed into one success flag. Results are positional (``results[i]`` ↔
+    ``urls[i]``); the per-item ``error`` reuses the same structured contract a
+    single-mode failure raises.
+
+    An ``"added"`` item also carries the source's ``status_label`` (the async-import
+    status) and, when the add response already reflects a failed import
+    (``is_error``), an inline ``warning`` — mirroring single mode's
+    :func:`_add_result_payload` failure-signaling (#1679) per entry.
+    """
+    results: list[dict[str, Any]] = []
+    for entry in urls:
+        try:
+            src = await _add_one(
+                client,
+                notebook_id,
+                entry,
+                source_type="url",
+                title=None,
+                mime_type=None,
+                allow_internal=allow_internal,
+            )
+        except Exception as exc:  # noqa: BLE001 - per-item isolation; CancelledError (BaseException) still propagates
+            results.append({"input": entry, "status": "error", "error": tool_error_payload(exc)})
+        else:
+            item: dict[str, Any] = {
+                "input": entry,
+                "status": "added",
+                "source_id": src.id,
+                "title": src.title,
+                "status_label": source_status_to_str(src.status),
+            }
+            if src.is_error:
+                item["warning"] = (
+                    "Import failed: the source row was created but processing errored "
+                    "(status_label='error'). Delete it with source_delete, or list "
+                    "failures via source_list(status='error')."
+                )
+            results.append(item)
+    # Derive the tallies from `results` (single source of truth) rather than
+    # maintaining parallel counters that must be kept in sync with each append.
+    added = sum(1 for item in results if item["status"] == "added")
+    return {
+        "notebook_id": notebook_id,
+        "added": added,
+        "failed": len(results) - added,
+        "results": results,
     }
 
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -22,11 +22,13 @@ from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guar
 
 from notebooklm._types.sources import SourceType  # noqa: E402 - after importorskip guard
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    NetworkError,
     RPCError,
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
 )
+from notebooklm.mcp._errors import tool_error_payload  # noqa: E402 - after importorskip guard
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
@@ -801,5 +803,241 @@ async def test_source_add_youtube_accepts_youtube_url(mcp_call, mock_client) -> 
     result = await mcp_call("source_add", {"notebook": NB_ID, "source_type": "youtube", "url": yt})
     assert result.structured_content == {
         "source": {"id": SRC_ID, "title": "Vid", "kind": "web_page", "status_label": "ready"}
+    }
+    mock_client.sources.add_url.assert_awaited_once_with(NB_ID, yt)
+
+
+# --- Batch mode (urls=[...]) -------------------------------------------------
+
+
+async def test_source_add_batch_all_success(mcp_call, mock_client) -> None:
+    """A batch of valid URLs returns a per-item ``added`` list, in input order."""
+    by_url = {
+        "https://example.com/a": FakeSource(id=SRC_ID, title="A"),
+        "https://example.com/b": FakeSource(id=SRC2_ID, title="B"),
+    }
+    mock_client.sources.add_url = AsyncMock(side_effect=lambda _nb, url: by_url[url])
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": ["https://example.com/a", "https://example.com/b"]},
+    )
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "added": 2,
+        "failed": 0,
+        "results": [
+            {
+                "input": "https://example.com/a",
+                "status": "added",
+                "source_id": SRC_ID,
+                "title": "A",
+                "status_label": "ready",
+            },
+            {
+                "input": "https://example.com/b",
+                "status": "added",
+                "source_id": SRC2_ID,
+                "title": "B",
+                "status_label": "ready",
+            },
+        ],
+    }
+    assert mock_client.sources.add_url.await_count == 2
+
+
+async def test_source_add_batch_partial_failure(mcp_call, mock_client) -> None:
+    """One bad URL does NOT abort the batch and is reported per-item, not collapsed."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Good"))
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": ["https://good.example.com", "ftp://bad.example.com"]},
+    )
+    sc = result.structured_content
+    assert sc["added"] == 1
+    assert sc["failed"] == 1
+    assert sc["results"][0] == {
+        "input": "https://good.example.com",
+        "status": "added",
+        "source_id": SRC_ID,
+        "title": "Good",
+        "status_label": "ready",
+    }
+    bad = sc["results"][1]
+    assert bad["input"] == "ftp://bad.example.com"
+    assert bad["status"] == "error"
+    assert bad["error"]["code"] == "VALIDATION"
+    # The disallowed scheme is rejected by validate_url before reaching the client.
+    mock_client.sources.add_url.assert_awaited_once_with(NB_ID, "https://good.example.com")
+
+
+async def test_source_add_batch_non_url_entry_errors_not_text(mcp_call, mock_client) -> None:
+    """Non-URL entries error as VALIDATION — never silently added as text/file."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    mock_client.sources.add_text = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    mock_client.sources.add_file = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": ["just some text", "/etc/hosts"]},
+    )
+    sc = result.structured_content
+    assert sc["added"] == 0
+    assert sc["failed"] == 2
+    assert [item["status"] for item in sc["results"]] == ["error", "error"]
+    assert all(item["error"]["code"] == "VALIDATION" for item in sc["results"])
+    mock_client.sources.add_url.assert_not_called()
+    mock_client.sources.add_text.assert_not_called()
+    mock_client.sources.add_file.assert_not_called()
+
+
+async def test_source_add_batch_server_error_isolated(mcp_call, mock_client) -> None:
+    """A mid-batch server/network failure is isolated to its item; the rest proceed."""
+    mock_client.sources.add_url = AsyncMock(
+        side_effect=[NetworkError("boom"), FakeSource(id=SRC2_ID, title="Second")]
+    )
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": ["https://first.example.com", "https://second.example.com"]},
+    )
+    sc = result.structured_content
+    assert sc["added"] == 1
+    assert sc["failed"] == 1
+    assert sc["results"][0]["status"] == "error"
+    # The per-item error carries the FULL structured contract a single-mode
+    # failure would raise (code/message/retriable/hint), not just a code.
+    assert sc["results"][0]["error"] == tool_error_payload(NetworkError("boom"))
+    assert sc["results"][1] == {
+        "input": "https://second.example.com",
+        "status": "added",
+        "source_id": SRC2_ID,
+        "title": "Second",
+        "status_label": "ready",
+    }
+    assert mock_client.sources.add_url.await_count == 2
+
+
+async def test_source_add_batch_flags_failed_import(mcp_call, mock_client) -> None:
+    """An added-but-errored source is reported status='added' with status_label
+    'error' + an inline warning — the #1679 failure-signaling, per batch item."""
+    mock_client.sources.add_url = AsyncMock(
+        return_value=FakeFailedSource(id=SRC_ID, title="Broken")
+    )
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "urls": ["https://broken.example.com"]}
+    )
+    sc = result.structured_content
+    # The add CALL succeeded (row created) → status 'added'; the async import errored.
+    assert sc["added"] == 1
+    assert sc["failed"] == 0
+    item = sc["results"][0]
+    assert item["status"] == "added"
+    assert item["status_label"] == "error"
+    assert "Import failed" in item["warning"]
+
+
+async def test_source_add_batch_propagates_cancellation(mock_client) -> None:
+    """Per-item isolation must NOT swallow CancelledError (a BaseException)."""
+    import asyncio
+
+    from notebooklm.mcp.tools.sources import _add_url_batch
+
+    mock_client.sources.add_url = AsyncMock(side_effect=asyncio.CancelledError())
+    with pytest.raises(asyncio.CancelledError):
+        await _add_url_batch(mock_client, NB_ID, ["https://example.com/a"], allow_internal=False)
+
+
+async def test_source_add_batch_allow_internal_passthrough(mcp_call, mock_client) -> None:
+    """``allow_internal`` is forwarded to every batch entry (and is not rejected)."""
+    internal = "http://127.0.0.1:8080/x"
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Local"))
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": [internal], "allow_internal": True},
+    )
+    sc = result.structured_content
+    assert sc["added"] == 1
+    mock_client.sources.add_url.assert_awaited_once_with(NB_ID, internal)
+
+
+async def test_source_add_batch_internal_rejected_without_allow_internal(
+    mcp_call, mock_client
+) -> None:
+    """The same internal URL errors per-item (not raised) when allow_internal is off."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    result = await mcp_call(
+        "source_add",
+        {"notebook": NB_ID, "urls": ["http://127.0.0.1:8080/x"]},
+    )
+    sc = result.structured_content
+    assert sc["added"] == 0
+    assert sc["results"][0]["status"] == "error"
+    assert sc["results"][0]["error"]["code"] == "VALIDATION"
+    mock_client.sources.add_url.assert_not_called()
+
+
+async def test_source_add_batch_empty_array_is_validation_error(mcp_call, mock_client) -> None:
+    """An empty ``urls`` list is rejected BEFORE any notebook I/O (uses a name ref)."""
+    mock_client.notebooks.list = AsyncMock(return_value=[])
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_add", {"notebook": "Some Notebook", "urls": []})
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.sources.add_url.assert_not_called()
+    # Mode validation runs before resolve_notebook, so a name is never looked up.
+    mock_client.notebooks.list.assert_not_called()
+
+
+async def test_source_add_batch_conflicts_with_source_type(mcp_call, mock_client) -> None:
+    """``urls`` together with ``source_type`` is an ambiguous-mode VALIDATION error."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_add",
+            {"notebook": NB_ID, "source_type": "url", "urls": ["https://example.com/a"]},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "scalar",
+    [
+        {"url": "https://example.com/x"},
+        {"text": "hi"},
+        {"title": "nope"},
+        {"path": "/tmp/x"},
+        {"document_id": "drivefile123"},
+        {"mime_type": "google-doc"},
+    ],
+)
+async def test_source_add_batch_conflicts_with_scalar(mcp_call, mock_client, scalar) -> None:
+    """ANY single-mode scalar supplied with ``urls`` is rejected (fail-closed)."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_add",
+            {"notebook": NB_ID, "urls": ["https://example.com/a"], **scalar},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.sources.add_url.assert_not_called()
+
+
+async def test_source_add_missing_mode_is_validation_error(mcp_call, mock_client) -> None:
+    """Neither ``source_type`` nor ``urls`` now fails in the body (source_type optional)."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_add", {"notebook": NB_ID})
+    assert "VALIDATION" in str(excinfo.value)
+
+
+async def test_source_add_batch_youtube_accepted(mcp_call, mock_client) -> None:
+    """A YouTube URL in the batch is accepted and added via add_url."""
+    yt = "https://www.youtube.com/watch?v=abc123"
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Vid"))
+    result = await mcp_call("source_add", {"notebook": NB_ID, "urls": [yt]})
+    sc = result.structured_content
+    assert sc["added"] == 1
+    assert sc["results"][0] == {
+        "input": yt,
+        "status": "added",
+        "source_id": SRC_ID,
+        "title": "Vid",
+        "status_label": "ready",
     }
     mock_client.sources.add_url.assert_awaited_once_with(NB_ID, yt)


### PR DESCRIPTION
## Summary
- Adds a **batch mode** to the MCP `source_add` tool: pass `urls=[...]` (http/https, YouTube included) to ingest many URLs in one call instead of one round-trip each (a real Claude Desktop session made 20 calls for 20 blog posts).
- Returns an **explicit per-item result list** so partial failure is never collapsed into one success flag (the anti-pattern called out in the issue):
  ```json
  {"notebook_id": "...", "added": 1, "failed": 1,
   "results": [{"input": "https://good", "status": "added", "source_id": "...", "title": "..."},
               {"input": "ftp://bad", "status": "error",
                "error": {"code": "VALIDATION", "message": "...", "retriable": false, "hint": "..."}}]}
  ```
- **Ceiling-neutral** (per #1685: "the quick-win batch is param-only, no count change") — overloads the existing tool, adds **no** new tool. `tests/unit/mcp/test_manifest.py` count/ceiling unchanged.

## Design
- `source_add` gains an optional `urls` param; `source_type` becomes optional. Exactly one mode per call, validated **fail-closed before notebook resolution**: both-set / neither-set / empty `[]` / any single-mode scalar (`url`/`text`/`title`/`path`/`document_id`/`mime_type`) alongside `urls` → `VALIDATION`. `allow_internal` is the one flag that legitimately co-applies to a batch.
- **URL-only, enforced (security).** Each entry is added with `source_type="url"`, so `validate_url` runs the http/https scheme allowlist + SSRF/internal-host guard per item. A non-URL entry (plain text, a local path, `file://`, `ftp://`) is reported as a per-item `VALIDATION` error and is **never** silently added as text or read off the local filesystem.
- **Failure isolation.** Each item is wrapped in `try/except Exception` (records + continues; `CancelledError`, a `BaseException`, still propagates). The per-item `error` reuses the same `tool_error_payload` `{code, message, retriable, hint?}` contract a single-mode failure raises — no new error vocabulary.
- **Single-add path is byte-identical.** Both single and batch route through a new `_add_one` seam — the point the sibling issue #1679 (add-time failure-signaling) can layer onto a single function rather than two divergent paths. The single-mode YouTube-host guard (`_select_content`) is untouched.

## Task
Closes #1673. Coordinates with #1685 (tool-count decision: param-only) and #1679 (shares the `_add_one` seam).

## Test plan
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Full `uv run pytest` — 11108 passed, 78 skipped, 1 xfailed
- [x] New tests: all-success, partial-failure, all-failure (non-URL → never text/file), mid-batch server-error isolation, empty array, mode conflicts (parametrized over every scalar), missing-mode, YouTube-in-batch, `allow_internal` passthrough (both ways), `CancelledError` propagation, full `tool_error_payload` contract.

## Deferred polish findings
- No batch-size cap / inter-item delay. Intentionally omitted: a per-item `RATE_LIMITED` failure is isolated and surfaced `retriable=true` rather than aborting the batch. Revisit on evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch ingestion for `source_add` using `urls=[...]` to add multiple web/YouTube links in one request.
  * Batch requests return ordered per-item outcomes with `added` and `error` results.
* **Bug Fixes**
  * Improved per-item validation and error reporting for mixed/invalid inputs, including empty lists and conflicting parameters.
  * Ensured cancellation errors propagate correctly during batch processing; also improved handling when a source returns an “added but errored” state.
  * `allow_internal` is now enforced per batch entry.
* **Documentation**
  * Updated the MCP guide and tool reference with the new batch syntax and response details.
* **Tests**
  * Added unit tests for success, partial failure, cancellation, and validation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->