### PR TITLE
perf(mcp): batch source-ref resolution to list sources once (#1689)

### DIFF
--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -50,7 +50,7 @@ from ..exceptions import (
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
-__all__ = ["resolve_note", "resolve_notebook", "resolve_source"]
+__all__ = ["resolve_note", "resolve_notebook", "resolve_source", "resolve_sources"]
 
 #: A token made only of hex digits and dashes routes to the id/prefix path; any
 #: other character (a space, a letter outside ``a-f``, punctuation) routes to the
@@ -200,6 +200,59 @@ async def resolve_source(client: NotebookLMClient, notebook_id: str, ref: str) -
     if _HEX_ISH.match(ref):
         return _resolve_hex(ref, items, not_found=SourceNotFoundError)
     return _resolve_by_title(ref, items, not_found=SourceNotFoundError)
+
+
+async def resolve_sources(
+    client: NotebookLMClient, notebook_id: str, refs: Sequence[str]
+) -> list[str]:
+    """Resolve many source references within a notebook, listing sources at most once.
+
+    The per-tool callers ``chat_ask`` / ``artifact_generate`` previously resolved N
+    refs via ``asyncio.gather(resolve_source(...) for ref in refs)``, which fired one
+    ``client.sources.list(notebook_id)`` per non-UUID ref — N identical concurrent
+    list RPCs. This resolves the whole batch against a single source-list snapshot.
+
+    Matching rules are identical to :func:`resolve_source` (full-UUID fast-path,
+    hex id/prefix, exact case-insensitive title) and reuse the same single-ref
+    helpers, so behavior per ref is unchanged. An all-UUID batch still makes no
+    list call (each ref takes the fast-path, as before). Two differences from the
+    old ``gather`` path:
+
+    * Non-UUID refs share a **single** ``sources.list`` snapshot instead of one
+      concurrent list call per ref.
+    * Errors are deterministic, not subject to ``gather``'s first-to-complete
+      race: every ref is ``validate_id``-checked first (so an empty/whitespace
+      ref raises before any resolution), then refs resolve sequentially over the
+      snapshot, so a not-found / ambiguous ref raises in input order.
+
+    Args:
+        client: The lifespan-bound client.
+        notebook_id: The (already-resolved) notebook id the sources live in.
+        refs: Source references (full/partial id or exact title).
+
+    Returns:
+        The resolved canonical ids, in the same order as ``refs``.
+
+    Raises:
+        ValidationError: A ref is empty/whitespace.
+        SourceNotFoundError: A ref matches no source in the notebook.
+        AmbiguousIdError: A ref matches more than one source by prefix or title.
+    """
+    validated = [validate_id(ref, "source") for ref in refs]
+    # If every ref is already a full UUID, skip the list call entirely.
+    if all(FULL_ID_PATTERN.fullmatch(ref) for ref in validated):
+        return validated
+    items = await client.sources.list(notebook_id)
+
+    # Same matching dispatch as resolve_source, but against one shared snapshot.
+    def match(ref: str) -> str:
+        if FULL_ID_PATTERN.fullmatch(ref):
+            return ref
+        if _HEX_ISH.match(ref):
+            return _resolve_hex(ref, items, not_found=SourceNotFoundError)
+        return _resolve_by_title(ref, items, not_found=SourceNotFoundError)
+
+    return [match(ref) for ref in validated]
 
 
 async def resolve_note(client: NotebookLMClient, notebook_id: str, ref: str) -> str:

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -231,7 +231,11 @@ async def resolve_sources(
         refs: Source references (full/partial id or exact title).
 
     Returns:
-        The resolved canonical ids, in the same order as ``refs``.
+        The resolved canonical ids, in the same order as ``refs``. An empty
+        ``refs`` returns an empty list (NOT ``None``): callers that treat
+        "no refs" as "all sources" must keep their own ``if refs else None``
+        guard — forwarding ``[]`` to the backend means "zero sources", which it
+        refuses for source-requiring artifact types (#1652).
 
     Raises:
         ValidationError: A ref is empty/whitespace.

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -23,7 +23,6 @@ than imported from ``cli/_download_specs.py``.
 
 from __future__ import annotations
 
-import asyncio
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -47,7 +46,7 @@ from .._confirm import READ_ONLY
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors
 from .._filelink import DOWNLOAD_TTL, FileTransferConfig
-from .._resolve import resolve_notebook, resolve_source
+from .._resolve import resolve_notebook, resolve_sources
 from ._passthrough import passthrough_notebook_id
 
 if TYPE_CHECKING:
@@ -561,13 +560,7 @@ def register(mcp: Any) -> None:
             # works elsewhere) or an empty string gets it validated/resolved, not
             # forwarded to the backend. Omitted/empty stays None (= all sources, #1652).
             resolved_source_ids = (
-                list(
-                    await asyncio.gather(
-                        *(resolve_source(client, nb_id, ref) for ref in source_ids)
-                    )
-                )
-                if source_ids
-                else None
+                await resolve_sources(client, nb_id, source_ids) if source_ids else None
             )
             raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[artifact_type])
             raw_args.update(

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -22,7 +22,6 @@ Both bodies wrap in :func:`mcp_errors`. This module imports NO ``click`` /
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Literal
 
 from fastmcp import Context
@@ -32,7 +31,7 @@ from ..._app.serialize import to_jsonable
 from .._coerce import coerce_list
 from .._context import get_client
 from .._errors import mcp_errors
-from .._resolve import resolve_notebook, resolve_source
+from .._resolve import resolve_notebook, resolve_sources
 
 #: Reference fields kept in the default ("lite") ``chat_ask`` projection. The full
 #: ``ChatReference`` also carries chunk-level char offsets / ``chunk_id`` /
@@ -77,11 +76,7 @@ def register(mcp: Any) -> None:
             # other source-accepting tool does. Omitted/empty stays None (=> all
             # sources, mirroring ``client.chat.ask``'s None contract).
             refs = coerce_list(source_ids)
-            resolved_source_ids = (
-                list(await asyncio.gather(*(resolve_source(client, nb_id, ref) for ref in refs)))
-                if refs
-                else None
-            )
+            resolved_source_ids = await resolve_sources(client, nb_id, refs) if refs else None
             result = await client.chat.ask(
                 nb_id,
                 question,

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -200,6 +200,31 @@ async def test_artifact_generate_resolves_source_id_prefix(mcp_call, mock_client
     assert kwargs["source_ids"] == (full,)
 
 
+async def test_artifact_generate_two_title_refs_list_once_order_preserved(
+    mcp_call, mock_client
+) -> None:
+    """Two non-UUID refs resolve via a single ``sources.list`` snapshot, in input order."""
+
+    @dataclass
+    class _Src:
+        id: str
+        title: str | None
+
+    src_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    src_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    mock_client.sources.list = AsyncMock(
+        return_value=[_Src(id=src_a, title="Alpha"), _Src(id=src_b, title="Beta")]
+    )
+    mock_client.artifacts.generate_audio = AsyncMock(return_value=FakeStatus(task_id=TASK_ID))
+    await mcp_call(
+        "artifact_generate",
+        {"notebook": NB_ID, "artifact_type": "audio", "source_ids": ["Beta", "Alpha"]},
+    )
+    mock_client.sources.list.assert_awaited_once_with(NB_ID)
+    kwargs = mock_client.artifacts.generate_audio.await_args.kwargs
+    assert kwargs["source_ids"] == (src_b, src_a)
+
+
 async def test_artifact_generate_omitting_source_ids_uses_all(mcp_call, mock_client) -> None:
     """Omitting ``source_ids`` must pass ``source_ids=None`` (=> all sources), NOT an
     empty tuple. An empty list reaches the backend as 'zero sources', which it refuses

--- a/tests/unit/mcp/test_chat.py
+++ b/tests/unit/mcp/test_chat.py
@@ -163,6 +163,31 @@ async def test_chat_ask_whitespace_source_ids_uses_all(mcp_call, mock_client) ->
     assert mock_client.chat.ask.await_args.kwargs["source_ids"] is None
 
 
+@dataclass
+class FakeSource:
+    id: str
+    title: str | None
+
+
+async def test_chat_ask_two_title_refs_list_once_order_preserved(mcp_call, mock_client) -> None:
+    """Two non-UUID refs resolve via a single ``sources.list`` snapshot, in input order."""
+    mock_client.sources.list = AsyncMock(
+        return_value=[
+            FakeSource(id=_SRC_A, title="Alpha"),
+            FakeSource(id=_SRC_B, title="Beta"),
+        ]
+    )
+    mock_client.chat.ask = AsyncMock(
+        return_value=FakeAskResult(answer="42", conversation_id=CONV_ID)
+    )
+    await mcp_call(
+        "chat_ask",
+        {"notebook": NB_ID, "question": "what?", "source_ids": ["Beta", "Alpha"]},
+    )
+    mock_client.sources.list.assert_awaited_once_with(NB_ID)
+    assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [_SRC_B, _SRC_A]
+
+
 async def test_chat_configure_goal_and_length(mcp_call, mock_client) -> None:
     mock_client.chat.configure = AsyncMock(return_value=None)
     result = await mcp_call(

--- a/tests/unit/mcp/test_resolve.py
+++ b/tests/unit/mcp/test_resolve.py
@@ -23,10 +23,12 @@ from notebooklm._app.resolve import AmbiguousIdError  # noqa: E402 - after impor
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     NotebookNotFoundError,
     SourceNotFoundError,
+    ValidationError,
 )
 from notebooklm.mcp._resolve import (  # noqa: E402 - after importorskip guard
     resolve_notebook,
     resolve_source,
+    resolve_sources,
 )
 
 FULL_A = "abc12345-6789-4abc-def0-1234567890ab"
@@ -184,3 +186,61 @@ async def test_source_hex_only_title_falls_back_to_title() -> None:
     """A source whose TITLE is all-hex resolves by name (id/prefix path misses)."""
     client = _client(sources=[_Src("0000aaaa1111", "beef"), _Src("cd0002abef", "Notes")])
     assert await resolve_source(client, "nb-1", "beef") == "0000aaaa1111"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_sources (batch — lists at most once)
+# --------------------------------------------------------------------------- #
+async def test_sources_all_full_uuid_skips_list() -> None:
+    """A batch of full UUIDs is returned verbatim with no list call."""
+    client = _client(sources=[_Src(FULL_A, "Doc")])
+    assert await resolve_sources(client, "nb-1", [FULL_A, FULL_B]) == [FULL_A, FULL_B]
+    client.sources.list.assert_not_called()
+
+
+async def test_sources_mixed_lists_exactly_once_order_preserved() -> None:
+    """A mix of prefix/title refs lists once and preserves input order."""
+    client = _client(
+        sources=[
+            _Src("ab0001cdef", "Report.pdf"),
+            _Src("cd0002abef", "Notes"),
+        ]
+    )
+    result = await resolve_sources(client, "nb-1", ["Notes", "ab0001", FULL_A])
+    assert result == ["cd0002abef", "ab0001cdef", FULL_A]
+    client.sources.list.assert_awaited_once_with("nb-1")
+
+
+async def test_sources_title_refs_list_exactly_once() -> None:
+    """Two non-UUID title refs share a single list snapshot, order preserved."""
+    client = _client(
+        sources=[
+            _Src("ab0001cdef", "Report.pdf"),
+            _Src("cd0002abef", "Notes"),
+        ]
+    )
+    result = await resolve_sources(client, "nb-1", ["Notes", "Report.pdf"])
+    assert result == ["cd0002abef", "ab0001cdef"]
+    client.sources.list.assert_awaited_once_with("nb-1")
+
+
+async def test_sources_no_match_raises_source_not_found() -> None:
+    client = _client(sources=[_Src("ab0001cdef", "Doc")])
+    with pytest.raises(SourceNotFoundError):
+        await resolve_sources(client, "nb-1", ["Doc", "Missing Title"])
+
+
+async def test_sources_ambiguous_title_raises() -> None:
+    client = _client(sources=[_Src("ab0001cdef", "Dup"), _Src("cd0002abef", "dup")])
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_sources(client, "nb-1", ["Dup"])
+    assert set(caught.value.candidate_ids) == {"ab0001cdef", "cd0002abef"}
+
+
+async def test_sources_whitespace_ref_raises_validation_before_listing() -> None:
+    """Every ref is ``validate_id``-checked first, so an empty/whitespace ref in the
+    batch raises ``ValidationError`` (no list call, per the documented contract)."""
+    client = _client(sources=[_Src("ab0001cdef", "Doc")])
+    with pytest.raises(ValidationError):
+        await resolve_sources(client, "nb-1", ["Doc", "   "])
+    client.sources.list.assert_not_called()


### PR DESCRIPTION
## Summary

`chat_ask` and `artifact_generate` resolved N source refs via `asyncio.gather(resolve_source(...) for ref in refs)`. Each non-UUID ref independently called `client.sources.list(notebook_id)` → N identical concurrent list RPCs for a single tool call.

This adds one shared batch resolver that lists the notebook's sources **at most once**:

- **`resolve_sources(client, notebook_id, refs) -> list[str]`** in `mcp/_resolve.py`:
  - `validate_id` every ref first (so an empty/whitespace ref raises `ValidationError` before any resolution).
  - If **every** validated ref is a full canonical UUID → return verbatim, **no list call** (parity with the single-ref fast-path).
  - Else list **once**, then resolve each ref over that single snapshot via the existing single-ref helpers (full-UUID → verbatim, hex → `_resolve_hex`, else `_resolve_by_title`). Same matching rules, same exceptions (`SourceNotFoundError` / `AmbiguousIdError`), **input order preserved**.
- Both call sites swapped to `await resolve_sources(client, nb_id, refs)`, keeping each caller's existing `if refs else None` guard (empty/omitted still means "all sources", #1652).
- Dropped the now-unused `import asyncio` and `resolve_source` import from both tool modules.

## Behavior delta

Resolution becomes sequential over one snapshot instead of N concurrent lists. Errors are now **deterministic** (raise in input order) rather than subject to `gather`'s first-to-complete race — a strict improvement. The single-ref `resolve_source` is untouched (still used by other tools).

## Tests

- `test_resolve.py`: all-UUID → zero list calls; mixed / title-only → exactly **one** list call with order preserved; non-match → `SourceNotFoundError`; ambiguous → `AmbiguousIdError`; whitespace ref in batch → `ValidationError` before listing.
- `test_chat.py` / `test_artifacts.py`: two non-UUID refs → `sources.list` awaited **exactly once**, resolved-id order matches input order.

Verification: `uv run pytest tests/unit/mcp/` (448 passed), `mypy`, `ruff check/format`, `audit_public_api_compat.py --check-stale`, and the MCP manifest/freshness checks all green.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk resolution of multiple source references for notebook tools, returning canonical source IDs in the same order they’re provided.
* **Bug Fixes**
  * Avoids repeated lookups by using a single sources listing per batch when needed, and returns full IDs unchanged.
  * Preserves consistent handling for missing, ambiguous, and invalid references.
* **Tests**
  * Added unit tests covering batch behavior, single-lookup execution, order preservation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->