### PR TITLE
fix(mcp): notebook_create returns non-null created_at/modified_at (#1699)

### DIFF
--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -63,18 +63,22 @@ def register(mcp: Any) -> None:
             # best-effort re-read to backfill just those two keys, skipping it
             # when both are already present (no wasted RPC) or the id is empty
             # (no ``get("")``). The create result stays authoritative for
-            # id/title/etc. The create already committed server-side, so a
-            # re-read failure (eventual-consistency NotebookNotFoundError, a
-            # transport blip) must degrade to the create timestamps rather than
-            # fail the create; ``except Exception`` still lets
-            # asyncio.CancelledError propagate.
+            # id/title/etc. The fill is PER-KEY and only applied when the
+            # re-read value is non-null, so a lagging re-read that returns null
+            # for a slot the create had already populated cannot REGRESS it back
+            # to null. The create already committed server-side, so a re-read
+            # failure (eventual-consistency NotebookNotFoundError, a transport
+            # blip) must degrade to the create timestamps rather than fail the
+            # create; ``except Exception`` still lets asyncio.CancelledError
+            # propagate.
             if notebook_id and (
                 record.get("created_at") is None or record.get("modified_at") is None
             ):
                 try:
                     fresh = to_jsonable(await client.notebooks.get(notebook_id))
-                    record["created_at"] = fresh.get("created_at")
-                    record["modified_at"] = fresh.get("modified_at")
+                    for key in ("created_at", "modified_at"):
+                        if fresh.get(key) is not None:
+                            record[key] = fresh[key]
                 except Exception:
                     logger.debug(
                         "notebook_create: timestamp re-read failed; returning "

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -76,9 +76,13 @@ def register(mcp: Any) -> None:
             ):
                 try:
                     fresh = to_jsonable(await client.notebooks.get(notebook_id))
-                    for key in ("created_at", "modified_at"):
-                        if record.get(key) is None and fresh.get(key) is not None:
-                            record[key] = fresh[key]
+                    # ``to_jsonable`` on the ``Notebook`` dataclass always yields
+                    # a dict; the isinstance guard makes the ``.get`` reads
+                    # explicitly safe regardless.
+                    if isinstance(fresh, dict):
+                        for key in ("created_at", "modified_at"):
+                            if record.get(key) is None and fresh.get(key) is not None:
+                                record[key] = fresh[key]
                 except Exception:
                     logger.debug(
                         "notebook_create: timestamp re-read failed; returning "

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -63,21 +63,21 @@ def register(mcp: Any) -> None:
             # best-effort re-read to backfill just those two keys, skipping it
             # when both are already present (no wasted RPC) or the id is empty
             # (no ``get("")``). The create result stays authoritative for
-            # id/title/etc. The fill is PER-KEY and only applied when the
-            # re-read value is non-null, so a lagging re-read that returns null
-            # for a slot the create had already populated cannot REGRESS it back
-            # to null. The create already committed server-side, so a re-read
-            # failure (eventual-consistency NotebookNotFoundError, a transport
-            # blip) must degrade to the create timestamps rather than fail the
-            # create; ``except Exception`` still lets asyncio.CancelledError
-            # propagate.
+            # id/title/etc. The fill is PER-KEY and strictly additive: a slot is
+            # filled only when the create left it null AND the re-read has a
+            # value, so a populated create timestamp is never touched and a
+            # lagging re-read that returns null cannot REGRESS one back to null.
+            # The create already committed server-side, so a re-read failure
+            # (eventual-consistency NotebookNotFoundError, a transport blip) must
+            # degrade to the create timestamps rather than fail the create;
+            # ``except Exception`` still lets asyncio.CancelledError propagate.
             if notebook_id and (
                 record.get("created_at") is None or record.get("modified_at") is None
             ):
                 try:
                     fresh = to_jsonable(await client.notebooks.get(notebook_id))
                     for key in ("created_at", "modified_at"):
-                        if fresh.get(key) is not None:
+                        if record.get(key) is None and fresh.get(key) is not None:
                             record[key] = fresh[key]
                 except Exception:
                     logger.debug(

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -16,6 +16,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastmcp import Context
@@ -28,6 +29,8 @@ from .._errors import mcp_errors
 from .._resolve import resolve_notebook
 from ._passthrough import passthrough_notebook_id
 from ._preview import title_for_id
+
+logger = logging.getLogger(__name__)
 
 
 def register(mcp: Any) -> None:
@@ -53,9 +56,32 @@ def register(mcp: Any) -> None:
             # record under a ``notebook`` key (#1540). The remaining Notebook
             # fields (title, created_at, sources_count, is_owner, modified_at)
             # stay at the top level so no metadata is dropped.
-            notebook = to_jsonable(result.notebook)
-            notebook_id = notebook.pop("id")
-            return {"notebook_id": notebook_id, **notebook}
+            record = to_jsonable(result.notebook)
+            notebook_id = record.pop("id")
+            # CREATE_NOTEBOOK leaves created_at/modified_at null even though
+            # GET_NOTEBOOK / notebook_list populate them (#1699). Do ONE
+            # best-effort re-read to backfill just those two keys, skipping it
+            # when both are already present (no wasted RPC) or the id is empty
+            # (no ``get("")``). The create result stays authoritative for
+            # id/title/etc. The create already committed server-side, so a
+            # re-read failure (eventual-consistency NotebookNotFoundError, a
+            # transport blip) must degrade to the create timestamps rather than
+            # fail the create; ``except Exception`` still lets
+            # asyncio.CancelledError propagate.
+            if notebook_id and (
+                record.get("created_at") is None or record.get("modified_at") is None
+            ):
+                try:
+                    fresh = to_jsonable(await client.notebooks.get(notebook_id))
+                    record["created_at"] = fresh.get("created_at")
+                    record["modified_at"] = fresh.get("modified_at")
+                except Exception:
+                    logger.debug(
+                        "notebook_create: timestamp re-read failed; returning "
+                        "create result with unpopulated timestamps",
+                        exc_info=True,
+                    )
+            return {"notebook_id": notebook_id, **record}
 
     @mcp.tool(annotations=READ_ONLY)
     async def notebook_describe(ctx: Context, notebook: str) -> dict[str, Any]:

--- a/tests/cassettes/notebooks_create.yaml
+++ b/tests/cassettes/notebooks_create.yaml
@@ -1767,4 +1767,43 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22afefc562-f8d1-41ec-a5d5-c197efdf52e1%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963936973&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED; __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED; OSID=SCRUBBED; __Secure-OSID=SCRUBBED; SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=rLM1Ne&source-path=%2Fnotebook%2Fafefc562-f8d1-41ec-a5d5-c197efdf52e1&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        354
+
+        [["wrb.fr","rLM1Ne","[[\"VCR Test Notebook\",null,\"afefc562-f8d1-41ec-a5d5-c197efdf52e1\",null,null,[1,false,true,null,null,[1768312219,407754000],1,null,[1768174413,819385000],null,null,null,false],null,null,null,null,null,[[\"6b8bc782-7624-47cd-a5ef-8679165c076f\"]]]]",null,null,null,"generic"],["di",200],["af.httprm",200,"-1234567890123456789",10]]
+
+        '
+    headers:
+      Content-Disposition:
+      - attachment; filename="response.txt"; filename*=UTF-8''response.txt
+      Content-Type:
+      - application/json+protobuf; charset=UTF-8
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/integration/mcp_vcr/test_notebooks.py
+++ b/tests/integration/mcp_vcr/test_notebooks.py
@@ -45,11 +45,13 @@ DELETE_NOTEBOOK_ID = "fc9cc125-fc20-439b-9f3d-d801c5b0de38"  # notebooks_delete.
 @pytest.mark.asyncio
 @notebooklm_vcr.use_cassette("notebooks_create.yaml")
 async def test_mcp_notebook_create_over_vcr() -> None:
-    """``notebook_create`` returns the created notebook through the real client.
+    """``notebook_create`` returns the created notebook with non-null timestamps.
 
     End-to-end: FastMCP ``Client`` -> ``notebook_create`` tool ->
     ``execute_notebook_create`` -> ``client.notebooks.create`` -> recorded
-    ``CREATE_NOTEBOOK`` (``CCqFvf``) RPC.
+    ``CREATE_NOTEBOOK`` (``CCqFvf``) RPC, THEN the #1699 best-effort re-read
+    ``client.notebooks.get`` -> recorded ``GET_NOTEBOOK`` (``rLM1Ne``) RPC whose
+    response carries populated ``meta[5]``/``meta[8]`` timestamps.
 
     Pins the *flat* wire shape: the created notebook's fields land at the top
     level with its id exposed as ``notebook_id`` (matching ``note_create`` and
@@ -77,6 +79,12 @@ async def test_mcp_notebook_create_over_vcr() -> None:
         "is_owner",
         "modified_at",
     }
+    # #1699: CREATE_NOTEBOOK returns null created_at/modified_at; the tool's
+    # GET_NOTEBOOK re-read populates them. Asserting NON-null is the load-bearing
+    # guard that the enrichment actually ran — a regression to the create result
+    # (or a silent fallback) would leave these null and fail here.
+    assert structured["created_at"] is not None, "created_at should be populated by the re-read"
+    assert structured["modified_at"] is not None, "modified_at should be populated by the re-read"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -141,6 +141,7 @@ async def test_notebook_create_reread_still_null_stays_null(mcp_call, mock_clien
         "is_owner": True,
         "modified_at": None,
     }
+    mock_client.notebooks.create.assert_awaited_once_with("New")
     mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
 
 
@@ -191,6 +192,7 @@ async def test_notebook_create_reread_null_does_not_regress(mcp_call, mock_clien
         "is_owner": True,
         "modified_at": None,  # stayed null, no value to backfill
     }
+    mock_client.notebooks.create.assert_awaited_once_with("New")
     mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
 
 

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -167,6 +167,33 @@ async def test_notebook_create_skips_reread_when_timestamps_present(mcp_call, mo
     mock_client.notebooks.get.assert_not_awaited()
 
 
+async def test_notebook_create_reread_null_does_not_regress(mcp_call, mock_client) -> None:
+    """A lagging GET re-read returning null must not wipe an already-populated
+    create timestamp (#1699 per-key, non-null backfill).
+
+    Here the create result already carries ``created_at`` but not
+    ``modified_at`` (one slot null fires the re-read guard); the re-read then
+    returns BOTH null. The populated ``created_at`` must be preserved (not
+    regressed to null) and ``modified_at`` simply stays null — no exception.
+    """
+    mock_client.notebooks.create = AsyncMock(
+        return_value=FakeNotebookFull(
+            id=NB_ID, title="New", created_at=CREATED_AT, modified_at=None
+        )
+    )
+    mock_client.notebooks.get = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
+    result = await mcp_call("notebook_create", {"title": "New"})
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "title": "New",
+        "created_at": CREATED_AT.isoformat(),  # preserved, NOT regressed to null
+        "sources_count": 0,
+        "is_owner": True,
+        "modified_at": None,  # stayed null, no value to backfill
+    }
+    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
+
+
 async def test_notebook_create_skips_reread_when_id_empty(mcp_call, mock_client) -> None:
     """No ``get("")`` on a degenerate empty-id create result (#1699).
 

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -168,29 +168,36 @@ async def test_notebook_create_skips_reread_when_timestamps_present(mcp_call, mo
     mock_client.notebooks.get.assert_not_awaited()
 
 
-async def test_notebook_create_reread_null_does_not_regress(mcp_call, mock_client) -> None:
-    """A lagging GET re-read returning null must not wipe an already-populated
-    create timestamp (#1699 per-key, non-null backfill).
+async def test_notebook_create_reread_backfills_missing_without_regressing(
+    mcp_call, mock_client
+) -> None:
+    """Per-key, non-null backfill in a single mixed re-read (#1699).
 
-    Here the create result already carries ``created_at`` but not
-    ``modified_at`` (one slot null fires the re-read guard); the re-read then
-    returns BOTH null. The populated ``created_at`` must be preserved (not
-    regressed to null) and ``modified_at`` simply stays null — no exception.
+    The create result carries ``created_at`` but not ``modified_at`` (one null
+    slot fires the re-read guard). The re-read then LAGS — it returns null for
+    the already-populated ``created_at`` while finally supplying
+    ``modified_at``. The populated ``created_at`` must be preserved (the lagging
+    null must NOT regress it), and the missing ``modified_at`` must be
+    backfilled from the re-read — both in the same call, no exception.
     """
     mock_client.notebooks.create = AsyncMock(
         return_value=FakeNotebookFull(
             id=NB_ID, title="New", created_at=CREATED_AT, modified_at=None
         )
     )
-    mock_client.notebooks.get = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
+    mock_client.notebooks.get = AsyncMock(
+        return_value=FakeNotebookFull(
+            id=NB_ID, title="New", created_at=None, modified_at=MODIFIED_AT
+        )
+    )
     result = await mcp_call("notebook_create", {"title": "New"})
     assert result.structured_content == {
         "notebook_id": NB_ID,
         "title": "New",
-        "created_at": CREATED_AT.isoformat(),  # preserved, NOT regressed to null
+        "created_at": CREATED_AT.isoformat(),  # kept; re-read's lagging null ignored
         "sources_count": 0,
         "is_owner": True,
-        "modified_at": None,  # stayed null, no value to backfill
+        "modified_at": MODIFIED_AT.isoformat(),  # backfilled from the re-read
     }
     mock_client.notebooks.create.assert_awaited_once_with("New")
     mock_client.notebooks.get.assert_awaited_once_with(NB_ID)

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -9,6 +9,7 @@ reaching the tool, the confirm preview-then-delete flow, and error projection.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -30,12 +31,31 @@ class FakeNotebook:
 
 
 @dataclass
+class FakeNotebookFull:
+    """A create-result-shaped notebook carrying the metadata the GET re-read adds.
+
+    Mirrors the real :class:`notebooklm.types.Notebook` field set so
+    ``to_jsonable`` emits the full flat shape (including ``created_at`` /
+    ``modified_at``) the #1699 enrichment surfaces.
+    """
+
+    id: str
+    title: str
+    created_at: datetime | None = None
+    sources_count: int = 0
+    is_owner: bool = True
+    modified_at: datetime | None = None
+
+
+@dataclass
 class FakeDescription:
     summary: str
 
 
 NB_ID = "11111111-1111-1111-1111-111111111111"
 NB2_ID = "22222222-2222-2222-2222-222222222222"
+CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+MODIFIED_AT = datetime(2026, 1, 3, 4, 5, 6, tzinfo=timezone.utc)
 
 
 async def test_notebook_list(mcp_call, mock_client) -> None:
@@ -45,13 +65,128 @@ async def test_notebook_list(mcp_call, mock_client) -> None:
     mock_client.notebooks.list.assert_awaited_once_with()
 
 
-async def test_notebook_create(mcp_call, mock_client) -> None:
-    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebook(id=NB_ID, title="New"))
+async def test_notebook_create_backfills_only_timestamps(mcp_call, mock_client) -> None:
+    """CREATE_NOTEBOOK returns null timestamps (#1699); a single GET re-read
+    backfills ONLY created_at/modified_at.
+
+    The create result is authoritative for id/title/sources_count/is_owner — the
+    re-read overwrites just the two timestamp keys, so a divergent GET payload
+    cannot clobber the rest. The flat shape (#1540) exposes the id as
+    ``notebook_id``.
+    """
+    mock_client.notebooks.create = AsyncMock(
+        return_value=FakeNotebookFull(id=NB_ID, title="New", sources_count=0, is_owner=True)
+    )
+    # GET intentionally diverges on the non-timestamp fields to prove only the
+    # two timestamp keys are taken from it.
+    mock_client.notebooks.get = AsyncMock(
+        return_value=FakeNotebookFull(
+            id=NB_ID,
+            title="Stale",
+            created_at=CREATED_AT,
+            sources_count=9,
+            is_owner=False,
+            modified_at=MODIFIED_AT,
+        )
+    )
     result = await mcp_call("notebook_create", {"title": "New"})
-    # Flat shape with the id exposed as ``notebook_id`` (#1540), matching
-    # ``note_create`` / ``notebook_delete`` rather than nesting under "notebook".
-    assert result.structured_content == {"notebook_id": NB_ID, "title": "New"}
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "title": "New",  # from create, NOT the divergent GET
+        "created_at": CREATED_AT.isoformat(),  # backfilled from GET
+        "sources_count": 0,  # from create
+        "is_owner": True,  # from create
+        "modified_at": MODIFIED_AT.isoformat(),  # backfilled from GET
+    }
     mock_client.notebooks.create.assert_awaited_once_with("New")
+    # The caller needs no follow-up: exactly one internal GET re-read by id.
+    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
+
+
+async def test_notebook_create_reread_failure_falls_back(mcp_call, mock_client) -> None:
+    """A failed GET re-read must not fail a successful create (#1699).
+
+    The create already committed server-side, so the cosmetic timestamp backfill
+    is best-effort: when ``get`` raises (e.g. an eventual-consistency
+    NotebookNotFoundError), the tool returns the create result with its
+    still-null timestamps instead of propagating the error.
+    """
+    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
+    mock_client.notebooks.get = AsyncMock(side_effect=NotebookNotFoundError(NB_ID))
+    result = await mcp_call("notebook_create", {"title": "New"})
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "title": "New",
+        "created_at": None,
+        "sources_count": 0,
+        "is_owner": True,
+        "modified_at": None,
+    }
+    mock_client.notebooks.create.assert_awaited_once_with("New")
+    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
+
+
+async def test_notebook_create_reread_still_null_stays_null(mcp_call, mock_client) -> None:
+    """Best-effort: if GET itself returns still-null timestamps (propagation
+    lag), the output stays null — no worse than today, no error (#1699).
+    """
+    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
+    mock_client.notebooks.get = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
+    result = await mcp_call("notebook_create", {"title": "New"})
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "title": "New",
+        "created_at": None,
+        "sources_count": 0,
+        "is_owner": True,
+        "modified_at": None,
+    }
+    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
+
+
+async def test_notebook_create_skips_reread_when_timestamps_present(mcp_call, mock_client) -> None:
+    """No wasted RPC: when CREATE already returns both timestamps, the tool
+    skips the GET re-read entirely (#1699).
+    """
+    mock_client.notebooks.create = AsyncMock(
+        return_value=FakeNotebookFull(
+            id=NB_ID, title="New", created_at=CREATED_AT, modified_at=MODIFIED_AT
+        )
+    )
+    mock_client.notebooks.get = AsyncMock()
+    result = await mcp_call("notebook_create", {"title": "New"})
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "title": "New",
+        "created_at": CREATED_AT.isoformat(),
+        "sources_count": 0,
+        "is_owner": True,
+        "modified_at": MODIFIED_AT.isoformat(),
+    }
+    mock_client.notebooks.create.assert_awaited_once_with("New")
+    mock_client.notebooks.get.assert_not_awaited()
+
+
+async def test_notebook_create_skips_reread_when_id_empty(mcp_call, mock_client) -> None:
+    """No ``get("")`` on a degenerate empty-id create result (#1699).
+
+    ``Notebook.from_api_response`` can parse a malformed row to an empty id; the
+    re-read guard requires a non-empty id, so such a create skips the follow-up
+    entirely rather than issuing a meaningless ``get("")``.
+    """
+    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id="", title="New"))
+    mock_client.notebooks.get = AsyncMock()
+    result = await mcp_call("notebook_create", {"title": "New"})
+    assert result.structured_content == {
+        "notebook_id": "",
+        "title": "New",
+        "created_at": None,
+        "sources_count": 0,
+        "is_owner": True,
+        "modified_at": None,
+    }
+    mock_client.notebooks.create.assert_awaited_once_with("New")
+    mock_client.notebooks.get.assert_not_awaited()
 
 
 async def test_notebook_describe_by_id(mcp_call, mock_client) -> None:


### PR DESCRIPTION
Closes #1699

## Problem

The `CREATE_NOTEBOOK` RPC returns a notebook whose metadata block is present but whose `created_at`/`modified_at` timestamp slots are not yet populated, so the `notebook_create` MCP tool surfaced `created_at`/`modified_at` = `null` — even though `notebook_list` / `notebook_describe` (which hit `GET_NOTEBOOK`) already carry them.

## Fix

After `execute_notebook_create`, do ONE best-effort `GET_NOTEBOOK` re-read to backfill the timestamp keys:

- **Outer guard:** only re-read when `notebook_id` is non-empty AND at least one timestamp is null. Skips the RPC entirely when both timestamps are already present (no wasted RPC) or the id is empty (no `get("")`).
- **Per-key, strictly-additive backfill:** a slot is filled only when the create result left it `None` AND the re-read supplies a non-null value (`if record.get(key) is None and fresh.get(key) is not None`). A populated create timestamp is therefore never overwritten, and a lagging re-read that returns `null` cannot regress an already-populated slot back to `null`. `id`/`title`/`sources_count`/`is_owner` always stay authoritative from the create result. Preserves the flattened `{notebook_id, **notebook}` shape (#1540).
- **Defensive `isinstance(fresh, dict)` guard** before the `.get()` reads (`to_jsonable(Notebook)` is always a dict; belt-and-suspenders).
- Wrapped in `try/except Exception` (NOT `BaseException`, so `asyncio.CancelledError` still propagates). The create already committed server-side, so a re-read failure (eventual-consistency `NotebookNotFoundError`, transport blip) degrades to the create result rather than failing the create.
- Best-effort: if `GET` itself returns still-null timestamps (propagation lag), the output stays null — no worse than today.

## Tests

`tests/unit/mcp/test_notebooks.py`:
- null create + populated `get` → output non-null (the GET payload deliberately diverges on non-timestamp fields to prove only the two timestamp keys are taken from it)
- `get` raises `NotebookNotFoundError` → still returns the created notebook, no exception, timestamps null
- `get` returns still-null timestamps → output null (documents best-effort)
- **mixed-lag regression:** create has `created_at` populated + `modified_at` null; the `get` re-read LAGS (returns `null` for `created_at`) while supplying `modified_at` → the populated `created_at` is preserved (lagging null ignored) AND the missing `modified_at` is backfilled, in one call
- create already has both timestamps → `get` NOT called
- empty-id create → `get` NOT called (no `get("")`)

`tests/integration/mcp_vcr/test_notebooks.py` + `tests/cassettes/notebooks_create.yaml`: end-to-end VCR replay (MCP tool → real `NotebookLMClient` → recorded `CREATE_NOTEBOOK` then `GET_NOTEBOOK`) asserting non-null timestamps in the serialized `structured_content`.

## Review handling

The per-key, non-null backfill guard is applied (it prevents a lagging re-read from regressing an already-populated create timestamp), directly addressing the gemini-code-assist and CodeRabbit review threads. Gemini's `isinstance(fresh, dict)` defensive guard is included to fully close that thread. Polished via the polish gate (code-simplifier + Claude + Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook creation now reliably exposes the notebook identifier (including when the API returns it nested under an `id` field).
  * If `created_at`/`modified_at` are missing from the create response, the system performs a best-effort re-fetch to populate only those missing timestamps.
  * Existing non-null timestamp values are preserved, and create results still succeed even if the refresh fails.
* **Tests**
  * Updated integration coverage and expanded unit scenarios to verify the two-step timestamp population behavior, including “no unnecessary lookups” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->