### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Maintenance backports on the 0.7.x line (cherry-picked from `main` ahead of
-the v0.8.0 breaking release).
+## [0.7.3] - 2026-06-29
+
+Maintenance patch on the 0.7.x line. Backports fixes from `main`
+(cherry-picked ahead of the v0.8.0 breaking release).
 
 ### Fixed
 
@@ -1221,7 +1223,8 @@ This is the initial public release of `notebooklm-py`. While core functionality 
 - **Authentication expiry**: CSRF tokens expire after some time. Re-run `notebooklm login` if you encounter auth errors.
 - **Large file uploads**: Files over 50MB may fail or timeout. Split large documents if needed.
 
-[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/teng-lin/notebooklm-py/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.6.0...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.7.2"
+version = "0.7.3"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -244,21 +244,36 @@ def _has_active_vcr_cassette() -> bool:
     on ``notebooklm_vcr`` is the primary protection — this guard is a
     secondary belt-and-braces check for unbound requests.
     """
+    # vcrpy installs ``functools.wraps``-style stubs (``__wrapped__`` points
+    # back to the original) on its HTTP interception points. The exact point
+    # moved across versions: vcrpy <=8.1 patched
+    # ``httpcore.AsyncConnectionPool.handle_async_request``; vcrpy >=8.2 patches
+    # ``httpx.AsyncHTTPTransport.handle_async_request`` (the transport layer)
+    # instead. Probe both so the guard survives either vcrpy generation.
+    candidates = []
+    try:
+        import httpx  # type: ignore[import-not-found]
+
+        candidates.append((httpx.AsyncHTTPTransport, "handle_async_request"))
+    except ImportError:
+        pass
     try:
         import httpcore  # type: ignore[import-not-found]
 
-        # When a vcrpy cassette is active, httpcore's AsyncConnectionPool gets
-        # its ``handle_async_request`` patched with a vcr-aware wrapper. The
-        # wrapper has a ``__wrapped__`` reference back to the original. If we
-        # see a wrapper, a cassette context is active somewhere.
-        handle = getattr(httpcore.AsyncConnectionPool, "handle_async_request", None)
-        if handle is None:
-            return True
-        # vcrpy uses ``functools.wraps`` or sets ``__wrapped__`` on its stubs.
-        return getattr(handle, "__wrapped__", None) is not None
-    except (ImportError, AttributeError):
-        # If httpcore is missing or vcr stubs aren't introspectable, fall
-        # open — we shouldn't break tests on environmental quirks.
+        candidates.append((httpcore.AsyncConnectionPool, "handle_async_request"))
+    except ImportError:
+        pass
+
+    if not candidates:
+        # Neither library importable — fall open rather than break tests on
+        # environmental quirks.
+        return True
+    try:
+        return any(
+            getattr(getattr(cls, attr, None), "__wrapped__", None) is not None
+            for cls, attr in candidates
+        )
+    except AttributeError:
         return True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1025,15 +1025,15 @@ wheels = [
 
 [[package]]
 name = "vcrpy"
-version = "8.1.1"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/db/08183b845b0040bb877dad2bd7e4e0976fc232bb3476d7ee369c6c4f8b5a/vcrpy-8.2.1.tar.gz", hash = "sha256:d73a6e4eb6dae8148e659764b7a00e68cc51ba29ba9e6a85e1f0790ad96b97df", size = 90511, upload-time = "2026-06-16T13:20:52.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7c/0e812ab83f5289404c674f3461ba783250b967d34b5ab034d361236ec042/vcrpy-8.2.1-py3-none-any.whl", hash = "sha256:7ce58c9e2792b246f79d6f4b3e9660676cc6f853be17e1547305b4437ab1ff85", size = 44925, upload-time = "2026-06-16T13:20:51.734Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release **v0.7.3** — maintenance patch on the 0.7.x line. (Supersedes #1706, which used a non-`release/*` branch name that blocked the live E2E/RPC gates.)

Bumps `pyproject.toml` + `uv.lock` 0.7.2 → 0.7.3 and finalizes the CHANGELOG (`[Unreleased]` → `[0.7.3]`, 2026-06-29, compare links).

### Included since v0.7.2 (backports from `main`)
- **`.md` uploads no longer fail on Python 3.10** (backport #1628; fixes #1627)
- **Clearer error on NotebookLM region / access-gate redirect** (backport #1630)
- **Interactive `notebooklm login` no longer hangs 5 min / silently fails to save auth** (backport #1700; fixes #1697)

### Release-infra fix folded in
- **`fix(deps): bump vcrpy 8.1.1 → 8.2.1` (GHSA-rpj2-4hq8-938g, backport #1607)** — pip-audit flagged the dev-only `vcrpy` pin; bump + the `_has_active_vcr_cassette()` dual-probe so VCR replay works on vcrpy ≥8.2.

### Pre-flight gates (local, all green)
- `pre-commit` ✓ · `mypy src/notebooklm` (198 files) ✓ · `pytest` 8454 passed ✓
- `integration` (post vcrpy bump) 709 passed ✓ · `pip-audit` no vulns ✓
- `audit_public_api_compat` compatible with v0.7.2 ✓ · install-parity / claude-md-freshness ✓

### Live gates (dispatched on `release/v0.7.3`)
- Nightly E2E + RPC Health Check — running against live API.

PATCH bump; tagged directly on `release/v0.7.x` after merge (maintenance-line pattern, not merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

