### PR TITLE
feat(mcp): warn on ready-but-untitled url/youtube source adds (#1698)

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -84,6 +84,30 @@ def _source_view(source: Any) -> dict[str, Any]:
     return view
 
 
+#: Surfaced when a URL/YouTube add lands READY with no title — the zero-RPC
+#: signal that the page is likely a dead link / empty / paywalled (a soft-404 that
+#: served a 200). Shared by single + batch so the two paths cannot drift. Never a
+#: rejection: a legitimately untitled live page keeps importing, just flagged.
+_THIN_SOURCE_WARNING = (
+    "Added and ready, but the fetched page has no title — it may be a dead link "
+    "or an empty/paywalled page; verify with source_get_content."
+)
+
+
+def _thin_source_warning(source: Any) -> str | None:
+    """Flag a ready-but-untitled add (likely a dead/soft-404 link), else ``None``.
+
+    ponytail: title-only is the ceiling — a zero-RPC heuristic off the add
+    response. It won't catch a soft-404 that returns a plausible title; the only
+    upgrade is a ready-gated fulltext probe (extra RPC), deferred unless
+    false-negatives bite. ``char_count`` lives on ``SourceFulltext``, not the
+    ``Source`` echoed here, so it is not available without that extra fetch.
+    """
+    if source.is_ready and not (source.title or "").strip():
+        return _THIN_SOURCE_WARNING
+    return None
+
+
 def _add_result_payload(source: Any, base: dict[str, Any]) -> dict[str, Any]:
     """Project a ``source_add`` result: enrich the added source + flag failure.
 
@@ -385,7 +409,9 @@ def register(mcp: Any) -> None:
         only AFTER processing. Confirm the outcome with ``source_wait`` or
         ``source_list(status="error")``. When the add response ALREADY reflects a
         failed import, ``source_add`` flags it inline (``status_label="error"`` plus
-        a top-level ``warning``) instead of looking like a clean add.
+        a top-level ``warning``) instead of looking like a clean add. A ``url`` /
+        ``youtube`` add that lands READY with no title is similarly flagged with a
+        ``warning`` (likely a dead link / empty / paywalled page) — never rejected.
 
         **Batch mode** — pass ``urls`` (a list of **http/https URLs**, YouTube links
         included) to add many in one call instead of one round-trip each. Each entry
@@ -493,7 +519,16 @@ def register(mcp: Any) -> None:
                 mime_type=mime_type,
                 allow_internal=allow_internal,
             )
-            return _add_result_payload(src, to_jsonable(add_core.SourceAddResult(source=src)))
+            payload = _add_result_payload(src, to_jsonable(add_core.SourceAddResult(source=src)))
+            # Thin-title (dead/soft-404) warning is scoped to url/youtube ONLY — a
+            # ready text/file source can legitimately be untitled, so it is NOT
+            # flagged here (and never inside the generic _add_result_payload). An
+            # is_error warning already set takes precedence (error > thin).
+            if source_type in {"url", "youtube"} and "warning" not in payload:
+                thin = _thin_source_warning(src)
+                if thin is not None:
+                    payload["warning"] = thin
+            return payload
 
 
 def _is_http_transport() -> bool:
@@ -655,9 +690,9 @@ async def _add_url_batch(
     single-mode failure raises.
 
     An ``"added"`` item also carries the source's ``status_label`` (the async-import
-    status) and, when the add response already reflects a failed import
-    (``is_error``), an inline ``warning`` — mirroring single mode's
-    :func:`_add_result_payload` failure-signaling (#1679) per entry.
+    status) and an inline ``warning`` when either the add reflects a failed import
+    (``is_error``, #1679) or it landed READY with no title (likely a dead/soft-404
+    link, #1698 — see :func:`_thin_source_warning`); ``is_error`` takes precedence.
     """
     results: list[dict[str, Any]] = []
     for entry in urls:
@@ -687,6 +722,12 @@ async def _add_url_batch(
                     "(status_label='error'). Delete it with source_delete, or list "
                     "failures via source_list(status='error')."
                 )
+            else:
+                # Batch is URL-only by construction, so the thin-title (dead/soft-404)
+                # warning applies per item. is_error takes precedence (handled above).
+                thin = _thin_source_warning(src)
+                if thin is not None:
+                    item["warning"] = thin
             results.append(item)
     # Derive the tallies from `results` (single source of truth) rather than
     # maintaining parallel counters that must be kept in sync with each append.

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -996,6 +996,143 @@ async def test_source_add_batch_conflicts_with_source_type(mcp_call, mock_client
     assert "VALIDATION" in str(excinfo.value)
 
 
+# --- #1698 thin/empty-title warning (url/youtube only, no extra RPC) ----------
+
+
+@pytest.mark.parametrize("blank_title", [None, "", "   "])
+async def test_source_add_url_thin_title_warns(mcp_call, mock_client, blank_title) -> None:
+    """A url add that lands READY with a blank/empty title is flagged inline as a
+    likely dead/soft-404 link — a ``warning``, never a rejection. (``"   "`` proves
+    the helper's ``.strip()``; the source is still echoed status_label='ready'.)"""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title=blank_title))
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "url", "url": "https://example.com/404"}
+    )
+    sc = result.structured_content
+    assert sc["source"]["status_label"] == "ready"
+    assert "dead link" in sc["warning"]
+
+
+async def test_source_add_youtube_thin_title_warns(mcp_call, mock_client) -> None:
+    """The thin-title warning also covers the ``youtube`` single-add branch."""
+    yt = "https://www.youtube.com/watch?v=abc123"
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))  # title=None
+    result = await mcp_call("source_add", {"notebook": NB_ID, "source_type": "youtube", "url": yt})
+    assert "dead link" in result.structured_content["warning"]
+
+
+async def test_source_add_url_real_title_no_warning(mcp_call, mock_client) -> None:
+    """A ready url add WITH a real title carries no thin-title warning."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Real Title"))
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "url", "url": "https://example.com/a"}
+    )
+    assert "warning" not in result.structured_content
+
+
+async def test_source_add_text_blank_title_no_thin_warning(mcp_call, mock_client) -> None:
+    """Scope guard (#1698): a ready TEXT source with no title is legitimate, so it
+    is NOT flagged by the url-scoped thin-title heuristic — even though text shares
+    the single-add final block (_select_content → _add_one → payload) with url."""
+    mock_client.sources.add_text = AsyncMock(return_value=FakeSource(id=SRC_ID))  # title=None
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "text", "text": "hello world"}
+    )
+    assert "warning" not in result.structured_content
+
+
+async def test_source_add_drive_blank_title_no_thin_warning(mcp_call, mock_client) -> None:
+    """Scope guard (#1698): a ready DRIVE source with no title is NOT flagged."""
+    mock_client.sources.add_drive = AsyncMock(return_value=FakeSource(id=SRC_ID))  # title=None
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "drive", "document_id": "drivefile123"}
+    )
+    assert "warning" not in result.structured_content
+
+
+async def test_source_add_file_blank_title_no_thin_warning(mcp_call, mock_client, tmp_path) -> None:
+    """Scope guard (#1698): a ready FILE source with no title is NOT flagged. File
+    flows through the SAME single-add final block as url, so this pins that the
+    warning is gated on source_type, not just on a missing title."""
+    f = tmp_path / "doc.pdf"
+    f.write_bytes(b"%PDF-1.4 test content")
+    mock_client.sources.add_file = AsyncMock(return_value=FakeSource(id=SRC_ID))  # title=None
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "file", "path": str(f)}
+    )
+    assert "warning" not in result.structured_content
+
+
+async def test_source_add_url_error_takes_precedence_over_thin(mcp_call, mock_client) -> None:
+    """An is_error add (also title-less) keeps its #1679 import-failed warning — the
+    error message wins, the thin-title text does not override it."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeFailedSource(id=SRC_ID))  # title=None
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "url", "url": "https://example.com/bad"}
+    )
+    sc = result.structured_content
+    assert sc["source"]["status_label"] == "error"
+    assert "Import failed" in sc["warning"]
+    assert "dead link" not in sc["warning"]
+
+
+async def test_source_add_url_not_ready_blank_title_no_warning(mcp_call, mock_client) -> None:
+    """A still-processing (not-ready) url add with a blank title gets NO thin-title
+    warning: the helper gates on ``is_ready``, so a fresh async import in flight is
+    never pre-flagged as a dead link (it has no title YET)."""
+    mock_client.sources.add_url = AsyncMock(
+        return_value=FakeNotReadySource(id=SRC_ID)
+    )  # title=None
+    result = await mcp_call(
+        "source_add", {"notebook": NB_ID, "source_type": "url", "url": "https://example.com/slow"}
+    )
+    sc = result.structured_content
+    assert sc["source"]["status_label"] == "processing"
+    assert "warning" not in sc
+
+
+async def test_source_add_batch_not_ready_blank_title_no_warning(mcp_call, mock_client) -> None:
+    """Batch: a not-ready item with a blank title is likewise not pre-flagged."""
+    mock_client.sources.add_url = AsyncMock(
+        return_value=FakeNotReadySource(id=SRC_ID)
+    )  # title=None
+    result = await mcp_call("source_add", {"notebook": NB_ID, "urls": ["https://example.com/slow"]})
+    item = result.structured_content["results"][0]
+    assert item["status"] == "added"
+    assert item["status_label"] == "processing"
+    assert "warning" not in item
+
+
+async def test_source_add_batch_thin_title_warns(mcp_call, mock_client) -> None:
+    """Batch (#1698): a ready URL item with a blank title gets the SAME thin-title
+    warning per item — the shared constant keeps single + batch from drifting."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID))  # title=None
+    result = await mcp_call("source_add", {"notebook": NB_ID, "urls": ["https://example.com/404"]})
+    sc = result.structured_content
+    assert sc["added"] == 1
+    item = sc["results"][0]
+    assert item["status"] == "added"
+    assert item["status_label"] == "ready"
+    assert "dead link" in item["warning"]
+
+
+async def test_source_add_batch_real_title_no_warning(mcp_call, mock_client) -> None:
+    """Batch: a ready URL item WITH a title carries no thin-title warning."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Page"))
+    result = await mcp_call("source_add", {"notebook": NB_ID, "urls": ["https://example.com/a"]})
+    assert "warning" not in result.structured_content["results"][0]
+
+
+async def test_source_add_batch_error_takes_precedence_over_thin(mcp_call, mock_client) -> None:
+    """Batch: an is_error item (also title-less) keeps its import-failed warning,
+    not the thin-title text (error precedence mirrors single mode)."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeFailedSource(id=SRC_ID))  # title=None
+    result = await mcp_call("source_add", {"notebook": NB_ID, "urls": ["https://example.com/bad"]})
+    item = result.structured_content["results"][0]
+    assert "Import failed" in item["warning"]
+    assert "dead link" not in item["warning"]
+
+
 @pytest.mark.parametrize(
     "scalar",
     [


### PR DESCRIPTION
## What

Dead/soft-404 URLs can ingest as `status:ready` ghost sources. A soft-404 serves a 200, so #1679's add-time ERROR signaling never fires and the dead link looks like a clean add.

This adds a **zero-RPC, title-only** heuristic: when a `url`/`youtube` add lands READY with a blank/empty title, attach a non-blocking top-level `warning` ("…the fetched page has no title — it may be a dead link or an empty/paywalled page; verify with source_get_content."). It **never rejects** — a legitimately untitled live page keeps importing, just flagged.

## How

- New `_thin_source_warning(source) -> str | None` helper + a single shared `_THIN_SOURCE_WARNING` constant.
- Applied to **`url`/`youtube` single adds only** and the **URL-only batch** path. Deliberately NOT inside the generic `_add_result_payload` — that projector also serves `text`/`drive`/`file`, where a null title is legitimate (e.g. untitled pasted text). Regression-guard tests pin that text/drive/file are not flagged.
- `is_error` warning takes precedence over the thin-title warning (single + batch).
- Single and batch share one constant so the two paths can't drift.

## Scope / known ceiling (deliberate)

Per the locked plan + momus fix: this is **title-only with no extra RPC**. `char_count` lives on `SourceFulltext`, not the `Source` echoed by the add response, so a content-length check would require a separate fetch (rejected here). A `ponytail:` comment in `_thin_source_warning` names this ceiling. Consequence: it catches *empty-title* soft-404s but **not** soft-404s that return a plausible title (e.g. the issue's own "Article | Heavy Chain Engineering" repro). Upgrade path if false-negatives bite = a ready-gated fulltext probe.

## Tests

`tests/unit/mcp/test_sources.py`: single url warn (None/`""`/`"   "` titles), youtube warn, real-title no-warn, **text/drive/file ready+blank-title NO warning** (scope guard), not-ready+blank-title no-warn (single + batch), error-precedence (single + batch), batch warn/no-warn. Full `tests/unit/mcp/` suite green (454 passed); mypy + ruff clean; public-API audit shows no breaks.

Closes #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when a newly added URL or YouTube source finishes as ready but has no meaningful title, helping flag likely dead links.
  * Kept existing error warnings unchanged so failure messages still take priority.
  * Applied the same behavior consistently for both single-item and batch source additions.
  * Ensured the warning only appears for ready URL/YouTube sources and does not affect text, file, or drive sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->