### PR TITLE
feat(mcp): reject incompatible single-mode source_add content scalars (#1696)

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -422,6 +422,7 @@ def register(mcp: Any) -> None:
             if urls is None and source_type is None:
                 raise ValidationError("provide 'source_type' (single add) or 'urls' (batch)")
             if urls is not None:
+                # Batch mode: reject single-mode scalars, then resolve + dispatch.
                 _reject_batch_scalars(
                     url=url,
                     text=text,
@@ -432,28 +433,41 @@ def register(mcp: Any) -> None:
                 )
                 if not urls:
                     raise ValidationError("urls must contain at least one URL")
-            elif (
+                nb_id = await resolve_notebook(client, notebook)
+                return await _add_url_batch(client, nb_id, urls, allow_internal=allow_internal)
+
+            # Single-add mode. The mode checks above guarantee source_type is set; a
+            # hard raise (not assert — stripped under ``python -O``) both narrows the
+            # type for the validators + dispatch below and fails loudly if the
+            # invariant is ever broken by a future edit.
+            if source_type is None:  # pragma: no cover - unreachable given the mode guards
+                raise ValidationError("internal error: source_type unexpectedly None")
+
+            # The drive-mime and content-scalar-exclusivity checks below run BEFORE
+            # resolve_notebook, so these malformed calls never pay a notebook
+            # round-trip. (Content *presence* + the YouTube-host guard still run
+            # later, during dispatch — that ordering is unchanged by #1696.)
+            if (
                 mime_type is not None
                 and source_type == "drive"
                 and mime_type not in _DRIVE_MIME_CHOICES
             ):
-                # Single-mode drive mime validation (kept pre-resolve, as before).
                 raise ValidationError(
                     f"Invalid mime_type {mime_type!r} for drive; "
                     f"expected one of {list(_DRIVE_MIME_CHOICES)}"
                 )
+            # Content-scalar exclusivity (fail-closed): reject any content scalar
+            # this source_type does not consume. title/mime_type are untouched —
+            # they are optional metadata, not content.
+            _reject_single_content_scalars(
+                source_type,
+                url=url,
+                text=text,
+                path=path,
+                document_id=document_id,
+            )
 
             nb_id = await resolve_notebook(client, notebook)
-
-            if urls is not None:
-                return await _add_url_batch(client, nb_id, urls, allow_internal=allow_internal)
-
-            # Single-add mode: the mode checks above guarantee source_type is set.
-            # A hard raise (not assert — stripped under ``python -O``) both narrows
-            # the type for the single-mode dispatch and fails loudly if the
-            # invariant is ever broken by a future edit.
-            if source_type is None:  # pragma: no cover - unreachable given the mode guards
-                raise ValidationError("internal error: source_type unexpectedly None")
 
             if source_type == "file":
                 cfg = get_file_transfer(ctx)
@@ -626,6 +640,52 @@ def _reject_batch_scalars(
     if offenders:
         raise ValidationError(
             "these arguments are not valid with 'urls' (batch mode): " + ", ".join(offenders)
+        )
+
+
+#: Maps each single-add *content* scalar to the ``source_type`` values that
+#: legitimately consume it. A content scalar supplied for any other source_type
+#: is silently ignored today; :func:`_reject_single_content_scalars` rejects it.
+#: ``title`` / ``mime_type`` are intentionally absent — they are optional metadata
+#: valid alongside several types, not content.
+_CONTENT_SCALAR_OWNERS: dict[str, frozenset[str]] = {
+    "url": frozenset({"url", "youtube"}),
+    "text": frozenset({"text"}),
+    "path": frozenset({"file"}),
+    "document_id": frozenset({"drive"}),
+}
+
+
+def _reject_single_content_scalars(
+    source_type: str,
+    *,
+    url: str | None,
+    text: str | None,
+    path: str | None,
+    document_id: str | None,
+) -> None:
+    """Reject content scalars that don't belong to this single-add ``source_type``.
+
+    Single mode consumes exactly one content scalar (the one its ``source_type``
+    needs) and historically ignored the rest, contradicting the docstring's
+    mutual-exclusivity claim. Fail closed instead — matching batch mode's posture
+    (:func:`_reject_batch_scalars`). Only *content* scalars are checked; ``title`` /
+    ``mime_type`` are legitimate optional metadata and are left alone.
+    """
+    offenders = [
+        name
+        for name, value in (
+            ("url", url),
+            ("text", text),
+            ("path", path),
+            ("document_id", document_id),
+        )
+        if value is not None and source_type not in _CONTENT_SCALAR_OWNERS[name]
+    ]
+    if offenders:
+        raise ValidationError(
+            f"these arguments are not valid with source_type {source_type!r}: "
+            + ", ".join(offenders)
         )
 
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -803,7 +803,8 @@ async def test_source_add_single_rejects_foreign_content_scalar(
     msg = str(excinfo.value)
     assert "VALIDATION" in msg
     # The message names the offending scalar (part of the rejection contract).
-    assert next(iter(foreign)) in msg
+    (foreign_key,) = foreign
+    assert foreign_key in msg
     # Rejection is pre-resolve, so a name is never looked up.
     mock_client.notebooks.list.assert_not_called()
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -763,6 +763,90 @@ async def test_source_add_drive_bad_mime_is_validation_error(mcp_call, mock_clie
     mock_client.sources.add_drive.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("source_type", "good", "foreign"),
+    [
+        # url consumes `url`; text/path/document_id are foreign.
+        ("url", {"url": "https://example.com/a"}, {"text": "hi"}),
+        ("url", {"url": "https://example.com/a"}, {"path": "/tmp/x"}),
+        ("url", {"url": "https://example.com/a"}, {"document_id": "drivefile123"}),
+        # text consumes `text`; url/path/document_id are foreign.
+        ("text", {"text": "hello"}, {"url": "https://example.com/a"}),
+        ("text", {"text": "hello"}, {"path": "/tmp/x"}),
+        ("text", {"text": "hello"}, {"document_id": "drivefile123"}),
+        # file consumes `path`; url/text/document_id are foreign.
+        ("file", {"path": "/tmp/doc.pdf"}, {"url": "https://example.com/a"}),
+        ("file", {"path": "/tmp/doc.pdf"}, {"text": "hi"}),
+        ("file", {"path": "/tmp/doc.pdf"}, {"document_id": "drivefile123"}),
+        # drive consumes `document_id`; url/text/path are foreign.
+        ("drive", {"document_id": "drivefile123"}, {"url": "https://example.com/a"}),
+        ("drive", {"document_id": "drivefile123"}, {"text": "hi"}),
+        ("drive", {"document_id": "drivefile123"}, {"path": "/tmp/x"}),
+        # youtube consumes `url`; text/path/document_id are foreign.
+        ("youtube", {"url": "https://www.youtube.com/watch?v=abc"}, {"text": "hi"}),
+        ("youtube", {"url": "https://www.youtube.com/watch?v=abc"}, {"path": "/tmp/x"}),
+        ("youtube", {"url": "https://www.youtube.com/watch?v=abc"}, {"document_id": "d"}),
+    ],
+)
+async def test_source_add_single_rejects_foreign_content_scalar(
+    mcp_call, mock_client, source_type, good, foreign
+) -> None:
+    """A content scalar that this source_type does not consume fails closed —
+    BEFORE any notebook I/O (mirrors batch mode). A notebook *title* is used so
+    a single ``notebooks.list`` lookup would be observable were rejection late."""
+    mock_client.notebooks.list = AsyncMock(return_value=[])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_add",
+            {"notebook": "Some Notebook", "source_type": source_type, **good, **foreign},
+        )
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    # The message names the offending scalar (part of the rejection contract).
+    assert next(iter(foreign)) in msg
+    # Rejection is pre-resolve, so a name is never looked up.
+    mock_client.notebooks.list.assert_not_called()
+
+
+async def test_source_add_single_lists_all_foreign_scalars(mcp_call, mock_client) -> None:
+    """Multiple foreign content scalars are all named in one rejection."""
+    mock_client.notebooks.list = AsyncMock(return_value=[])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_add",
+            {
+                "notebook": "Some Notebook",
+                "source_type": "text",
+                "text": "hello",
+                "url": "https://example.com/a",
+                "path": "/tmp/x",
+            },
+        )
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    assert "url" in msg and "path" in msg
+    mock_client.notebooks.list.assert_not_called()
+
+
+async def test_source_add_single_metadata_not_rejected(mcp_call, mock_client) -> None:
+    """``title`` / ``mime_type`` are optional metadata, NOT content scalars — a
+    valid single add carrying them alongside its one content scalar still works."""
+    mock_client.sources.add_url = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Page"))
+    result = await mcp_call(
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "source_type": "url",
+            "url": "https://example.com/a",
+            "title": "My Page",
+            "mime_type": "text/html",
+        },
+    )
+    assert result.structured_content == {
+        "source": {"id": SRC_ID, "title": "Page", "kind": "web_page", "status_label": "ready"}
+    }
+
+
 async def test_source_get_content_not_found_projects_tool_error(mcp_call, mock_client) -> None:
     def _raise(*_a: Any, **_k: Any) -> Any:
         raise SourceNotFoundError(SRC_ID)

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -845,6 +845,10 @@ async def test_source_add_single_metadata_not_rejected(mcp_call, mock_client) ->
     assert result.structured_content == {
         "source": {"id": SRC_ID, "title": "Page", "kind": "web_page", "status_label": "ready"}
     }
+    # The add actually proceeded (not silently rejected). A url source ignores
+    # title/mime_type downstream — add_url takes only (notebook_id, url) — so the
+    # point here is that supplying them does not trip the content-scalar gate.
+    mock_client.sources.add_url.assert_awaited_once_with(NB_ID, "https://example.com/a")
 
 
 async def test_source_get_content_not_found_projects_tool_error(mcp_call, mock_client) -> None:


### PR DESCRIPTION
Closes #1696.

## Problem

Single-mode `source_add` selects the one content scalar its `source_type` needs and **silently ignores the rest** — e.g. `source_type="url"` with a `text=...` also supplied would add the URL and drop the text with no signal. The docstring already claims these are mutually exclusive, so the behavior contradicts the documented contract.

## Change (fail-closed, content scalars only)

This is a deliberate **fail-closed behavior change**, matching batch mode's existing posture (`_reject_batch_scalars`):

- New helper `_reject_single_content_scalars(source_type, *, url, text, path, document_id)` raises `ValidationError` listing every content scalar the chosen `source_type` does **not** consume. Message shape mirrors `_reject_batch_scalars`.
- Ownership map `_CONTENT_SCALAR_OWNERS`: `url`→`{url,youtube}`, `text`→`{text}`, `path`→`{file}`, `document_id`→`{drive}`.
- `title` / `mime_type` are intentionally **not** rejected — they are legitimate optional metadata, and rejecting them would be a gratuitous break.
- The check runs **before `resolve_notebook`**, so a malformed call never pays a notebook round-trip (pure arg validation).

The single/batch dispatch in `source_add` was restructured so the batch path is self-contained (resolves + returns inside its branch) and a single hard-raise narrows `source_type` for all single-mode validation — this keeps the new validator `mypy`-clean without a `# type: ignore` or a duplicate narrowing.

## Tests

`tests/unit/mcp/test_sources.py`:
- Parametrized over every `source_type` × each foreign content scalar → `VALIDATION`, the offender is named in the message, and `notebooks.list` is **not** called (a notebook *title* is used to prove pre-resolve rejection).
- Multi-offender case → all offenders listed.
- A valid single add carrying `title` + `mime_type` alongside its one content scalar → still works (metadata untouched).

## Verification

- `uv run pytest tests/unit/mcp/` (465 passed)
- `uv run pre-commit run --all-files` (ruff format + lint)
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run python scripts/audit_public_api_compat.py --check-stale`

Polished via the claude+codex gate (code-simplifier found nothing to change; both reviewers confirmed the scalar→source_type mapping is exact and the restructure preserved batch-resolve timing / drive-mime ordering / dispatch). Review notes addressed: tightened the pre-resolve comment to not overclaim, and strengthened the tests to assert offenders are named (single + multi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened source-adding validation so only inputs matching the selected source type are accepted.
  * Invalid content fields are now rejected earlier with clearer error messages, instead of being ignored.
  * Batch and single add flows now handle input validation more consistently.
* **Tests**
  * Added coverage for invalid content combinations and for valid single-add requests that include metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->