### PR TITLE
fix(mcp): redact secrets in tool errors + hide auth path (#1682)

### DIFF
--- a/src/notebooklm/mcp/_errors.py
+++ b/src/notebooklm/mcp/_errors.py
@@ -16,15 +16,20 @@ Agents branch on ``code`` (back off on ``RATE_LIMITED`` / ``SERVER`` /
 ``TIMEOUT`` / ``ARTIFACT_TIMEOUT`` / ``NETWORK``, re-auth on ``AUTH``, stop on
 ``NOT_FOUND`` / ``VALIDATION``) and on the boolean ``retriable``; the optional
 ``hint`` carries a short remediation string for the actionable categories. The
-``message`` is whitespace-collapsed and length-capped for the wire, but ``code``
-and ``retriable`` are always preserved.
+``message`` is passed through :func:`redact` — the shared package secret-scrubber
+(:func:`notebooklm._logging.scrub_secrets`, which masks bearer tokens / session
+cookies / Google credential shapes) plus two MCP-specific patterns (signed
+``/files/*`` URL tokens and local home-directory paths) — then whitespace-collapsed
+and length-capped for the wire, while ``code`` and ``retriable`` are always
+preserved.
 
-This module imports NO ``click`` / ``rich`` / ``cli`` — only ``fastmcp`` and the
-``_app`` classification core.
+This module imports NO ``click`` / ``rich`` / ``cli`` — only ``fastmcp``, the
+``_app`` classification core, and the package secret-scrubber (``_logging``).
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -32,18 +37,62 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 
 from .._app.errors import ErrorCategory, classify
+from .._logging import scrub_secrets
 from ..exceptions import NotebookLMError
 
 __all__ = [
     "CATEGORY_TABLE",
     "ERROR_CODES",
     "mcp_errors",
+    "redact",
     "to_tool_error",
     "tool_error_payload",
 ]
 
 #: Maximum wire length for a tool-error message before it is truncated.
 _MAX_MESSAGE = 300
+
+#: Generic message returned for an UNEXPECTED (non-library) exception. A bug's
+#: ``str(exc)`` can carry anything (arbitrary paths, env-derived detail), and
+#: :func:`redact` is a *denylist* of known credential/path shapes — so the raw text
+#: of an unexpected error is never echoed. Mirrors the REST server's
+#: ``server/_errors._UNEXPECTED_MESSAGE`` policy (the ``code``/``retriable`` flags
+#: are still preserved so agents branch correctly).
+_UNEXPECTED_MESSAGE = "An unexpected internal error occurred."
+
+#: MCP-specific redaction patterns applied AFTER the shared ``scrub_secrets`` pass
+#: (which already covers bearer tokens / session cookies / Google credential
+#: shapes). Two surfaces only the MCP transport produces:
+#:
+#: 1. **Signed file-transfer URL tokens.** The ``/files/(dl|ul)/<token>``
+#:    side-channel (ADR-0024) carries an HMAC token ``b64url(body).b64url(mac)``;
+#:    the route prefix is kept as a shape hint and the whole token segment is
+#:    dropped. The dot-inclusive class redacts the entire segment regardless of dot
+#:    count (a malformed ``/files/dl/a.b.c`` leaves no ``.c`` tail), and it stops at
+#:    ``/``, ``?``, whitespace, or end — so a token inside a full
+#:    ``https://host/files/dl/<tok>?x=1`` URL is redacted in place.
+#: 2. **Home-directory paths** (the OS username is PII / host disclosure). The
+#:    username segment allows at most one embedded space (covers ``First Last``
+#:    macOS/Windows account names) and REQUIRES a following path separator, so a
+#:    username with a space is redacted WITHOUT eating prose across multiple paths:
+#:    a naive ``[^/]+`` would greedily cross prose to a later ``/`` (e.g.
+#:    ``/home/alice or /home/bob/x`` would swallow ``" or "``). Deliberate bounds
+#:    (fail-safe): a bare terminal ``/home/<user>`` (no following component) and a
+#:    username with two+ spaces are left alone; ``/Users/Shared/…`` over-redacts —
+#:    all err toward not mangling the message. Generic absolute paths
+#:    (``/var``/``/tmp``) are intentionally NOT redacted (would mangle id-shaped
+#:    ``NOT_FOUND``/RPC text for little gain).
+_EXTRA_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(/files/(?:dl|ul)/)[A-Za-z0-9._-]+"), r"\1***"),
+    (re.compile(r"(/(?:home|Users)/)[^/ \r\n]+(?: [^/ \r\n]+)?(?=/)"), r"\1***"),
+    (
+        re.compile(
+            r"([A-Za-z]:[\\/]Users[\\/])[^\\/ \r\n]+(?: [^\\/ \r\n]+)?(?=[\\/])",
+            re.IGNORECASE,
+        ),
+        r"\1***",
+    ),
+)
 
 #: The MCP projection of each neutral :class:`ErrorCategory`: ``(code, hint)``.
 #: Covers EVERY ``ErrorCategory`` value (pinned by ``test_errors.py``). ``hint``
@@ -103,17 +152,28 @@ CATEGORY_TABLE: dict[ErrorCategory, tuple[str, str | None]] = {
 ERROR_CODES: frozenset[str] = frozenset(code for code, _ in CATEGORY_TABLE.values())
 
 
-def _redact(message: str) -> str:
-    """Collapse whitespace and length-cap a message for the wire.
+def redact(message: str) -> str:
+    """Scrub secrets, collapse whitespace, and length-cap a message for the wire.
 
     SDK exception messages are already designed to be secret-free (raw responses
-    are truncated at construction, per ADR-0019); we additionally cap the length
-    so an unexpectedly long body cannot bloat the tool-error payload.
+    are truncated at construction, per ADR-0019), but a tool-error message can also
+    carry upstream text or local paths. As defense-in-depth this runs the shared
+    package scrubber (:func:`notebooklm._logging.scrub_secrets`, masking bearer
+    tokens / session cookies / Google credential shapes) and the MCP-specific
+    :data:`_EXTRA_PATTERNS` (signed ``/files/*`` URL tokens + local home-directory
+    paths), THEN collapses whitespace and caps the length. Redaction runs **before**
+    the length cap so a secret sitting near the cap can never be partially revealed.
+
+    The single chokepoint is reused by both :func:`tool_error_payload` (MCP
+    JSON-RPC tool errors) and the ``/files/*`` route handlers (:mod:`._fileroutes`).
     """
-    message = " ".join(message.split())
-    if len(message) > _MAX_MESSAGE:
-        message = message[:_MAX_MESSAGE] + "…"
-    return message
+    text = scrub_secrets(message)
+    for pattern, replacement in _EXTRA_PATTERNS:
+        text = pattern.sub(replacement, text)
+    text = " ".join(text.split())
+    if len(text) > _MAX_MESSAGE:
+        text = text[:_MAX_MESSAGE] + "…"
+    return text
 
 
 def tool_error_payload(exc: BaseException) -> dict[str, Any]:
@@ -121,13 +181,19 @@ def tool_error_payload(exc: BaseException) -> dict[str, Any]:
 
     The category + retriability come from :func:`_app.errors.classify`; the code
     and hint come from :data:`CATEGORY_TABLE`. ``hint`` is omitted entirely when
-    the category has no remediation string.
+    the category has no remediation string. For the UNEXPECTED category (a
+    non-library bug, whose ``str(exc)`` could carry anything ``redact`` does not
+    know to scrub) the message is the fixed :data:`_UNEXPECTED_MESSAGE` rather than
+    the redacted exception text.
     """
     classified = classify(exc)
     code, hint = CATEGORY_TABLE[classified.category]
+    message = (
+        _UNEXPECTED_MESSAGE if classified.category is ErrorCategory.UNEXPECTED else redact(str(exc))
+    )
     payload: dict[str, Any] = {
         "code": code,
-        "message": _redact(str(exc)),
+        "message": message,
         "retriable": classified.retriable,
     }
     if hint is not None:

--- a/src/notebooklm/mcp/_errors.py
+++ b/src/notebooklm/mcp/_errors.py
@@ -72,22 +72,30 @@ _UNEXPECTED_MESSAGE = "An unexpected internal error occurred."
 #:    ``/``, ``?``, whitespace, or end — so a token inside a full
 #:    ``https://host/files/dl/<tok>?x=1`` URL is redacted in place.
 #: 2. **Home-directory paths** (the OS username is PII / host disclosure). The
-#:    username segment allows at most one embedded space (covers ``First Last``
-#:    macOS/Windows account names) and REQUIRES a following path separator, so a
-#:    username with a space is redacted WITHOUT eating prose across multiple paths:
-#:    a naive ``[^/]+`` would greedily cross prose to a later ``/`` (e.g.
-#:    ``/home/alice or /home/bob/x`` would swallow ``" or "``). Deliberate bounds
-#:    (fail-safe): a bare terminal ``/home/<user>`` (no following component) and a
-#:    username with two+ spaces are left alone; ``/Users/Shared/…`` over-redacts —
-#:    all err toward not mangling the message. Generic absolute paths
-#:    (``/var``/``/tmp``) are intentionally NOT redacted (would mangle id-shaped
-#:    ``NOT_FOUND``/RPC text for little gain).
+#:    username matcher (:data:`_HOME_USER`) is a word token (alphanumerics /
+#:    underscore with INTERNAL dots/hyphens — ``john.doe``, ``web-admin`` — but no
+#:    leading/trailing punctuation, so a trailing ``.``/``:``/``)`` of surrounding
+#:    prose is never eaten). Two cases:
+#:      * a single-word username is redacted ANYWHERE (no trailing separator
+#:        needed — it has no space, so it cannot greedily cross prose), so a bare
+#:        terminal ``/home/alice`` and ``/home/alice: denied`` are both masked
+#:        while the prose survives;
+#:      * a ``First Last`` username (one space) is only redacted when followed by a
+#:        path separator, so the space cannot swallow following prose across
+#:        multiple paths (``/home/a or /home/b/x`` must not become ``/home/***/x``).
+#:    Deliberate fail-safe bounds: a two-word username NOT followed by a separator
+#:    masks only its first word; ``/Users/Shared/…`` over-redacts; both err toward
+#:    not mangling the message. Generic absolute paths (``/var``/``/tmp``) are
+#:    intentionally NOT redacted (would mangle id-shaped ``NOT_FOUND``/RPC text for
+#:    little gain). The token alternation is anchored on disjoint character classes
+#:    (no overlapping quantifiers), so there is no catastrophic-backtracking risk.
+_HOME_USER = r"\w+(?:[.-]+\w+)*"
 _EXTRA_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(/files/(?:dl|ul)/)[A-Za-z0-9._-]+"), r"\1***"),
-    (re.compile(r"(/(?:home|Users)/)[^/ \r\n]+(?: [^/ \r\n]+)?(?=/)"), r"\1***"),
+    (re.compile(rf"(/(?:home|Users)/)(?:{_HOME_USER} {_HOME_USER}(?=/)|{_HOME_USER})"), r"\1***"),
     (
         re.compile(
-            r"([A-Za-z]:[\\/]Users[\\/])[^\\/ \r\n]+(?: [^\\/ \r\n]+)?(?=[\\/])",
+            rf"([A-Za-z]:[\\/]Users[\\/])(?:{_HOME_USER} {_HOME_USER}(?=[\\/])|{_HOME_USER})",
             re.IGNORECASE,
         ),
         r"\1***",

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -90,10 +90,15 @@ _HTML_SECURITY_HEADERS = {
 #: This mirrors the REST server's ``CATEGORY_STATUS`` but is defined locally — the
 #: MCP layer must NOT import ``notebooklm.server`` (it pulls ``fastapi``; the
 #: boundary is enforced by ``tests/_guardrails/test_mcp_boundary.py``). Deliberate
-#: deviation: ``AUTH`` / ``CONFIG`` → **502**, not 401/500. These routes are
-#: authenticated by the signed token, so a *server-side* broken Google session is
-#: an upstream-dependency failure (Bad Gateway) the token-bearing caller cannot fix
-#: by re-authenticating — 401 would be misleading.
+#: deviations from the REST table (because these routes are a *gateway* to the
+#: NotebookLM backend, not the backend itself): ``AUTH`` / ``CONFIG`` → **502**, not
+#: 401/500 — they are authenticated by the signed token, so a *server-side* broken
+#: Google session is an upstream-dependency failure (Bad Gateway) the token-bearing
+#: caller cannot fix by re-authenticating (401 would be misleading); and
+#: ``LIBRARY`` → **502**, not 500, for the same gateway reason (an unclassified
+#: library error reaching here is still an upstream failure, not an internal bug of
+#: the route). ``UNEXPECTED`` stays 500 (a genuine route bug) but is unreachable via
+#: :func:`_upstream_error_response`, which only takes ``NotebookLMError``.
 _FILE_ROUTE_STATUS: dict[ErrorCategory, int] = {
     ErrorCategory.NOT_FOUND: 404,
     ErrorCategory.AUTH: 502,

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -45,8 +45,10 @@ from starlette.responses import (
 
 from .._app import download as download_core
 from .._app import source_add as add_core
-from ..exceptions import ValidationError
+from .._app.errors import ErrorCategory, classify
+from ..exceptions import NotebookLMError, ValidationError
 from ._context import get_client_from_app
+from ._errors import redact
 from ._filelink import FileLinkError, FileTransferConfig
 from .tools.artifacts import _DOWNLOAD_SPECS
 
@@ -81,6 +83,52 @@ _HTML_SECURITY_HEADERS = {
         "connect-src 'self'; form-action 'none'; base-uri 'none'"
     ),
 }
+
+
+#: HTTP status each neutral :class:`ErrorCategory` projects onto for the
+#: ``/files/*`` routes. Covers EVERY category (pinned by ``test_fileroutes.py``).
+#: This mirrors the REST server's ``CATEGORY_STATUS`` but is defined locally — the
+#: MCP layer must NOT import ``notebooklm.server`` (it pulls ``fastapi``; the
+#: boundary is enforced by ``tests/_guardrails/test_mcp_boundary.py``). Deliberate
+#: deviation: ``AUTH`` / ``CONFIG`` → **502**, not 401/500. These routes are
+#: authenticated by the signed token, so a *server-side* broken Google session is
+#: an upstream-dependency failure (Bad Gateway) the token-bearing caller cannot fix
+#: by re-authenticating — 401 would be misleading.
+_FILE_ROUTE_STATUS: dict[ErrorCategory, int] = {
+    ErrorCategory.NOT_FOUND: 404,
+    ErrorCategory.AUTH: 502,
+    ErrorCategory.RATE_LIMITED: 429,
+    ErrorCategory.VALIDATION: 400,
+    ErrorCategory.CONFIG: 502,
+    ErrorCategory.NETWORK: 502,
+    ErrorCategory.NOTEBOOK_LIMIT: 409,
+    ErrorCategory.ARTIFACT_TIMEOUT: 504,
+    ErrorCategory.TIMEOUT: 504,
+    ErrorCategory.SERVER: 502,
+    ErrorCategory.RPC: 502,
+    ErrorCategory.SOURCE_MUTATION: 422,
+    ErrorCategory.LIBRARY: 502,
+    ErrorCategory.UNEXPECTED: 500,
+}
+
+
+def _upstream_error_response(exc: NotebookLMError) -> PlainTextResponse:
+    """Project an upstream ``NotebookLMError`` onto a classified, redacted response.
+
+    A ``NotebookLMError`` raised inside a ``/files/*`` handler (e.g. the artifact
+    ``list`` RPC inside ``execute_download``, which is not wrapped by the core, or
+    ``execute_source_add``) would otherwise escape to a raw Starlette 500. Classify
+    it via the shared :func:`_app.errors.classify`, map the category to an HTTP
+    status, and return the secret-scrubbed message (the same :func:`redact`
+    chokepoint the MCP tool errors use). ``.get(..., 502)`` is defense-in-depth —
+    every category is in the table (pinned by a coverage test).
+    """
+    status = _FILE_ROUTE_STATUS.get(classify(exc).category, 502)
+    return PlainTextResponse(
+        f"Upstream NotebookLM error: {redact(str(exc))}",
+        status_code=status,
+        headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+    )
 
 
 def _safe_upload_name(filename: str | None) -> str:
@@ -202,6 +250,14 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 # invoked — supply the required identity stub inline.
                 artifact_resolver=lambda _artifacts, artifact_id: artifact_id,
             )
+        except NotebookLMError as exc:
+            # An upstream error raised out of the core (e.g. the artifact ``list``
+            # RPC inside ``execute_download`` is not wrapped) would otherwise become
+            # a raw 500. Classify + redact it instead. (Failures that the core
+            # *returns* as a non-success ``DownloadResult`` fall through to the
+            # generic 409 below — that path already leaks nothing.)
+            _cleanup(temp_dir)
+            return _upstream_error_response(exc)
         except BaseException:
             _cleanup(temp_dir)
             raise
@@ -334,7 +390,18 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                     headers=_HTML_SECURITY_HEADERS,
                 )
             except ValidationError as exc:
-                return PlainTextResponse(f"Upload rejected: {exc}", status_code=400)
+                # ValidationError ⊂ NotebookLMError, so this MUST precede the
+                # NotebookLMError handler. ``validate_upload_path`` rejections can
+                # embed the local file path, so the detail is redacted.
+                return PlainTextResponse(
+                    f"Upload rejected: {redact(str(exc))}",
+                    status_code=400,
+                    headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+                )
+            except NotebookLMError as exc:
+                # An upstream auth/server/rate-limit error from execute_source_add
+                # (add_file → RPC) would otherwise escape as a raw 500.
+                return _upstream_error_response(exc)
             except OSError:
                 # A bad filename / fs error (e.g. a name that survives sanitization
                 # but the fs rejects) is a clean 400, not a bare 500.

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -45,10 +45,15 @@ def register(mcp: Any) -> None:
         """Report the server version and local authentication health.
 
         Takes no arguments. Returns the package ``version`` and an ``auth`` block
-        (``authenticated`` / ``storage_exists`` / ``sid_cookie`` / ``profile`` /
-        ``storage_path``). Use it to confirm the server is logged in before
-        driving notebook tools; if ``authenticated`` is false, run
+        (``authenticated`` / ``storage_exists`` / ``json_valid`` / ``cookies_present``
+        / ``sid_cookie`` / ``profile``). Use it to confirm the server is logged in
+        before driving notebook tools; if ``authenticated`` is false, run
         ``notebooklm login`` on the server host.
+
+        The absolute on-disk storage path is deliberately **not** returned: it
+        leaks the server-host OS username / filesystem layout to any (possibly
+        remote) caller, while telling the agent nothing it can act on. The
+        ``profile`` name + booleans are sufficient to diagnose auth health.
         """
         with mcp_errors():
             profile = get_active_profile()
@@ -73,6 +78,5 @@ def register(mcp: Any) -> None:
                     "cookies_present": bool(result.checks.get("cookies_present")),
                     "sid_cookie": bool(result.checks.get("sid_cookie")),
                     "profile": profile,
-                    "storage_path": str(storage_path),
                 },
             }

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -32,6 +32,7 @@ from notebooklm.mcp._errors import (  # noqa: E402 - after importorskip guard
     CATEGORY_TABLE,
     ERROR_CODES,
     mcp_errors,
+    redact,
     to_tool_error,
     tool_error_payload,
 )
@@ -173,3 +174,120 @@ def test_mcp_errors_propagates_base_exceptions() -> None:
 
     with pytest.raises(asyncio.CancelledError), mcp_errors():
         raise asyncio.CancelledError
+
+
+# --------------------------------------------------------------------------- #
+# redact() — secret / path pattern redaction (#1682)
+# --------------------------------------------------------------------------- #
+def test_redact_strips_bearer_token() -> None:
+    """An ``Authorization: Bearer`` header value is masked (via scrub_secrets).
+
+    Uses the header form (which redacts ANY value) rather than a bare token, whose
+    shape regex intentionally ignores short non-realistic tokens.
+    """
+    out = redact("RPC failed: Authorization: Bearer ya29.s3cr3t-Token_VALUE-abc123")
+    assert "ya29.s3cr3t-Token_VALUE-abc123" not in out
+    assert "Bearer" in out  # the header name survives as a shape hint
+
+
+def test_redact_strips_session_cookie_values() -> None:
+    """A ``Cookie:`` header and a ``__Secure-*`` cookie value are masked."""
+    out = redact("boom Cookie: SID=AAAA1111secret; HSID=BBBB2222secret")
+    assert "AAAA1111secret" not in out
+    assert "BBBB2222secret" not in out
+    out2 = redact("__Secure-1PSIDTS=zzzzSECRETvalue")
+    assert "zzzzSECRETvalue" not in out2
+
+
+def test_redact_strips_signed_files_url_token_bare_and_in_url() -> None:
+    """The ``/files/(dl|ul)/<token>`` side-channel token is redacted."""
+    bare = redact("link is /files/dl/eyJvcCI6ImRsIn0.ZmFrZW1hYw and expired")
+    assert "/files/dl/***" in bare
+    assert "eyJvcCI6ImRsIn0" not in bare
+    in_url = redact("open https://files.test/files/ul/eyJvcCI6InVsIn0.bWFjbWFj?x=1 now")
+    assert "/files/ul/***" in in_url
+    assert "eyJvcCI6InVsIn0" not in in_url
+    # A malformed multi-dot token leaves no tail.
+    multidot = redact("/files/dl/a.b.c")
+    assert multidot == "/files/dl/***"
+
+
+@pytest.mark.parametrize(
+    ("message", "leaked", "expected_fragment"),
+    [
+        (
+            "open /home/alice/.notebooklm/default/storage_state.json failed",
+            "alice",
+            "/home/***/.notebooklm/default/storage_state.json",
+        ),
+        # macOS account name with a space (the round-1 codex concern).
+        (
+            "read /Users/Alice Smith/Library/data.json",
+            "Smith",
+            "/Users/***/Library/data.json",
+        ),
+        # Windows account name with a space.
+        (r"open C:\Users\Bob Smith\app\state failed", "Bob", r"C:\Users\***\app\state"),
+    ],
+)
+def test_redact_masks_home_directory_usernames(message, leaked, expected_fragment) -> None:
+    out = redact(message)
+    assert leaked not in out
+    assert expected_fragment in out
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Bare terminal home dir (no following path component) is left alone so we
+        # never eat trailing prose.
+        "/home/alice: permission denied",
+        # Multi-path prose must NOT be eaten reaching for a later separator.
+        "Could not find /home/alice or /home/bob/config",
+        "/Users/Alice Smith: permission denied for /Users/Bob/x",
+    ],
+)
+def test_redact_never_eats_prose_between_paths(message) -> None:
+    out = redact(message)
+    # The prose words between path-ish fragments survive verbatim.
+    for word in ("permission", "denied", "Could", "find", "or", "for"):
+        if word in message:
+            assert word in out
+
+
+def test_redact_does_not_eat_prose_first_segment_examples() -> None:
+    """Exact-output guards for the two multi-path prose cases."""
+    assert (
+        redact("Could not find /home/alice or /home/bob/config")
+        == "Could not find /home/alice or /home/***/config"
+    )
+    assert (
+        redact("/Users/Alice Smith: permission denied for /Users/Bob/x")
+        == "/Users/Alice Smith: permission denied for /Users/***/x"
+    )
+
+
+def test_unexpected_exception_message_is_generic_not_raw_text() -> None:
+    """A non-library bug's raw ``str(exc)`` is never echoed (redact is a denylist).
+
+    ``redact`` only masks KNOWN credential/path shapes, so an unexpected exception
+    could otherwise leak arbitrary text (env detail, non-home paths). The UNEXPECTED
+    category therefore returns a fixed generic message while preserving code +
+    retriable (mirrors the REST server policy).
+    """
+    leaky = RuntimeError("kaboom: opened /var/lib/notebooklm/secret.cfg key=hunter2")
+    payload = tool_error_payload(leaky)
+    assert payload["code"] == "UNEXPECTED"
+    assert payload["retriable"] is False
+    assert "secret.cfg" not in payload["message"]
+    assert "hunter2" not in payload["message"]
+    assert "/var/lib/notebooklm" not in payload["message"]
+
+
+def test_redact_runs_before_truncation_so_secret_not_half_cut() -> None:
+    """A secret sitting near the length cap must be fully redacted, never half-shown."""
+    filler = "x" * 290
+    secret = "AAAA1111-this-is-a-secret-cookie-value"
+    out = redact(f"{filler} Cookie: SID={secret}")
+    assert secret not in out
+    assert "1111-this-is-a-secret" not in out  # no partial tail survived the cap

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -239,8 +239,8 @@ def test_redact_masks_home_directory_usernames(message, leaked, expected_fragmen
 @pytest.mark.parametrize(
     "message",
     [
-        # Bare terminal home dir (no following path component) is left alone so we
-        # never eat trailing prose.
+        # A single-word terminal username IS redacted, but surrounding prose /
+        # punctuation must survive verbatim.
         "/home/alice: permission denied",
         # Multi-path prose must NOT be eaten reaching for a later separator.
         "Could not find /home/alice or /home/bob/config",
@@ -255,16 +255,45 @@ def test_redact_never_eats_prose_between_paths(message) -> None:
             assert word in out
 
 
-def test_redact_does_not_eat_prose_first_segment_examples() -> None:
-    """Exact-output guards for the two multi-path prose cases."""
+def test_redact_masks_terminal_and_punctuation_bounded_usernames() -> None:
+    """A single-word username is redacted even without a trailing separator.
+
+    It cannot eat prose (the token stops at whitespace/punctuation), so requiring a
+    trailing ``/`` would needlessly leak terminal usernames (gemini #1695). Internal
+    dots/hyphens are part of the name; a trailing ``.``/``)`` of prose is preserved.
+    """
+    assert redact("dir is /home/alice") == "dir is /home/***"
+    assert redact("/home/alice: permission denied") == "/home/***: permission denied"
+    assert redact("Could not find /home/alice.") == "Could not find /home/***."
+    assert redact("see (/home/alice)") == "see (/home/***)"
+    assert redact("/home/john.doe/x") == "/home/***/x"  # internal dot kept inside name
+    assert redact("/home/web-admin") == "/home/***"  # internal hyphen kept inside name
+
+
+def test_redact_exact_output_for_multi_path_prose() -> None:
+    """Exact-output guards: every path component is masked, all prose survives."""
     assert (
         redact("Could not find /home/alice or /home/bob/config")
-        == "Could not find /home/alice or /home/***/config"
+        == "Could not find /home/*** or /home/***/config"
     )
+    # A two-word username NOT followed by a separator masks only its first word
+    # (documented fail-safe bound); the prose is still fully preserved.
     assert (
         redact("/Users/Alice Smith: permission denied for /Users/Bob/x")
-        == "/Users/Alice Smith: permission denied for /Users/***/x"
+        == "/Users/*** Smith: permission denied for /Users/***/x"
     )
+
+
+def test_redact_home_pattern_capture_group_is_only_the_prefix() -> None:
+    """The ``\\1`` capture is just the ``/home/`` prefix — the username is the part
+    dropped, not coincidentally preserved (gemini #1695 testing guidance)."""
+    from notebooklm.mcp._errors import _EXTRA_PATTERNS
+
+    home_pattern = _EXTRA_PATTERNS[1][0]
+    m = home_pattern.search("Could not find /home/alice")
+    assert m is not None
+    assert m.group(1) == "/home/"
+    assert m.group(0) == "/home/alice"  # the whole match (prefix + username) is replaced
 
 
 def test_unexpected_exception_message_is_generic_not_raw_text() -> None:

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -392,3 +392,107 @@ def test_lifespan_not_set_returns_500(mock_client, config) -> None:
     client = starlette_testclient.TestClient(app)
     resp = client.get(_path(url))
     assert resp.status_code == 500
+
+
+# --------------------------------------------------------------------------- #
+# Upstream-error classification + redaction (#1682)
+# --------------------------------------------------------------------------- #
+def _raising_download(exc: BaseException):
+    async def fake(plan, client, *, notebook_resolver, artifact_resolver, progress=None):
+        raise exc
+
+    return fake
+
+
+def test_download_raised_auth_error_is_502_not_raw_500(monkeypatch, mock_client, config) -> None:
+    # A NotebookLMError raised out of execute_download (e.g. the unwrapped artifact
+    # list RPC) must classify to a clean status, not bubble up as a raw Starlette 500.
+    from notebooklm.exceptions import AuthError
+
+    monkeypatch.setattr(
+        _fileroutes.download_core,
+        "execute_download",
+        _raising_download(AuthError("session expired: cookie SID=AAAA1111secret")),
+    )
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 502  # AUTH → 502 (token-authed route; upstream failure)
+    assert "AAAA1111secret" not in resp.text  # the cookie value is redacted
+
+
+def test_download_raised_not_found_is_404(monkeypatch, mock_client, config) -> None:
+    from notebooklm.exceptions import NotFoundError
+
+    monkeypatch.setattr(
+        _fileroutes.download_core,
+        "execute_download",
+        _raising_download(NotFoundError("notebook gone")),
+    )
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 404
+
+
+def test_download_returned_error_outcome_stays_409_and_hides_detail(
+    monkeypatch, mock_client, config
+) -> None:
+    # A FAILURE the core *returns* (DownloadOutcome.ERROR, e.g. a full-id not-found)
+    # stays a generic 409 with the error detail discarded — deliberately NOT
+    # re-statused to 502 (that would regress not-found) and never leaks result.error.
+    async def fake(plan, client, *, notebook_resolver, artifact_resolver, progress=None):
+        return _fileroutes.download_core.DownloadResult(
+            outcome=_fileroutes.download_core.DownloadOutcome.ERROR,
+            error="boom /home/secretuser/leak.json",
+        )
+
+    monkeypatch.setattr(_fileroutes.download_core, "execute_download", fake)
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 409
+    assert "secretuser" not in resp.text
+    assert "leak.json" not in resp.text
+
+
+def test_upload_raised_server_error_is_502(monkeypatch, mock_client, config) -> None:
+    from notebooklm.exceptions import ServerError
+
+    async def fake(client, exec_plan):
+        raise ServerError("upstream 503")
+
+    monkeypatch.setattr(_fileroutes.add_core, "execute_source_add", fake)
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert resp.status_code == 502
+
+
+def test_upload_validation_error_redacts_local_path(monkeypatch, mock_client, config) -> None:
+    # A validate-path rejection can embed the local file path; the 400 body must be
+    # redacted (the home-dir username masked) while keeping the friendly prefix.
+    from notebooklm.exceptions import ValidationError
+
+    async def fake(client, exec_plan):
+        raise ValidationError("path /home/secretuser/private/x.pdf is not allowed")
+
+    monkeypatch.setattr(_fileroutes.add_core, "execute_source_add", fake)
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert resp.status_code == 400
+    assert "Upload rejected:" in resp.text
+    assert "secretuser" not in resp.text  # home-dir username redacted
+
+
+def test_file_route_status_table_covers_every_error_category() -> None:
+    """Every ``ErrorCategory`` has a file-route status (no silent fallback)."""
+    from notebooklm._app.errors import ErrorCategory
+
+    assert set(_fileroutes._FILE_ROUTE_STATUS) == set(ErrorCategory)

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -60,3 +60,25 @@ async def test_server_info_auth_present(mcp_call, mock_client, tmp_path, monkeyp
     assert auth["storage_exists"] is True
     assert auth["sid_cookie"] is True
     assert auth["authenticated"] is True
+
+
+async def test_server_info_does_not_leak_absolute_storage_path(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """Security (#1682): the absolute auth storage path must never reach a caller.
+
+    ``server_info`` is readable by any authenticated (possibly remote) client, so
+    it must not disclose the server-host OS username / filesystem layout. It returns
+    only the ``profile`` name + auth booleans.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    result = await mcp_call("server_info")
+    auth = result.structured_content["auth"]
+    # No path-shaped field is exposed...
+    assert "storage_path" not in auth
+    # ...and the resolved storage directory does not appear anywhere in the payload
+    # (guards against a path leaking via any other key, present or future).
+    assert str(tmp_path) not in json.dumps(result.structured_content)
+    # The non-sensitive identity fields are still present.
+    assert "profile" in auth
+    assert "authenticated" in auth


### PR DESCRIPTION
## Summary

Closes #1682. Three MCP info-leak hardenings from the Codex security review, all behind the opt-in `mcp` extra:

1. **`server_info` no longer returns the absolute auth storage path.** It disclosed the server-host OS username / filesystem layout to any (possibly remote) authenticated caller while telling the agent nothing actionable. The `auth` block now returns only the `profile` name + health booleans (`authenticated`/`storage_exists`/`json_valid`/`cookies_present`/`sid_cookie`).

2. **`mcp/_errors._redact` → public `redact()` now pattern-redacts secrets.** It runs the shared package scrubber (`notebooklm._logging.scrub_secrets` — bearer tokens, session cookies, Google credential shapes) **plus** two MCP-specific patterns — signed `/files/(dl|ul)/<token>` URLs and local home-directory paths — **before** the length cap (so a secret sitting near the cap can never be half-revealed). This reuses the exact chokepoint the REST server's error handler (`server/_errors.py`) already uses, rather than reinventing redaction. `UNEXPECTED` (non-library bug) errors now return a fixed generic message instead of redacted `str(exc)`, since `redact()` is a denylist and a bug's text can carry anything (mirrors `server/_errors._UNEXPECTED_MESSAGE`).

3. **The `/files/*` routes classify + redact raised upstream errors.** A `NotebookLMError` raised out of the core (e.g. the artifact-`list` RPC inside `execute_download`, which is not wrapped; or `execute_source_add`) previously escaped as a raw Starlette 500. It is now projected onto a proper HTTP status via a local `ErrorCategory`→status table with a redacted body. The upload `ValidationError` body is now redacted too (a `validate_upload_path` rejection can embed the local file path).

### Design notes / deliberate decisions

- **Reuse over reinvention:** redaction delegates to the already-tested `scrub_secrets` pipeline; only the two MCP-only surfaces (`/files/*` tokens, home paths) are added locally.
- **Home-path regex is prose-safe:** the username segment allows at most one embedded space (covers `First Last` accounts) and requires a following path separator, so usernames with spaces are redacted **without** eating prose across multiple paths (a naive `[^/]+(?=/)` would swallow `" or "` in `/home/a or /home/b/x`). Documented fail-safe bounds: a bare terminal `/home/<user>` and two-space usernames are left alone.
- **`_FILE_ROUTE_STATUS` deviation:** `AUTH`/`CONFIG` → **502** (not 401/500). These routes are authenticated by the signed token, so a *server-side* broken Google session is an upstream-dependency failure the caller cannot fix by re-authenticating.
- **`DownloadOutcome.ERROR` stays a generic 409 (not split to 502):** that outcome also covers full-id not-found, so re-statusing would regress not-found; and the path already discards `result.error` (leaks nothing). The in-scope raw-500 vector is the *raised* error, which is what this PR catches.
- The MCP→`server` import boundary is respected (status table defined locally, not imported from the `fastapi`-bound `server/`).

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Full `uv run pytest` — 11110 passed, 78 skipped, 1 xfailed
- New unit tests cover: `server_info` no path leak; `redact` for bearer/cookie/`/files/` tokens/home paths incl. **usernames with spaces**, **multi-path prose (no over-redaction)**, and **Windows paths**; redact-before-cap; the UNEXPECTED generic message; `/files/*` raised `AuthError`→502 / `NotFoundError`→404 / upload `ServerError`→502; upload `ValidationError` path redaction; `ERROR`-outcome stays 409 and hides detail; full `ErrorCategory` status-table coverage.

## Deferred (out of scope for #1682)

- A few **pre-existing** `/files/*` plaintext responses (e.g. the 403/413/429 early returns) omit `Cache-Control: no-store` / `Referrer-Policy: no-referrer`. All responses *introduced by this PR* set both. Centralizing the headers across the pre-existing responses is a separate, pre-existing hardening — left for a follow-up to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

