### PR TITLE
fix(auth): interactive `notebooklm login` no longer hangs 5 min (wait_until="commit") (#1697)

### DIFF
--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -529,7 +529,13 @@ def run_browser_capture(
             # Retry navigation on transient connection errors with backoff
             for attempt in range(1, LOGIN_MAX_RETRIES + 1):
                 try:
-                    page.goto(f"{get_base_url()}/", timeout=30000)
+                    # wait_until="commit": notebooklm.google.com is a streaming
+                    # SPA that never fires the "load" event (readyState stays
+                    # "interactive"), so Playwright's default wait_until="load"
+                    # would block until timeout. "commit" resolves once response
+                    # headers are processed -- enough to land on the host and
+                    # classify page.url. See #1697 (and the #214 precedent below).
+                    page.goto(f"{get_base_url()}/", wait_until="commit", timeout=30000)
                     break
                 except PlaywrightError as exc:
                     error_str = str(exc)
@@ -608,7 +614,14 @@ def run_browser_capture(
                 io.emit("2. Authentication will be saved automatically once login is detected\n")
                 io.emit("[dim]Waiting for login (up to 5 minutes)...[/dim]")
                 try:
-                    page.wait_for_url(f"{get_base_url()}/**", timeout=300_000)
+                    # wait_until="commit", not the default "load": the SPA never
+                    # fires "load", so a load-gated wait hangs the full 5 min even
+                    # though sign-in already succeeded and the URL already matches
+                    # (the #1697 symptom). "commit" returns as soon as we reach the
+                    # host. Cookies are read later at storage_state() (after the
+                    # cookie-forcing round-trips), so resolving early is safe;
+                    # page.content() at capture time is best-effort/None-tolerant.
+                    page.wait_for_url(f"{get_base_url()}/**", wait_until="commit", timeout=300_000)
                 except PlaywrightTimeout:
                     io.emit(
                         "[red]Login not detected within 5 minutes.[/red]\n"
@@ -828,7 +841,11 @@ def run_cdp_capture(
             # This avoids navigating (and thereby disrupting) a tab the operator
             # is actively using.
             page = context.new_page()
-            page.goto(f"{get_base_url()}/", timeout=30000)
+            # wait_until="commit": same streaming-SPA reason as the headed login
+            # arm -- the default "load" never fires on notebooklm.google.com, so
+            # this CDP re-auth goto would otherwise waste 30s then TimeoutError
+            # before landing classification. See #1697.
+            page.goto(f"{get_base_url()}/", wait_until="commit", timeout=30000)
 
             # SAME landing classification as the headless launch arm: if we did
             # not land on the NotebookLM host, the attached browser's Google

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -386,8 +386,12 @@ class TestLoginCommand:
         goto_calls = mock_page.goto.call_args_list
         # 3 calls: initial NOTEBOOKLM_URL, then accounts.google.com, then NOTEBOOKLM_URL
         assert len(goto_calls) == 3
-        assert goto_calls[1].kwargs.get("wait_until") == "commit"
-        assert goto_calls[2].kwargs.get("wait_until") == "commit"
+        # Every goto in the login flow must use an early lifecycle state, NOT the
+        # Playwright default "load" -- the NotebookLM SPA never fires "load", so a
+        # load-gated goto hangs (#1697). Assert the invariant (not the literal
+        # "commit") so a future switch to "domcontentloaded" doesn't spuriously fail.
+        for call in goto_calls:
+            assert call.kwargs.get("wait_until") in {"commit", "domcontentloaded"}
 
     def test_login_auto_detect_skipped_when_already_logged_in(
         self, runner, mock_login_browser_with_storage
@@ -422,6 +426,14 @@ class TestLoginCommand:
         mock_page.wait_for_url.assert_called_once()
         # Verify timeout=300_000 (5 minutes) is passed
         assert mock_page.wait_for_url.call_args.kwargs.get("timeout") == 300_000
+        # The detector must NOT inherit Playwright's default wait_until="load":
+        # notebooklm.google.com is a streaming SPA that never fires "load", so a
+        # load-gated wait hangs the full 5 min even though login already succeeded
+        # (#1697). Assert the invariant rather than the literal "commit".
+        assert mock_page.wait_for_url.call_args.kwargs.get("wait_until") in {
+            "commit",
+            "domcontentloaded",
+        }
         assert "Login detected" in result.output
 
     @pytest.mark.requires_playwright

--- a/tests/unit/test_browser_capture_cdp_arm.py
+++ b/tests/unit/test_browser_capture_cdp_arm.py
@@ -130,8 +130,11 @@ def test_cdp_authenticated_landing_persists_and_filters(tmp_path: Path) -> None:
 
     # Attached to the operator-pointed endpoint.
     playwright.chromium.connect_over_cdp.assert_called_once_with("http://127.0.0.1:9222")
-    # We navigated our temporary page to the NotebookLM base URL.
+    # We navigated our temporary page to the NotebookLM base URL, using an early
+    # lifecycle state -- the streaming SPA never fires "load", so the default
+    # wait_until would waste 30s then TimeoutError before classification (#1697).
     page.goto.assert_called_once()
+    assert page.goto.call_args.kwargs.get("wait_until") in {"commit", "domcontentloaded"}
     # Persisted, with the same domain allowlist (mail.google.com dropped).
     storage = tmp_path / "storage_state.json"
     assert storage.exists()


### PR DESCRIPTION
## Summary

Fixes #1697.

`notebooklm login` opened headed Chromium, the user signed in successfully (cookies landed in the persistent profile), but the success detector never fired — it hung the full 5 minutes, printed "Login not detected within 5 minutes", and **never wrote `storage_state.json`**, despite authentication having succeeded.

## Root cause

`page.wait_for_url(...)` and `page.goto(...)` default to Playwright's `wait_until="load"`. `notebooklm.google.com` is a streaming SPA that reaches DOMContentLoaded (`readyState === "interactive"`) but **never fires the `load` event** (long-lived connection stays open), so a `load`-gated wait blocks until timeout even though the URL already matches and cookies are present.

The reporter's evidence confirms the key link: the same `wait_for_url` with `wait_until="commit"` returns in ~0.0s while the `load` default times out.

The defect has been latent since #415 (the bare `wait_for_url(..., timeout=300_000)` was never given a `wait_until`), relocated verbatim into `browser_capture.py` by #1512. It reproduces identically on 0.7.2 and `main` with no relevant code change between them — the fingerprint of a Google-side change making the page more aggressively streaming, on a path most users never re-run once they have cached auth.

## Fix

Add `wait_until="commit"` to the three NotebookLM-host navigations that defaulted to `load`:

- `browser_capture.py` — initial login `goto`
- `browser_capture.py` — success-detector `wait_for_url` (the headline symptom)
- `browser_capture.py` — `connect_over_cdp` re-auth `goto` (same defect; would otherwise waste 30s → `TimeoutError`)

`commit` resolves once response headers are processed — the same level the regional cookie-forcing gotos already use (#214) — which is all detection needs. Cookies are still read later at `context.storage_state()` (after the cookie-forcing round-trips), so resolving early is safe. This also **repairs** the already-logged-in and headless re-auth branches, whose initial `goto` hit the same `load` timeout today.

`master_token.py`'s `goto(_EMBEDDED_SETUP_URL)` was considered and left unchanged — different host (`accounts.google.com`), fires `load` normally, and polls the cookie jar rather than URL-waiting.

## Tests

Regression assertions at all three sites verify the **invariant** — `wait_until` is set and is not the `load` default (i.e. in `{"commit", "domcontentloaded"}`) — rather than the literal `"commit"`, so a future switch to `domcontentloaded` won't spuriously fail but a regression to the default will. Verified red→green against the unfixed code (the unfixed sites have `wait_until` absent → `.get()` returns `None` ∉ the set → assertion fails).

- `tests/unit/cli/test_login.py` — initial goto + success-detector `wait_for_url`
- `tests/unit/test_browser_capture_cdp_arm.py` — CDP re-auth goto

Full local sweep: 294 passed across `test_login` / `test_browser_capture_*` / `test_auth_*`; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login and re-auth navigation so browser sign-in flows complete more reliably without hanging on page load.
  * Reduced timeouts when opening the app during interactive and automated login steps.
  * Better handling of streaming web pages, making sign-in and landing detection smoother.

* **Tests**
  * Strengthened automated checks to ensure browser navigation uses faster, non-default wait behavior during login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->